### PR TITLE
sc-5605: provision the prompt_refine model (catalog/manifest + HF download/readiness + Refine UX)

### DIFF
--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -8178,3 +8178,44 @@ fn resolve_base_model_path_prefers_converted_mlx_dir_for_conversion_models() {
         "with no converted dir, fall back to the HF snapshot"
     );
 }
+
+#[test]
+fn builtin_manifest_registers_the_prompt_refine_model() {
+    // sc-5605: the native prompt_refine worker (prompt_refine_jobs.rs) resolves an
+    // already-cached HF snapshot via huggingface_snapshot_dir and does NOT auto-download
+    // (unlike the retired Python PromptRefiner's from_pretrained). The refine LLM must
+    // therefore be a provisionable catalog artifact so Model Manager can download it into
+    // the HF cache the worker reads from. This guards the real manifest entry against
+    // accidental removal and against the repo string drifting from the worker's
+    // DEFAULT_REFINE_MODEL.
+    let manifest_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../config/manifests/builtin.models.jsonc");
+    let raw = std::fs::read_to_string(&manifest_path).expect("read builtin.models.jsonc");
+    let manifest: Value =
+        serde_json::from_str(&strip_jsonc_comments(&raw)).expect("parse builtin.models.jsonc");
+    let model = manifest["models"]
+        .as_array()
+        .expect("models array")
+        .iter()
+        .find(|entry| entry["id"] == "prompt_refine_llama_3_2_3b")
+        .expect("prompt_refine_llama_3_2_3b is registered in the catalog");
+    // A non-generation utility entry (mirrors the upscalers): absent from the image/video
+    // studio pickers, present + downloadable in Model Manager.
+    assert_eq!(model["type"], "utility");
+    let download = model["downloads"]
+        .as_array()
+        .and_then(|downloads| downloads.first())
+        .expect("a download entry");
+    assert_eq!(download["provider"], "huggingface");
+    // Must match the worker's DEFAULT_REFINE_MODEL (prompt_refine_jobs.rs) — the string the
+    // worker passes to huggingface_snapshot_dir.
+    assert_eq!(
+        download["repo"], "huihui-ai/Llama-3.2-3B-Instruct-abliterated",
+        "manifest repo must match the worker's DEFAULT_REFINE_MODEL"
+    );
+    // The catalog install-state path must resolve the same HF repo the worker does.
+    assert_eq!(
+        model["paths"]["model"],
+        "${HF_CACHE}/huihui-ai/Llama-3.2-3B-Instruct-abliterated"
+    );
+}

--- a/apps/web/public/prompt-guides/prompt-refine.md
+++ b/apps/web/public/prompt-guides/prompt-refine.md
@@ -1,0 +1,19 @@
+# Prompt Refiner Guide
+
+The Prompt Refiner is a small instruction LLM (Llama-3.2-3B) that powers the "Refine my prompt" control in Image and Video Studio. It rewrites your prompt to follow the selected generation model's own prompt guide — it does not generate images or video itself.
+
+## What It Does
+
+When you click **Refine my prompt**, your current prompt and the selected model's prompt guide are sent to this model. It returns a single rewritten prompt that preserves your intent (subjects, attributes, actions, setting) while tightening phrasing and adding only details that keep the result coherent and on-guide. You review the rewrite and choose **Apply** or **Keep original** — your prompt is never changed automatically.
+
+## Installation
+
+The refiner runs in-process on the native worker (MLX on macOS, candle on Windows/CUDA) and is **not** auto-downloaded. Install it once from the **Models** screen (it is also offered inline the first time you refine before it is present). It is about 7 GB and downloads into the shared Hugging Face cache, so other tools reuse it.
+
+## Practical Notes
+
+The refiner matches the language of your prompt: a non-English prompt is rewritten in the same language.
+
+It works without a model guide, but the rewrite is most useful when the selected generation model ships one — the refiner follows that guide's recommended structure and what-to-avoid guidance.
+
+If a prompt is already detailed and on-guide, the refiner makes only minimal edits for fluency.

--- a/apps/web/src/components/RefinePrompt.test.jsx
+++ b/apps/web/src/components/RefinePrompt.test.jsx
@@ -131,4 +131,69 @@ describe("RefinePromptControl", () => {
     expect(refinePrompt).toHaveBeenCalledWith({ prompt: "dog", modelId: "z", workflow: "video", guide: "" });
     expect(container.querySelector(".refine-review-text").textContent).toBe("rewritten");
   });
+
+  it("offers to download the refinement model when it isn't installed (sc-5605)", async () => {
+    const refinePrompt = vi.fn(async () => {
+      throw new Error("prompt-refine model path snapshot is not cached for huihui-ai/Llama-3.2-3B-Instruct-abliterated.");
+    });
+    const onDownloadRefineModel = vi.fn(async () => ({ id: "job-1" }));
+    render(
+      <RefinePromptControl
+        prompt="dog"
+        guidePath=""
+        modelId="z"
+        workflow="image"
+        refinePrompt={refinePrompt}
+        onApply={vi.fn()}
+        refineModel={{ id: "prompt_refine_llama_3_2_3b", name: "Prompt Refiner", installState: "missing", downloadSizeBytes: 7222715642 }}
+        onDownloadRefineModel={onDownloadRefineModel}
+      />,
+    );
+
+    await act(async () => {
+      refineButton(container).click();
+    });
+    await settle();
+
+    // The raw worker error is replaced by a download affordance with a size hint.
+    expect(container.querySelector(".refine-missing-model").textContent).toContain("isn’t installed");
+    expect(container.querySelector(".refine-missing-model").textContent).toContain("7.2 GB");
+    const downloadButton = buttonByText(container, "Download refinement model");
+    expect(downloadButton).toBeTruthy();
+
+    await act(async () => {
+      downloadButton.click();
+    });
+    await settle();
+
+    expect(onDownloadRefineModel).toHaveBeenCalledTimes(1);
+    expect(container.querySelector(".refine-missing-model").textContent).toContain("Downloading");
+  });
+
+  it("shows a plain error (no download CTA) when the refinement model is installed", async () => {
+    const refinePrompt = vi.fn(async () => {
+      throw new Error("Prompt refinement failed.");
+    });
+    render(
+      <RefinePromptControl
+        prompt="dog"
+        guidePath=""
+        modelId="z"
+        workflow="image"
+        refinePrompt={refinePrompt}
+        onApply={vi.fn()}
+        refineModel={{ id: "prompt_refine_llama_3_2_3b", name: "Prompt Refiner", installState: "installed" }}
+        onDownloadRefineModel={vi.fn()}
+      />,
+    );
+
+    await act(async () => {
+      refineButton(container).click();
+    });
+    await settle();
+
+    expect(container.querySelector(".refine-missing-model")).toBeNull();
+    expect(container.querySelector(".refine-error").textContent).toContain("Prompt refinement failed.");
+    expect(buttonByText(container, "Download refinement model")).toBeUndefined();
+  });
 });

--- a/apps/web/src/components/RefinePromptControl.jsx
+++ b/apps/web/src/components/RefinePromptControl.jsx
@@ -1,18 +1,66 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Icon } from "./Icons.jsx";
+
+// Humanize a byte count to a "7.2 GB" label; null when the size is unknown.
+function formatGb(bytes) {
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return null;
+  }
+  return `${(bytes / 1e9).toFixed(1)} GB`;
+}
+
+// Detect the "refinement model isn't provisioned" failure (sc-5605) so we can offer a
+// one-click download instead of a raw worker error. The native worker resolves an
+// already-cached snapshot and fast-fails with "…snapshot is not cached…" when the model
+// is absent (the retired Python path auto-downloaded). Prefer the catalog install state
+// when the entry is supplied; fall back to the worker message otherwise.
+function isModelMissing(refineModel, errorMessage) {
+  if (refineModel?.installState) {
+    return refineModel.installState === "missing";
+  }
+  return /not cached|not installed|snapshot is not/i.test(errorMessage ?? "");
+}
 
 // "Refine my prompt" affordance shared by Image and Video Studio (sc-2041).
 // Sends the current prompt + the selected model's guide to the refinement worker
 // (via the context `refinePrompt`), then shows the rewrite for review. The
 // original prompt is never changed until the user clicks Apply.
-export function RefinePromptControl({ prompt, guidePath, modelId, workflow, refinePrompt, onApply }) {
+//
+// When the refinement model isn't provisioned, the worker fails fast; instead of a
+// raw error we surface a download affordance (sc-5605). `refineModel` is the catalog
+// entry for the refinement LLM (PROMPT_REFINE_MODEL_ID) and `onDownloadRefineModel`
+// enqueues its ModelDownload job; both are optional so older callers still work.
+export function RefinePromptControl({
+  prompt,
+  guidePath,
+  modelId,
+  workflow,
+  refinePrompt,
+  onApply,
+  refineModel,
+  onDownloadRefineModel,
+}) {
   const [status, setStatus] = useState("idle"); // idle | loading | review | error
   const [refined, setRefined] = useState("");
   const [error, setError] = useState("");
+  const [downloadRequested, setDownloadRequested] = useState(false);
 
   const trimmed = (prompt ?? "").trim();
   const busy = status === "loading";
   const disabled = busy || !trimmed || typeof refinePrompt !== "function";
+
+  const modelMissing = status === "error" && isModelMissing(refineModel, error);
+  const installState = refineModel?.installState;
+
+  // When the refinement model finishes downloading (a catalog refresh flips its
+  // installState to "installed"), clear the missing-model error so the user can retry.
+  useEffect(() => {
+    if (installState === "installed" && downloadRequested) {
+      setDownloadRequested(false);
+      setStatus((current) => (current === "error" ? "idle" : current));
+      setError((current) => (current ? "" : current));
+    }
+  }, [installState, downloadRequested]);
 
   async function handleRefine() {
     setStatus("loading");
@@ -38,13 +86,53 @@ export function RefinePromptControl({ prompt, guidePath, modelId, workflow, refi
     }
   }
 
+  async function handleDownloadModel() {
+    if (typeof onDownloadRefineModel !== "function") return;
+    try {
+      // The download enqueuer resolves to the job, or null when it failed (it surfaces
+      // its own error). Only switch to the "downloading" note on a real job.
+      const job = await onDownloadRefineModel();
+      if (job) {
+        setDownloadRequested(true);
+      }
+    } catch (err) {
+      // Surface an unexpected enqueue failure inline; the Models screen owns progress.
+      setError(err?.message || "Could not start the refinement model download.");
+    }
+  }
+
+  const sizeLabel = formatGb(refineModel?.downloadSizeBytes);
+  const modelName = refineModel?.name || "Prompt Refiner";
+
   return (
     <div className="refine-control">
       <button className="hero-link refine-button" disabled={disabled} onClick={handleRefine} type="button">
         <Icon.Wand size={14} /> {busy ? "Refining…" : "Refine my prompt"}
       </button>
 
-      {status === "error" ? (
+      {status === "error" && modelMissing ? (
+        <div className="refine-missing-model" role="alert">
+          {downloadRequested ? (
+            <p className="refine-error">
+              Downloading the prompt refinement model… track progress on the Models screen, then try Refine
+              again.
+            </p>
+          ) : (
+            <>
+              <p className="refine-error">
+                The prompt refinement model{sizeLabel ? ` (${sizeLabel})` : ""} isn’t installed yet.
+              </p>
+              {typeof onDownloadRefineModel === "function" ? (
+                <button className="secondary-action" onClick={handleDownloadModel} type="button">
+                  Download refinement model
+                </button>
+              ) : (
+                <p className="refine-error">Open the Models screen to download “{modelName}”.</p>
+              )}
+            </>
+          )}
+        </div>
+      ) : status === "error" ? (
         <p className="refine-error" role="alert">
           {error}
         </p>

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -16,6 +16,12 @@ export const INTERLEAVE_RESOLUTION_OPTIONS = [
 ];
 export const DEFAULT_INTERLEAVE_RESOLUTION = "2048x1152";
 
+// Catalog id of the prompt-refinement LLM (sc-5605, builtin.models.jsonc). The native
+// worker resolves the model by repo string, not this id; the web uses it to look up the
+// catalog entry's install state and to enqueue its ModelDownload job when "Refine my
+// prompt" fails because the model isn't provisioned.
+export const PROMPT_REFINE_MODEL_ID = "prompt_refine_llama_3_2_3b";
+
 // Default interleave system prompt (the think/no-think protocol). Prefilled in
 // Document Studio; the worker falls back to this same text when the field is blank.
 // Keep in sync with apps/worker/scene_worker/image_adapters.py::_INTERLEAVE_SYSTEM_MESSAGE.

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -83,6 +83,7 @@ import {
   useGenerationStudio,
 } from "./generationStudio.jsx";
 import { useAppContext } from "../context/AppContext.js";
+import { PROMPT_REFINE_MODEL_ID } from "../constants.js";
 import {
   DEFAULT_MAC_CAPABILITIES,
   macAvailableModels,
@@ -220,10 +221,12 @@ export function ImageStudio() {
     createImageJob,
     createPreset,
     refinePrompt,
+    createModelDownloadJob,
     deleteAsset,
     purgeAsset,
     gpuOptions,
     imageModels,
+    models = [],
     importAsset,
     latestImageAssets,
     recentImageAssets,
@@ -241,6 +244,13 @@ export function ImageStudio() {
     updateAssetStatus,
     macCapabilities = DEFAULT_MAC_CAPABILITIES,
   } = useAppContext();
+  // Prompt-refinement model catalog entry (sc-5605) — drives the "download the
+  // refinement model" affordance in RefinePromptControl when Refine fails because the
+  // model isn't provisioned on the native worker.
+  const refineModel = useMemo(
+    () => models.find((entry) => entry.id === PROMPT_REFINE_MODEL_ID),
+    [models],
+  );
   // Recent Assets list (sc-2088). When the new context value is available, use
   // the bounded 20-most-recent list; fall back to the legacy single-generation
   // list for test contexts that haven't migrated. The existing useGenerationStudio
@@ -1081,6 +1091,8 @@ export function ImageStudio() {
             onApply={setPromptFromUser}
             prompt={prompt}
             refinePrompt={refinePrompt}
+            refineModel={refineModel}
+            onDownloadRefineModel={refineModel ? () => createModelDownloadJob(refineModel) : undefined}
             workflow="image"
           />
 

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -81,6 +81,7 @@ import {
 } from "./generationStudio.jsx";
 import { ReplacePersonPanel, findReplacementModel } from "./ReplacePersonPanel.jsx";
 import { useAppContext } from "../context/AppContext.js";
+import { PROMPT_REFINE_MODEL_ID } from "../constants.js";
 import {
   DEFAULT_MAC_CAPABILITIES,
   macAvailableModels,
@@ -118,6 +119,7 @@ export function VideoStudio() {
     createVideoUpscaleJob,
     createPreset,
     refinePrompt,
+    createModelDownloadJob,
     deleteAsset,
     purgeAsset,
     gpuOptions,
@@ -141,8 +143,16 @@ export function VideoStudio() {
     setRequestedGpu,
     updateAssetStatus,
     videoModels,
+    models = [],
     macCapabilities = DEFAULT_MAC_CAPABILITIES,
   } = useAppContext();
+  // Prompt-refinement model catalog entry (sc-5605) — drives the "download the
+  // refinement model" affordance in RefinePromptControl when Refine fails because the
+  // model isn't provisioned on the native worker.
+  const refineModel = useMemo(
+    () => models.find((entry) => entry.id === PROMPT_REFINE_MODEL_ID),
+    [models],
+  );
   // Recent Assets (sc-2089) — 20 most recent video assets in the active
   // project. Falls back to the legacy single-generation list for test
   // contexts that haven't migrated.
@@ -884,6 +894,8 @@ export function VideoStudio() {
               onApply={setPrompt}
               prompt={prompt}
               refinePrompt={refinePrompt}
+              refineModel={refineModel}
+              onDownloadRefineModel={refineModel ? () => createModelDownloadJob(refineModel) : undefined}
               workflow="video"
             />
           )}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1426,6 +1426,14 @@ label {
   color: var(--danger, #d14343);
 }
 
+/* Missing prompt-refinement model affordance (sc-5605): the inline "download the
+   refinement model" prompt shown when Refine fails because the model isn't provisioned. */
+.refine-missing-model {
+  display: grid;
+  gap: 8px;
+  justify-items: start;
+}
+
 .refine-review {
   display: grid;
   gap: 8px;

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2555,6 +2555,60 @@
           ]
         }
       }
+    },
+    {
+      // Prompt-refinement LLM (sc-5605). The native worker (`prompt_refine_jobs.rs`)
+      // refines a user's prompt with a small in-process Llama-3.2-3B instruction model
+      // through the gen-core `TextLlm` contract — MLX on macOS (sc-5552) and candle on
+      // the Windows/CUDA build (sc-5525). Unlike the retired Python `PromptRefiner`
+      // (`from_pretrained` auto-downloaded on first use), the native path only *resolves*
+      // an already-cached snapshot via `huggingface_snapshot_dir`, so the model has to be
+      // a provisionable catalog artifact. Cataloging it here lets Model Manager download
+      // it into the HF cache the worker reads from; the worker still references it by repo
+      // string (`DEFAULT_REFINE_MODEL`), not by this id.
+      //
+      // Stock repo, pulled as-is: it is a standard transformers safetensors checkpoint —
+      // NOT MLX-converted and NOT requiring conversion (the mlx-gen-prompt-refine provider
+      // reads the stock config/safetensors/tokenizer directly; mlx-gen #457 validated
+      // against this exact repo), so the epic-5594 re-host pattern (conversion-required
+      // models) does not apply. `files: []` pulls the repo's own LICENSE.txt + USE_POLICY
+      // (Llama community license) alongside the weights.
+      "id": "prompt_refine_llama_3_2_3b",
+      "name": "Prompt Refiner (Llama-3.2-3B)",
+      "family": "prompt-refine",
+      "type": "utility",
+      "adapter": "prompt-refine",
+      "capabilities": [],
+      "downloads": [
+        {
+          "provider": "huggingface",
+          "repo": "huihui-ai/Llama-3.2-3B-Instruct-abliterated",
+          "files": [],
+          "estimatedSizeBytes": 7222715642
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/huihui-ai/Llama-3.2-3B-Instruct-abliterated"
+      },
+      "defaults": {},
+      "limits": {},
+      "loraCompatibility": {
+        "families": [],
+        "types": []
+      },
+      "ui": {
+        "label": "Prompt Refiner (Llama-3.2-3B)",
+        "description": "Optional small instruction LLM used by the \"Refine my prompt\" control to rewrite prompts to follow the selected model's guide. Runs in-process on the native worker (MLX on macOS, candle on Windows/CUDA).",
+        "recommendedFor": ["prompt_refine"],
+        "promptGuide": {
+          "title": "Prompt Refiner Guide",
+          "path": "/prompt-guides/prompt-refine.md",
+          "sources": [
+            { "label": "huihui-ai Llama-3.2-3B-Instruct-abliterated model card", "url": "https://huggingface.co/huihui-ai/Llama-3.2-3B-Instruct-abliterated" },
+            { "label": "Meta Llama-3.2-3B-Instruct", "url": "https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct" }
+          ]
+        }
+      }
     }
   ]
 }

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -375,11 +375,14 @@ string_enum! {
         // jobs_store::worker_supports_job and apps/worker/scene_worker/runtime.py.
         LoraTrainExecute => "lora_train_execute",
         // Prompt refinement (LLM rewrite of a user prompt) by a small in-process instruction LLM
-        // (Llama-3.2-3B-Instruct). The Python worker advertises it via the torch `PromptRefiner` (the
-        // Mac + default-installer fallback); the Windows/CUDA candle worker advertises it via the
-        // native `TextLlm` provider (`gen_core::load_textllm`, zero torch — sc-5525), derived in
-        // engines::registry_capabilities when `backend_candle_enabled`. Routed by capability match.
-        // See apps/worker/scene_worker/runtime.py and crates/sceneworks-worker/src/prompt_refine_jobs.rs.
+        // (Llama-3.2-3B-Instruct). Advertised via the native `TextLlm` provider
+        // (`gen_core::load_textllm`, zero torch), derived in engines::registry_capabilities: MLX on
+        // macOS (sc-5552) and candle on the Windows/CUDA build when `backend_candle_enabled`
+        // (sc-5525). The torch `PromptRefiner` remains only as the fallback on platforms with neither
+        // native provider (e.g. the candle-less Desktop installer / Linux). The model is provisioned
+        // from the catalog (`prompt_refine_llama_3_2_3b`, sc-5605) into the HF cache the worker
+        // resolves; the native path does not auto-download. Routed by capability match. See
+        // apps/worker/scene_worker/runtime.py and crates/sceneworks-worker/src/prompt_refine_jobs.rs.
         PromptRefine => "prompt_refine",
     }
 }

--- a/docs/sc-5525/prompt-refine-candle-cutover.md
+++ b/docs/sc-5525/prompt-refine-candle-cutover.md
@@ -46,8 +46,12 @@ Build with **VS2022 BuildTools MSVC 14.44** (CUDA 12.9 rejects VS18/14.51), `CUD
 ### Prerequisites
 - Worker built `--features backend-candle` (MSVC 14.44 / CUDA 12.9) and deployed.
 - `SCENEWORKS_BACKEND_CANDLE_ENABLED=1` in the worker environment.
-- The refine model present in the HF cache (download via Model Manager / Settings):
-  `huihui-ai/Llama-3.2-3B-Instruct-abliterated`.
+- The refine model present in the HF cache. It is now a catalog artifact —
+  `prompt_refine_llama_3_2_3b` in `config/manifests/builtin.models.jsonc` (sc-5605) —
+  so download it from the **Models** screen (or it is offered inline when "Refine my
+  prompt" runs before the model is provisioned). The native path only *resolves* an
+  already-cached snapshot (`huggingface_snapshot_dir`); it does not auto-download like
+  the retired Python `PromptRefiner`. Repo: `huihui-ai/Llama-3.2-3B-Instruct-abliterated`.
 - No co-resident Python worker also advertising `prompt_refine` (else routing may pick either —
   preferring the candle worker is a future routing refinement; see below).
 


### PR DESCRIPTION
Closes the provisioning gap surfaced while closing **sc-5552**: after the native `prompt_refine` cutover (candle sc-5525 + MLX sc-5552), the worker resolves an already-cached HF snapshot via `huggingface_snapshot_dir` and does **not** auto-download like the retired Python `PromptRefiner`. `huihui-ai/Llama-3.2-3B-Instruct-abliterated` wasn't a catalog artifact, so on a fresh install Refine failed with `prompt-refine model snapshot is not cached`. Shared by both native backends (macOS MLX + Windows candle). Mirrors **sc-5447** (SCAIL-2 catalog/manifest + download/readiness).

## Changes
- **`config/manifests/builtin.models.jsonc`** — new `prompt_refine_llama_3_2_3b` entry (`type: "utility"`, mirrors the `real_esrgan`/`aura_sr_v2` upscaler pattern: `capabilities: []`, `${HF_CACHE}` path). The existing `ModelDownload` job runs `hf download --cache-dir <hub_cache>` into the HF cache the worker reads from; catalog `installState` derives from HF-cache health. **Stock repo pulled as-is** — it's a standard transformers safetensors checkpoint (no MLX conversion; mlx-gen #457 validated against this exact repo), so epic-5594's re-host pattern (conversion-required models) does not apply. `files: []` (≈7.2 GB) also pulls the repo's own Llama `LICENSE.txt` + `USE_POLICY.md`.
- **Refine UX** (`RefinePromptControl.jsx` + `ImageStudio.jsx`/`VideoStudio.jsx` + `PROMPT_REFINE_MODEL_ID`) — on a refine failure where the refine model's catalog `installState === "missing"`, surface a one-click **"Download refinement model (~7.2 GB)"** affordance (enqueues the existing `ModelDownload` job; clears once the catalog refresh flips `installState`) instead of the raw worker error. Failure-driven, so torch platforms (which auto-download) aren't nagged.
- **`crates/sceneworks-core/src/contracts.rs`** — refresh the now-stale `PromptRefine` capability comment (Mac is native MLX now, not the torch `PromptRefiner` fallback).
- **Docs** — `docs/sc-5525/prompt-refine-candle-cutover.md` "download via Model Manager" assumption is now actually wired; new `apps/web/public/prompt-guides/prompt-refine.md`.

## Tests / validation
- `node scripts/check-scaffold.mjs` ✅ (manifest schema + prompt-guide existence)
- web: `eslint src` 0 errors; **419/419 vitest** (incl. 2 new `RefinePromptControl` CTA cases)
- rust: `fmt --check` clean; new `builtin_manifest_registers_the_prompt_refine_model` guard (entry present, repo == worker `DEFAULT_REFINE_MODEL`, `${HF_CACHE}` path); `clippy --all-targets -D warnings` clean
- **Live** `GET /api/v1/models` against the edited manifest: model cached → `installState: installed`, `installedPath` == the worker's snapshot dir, `downloadSizeBytes: 7222715642`; empty HF cache → `installState: missing` + `downloadable: true`.

## Remaining
Full hardware e2e (fresh state → download via the desktop app → worker on-guide rewrite) is the final acceptance step — the engine + worker refine path are already real-weights-proven (mlx-gen #457 + sc-5552); this PR closes the provisioning + UX gap. **Not auto-merging** — leaving the merge to Michael.

## Follow-up (not in scope)
JoyCaption (`fancyfeast/llama-joycaption-beta-one-hf-llava`, native captioning during LoRA training) has the identical root cause (same `resolve_app_managed_model_dir`, also absent from the catalog). Filing a separate story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)