### PR TITLE
sc-5501: wire candle SenseNova-U1 VQA + interleave into the worker (off-Mac)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=15663b1f618e827e06905340d4e2c339a690707e#15663b1f618e827e06905340d4e2c339a690707e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=dbe5560787a6f71a80b78ffed52114a471bd3eba#dbe5560787a6f71a80b78ffed52114a471bd3eba"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=15663b1f618e827e06905340d4e2c339a690707e#15663b1f618e827e06905340d4e2c339a690707e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=dbe5560787a6f71a80b78ffed52114a471bd3eba#dbe5560787a6f71a80b78ffed52114a471bd3eba"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=15663b1f618e827e06905340d4e2c339a690707e#15663b1f618e827e06905340d4e2c339a690707e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=dbe5560787a6f71a80b78ffed52114a471bd3eba#dbe5560787a6f71a80b78ffed52114a471bd3eba"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -480,7 +480,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=15663b1f618e827e06905340d4e2c339a690707e#15663b1f618e827e06905340d4e2c339a690707e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=dbe5560787a6f71a80b78ffed52114a471bd3eba#dbe5560787a6f71a80b78ffed52114a471bd3eba"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -494,7 +494,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=15663b1f618e827e06905340d4e2c339a690707e#15663b1f618e827e06905340d4e2c339a690707e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=dbe5560787a6f71a80b78ffed52114a471bd3eba#dbe5560787a6f71a80b78ffed52114a471bd3eba"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -505,7 +505,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=15663b1f618e827e06905340d4e2c339a690707e#15663b1f618e827e06905340d4e2c339a690707e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=dbe5560787a6f71a80b78ffed52114a471bd3eba#dbe5560787a6f71a80b78ffed52114a471bd3eba"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -518,7 +518,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=15663b1f618e827e06905340d4e2c339a690707e#15663b1f618e827e06905340d4e2c339a690707e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=dbe5560787a6f71a80b78ffed52114a471bd3eba#dbe5560787a6f71a80b78ffed52114a471bd3eba"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -531,7 +531,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=15663b1f618e827e06905340d4e2c339a690707e#15663b1f618e827e06905340d4e2c339a690707e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=dbe5560787a6f71a80b78ffed52114a471bd3eba#dbe5560787a6f71a80b78ffed52114a471bd3eba"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -543,7 +543,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=15663b1f618e827e06905340d4e2c339a690707e#15663b1f618e827e06905340d4e2c339a690707e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=dbe5560787a6f71a80b78ffed52114a471bd3eba#dbe5560787a6f71a80b78ffed52114a471bd3eba"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -554,7 +554,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=15663b1f618e827e06905340d4e2c339a690707e#15663b1f618e827e06905340d4e2c339a690707e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=dbe5560787a6f71a80b78ffed52114a471bd3eba#dbe5560787a6f71a80b78ffed52114a471bd3eba"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -568,7 +568,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=15663b1f618e827e06905340d4e2c339a690707e#15663b1f618e827e06905340d4e2c339a690707e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=dbe5560787a6f71a80b78ffed52114a471bd3eba#dbe5560787a6f71a80b78ffed52114a471bd3eba"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -586,7 +586,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=15663b1f618e827e06905340d4e2c339a690707e#15663b1f618e827e06905340d4e2c339a690707e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=dbe5560787a6f71a80b78ffed52114a471bd3eba#dbe5560787a6f71a80b78ffed52114a471bd3eba"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -599,7 +599,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=15663b1f618e827e06905340d4e2c339a690707e#15663b1f618e827e06905340d4e2c339a690707e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=dbe5560787a6f71a80b78ffed52114a471bd3eba#dbe5560787a6f71a80b78ffed52114a471bd3eba"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -612,7 +612,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=15663b1f618e827e06905340d4e2c339a690707e#15663b1f618e827e06905340d4e2c339a690707e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=dbe5560787a6f71a80b78ffed52114a471bd3eba#dbe5560787a6f71a80b78ffed52114a471bd3eba"
 dependencies = [
  "candle-core",
  "candle-gen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=152974d7d462cb7efeb90311885189ad75befc73#152974d7d462cb7efeb90311885189ad75befc73"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=15663b1f618e827e06905340d4e2c339a690707e#15663b1f618e827e06905340d4e2c339a690707e"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=152974d7d462cb7efeb90311885189ad75befc73#152974d7d462cb7efeb90311885189ad75befc73"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=15663b1f618e827e06905340d4e2c339a690707e#15663b1f618e827e06905340d4e2c339a690707e"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=152974d7d462cb7efeb90311885189ad75befc73#152974d7d462cb7efeb90311885189ad75befc73"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=15663b1f618e827e06905340d4e2c339a690707e#15663b1f618e827e06905340d4e2c339a690707e"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -480,7 +480,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=152974d7d462cb7efeb90311885189ad75befc73#152974d7d462cb7efeb90311885189ad75befc73"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=15663b1f618e827e06905340d4e2c339a690707e#15663b1f618e827e06905340d4e2c339a690707e"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -494,7 +494,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=152974d7d462cb7efeb90311885189ad75befc73#152974d7d462cb7efeb90311885189ad75befc73"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=15663b1f618e827e06905340d4e2c339a690707e#15663b1f618e827e06905340d4e2c339a690707e"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -505,7 +505,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=152974d7d462cb7efeb90311885189ad75befc73#152974d7d462cb7efeb90311885189ad75befc73"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=15663b1f618e827e06905340d4e2c339a690707e#15663b1f618e827e06905340d4e2c339a690707e"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -518,7 +518,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=152974d7d462cb7efeb90311885189ad75befc73#152974d7d462cb7efeb90311885189ad75befc73"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=15663b1f618e827e06905340d4e2c339a690707e#15663b1f618e827e06905340d4e2c339a690707e"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -531,7 +531,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=152974d7d462cb7efeb90311885189ad75befc73#152974d7d462cb7efeb90311885189ad75befc73"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=15663b1f618e827e06905340d4e2c339a690707e#15663b1f618e827e06905340d4e2c339a690707e"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -543,7 +543,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=152974d7d462cb7efeb90311885189ad75befc73#152974d7d462cb7efeb90311885189ad75befc73"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=15663b1f618e827e06905340d4e2c339a690707e#15663b1f618e827e06905340d4e2c339a690707e"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -554,7 +554,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=152974d7d462cb7efeb90311885189ad75befc73#152974d7d462cb7efeb90311885189ad75befc73"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=15663b1f618e827e06905340d4e2c339a690707e#15663b1f618e827e06905340d4e2c339a690707e"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -568,7 +568,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=152974d7d462cb7efeb90311885189ad75befc73#152974d7d462cb7efeb90311885189ad75befc73"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=15663b1f618e827e06905340d4e2c339a690707e#15663b1f618e827e06905340d4e2c339a690707e"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -586,7 +586,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=152974d7d462cb7efeb90311885189ad75befc73#152974d7d462cb7efeb90311885189ad75befc73"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=15663b1f618e827e06905340d4e2c339a690707e#15663b1f618e827e06905340d4e2c339a690707e"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -599,7 +599,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=152974d7d462cb7efeb90311885189ad75befc73#152974d7d462cb7efeb90311885189ad75befc73"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=15663b1f618e827e06905340d4e2c339a690707e#15663b1f618e827e06905340d4e2c339a690707e"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -612,7 +612,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=152974d7d462cb7efeb90311885189ad75befc73#152974d7d462cb7efeb90311885189ad75befc73"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=15663b1f618e827e06905340d4e2c339a690707e#15663b1f618e827e06905340d4e2c339a690707e"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -3219,7 +3219,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3231,7 +3231,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "image",
  "inventory",
@@ -3245,7 +3245,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3257,7 +3257,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3266,7 +3266,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3278,7 +3278,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3289,7 +3289,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3300,7 +3300,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3310,7 +3310,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "image",
  "inventory",
@@ -3322,7 +3322,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "image",
  "inventory",
@@ -3335,7 +3335,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "image",
  "inventory",
@@ -3347,7 +3347,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3359,7 +3359,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3369,7 +3369,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3378,7 +3378,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3387,7 +3387,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "image",
  "inventory",
@@ -3400,7 +3400,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3411,7 +3411,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3422,7 +3422,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3433,7 +3433,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "image",
  "inventory",
@@ -3447,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "image",
  "inventory",
@@ -5075,7 +5075,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "inventory",
  "safetensors 0.4.5",
@@ -5123,6 +5123,7 @@ name = "sceneworks-worker"
 version = "0.2.0"
 dependencies = [
  "axum",
+ "candle-gen",
  "candle-gen-chroma",
  "candle-gen-flux",
  "candle-gen-flux2",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3968,6 +3968,16 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
         if matches!(job.job_type, JobType::TrainingCaption) && !caption_job_is_mlx_eligible(job) {
             return false;
         }
+        // SenseNova-U1 understanding (sc-5501): the candle worker serves `image_vqa` /
+        // `image_interleave` only for the SenseNova-U1 ids (via the concrete candle `T2iModel::{vqa,
+        // interleave_gen}` — the off-Mac sibling of the MLX understanding path). Eligibility is
+        // backend-neutral (the model is SenseNova-U1), so reuse the understanding gate; a
+        // non-SenseNova understanding job stays on the Python torch worker.
+        if matches!(job.job_type, JobType::ImageVqa | JobType::ImageInterleave)
+            && !understanding_job_is_mlx_eligible(job)
+        {
+            return false;
+        }
     }
     let advertises = |capability: &str| {
         worker
@@ -4864,6 +4874,55 @@ mod candle_routing_tests {
         assert!(worker_supports_job(
             &torch,
             &caption_job(json!({ "captioner": "blip2", "datasetId": "ds_1" }))
+        ));
+    }
+
+    /// sc-5501: the candle worker claims SenseNova-U1 `image_vqa` / `image_interleave` (served off-Mac
+    /// by the concrete candle `T2iModel::{vqa, interleave_gen}`) but refuses other models, which stay
+    /// on the Python torch worker.
+    #[test]
+    fn candle_worker_claims_sensenova_understanding_but_refuses_other_models() {
+        let candle = gpu_worker(&["gpu", "image_vqa", "image_interleave", "candle"]);
+        let understanding_job = |job_type: &str, payload: Value| -> JobSnapshot {
+            serde_json::from_value(json!({
+                "id": "job_u",
+                "type": job_type,
+                "status": "queued",
+                "payload": payload,
+                "result": {},
+                "requestedGpu": "auto",
+                "progress": 0,
+                "stage": "queued",
+                "message": "",
+                "attempts": 1,
+                "cancelRequested": false,
+                "createdAt": "2026-06-14T00:00:00Z",
+                "updatedAt": "2026-06-14T00:00:00Z",
+            }))
+            .expect("valid JobSnapshot")
+        };
+        // Claims SenseNova-U1 VQA + interleave (base + `_fast` ids).
+        assert!(worker_supports_job(
+            &candle,
+            &understanding_job(
+                "image_vqa",
+                json!({ "model": "sensenova_u1_8b", "question": "what is this?", "sourceAssetId": "a1" })
+            )
+        ));
+        assert!(worker_supports_job(
+            &candle,
+            &understanding_job(
+                "image_interleave",
+                json!({ "model": "sensenova_u1_8b_fast", "prompt": "a short illustrated story" })
+            )
+        ));
+        // Refuses a non-SenseNova understanding job → falls back to the Python torch worker.
+        assert!(!worker_supports_job(
+            &candle,
+            &understanding_job(
+                "image_vqa",
+                json!({ "model": "some_other_vlm", "question": "?", "sourceAssetId": "a1" })
+            )
         ));
     }
 }

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -489,30 +489,37 @@ mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3e
 # `_fast` sm_120 CPU distill-LoRA merge fix) with sc-5551's `fa0f75b` re-pin — plus LINKS the candle
 # Kolors (`kolors`) + SenseNova-U1 (`sensenova_u1_8b` / `_fast`) image providers wired below. ALL candle
 # deps MUST share this rev.
+#
+# sc-5501 bumps the candle pin `152974d` -> `dbe5560` (candle-gen main HEAD, #56+#58): LINKS the candle
+# SenseNova-U1 understanding surface — `T2iModel::{vqa, interleave_gen}` (#56) + the input-device fix
+# (#58) — that `sensenova_jobs.rs` drives off-registry for `image_vqa` / `image_interleave`. candle-gen
+# #57 moved its `sceneworks-gen-core` `fa0f75b` -> `d3ec5e5`, so this worker's mlx-gen + gen-core pins
+# are bumped to `d3ec5e5` in LOCKSTEP (above) to keep the candle lane on ONE gen-core rev. ALL candle
+# deps MUST share this rev.
 [target.'cfg(target_os = "windows")'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "15663b1f618e827e06905340d4e2c339a690707e", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "dbe5560787a6f71a80b78ffed52114a471bd3eba", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "15663b1f618e827e06905340d4e2c339a690707e", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "15663b1f618e827e06905340d4e2c339a690707e", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "15663b1f618e827e06905340d4e2c339a690707e", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "15663b1f618e827e06905340d4e2c339a690707e", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "dbe5560787a6f71a80b78ffed52114a471bd3eba", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "dbe5560787a6f71a80b78ffed52114a471bd3eba", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "dbe5560787a6f71a80b78ffed52114a471bd3eba", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "dbe5560787a6f71a80b78ffed52114a471bd3eba", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "15663b1f618e827e06905340d4e2c339a690707e", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "dbe5560787a6f71a80b78ffed52114a471bd3eba", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b`; ltx registers `ltx_2_3_distilled` (txt2video first slice — no conditioning/audio/
 # LoRA/quant). Force-linked in video_jobs.rs (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "15663b1f618e827e06905340d4e2c339a690707e", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "15663b1f618e827e06905340d4e2c339a690707e", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "dbe5560787a6f71a80b78ffed52114a471bd3eba", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "dbe5560787a6f71a80b78ffed52114a471bd3eba", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "15663b1f618e827e06905340d4e2c339a690707e", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "dbe5560787a6f71a80b78ffed52114a471bd3eba", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -521,19 +528,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "15663b1f618e827e06905340d4e2c339a690707e", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "dbe5560787a6f71a80b78ffed52114a471bd3eba", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "15663b1f618e827e06905340d4e2c339a690707e", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "dbe5560787a6f71a80b78ffed52114a471bd3eba", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "15663b1f618e827e06905340d4e2c339a690707e", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "dbe5560787a6f71a80b78ffed52114a471bd3eba", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -542,12 +549,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "15663b1f618e827e06905340d4e2c339a690707e", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "dbe5560787a6f71a80b78ffed52114a471bd3eba", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "15663b1f618e827e06905340d4e2c339a690707e", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "dbe5560787a6f71a80b78ffed52114a471bd3eba", features = ["cuda"], optional = true }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -35,11 +35,15 @@ sceneworks-core = { path = "../sceneworks-core" }
 # image per-step cancel — so a mid-clip video cancel interrupts within ~a step (the worker-side
 # defer-terminal fix sc-5516 / #662 is already merged; this pin makes its video path responsive).
 # gen-core delta over the range is EMPTY (the range touched only the wan/ltx + scail2 provider crates,
-# not gen-core), so the worker's import surface is unchanged → skew gate stays green at one rev. The
-# candle-gen pin in the macOS block is re-pinned in LOCKSTEP to a candle-gen rev whose gen-core is
-# fa0f75b too (candle-gen #55), so the `--features backend-candle` lane also resolves one gen-core rev.
+# not gen-core), so the worker's import surface is unchanged → skew gate stays green at one rev.
+# Rev d3ec5e5 (mlx-gen main, sc-5552): bumps fa0f75b -> d3ec5e5 in LOCKSTEP with candle-gen #57 (which
+# moved its gen-core fa0f75b -> d3ec5e5) so the `--features backend-candle` lane resolves ONE gen-core
+# rev again — required by sc-5501's candle SenseNova VQA/interleave wiring, which hands the worker's
+# `gen_core::{Image, CancelFlag}` into `candle_gen_sensenova::T2iModel` (same crate only when the revs
+# match). gen-core delta fa0f75b -> d3ec5e5 is EMPTY; the mlx-gen delta is purely additive (the new
+# `mlx-gen-prompt-refine` crate, which the worker does not link), so the MLX lane is unchanged.
 # mlx-gen's internal mlx-rs rev is unchanged (44929a0), so the direct `mlx-rs` pin below stays put.
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -106,6 +110,9 @@ backend-candle = [
     # `engines::registry_capabilities` advertises them off-Mac with no further change.
     "dep:candle-gen-kolors",
     "dep:candle-gen-sensenova",
+    # sc-5501 (epic 5164): candle-gen core, so the worker can build the understanding-path input
+    # tensors that drive `candle_gen_sensenova::T2iModel::{vqa, interleave_gen}` off the registry.
+    "dep:candle-gen",
     # sc-5126 (epic 5107): the candle Lens / Lens-Turbo image provider — gpt-oss-20b MoE encoder +
     # 48-layer MMDiT + Flux.2 VAE. The first candle family with Q4/Q8 quant + LoRA/LoKr; pure T2I.
     "dep:candle-gen-lens",
@@ -281,7 +288,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -293,55 +300,55 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe
 # internal pin (the Lens engine PRs #407–#414 did not move it; nor did the seedvr2 engine #416/#419/
 # #421 or the softness PR #422, so the 1a97909 bump above leaves mlx-rs at 44929a0).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "44929a001ab8a8837403a71c65cf064224de0cdc" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -350,12 +357,12 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -364,7 +371,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -372,7 +379,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "f
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -383,7 +390,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -394,7 +401,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f7
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -409,7 +416,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75
 # converted in-memory at load (no Python); the precomputed neg-prompt embedding is bundled in-crate. No
 # LoRA/guidance/CFG (one-step). 3B fp16 only here — 7B (sc-5197) + int8 (sc-5198) are engine-side and
 # unwired. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -420,7 +427,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -483,29 +490,29 @@ mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0
 # Kolors (`kolors`) + SenseNova-U1 (`sensenova_u1_8b` / `_fast`) image providers wired below. ALL candle
 # deps MUST share this rev.
 [target.'cfg(target_os = "windows")'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "152974d7d462cb7efeb90311885189ad75befc73", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "15663b1f618e827e06905340d4e2c339a690707e", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "152974d7d462cb7efeb90311885189ad75befc73", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "152974d7d462cb7efeb90311885189ad75befc73", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "152974d7d462cb7efeb90311885189ad75befc73", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "152974d7d462cb7efeb90311885189ad75befc73", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "15663b1f618e827e06905340d4e2c339a690707e", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "15663b1f618e827e06905340d4e2c339a690707e", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "15663b1f618e827e06905340d4e2c339a690707e", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "15663b1f618e827e06905340d4e2c339a690707e", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "152974d7d462cb7efeb90311885189ad75befc73", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "15663b1f618e827e06905340d4e2c339a690707e", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b`; ltx registers `ltx_2_3_distilled` (txt2video first slice — no conditioning/audio/
 # LoRA/quant). Force-linked in video_jobs.rs (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "152974d7d462cb7efeb90311885189ad75befc73", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "152974d7d462cb7efeb90311885189ad75befc73", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "15663b1f618e827e06905340d4e2c339a690707e", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "15663b1f618e827e06905340d4e2c339a690707e", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "152974d7d462cb7efeb90311885189ad75befc73", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "15663b1f618e827e06905340d4e2c339a690707e", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -514,25 +521,33 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "152974d7d462cb7efeb90311885189ad75befc73", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "15663b1f618e827e06905340d4e2c339a690707e", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "152974d7d462cb7efeb90311885189ad75befc73", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "15663b1f618e827e06905340d4e2c339a690707e", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "152974d7d462cb7efeb90311885189ad75befc73", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "15663b1f618e827e06905340d4e2c339a690707e", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
-# #54's sm_120 fix). Unified Qwen3-MoT backbone + flow-matching head; pure T2I (edit / VQA / interleave
-# stay on Python). Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "152974d7d462cb7efeb90311885189ad75befc73", features = ["cuda"], optional = true }
+# #54's sm_120 fix). Unified Qwen3-MoT backbone + flow-matching head. T2I self-registers via
+# inventory; the VQA + Document-Studio interleave understanding modes (sc-5501, candle-gen #56) are
+# driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
+# (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
+# torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "15663b1f618e827e06905340d4e2c339a690707e", features = ["cuda"], optional = true }
+# candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
+# input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
+# rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
+# candle-gen / gen-core build (the skew gate stays single-rev).
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "15663b1f618e827e06905340d4e2c339a690707e", features = ["cuda"], optional = true }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -56,6 +56,20 @@ fn with_candle_capabilities(mut gpu: DiscoveredGpu, settings: &Settings) -> Disc
                     gpu.capabilities.push(capability);
                 }
             }
+            // SenseNova-U1 VQA + Document-Studio interleave (sc-5501) run off the `Generator`
+            // registry via the concrete candle `T2iModel::{vqa, interleave_gen}` (their text /
+            // text+image output the neutral contract can't express), so they are NOT in
+            // `registry_capabilities`. Advertise them explicitly — the candle SenseNova provider is
+            // force-linked under `backend-candle`, and the routing gate confines them to the
+            // SenseNova-U1 ids (`understanding_job_is_mlx_eligible`).
+            for capability in [
+                WorkerCapability::ImageVqa,
+                WorkerCapability::ImageInterleave,
+            ] {
+                if !gpu.capabilities.contains(&capability) {
+                    gpu.capabilities.push(capability);
+                }
+            }
             // The lane marker the routing gate keys off (mirrors the existing `nvidia` marker).
             gpu.capabilities
                 .push(WorkerCapability::Unknown("candle".to_owned()));

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -106,8 +106,9 @@ fn model_repo(request: &ImageRequest, model: &ResolvedModel) -> String {
 
 /// Resolve the weights snapshot directory: an explicit `modelPath` dir wins, else the
 /// HuggingFace cache snapshot for the model repo. `None` when the model is not a known
-/// engine family or its snapshot is absent.
-#[cfg(target_os = "macos")]
+/// engine family or its snapshot is absent. Available on the candle lane too (sc-5501): the
+/// off-Mac SenseNova-U1 VQA / interleave handlers resolve their snapshot through it.
+#[cfg(any(target_os = "macos", feature = "backend-candle"))]
 pub(crate) fn resolve_weights_dir(
     request: &ImageRequest,
     settings: &Settings,

--- a/crates/sceneworks-worker/src/sensenova_jobs.rs
+++ b/crates/sceneworks-worker/src/sensenova_jobs.rs
@@ -9,33 +9,35 @@
 //!   ordered text + generated images, persisted as image assets plus an
 //!   [`InterleavedDocument`](sceneworks_core::contracts::InterleavedDocument) `document` asset.
 //!
-//! Path A (sc-3900) routes the image-producing modes through the `Generator` registry and bumped
-//! the `mlx-gen` pin + force-linked `mlx_gen_sensenova`; this module reuses that dependency. The
-//! `Generator` crate has no public `SenseNova` constructor, so the worker assembles a concrete
-//! `T2iModel` here (replicating the engine's private `load_inner`) from the public re-exports.
+//! Each backend assembles its own concrete `T2iModel` from the provider's public re-exports (the
+//! `Generator` crate has no public constructor): macOS drives `mlx_gen_sensenova::T2iModel`; the
+//! candle (Windows/CUDA) lane drives `candle_gen_sensenova::T2iModel` via `load_understanding`
+//! (sc-5501), retiring the off-Mac Python torch VQA/interleave path. The handler shape, request
+//! parsing, and document assembly are shared and backend-neutral.
 //!
 //! Parity: VQA mirrors the Python `SenseNovaU1Adapter.answer_question`; interleave mirrors
-//! `generate_interleaved` / `_write_interleaved_document` byte-for-byte (request fields, the
-//! interleave resolution buckets + think/no-think system protocol, and the response/asset shapes).
-//! The understanding + generation model loads dense (no distill LoRA, no quantization) exactly as
-//! the torch adapter does (`_load_model(distill_lora=None)`), keeping the VQA decode bit-identical.
+//! `generate_interleaved` / `_write_interleaved_document` (request fields, the interleave resolution
+//! buckets + think/no-think system protocol, and the response/asset shapes). The understanding +
+//! generation model loads dense (no distill LoRA, no quantization) exactly as the torch adapter does
+//! (`_load_model(distill_lora=None)`) — the full base model.
 //!
-//! Off macOS the in-process engine is unavailable and the `image_vqa` / `image_interleave`
-//! capabilities are never advertised by this worker, so the handlers are unreachable stubs that
-//! error loudly (the Python torch worker serves these modes on Windows/Linux).
+//! When neither the MLX nor the candle engine is linked (a non-macOS build with `backend-candle`
+//! off), the `image_vqa` / `image_interleave` capabilities are not advertised and the handlers are
+//! stubs that error loudly (the Python torch worker serves these modes there).
 
 use super::*;
-// Only the macOS handlers parse an `ImageRequest`; the non-macOS stubs don't.
-#[cfg(target_os = "macos")]
+// The macOS (MLX) and candle (Windows/CUDA) handlers parse an `ImageRequest`; the torch-defer stub
+// doesn't.
+#[cfg(any(target_os = "macos", feature = "backend-candle"))]
 use sceneworks_core::image_request::ImageRequest;
 
 // CARVE-OUT(epic 3720): backend-specific; absorbed by TextLlm in Phase 5.
-// VQA + Document-Studio interleave bypass the `Generator` registry and drive the concrete
-// `mlx_gen_sensenova::T2iModel` directly (text / text+images output the neutral `GenerationOutput`
-// contract can't express). The whole module stays mlx-gen-typed — `Image`, `TextTokenizer`,
-// `resize_bicubic_u8`, and `decoded_to_image` (which operates on a backend tensor and MUST stay
-// mlx-gen-local) are kept on the `mlx_gen::` paths to protect byte-identical VQA/interleave
-// decode — until the understanding path is lifted onto a neutral TextLlm contract.
+// VQA + Document-Studio interleave bypass the `Generator` registry and drive the concrete unified
+// `T2iModel` directly (text / text+images output the neutral `GenerationOutput` contract can't
+// express). macOS drives `mlx_gen_sensenova::T2iModel`; off-Mac the candle (Windows/CUDA) lane drives
+// `candle_gen_sensenova::T2iModel` (the sibling carve-outs, sc-5501) — retiring the off-Mac torch
+// VQA/interleave path. Each lane keeps its own engine-typed imports; the document-assembly +
+// request-parsing helpers below are backend-neutral and shared.
 #[cfg(target_os = "macos")]
 use mlx_gen::image::{decoded_to_image, resize_bicubic_u8};
 #[cfg(target_os = "macos")]
@@ -52,10 +54,26 @@ use mlx_rs::ops::divide;
 #[cfg(target_os = "macos")]
 use mlx_rs::Array;
 
-/// The adapter id recorded on the generated assets + the interleaved document (the MLX SenseNova
-/// path, matching the `adapter_label` the sc-3900 image rows use).
+// Candle (Windows/CUDA) understanding path (sc-5501). `Image` is the neutral `gen_core::Image`
+// (`load_reference_image`'s return); the source-image preprocessing + tensor construction live in
+// `image_to_chw01_candle` (the `image` crate's resampler + `candle_gen::candle_core`).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+use candle_gen::candle_core::{DType, Device, Tensor};
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+use candle_gen_sensenova::{
+    load_understanding, smart_resize, tensor_to_image, Sampler, T2iOptions, INTERLEAVE_RESOLUTIONS,
+    INTERLEAVE_SYSTEM_MESSAGE,
+};
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+use gen_core::Image;
+
+/// The adapter id recorded on the generated assets + the interleaved document, matching the
+/// per-backend `adapter_label` the image rows use: `mlx_sensenova` on macOS, `candle_sensenova` on
+/// the candle lane (sc-5576).
 #[cfg(target_os = "macos")]
 const SENSENOVA_ADAPTER: &str = "mlx_sensenova";
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+const SENSENOVA_ADAPTER: &str = "candle_sensenova";
 
 // ===========================================================================
 // VQA (image_vqa)
@@ -217,16 +235,169 @@ pub(crate) async fn run_vqa_job(
     Ok(())
 }
 
-/// Off macOS the in-process engine is unavailable; `image_vqa` is served by the Python torch
-/// worker (the `mlx` worker — the only one advertising this capability — is macOS-only).
-#[cfg(not(target_os = "macos"))]
+/// Candle (Windows/CUDA) VQA — the off-Mac sibling of the macOS MLX handler (sc-5501). Builds the
+/// dense candle `T2iModel` via `load_understanding` and calls `T2iModel::vqa`, retiring the Python
+/// torch `image_vqa` path off-Mac. Same request fields + `{answer, question, sourceAssetId, model,
+/// realModelInference}` result, no asset write.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+pub(crate) async fn run_vqa_job(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+) -> WorkerResult<()> {
+    let request = ImageRequest::from_payload(&job.payload);
+    if request.project_id.trim().is_empty() {
+        return Err(WorkerError::InvalidPayload(
+            "Missing payload.projectId".to_owned(),
+        ));
+    }
+    let model_id = if request.model.trim().is_empty() {
+        "sensenova_u1_8b".to_owned()
+    } else {
+        request.model.clone()
+    };
+    let question = job
+        .payload
+        .get("question")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload("Visual question answering requires a question.".to_owned())
+        })?
+        .to_owned();
+    let source_asset_id = job
+        .payload
+        .get("sourceAssetId")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload(
+                "Visual question answering requires a source image asset.".to_owned(),
+            )
+        })?
+        .to_owned();
+
+    let max_new_tokens = payload_int(&job.payload, "maxNewTokens", 256, 16, 2048) as usize;
+    let max_image_pixels = payload_int(
+        &job.payload,
+        "maxImagePixels",
+        768 * 768,
+        256 * 256,
+        2048 * 2048,
+    );
+
+    let weights_dir = resolve_weights_dir(&request, settings)?
+        .ok_or_else(|| WorkerError::InvalidPayload("SenseNova-U1 weights not found".to_owned()))?;
+
+    let project =
+        ProjectStore::new(settings.data_dir.clone(), "worker").get_project(&request.project_id)?;
+    let project_path = PathBuf::from(project.path);
+    let backend = backend_label(&settings.gpu_id).to_owned();
+
+    heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+    update_job(
+        api,
+        &job.id,
+        image_progress(
+            JobStatus::Preparing,
+            ProgressStage::Preparing,
+            0.08,
+            "Preparing visual question.",
+            None,
+            &backend,
+        ),
+    )
+    .await?;
+
+    let source = load_reference_image(
+        &settings.data_dir,
+        &request.project_id,
+        &source_asset_id,
+        &project_path,
+    )?;
+
+    update_job(
+        api,
+        &job.id,
+        image_progress(
+            JobStatus::Running,
+            ProgressStage::Generating,
+            0.6,
+            "Analyzing image.",
+            None,
+            &backend,
+        ),
+    )
+    .await?;
+
+    let job_id = job.id.clone();
+    let question_for_vqa = question.clone();
+    let answer = tokio::task::spawn_blocking(move || -> WorkerResult<String> {
+        emit_load_event("image_pipeline_load_start", &job_id, "sensenova_u1_8b", 0);
+        let (model, tokenizer) = load_understanding(&weights_dir)
+            .map_err(|error| WorkerError::Engine(format!("SenseNova-U1 load: {error}")))?;
+        emit_load_event(
+            "image_pipeline_load_complete",
+            &job_id,
+            "sensenova_u1_8b",
+            0,
+        );
+        // ImageNet-normalized inside `vqa`; pass [3,H,W] in [0,1], 32-aligned, within the
+        // understanding pixel budget (default 768², min 256²).
+        let pixel_values = image_to_chw01_candle(&source, 256 * 256, max_image_pixels)?;
+        let answer = model
+            .vqa(
+                &tokenizer,
+                &question_for_vqa,
+                std::slice::from_ref(&pixel_values),
+                max_new_tokens,
+                Sampler::Greedy,
+            )
+            .map_err(|error| WorkerError::Engine(format!("SenseNova VQA failed: {error}")))?;
+        Ok(strip_reasoning(&answer))
+    })
+    .await
+    .map_err(|error| task_join_error("VQA task join", error))??;
+
+    let result = json!({
+        "answer": answer,
+        "question": question,
+        "sourceAssetId": source_asset_id,
+        "model": model_id,
+        "realModelInference": true,
+    })
+    .as_object()
+    .cloned()
+    .expect("json! object literal");
+
+    update_job(
+        api,
+        &job.id,
+        image_progress(
+            JobStatus::Completed,
+            ProgressStage::Completed,
+            1.0,
+            "Answer ready.",
+            Some(result),
+            &backend,
+        ),
+    )
+    .await?;
+    Ok(())
+}
+
+/// Off macOS without the candle backend the in-process engine is unavailable; `image_vqa` is served
+/// by the Python torch worker (macOS runs the MLX engine; Windows/CUDA runs candle when enabled).
+#[cfg(all(not(target_os = "macos"), not(feature = "backend-candle")))]
 pub(crate) async fn run_vqa_job(
     _api: &ApiClient,
     _settings: &Settings,
     _job: &JobSnapshot,
 ) -> WorkerResult<()> {
     Err(WorkerError::InvalidPayload(
-        "image_vqa runs on the macOS MLX worker or the Python torch worker, not this Rust worker"
+        "image_vqa runs on the macOS MLX worker, the candle (Windows/CUDA) worker, or the Python torch worker, not this Rust worker"
             .to_owned(),
     ))
 }
@@ -481,16 +652,254 @@ pub(crate) async fn run_interleave_job(
     Ok(())
 }
 
-/// Off macOS the in-process engine is unavailable; `image_interleave` is served by the Python torch
-/// worker (the `mlx` worker — the only one advertising this capability — is macOS-only).
-#[cfg(not(target_os = "macos"))]
+/// Candle (Windows/CUDA) interleave — the off-Mac sibling of the macOS MLX handler (sc-5501). Builds
+/// the dense candle `T2iModel` via `load_understanding` and calls `T2iModel::interleave_gen`,
+/// retiring the Python torch `image_interleave` path off-Mac. Same request fields, resolution
+/// buckets, think/no-think protocol, and `document` asset shape (the assembly is the shared
+/// `write_interleaved_document`).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+pub(crate) async fn run_interleave_job(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+) -> WorkerResult<()> {
+    let request = ImageRequest::from_payload(&job.payload);
+    if request.project_id.trim().is_empty() {
+        return Err(WorkerError::InvalidPayload(
+            "Missing payload.projectId".to_owned(),
+        ));
+    }
+    let prompt = request.prompt.trim().to_owned();
+    if prompt.is_empty() {
+        return Err(WorkerError::InvalidPayload(
+            "Interleaved generation requires a prompt.".to_owned(),
+        ));
+    }
+    let model_id = if request.model.trim().is_empty() {
+        "sensenova_u1_8b".to_owned()
+    } else {
+        request.model.clone()
+    };
+    let advanced = &request.advanced;
+
+    let max_images = advanced_int(advanced, "maxImages", 6, 1, 10) as usize;
+    let req_width = payload_int(&job.payload, "width", 2048, 256, 4096);
+    let req_height = payload_int(&job.payload, "height", 1152, 256, 4096);
+    let (width, height) = interleave_resolution_snap(req_width, req_height);
+
+    let source_asset_ids: Vec<String> = job
+        .payload
+        .get("sourceAssetIds")
+        .and_then(Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_owned)
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let steps = advanced_int(advanced, "numInferenceSteps", 50, 1, 100) as usize;
+    let cfg_scale = advanced_float(advanced, "guidanceScale", 4.0);
+    let img_cfg_scale = advanced_float(advanced, "imageGuidanceScale", 1.0);
+    let timestep_shift = advanced_float(advanced, "timestepShift", 3.0);
+    let max_new_tokens = advanced_int(advanced, "maxNewTokens", 2048, 64, 8192) as usize;
+    let think_mode = advanced
+        .get("thinkMode")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let system_message = advanced
+        .get("systemMessage")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .unwrap_or_else(|| INTERLEAVE_SYSTEM_MESSAGE.to_owned());
+    let seed = resolve_seed(&request, 0);
+
+    let weights_dir = resolve_weights_dir(&request, settings)?
+        .ok_or_else(|| WorkerError::InvalidPayload("SenseNova-U1 weights not found".to_owned()))?;
+
+    let project =
+        ProjectStore::new(settings.data_dir.clone(), "worker").get_project(&request.project_id)?;
+    let project_path = PathBuf::from(project.path);
+    tokio::fs::create_dir_all(project_path.join("assets").join("documents")).await?;
+    tokio::fs::create_dir_all(project_path.join("assets").join("images")).await?;
+    let backend = backend_label(&settings.gpu_id).to_owned();
+
+    heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+    update_job(
+        api,
+        &job.id,
+        image_progress(
+            JobStatus::Preparing,
+            ProgressStage::Preparing,
+            0.08,
+            "Preparing interleaved document.",
+            None,
+            &backend,
+        ),
+    )
+    .await?;
+
+    let mut input_images = Vec::with_capacity(source_asset_ids.len());
+    for asset_id in &source_asset_ids {
+        input_images.push(load_reference_image(
+            &settings.data_dir,
+            &request.project_id,
+            asset_id,
+            &project_path,
+        )?);
+    }
+
+    match check_cancel(api, &job.id, "Interleaved generation canceled by user.").await {
+        Ok(()) => {}
+        Err(WorkerError::Canceled(_)) => return Ok(()),
+        Err(other) => return Err(other),
+    }
+
+    update_job(
+        api,
+        &job.id,
+        image_progress(
+            JobStatus::Running,
+            ProgressStage::Generating,
+            0.45,
+            "Composing interleaved document.",
+            None,
+            &backend,
+        ),
+    )
+    .await?;
+    heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+
+    let job_id = job.id.clone();
+    let prompt_for_gen = prompt.clone();
+    let (generated_text, images) =
+        tokio::task::spawn_blocking(move || -> WorkerResult<(String, Vec<Image>)> {
+            emit_load_event("image_pipeline_load_start", &job_id, "sensenova_u1_8b", 0);
+            let (model, tokenizer) = load_understanding(&weights_dir)
+                .map_err(|error| WorkerError::Engine(format!("SenseNova-U1 load: {error}")))?;
+            emit_load_event(
+                "image_pipeline_load_complete",
+                &job_id,
+                "sensenova_u1_8b",
+                0,
+            );
+
+            // Source images: [3,H,W] in [0,1], 32-aligned. Bounds mirror the torch
+            // `interleave_gen` (`load_image_native` min 512², max min(2048², 4096²/n)).
+            let n = input_images.len().max(1) as i64;
+            let max_pixels = (2048 * 2048).min((4096 * 4096) / n);
+            let mut input_arrays = Vec::with_capacity(input_images.len());
+            for image in &input_images {
+                input_arrays.push(image_to_chw01_candle(image, 512 * 512, max_pixels)?);
+            }
+
+            let opts = T2iOptions {
+                cfg_scale,
+                img_cfg_scale,
+                num_steps: steps,
+                timestep_shift,
+                seed: seed as u64,
+                think_mode,
+                ..Default::default()
+            };
+            // The rollout is a single uninterruptible pass (like the macOS handler); cancel is
+            // checked before launch. Pass an un-tripped flag the engine polls between text tokens /
+            // denoise steps.
+            let cancel = gen_core::CancelFlag::new();
+            let out = model
+                .interleave_gen(
+                    &tokenizer,
+                    &prompt_for_gen,
+                    &input_arrays,
+                    width as usize,
+                    height as usize,
+                    &opts,
+                    &system_message,
+                    max_new_tokens,
+                    max_images,
+                    &cancel,
+                )
+                .map_err(|error| {
+                    WorkerError::Engine(format!("SenseNova interleave failed: {error}"))
+                })?;
+            // The generated images are model-space [-1,1] `[1,3,H,W]` tensors — decode each to RGB8.
+            let mut decoded = Vec::with_capacity(out.images.len());
+            for image in &out.images {
+                decoded.push(tensor_to_image(image).map_err(|error| {
+                    WorkerError::InvalidPayload(format!("SenseNova interleave decode: {error}"))
+                })?);
+            }
+            Ok((out.text, decoded))
+        })
+        .await
+        .map_err(|error| task_join_error("interleave task join", error))??;
+
+    update_job(
+        api,
+        &job.id,
+        image_progress(
+            JobStatus::Saving,
+            ProgressStage::Saving,
+            0.9,
+            "Saving interleaved document.",
+            None,
+            &backend,
+        ),
+    )
+    .await?;
+
+    let result = write_interleaved_document(
+        &request,
+        job,
+        &project_path,
+        &prompt,
+        &model_id,
+        seed,
+        max_images,
+        width,
+        height,
+        steps,
+        cfg_scale,
+        img_cfg_scale,
+        timestep_shift,
+        max_new_tokens,
+        think_mode,
+        &generated_text,
+        images,
+    )?;
+
+    update_job(
+        api,
+        &job.id,
+        image_progress(
+            JobStatus::Completed,
+            ProgressStage::Completed,
+            1.0,
+            "Interleaved document ready.",
+            Some(result),
+            &backend,
+        ),
+    )
+    .await?;
+    Ok(())
+}
+
+/// Off macOS without the candle backend the in-process engine is unavailable; `image_interleave` is
+/// served by the Python torch worker (macOS runs MLX; Windows/CUDA runs candle when enabled).
+#[cfg(all(not(target_os = "macos"), not(feature = "backend-candle")))]
 pub(crate) async fn run_interleave_job(
     _api: &ApiClient,
     _settings: &Settings,
     _job: &JobSnapshot,
 ) -> WorkerResult<()> {
     Err(WorkerError::InvalidPayload(
-        "image_interleave runs on the macOS MLX worker or the Python torch worker, not this Rust worker"
+        "image_interleave runs on the macOS MLX worker, the candle (Windows/CUDA) worker, or the Python torch worker, not this Rust worker"
             .to_owned(),
     ))
 }
@@ -501,7 +910,7 @@ pub(crate) async fn run_interleave_job(
 // `document` asset fact. Mirrors the Python `_write_interleaved_document` / `_build_interleaved_segments`.
 // ---------------------------------------------------------------------------
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", feature = "backend-candle"))]
 #[allow(clippy::too_many_arguments)]
 fn write_interleaved_document(
     request: &ImageRequest,
@@ -645,7 +1054,7 @@ fn write_interleaved_document(
 /// Split the model output on its inline `<image>` markers and slot the generated image assets in
 /// order: text[0], image[0], text[1], image[1], …. Mirrors the Python `_build_interleaved_segments`
 /// (reads each image fact's `assetId` + `mediaPath`).
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", feature = "backend-candle"))]
 fn build_interleaved_segments(generated_text: &str, image_writes: &[Value]) -> Vec<Value> {
     let mut segments = Vec::new();
     for (index, part) in generated_text.split("<image>").enumerate() {
@@ -709,8 +1118,43 @@ fn image_to_chw01(img: &Image, min_pixels: i64, max_pixels: i64) -> WorkerResult
         .map_err(|error| WorkerError::InvalidPayload(format!("image normalize: {error}")))
 }
 
+/// Candle sibling of [`image_to_chw01`] (sc-5501): decode an [`Image`] (RGB8 HWC) to a `[3,H,W]` f32
+/// candle `Tensor` in `[0,1]`, smart-resized (Lanczos3, the worker's house resampler) to a 32-aligned
+/// bucket within `[min_pixels, max_pixels]`. The understanding `T2iModel::{vqa, interleave_gen}`
+/// ImageNet-normalize internally, so this stays in `[0,1]`. Built on **CPU**; the engine relocates it
+/// to the model's device (candle treats each `new_cuda(0)` handle as distinct, so building it on the
+/// worker's own device handle would mismatch the model's).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn image_to_chw01_candle(img: &Image, min_pixels: i64, max_pixels: i64) -> WorkerResult<Tensor> {
+    let (out_h, out_w) = smart_resize(
+        img.height as i32,
+        img.width as i32,
+        32,
+        min_pixels,
+        max_pixels,
+    );
+    let rgb =
+        image::RgbImage::from_raw(img.width, img.height, img.pixels.clone()).ok_or_else(|| {
+            WorkerError::InvalidPayload("reference image buffer size mismatch".to_owned())
+        })?;
+    let resized = image::imageops::resize(
+        &rgb,
+        out_w as u32,
+        out_h as u32,
+        image::imageops::FilterType::Lanczos3,
+    );
+    let (rw, rh) = (resized.width() as usize, resized.height() as usize);
+    // [H,W,3] u8 -> [3,H,W] f32 in [0,1], on CPU (the engine moves it to the model device).
+    let hwc = Tensor::from_vec(resized.into_raw(), (rh, rw, 3), &Device::Cpu)
+        .and_then(|tensor| tensor.to_dtype(DType::F32))
+        .map_err(|error| WorkerError::Engine(format!("image tensor: {error}")))?;
+    hwc.permute((2, 0, 1))
+        .and_then(|chw| chw / 255.0)
+        .map_err(|error| WorkerError::Engine(format!("image normalize: {error}")))
+}
+
 /// The SenseNova-U1 repo (manifest `repo` else the default), for the document telemetry.
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", feature = "backend-candle"))]
 fn model_repo_for(request: &ImageRequest) -> String {
     request
         .model_manifest_entry
@@ -725,7 +1169,7 @@ fn model_repo_for(request: &ImageRequest) -> String {
 /// Snap a requested W×H to the nearest interleave bucket by aspect ratio in log-space (ties resolve
 /// to the first bucket). Mirrors the Python `snap_to_aspect_bucket` over the same
 /// `INTERLEAVE_RESOLUTIONS` table (priority order).
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", feature = "backend-candle"))]
 fn interleave_resolution_snap(width: i64, height: i64) -> (i32, i32) {
     let target = (width.max(1) as f64 / height.max(1) as f64).ln();
     let mut best = INTERLEAVE_RESOLUTIONS[0].1;
@@ -744,7 +1188,7 @@ fn interleave_resolution_snap(width: i64, height: i64) -> (i32, i32) {
 /// blocks and any dangling/unclosed one (reasoning truncated by `max_new_tokens`). Mirrors the
 /// Python `SenseNovaU1Adapter._strip_reasoning`. Used by the macOS VQA handler; also unit-tested
 /// cross-platform (it is pure string logic), so it compiles under `test` off macOS too.
-#[cfg(any(target_os = "macos", test))]
+#[cfg(any(target_os = "macos", test, feature = "backend-candle"))]
 fn strip_reasoning(text: &str) -> String {
     let mut out = String::with_capacity(text.len());
     let mut rest = text;
@@ -767,7 +1211,7 @@ fn strip_reasoning(text: &str) -> String {
 
 /// `safe_int` over a top-level payload field: parse (int / float / numeric string) else `default`,
 /// then clamp to `[lo, hi]`. Used by the macOS handlers; also unit-tested cross-platform.
-#[cfg(any(target_os = "macos", test))]
+#[cfg(any(target_os = "macos", test, feature = "backend-candle"))]
 fn payload_int(payload: &JsonObject, key: &str, default: i64, lo: i64, hi: i64) -> i64 {
     payload
         .get(key)
@@ -777,13 +1221,13 @@ fn payload_int(payload: &JsonObject, key: &str, default: i64, lo: i64, hi: i64) 
 }
 
 /// `safe_int` over an `advanced` field (same parse/clamp as [`payload_int`]).
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", feature = "backend-candle"))]
 fn advanced_int(advanced: &JsonObject, key: &str, default: i64, lo: i64, hi: i64) -> i64 {
     payload_int(advanced, key, default, lo, hi)
 }
 
 /// `_advanced_float`: parse an `advanced` field as f32 else `default`.
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", feature = "backend-candle"))]
 fn advanced_float(advanced: &JsonObject, key: &str, default: f32) -> f32 {
     advanced
         .get(key)
@@ -796,7 +1240,7 @@ fn advanced_float(advanced: &JsonObject, key: &str, default: f32) -> f32 {
         .unwrap_or(default)
 }
 
-#[cfg(any(target_os = "macos", test))]
+#[cfg(any(target_os = "macos", test, feature = "backend-candle"))]
 fn json_to_i64(value: &Value) -> Option<i64> {
     value
         .as_i64()


### PR DESCRIPTION
Retires the off-Mac Python torch **VQA / interleave** path for SenseNova-U1: the worker now drives the candle understanding surface ([candle-gen #56](https://github.com/michaeltrefry/candle-gen/pull/56) + [#58](https://github.com/michaeltrefry/candle-gen/pull/58)) the way the macOS worker drives the MLX one. The engine half of [sc-5501](https://app.shortcut.com/trefry/story/5501) (epic 5164); this is the worker cutover.

## Changes
- **`sensenova_jobs.rs`** — candle `run_vqa_job` / `run_interleave_job` off-Mac (`cfg(all(not(macos), backend-candle))`): build the dense candle `T2iModel` via `load_understanding` and call `vqa` / `interleave_gen`, mirroring the macOS MLX handlers. The torch-defer stub stays only when neither engine is linked. The document-assembly + request-parsing helpers are now **shared** across both lanes. New `image_to_chw01_candle` builds the `[3,H,W]` f32 input on **CPU** (Lanczos3 + `smart_resize`); the engine relocates it to the model device (#58). Adapter label `candle_sensenova`.
- **`gpu.rs`** — advertise `image_vqa` / `image_interleave` on the candle lane (they run off the `Generator` registry, so they're not in `registry_capabilities`).
- **`jobs_store.rs`** — gate the candle worker's understanding jobs to the SenseNova-U1 ids (reuse `understanding_job_is_mlx_eligible`); a non-SenseNova understanding job stays on torch. + a routing unit test.
- **`image_jobs/base.rs`** — `resolve_weights_dir` available on the candle lane.

## Pin coordination
- candle-gen `152974d` → `15663b1` (#56 VQA/interleave + #58 input-device fix).
- In lockstep with [candle-gen #57](https://github.com/michaeltrefry/candle-gen/pull/57) (sc-5552, which moved candle-gen's gen-core `fa0f75b` → `d3ec5e5`), bump the worker's mlx-gen + gen-core `fa0f75b` → `d3ec5e5` so the `--features backend-candle` graph resolves **one** gen-core rev. gen-core delta is **empty**; the mlx-gen delta is purely additive (the new `mlx-gen-prompt-refine` crate the worker doesn't link), so the MLX lane is unchanged. Adds `candle-gen` core as a direct dep so the worker can build the input tensors.
- Default off (`backend_candle_enabled`) → production routing unchanged.

## Verification
- Default lane: `fmt --check`, `clippy -D warnings`, tests (core **170** + worker **124**) — green.
- Candle lane: `cargo clippy -p sceneworks-worker --features backend-candle -- -D warnings` (CUDA sm_120, MSVC 14.44) — green.
- gen-core skew gate: the lock resolves a single `sceneworks-gen-core` rev (`d3ec5e5`).
- Real-weights GPU smoke (VQA non-empty answer; interleave produces a document with ≥1 image) to follow.

> **Depends on candle-gen [#58](https://github.com/michaeltrefry/candle-gen/pull/58)** — the candle-gen pin (`15663b1`) is that PR's branch HEAD (gen-core `d3ec5e5` + the input-device fix). Re-pin to the merged-main SHA once #58 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)