### PR TITLE
SceneWorks: SCAIL-2 UI — animate_character mode + replacement engine picker (sc-5449)

### DIFF
--- a/apps/web/src/screens/ReplacePersonPanel.jsx
+++ b/apps/web/src/screens/ReplacePersonPanel.jsx
@@ -349,8 +349,18 @@ export function ReplacePersonPanel({
   replacementMode,
   saveTrackCorrections,
   videoAssets,
+  videoModels = [],
+  model,
+  setModel,
   personReadiness = {},
 }) {
+  // The replacement backend = the replace-capable video models. The user picks one here (it drives
+  // the job's `model`); SCAIL-2 (scail2_14b) is the native cross-identity engine, the others inpaint
+  // the masked region via Wan-VACE (sc-5449 / sc-5452).
+  const replacementModels = useMemo(
+    () => videoModels.filter((item) => item.capabilities?.includes("replace_person")),
+    [videoModels],
+  );
   // Default-open: only gate when readiness explicitly reports a backend missing.
   const detectReady = personReadiness?.detect?.ready !== false;
   const trackReady = personReadiness?.track?.ready !== false;
@@ -480,6 +490,29 @@ export function ReplacePersonPanel({
           sourceClip={selectedTrackSourceClip}
           track={selectedTrack}
         />
+      ) : null}
+
+      {replacementModels.length > 1 && setModel ? (
+        <label>
+          Replacement engine
+          <select onChange={(event) => setModel(event.target.value)} value={model}>
+            {replacementModels.map((item) => (
+              <option key={item.id} value={item.id}>
+                {item.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      ) : null}
+
+      {model === "scail2_14b" ? (
+        <div className="guidance-strip">
+          <strong>SCAIL-2 full-character replacement</strong>
+          <span>
+            SCAIL-2 re-renders the whole tracked person from the character reference, so the
+            Replacement mode below (face-only / keep-outfit) does not apply.
+          </span>
+        </div>
       ) : null}
 
       <label>

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -286,6 +286,7 @@ export function VideoStudio() {
     "reference_video_to_video",
     "multi_video_to_video",
     "ads2v",
+    "animate_character",
   ].includes(mode);
   const {
     availablePresets,
@@ -513,6 +514,19 @@ export function VideoStudio() {
     }
   }, [mode, supportsMode, videoModels]);
 
+  // SCAIL-2 character animation (sc-5449): like replace_person, animate_character runs only on the
+  // model that advertises the capability (scail2_14b). Auto-switch to it when the user picks the
+  // mode on a model that can't serve it, so the mode is usable without first hunting for the model.
+  useEffect(() => {
+    if (mode !== "animate_character" || supportsMode) {
+      return;
+    }
+    const animateModel = videoModels.find((item) => item.capabilities?.includes("animate_character"));
+    if (animateModel) {
+      setModel(animateModel.id);
+    }
+  }, [mode, supportsMode, videoModels]);
+
   // When restoring a snapshot, the saved length/fps/quality/resolution/negativePrompt
   // already reflect the user's last state — skip the one preset-default pass that fires
   // as the restored preset resolves so it doesn't overwrite them. "None" applies no
@@ -628,6 +642,10 @@ export function VideoStudio() {
     ["reference_video_to_video", "Reference + Video"],
     ["multi_video_to_video", "Multi-Clip → Video"],
     ["ads2v", "Clip + Ref Video"],
+    // SCAIL-2 character animation (epic 5439 / sc-5449): a reference character image + a driving
+    // video → the character animated with the driving motion. Enabled only on the model whose
+    // capabilities include it (today: scail2_14b); the same per-model gating as the others.
+    ["animate_character", "Animate character"],
   ];
   // Mac UI gating (sc-3486, sc-3773): every video mode is disabled per-model via the selected
   // model's `macSupport.features.videoModes` — FLF on the non-Keyframe Wan MoE engines,
@@ -665,7 +683,9 @@ export function VideoStudio() {
     // Bernini multi-source modes (sc-5425): mv2v needs >=2 clips; ads2v needs a source
     // clip, a reference video, and >=1 reference image.
     (mode === "multi_video_to_video" && sourceClipAssetIds.length >= 2) ||
-    (mode === "ads2v" && sourceClipAssetId && referenceClipAssetId && referenceAssetIds.length > 0);
+    (mode === "ads2v" && sourceClipAssetId && referenceClipAssetId && referenceAssetIds.length > 0) ||
+    // SCAIL-2 character animation (sc-5449): a driving video + a reference character image.
+    (mode === "animate_character" && sourceClipAssetId && referenceAssetIds.length > 0);
   // Don't let Replace Person queue a job the readiness endpoint says no live
   // worker can run — that would sit unclaimable instead of honoring the gate.
   const replaceReady = mode !== "replace_person" || personReadiness?.replace?.ready !== false;
@@ -737,14 +757,22 @@ export function VideoStudio() {
           "video_to_video",
           "reference_video_to_video",
           "ads2v",
+          // SCAIL-2 character animation (sc-5449): the driving video.
+          "animate_character",
         ].includes(mode)
           ? sourceClipAssetId || null
           : null,
         // Bernini multi-source clips (sc-5425) — only mv2v carries the array.
         sourceClipAssetIds: mode === "multi_video_to_video" ? sourceClipAssetIds : [],
         bridgeRightClipAssetId: mode === "video_bridge" ? bridgeRightClipAssetId || null : null,
-        // Bernini subject references (sc-4703 / sc-5425) — the reference-driven modes + ads2v carry them.
-        referenceAssetIds: ["reference_to_video", "reference_video_to_video", "ads2v"].includes(mode)
+        // Bernini subject references (sc-4703 / sc-5425) — the reference-driven modes + ads2v carry
+        // them; SCAIL-2 character animation (sc-5449) carries the reference character image.
+        referenceAssetIds: [
+          "reference_to_video",
+          "reference_video_to_video",
+          "ads2v",
+          "animate_character",
+        ].includes(mode)
           ? referenceAssetIds
           : [],
         // Bernini ads2v reference video (sc-5425).
@@ -1020,6 +1048,30 @@ export function VideoStudio() {
               />
             ) : null}
 
+            {mode === "animate_character" ? (
+              <>
+                <AssetPickerField
+                  assets={videoAssets}
+                  buttonLabel="Select clip"
+                  emptyLabel="No driving video selected"
+                  label="Driving video"
+                  onChange={setSourceClipAssetId}
+                  value={sourceClipAssetId}
+                />
+                {/* One character today; the worker reads the first reference. Multi-reference is
+                    experimental and tracked separately (sc-5583), so this stays a single image. */}
+                <AssetPickerField
+                  assets={imageAssets}
+                  buttonLabel="Select image"
+                  changeLabel="Change character"
+                  emptyLabel="No reference character selected"
+                  label="Reference character"
+                  onChange={(id) => setReferenceAssetIds(id ? [id] : [])}
+                  value={referenceAssetIds[0] ?? ""}
+                />
+              </>
+            ) : null}
+
             {mode === "replace_person" ? (
               <ReplacePersonPanel
                 createPersonDetectionJob={createPersonDetectionJob}
@@ -1041,6 +1093,9 @@ export function VideoStudio() {
                 sourceClipAssetId={sourceClipAssetId}
                 trackName={trackName}
                 videoAssets={videoAssets}
+                videoModels={videoModels}
+                model={model}
+                setModel={setModel}
               />
             ) : null}
           </div>

--- a/apps/web/src/screens/VideoStudio.test.jsx
+++ b/apps/web/src/screens/VideoStudio.test.jsx
@@ -490,3 +490,143 @@ describe("VideoStudio Bernini task modes", () => {
     expect(container.textContent).toContain("does not support this mode");
   });
 });
+
+describe("VideoStudio SCAIL-2 character animation + replacement backend", () => {
+  let container;
+  let root;
+
+  const SCAIL2 = {
+    id: "scail2_14b",
+    name: "SCAIL-2",
+    type: "video",
+    family: "scail2",
+    capabilities: ["animate_character", "replace_person"],
+    defaults: { duration: 5, resolution: "832x480", fps: 16 },
+    limits: { durations: [3, 4, 5], fps: [16], resolutions: ["832x480", "480x832"] },
+    quantization: {},
+    loraCompatibility: {},
+    ui: {},
+  };
+  // A Wan-VACE-style replace-capable model — the default replacement backend SCAIL-2 augments.
+  const WAN = {
+    id: "wan_2_2",
+    name: "Wan 2.2",
+    type: "video",
+    family: "wan-video",
+    capabilities: ["image_to_video", "text_to_video", "replace_person"],
+    defaults: { duration: 5, resolution: "832x480", fps: 16 },
+    limits: { durations: [3, 4, 5], fps: [16], resolutions: ["832x480", "480x832"] },
+    quantization: {},
+    loraCompatibility: {},
+    ui: {},
+  };
+
+  const clip = { id: "vid_src", type: "video", projectId: "project_1", displayName: "Driving Clip" };
+  const character = { id: "img_ref_a", type: "image", projectId: "project_1", displayName: "Character A" };
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <VideoStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  const pickerLabels = () =>
+    [...(container.querySelector(".studio-source-band")?.querySelectorAll(".asset-picker-label") ?? [])].map(
+      (el) => el.textContent,
+    );
+  const modeButton = (label) => buttonWithText(container.querySelector(".mode-control"), label);
+
+  it("shows the driving video + reference character slots for animate_character", async () => {
+    const context = baseContext({ videoModels: [SCAIL2], assets: [clip, character] });
+    await render(context);
+    await click(modeButton("Animate character"));
+
+    expect(pickerLabels()).toEqual(expect.arrayContaining(["Driving video", "Reference character"]));
+  });
+
+  it("submits the driving clip + reference character for animate_character", async () => {
+    const context = baseContext({ videoModels: [SCAIL2], assets: [clip, character] });
+    await render(context);
+    await click(modeButton("Animate character"));
+
+    // Both inputs required → Render stays disabled until selected.
+    expect(buttonWithText(container, "Render clip").disabled).toBe(true);
+
+    await click(buttonWithText(container, "Select clip"));
+    let modal = document.querySelector(".asset-picker-modal");
+    await doubleClick(
+      [...modal.querySelectorAll('[role="option"]')].find((el) => el.textContent.includes("Driving Clip")),
+    );
+
+    await click(buttonWithText(container, "Select image"));
+    modal = document.querySelector(".asset-picker-modal");
+    await doubleClick(
+      [...modal.querySelectorAll('[role="option"]')].find((el) => el.textContent.includes("Character A")),
+    );
+
+    expect(buttonWithText(container, "Render clip").disabled).toBe(false);
+    await click(buttonWithText(container, "Render clip"));
+
+    expect(context.createVideoJob).toHaveBeenCalledTimes(1);
+    const payload = context.createVideoJob.mock.calls[0][0];
+    expect(payload).toMatchObject({
+      mode: "animate_character",
+      model: "scail2_14b",
+      sourceClipAssetId: "vid_src",
+    });
+    expect(payload.referenceAssetIds).toEqual(["img_ref_a"]);
+  });
+
+  it("offers SCAIL-2 as a replacement engine when 2+ backends can replace", async () => {
+    const context = baseContext({ videoModels: [WAN, SCAIL2], assets: [clip] });
+    await render(context);
+    await click(modeButton("Replace person"));
+
+    const engineLabel = [...container.querySelectorAll("label")].find((el) =>
+      el.textContent.includes("Replacement engine"),
+    );
+    expect(engineLabel).toBeTruthy();
+    const engineSelect = engineLabel.querySelector("select");
+    expect([...engineSelect.options].map((o) => o.value)).toEqual(
+      expect.arrayContaining(["wan_2_2", "scail2_14b"]),
+    );
+
+    // Choosing SCAIL-2 switches the active model and surfaces the full-character note.
+    const setSelect = Object.getOwnPropertyDescriptor(window.HTMLSelectElement.prototype, "value").set;
+    await act(async () => {
+      setSelect.call(engineSelect, "scail2_14b");
+      engineSelect.dispatchEvent(new window.Event("change", { bubbles: true }));
+    });
+    expect(container.textContent).toContain("SCAIL-2 full-character replacement");
+  });
+
+  it("hides the replacement engine picker when only one backend can replace", async () => {
+    const context = baseContext({ videoModels: [WAN], assets: [clip] });
+    await render(context);
+    await click(modeButton("Replace person"));
+
+    const engineLabel = [...container.querySelectorAll("label")].find((el) =>
+      el.textContent.includes("Replacement engine"),
+    );
+    expect(engineLabel).toBeFalsy();
+  });
+});


### PR DESCRIPTION
The user-facing Video Studio surface for SCAIL-2 (epic 5439). The worker routing (sc-5448 `animate_character`, sc-5452 `replace_person`) and the manifest capabilities + prompt guide (sc-5447) already shipped; this exposes them in the UI, mirroring the Bernini modes (sc-4703).

## What's new
- **`animate_character` mode** — a new Video Studio mode: a **driving video** + a **reference character image** → an animated clip. Media slots mirror Bernini's clip/reference pickers; per-mode validation requires both inputs; the payload carries `sourceClipAssetId` + `referenceAssetIds` (the worker reads `referenceAssetIds[0]`). Selecting the mode auto-switches to the model that advertises the capability (`scail2_14b`), exactly like `replace_person`. The reference is a **single image** today.
- **Replacement engine picker** — a "Replacement engine" `<select>` in `ReplacePersonPanel` lists the replace-capable models so the user can choose **SCAIL-2** vs the default **Wan-VACE** backend; it drives the job's `model`. A note explains SCAIL-2 re-renders the whole tracked person, so the `face_only`/keep-outfit Replacement mode doesn't apply to it. (This is the picker sc-5452 deferred here.)

## Notes
- `scail2_14b` is **backend-driven** (already in the model catalog), so the Model dropdown lists it on Mac — **no `constants.js` change**. Mac/runtime gating and the prompt-guide modal flow through the existing manifest path (`ui.promptGuide → /prompt-guides/scail2.md`, sc-5447). No new request fields → no contract-snapshot change.

## Deferred (surfaced, **not** built as inert UI)
Building UI for capabilities the worker can't yet serve would create broken affordances, so these are explicitly left out and tracked:
- **Pose-driven driving** — needs the DWPose native port (**sc-5444**, not done).
- **Multi-reference** (experimental) — engine request-contract blocked (**sc-5583**).
- **"Animal-driving"** — not a distinct engine mode; it's `animate_character` with an animal reference image (already covered).

## Verification
- web lint: 0 errors (pre-existing exhaustive-deps warnings only)
- web tests: **423 passed** (4 new — animate_character slots/validation/payload + the engine picker shows with 2+ backends / hides with one; the new tests mount the real `VideoStudio` + `ReplacePersonPanel` with a SCAIL-2 model)
- `npm run build`: clean

Browser-preview note: the SCAIL-2 Video Studio isn't observable in a bare dev server (it needs the backend manifest's mac-only `scail2_14b`, an authenticated session, a project, and assets), so the component tests that mount the real screens are the verification rather than a backendless screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)