### PR TITLE
Epic 5558 Wave A: ship candle (CUDA) in the Windows desktop installer (sc-5559..5562)

### DIFF
--- a/.github/workflows/desktop-candle-windows.yml
+++ b/.github/workflows/desktop-candle-windows.yml
@@ -1,0 +1,86 @@
+name: Desktop Candle (Windows/CUDA)
+
+# Compile-checks + builds the candle (Windows/CUDA) desktop sidecar (epic 5558,
+# sc-5562). The candle backend has NO standing CI otherwise: the Linux `parity`
+# job and `desktop-windows.yml` both build WITHOUT `--features backend-candle`, so
+# candle-gated code (crates/sceneworks-worker's caption/image/video/engines/gpu
+# paths) is only ever validated by hand on the dev box — until this lane.
+#
+# Manual `workflow_dispatch` only: there's no standing self-hosted GPU runner and a
+# candle build (nvcc compiles every provider's CUDA kernels) is heavy, so we don't
+# run it on every push — the same call sc-3676 made for the standalone worker lane.
+# Compilation does NOT need a GPU (nvcc + the host MSVC suffice); only running the
+# binary would. Trigger it from the Actions tab before merging candle changes.
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: desktop-candle-windows-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-candle:
+    # windows-2022 ships VS2022 with an MSVC 14.4x toolset; CUDA 12.9's nvcc rejects
+    # VS2026's 14.51 (sc-3676), so pin the older image rather than windows-latest.
+    runs-on: windows-2022
+    env:
+      # compute_80 PTX the driver JITs forward to sm_120 — one binary covers
+      # Ampere->Blackwell (sc-3676). build-sidecar.mjs defaults this too; set it
+      # explicitly so the candle cargo build is reproducible here.
+      CUDA_COMPUTE_CAP: "80"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      # Put the VS2022 MSVC toolchain (cl.exe) on PATH so nvcc finds the host
+      # compiler when candle-kernels' build script compiles the CUDA kernels.
+      - name: Set up MSVC developer environment
+        uses: ilammy/msvc-dev-cmd@v1
+      # Install the CUDA 12.9 Toolkit (nvcc + cudart/cublas/curand/nvrtc dev libs)
+      # the candle `cuda` feature links against. Sets CUDA_PATH for the build.
+      - name: Install CUDA Toolkit 12.9
+        uses: Jimver/cuda-toolkit@v0.2.21
+        with:
+          cuda: "12.9.1"
+          method: "network"
+      # The candle-gen single-rev invariant the default skew gate is blind to: with
+      # `--features backend-candle` the optional candle-gen providers are pulled, so
+      # a candle-gen pin that resolves a different gen-core rev would split the
+      # inventory registry => runtime "engine not found" (sc-4482). `--target all`
+      # also resolves the macOS-only mlx-gen transitive gen-core.
+      - name: Guard against gen-core version skew (candle)
+        shell: bash
+        run: |
+          bash scripts/check-gen-core-skew.sh --self-test
+          bash scripts/check-gen-core-skew.sh sceneworks-worker --features backend-candle
+          bash scripts/check-gen-core-skew.sh sceneworks-rust-api --features embed-web,backend-candle
+      # Lint the candle-gated code so it can't silently rot between hand-builds. The
+      # worker carries all the `#[cfg(feature = "backend-candle")]` paths; checking it
+      # alone (no embed-web) avoids a web build for the rot guard.
+      - name: Clippy candle-gated code
+        run: cargo clippy -p sceneworks-worker --features backend-candle -- -D warnings
+      - name: Install web dependencies
+        run: npm ci --prefix apps/web
+      - name: Install desktop dependencies
+        run: npm ci --prefix apps/desktop
+      # The faithful "build the candle desktop bundle" step: build-sidecar.mjs with
+      # SCENEWORKS_DESKTOP_CANDLE=1 runs the candle path — web build + `cargo build
+      # -p sceneworks-rust-api --release --features embed-web,backend-candle` + stages
+      # the CUDA redist DLLs (sc-5559/sc-5560). Exercises the real desktop build
+      # wiring without the heavy NSIS packaging (covered by desktop-windows.yml).
+      - name: Build candle desktop sidecar (+ stage CUDA redist)
+        env:
+          SCENEWORKS_DESKTOP_CANDLE: "1"
+        run: node apps/desktop/scripts/build-sidecar.mjs
+      - name: Upload candle sidecar artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sceneworks-api-candle-windows
+          path: apps/desktop/binaries/sceneworks-api-*.exe
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -222,6 +222,8 @@ apps/desktop/python-src/
 apps/desktop/onnxruntime/
 # static ffmpeg staged by build-sidecar.mjs for the Rust worker (sc-3767)
 apps/desktop/ffmpeg/
+# CUDA runtime redist DLLs staged by build-sidecar.mjs for the candle worker (sc-5560)
+apps/desktop/cuda/
 
 # SceneWorks local runtime data
 # user.*.jsonc manifests are rewritten by the SceneWorks API at runtime (local state, not source).

--- a/apps/desktop/licenses/cuda/NOTICE.txt
+++ b/apps/desktop/licenses/cuda/NOTICE.txt
@@ -1,0 +1,34 @@
+NVIDIA CUDA Runtime Redistributable Libraries
+=============================================
+
+SceneWorks (Windows) bundles the following NVIDIA CUDA runtime redistributable
+libraries so the native candle (CUDA) generation backend runs on a machine that
+does NOT have the CUDA Toolkit installed:
+
+  cudart64_12.dll            CUDA Runtime
+  cublas64_12.dll            cuBLAS
+  cublasLt64_12.dll          cuBLAS Lt
+  curand64_10.dll            cuRAND
+  nvrtc64_120_0.dll          NVRTC (runtime kernel compilation)
+  nvrtc-builtins64_129.dll   NVRTC built-ins
+
+These files are part of the NVIDIA CUDA Toolkit 12.9 and are redistributed under
+the NVIDIA CUDA Toolkit End User License Agreement, which permits redistribution
+of the runtime libraries enumerated in its "Attachment A".
+
+  CUDA EULA: https://docs.nvidia.com/cuda/eula/index.html
+
+Copyright (c) NVIDIA Corporation. All rights reserved.
+
+Runtime requirements
+--------------------
+- An NVIDIA (CUDA-capable) GPU. SceneWorks generation on Windows is CUDA-only:
+  there is no CPU or AMD/ROCm fallback (the 3B-14B models cannot run on CPU).
+- NVIDIA display driver >= 576.02 — the minimum that supports the CUDA 12.9
+  runtime and forward-JIT-compiles the bundled compute_80 PTX onto newer
+  architectures (through Blackwell / sm_120).
+
+The CUDA driver itself (nvcuda.dll) ships with the NVIDIA display driver and is
+NOT bundled here. Install or update the driver from:
+
+  https://www.nvidia.com/Download/index.aspx

--- a/apps/desktop/licenses/manifest.json
+++ b/apps/desktop/licenses/manifest.json
@@ -29,6 +29,19 @@
         { "label": "Notice", "key": "onnxruntime-notice" },
         { "label": "MIT License", "key": "onnxruntime-license" }
       ]
+    },
+    {
+      "id": "cuda",
+      "name": "NVIDIA CUDA Runtime Libraries",
+      "version": "12.9",
+      "publisher": "NVIDIA Corporation",
+      "license": "NVIDIA CUDA Toolkit EULA",
+      "homepage": "https://developer.nvidia.com/cuda-toolkit",
+      "platforms": ["windows"],
+      "usage": "Bundled CUDA runtime redistributable DLLs (cudart, cuBLAS, cuBLAS Lt, cuRAND, NVRTC), loaded at runtime by the native candle (CUDA) generation backend. Requires an NVIDIA GPU and display driver 576.02 or newer.",
+      "documents": [
+        { "label": "Notice & CUDA EULA reference", "key": "cuda-notice" }
+      ]
     }
   ]
 }

--- a/apps/desktop/scripts/build-sidecar.mjs
+++ b/apps/desktop/scripts/build-sidecar.mjs
@@ -37,7 +37,31 @@ const exe = triple.includes("windows") ? ".exe" : "";
 // truth for the embedded build). Empty VITE_API_BASE_URL makes the embedded UI
 // talk to its own origin (the API serves it), so it works on the dynamic port
 // with no CORS.
-run(npmCmd, ["run", "api:build:embedded"], { VITE_API_BASE_URL: "" });
+//
+// Opt-in candle (Windows/CUDA) backend (sc-5559): set SCENEWORKS_DESKTOP_CANDLE=1
+// to compile the sidecar with `--features embed-web,backend-candle` so the
+// desktop's Rust worker runs candle for its eligible surface. CUDA-only (product
+// decision: no CPU/AMD); requires the build box to have the CUDA Toolkit 12.9 +
+// VS2022 BuildTools MSVC 14.44 toolset on PATH (run from its vcvars64 — CUDA 12.9
+// rejects VS2026's 14.51). Default OFF keeps the plain build intact for boxes
+// without the CUDA toolkit (windows-latest CI, macOS — candle is Windows-gated).
+const candle =
+  process.platform === "win32" && process.env.SCENEWORKS_DESKTOP_CANDLE === "1";
+if (candle) {
+  // CUDA_COMPUTE_CAP=80 builds `compute_80` PTX the driver JITs forward to sm_120
+  // (Blackwell) — one binary covers Ampere→Blackwell (per sc-3676). Honor an
+  // explicit override (e.g. a single-arch dev build) if the env already set it.
+  const candleEnv = { VITE_API_BASE_URL: "" };
+  if (!process.env.CUDA_COMPUTE_CAP) {
+    candleEnv.CUDA_COMPUTE_CAP = "80";
+  }
+  console.log(
+    `build-sidecar: candle backend ON (CUDA_COMPUTE_CAP=${process.env.CUDA_COMPUTE_CAP ?? "80"})`,
+  );
+  run(npmCmd, ["run", "api:build:embedded:candle"], candleEnv);
+} else {
+  run(npmCmd, ["run", "api:build:embedded"], { VITE_API_BASE_URL: "" });
+}
 
 const src = join(repoRoot, "target", "release", `sceneworks-rust-api${exe}`);
 const outDir = join(desktopDir, "binaries");

--- a/apps/desktop/scripts/build-sidecar.mjs
+++ b/apps/desktop/scripts/build-sidecar.mjs
@@ -3,7 +3,14 @@
 // as a Tauri sidecar named for the host target triple. Wired as the
 // tauri.conf.json `beforeBuildCommand` so `tauri build` is self-contained.
 import { execFileSync, execSync } from "node:child_process";
-import { copyFileSync, mkdirSync, chmodSync, writeFileSync } from "node:fs";
+import {
+  copyFileSync,
+  mkdirSync,
+  chmodSync,
+  writeFileSync,
+  existsSync,
+  readdirSync,
+} from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import process from "node:process";
@@ -139,4 +146,70 @@ if (triple.includes("apple-darwin")) {
     "Static ffmpeg is bundled on macOS only (sc-3767); Windows/Linux use PATH ffmpeg.\n",
   );
   console.log(`build-sidecar: ${ffmpegDir} placeholder (non-macOS, PATH ffmpeg)`);
+}
+
+// The candle (Windows/CUDA) worker links cudarc with dynamic-linking, which
+// LoadLibrary's the CUDA runtime redist DLLs by name at runtime. Bundle them as a
+// Tauri resource (tauri.conf.json `resources` -> `cuda/**/*`) so a clean NVIDIA
+// machine (driver >= 576.02, no CUDA toolkit) runs the candle worker; setup.rs
+// prepends this dir to the sidecar's PATH so the loader finds them (sc-5560). Like
+// the onnxruntime/ffmpeg dirs above, `cuda` must exist on EVERY platform (Tauri
+// errors on an empty glob); only the Windows candle build (SCENEWORKS_DESKTOP_CANDLE
+// =1, set above) stages the real DLLs — every other build ships a placeholder.
+const cudaDir = join(desktopDir, "cuda");
+mkdirSync(cudaDir, { recursive: true });
+if (candle) {
+  // Resolve the CUDA Toolkit bin dir the redist DLLs are copied from (same
+  // CUDA_PATH the cargo build linked against); default to the 12.9 install path.
+  const cudaBin = join(
+    process.env.CUDA_PATH ??
+      "C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v12.9",
+    "bin",
+  );
+  // Match by prefix so a minor CUDA point-release (different version suffix) still
+  // resolves; the regexes exclude variants like `nvrtc64_120_0.alt.dll`.
+  const dllPatterns = [
+    /^cudart64_\d+\.dll$/,
+    /^cublas64_\d+\.dll$/,
+    /^cublasLt64_\d+\.dll$/,
+    /^curand64_\d+\.dll$/,
+    /^nvrtc64_\d+_\d+\.dll$/,
+    /^nvrtc-builtins64_\d+\.dll$/,
+  ];
+  if (!existsSync(cudaBin)) {
+    console.error(
+      `build-sidecar: CUDA bin dir not found: ${cudaBin} (set CUDA_PATH to the CUDA 12.9 install for the candle bundle)`,
+    );
+    process.exit(1);
+  }
+  const binFiles = readdirSync(cudaBin);
+  const staged = [];
+  for (const re of dllPatterns) {
+    const match = binFiles.find((f) => re.test(f));
+    if (!match) {
+      console.error(
+        `build-sidecar: no CUDA redist DLL matching ${re} in ${cudaBin}`,
+      );
+      process.exit(1);
+    }
+    copyFileSync(join(cudaBin, match), join(cudaDir, match));
+    staged.push(match);
+  }
+  // NVIDIA CUDA redistributables ship under the CUDA EULA — stage the tracked
+  // notice (CUDA EULA reference + min-driver/NVIDIA requirement) next to the DLLs,
+  // mirroring the ffmpeg/onnxruntime license staging above. Same source of truth as
+  // the in-app About -> Licenses screen (apps/desktop/licenses/cuda/NOTICE.txt).
+  copyFileSync(
+    join(desktopDir, "licenses", "cuda", "NOTICE.txt"),
+    join(cudaDir, "NOTICE.txt"),
+  );
+  console.log(
+    `build-sidecar: staged ${staged.length} CUDA redist DLLs from ${cudaBin}: ${staged.join(", ")}`,
+  );
+} else {
+  writeFileSync(
+    join(cudaDir, "README.txt"),
+    "CUDA runtime redist DLLs are bundled only on the Windows candle build (SCENEWORKS_DESKTOP_CANDLE=1, sc-5560).\n",
+  );
+  console.log(`build-sidecar: ${cudaDir} placeholder (no candle / non-Windows)`);
 }

--- a/apps/desktop/scripts/stage-test-sidecars.mjs
+++ b/apps/desktop/scripts/stage-test-sidecars.mjs
@@ -34,7 +34,7 @@ for (const name of ["sceneworks-api", "uv"]) {
   console.log(`stage-test-sidecars: staged ${path}`);
 }
 
-for (const dir of ["python-src", "onnxruntime", "ffmpeg"]) {
+for (const dir of ["python-src", "onnxruntime", "ffmpeg", "cuda"]) {
   const path = join(desktopDir, dir);
   mkdirSync(path, { recursive: true });
   writeFileSync(

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -73,6 +73,12 @@ pub struct Managed {
     /// binary re-launched in worker mode (`SCENEWORKS_WORKER_ONLY=1`,
     /// `SCENEWORKS_GPU_ID=mlx`). Only populated on macOS.
     pub mlx_worker: Mutex<Option<CommandChild>>,
+    /// The Windows candle (CUDA) GPU worker (sc-5561): the same `sceneworks-api`
+    /// binary re-launched in worker mode (`SCENEWORKS_WORKER_ONLY=1`,
+    /// `SCENEWORKS_GPU_ID=0`, `SCENEWORKS_BACKEND_CANDLE_ENABLED=true`). Runs
+    /// alongside the Python torch worker (Wave A). Only populated on the Windows
+    /// candle build.
+    pub candle_worker: Mutex<Option<CommandChild>>,
     /// OS-assigned API port, discovered from the sidecar's startup line.
     api_port: Mutex<Option<u16>>,
     /// PIDs of the spawned sidecars, persisted to disk so an unclean exit
@@ -92,6 +98,10 @@ struct SidecarPids {
     /// an older build (no such field) still deserializes for reaping.
     #[serde(default)]
     mlx_worker: Option<u32>,
+    /// The Windows candle GPU worker (sc-5561). `#[serde(default)]` so an older
+    /// pidfile (no such field) still deserializes for reaping.
+    #[serde(default)]
+    candle_worker: Option<u32>,
 }
 
 #[derive(Clone, Serialize)]
@@ -1019,7 +1029,19 @@ fn gate_window(app: AppHandle) {
                         supervise_mlx_worker(app, port);
                     }
                     #[cfg(not(target_os = "macos"))]
-                    supervise_worker(app, port);
+                    {
+                        // The Windows candle (CUDA) GPU worker (sc-5561) runs
+                        // candle-eligible jobs alongside the Python torch worker
+                        // (Wave A), exactly like the server lane — the existing
+                        // jobs_store claim/defer routing sends candle-eligible jobs
+                        // here and everything else to Python. Only when the candle
+                        // backend is actually bundled (a plain build has no DLLs).
+                        #[cfg(target_os = "windows")]
+                        if resolve_bundled_cuda_dir(&app).is_some() {
+                            supervise_candle_worker(app.clone(), port);
+                        }
+                        supervise_worker(app, port);
+                    }
                     return;
                 }
             }
@@ -1333,6 +1355,169 @@ fn supervise_mlx_worker(app: AppHandle, api_port: u16) {
     });
 }
 
+/// Spawn and supervise the Windows candle (CUDA) GPU worker (sc-5561): the same
+/// `sceneworks-api` sidecar re-launched in worker mode (`SCENEWORKS_WORKER_ONLY=1`)
+/// with `SCENEWORKS_GPU_ID=0` (the first NVIDIA GPU) and the candle backend enabled
+/// (`SCENEWORKS_BACKEND_CANDLE_ENABLED=true`), so candle-eligible image/video/caption
+/// jobs run on the in-process candle gen-core engines instead of the Python torch
+/// path. A crash-isolated sibling of the API process; restarted with exponential
+/// backoff while the app is open. Output goes to candle-worker.log.
+///
+/// The Windows analogue of `supervise_mlx_worker`. Runs ALONGSIDE the Python torch
+/// worker (Wave A): the existing `jobs_store` claim/defer routing
+/// (`torch_worker_claims_everything_the_candle_worker_defers`) confines this worker
+/// to the candle lane and keeps everything else on Python. Only spawned when the
+/// candle redist DLLs are actually bundled (`resolve_bundled_cuda_dir`), so a plain
+/// desktop build never starts it.
+#[cfg(target_os = "windows")]
+fn supervise_candle_worker(app: AppHandle, api_port: u16) {
+    std::thread::spawn(move || {
+        let log_path = logs_dir().join("candle-worker.log");
+        let api_url = format!("http://127.0.0.1:{api_port}");
+        // Match the API sidecar's HF cache root so the engine reads the same
+        // downloaded weights the catalog tracks.
+        let hf_home = huggingface_home().to_string_lossy().to_string();
+        // Unique per launch (distinct prefix from the Python `worker-local-*`, the
+        // macOS `mlx-worker-local-*`, and the in-process utility worker) so the
+        // workers never collide in the shared jobs.db.
+        let worker_id = format!(
+            "candle-worker-local-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|elapsed| elapsed.as_millis())
+                .unwrap_or_default()
+        );
+        let mut backoff = 1u64;
+        loop {
+            if app.state::<Managed>().shutting_down.load(Ordering::SeqCst) {
+                return;
+            }
+            let sidecar = match app.shell().sidecar("sceneworks-api") {
+                Ok(command) => command,
+                Err(error) => {
+                    append_log(
+                        &log_path,
+                        &format!("[desktop] candle worker: locate sidecar failed: {error}\n"),
+                    );
+                    return;
+                }
+            };
+            let mut command = sidecar
+                // Dispatches `main` to `run_worker()` (HTTP API never starts).
+                .env("SCENEWORKS_WORKER_ONLY", "1")
+                // The first NVIDIA GPU (nvidia-smi index 0); a bare index runs the
+                // single-GPU `run_worker_loop` (not the `auto` multi-GPU supervisor).
+                .env("SCENEWORKS_GPU_ID", "0")
+                // Light up the candle lane on the discovered NVIDIA GPU
+                // (gpu::with_candle_capabilities + engines::registry_capabilities).
+                .env("SCENEWORKS_BACKEND_CANDLE_ENABLED", "true")
+                .env("SCENEWORKS_WORKER_ID", &worker_id)
+                .env("SCENEWORKS_API_URL", &api_url)
+                .env("HF_HOME", &hf_home)
+                // Parent-death watchdog (run_worker() honours this): a force-quit
+                // self-terminates the worker so its multi-GB model + CUDA context
+                // isn't orphaned.
+                .env("SCENEWORKS_PARENT_PID", std::process::id().to_string())
+                .env(
+                    "SCENEWORKS_DATA_DIR",
+                    resolved_data_dir().to_string_lossy().to_string(),
+                )
+                .env(
+                    "SCENEWORKS_CONFIG_DIR",
+                    config_dir().to_string_lossy().to_string(),
+                );
+            // cudarc dynamic-linking `LoadLibrary`s the CUDA runtime DLLs by name;
+            // prepend the bundled redist dir to this worker's PATH so they resolve
+            // without a CUDA Toolkit on the machine (sc-5560).
+            if let Some(cuda_dir) = resolve_bundled_cuda_dir(&app) {
+                let existing = std::env::var_os("PATH").unwrap_or_default();
+                let mut paths = vec![cuda_dir];
+                paths.extend(std::env::split_paths(&existing));
+                if let Ok(joined) = std::env::join_paths(paths) {
+                    command = command.env("PATH", joined);
+                }
+            }
+            // The worker muxes generated video with ffmpeg; point it at the bundled
+            // binary when staged (else it falls back to PATH ffmpeg), as spawn_api does.
+            if let Some(ffmpeg) = resolve_bundled_ffmpeg(&app) {
+                command = command.env("SCENEWORKS_FFMPEG", ffmpeg);
+            }
+            if let Some(token) = crate::settings::read_hf_token() {
+                command = command.env("HF_TOKEN", token);
+            }
+            if let Some(credentials) = crate::settings::credentials_env_json() {
+                command = command.env("SCENEWORKS_CREDENTIALS", credentials);
+            }
+            let spawned = command.spawn();
+            let (mut events, child) = match spawned {
+                Ok(pair) => pair,
+                Err(error) => {
+                    append_log(
+                        &log_path,
+                        &format!("[desktop] candle worker spawn failed: {error}\n"),
+                    );
+                    std::thread::sleep(Duration::from_secs(backoff));
+                    backoff = (backoff * 2).min(30);
+                    continue;
+                }
+            };
+            record_candle_worker_pid(&app, Some(child.pid()));
+            app.state::<Managed>()
+                .candle_worker
+                .lock()
+                .expect("candle worker lock")
+                .replace(child);
+            let started = Instant::now();
+            loop {
+                match tauri::async_runtime::block_on(events.recv()) {
+                    Some(CommandEvent::Stdout(bytes)) | Some(CommandEvent::Stderr(bytes)) => {
+                        append_log(&log_path, &String::from_utf8_lossy(&bytes));
+                    }
+                    Some(CommandEvent::Terminated(payload)) => {
+                        append_log(
+                            &log_path,
+                            &format!(
+                                "[desktop] candle worker terminated: code={:?} signal={:?}\n",
+                                payload.code, payload.signal
+                            ),
+                        );
+                        break;
+                    }
+                    Some(CommandEvent::Error(error)) => {
+                        append_log(
+                            &log_path,
+                            &format!("[desktop] candle worker error: {error}\n"),
+                        );
+                        break;
+                    }
+                    None => break,
+                    _ => {}
+                }
+            }
+            let _ = app
+                .state::<Managed>()
+                .candle_worker
+                .lock()
+                .expect("candle worker lock")
+                .take();
+            record_candle_worker_pid(&app, None);
+            if app.state::<Managed>().shutting_down.load(Ordering::SeqCst) {
+                return;
+            }
+            if started.elapsed() > Duration::from_secs(20) {
+                backoff = 1;
+            }
+            append_log(
+                &log_path,
+                &format!("[desktop] restarting candle worker in {backoff}s\n"),
+            );
+            std::thread::sleep(Duration::from_secs(backoff));
+            backoff = (backoff * 2).min(30);
+        }
+    });
+}
+
 #[cfg(unix)]
 fn pid_alive(pid: u32) -> bool {
     nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid as i32), None).is_ok()
@@ -1381,6 +1566,14 @@ fn record_mlx_worker_pid(app: &AppHandle, pid: Option<u32>) {
     let state = app.state::<Managed>();
     let mut pids = state.pids.lock().expect("pids lock");
     pids.mlx_worker = pid;
+    write_sidecar_pidfile(&pids);
+}
+
+#[cfg(target_os = "windows")]
+fn record_candle_worker_pid(app: &AppHandle, pid: Option<u32>) {
+    let state = app.state::<Managed>();
+    let mut pids = state.pids.lock().expect("pids lock");
+    pids.candle_worker = pid;
     write_sidecar_pidfile(&pids);
 }
 
@@ -1447,7 +1640,7 @@ pub fn reap_stale_sidecars() {
         return;
     };
     let pids: SidecarPids = serde_json::from_slice(&bytes).unwrap_or_default();
-    for pid in [pids.api, pids.worker, pids.mlx_worker]
+    for pid in [pids.api, pids.worker, pids.mlx_worker, pids.candle_worker]
         .into_iter()
         .flatten()
     {
@@ -1470,6 +1663,11 @@ pub fn begin_shutdown(app: &AppHandle) -> bool {
     }
     let worker = managed.worker.lock().expect("worker lock").take();
     let mlx_worker = managed.mlx_worker.lock().expect("mlx worker lock").take();
+    let candle_worker = managed
+        .candle_worker
+        .lock()
+        .expect("candle worker lock")
+        .take();
     let api_child = managed.api.lock().expect("api lock").take();
     let handle = app.clone();
     std::thread::spawn(move || {
@@ -1509,6 +1707,12 @@ pub fn begin_shutdown(app: &AppHandle) -> bool {
         if let Some(child) = mlx_worker {
             let _ = child.kill();
         }
+        // Windows-only (candle is Windows); None elsewhere. The Windows shutdown
+        // path force-kills (no SIGTERM grace above), and the worker also honours the
+        // parent-death watchdog, so this is the belt to that suspenders.
+        if let Some(child) = candle_worker {
+            let _ = child.kill();
+        }
         if let Some(child) = api_child {
             let _ = child.kill();
         }
@@ -1520,6 +1724,69 @@ pub fn begin_shutdown(app: &AppHandle) -> bool {
     true
 }
 
+/// Minimum NVIDIA display driver for the bundled CUDA 12.9 runtime (sc-3676 /
+/// sc-5560): the floor that supports it and forward-JITs the compute_80 PTX.
+#[cfg(target_os = "windows")]
+const MIN_NVIDIA_DRIVER: f64 = 576.02;
+
+#[cfg(target_os = "windows")]
+const CUDA_REQUIREMENT: &str = "SceneWorks on Windows requires an NVIDIA (CUDA) GPU. \
+    No NVIDIA GPU was detected — SceneWorks needs an NVIDIA GPU with driver 576.02 or \
+    newer (there is no CPU or AMD fallback).";
+
+/// Decide the preflight verdict from `nvidia-smi --query-gpu=name,driver_version`
+/// output (`None` = nvidia-smi missing/failed). Pure so it's unit-testable; the IO
+/// lives in `cuda_preflight`. `Ok(())` when a usable GPU is present; `Err(message)`
+/// with a clear requirement otherwise (no GPU, or a driver below the floor).
+#[cfg(target_os = "windows")]
+fn evaluate_nvidia_preflight(smi_output: Option<&str>) -> Result<(), String> {
+    let Some(line) =
+        smi_output.and_then(|out| out.lines().map(str::trim).find(|line| !line.is_empty()))
+    else {
+        return Err(CUDA_REQUIREMENT.to_owned());
+    };
+    let mut parts = line.split(',').map(str::trim);
+    let name = parts.next().unwrap_or("");
+    let driver = parts.next().unwrap_or("");
+    // Block on a too-old driver; if the version is unparseable, don't block on it
+    // (the GPU is present — let the worker surface any deeper issue).
+    if let Ok(version) = driver.parse::<f64>() {
+        if version < MIN_NVIDIA_DRIVER {
+            return Err(format!(
+                "SceneWorks on Windows requires NVIDIA driver {MIN_NVIDIA_DRIVER} or newer \
+                 (found {driver} on {name}). Update your NVIDIA driver to continue."
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Windows CUDA preflight (sc-5561). SceneWorks generation off-Mac is CUDA-only —
+/// no CPU/AMD fallback — so a machine without an NVIDIA GPU + an adequate driver
+/// can run neither candle nor the Python torch worker's cu128 wheels. Probe
+/// `nvidia-smi` for a GPU + driver version and return a clear, actionable error so
+/// the app says "requires an NVIDIA GPU" up front instead of provisioning a venv and
+/// then dead-polling jobs it can never run. `Ok(())` when a usable GPU is present.
+#[cfg(target_os = "windows")]
+fn cuda_preflight() -> Result<(), String> {
+    use std::os::windows::process::CommandExt;
+    let mut command = std::process::Command::new("nvidia-smi");
+    command.args([
+        "--query-gpu=name,driver_version",
+        "--format=csv,noheader,nounits",
+    ]);
+    // Don't flash a console window when probing from the GUI app.
+    command.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
+    let stdout = match command.output() {
+        Ok(output) if output.status.success() => {
+            String::from_utf8_lossy(&output.stdout).into_owned()
+        }
+        // Missing (no NVIDIA driver) or errored → treat as no usable GPU.
+        _ => return Err(CUDA_REQUIREMENT.to_owned()),
+    };
+    evaluate_nvidia_preflight(Some(&stdout))
+}
+
 async fn run_startup(app: AppHandle) {
     // Provide the builtin model catalog the rust-api/worker expect before they
     // start, so Model Manager is populated and native video resources resolve.
@@ -1527,6 +1794,19 @@ async fn run_startup(app: AppHandle) {
     if let Err(error) = seed_builtin_manifests() {
         emit(&app, "error", format!("Setup failed: {error}"), true);
         return;
+    }
+    // CUDA-only on Windows (sc-5561): fail fast with a clear requirement message on a
+    // machine with no NVIDIA GPU / too-old driver, before the slow venv provisioning,
+    // rather than silently failing or dead-polling a job later. The setup page renders
+    // this `error` event (apps/desktop/ui/index.html). Gated on the candle backend being
+    // bundled (the same signal that turns candle on) so the 576.02 floor only binds the
+    // shipping CUDA desktop, not a hypothetical plain/dev build without the redist DLLs.
+    #[cfg(target_os = "windows")]
+    if resolve_bundled_cuda_dir(&app).is_some() {
+        if let Err(error) = cuda_preflight() {
+            emit(&app, "error", error, true);
+            return;
+        }
     }
     // macOS is MLX-only (epic 3482, sc-3492/sc-3493): no Python venv is bundled or
     // bootstrapped — skip provisioning entirely so first run starts straight on the
@@ -1586,4 +1866,37 @@ pub async fn start_setup(app: AppHandle) {
     app.state::<Managed>()
         .running
         .store(false, Ordering::SeqCst);
+}
+
+#[cfg(all(test, target_os = "windows"))]
+mod preflight_tests {
+    use super::{evaluate_nvidia_preflight, MIN_NVIDIA_DRIVER};
+
+    #[test]
+    fn no_nvidia_smi_output_requires_an_nvidia_gpu() {
+        // nvidia-smi missing/failed (None) or empty output → requirement error.
+        assert!(evaluate_nvidia_preflight(None).is_err());
+        assert!(evaluate_nvidia_preflight(Some("")).is_err());
+        assert!(evaluate_nvidia_preflight(Some("   \n")).is_err());
+    }
+
+    #[test]
+    fn adequate_driver_passes() {
+        assert!(evaluate_nvidia_preflight(Some("NVIDIA RTX PRO 6000, 576.02\n")).is_ok());
+        assert!(evaluate_nvidia_preflight(Some("NVIDIA GeForce RTX 4090, 597.36")).is_ok());
+    }
+
+    #[test]
+    fn too_old_driver_is_rejected_with_the_floor() {
+        let verdict = evaluate_nvidia_preflight(Some("NVIDIA GeForce RTX 3090, 560.94"));
+        let message = verdict.expect_err("a sub-576.02 driver must fail preflight");
+        assert!(message.contains(&MIN_NVIDIA_DRIVER.to_string()));
+        assert!(message.contains("560.94"));
+    }
+
+    #[test]
+    fn unparseable_driver_does_not_block_a_present_gpu() {
+        // The GPU is present; an odd version string shouldn't hard-block startup.
+        assert!(evaluate_nvidia_preflight(Some("NVIDIA RTX, not-a-version")).is_ok());
+    }
 }

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -849,6 +849,25 @@ h=glob.glob(os.path.join(d,'capi','libonnxruntime*.dylib'));sys.stdout.write(h[0
     (!path.is_empty() && Path::new(&path).exists()).then_some(path)
 }
 
+/// Resolve the bundled CUDA runtime redistributable DLL directory (sc-5560). The
+/// candle (Windows/CUDA) worker links cudarc with dynamic-linking, which
+/// `LoadLibrary`s cudart/cublas/cublasLt/curand/nvrtc by name at runtime; bundling
+/// them (staged by build-sidecar.mjs into the `cuda` resource dir on the Windows
+/// candle build) lets a clean NVIDIA machine run without a CUDA Toolkit install.
+/// `spawn_api` prepends this dir to the sidecar's PATH so the loader finds them.
+/// Returns None on a plain build — the placeholder dir ships only a README, no DLL,
+/// so a non-candle desktop leaves PATH untouched. Windows-only (candle is Windows-
+/// gated); the bundled driver-side CUDA (nvcuda.dll) is NOT shipped — it comes with
+/// the user's NVIDIA display driver (>= 576.02).
+#[cfg(target_os = "windows")]
+fn resolve_bundled_cuda_dir(app: &AppHandle) -> Option<std::path::PathBuf> {
+    let resources = app.path().resource_dir().ok()?;
+    let dir = resources.join("cuda");
+    // Probe for a real redist DLL; the placeholder (non-candle) build ships only a
+    // README, so this stays None there and the candle DLLs gate themselves.
+    dir.join("cudart64_12.dll").exists().then_some(dir)
+}
+
 /// Spawn the API sidecar, pipe its output to api.log, and return the chosen port.
 fn spawn_api(app: &AppHandle) -> Result<(), String> {
     let mut command = app
@@ -899,6 +918,19 @@ fn spawn_api(app: &AppHandle) -> Result<(), String> {
     #[cfg(target_os = "macos")]
     if let Some(ort_dylib) = resolve_bundled_onnxruntime(app) {
         command = command.env("ORT_DYLIB_PATH", ort_dylib);
+    }
+    // The candle (Windows/CUDA) worker's cudarc dynamic-linking `LoadLibrary`s the
+    // CUDA runtime DLLs by name; prepend the bundled redist dir to the sidecar's
+    // PATH so they resolve without a CUDA Toolkit on the machine (sc-5560). No-op on
+    // a plain build — the resolver returns None when only the placeholder is staged.
+    #[cfg(target_os = "windows")]
+    if let Some(cuda_dir) = resolve_bundled_cuda_dir(app) {
+        let existing = std::env::var_os("PATH").unwrap_or_default();
+        let mut paths = vec![cuda_dir];
+        paths.extend(std::env::split_paths(&existing));
+        if let Ok(joined) = std::env::join_paths(paths) {
+            command = command.env("PATH", joined);
+        }
     }
     // FLUX.2-klein true_v2 single-file conversion is now in-process Rust/MLX
     // (mlx_gen_flux2::convert_and_assemble, sc-3136) — no sidecar venv / converter

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -28,7 +28,12 @@
     "active": true,
     "targets": "all",
     "externalBin": ["binaries/sceneworks-api", "binaries/uv"],
-    "resources": ["python-src/**/*", "onnxruntime/**/*", "ffmpeg/**/*"],
+    "resources": [
+      "python-src/**/*",
+      "onnxruntime/**/*",
+      "ffmpeg/**/*",
+      "cuda/**/*"
+    ],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/apps/rust-api/Cargo.toml
+++ b/apps/rust-api/Cargo.toml
@@ -35,6 +35,15 @@ nix = { version = "0.29", default-features = false, features = ["signal"] }
 # release pipeline runs `npm --prefix apps/web run build` then enables this.
 [features]
 embed-web = ["dep:rust-embed", "dep:mime_guess"]
+# Opt-in passthrough to sceneworks-worker's candle (Windows/CUDA) backend so the
+# desktop sidecar (this binary) can be built candle-enabled — `--features
+# embed-web,backend-candle`. Off by default: the plain desktop/server build (no
+# CUDA toolkit, windows-latest CI, macOS) resolves WITHOUT candle/cudarc/nvcc,
+# exactly as sceneworks-worker keeps it out of its default set. Linking does NOT
+# enable candle at runtime — that is the `backend_candle_enabled` setting (sc-5561).
+# See crates/sceneworks-worker/Cargo.toml's `backend-candle` for the providers it
+# pulls. (sc-5559)
+backend-candle = ["sceneworks-worker/backend-candle"]
 
 [dev-dependencies]
 tempfile = "3.13"

--- a/apps/web/src/data/bundledLicenses.js
+++ b/apps/web/src/data/bundledLicenses.js
@@ -12,6 +12,7 @@ import ffmpegNotice from "../../../desktop/licenses/ffmpeg/NOTICE.txt?raw";
 import ffmpegGpl from "../../../desktop/licenses/ffmpeg/COPYING.GPLv3?raw";
 import onnxruntimeNotice from "../../../desktop/licenses/onnxruntime/NOTICE.txt?raw";
 import onnxruntimeLicense from "../../../desktop/licenses/onnxruntime/LICENSE?raw";
+import cudaNotice from "../../../desktop/licenses/cuda/NOTICE.txt?raw";
 
 // Maps a manifest document `key` to its imported text. New components: add the
 // files under apps/desktop/licenses/<id>/, list them in manifest.json, and wire
@@ -21,6 +22,7 @@ const DOCUMENT_TEXT = {
   "ffmpeg-gpl": ffmpegGpl,
   "onnxruntime-notice": onnxruntimeNotice,
   "onnxruntime-license": onnxruntimeLicense,
+  "cuda-notice": cudaNotice,
 };
 
 // Resolve each component's document keys to its actual text once, at module load.

--- a/docs/sc-5560/cuda-bundling.md
+++ b/docs/sc-5560/cuda-bundling.md
@@ -1,0 +1,60 @@
+# sc-5560 — Bundled CUDA runtime: provenance, requirements & licensing
+
+Epic 5558 (candle on the Windows desktop). The native **candle (CUDA)** generation
+backend — built into the desktop sidecar by [sc-5559](https://app.shortcut.com/trefry/story/5559)
+when `SCENEWORKS_DESKTOP_CANDLE=1` — links `cudarc` with **dynamic-linking**, so it
+`LoadLibrary`s the CUDA runtime libraries by name at runtime instead of static-linking
+them. The desktop must therefore ship those libraries; the standalone candle worker
+(sc-3676 / `package-cuda.ps1`) already does this, and this story brings the same set
+into the Tauri installer.
+
+## What we ship
+
+Staged by `apps/desktop/scripts/build-sidecar.mjs` (Windows candle build only) into
+the `apps/desktop/cuda/` Tauri resource dir (`tauri.conf.json` `resources` ->
+`cuda/**/*`), copied from the CUDA Toolkit 12.9 `bin` dir (`$CUDA_PATH\bin`):
+
+| DLL | Library |
+| --- | --- |
+| `cudart64_12.dll` | CUDA Runtime |
+| `cublas64_12.dll` | cuBLAS |
+| `cublasLt64_12.dll` | cuBLAS Lt |
+| `curand64_10.dll` | cuRAND |
+| `nvrtc64_120_0.dll` | NVRTC (runtime kernel compilation) |
+| `nvrtc-builtins64_129.dll` | NVRTC built-ins |
+
+The DLLs are matched by version-agnostic prefix (e.g. `cudart64_\d+.dll`) so a minor
+CUDA point-release still resolves; the `.alt` NVRTC variant is excluded.
+
+**Not bundled:** the CUDA *driver* API (`nvcuda.dll`). It ships with the user's NVIDIA
+display driver, which also JIT-compiles the binary's `compute_80` PTX forward onto
+newer architectures (through Blackwell / sm_120, per sc-3676).
+
+## Runtime requirements (CUDA-only — product decision 2026-06-14)
+
+- **An NVIDIA (CUDA-capable) GPU.** SceneWorks generation on Windows is CUDA-only:
+  no CPU fallback (3B-14B models can't run on CPU) and no AMD/ROCm. A non-NVIDIA
+  Windows machine is unsupported off-Mac once Python is dropped (sc-5563); the app
+  must say so clearly (preflight gate — sc-5561) rather than silently fail.
+- **NVIDIA display driver >= 576.02** — the minimum that supports the CUDA 12.9
+  runtime and forward-JITs the bundled `compute_80` PTX (documented in sc-3676 /
+  `package-cuda.ps1`).
+
+## How the loader finds the DLLs
+
+The DLLs land in a `cuda` resource sub-dir, not next to the sidecar `.exe`, so they
+are not on the default Windows DLL search path. `apps/desktop/src/setup.rs`
+(`resolve_bundled_cuda_dir` + `spawn_api`) prepends the resolved `cuda` resource dir
+to the sidecar process's `PATH` on Windows, which the `LoadLibrary` search order
+includes. The resolver returns `None` on a plain (non-candle) build — that build
+ships only a placeholder `README.txt` in `cuda/`, so `PATH` is left untouched.
+
+## Licensing
+
+These are NVIDIA CUDA **redistributable** runtime libraries, redistributed under the
+NVIDIA CUDA Toolkit EULA (which enumerates the redistributable runtime libraries in
+its "Attachment A"): <https://docs.nvidia.com/cuda/eula/index.html>. The tracked
+notice — `apps/desktop/licenses/cuda/NOTICE.txt` — is staged next to the DLLs and is
+the single source of truth for the in-app **About -> Licenses** screen
+(`apps/desktop/licenses/manifest.json` + `apps/web/src/data/bundledLicenses.js`,
+sc-3778), the same pattern as the bundled ffmpeg/onnxruntime notices.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "desktop:check": "cargo clippy -p sceneworks-desktop --all-targets -- -D warnings",
     "web:build": "npm --prefix apps/web run build",
     "api:build:embedded": "npm run web:build && cargo build -p sceneworks-rust-api --release --features embed-web",
+    "api:build:embedded:candle": "npm run web:build && cargo build -p sceneworks-rust-api --release --features embed-web,backend-candle",
     "tauri:dev": "npm --prefix apps/desktop run dev",
     "tauri:build": "npm --prefix apps/desktop run build"
   },

--- a/scripts/check-gen-core-skew.sh
+++ b/scripts/check-gen-core-skew.sh
@@ -88,12 +88,44 @@ self_test() {
   return "$rc"
 }
 
-if [ "${1:-}" = "--self-test" ]; then
-  self_test
-  exit $?
-fi
+# Args: [PKG] [--features <list>]. PKG defaults to sceneworks-worker. `--features` is
+# passed through to `cargo tree` so the Windows candle lane (epic 5558, sc-5562) can
+# resolve the optional, feature-gated candle-gen providers
+# (`--features backend-candle`) that the default check can't see — the gate is blind
+# to them otherwise, so a candle-gen pin skew would only surface on the GPU box.
+PKG=""
+FEATURES=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --self-test)
+      self_test
+      exit $?
+      ;;
+    --features)
+      FEATURES="${2:-}"
+      shift 2
+      ;;
+    --features=*)
+      FEATURES="${1#--features=}"
+      shift
+      ;;
+    *)
+      PKG="$1"
+      shift
+      ;;
+  esac
+done
+PKG="${PKG:-sceneworks-worker}"
 
-PKG="${1:-sceneworks-worker}"
+# Run `cargo tree`, optionally with the requested features. A comma-separated feature
+# list is a single shell token, so the branch keeps quoting simple under `set -u`.
+run_tree() {
+  if [ -n "$FEATURES" ]; then
+    cargo tree -p "$PKG" --features "$FEATURES" --target all --color never --prefix none 2>/dev/null
+  else
+    cargo tree -p "$PKG" --target all --color never --prefix none 2>/dev/null
+  fi
+}
 
 # Flatten the tree (`--prefix none`), strip the ` (*)` dedupe marker cargo appends to repeated
 # nodes, keep only the contract crate, and unique-sort. Each unique (version + source) line is one
@@ -103,7 +135,7 @@ PKG="${1:-sceneworks-worker}"
 # marker in ANSI codes so the `(*)$` strip misses it and a deduped node looks "distinct" — a false
 # skew). The ESC-strip sed is a portable backstop (works on BSD + GNU sed).
 esc=$(printf '\033')
-cargo tree -p "$PKG" --target all --color never --prefix none 2>/dev/null \
+run_tree \
   | sed "s/${esc}\\[[0-9;]*m//g" \
   | sed 's/ (\*)$//' \
   | grep -E "^${CRATE} v" \


### PR DESCRIPTION
## Epic 5558 Wave A — get the candle (CUDA) native worker INTO the Windows desktop

Today `apps/desktop` builds its `sceneworks-rust-api` sidecar **plain** (`embed-web` only) and bundles only the Python torch worker, so none of the candle work (epics 3672/3692/5095/5164/...) reaches the desktop. This PR is Wave A of [epic 5558](https://app.shortcut.com/trefry/epic/5558): build + bundle + GPU-gate so the desktop runs candle for its eligible surface **alongside** the Python worker (exactly like the server lane). CUDA-only by product decision (NVIDIA + driver ≥ 576.02; no CPU/AMD fallback).

Wave B (drop Python from the desktop, [sc-5563](https://app.shortcut.com/trefry/story/5563)) is **not** in this PR — it is blocked on candle parity (Phases 3–6).

### Stories

- **[sc-5559](https://app.shortcut.com/trefry/story/5559)** — build the sidecar with `--features backend-candle` (opt-in `SCENEWORKS_DESKTOP_CANDLE=1`, Windows-only). `apps/rust-api` gets a `backend-candle` forwarding feature; `package.json` gets `api:build:embedded:candle`; `build-sidecar.mjs` gets the candle branch (defaults `CUDA_COMPUTE_CAP=80` → compute_80 PTX, Ampere→Blackwell). Default/macOS/CI build path untouched.
- **[sc-5560](https://app.shortcut.com/trefry/story/5560)** — bundle the CUDA runtime redist DLLs (cudart/cublas/cublasLt/curand/nvrtc + builtins) into the Tauri `cuda/**/*` resource; `setup.rs` prepends the dir to the worker PATH (cudarc dynamic-linking). Tracked NOTICE → About→Licenses screen; min-driver doc (`docs/sc-5560/cuda-bundling.md`).
- **[sc-5561](https://app.shortcut.com/trefry/story/5561)** — spawn a candle GPU worker (`supervise_candle_worker`, the Windows analogue of the macOS MLX worker) alongside Python, default the backend on, and add an `nvidia-smi` preflight that fails fast with a clear "requires an NVIDIA (CUDA) GPU" message (rendered by the existing setup page). Existing `jobs_store` routing (`torch_worker_claims_everything_the_candle_worker_defers`) confines it to the candle lane.
- **[sc-5562](https://app.shortcut.com/trefry/story/5562)** — teach `check-gen-core-skew.sh` about `--features`, and add a `workflow_dispatch` candle CI lane (windows-2022, CUDA 12.9, skew guard + candle clippy + candle bundle build). Candle had zero standing CI before this.

### Verified on RTX PRO 6000 (Blackwell)

- Candle build (MSVC 14.44 + CUDA 12.9): all 11 providers link, **single** gen-core rev under `--features backend-candle` (skew gate holds), 126 MB binary boots.
- All 6 bundled CUDA DLLs `LoadLibrary` **with the CUDA toolkit stripped from PATH**.
- The candle worker registers with `gpu_id=0` + the `candle` marker + the candle capability set (`image_generate`/`video_generate`/`lora_train`/`prompt_refine`/...) alongside the cpu utility worker.
- `desktop:check` + 8 desktop tests (incl. 4 new preflight tests) green; `cargo fmt` clean; skew script validated across self-test/default/candle paths.

### Not yet validated (limits of local validation for a desktop installer)

- No full candle **generation** job end-to-end on the desktop, no truly-clean (no-toolkit) third machine, and the non-NVIDIA failure path is unit-tested (evaluator) rather than run on real hardware.
- The CI lane has **not** been dispatched on GitHub — the Jimver CUDA-action version pin + runner MSVC are the only unverified bits.
- No full `tauri build` → NSIS installer produced (bundling config is correct; artifact not generated).

### Note

The CUDA redist set is **~900 MB uncompressed** (cublasLt64 alone is 636 MB) — matches sc-3676's verified set; flagging the installer-size impact in case trimming is worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
