### PR TITLE
SceneWorks: SCAIL-2 as the replace_person backend (sc-5452)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2444,8 +2444,10 @@
     // Distributed the SceneWorks/*-mlx turnkey way: the converted bf16 snapshot is
     // published as `SceneWorks/scail2-mlx`, downloaded on first use (engine quantizes
     // Q4 at load). This entry covers the standalone `animate_character` mode (sc-5447 /
-    // sc-5448). Cross-identity `replace_person` is the SAME engine with replace_flag=true,
-    // wired under sc-5452; LoRA refinement under sc-5451 — not declared until wired.
+    // sc-5448) AND cross-identity `replace_person` (sc-5452 — the SAME engine with
+    // replace_flag=true, offered as the higher-quality backend behind the existing
+    // person-track replacement pipeline). LoRA refinement under sc-5451 — not declared
+    // until wired.
     {
       "id": "scail2_14b",
       "name": "SCAIL-2",
@@ -2453,7 +2455,8 @@
       "type": "video",
       "adapter": "scail2",
       "capabilities": [
-        "animate_character"
+        "animate_character",
+        "replace_person"
       ],
       "downloads": [
         {

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -2012,13 +2012,14 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
             Some("epic 3040"),
         )),
 
-        // replace_person → native Wan-VACE is MLX-eligible on the replace-capable models
-        // (handled by the early `job_is_any_mlx_eligible` Ok above, sc-3521). This arm is only
-        // reached for a replace_person job on a model with no MLX video engine — that stays torch.
+        // replace_person → native Wan-VACE (the replace-capable models) or native SCAIL-2
+        // (scail2_14b, sc-5452) is MLX-eligible (handled by the early `job_is_any_mlx_eligible` Ok
+        // above). This arm is only reached for a replace_person job on a model with no MLX video
+        // engine — that stays torch.
         JobType::PersonReplace => Err(UnsupportedReason::new(
             model,
             "replace_person",
-            "person replacement runs on native Wan-VACE only for the replace-capable MLX video models; this model has no MLX video engine, so it stays on the Python torch path.",
+            "person replacement runs on native Wan-VACE (the replace-capable MLX video models) or native SCAIL-2 (scail2_14b); this model has no MLX video engine, so it stays on the Python torch path.",
             Some("epic 3040"),
         )),
 
@@ -3704,13 +3705,14 @@ fn video_mode_is_mlx_eligible(model: &str, mode: &str) -> bool {
                 | "ads2v"
         );
     }
-    // SCAIL-2 (epic 5439 / sc-5448) is a Wan2.1-14B I2V character-animation engine: a reference
-    // character image + a driving video → an animated clip. It serves the standalone
-    // `animate_character` mode (the worker paints the color-coded masks from native SAM3). It has no
-    // classic text/image-to-video; cross-identity `replace_person` reuses the same engine but is wired
-    // separately (sc-5452), so it is not admitted here yet.
+    // SCAIL-2 (epic 5439) is a Wan2.1-14B I2V character-animation engine: a reference character
+    // image + a driving video → an animated clip. It serves the standalone `animate_character` mode
+    // (sc-5448, the worker paints the color-coded masks from native SAM3) AND cross-identity
+    // `replace_person` (sc-5452, the integrated backend behind the YOLO11 → ByteTrack → SAM3
+    // person-track pipeline). Both run the same engine; `replace_person` flips the engine
+    // `replace_flag`. It has no classic text/image-to-video.
     if model == "scail2_14b" {
-        return mode == "animate_character";
+        return matches!(mode, "animate_character" | "replace_person");
     }
     match mode {
         "text_to_video" | "image_to_video" => true,
@@ -5251,20 +5253,21 @@ mod mlx_routing_tests {
                 );
             }
         }
-        // SCAIL-2 (sc-5448) serves ONLY the standalone character-animation mode (the worker paints
-        // its masks from native SAM3). No text/image-to-video; cross-identity replace_person is wired
-        // separately (sc-5452), so it is not admitted here yet.
-        assert!(
-            video_mode_is_mlx_eligible("scail2_14b", "animate_character"),
-            "scail2 should serve animate_character"
-        );
+        // SCAIL-2 serves the standalone character-animation mode (sc-5448, the worker paints its
+        // masks from native SAM3) AND cross-identity replace_person (sc-5452, the integrated backend
+        // behind the person-track pipeline). No text/image-to-video.
+        for mode in ["animate_character", "replace_person"] {
+            assert!(
+                video_mode_is_mlx_eligible("scail2_14b", mode),
+                "scail2 should serve {mode}"
+            );
+        }
         for mode in [
             "text_to_video",
             "image_to_video",
             "first_last_frame",
             "extend_clip",
             "video_bridge",
-            "replace_person",
             "video_to_video",
             "nonsense",
         ] {

--- a/crates/sceneworks-core/src/lora_family.rs
+++ b/crates/sceneworks-core/src/lora_family.rs
@@ -299,13 +299,14 @@ pub fn model_capabilities_for_type_and_family(model_type: &str, family: &str) ->
         // SCAIL-2 (epic 5439) is a Wan2.1-14B I2V end-to-end character-animation
         // engine: a reference character image + a driving video → an animated clip.
         // Its engine descriptor is `Modality::Video` with conditioning
-        // `[Reference, Mask, MultiReference, ControlClip]`. The standalone
-        // `animate_character` mode is wired in sc-5448 (the worker paints the
-        // color-coded masks from native SAM3). Cross-identity `replace_person` is the
-        // same engine with replace_flag=true (sc-5452); LoRA is sc-5451 — neither is
-        // declared until wired. Multi-character (paired ref+mask) awaits the engine
-        // request-contract extension.
-        ("video", "scail2") => vec!["animate_character"],
+        // `[Reference, Mask, MultiReference, ControlClip]`. It serves the standalone
+        // `animate_character` mode (sc-5448, the worker paints the color-coded masks
+        // from native SAM3) and cross-identity `replace_person` (sc-5452, the same
+        // engine with replace_flag=true, as the higher-quality backend behind the
+        // existing person-track replacement pipeline). LoRA is sc-5451 — not declared
+        // until wired. Multi-character (paired ref+mask) awaits the engine
+        // request-contract extension (sc-5583).
+        ("video", "scail2") => vec!["animate_character", "replace_person"],
         _ => Vec::new(),
     }
 }

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -2454,9 +2454,10 @@ fn model_mac_support_feature_flags_mirror_routing_without_over_gating() {
         bernini.features.video_modes.get("replace_person"),
         Some(&false)
     );
-    // SCAIL-2 (epic 5439) is MLX-routed for the standalone character-animation mode only (sc-5448);
-    // the worker paints its masks from native SAM3. No text/image-to-video; cross-identity
-    // replace_person reuses the same engine but is wired separately (sc-5452).
+    // SCAIL-2 (epic 5439) is MLX-routed for the standalone character-animation mode (sc-5448) AND
+    // cross-identity replace_person (sc-5452 — the same engine, replace_flag=true, as the integrated
+    // backend behind the person-track pipeline); the worker paints its masks from native SAM3. No
+    // text/image-to-video.
     let scail2 = model_mac_support("scail2_14b", "video");
     assert!(scail2.supported, "scail2 should be MLX-supported");
     assert!(scail2.reason.is_none());
@@ -2465,15 +2466,15 @@ fn model_mac_support_feature_flags_mirror_routing_without_over_gating() {
         Some(&true)
     );
     assert_eq!(
+        scail2.features.video_modes.get("replace_person"),
+        Some(&true)
+    );
+    assert_eq!(
         scail2.features.video_modes.get("text_to_video"),
         Some(&false)
     );
     assert_eq!(
         scail2.features.video_modes.get("image_to_video"),
-        Some(&false)
-    );
-    assert_eq!(
-        scail2.features.video_modes.get("replace_person"),
         Some(&false)
     );
 }

--- a/crates/sceneworks-worker/src/scail2_masks.rs
+++ b/crates/sceneworks-worker/src/scail2_masks.rs
@@ -14,6 +14,7 @@
 //! **black**, used by sc-5452).
 
 use gen_core::Image;
+use image::RgbImage;
 
 use crate::person_segment_sam3::AllPersonMasks;
 use crate::{WorkerError, WorkerResult};
@@ -123,6 +124,41 @@ pub(crate) fn paint_reference_mask(masks: &AllPersonMasks, bg: [u8; 3]) -> Worke
     })
 }
 
+/// Convert the **existing** person-track binary masks into SCAIL-2's color-coded driving masks for
+/// the integrated `replace_person` path (sc-5452). Each input is one grayscale
+/// `image::RgbImage` per driving frame as produced by `person_replace::person_track_masks` (the
+/// YOLO11 → ByteTrack → SAM3 track, corrections applied; white = the tracked person to regenerate).
+/// The tracked person is painted blue — person 0, so it pairs with the blue reference identity — and
+/// everything else is the solid `bg`. Cross-identity replacement keeps the **driving** clip's world,
+/// so the worker passes [`BG_WHITE`]. The grayscale mask is binarized at the engine's 0.5 midpoint
+/// (red channel ≥ 128 = the person). One color mask per frame, same order and pixel size as input.
+///
+/// This is the integrated counterpart to [`paint_driving_masks`]: that one paints *several* people
+/// from a fresh native-SAM3 pass (the standalone `animate_character` flow); this one paints the
+/// *single* already-tracked person SceneWorks selected for replacement.
+pub(crate) fn paint_track_driving_masks(binary: &[RgbImage], bg: [u8; 3]) -> Vec<Image> {
+    binary
+        .iter()
+        .map(|mask| {
+            let (w, h) = (mask.width() as usize, mask.height() as usize);
+            let mut px = filled(w, h, bg);
+            for (i, pixel) in mask.pixels().enumerate() {
+                if pixel.0[0] >= 128 {
+                    let o = i * 3;
+                    if o + 3 <= px.len() {
+                        px[o..o + 3].copy_from_slice(&PALETTE[0]);
+                    }
+                }
+            }
+            Image {
+                width: mask.width(),
+                height: mask.height(),
+                pixels: px,
+            }
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -212,5 +248,38 @@ mod tests {
             height: 1,
         };
         assert!(paint_reference_mask(&masks, BG_WHITE).is_err());
+    }
+
+    #[test]
+    fn track_driving_paints_tracked_person_blue_on_bg() {
+        // A 3-px grayscale track mask: white (tracked person) at px1, black (bg) at px0/px2; one
+        // intermediate value (200) at... only px1 here. Replacement uses a white background.
+        let mask = RgbImage::from_fn(3, 1, |x, _| {
+            if x == 1 {
+                image::Rgb([255, 255, 255])
+            } else {
+                image::Rgb([0, 0, 0])
+            }
+        });
+        let out = paint_track_driving_masks(std::slice::from_ref(&mask), BG_WHITE);
+        assert_eq!(out.len(), 1);
+        assert_eq!(&out[0].pixels[0..3], &BG_WHITE, "bg pixel stays white");
+        assert_eq!(&out[0].pixels[3..6], &PALETTE[0], "tracked person → blue");
+        assert_eq!(&out[0].pixels[6..9], &BG_WHITE, "bg pixel stays white");
+    }
+
+    #[test]
+    fn track_driving_binarizes_at_midpoint() {
+        // Bilinear-resize artifacts produce intermediate grays; ≥128 is the person, <128 is bg.
+        let mask = RgbImage::from_fn(2, 1, |x, _| {
+            if x == 0 {
+                image::Rgb([127, 127, 127])
+            } else {
+                image::Rgb([128, 128, 128])
+            }
+        });
+        let out = paint_track_driving_masks(std::slice::from_ref(&mask), BG_WHITE);
+        assert_eq!(&out[0].pixels[0..3], &BG_WHITE, "127 < 128 → bg");
+        assert_eq!(&out[0].pixels[3..6], &PALETTE[0], "128 ≥ 128 → person");
     }
 }

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -186,14 +186,41 @@ pub(crate) async fn run_video_generate_job(
     // `replacementStatus` the asset sidecar folds in (project_store::build_video_sidecar_parts).
     #[cfg(target_os = "macos")]
     let (decoded, adapter, raw_settings, replacement_status) = if request.mode == "replace_person" {
-        let (decoded, status) =
-            generate_wan_vace(api, settings, job, &request, &project_path, backend).await?;
-        (
-            decoded,
-            WAN_VACE_ADAPTER,
-            wan_vace_raw_settings(&request),
-            Some(status),
-        )
+        // sc-5452: SCAIL-2 is a higher-quality cross-identity replacement backend behind the same
+        // YOLO11 → ByteTrack → SAM3 person-track pipeline. A `scail2_14b` person-replace job routes
+        // to SCAIL-2 (the tracked person's masks + the character reference → the engine's
+        // replacement conditioning, `replace_flag = true`); every other replace-capable model keeps
+        // native Wan-VACE (sc-3521). Routed by model id, not weight availability: like the Wan-VACE
+        // path, `generate_scail2_replace` resolves-or-errors loudly if the snapshot is unprovisioned
+        // (a person-replace must never silently degrade to a different backend or the stub). Both
+        // report the honest `replacementStatus` the asset sidecar folds in.
+        if let Some(engine_id) = scail2_engine_id(&request.model) {
+            let (decoded, status) = generate_scail2_replace(
+                api,
+                settings,
+                job,
+                &request,
+                &project_path,
+                engine_id,
+                backend,
+            )
+            .await?;
+            (
+                decoded,
+                SCAIL2_ADAPTER,
+                scail2_raw_settings(&request),
+                Some(status),
+            )
+        } else {
+            let (decoded, status) =
+                generate_wan_vace(api, settings, job, &request, &project_path, backend).await?;
+            (
+                decoded,
+                WAN_VACE_ADAPTER,
+                wan_vace_raw_settings(&request),
+                Some(status),
+            )
+        }
     } else if matches!(request.mode.as_str(), "extend_clip" | "video_bridge")
         && wan_engine_id(&request.model) == Some("wan2_2_ti2v_5b")
         && wan_available(&request, settings)
@@ -3281,6 +3308,166 @@ async fn generate_scail2(
     generate_video(api, settings, job, backend, input).await
 }
 
+/// Resolve a `replace_person` request into SCAIL-2 cross-identity replacement conditioning (sc-5452,
+/// the **integrated** surface). Unlike the standalone `animate_character` path
+/// ([`resolve_scail2_conditioning`], which segments a fresh driving clip), this reuses the masks
+/// SceneWorks already computed: the saved person track (native YOLO11 → ByteTrack → SAM3,
+/// corrections applied) supplies the per-frame driving masks, and the character's approved reference
+/// image is the identity. Driving frames come from the source clip exactly as the Wan-VACE backend
+/// loads them ([`load_source_video_frames`]), so the resampled track masks stay frame-aligned 1:1.
+/// Replacement keeps the **driving** clip's world (driving mask bg white, reference mask bg black);
+/// `video_mode = "replacement"` flips the engine `replace_flag`. SCAIL-2 is a full-character model —
+/// it replaces the whole tracked person, so the face_only/full_person `replacementMode` knob and
+/// `maskingStrength` are inert (the engine reads only the color masks). Multi-character (the extra
+/// references) awaits the engine request-contract extension (sc-5583), so only the first reference
+/// is used. Returns the conditioning plus the honest `replacementStatus` for the asset sidecar.
+#[cfg(target_os = "macos")]
+async fn resolve_scail2_replace_conditioning(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &VideoRequest,
+    project_path: &Path,
+) -> WorkerResult<(Vec<Conditioning>, Value)> {
+    let track_id = request.person_track_id.as_deref().ok_or_else(|| {
+        WorkerError::InvalidPayload(
+            "replace_person requires a person track (personTrackId).".to_owned(),
+        )
+    })?;
+    let track = ProjectStore::new(settings.data_dir.clone(), "worker")
+        .get_person_track(&request.project_id, track_id)
+        .map_err(|error| {
+            WorkerError::InvalidPayload(format!("person track {track_id}: {error}"))
+        })?;
+
+    // Driving frames + their per-frame binary person masks — the same source the Wan-VACE backend
+    // consumes, loaded identically so the resampled masks align 1:1 with the frames.
+    let frame_count = wan_frame_count(request.raw_frame_count()) as usize;
+    let driving =
+        load_source_video_frames(api, settings, job, request, project_path, frame_count).await?;
+    let frame_total = driving.len();
+    let (binary_masks, mask_mode) = crate::person_replace::person_track_masks(
+        project_path,
+        &track,
+        request.width,
+        request.height,
+        frame_total,
+    )?;
+    // The tracked person → blue (person 0); replacement keeps the driving's world → white bg.
+    let driving_masks = crate::scail2_masks::paint_track_driving_masks(
+        &binary_masks,
+        crate::scail2_masks::BG_WHITE,
+    );
+
+    // The character identity: the first approved reference image (multi-ref = sc-5583).
+    let references = resolve_character_references(settings, request, project_path)?;
+    let reference_count = references.len();
+    let reference = references.into_iter().next().ok_or_else(|| {
+        WorkerError::InvalidPayload(
+            "Replace Person requires at least one approved character reference image.".to_owned(),
+        )
+    })?;
+
+    // The reference color mask: a fresh native-SAM3 pass on the reference image → the primary person
+    // painted blue on a black background (replacement discards the reference's surrounding world).
+    let client = reqwest::Client::new();
+    let context = crate::downloads::DownloadContext {
+        api,
+        client: &client,
+        settings,
+        job_id: &job.id,
+        cancel_message: "SCAIL-2 canceled while fetching the SAM3 segmenter weights.",
+        fresh_download: false,
+    };
+    let (sam_model, sam_tokenizer) =
+        crate::person_segment_sam3::ensure_segmenter_weights(settings, &context).await?;
+    let ref_rgb =
+        image::RgbImage::from_raw(reference.width, reference.height, reference.pixels.clone())
+            .ok_or_else(|| {
+                WorkerError::InvalidPayload("scail2 reference image is malformed".into())
+            })?;
+    let ref_mask = tokio::task::spawn_blocking(move || -> WorkerResult<Image> {
+        let masks = crate::person_segment_sam3::segment_all_persons_in_memory(
+            &sam_model,
+            &sam_tokenizer,
+            std::slice::from_ref(&ref_rgb),
+        )?;
+        crate::scail2_masks::paint_reference_mask(&masks, crate::scail2_masks::BG_BLACK)
+    })
+    .await
+    .map_err(|error| WorkerError::Io(std::io::Error::other(error)))??;
+
+    let conditioning = vec![
+        Conditioning::Reference {
+            image: reference,
+            strength: None,
+        },
+        Conditioning::Mask { image: ref_mask },
+        Conditioning::ControlClip {
+            frames: driving,
+            mask: driving_masks,
+            // masking_strength / start_frame / mode are inert for SCAIL-2 (it reads only the color
+            // masks); carried at neutral defaults for the shared ControlClip contract.
+            masking_strength: 1.0,
+            start_frame: 0,
+            mode: ReplacementMode::default(),
+        },
+    ];
+    // maskingStrength is recorded as 1.0 — SCAIL-2 always does a full-character replacement, so the
+    // Wan-VACE partial-mask knob does not apply.
+    let status = replacement_status_value(
+        &track,
+        track_id,
+        mask_mode,
+        1.0,
+        reference_count,
+        frame_total,
+        SCAIL2_ADAPTER,
+    );
+    Ok((conditioning, status))
+}
+
+/// Real MLX SCAIL-2 cross-identity replacement (epic 5439 / sc-5452): the integrated backend behind
+/// the existing `replace_person` pipeline. Builds the replacement conditioning from the saved person
+/// track + character reference ([`resolve_scail2_replace_conditioning`]) and runs the shared
+/// `generate_video` path with `video_mode = "replacement"` (engine `replace_flag = true`). Returns
+/// the decoded video plus the honest `replacementStatus` (adapter `mlx_scail2`). Mirrors
+/// [`generate_wan_vace`]'s return shape so the dispatch folds the status identically.
+#[cfg(target_os = "macos")]
+async fn generate_scail2_replace(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &VideoRequest,
+    project_path: &Path,
+    engine_id: &'static str,
+    backend: &str,
+) -> WorkerResult<(DecodedVideo, Value)> {
+    let negative_prompt = {
+        let trimmed = request.negative_prompt.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_owned())
+    };
+    let (conditioning, status) =
+        resolve_scail2_replace_conditioning(api, settings, job, request, project_path).await?;
+    let input = VideoGenInput {
+        engine_id,
+        model_dir: resolve_scail2_model_dir(settings)?,
+        quant: resolve_scail2_quant(request),
+        conditioning,
+        prompt: request.prompt.clone(),
+        negative_prompt,
+        width: request.width,
+        height: request.height,
+        frames: wan_frame_count(request.raw_frame_count()),
+        fps: request.fps,
+        seed: resolve_video_seed(request) as u64,
+        video_mode: Some(scail2_engine_video_mode(&request.mode).to_owned()),
+        ..VideoGenInput::default()
+    };
+    let decoded = generate_video(api, settings, job, backend, input).await?;
+    Ok((decoded, status))
+}
+
 // ---------------------------------------------------------------------------
 // Real MLX LTX-2.3 generation (macOS, via mlx-gen-ltx, sc-3035): T2V/I2V with
 // SYNCHRONIZED AUDIO (the 2-stage distilled A/V pipeline; CFG forced 1.0). One
@@ -4484,6 +4671,7 @@ fn replacement_status_value(
     masking_strength: f32,
     reference_count: usize,
     frame_count: usize,
+    adapter: &str,
 ) -> Value {
     let status = track.get("status").and_then(Value::as_object);
     let person_tracking_active = status
@@ -4502,7 +4690,7 @@ fn replacement_status_value(
         "personDetectionActive": true,
         "personTrackingActive": person_tracking_active,
         "replacementActive": true,
-        "replacementAdapter": WAN_VACE_ADAPTER,
+        "replacementAdapter": adapter,
         "maskMode": mask_mode,
         "maskState": mask_state,
         "maskingStrength": masking_strength,
@@ -4606,6 +4794,7 @@ async fn generate_wan_vace(
         masking_strength,
         reference_count,
         frame_total,
+        WAN_VACE_ADAPTER,
     );
     Ok((decoded, status))
 }
@@ -5204,6 +5393,30 @@ mod tests {
         assert_eq!(replacement_mode_from("nonsense"), ReplacementMode::FaceOnly);
     }
 
+    /// SCAIL-2 maps the SceneWorks video mode to the engine `video_mode` task: cross-identity
+    /// `replace_person` → "replacement" (engine flips `replace_flag`), everything else (standalone
+    /// `animate_character`) → "animation" (sc-5448 / sc-5452).
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn scail2_mode_maps_replacement_vs_animation() {
+        assert_eq!(scail2_engine_video_mode("replace_person"), "replacement");
+        assert_eq!(scail2_engine_video_mode("animate_character"), "animation");
+        assert_eq!(scail2_engine_video_mode("text_to_video"), "animation");
+    }
+
+    /// The replacement status records the actual engine adapter, so a SCAIL-2-backed person-replace
+    /// (sc-5452) reports `mlx_scail2` (not the Wan-VACE default).
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn replacement_status_records_scail2_adapter() {
+        let track = json!({ "id": "trk_1", "status": { "maskState": "active" } });
+        let status =
+            replacement_status_value(&track, "trk_1", "segmentation", 1.0, 1, 81, SCAIL2_ADAPTER);
+        assert_eq!(status["replacementAdapter"], json!("mlx_scail2"));
+        assert_eq!(status["replacementActive"], json!(true));
+        assert_eq!(status["controlFrameCount"], json!(81));
+    }
+
     /// The Wan-VACE conditioning is one ControlClip (frames + per-frame mask) followed by one
     /// Reference per character image; mismatched frame/mask counts fail clearly.
     #[cfg(target_os = "macos")]
@@ -5385,7 +5598,15 @@ mod tests {
             "corrections": [ { "frameIndex": 0 }, { "frameIndex": 3 } ]
         });
         // 0.5 is exactly representable as f32 so the JSON widen to f64 is exact.
-        let status = replacement_status_value(&track, "ignored", "segmentation", 0.5, 2, 81);
+        let status = replacement_status_value(
+            &track,
+            "ignored",
+            "segmentation",
+            0.5,
+            2,
+            81,
+            WAN_VACE_ADAPTER,
+        );
         assert_eq!(status["personDetectionActive"], json!(true));
         assert_eq!(status["personTrackingActive"], json!(true));
         assert_eq!(status["replacementActive"], json!(true));


### PR DESCRIPTION
Wires **SCAIL-2** as a higher-quality cross-identity replacement backend behind the existing `replace_person` pipeline (epic 5439, sc-5452 — the *integrated* surface; the standalone `animate_character` surface shipped in sc-5448).

## What it does
A `replace_person` job whose model is `scail2_14b` now routes to the native MLX SCAIL-2 engine (`replace_flag = true`); every other replace-capable model (ltx_2_3 / ltx_2_3_eros / wan_2_2) keeps native Wan-VACE unchanged. **Augments, doesn't replace** — additive and non-breaking.

The bridge reuses the masks SceneWorks already computes: the saved person track (YOLO11 → ByteTrack → SAM3, corrections applied) supplies the per-frame driving masks, painted into SCAIL-2's color convention (the tracked person → blue = person 0; cross-identity replacement keeps the **driving** clip's world → white background). The character's approved reference image is the identity, its color mask painted from a fresh native-SAM3 pass (primary person → blue on a black background). Driving frames load identically to the Wan-VACE path, so the resampled track masks stay frame-aligned 1:1.

## Changes
- **worker** (`video_jobs.rs`): `generate_scail2_replace` + `resolve_scail2_replace_conditioning`; the `replace_person` dispatch routes by model id and fails loudly if the snapshot is unprovisioned (a person-replace must never silently degrade to a different backend or the stub). `replacement_status_value` gains an `adapter` arg so the asset sidecar records `mlx_scail2` vs `mlx_wan_vace` honestly.
- **worker** (`scail2_masks.rs`): `paint_track_driving_masks` converts the binary person-track masks → single-person color driving masks.
- **core** (`jobs_store.rs`): `scail2_14b` admits `replace_person` (eligibility + gap-analysis message). **core** (`lora_family.rs` + `builtin.models.jsonc`): declare the `replace_person` capability.
- **tests**: eligibility, mac-support (`replace_person` → true), and worker unit tests for the mode→task mapping, the adapter in the status, and the track-mask painter.

## Engine facts (verified at the pinned rev `d3ec5e5`)
SCAIL-2's pipeline reads only `ControlClip.frames` + `.mask`; `mode`/`masking_strength`/`start_frame` are inert (a Wan-VACE/LTX concept). `replace_flag = video_mode == "replacement"`. SCAIL-2 is a full-character model, so the face_only/full_person `replacementMode` knob does not change its output.

## Scope / follow-ups (surfaced, not buried)
- The replace-person **UI backend picker** is **sc-5449** — the current `ReplacePersonPanel` auto-selects the first replace-capable model (ltx/wan, which precede scail2 in manifest order), so this PR does not change the current UI default; the SCAIL-2 backend is reachable by a `scail2_14b` job and declared so sc-5449 can build the picker on top.
- The **real-weight detect → track → segment → SCAIL-2 replace e2e smoke** is **sc-5450** (this PR is compile + unit + eligibility + full CI).
- **Multi-character** (paired ref+mask) stays engine-blocked (**sc-5583**).

## Verification
- `cargo check` / `clippy --all-targets` clean (worker + core)
- `cargo fmt --check` clean
- core: 171 lib + 109 jobs_store integration tests pass
- worker: 285 lib tests pass (62 real-weight gated tests ignored)
- gen-core skew gate: single rev `d3ec5e5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)