### PR TITLE
sc-5620: provision the JoyCaption model (catalog/manifest + HF download/readiness + caption UX)

### DIFF
--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -8219,3 +8219,38 @@ fn builtin_manifest_registers_the_prompt_refine_model() {
         "${HF_CACHE}/huihui-ai/Llama-3.2-3B-Instruct-abliterated"
     );
 }
+
+#[test]
+fn builtin_manifest_registers_the_joycaption_model() {
+    // sc-5620: the native captioner (caption_jobs.rs, the training_caption job) resolves an
+    // already-cached HF snapshot via the same resolve_app_managed_model_dir seam and does NOT
+    // auto-download. JoyCaption must be a provisionable catalog artifact (same gap as sc-5605's
+    // prompt_refine). Guards the entry + repo == caption_jobs::JOY_CAPTION_MODEL + the cache path.
+    let manifest_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../config/manifests/builtin.models.jsonc");
+    let raw = std::fs::read_to_string(&manifest_path).expect("read builtin.models.jsonc");
+    let manifest: Value =
+        serde_json::from_str(&strip_jsonc_comments(&raw)).expect("parse builtin.models.jsonc");
+    let model = manifest["models"]
+        .as_array()
+        .expect("models array")
+        .iter()
+        .find(|entry| entry["id"] == "joycaption_beta_one")
+        .expect("joycaption_beta_one is registered in the catalog");
+    assert_eq!(model["type"], "utility");
+    let download = model["downloads"]
+        .as_array()
+        .and_then(|downloads| downloads.first())
+        .expect("a download entry");
+    assert_eq!(download["provider"], "huggingface");
+    // Must match the worker's JOY_CAPTION_MODEL (caption_jobs.rs) — the string the worker passes
+    // to huggingface_snapshot_dir.
+    assert_eq!(
+        download["repo"], "fancyfeast/llama-joycaption-beta-one-hf-llava",
+        "manifest repo must match the worker's JOY_CAPTION_MODEL"
+    );
+    assert_eq!(
+        model["paths"]["model"],
+        "${HF_CACHE}/fancyfeast/llama-joycaption-beta-one-hf-llava"
+    );
+}

--- a/apps/web/public/prompt-guides/joycaption.md
+++ b/apps/web/public/prompt-guides/joycaption.md
@@ -1,0 +1,23 @@
+# JoyCaption Captioning Guide
+
+JoyCaption is a vision-language model used by **training-dataset captioning** ("Caption images" / "Re-caption"). It looks at each image in a dataset and writes a caption — it does not generate images or video. Good captions help a LoRA learn the right concepts, so this step matters for training quality.
+
+## Installation
+
+JoyCaption runs in-process on the native worker (MLX on macOS, candle on Windows/CUDA) and is **not** auto-downloaded. Install it once from the **Models** screen (the caption dialog also offers a download when it's missing). It is about 17 GB and downloads into the shared Hugging Face cache, so other tools reuse it.
+
+## Caption Settings
+
+**Type** picks the caption style (e.g. Descriptive). **Length** trades brevity against detail — shorter captions for tight concept LoRAs, longer for rich scene description.
+
+**Character name** injects a consistent name/trigger into captions, useful for character LoRAs.
+
+**Caption prompt** is the instruction sent to the model; leave it blank to use the type/length defaults, or override it for full control.
+
+## Practical Notes
+
+Captioning runs as a background job — queue it from the dataset editor and track progress in the Queue.
+
+"Re-caption" overwrites existing captions; leave it off to only fill in images that have no caption yet.
+
+Review and edit captions before training — automatic captions are a fast first pass, not a substitute for a quick human check.

--- a/apps/web/src/components/DatasetCaptionDialog.jsx
+++ b/apps/web/src/components/DatasetCaptionDialog.jsx
@@ -1,10 +1,16 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Modal } from "./Modal.jsx";
 
 // Caption settings modal (sc-2025). One dialog drives both "Caption all" and a
 // single image's "Re-Caption" — the dataset editor owns the captioner settings
 // state and the job submission; this component only renders the controls and a
 // Run button scoped to the target.
+//
+// When the JoyCaption model isn't provisioned on the native worker (sc-5620), the
+// caption job would just fail in the Queue (captioning is fire-and-forget, not polled
+// inline), so we surface a proactive "download the captioning model" affordance and
+// block Run. `modelMissing` is gated by the parent (Mac + catalog installState
+// "missing" + the default model selected); `onDownloadModel` enqueues its download.
 export function DatasetCaptionDialog({
   settings,
   onChange,
@@ -18,11 +24,34 @@ export function DatasetCaptionDialog({
   onRun,
   onToggleExtra,
   onClose,
+  modelMissing = false,
+  onDownloadModel,
+  modelSizeLabel = "",
+  modelName = "JoyCaption",
 }) {
   const single = scope?.type === "item";
   const title = single ? `Re-caption ${scope.name ?? "image"}` : "Caption images";
   const runLabel = single ? "Re-caption image" : settings.recaption ? "Re-caption all" : "Caption missing";
   const joy = settings.captioner === "joy_caption";
+  const [downloadRequested, setDownloadRequested] = useState(false);
+
+  // Once the model finishes downloading (parent's catalog refresh flips modelMissing to
+  // false), clear the "downloading" note so Run re-enables.
+  useEffect(() => {
+    if (!modelMissing) {
+      setDownloadRequested(false);
+    }
+  }, [modelMissing]);
+
+  const blockRun = joy && modelMissing;
+
+  async function handleDownloadModel() {
+    if (typeof onDownloadModel !== "function") return;
+    const job = await onDownloadModel();
+    if (job) {
+      setDownloadRequested(true);
+    }
+  }
 
   return (
     <Modal className="dataset-caption-modal" labelledBy="dataset-caption-title" onClose={onClose}>
@@ -44,6 +73,31 @@ export function DatasetCaptionDialog({
             <option value="metadata">Metadata fallback</option>
           </select>
         </label>
+
+        {blockRun ? (
+          <div className="caption-missing-model" role="alert">
+            {downloadRequested ? (
+              <p className="inline-warning">
+                Downloading the captioning model… track progress on the Models screen, then caption
+                again.
+              </p>
+            ) : (
+              <>
+                <p className="inline-warning">
+                  The captioning model{modelSizeLabel ? ` (${modelSizeLabel})` : ""} isn’t installed
+                  yet.
+                </p>
+                {typeof onDownloadModel === "function" ? (
+                  <button className="secondary-action" onClick={handleDownloadModel} type="button">
+                    Download captioning model
+                  </button>
+                ) : (
+                  <p className="inline-warning">Open the Models screen to download “{modelName}”.</p>
+                )}
+              </>
+            )}
+          </div>
+        ) : null}
 
         {joy ? (
           <>
@@ -156,7 +210,7 @@ export function DatasetCaptionDialog({
         <button onClick={onClose} type="button">
           Cancel
         </button>
-        <button className="primary-action" disabled={running} onClick={onRun} type="button">
+        <button className="primary-action" disabled={running || blockRun} onClick={onRun} type="button">
           {running ? "Queuing…" : runLabel}
         </button>
       </footer>

--- a/apps/web/src/components/DatasetCaptionDialog.test.jsx
+++ b/apps/web/src/components/DatasetCaptionDialog.test.jsx
@@ -1,0 +1,103 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DatasetCaptionDialog } from "./DatasetCaptionDialog.jsx";
+
+const baseSettings = {
+  captioner: "joy_caption",
+  modelNameOrPath: "",
+  requestedGpu: "auto",
+  captionType: "Descriptive",
+  captionLength: "long",
+  nameInput: "",
+  temperature: 0.6,
+  topP: 0.9,
+  maxNewTokens: 256,
+  lowVram: false,
+  recaption: false,
+  extraOptions: [],
+};
+
+function buttonByText(container, text) {
+  return [...container.querySelectorAll("button")].find((button) => button.textContent.trim() === text);
+}
+
+async function settle() {
+  await act(async () => {
+    for (let index = 0; index < 8; index += 1) {
+      await Promise.resolve();
+    }
+  });
+}
+
+describe("DatasetCaptionDialog", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  function render(ui) {
+    root = createRoot(container);
+    act(() => root.render(ui));
+  }
+
+  it("offers a download + blocks Run when the captioning model is missing (sc-5620)", async () => {
+    const onDownloadModel = vi.fn(async () => ({ id: "job-1" }));
+    render(
+      <DatasetCaptionDialog
+        settings={baseSettings}
+        onChange={vi.fn()}
+        onRun={vi.fn()}
+        onToggleExtra={vi.fn()}
+        onClose={vi.fn()}
+        scope={{ type: "all" }}
+        modelMissing
+        onDownloadModel={onDownloadModel}
+        modelSizeLabel="17.0 GB"
+        modelName="JoyCaption (beta one)"
+      />,
+    );
+
+    expect(container.querySelector(".caption-missing-model").textContent).toContain("isn’t installed");
+    expect(container.querySelector(".caption-missing-model").textContent).toContain("17.0 GB");
+    // Run is blocked while the model is missing.
+    expect(buttonByText(container, "Caption missing").disabled).toBe(true);
+
+    const download = buttonByText(container, "Download captioning model");
+    expect(download).toBeTruthy();
+    await act(async () => {
+      download.click();
+    });
+    await settle();
+
+    expect(onDownloadModel).toHaveBeenCalledTimes(1);
+    expect(container.querySelector(".caption-missing-model").textContent).toContain("Downloading");
+  });
+
+  it("shows no affordance and enables Run when the captioning model is present", () => {
+    render(
+      <DatasetCaptionDialog
+        settings={baseSettings}
+        onChange={vi.fn()}
+        onRun={vi.fn()}
+        onToggleExtra={vi.fn()}
+        onClose={vi.fn()}
+        scope={{ type: "all" }}
+        modelMissing={false}
+      />,
+    );
+
+    expect(container.querySelector(".caption-missing-model")).toBeNull();
+    expect(buttonByText(container, "Caption missing").disabled).toBe(false);
+  });
+});

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -22,6 +22,11 @@ export const DEFAULT_INTERLEAVE_RESOLUTION = "2048x1152";
 // prompt" fails because the model isn't provisioned.
 export const PROMPT_REFINE_MODEL_ID = "prompt_refine_llama_3_2_3b";
 
+// Catalog id of the dataset-captioning model (sc-5620, builtin.models.jsonc). Same pattern
+// as PROMPT_REFINE_MODEL_ID — the native captioner resolves it by repo string; the web uses
+// this id to look up install state and offer a download in the caption dialog when missing.
+export const JOY_CAPTION_MODEL_ID = "joycaption_beta_one";
+
 // Default interleave system prompt (the think/no-think protocol). Prefilled in
 // Document Studio; the worker falls back to this same text when the field is blank.
 // Keep in sync with apps/worker/scene_worker/image_adapters.py::_INTERLEAVE_SYSTEM_MESSAGE.

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -5,7 +5,7 @@ import { API_BASE_URL } from "../api.js";
 import { assetCanRenderAsImage } from "../components/assetMedia.jsx";
 import { Icon } from "../components/Icons.jsx";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
-import { terminalStatuses } from "../constants.js";
+import { JOY_CAPTION_MODEL_ID, terminalStatuses } from "../constants.js";
 import {
   buildJoyCaptionPrompt,
   defaultCaptionSettings,
@@ -297,6 +297,8 @@ export function TrainingStudio({ mode = "training" } = {}) {
     trainingTargetsError = "",
     setActiveView,
     studioLaunch,
+    models = [],
+    createModelDownloadJob,
     macCapabilities = DEFAULT_MAC_CAPABILITIES,
   } = useAppContext();
   const datasets = trainingDatasetsProjectId === activeProject?.id ? trainingDatasets : [];
@@ -432,6 +434,26 @@ export function TrainingStudio({ mode = "training" } = {}) {
     !savingDataset &&
     (!activeDataset || dirty);
   const displayedCaptionPrompt = captionSettings.captionPrompt || buildJoyCaptionPrompt(captionSettings);
+  // JoyCaption model provisioning (sc-5620): the native captioner has no auto-download (unlike
+  // the torch path), so on a gated Mac a missing model would just fail the queued caption job.
+  // Surface a download affordance in the caption dialog instead. Mac-gated because Windows/Linux
+  // torch still auto-downloads (missing ≠ broken there); scoped to the default/cataloged model.
+  const captionModel = useMemo(
+    () => models.find((entry) => entry.id === JOY_CAPTION_MODEL_ID),
+    [models],
+  );
+  const selectedCaptionModel = String(captionSettings.modelNameOrPath ?? "").trim() || joyCaptionModel;
+  const captionModelMissing =
+    Boolean(macCapabilities?.macGatingActive) &&
+    captionModel?.installState === "missing" &&
+    selectedCaptionModel === joyCaptionModel;
+  const captionModelSizeLabel = useMemo(() => {
+    const bytes = Number(captionModel?.downloadSizeBytes);
+    return Number.isFinite(bytes) && bytes > 0 ? `${(bytes / 1e9).toFixed(1)} GB` : "";
+  }, [captionModel?.downloadSizeBytes]);
+  const onDownloadCaptionModel = captionModel && typeof createModelDownloadJob === "function"
+    ? () => createModelDownloadJob(captionModel)
+    : undefined;
   const firstTarget = trainingTargets[0] ?? null;
   // Mac UI gating (sc-3486): a target whose kernel has no native mlx-gen Rust trainer
   // (kolors_lora / lens_lora) can't train on a gated Mac — disable it and snap off it.
@@ -1136,6 +1158,10 @@ export function TrainingStudio({ mode = "training" } = {}) {
                   toggleCaptionExtraOption={toggleCaptionExtraOption}
                   displayedCaptionPrompt={displayedCaptionPrompt}
                   captionSettings={captionSettings}
+                  captionModelMissing={captionModelMissing}
+                  onDownloadCaptionModel={onDownloadCaptionModel}
+                  captionModelSizeLabel={captionModelSizeLabel}
+                  captionModelName={captionModel?.name ?? "JoyCaption"}
                 />
               ) : null}
 

--- a/apps/web/src/screens/training/DatasetEditorPanel.jsx
+++ b/apps/web/src/screens/training/DatasetEditorPanel.jsx
@@ -91,6 +91,10 @@ export function DatasetEditorPanel({
   toggleCaptionExtraOption,
   displayedCaptionPrompt,
   captionSettings,
+  captionModelMissing = false,
+  onDownloadCaptionModel,
+  captionModelSizeLabel = "",
+  captionModelName = "JoyCaption",
 }) {
   return (
     <>
@@ -282,6 +286,10 @@ export function DatasetEditorPanel({
               onToggleExtra={toggleCaptionExtraOption}
               promptValue={displayedCaptionPrompt}
               running={captioning}
+              modelMissing={captionModelMissing}
+              onDownloadModel={onDownloadCaptionModel}
+              modelSizeLabel={captionModelSizeLabel}
+              modelName={captionModelName}
               scope={
                 captionDialog.type === "item"
                   ? {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1434,6 +1434,14 @@ label {
   justify-items: start;
 }
 
+/* Missing captioning-model affordance (sc-5620): the proactive "download the captioning
+   model" prompt in the caption dialog when JoyCaption isn't provisioned on a native Mac. */
+.caption-missing-model {
+  display: grid;
+  gap: 8px;
+  justify-items: start;
+}
+
 .refine-review {
   display: grid;
   gap: 8px;

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2709,6 +2709,58 @@
           ]
         }
       }
+    },
+    {
+      // Dataset captioning LLM (sc-5620, the JoyCaption twin of the sc-5605 prompt_refine gap).
+      // The native captioner (`caption_jobs.rs`, the `training_caption` job used by LoRA-training
+      // auto-captioning) runs JoyCaption in-process — the MLX provider on macOS (sc-3556) and
+      // candle-gen-joycaption off-Mac — and resolves the model via the same
+      // `resolve_app_managed_model_dir` → `huggingface_snapshot_dir` seam that only *resolves* an
+      // already-cached snapshot (no auto-download like the torch path). Cataloging it lets Model
+      // Manager download it into the HF cache the worker reads from; the worker references it by
+      // repo string (`caption_jobs::JOY_CAPTION_MODEL`), not by this id.
+      //
+      // Stock repo, pulled as-is: a standard LLaVA transformers safetensors checkpoint — NOT
+      // MLX-converted and NOT requiring conversion (the mlx-gen-joycaption provider reads the stock
+      // config/safetensors/tokenizer/processor directly), so the epic-5594 re-host pattern
+      // (conversion-required models) does not apply. `files: []` pulls the repo's own LLAMA_LICENSE
+      // + LLAMA_USE_POLICY (Llama community license) alongside the weights.
+      "id": "joycaption_beta_one",
+      "name": "JoyCaption (beta one)",
+      "family": "joycaption",
+      "type": "utility",
+      "adapter": "joycaption",
+      "capabilities": [],
+      "downloads": [
+        {
+          "provider": "huggingface",
+          "repo": "fancyfeast/llama-joycaption-beta-one-hf-llava",
+          "files": [],
+          "estimatedSizeBytes": 16977442945
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/fancyfeast/llama-joycaption-beta-one-hf-llava"
+      },
+      "defaults": {},
+      "limits": {},
+      "loraCompatibility": {
+        "families": [],
+        "types": []
+      },
+      "ui": {
+        "label": "JoyCaption (beta one)",
+        "description": "Optional vision-language model used by training-dataset captioning (\"Caption images\") to describe images. Runs in-process on the native worker (MLX on macOS, candle on Windows/CUDA).",
+        "recommendedFor": ["training_caption"],
+        "promptGuide": {
+          "title": "JoyCaption Captioning Guide",
+          "path": "/prompt-guides/joycaption.md",
+          "sources": [
+            { "label": "JoyCaption beta-one model card", "url": "https://huggingface.co/fancyfeast/llama-joycaption-beta-one-hf-llava" },
+            { "label": "JoyCaption project (GitHub)", "url": "https://github.com/fpgaminer/joycaption" }
+          ]
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
The JoyCaption twin of **sc-5605** (merged). The native captioner (`caption_jobs.rs`, the `training_caption` job used by LoRA-training auto-captioning) resolves an already-cached HF snapshot via `resolve_app_managed_model_dir` → `huggingface_snapshot_dir` and does **not** auto-download like the torch path. `fancyfeast/llama-joycaption-beta-one-hf-llava` wasn't a catalog artifact, so a fresh install failed with `JoyCaption model path snapshot is not cached`.

## Changes
- **`config/manifests/builtin.models.jsonc`** — new `joycaption_beta_one` entry (`type: "utility"`, mirrors `real_esrgan`/`aura_sr_v2`/`prompt_refine_llama_3_2_3b`). **Stock repo pulled as-is** — standard LLaVA transformers safetensors (no MLX conversion; `mlx-gen-joycaption` reads it directly), so epic-5594's re-host pattern doesn't apply. `files: []` (≈17 GB) also pulls the repo's own `LLAMA_LICENSE` + `LLAMA_USE_POLICY.md`. Ungated.
- **Caption UX** (`DatasetCaptionDialog.jsx` + `DatasetEditorPanel.jsx` + `TrainingStudio.jsx` + `JOY_CAPTION_MODEL_ID`) — a **proactive** "Download captioning model (~17 GB)" affordance that blocks Run when the cataloged model is missing. Proactive (not failure-driven like Refine) because captioning is fire-and-forget to the Queue, not polled inline; **Mac-gated** (`macGatingActive`) since torch Windows/Linux still auto-downloads (missing ≠ broken there), and scoped to the default/cataloged model.
- **`apps/web/public/prompt-guides/joycaption.md`** — new guide (scaffold mandates one per builtin model).

## Tests / validation
- `node scripts/check-scaffold.mjs` ✅
- web: `eslint src` 0 errors; **421/421 vitest** (incl. 2 new `DatasetCaptionDialog` cases)
- rust: `fmt --check` clean; new `builtin_manifest_registers_the_joycaption_model` guard (entry present, repo == worker `JOY_CAPTION_MODEL`, `${HF_CACHE}` path); `clippy --all-targets -D warnings` clean
- **Live** `GET /api/v1/models` against the edited manifest: cached → `installState: installed`, `installedPath` == the worker's snapshot dir, `downloadSizeBytes: 16977442945`; empty HF cache → `missing` + `downloadable`.

## Verification boundary (stated, not hidden)
I did not run a full caption-an-image job here: the JoyCaption captioner is already production-proven (sc-3556), and the model-resolution seam (`resolve_app_managed_model_dir`) was proven end-to-end by the **sc-5605 live refine e2e** on the same code path. This PR's change is the provisioning surface, which the live `GET /models` check validates directly. The fresh-state caption run is the remaining QA-pass acceptance (analogous to the literal 7 GB download for sc-5605). **Not auto-merging** — leaving the merge to Michael.

🤖 Generated with [Claude Code](https://claude.com/claude-code)