### PR TITLE
SceneWorks: SCAIL-2 character-animation catalog + worker routing (sc-5447 / sc-5448)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3396,6 +3396,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mlx-gen-scail2"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
+dependencies = [
+ "inventory",
+ "mlx-gen",
+ "mlx-gen-wan",
+ "pmetal-mlx-rs",
+ "serde_json",
+]
+
+[[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
 source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
@@ -3765,7 +3777,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5168,6 +5180,7 @@ dependencies = [
  "mlx-gen-qwen-image",
  "mlx-gen-sam2",
  "mlx-gen-sam3",
+ "mlx-gen-scail2",
  "mlx-gen-sdxl",
  "mlx-gen-seedvr2",
  "mlx-gen-sensenova",

--- a/apps/web/public/prompt-guides/scail2.md
+++ b/apps/web/public/prompt-guides/scail2.md
@@ -1,0 +1,79 @@
+# SCAIL-2 Prompt Guide
+
+## Best For
+
+**Character animation** — you have a reference image of a character and a driving video of someone
+(or something) moving, and you want your character to perform that motion. SCAIL-2 transfers the
+driving clip's motion and timing onto your character while keeping the character's identity and look.
+
+> SCAIL-2 is heavy: it runs a segmented 14B denoise, so a clip takes several minutes. Keep clips short
+> and choose a driving video whose motion completes within the selected duration.
+
+## What You Provide
+
+| Input | What it's for |
+|---|---|
+| **Reference character image** | The character to animate — its identity, face, wardrobe, and look. Use a clean, well-lit, unobstructed image where the whole subject is visible. |
+| **Driving video** | The motion and timing to transfer. The output matches the driving clip's framing and aspect, so pick a bucket (e.g. 480×832 portrait, 832×480 landscape) that matches it. |
+| **Prompt** | Describes the result — the scene, mood, and any details to reinforce. SCAIL-2 leans on the reference + driving for identity and motion, so the prompt is supporting guidance, not the whole story. |
+
+The color-coded segmentation masks SCAIL-2 needs are generated for you from the driving clip and the
+reference image — you don't supply masks.
+
+## Choosing A Driving Video
+
+The driving clip is the most important input after the reference:
+
+- **One clear subject, fully in frame.** SCAIL-2 segments the moving person automatically; a single,
+  unobstructed subject animates most cleanly.
+- **Motion that fits the duration.** A gesture or step that completes within 5s reads better than a
+  long action that gets cut off.
+- **Steady framing.** Heavy camera shake or rapid cuts make the transferred motion noisier.
+- **Match the aspect.** The output adopts the driving clip's framing — a portrait driver gives a
+  portrait result.
+
+## Choosing A Reference
+
+- **Clean and well-lit**, with the character's face and body clearly visible.
+- **Front-facing or three-quarter** views hold identity better than extreme angles.
+- **Uncluttered background** — the character should be the obvious subject.
+
+## Prompt Shape
+
+`subject + scene + mood/style`
+
+Because the reference carries identity and the driving clip carries motion, keep the prompt focused on
+the **scene and look** you want the animated character placed into:
+
+- Reinforce the character (`a young woman in a red jacket`) so the identity stays stable.
+- Set the scene (`on a city street at dusk`, `in a softly lit studio`).
+- Add a style label (`cinematic`, `photorealistic`, `warm commercial video`).
+
+### Negative Prompt
+
+Reduce common video artifacts: `blurry details, distorted face, extra limbs, flicker, warping,
+duplicated subject, low quality`.
+
+## Quality & Speed Notes
+
+- **Resolution:** use a native bucket that matches the driving clip (480×832 / 832×480 / 720p). Very
+  small frames look degraded.
+- **Quantization:** Q4 is the default (fits ~48–64 GB Macs, faster). Opt into Q8 (advanced setting)
+  for a small quality gain if you have the memory.
+- **Steps:** more steps = cleaner motion but longer renders; keep them modest while iterating.
+- **Duration:** longer clips stitch multiple 14B denoise segments — each segment adds minutes. Keep
+  clips at 5s or less.
+
+## Example Prompts
+
+`A young woman with long dark hair in a green raincoat, walking through a rain-soaked city street at
+night, neon reflections on the pavement. Cinematic, moody, shallow depth of field.`
+
+`An older man in a tweed jacket gesturing as he speaks, seated in a warm wood-paneled study, soft
+window light. Photorealistic, documentary feel.`
+
+## Sources
+
+- [SCAIL-2 model card](https://huggingface.co/zai-org/SCAIL-2)
+- [SCAIL-2 GitHub repo](https://github.com/zai-org/SCAIL-2)
+- [Wan2.1 GitHub repo](https://github.com/Wan-Video/Wan2.1)

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2434,6 +2434,103 @@
         }
       }
     },
+    // SCAIL-2 (epic 5439): zai-org's end-to-end controlled character-animation /
+    // motion-transfer model. Give a reference character image + a driving video and
+    // SCAIL-2 animates the character with the driving motion. Backbone is Wan2.1-14B
+    // I2V (dense) + the stock Wan2.1 z16 VAE / umt5-xxl + an open-CLIP XLM-RoBERTa
+    // ViT-H/14 image tower; packed-token conditioning with auto-generated color-coded
+    // segmentation masks (the worker paints them from native SAM3 — no user masks).
+    // macOS-only native MLX (mlx-gen-scail2, engine id "scail2_14b"); no Torch path.
+    // Distributed the SceneWorks/*-mlx turnkey way: the converted bf16 snapshot is
+    // published as `SceneWorks/scail2-mlx`, downloaded on first use (engine quantizes
+    // Q4 at load). This entry covers the standalone `animate_character` mode (sc-5447 /
+    // sc-5448). Cross-identity `replace_person` is the SAME engine with replace_flag=true,
+    // wired under sc-5452; LoRA refinement under sc-5451 — not declared until wired.
+    {
+      "id": "scail2_14b",
+      "name": "SCAIL-2",
+      "family": "scail2",
+      "type": "video",
+      "adapter": "scail2",
+      "capabilities": [
+        "animate_character"
+      ],
+      "downloads": [
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/scail2-mlx",
+          "files": [],
+          "platforms": ["macos"],
+          // Pre-converted MLX snapshot (bf16 DiT + stock Wan2.1 VAE / umt5-xxl +
+          // open-CLIP ViT-H/14 visual tower). PROVISIONAL size: the published repo
+          // still carries the redundant raw torch pickles (~15 GB) alongside the
+          // loadable safetensors; sc-5445 prunes them at ship-time, dropping this to
+          // ~34 GB. Self-contained — no Wan base needed at runtime. Q4 default at load.
+          "estimatedSizeBytes": 48440000000
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/SceneWorks/scail2-mlx"
+      },
+      "defaults": {
+        "duration": 5,
+        "fps": 16,
+        "resolution": "832x480",
+        "quality": "balanced",
+        "sampler": "default",
+        "scheduler": "default"
+      },
+      "limits": {
+        // One 81-frame driving segment ≈ 5s at 16fps (longer clips stitch segments —
+        // each is a full 14B denoise, so keep clips short). Core aligns W×H to a
+        // multiple of 32; engine max_size 1280. The output bucket should match the
+        // driving clip's aspect (the clip sets the motion + framing).
+        "durations": [3, 4, 5],
+        "recommendedMaxDuration": 5,
+        "hardMaxDuration": 5,
+        "fps": [16],
+        "resolutions": ["832x480", "480x832", "1280x704", "704x1280"],
+        "samplers": ["default"],
+        "schedulers": ["default"]
+      },
+      "loraCompatibility": {
+        // The Bias-Aware DPO refinement LoRA + general LoRA are wired in sc-5451; the
+        // engine descriptor currently reports supports_lora: false.
+        "families": ["scail2"],
+        "types": []
+      },
+      "mlx": {
+        // Turnkey pre-converted MLX repo (no requiresConversion). The worker resolves
+        // env override (SCENEWORKS_MLX_SCAIL2_DIR) → local <data>/models/mlx/scail2 →
+        // this download-on-first-use snapshot, mirroring bernini.
+        // minMemoryGb is PROVISIONAL pending the real-size Mac measurement in sc-5445.
+        // Independent estimate: SCAIL-2 is a single Wan2.1-14B DiT (~1/3 of Bernini's
+        // dual-14B + 7B-planner stack, which needs 64) — Q4 weights ~8.4 GB; the 256²
+        // e2e smoke peaked 16.4 GB RSS (Metal-wired memory is not counted in RSS). 48
+        // is a conservative floor that still fits 64 GB-class Macs and gates out 32 GB.
+        "minMemoryGb": 48,
+        "repo": "SceneWorks/scail2-mlx",
+        "quantize": 4,
+        "limits": {
+          "samplers": ["default"],
+          "schedulers": ["default"]
+        }
+      },
+      "ui": {
+        "label": "SCAIL-2",
+        "description": "zai-org SCAIL-2 character animation: give a reference character image and a driving video, and SCAIL-2 animates your character with the driving motion (the driving clip sets the motion and timing). Built on Wan2.1-14B; macOS native MLX only. Needs ample unified memory and runs minutes-per-clip (segmented 14B denoise).",
+        "recommendedFor": ["animate_character"],
+        "durationHint": "Segmented 14B denoise — keep clips at 5s or less. Generates at 16fps; the driving clip sets the motion and timing.",
+        "promptGuide": {
+          "title": "SCAIL-2 Prompt Guide",
+          "path": "/prompt-guides/scail2.md",
+          "sources": [
+            { "label": "SCAIL-2 model card", "url": "https://huggingface.co/zai-org/SCAIL-2" },
+            { "label": "SCAIL-2 GitHub repo", "url": "https://github.com/zai-org/SCAIL-2" }
+          ]
+        }
+      }
+    },
     {
       "id": "real_esrgan",
       "name": "Real-ESRGAN Upscaler",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -2253,6 +2253,10 @@ const VIDEO_UI_MODES: &[&str] = &[
     "reference_video_to_video",
     "multi_video_to_video",
     "ads2v",
+    // SCAIL-2 standalone character animation (epic 5439 / sc-5448): only `scail2_14b` is
+    // eligible; surfaces disabled on the other models. Reference character + driving video
+    // → animated clip. (Cross-identity replacement reuses `replace_person`, wired in sc-5452.)
+    "animate_character",
 ];
 
 fn video_model_mac_support(model: &str) -> ModelMacSupport {
@@ -3596,6 +3600,10 @@ const VIDEO_MLX_ROUTED_MODELS: &[&str] = &[
     // only; the editing/reference video modes (v2v/mv2v/r2v/rv2v/ads2v) are
     // net-new UI vocabulary tracked under sc-4703.
     "bernini",
+    // SCAIL-2 (epic 5439 / sc-5448): Wan2.1-14B I2V end-to-end character animation,
+    // native MLX (engine id "scail2_14b"). Serves the standalone `animate_character`
+    // mode; cross-identity `replace_person` reuses the same engine, wired in sc-5452.
+    "scail2_14b",
 ];
 
 /// Epic 3018 routing (sc-3036, the video sibling of [`image_job_is_mlx_eligible`]):
@@ -3695,6 +3703,14 @@ fn video_mode_is_mlx_eligible(model: &str, mode: &str) -> bool {
                 | "multi_video_to_video"
                 | "ads2v"
         );
+    }
+    // SCAIL-2 (epic 5439 / sc-5448) is a Wan2.1-14B I2V character-animation engine: a reference
+    // character image + a driving video → an animated clip. It serves the standalone
+    // `animate_character` mode (the worker paints the color-coded masks from native SAM3). It has no
+    // classic text/image-to-video; cross-identity `replace_person` reuses the same engine but is wired
+    // separately (sc-5452), so it is not admitted here yet.
+    if model == "scail2_14b" {
+        return mode == "animate_character";
     }
     match mode {
         "text_to_video" | "image_to_video" => true,
@@ -5161,17 +5177,18 @@ mod mlx_routing_tests {
     #[test]
     fn video_mode_eligibility_admits_flf_only_on_flf_capable_engines() {
         // image_to_video is MLX on every routed model EXCEPT Bernini (text_to_video only — its
-        // renderer is Wan2.2-T2V, no still-image-to-video); text_to_video on every routed model
-        // EXCEPT SVD (image-conditioned only, sc-3523).
+        // renderer is Wan2.2-T2V, no still-image-to-video) and SCAIL-2 (animate_character only);
+        // text_to_video on every routed model EXCEPT SVD (image-conditioned only, sc-3523) and
+        // SCAIL-2 (animate_character only — sc-5448).
         for model in VIDEO_MLX_ROUTED_MODELS {
             assert_eq!(
                 video_mode_is_mlx_eligible(model, "image_to_video"),
-                *model != "bernini",
+                *model != "bernini" && *model != "scail2_14b",
                 "image_to_video eligibility for {model}"
             );
             assert_eq!(
                 video_mode_is_mlx_eligible(model, "text_to_video"),
-                *model != "svd",
+                *model != "svd" && *model != "scail2_14b",
                 "text_to_video eligibility for {model}"
             );
         }
@@ -5233,6 +5250,38 @@ mod mlx_routing_tests {
                     "{mode} should be Bernini-only, not eligible on {model}"
                 );
             }
+        }
+        // SCAIL-2 (sc-5448) serves ONLY the standalone character-animation mode (the worker paints
+        // its masks from native SAM3). No text/image-to-video; cross-identity replace_person is wired
+        // separately (sc-5452), so it is not admitted here yet.
+        assert!(
+            video_mode_is_mlx_eligible("scail2_14b", "animate_character"),
+            "scail2 should serve animate_character"
+        );
+        for mode in [
+            "text_to_video",
+            "image_to_video",
+            "first_last_frame",
+            "extend_clip",
+            "video_bridge",
+            "replace_person",
+            "video_to_video",
+            "nonsense",
+        ] {
+            assert!(
+                !video_mode_is_mlx_eligible("scail2_14b", mode),
+                "scail2 should not serve {mode}"
+            );
+        }
+        // animate_character is SCAIL-2-only — every other routed model rejects it.
+        for model in VIDEO_MLX_ROUTED_MODELS {
+            if *model == "scail2_14b" {
+                continue;
+            }
+            assert!(
+                !video_mode_is_mlx_eligible(model, "animate_character"),
+                "animate_character should be SCAIL-2-only, not eligible on {model}"
+            );
         }
         // first_last_frame: MLX on LTX (base + eros) + Wan TI2V-5B (sc-3055 cutover).
         assert!(video_mode_is_mlx_eligible("ltx_2_3", "first_last_frame"));

--- a/crates/sceneworks-core/src/lora_family.rs
+++ b/crates/sceneworks-core/src/lora_family.rs
@@ -228,6 +228,9 @@ pub fn model_adapter_for_family(family: &str) -> Option<&'static str> {
         // adapter. This label is recorded in recipe/lineage only; on Mac the job is
         // MLX-routed by engine id, never instantiated through a Torch adapter.
         "bernini" => Some("bernini"),
+        // SCAIL-2 (epic 5439) is likewise macOS-only native MLX (engine id
+        // "scail2_14b"); no Torch/diffusers adapter. Lineage label only.
+        "scail2" => Some("scail2"),
         _ => None,
     }
 }
@@ -293,6 +296,16 @@ pub fn model_capabilities_for_type_and_family(model_type: &str, family: &str) ->
             "multi_video_to_video",
             "ads2v",
         ],
+        // SCAIL-2 (epic 5439) is a Wan2.1-14B I2V end-to-end character-animation
+        // engine: a reference character image + a driving video → an animated clip.
+        // Its engine descriptor is `Modality::Video` with conditioning
+        // `[Reference, Mask, MultiReference, ControlClip]`. The standalone
+        // `animate_character` mode is wired in sc-5448 (the worker paints the
+        // color-coded masks from native SAM3). Cross-identity `replace_person` is the
+        // same engine with replace_flag=true (sc-5452); LoRA is sc-5451 — neither is
+        // declared until wired. Multi-character (paired ref+mask) awaits the engine
+        // request-contract extension.
+        ("video", "scail2") => vec!["animate_character"],
         _ => Vec::new(),
     }
 }

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -2454,6 +2454,28 @@ fn model_mac_support_feature_flags_mirror_routing_without_over_gating() {
         bernini.features.video_modes.get("replace_person"),
         Some(&false)
     );
+    // SCAIL-2 (epic 5439) is MLX-routed for the standalone character-animation mode only (sc-5448);
+    // the worker paints its masks from native SAM3. No text/image-to-video; cross-identity
+    // replace_person reuses the same engine but is wired separately (sc-5452).
+    let scail2 = model_mac_support("scail2_14b", "video");
+    assert!(scail2.supported, "scail2 should be MLX-supported");
+    assert!(scail2.reason.is_none());
+    assert_eq!(
+        scail2.features.video_modes.get("animate_character"),
+        Some(&true)
+    );
+    assert_eq!(
+        scail2.features.video_modes.get("text_to_video"),
+        Some(&false)
+    );
+    assert_eq!(
+        scail2.features.video_modes.get("image_to_video"),
+        Some(&false)
+    );
+    assert_eq!(
+        scail2.features.video_modes.get("replace_person"),
+        Some(&false)
+    );
 }
 
 #[test]

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -142,6 +142,23 @@ backend-candle = [
 # desktop packager (build-sidecar.mjs) has a dylib to stage and dev runs work.
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
+# Rev fa0f75b (mlx-gen main, merged PRs #453/#454/#455 + #456, epic 5439 / sc-5448): adds the full
+# **SCAIL-2** provider (`mlx-gen-scail2`, dep below) — a Wan2.1-14B I2V end-to-end character-animation /
+# cross-identity-replacement Generator self-registering as `scail2_14b` (reference character image +
+# driving video + auto-generated color-coded masks → animated/identity-replaced video; packed-token
+# conditioning + per-source RoPE + open-CLIP ViT-H/14 image cross-attn; reuses mlx-gen-wan's VAE/UMT5/
+# scheduler and depends on mlx-gen-wan internally). The new request conditioning the worker builds —
+# `Conditioning::Mask` (the reference's color mask) paired with `Reference`, plus the driving
+# `ControlClip{frames, mask}` — landed in gen-core at this rev (the descriptor advertises
+# `ConditioningKind::Mask`). Also bundles sc-5551 (#456): honor the cancel flag per-step in Wan/LTX
+# video denoise (output-neutral; the worker's existing cancel path just gets finer-grained). ⚠️ mlx-rs
+# stays `44929a0` (mlx-gen HEAD's internal mlx-rs rev is unchanged at this pin), so the direct `mlx-rs`
+# pin below is unchanged and MLX rebuilds only the new `mlx-gen-scail2` crate (+ its mlx-gen-wan dep).
+# `sceneworks-gen-core` is bumped in lockstep (the macOS block + the direct dep at line 33) so the skew
+# gate stays green (ONE rev). This bump moves EVERY mlx-gen crate rev to fa0f75b. The candle-gen pin
+# (`c032f16`) is NOT touched: candle deps are `optional` (off in the default `cargo tree --target all`
+# skew graph), so candle catches up to fa0f75b's gen-core separately in its own repo — exactly as the
+# 41c95a1 bernini bump below left candle at c032f16 and kept main green. On top of:
 # Rev 41c95a1 (mlx-gen main, merged PR #433, epic 4699 / sc-4707): adds the full **Bernini** provider
 # (`mlx-gen-bernini`, dep below) — a Qwen2.5-VL-7B semantic planner + Wan2.2-T2V-A14B dual-expert
 # renderer self-registering as `bernini`. The delta vs `1a97909` (which already carried the bernini
@@ -437,6 +454,18 @@ mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3e
 # tokenizer.json + model-*.safetensors; default `huihui-ai/Llama-3.2-3B-Instruct-abliterated`). Same
 # git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
 mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
+# SCAIL-2 (zai-org) end-to-end character-animation provider (epic 5439, sc-5448). An inventory-registered
+# `Generator` under id `scail2_14b` (`Modality::Video`): a Wan2.1-14B I2V DiT that animates a reference
+# character with a driving video's motion (`video_mode == "replacement"` flips the cross-identity
+# replace path for sc-5452). Conditioning = `Reference` (the character) + `Mask` (its color-coded seg
+# mask) + `ControlClip{frames, mask}` (driving video + per-frame color masks); the worker paints those
+# masks from native SAM3 (`mlx-gen-sam3`, above). Reuses mlx-gen-wan's VAE/UMT5/scheduler (depends on
+# mlx-gen-wan internally) + an open-CLIP ViT-H/14 image tower. `mac_only` native MLX (no torch fallback).
+# Q4 default / Q8 opt-in at load. The worker reaches it through the registry (`gen_core::load("scail2_14b")`
+# → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
+# drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
+# `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -125,6 +125,11 @@ mod person_segment;
 // Windows/Linux backend until a parallel candle backport (cf. epic 3792).
 #[cfg(target_os = "macos")]
 mod person_segment_sam3;
+// SCAIL-2 color-coded segmentation-mask painting (epic 5439, sc-5448): turns native SAM3
+// per-person masks into the palette-painted RGB masks the SCAIL-2 engine consumes. macOS-only
+// like its SAM3 dependency.
+#[cfg(target_os = "macos")]
+mod scail2_masks;
 use downloads::*;
 #[cfg(target_os = "macos")]
 use kps_jobs::*;

--- a/crates/sceneworks-worker/src/person_segment_sam3.rs
+++ b/crates/sceneworks-worker/src/person_segment_sam3.rs
@@ -340,6 +340,138 @@ pub(crate) fn segment_track_blocking(
     Ok(masks)
 }
 
+/// Every tracked person's per-frame mask + a stable left-to-right paint order — the input to the
+/// SCAIL-2 color-mask painter (sc-5448). Unlike [`segment_track_blocking`] (which selects ONE person
+/// via ByteTrack anchors for replace_person), this keeps EVERY SAM3 object so each person can be
+/// painted a distinct palette color.
+pub(crate) struct AllPersonMasks {
+    /// SAM3 object ids in left-to-right paint order (ascending centroid-x in the frame where each
+    /// object first appears); person index 0 = leftmost = the SCAIL-2 palette's first color.
+    pub order: Vec<i32>,
+    /// `per_frame[f]` = `(obj_id, binary mask row-major width*height, 0/255)` for every object
+    /// present on frame `f` (empty masks dropped). Object ids index into [`AllPersonMasks::order`].
+    pub per_frame: Vec<Vec<(i32, Vec<u8>)>>,
+    pub width: u32,
+    pub height: u32,
+}
+
+/// Normalized centroid-x (0..1) of a SAM3 low-res mask's foreground (logit `> 0`); `None` if the
+/// mask is empty. Used to sort tracked people left-to-right for deterministic palette assignment.
+fn mask_centroid_x(mask_logits: &[f32], grid: usize) -> Option<f64> {
+    let (mut sum_x, mut n) = (0f64, 0u64);
+    for my in 0..grid {
+        for mx in 0..grid {
+            if mask_logits[my * grid + mx] > 0.0 {
+                sum_x += (mx as f64 + 0.5) / grid as f64;
+                n += 1;
+            }
+        }
+    }
+    (n > 0).then(|| sum_x / n as f64)
+}
+
+/// Segment + track every "person" across already-decoded RGB `frames` with the SAM3 text-concept
+/// (PCS) video pipeline, returning all objects' per-frame masks + the left-to-right paint order.
+/// In-memory sibling of [`segment_track_blocking`] (no temp frame files): the SCAIL-2 reference /
+/// driving frames are already decoded `Image`s, so the temp-PNG round-trip is skipped. `frames` must
+/// be non-empty and uniform-sized. The checkpoint parses once and is cached process-wide; run under
+/// `spawn_blocking` (GPU inference is blocking).
+pub(crate) fn segment_all_persons_in_memory(
+    model_path: &Path,
+    tokenizer_path: &Path,
+    frames: &[image::RgbImage],
+) -> WorkerResult<AllPersonMasks> {
+    let first = frames.first().ok_or_else(|| {
+        WorkerError::InvalidPayload("scail2 segmentation: no frames to segment".into())
+    })?;
+    let (width, height) = (first.width(), first.height());
+    if frames
+        .iter()
+        .any(|f| f.width() != width || f.height() != height)
+    {
+        return Err(WorkerError::InvalidPayload(
+            "scail2 segmentation: frames are not all the same size".into(),
+        ));
+    }
+    let tensors: Vec<Array> = frames.iter().map(input_tensor).collect();
+
+    // Cached checkpoint; recover from a poisoned lock by dropping + reloading (mirrors
+    // `segment_track_blocking` / sc-4277 F-MLXW-13).
+    let cell = WEIGHTS.get_or_init(|| Mutex::new(None));
+    let mut guard = cell.lock().unwrap_or_else(|poisoned| {
+        let mut guard = poisoned.into_inner();
+        *guard = None;
+        guard
+    });
+    if guard.is_none() {
+        let weights = Weights::from_file(model_path)
+            .map_err(|e| WorkerError::Engine(format!("sam3 weights load: {e}")))?;
+        *guard = Some(weights);
+    }
+    let weights = guard.as_ref().expect("weights loaded");
+
+    let mut model = Sam3VideoModel::from_weights(weights)
+        .map_err(|e| WorkerError::Engine(format!("sam3 model build: {e}")))?;
+    if let Some(bits) = quant_bits() {
+        model
+            .quantize(bits)
+            .map_err(|e| WorkerError::Engine(format!("sam3 quantize q{bits}: {e}")))?;
+    }
+    let tokenizer = Sam3Tokenizer::from_file(tokenizer_path, &Sam3TextConfig::sam3())
+        .map_err(|e| WorkerError::Engine(format!("sam3 tokenizer load: {e}")))?;
+    let (input_ids, text_mask) = tokenizer
+        .encode(CONCEPT_PROMPT)
+        .map_err(|e| WorkerError::Engine(format!("sam3 tokenize: {e}")))?;
+
+    let outputs = model
+        .propagate(&tensors, &input_ids, &text_mask)
+        .map_err(|e| WorkerError::Engine(format!("sam3 propagate: {e}")))?;
+
+    // Paint order: each object's centroid-x in the FIRST frame it appears, ascending (tie-break on
+    // first-seen frame, then object id, so repeated runs agree).
+    use std::collections::BTreeMap;
+    let mut first_seen: BTreeMap<i32, (usize, f64)> = BTreeMap::new();
+    for (f, frame) in outputs.iter().enumerate() {
+        for (oid, logits) in frame.obj_ids.iter().zip(&frame.masks) {
+            if first_seen.contains_key(oid) {
+                continue;
+            }
+            if let Some(cx) = mask_centroid_x(logits, MASK_GRID) {
+                first_seen.insert(*oid, (f, cx));
+            }
+        }
+    }
+    let mut order: Vec<i32> = first_seen.keys().copied().collect();
+    order.sort_by(|a, b| {
+        let (fa, xa) = first_seen[a];
+        let (fb, xb) = first_seen[b];
+        xa.partial_cmp(&xb)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(fa.cmp(&fb))
+            .then(a.cmp(b))
+    });
+
+    let per_frame = outputs
+        .iter()
+        .map(|frame| {
+            frame
+                .obj_ids
+                .iter()
+                .zip(&frame.masks)
+                .map(|(oid, logits)| (*oid, mask_to_frame(logits, MASK_GRID, width, height)))
+                .filter(|(_, mask)| !mask.is_empty())
+                .collect()
+        })
+        .collect();
+
+    Ok(AllPersonMasks {
+        order,
+        per_frame,
+        width,
+        height,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/sceneworks-worker/src/scail2_masks.rs
+++ b/crates/sceneworks-worker/src/scail2_masks.rs
@@ -1,0 +1,216 @@
+//! SCAIL-2 color-coded segmentation-mask painting (epic 5439, sc-5448).
+//!
+//! SCAIL-2 conditions on **color-coded** segmentation masks, not binary ones: each tracked person is
+//! painted a distinct solid color, on a solid background, and the engine's
+//! `extract_and_compress_mask_to_latent` reads those colors as one of seven exclusive classes
+//! (threshold ≥ 225 per channel → white = R&G&B, red = R, green = G, blue = B, yellow = R&G,
+//! magenta = R&B, cyan = G&B; all-off black = the "hidden" background class). This module turns the
+//! native-SAM3 per-person masks ([`AllPersonMasks`]) into those painted RGB masks.
+//!
+//! Palette + conventions mirror upstream **SCAIL-Pose** (`TrackSam3/track.py`): one color per WHOLE
+//! person (never per-body-part), persons ordered left-to-right, and the background encodes
+//! whose-world-to-keep — animation keeps the reference's world (driving-mask bg **black**, ref-mask bg
+//! **white**); cross-identity replacement keeps the driving's world (driving bg **white**, ref bg
+//! **black**, used by sc-5452).
+
+use gen_core::Image;
+
+use crate::person_segment_sam3::AllPersonMasks;
+use crate::{WorkerError, WorkerResult};
+
+/// Person palette in RGB, person 0 = leftmost. Maps onto the engine's six chromatic color classes
+/// (the seventh, white, is the "visible background" class). Upstream `DEFAULT_PALETTE_BGR` is written
+/// BGR→RGB so the engine sees: 0 = blue, 1 = red, 2 = green, 3 = magenta, 4 = cyan, 5 = yellow.
+pub(crate) const PALETTE: [[u8; 3]; 6] = [
+    [0, 0, 255],   // person 0 — blue
+    [255, 0, 0],   // person 1 — red
+    [0, 255, 0],   // person 2 — green
+    [255, 0, 255], // person 3 — magenta
+    [0, 255, 255], // person 4 — cyan
+    [255, 255, 0], // person 5 — yellow
+];
+
+/// Solid backgrounds: black = the "hidden" class (no channel on); white = the "visible" class.
+pub(crate) const BG_BLACK: [u8; 3] = [0, 0, 0];
+pub(crate) const BG_WHITE: [u8; 3] = [255, 255, 255];
+
+/// The palette color for an object id, or `None` if the object is past the 6-color cap (SCAIL-2's
+/// scheme has six person classes; extra people get no color and read as background).
+fn color_for(order: &[i32], oid: i32) -> Option<[u8; 3]> {
+    order
+        .iter()
+        .position(|&o| o == oid)
+        .filter(|&i| i < PALETTE.len())
+        .map(|i| PALETTE[i])
+}
+
+/// Fill an RGB pixel buffer with a solid background color.
+fn filled(width: usize, height: usize, bg: [u8; 3]) -> Vec<u8> {
+    let mut px = vec![0u8; width * height * 3];
+    for chunk in px.chunks_exact_mut(3) {
+        chunk.copy_from_slice(&bg);
+    }
+    px
+}
+
+/// Paint one person's binary mask into the RGB buffer with `color`.
+fn paint(px: &mut [u8], mask: &[u8], color: [u8; 3]) {
+    for (p, &m) in mask.iter().enumerate() {
+        if m > 0 {
+            let o = p * 3;
+            if o + 3 <= px.len() {
+                px[o..o + 3].copy_from_slice(&color);
+            }
+        }
+    }
+}
+
+/// Paint the per-frame **driving** color masks: a solid `bg`, each tracked person filled its palette
+/// color. People are painted in left-to-right order so a right-neighbor overlap wins (the upstream
+/// paint order), keeping assignments deterministic. Returns one RGB mask per driving frame.
+pub(crate) fn paint_driving_masks(masks: &AllPersonMasks, bg: [u8; 3]) -> Vec<Image> {
+    let (w, h) = (masks.width as usize, masks.height as usize);
+    masks
+        .per_frame
+        .iter()
+        .map(|frame| {
+            let mut px = filled(w, h, bg);
+            for &oid in &masks.order {
+                let Some(color) = color_for(&masks.order, oid) else {
+                    continue;
+                };
+                if let Some((_, mask)) = frame.iter().find(|(o, _)| *o == oid) {
+                    paint(&mut px, mask, color);
+                }
+            }
+            Image {
+                width: masks.width,
+                height: masks.height,
+                pixels: px,
+            }
+        })
+        .collect()
+}
+
+/// Paint the **reference** character mask: the primary (largest-area) detected person filled blue
+/// (the person-0 palette color, so it pairs with the driving clip's person 0) on a solid `bg`. The
+/// reference is a single image → a single-frame [`AllPersonMasks`]. Errors if SAM3 found no person
+/// (the reference must be a clear, unobstructed photo of the character).
+pub(crate) fn paint_reference_mask(masks: &AllPersonMasks, bg: [u8; 3]) -> WorkerResult<Image> {
+    let (w, h) = (masks.width as usize, masks.height as usize);
+    let frame = masks.per_frame.first().ok_or_else(|| {
+        WorkerError::InvalidPayload(
+            "scail2 reference: SAM3 returned no frame for the reference image".into(),
+        )
+    })?;
+    let primary = frame
+        .iter()
+        .max_by_key(|(_, mask)| mask.iter().filter(|&&v| v > 0).count())
+        .filter(|(_, mask)| mask.iter().any(|&v| v > 0))
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload(
+                "scail2 reference: no person detected in the reference image — use a clear, \
+                 unobstructed photo of the character"
+                    .into(),
+            )
+        })?;
+    let mut px = filled(w, h, bg);
+    paint(&mut px, &primary.1, PALETTE[0]);
+    Ok(Image {
+        width: masks.width,
+        height: masks.height,
+        pixels: px,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A 2×1 frame: pixel 0 owned by object 7, pixel 1 by object 3.
+    fn two_person_masks() -> AllPersonMasks {
+        // Object 3 is leftmost (paint order 0 → blue); object 7 is to its right (order 1 → red).
+        AllPersonMasks {
+            order: vec![3, 7],
+            per_frame: vec![vec![(7, vec![0, 255]), (3, vec![255, 0])]],
+            width: 2,
+            height: 1,
+        }
+    }
+
+    #[test]
+    fn driving_paints_palette_by_left_to_right_order_on_bg() {
+        let out = paint_driving_masks(&two_person_masks(), BG_BLACK);
+        assert_eq!(out.len(), 1);
+        // pixel 0 = object 3 = order[0] = blue; pixel 1 = object 7 = order[1] = red.
+        assert_eq!(&out[0].pixels[0..3], &PALETTE[0], "leftmost person → blue");
+        assert_eq!(&out[0].pixels[3..6], &PALETTE[1], "next person → red");
+    }
+
+    #[test]
+    fn driving_background_is_solid_where_no_person() {
+        let masks = AllPersonMasks {
+            order: vec![1],
+            per_frame: vec![vec![(1, vec![255, 0])]],
+            width: 2,
+            height: 1,
+        };
+        let out = paint_driving_masks(&masks, BG_WHITE);
+        assert_eq!(&out[0].pixels[0..3], &PALETTE[0], "person → blue");
+        assert_eq!(&out[0].pixels[3..6], &BG_WHITE, "empty pixel → white bg");
+    }
+
+    #[test]
+    fn objects_past_six_get_no_color() {
+        // Seven objects; the seventh (order index 6) is past the palette cap → stays background.
+        let order: Vec<i32> = (0..7).collect();
+        let per_frame = vec![(0..7)
+            .map(|i: i32| (i, vec![if i == 6 { 255u8 } else { 0 }]))
+            .collect()];
+        let masks = AllPersonMasks {
+            order,
+            per_frame,
+            width: 1,
+            height: 1,
+        };
+        let out = paint_driving_masks(&masks, BG_BLACK);
+        assert_eq!(
+            &out[0].pixels[0..3],
+            &BG_BLACK,
+            "7th person → no color, stays bg"
+        );
+    }
+
+    #[test]
+    fn reference_paints_largest_person_blue() {
+        // Object 9 has 1 pixel, object 4 has 3 pixels → object 4 is the primary character.
+        let masks = AllPersonMasks {
+            order: vec![4, 9],
+            per_frame: vec![vec![(9, vec![255, 0, 0, 0]), (4, vec![0, 255, 255, 255])]],
+            width: 4,
+            height: 1,
+        };
+        let out = paint_reference_mask(&masks, BG_WHITE).expect("a person is present");
+        assert_eq!(
+            &out.pixels[0..3],
+            &BG_WHITE,
+            "object-9 pixel is not the primary → bg"
+        );
+        assert_eq!(
+            &out.pixels[3..6],
+            &PALETTE[0],
+            "largest person painted blue"
+        );
+    }
+
+    #[test]
+    fn reference_errors_when_no_person() {
+        let masks = AllPersonMasks {
+            order: vec![],
+            per_frame: vec![vec![]],
+            width: 2,
+            height: 1,
+        };
+        assert!(paint_reference_mask(&masks, BG_WHITE).is_err());
+    }
+}

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -64,6 +64,11 @@ use mlx_gen_wan as _;
 // `gen_core::load("bernini")`, no direct type contact — the "no generator registered" trap).
 #[cfg(target_os = "macos")]
 use mlx_gen_bernini as _;
+// SCAIL-2 (epic 5439): the character-animation `Generator` registers under `scail2_14b` via
+// `inventory::submit!`; force-link so the registration survives the linker (reached only through
+// `gen_core::load("scail2_14b")`, no direct type contact — the "no generator registered" trap).
+#[cfg(target_os = "macos")]
+use mlx_gen_scail2 as _;
 // Candle (Windows/CUDA) video providers (sc-5097) — force-link anchors so their `inventory::submit!`
 // registrations (`wan2_2_ti2v_5b` / `ltx_2_3_distilled`) survive the MSVC release linker, mirroring
 // the image providers in image_jobs.rs.
@@ -309,6 +314,28 @@ pub(crate) async fn run_video_generate_job(
             .await?,
             BERNINI_ADAPTER,
             bernini_raw_settings(&request),
+            None,
+        )
+    } else if let Some(engine_id) =
+        scail2_engine_id(&request.model).filter(|_| scail2_available(&request, settings))
+    {
+        // SCAIL-2 (epic 5439 / sc-5448): Wan2.1-14B I2V character animation. `generate_scail2`
+        // segments the reference image + driving frames with native SAM3, paints the color-coded
+        // masks, and maps the SceneWorks mode to the engine task (animate_character → animation;
+        // replace_person → replacement is wired in sc-5452). No torch path (mac-only engine).
+        (
+            generate_scail2(
+                api,
+                settings,
+                job,
+                &request,
+                &project_path,
+                engine_id,
+                backend,
+            )
+            .await?,
+            SCAIL2_ADAPTER,
+            scail2_raw_settings(&request),
             None,
         )
     } else {
@@ -1443,6 +1470,9 @@ pub(crate) fn ensure_video_engine_weights(
     }
     if bernini_engine_id(&request.model).is_some() {
         resolve_bernini_model_dir(settings)?;
+    }
+    if scail2_engine_id(&request.model).is_some() {
+        resolve_scail2_model_dir(settings)?;
     }
     Ok(())
 }
@@ -2991,6 +3021,261 @@ async fn generate_bernini(
         fps: request.fps,
         seed: resolve_video_seed(request) as u64,
         video_mode: Some(bernini_engine_video_mode(&request.mode).to_owned()),
+        ..VideoGenInput::default()
+    };
+    generate_video(api, settings, job, backend, input).await
+}
+
+// ---------------------------------------------------------------------------
+// Real MLX SCAIL-2 generation (macOS, via mlx-gen-scail2, epic 5439 / sc-5448): end-to-end character
+// animation — a reference character image + a driving video → an animated clip of the character
+// performing the driving motion. The worker paints the color-coded segmentation masks the engine
+// needs from native SAM3 (no user masks): the reference image and the driving frames are each
+// segmented (every person → a distinct palette color, left-to-right) and painted onto the
+// whose-world-to-keep background (animation: driving bg black, ref bg white). Conditioning =
+// `Reference` (the character) + `Mask` (its color mask) + `ControlClip{frames, mask}` (driving video +
+// per-frame color masks). `replace_person` (cross-identity, replace_flag=true) is the same engine,
+// wired in sc-5452; multi-character (paired ref+mask) awaits the engine request-contract extension.
+// ---------------------------------------------------------------------------
+
+/// Adapter id recorded on a real MLX SCAIL-2 asset.
+#[cfg(target_os = "macos")]
+const SCAIL2_ADAPTER: &str = "mlx_scail2";
+
+/// SceneWorks SCAIL-2 model id → mlx-gen registry id, or `None` if `model` is not SCAIL-2.
+#[cfg(target_os = "macos")]
+fn scail2_engine_id(model: &str) -> Option<&'static str> {
+    (model == "scail2_14b").then_some("scail2_14b")
+}
+
+/// Whether the linked SCAIL-2 engine can serve this request now (resolvable weights).
+#[cfg(target_os = "macos")]
+fn scail2_available(_request: &VideoRequest, settings: &Settings) -> bool {
+    resolve_scail2_model_dir(settings).is_ok()
+}
+
+/// Resolve the SCAIL-2 MLX snapshot dir: env override (`SCENEWORKS_MLX_SCAIL2_DIR`) → app-managed
+/// `<data>/models/mlx/scail2` → the turnkey download-on-first-use `SceneWorks/scail2-mlx` snapshot
+/// (mirrors `resolve_bernini_model_dir`). Errors clearly if none is present (no stub fallback).
+#[cfg(target_os = "macos")]
+fn resolve_scail2_model_dir(settings: &Settings) -> WorkerResult<PathBuf> {
+    if let Some(dir) = local_mlx_dir(settings, "SCENEWORKS_MLX_SCAIL2_DIR", "scail2") {
+        return Ok(dir);
+    }
+    if let Some(dir) = huggingface_snapshot_dir(&settings.data_dir, "SceneWorks/scail2-mlx") {
+        return Ok(dir);
+    }
+    Err(WorkerError::InvalidPayload(format!(
+        "scail2: no MLX weights found. Download the turnkey SceneWorks/scail2-mlx snapshot via the \
+         Model Manager, set $SCENEWORKS_MLX_SCAIL2_DIR, or place a converted snapshot at {}.",
+        settings
+            .data_dir
+            .join("models")
+            .join("mlx")
+            .join("scail2")
+            .display(),
+    )))
+}
+
+/// MLX quantization for a SCAIL-2 load: Q4 default, Q8 opt-in via the advanced `mlxQuantize: 8`
+/// control, explicit `<= 0` ⇒ bf16 (power users with ample RAM). Mirrors `resolve_bernini_quant`.
+#[cfg(target_os = "macos")]
+fn resolve_scail2_quant(request: &VideoRequest) -> Option<Quant> {
+    match request.advanced.get("mlxQuantize").and_then(|value| {
+        value
+            .as_i64()
+            .or_else(|| value.as_str()?.trim().parse().ok())
+    }) {
+        Some(bits) if bits <= 0 => None,
+        Some(bits) if bits <= 4 => Some(Quant::Q4),
+        Some(_) => Some(Quant::Q8),
+        None => Some(Quant::Q4),
+    }
+}
+
+/// Raw-settings recorded on a real MLX SCAIL-2 asset (mirrors `bernini_raw_settings`).
+#[cfg(target_os = "macos")]
+fn scail2_raw_settings(request: &VideoRequest) -> Value {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("model".to_owned(), Value::String(request.model.clone()));
+    raw.insert("frameCount".to_owned(), json!(request.frame_count()));
+    raw.insert("fps".to_owned(), json!(request.fps));
+    // The engine task the SceneWorks mode resolved to (lineage / observability).
+    raw.insert(
+        "scail2Task".to_owned(),
+        Value::String(scail2_engine_video_mode(&request.mode).to_owned()),
+    );
+    Value::Object(raw)
+}
+
+/// Map a SceneWorks video mode to the SCAIL-2 engine `video_mode` task string. `replace_person`
+/// (cross-identity, sc-5452) flips the engine `replace_flag`; everything else (`animate_character`)
+/// is plain animation.
+#[cfg(target_os = "macos")]
+fn scail2_engine_video_mode(mode: &str) -> &'static str {
+    match mode {
+        "replace_person" => "replacement",
+        _ => "animation",
+    }
+}
+
+/// Resolve a SCAIL-2 request into the engine conditioning: load the reference character image and the
+/// driving clip, segment both with native SAM3 (every person → a palette color), paint the color-coded
+/// masks (animation background convention), and assemble `Reference` + `Mask` + `ControlClip`. The
+/// segmentation + painting run on the blocking pool (GPU inference). The reference is
+/// `referenceAssetIds[0]` (preferred) or `sourceAssetId`; the driving clip is `sourceClipAssetId`.
+#[cfg(target_os = "macos")]
+async fn resolve_scail2_conditioning(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &VideoRequest,
+    project_path: &Path,
+) -> WorkerResult<Vec<Conditioning>> {
+    // The character: a reference image (referenceAssetIds first, else the i2v sourceAssetId).
+    let ref_id = request
+        .reference_asset_ids
+        .first()
+        .map(String::as_str)
+        .or(request.source_asset_id.as_deref())
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload(
+                "scail2 animate_character requires a reference character image (referenceAssetIds \
+                 or sourceAssetId)."
+                    .into(),
+            )
+        })?;
+    let reference = load_reference_image(
+        &settings.data_dir,
+        &request.project_id,
+        ref_id,
+        project_path,
+    )?;
+
+    // The driving video → frames at the output size (the engine re-resizes internally).
+    let clip_id = request.source_clip_asset_id.as_deref().ok_or_else(|| {
+        WorkerError::InvalidPayload(
+            "scail2 animate_character requires a driving video (sourceClipAssetId).".into(),
+        )
+    })?;
+    let driving = extract_clip_frames(
+        api,
+        settings,
+        job,
+        &request.project_id,
+        project_path,
+        clip_id,
+        request.width,
+        request.height,
+        wan_frame_count(request.raw_frame_count()),
+    )
+    .await?;
+
+    // SAM3 segmenter weights (download-on-first-use), shared by both segmentation passes.
+    let client = reqwest::Client::new();
+    let context = crate::downloads::DownloadContext {
+        api,
+        client: &client,
+        settings,
+        job_id: &job.id,
+        cancel_message: "SCAIL-2 canceled while fetching the SAM3 segmenter weights.",
+        fresh_download: false,
+    };
+    let (sam_model, sam_tokenizer) =
+        crate::person_segment_sam3::ensure_segmenter_weights(settings, &context).await?;
+
+    // Decode the engine `Image`s to `RgbImage`s for SAM3 (it normalizes RGB internally).
+    let ref_rgb =
+        image::RgbImage::from_raw(reference.width, reference.height, reference.pixels.clone())
+            .ok_or_else(|| {
+                WorkerError::InvalidPayload("scail2 reference image is malformed".into())
+            })?;
+    let driving_rgb: Vec<image::RgbImage> = driving
+        .iter()
+        .map(|f| image::RgbImage::from_raw(f.width, f.height, f.pixels.clone()))
+        .collect::<Option<Vec<_>>>()
+        .ok_or_else(|| WorkerError::InvalidPayload("scail2 driving frame is malformed".into()))?;
+
+    // Segment + paint the reference mask (animation keeps the reference's world → white background).
+    let (rm, rt) = (sam_model.clone(), sam_tokenizer.clone());
+    let ref_mask = tokio::task::spawn_blocking(move || -> WorkerResult<Image> {
+        let masks = crate::person_segment_sam3::segment_all_persons_in_memory(
+            &rm,
+            &rt,
+            std::slice::from_ref(&ref_rgb),
+        )?;
+        crate::scail2_masks::paint_reference_mask(&masks, crate::scail2_masks::BG_WHITE)
+    })
+    .await
+    .map_err(|error| WorkerError::Io(std::io::Error::other(error)))??;
+
+    // Segment + paint the per-frame driving masks (animation → black background).
+    let driving_mask = tokio::task::spawn_blocking(move || -> WorkerResult<Vec<Image>> {
+        let masks = crate::person_segment_sam3::segment_all_persons_in_memory(
+            &sam_model,
+            &sam_tokenizer,
+            &driving_rgb,
+        )?;
+        Ok(crate::scail2_masks::paint_driving_masks(
+            &masks,
+            crate::scail2_masks::BG_BLACK,
+        ))
+    })
+    .await
+    .map_err(|error| WorkerError::Io(std::io::Error::other(error)))??;
+
+    Ok(vec![
+        Conditioning::Reference {
+            image: reference,
+            strength: None,
+        },
+        Conditioning::Mask { image: ref_mask },
+        Conditioning::ControlClip {
+            frames: driving,
+            mask: driving_mask,
+            masking_strength: 1.0,
+            start_frame: 0,
+            mode: ReplacementMode::default(),
+        },
+    ])
+}
+
+/// Real MLX SCAIL-2 generation (epic 5439 / sc-5448): build the `VideoGenInput` and run the shared
+/// `generate_video` path. The SceneWorks mode resolves to the engine `video_mode` task
+/// ([`scail2_engine_video_mode`]) and the source media into the SAM3-painted conditioning
+/// ([`resolve_scail2_conditioning`]). No LoRA (the engine reports `supports_lora=false`, sc-5451);
+/// steps/guidance stay at the engine defaults. Frame count uses the Wan 1-mod-4 stride coercion (the
+/// renderer is Wan2.1); the engine stitches > 81-frame clips into overlapping segments internally.
+#[cfg(target_os = "macos")]
+async fn generate_scail2(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &VideoRequest,
+    project_path: &Path,
+    engine_id: &'static str,
+    backend: &str,
+) -> WorkerResult<DecodedVideo> {
+    let negative_prompt = {
+        let trimmed = request.negative_prompt.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_owned())
+    };
+    let conditioning =
+        resolve_scail2_conditioning(api, settings, job, request, project_path).await?;
+    let input = VideoGenInput {
+        engine_id,
+        model_dir: resolve_scail2_model_dir(settings)?,
+        quant: resolve_scail2_quant(request),
+        conditioning,
+        prompt: request.prompt.clone(),
+        negative_prompt,
+        width: request.width,
+        height: request.height,
+        frames: wan_frame_count(request.raw_frame_count()),
+        fps: request.fps,
+        seed: resolve_video_seed(request) as u64,
+        video_mode: Some(scail2_engine_video_mode(&request.mode).to_owned()),
         ..VideoGenInput::default()
     };
     generate_video(api, settings, job, backend, input).await


### PR DESCRIPTION
Bring **SCAIL-2** (zai-org end-to-end character animation, Wan2.1-14B I2V) into SceneWorks as a native-MLX, macOS-only video model — the SceneWorks side of [epic 5439](https://app.shortcut.com/trefry/epic/5439). The engine (`mlx-gen-scail2`) is merged + real-weight parity-validated; this PR catalogs it and routes the standalone **`animate_character`** mode end-to-end. Atomic catalog+routing vertical (no broken intermediate state), mirroring Bernini's PR #650.

## sc-5447 — model catalog
- `builtin.models.jsonc`: `scail2_14b` video entry — `platforms:["macos"]`, turnkey `SceneWorks/scail2-mlx` snapshot (download-on-first-use), Q4 default, `SCENEWORKS_MLX_SCAIL2_DIR` override. `minMemoryGb: 48` is **provisional** pending the real-size Mac measurement in sc-5445 (independent estimate: a single Wan2.1-14B DiT, ~⅓ of Bernini's stack which needs 64; Q4 weights ~8.4 GB; 256² smoke peaked 16.4 GB RSS). Download size is also provisional (the repo still carries redundant raw pickles, pruned at ship-time).
- `lora_family.rs`: `scail2` family → adapter + default capability `animate_character` (lineage label only — MLX-routed by engine id, no Torch adapter).
- `prompt-guides/scail2.md`: character-animation prompt guide.

## sc-5448 — worker MLX routing
- **Pin:** `mlx-gen` + `sceneworks-gen-core` + every mlx-gen family crate `41c95a1` → `fa0f75b` (HEAD; adds `mlx-gen-scail2` + sc-5551 per-step video cancel). Direct `mlx-rs` stays `44929a0` (HEAD's internal rev is unchanged → no lockstep change); gen-core moves in lockstep so the skew gate stays single-rev. candle-gen untouched (optional, off in the default skew graph).
- **Routing:** force-link `mlx_gen_scail2`; `generate_scail2` + `resolve_scail2_*` helpers + dispatch arm + prevalidation, mirroring bernini. Mode map: `animate_character` → engine `"animation"` (`replace_person` → `"replacement"` is sc-5452).
- **Masks (the net-new piece):** the worker paints SCAIL-2's color-coded segmentation masks from **native SAM3** — no user masks. `person_segment_sam3::segment_all_persons_in_memory` keeps every tracked person (vs `segment_track_blocking`'s single selected person); `scail2_masks` palette-paints them (person0=blue … 5=yellow, matching the engine's 7 color classes) on the whose-world-to-keep background (animation: driving bg black, ref bg white). Conditioning = `Reference` + `Mask` + `ControlClip{frames, mask}`.
- **Eligibility:** `animate_character` → `VIDEO_UI_MODES`; `scail2_14b` → `VIDEO_MLX_ROUTED_MODELS`; per-mode `video_mode_is_mlx_eligible`.

## Validation
- `cargo check`/`clippy` clean (worker + core), `cargo fmt` clean.
- **Tests:** 322 core (incl. new SCAIL-2 mac-support + mode-eligibility), 269 worker lib (incl. 5 new `scail2_masks` palette tests). All green.
- **No contract-snapshot change** — no new VideoJobRequest field (reuses `referenceAssetIds`/`sourceClipAssetId`/`sourceAssetId`); the snapshot has no catalog/videoModes section.

## Scope surfaced (not buried)
- **Multi-character** (multiple paired ref+mask) is blocked **engine-side**: `mlx-gen-scail2/pipeline.rs` hardcodes `additional: empty` and gen-core's `Conditioning` can't pair an extra-ref image with its mask. That's a gen-core/engine contract extension (separate mlx-gen PR + pin bump), tracked separately — this PR ships **single-character animation fully**.
- **`replace_person`** (cross-identity) = sc-5452 (reuses `generate_scail2` with replace_flag=true). **LoRA** = sc-5451.
- **Real-weight worker e2e smoke** (SAM3 mask-gen → engine on a real Mac) = sc-5450; here the path is compile + unit (painter) + eligibility validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)