### PR TITLE
sc-5599/5600/5607: re-host Wan2.2 MLX models on SceneWorks HF (epic 5594)

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -1618,14 +1618,26 @@ pub(crate) fn mlx_catalog_status(
             converted_path: None,
         })
     } else {
-        let installed = mlx
+        let repo_installed = mlx
             .get("repo")
             .and_then(Value::as_str)
             .is_some_and(repo_cached);
+        // A turnkey model may still be served by a pre-existing local conversion at
+        // <data>/models/mlx/<id> — the worker's resolve_*_model_dir prefers a local dir over
+        // the turnkey download. Count that as installed too, so a model flipped from
+        // requiresConversion → turnkey (sc-5599) doesn't read as "missing" for users who had
+        // already converted it locally.
+        let model_id = model.get("id").and_then(Value::as_str).unwrap_or_default();
+        let local_dir = data_dir.join("models").join("mlx").join(model_id);
+        let local_installed = local_dir.join("config.json").is_file();
         Some(MlxCatalogStatus {
-            install_state: if installed { "installed" } else { "missing" },
+            install_state: if repo_installed || local_installed {
+                "installed"
+            } else {
+                "missing"
+            },
             conversion_state: "ready",
-            converted_path: None,
+            converted_path: local_installed.then_some(local_dir),
         })
     }
 }

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1946,16 +1946,16 @@
       "type": "video",
       "adapter": "wan_video",
       "capabilities": ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "video_bridge", "replace_person"],
-      // Per-platform source (sc-3240): macOS converts the native checkpoint to MLX in-process
-      // (mlx-gen-wan ingests native Wan format only); Windows/Linux load the diffusers layout via
-      // the torch wan_video adapter. The API serves only the entry matching the running OS.
+      // Per-platform source: macOS downloads the turnkey pre-converted MLX snapshot from the
+      // SceneWorks HF org (sc-5599, epic 5594); Windows/Linux load the diffusers layout via the
+      // torch wan_video adapter. The API serves only the entry matching the running OS.
       "downloads": [
         {
           "provider": "huggingface",
-          "repo": "Wan-AI/Wan2.2-TI2V-5B",
+          "repo": "SceneWorks/wan2.2-ti2v-5b-mlx",
           "files": [],
           "platforms": ["macos"],
-          "estimatedSizeBytes": 34196904505
+          "estimatedSizeBytes": 24197123156
         },
         {
           "provider": "huggingface",
@@ -1966,7 +1966,7 @@
         }
       ],
       "paths": {
-        "model": "${HF_CACHE}/Wan-AI/Wan2.2-TI2V-5B"
+        "model": "${HF_CACHE}/SceneWorks/wan2.2-ti2v-5b-mlx"
       },
       "defaults": {
         "duration": 5,
@@ -2012,13 +2012,14 @@
         }
       },
       "mlx": {
-        // TI2V-5B has no published MLX repo; the native checkpoint is converted locally
-        // in-process by the Rust mlx-gen-wan converter (sc-3240, converter "wan_ti2v_5b")
-        // into <data>/models/mlx/wan_2_2. Dense bf16 (no quantization).
+        // Turnkey pre-converted MLX snapshot on the SceneWorks HF org (sc-5599, epic 5594):
+        // dense bf16, self-contained (DiT + UMT5 encoder + VAE + tokenizer), downloaded on
+        // first use — no in-app conversion. The worker still resolves env override
+        // (SCENEWORKS_MLX_WAN5B_DIR) → local <data>/models/mlx/wan_2_2 (a local conversion
+        // supersedes) → this turnkey snapshot. Source Wan-AI/Wan2.2-TI2V-5B is Apache-2.0;
+        // converter "wan_ti2v_5b" emits bf16 (Q4/Q8 applied at load, not baked in).
         "minMemoryGb": 45,
-        "requiresConversion": true,
-        "converter": "wan_ti2v_5b",
-        "convertSourceRepo": "Wan-AI/Wan2.2-TI2V-5B",
+        "repo": "SceneWorks/wan2.2-ti2v-5b-mlx",
         // MLX path is sealed (own ODE solver, no diffusers scheduler) — override
         // the top-level sampler/scheduler menu to default-only (epic 1753 §14).
         "limits": {
@@ -2052,16 +2053,27 @@
       "type": "video",
       "adapter": "wan_video",
       "capabilities": ["text_to_video"],
+      // Per-platform source: macOS downloads the turnkey pre-converted dual-expert MLX snapshot
+      // from the SceneWorks HF org (sc-5607, epic 5594; replaces the third-party AITRADER mirror);
+      // Windows/Linux load the diffusers/GGUF layout via the torch wan_video adapter.
       "downloads": [
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/wan2.2-t2v-a14b-mlx",
+          "files": [],
+          "platforms": ["macos"],
+          "estimatedSizeBytes": 69040469369
+        },
         {
           "provider": "huggingface",
           "repo": "Wan-AI/Wan2.2-T2V-A14B-Diffusers",
           "files": [],
+          "platforms": ["windows", "linux"],
           "estimatedSizeBytes": 72000000000
         }
       ],
       "paths": {
-        "model": "${HF_CACHE}/Wan-AI/Wan2.2-T2V-A14B-Diffusers"
+        "model": "${HF_CACHE}/SceneWorks/wan2.2-t2v-a14b-mlx"
       },
       "defaults": {
         "duration": 5,
@@ -2111,10 +2123,15 @@
         }
       },
       "mlx": {
-        // Turnkey: pre-converted MLX repo + the lightx2v 4-step Lightning LoRA
-        // (downloaded on demand by MlxVideoAdapter at generation time).
+        // Turnkey pre-converted dual-expert MLX snapshot on the SceneWorks HF org (sc-5607,
+        // epic 5594) — replaces the third-party AITRADER/Wan2.2-T2V-A14B-mlx-bf16 mirror. Dense
+        // bf16, self-contained (high/low-noise experts + UMT5 encoder + z16 VAE + tokenizer),
+        // downloaded on first use. The worker resolves env override (SCENEWORKS_MLX_WAN14B_T2V_DIR)
+        // → local <data>/models/mlx/wan_2_2_t2v_14b → this snapshot. Source Wan-AI/Wan2.2-T2V-A14B
+        // is Apache-2.0; converter "wan_t2v_14b" emits bf16 (Q4/Q8 at load). The lightx2v 4-step
+        // Lightning LoRA is downloaded on demand by MlxVideoAdapter at generation time.
         "minMemoryGb": 133,
-        "repo": "AITRADER/Wan2.2-T2V-A14B-mlx-bf16",
+        "repo": "SceneWorks/wan2.2-t2v-a14b-mlx",
         "limits": {
           "samplers": ["default"],
           "schedulers": ["default"]
@@ -2143,17 +2160,16 @@
       "type": "video",
       "adapter": "wan_video",
       "capabilities": ["image_to_video", "first_last_frame", "extend_clip", "video_bridge"],
-      // Per-platform source (sc-3240): macOS converts the native dual-expert checkpoint to MLX
-      // in-process (mlx-gen-wan); Windows/Linux load the diffusers/GGUF layout via the torch
-      // wan_video adapter. Native is larger than the diffusers layout (~126 GB vs ~72 GB). The
-      // API serves only the entry matching the running OS.
+      // Per-platform source: macOS downloads the turnkey pre-converted dual-expert MLX snapshot
+      // from the SceneWorks HF org (sc-5600, epic 5594); Windows/Linux load the diffusers/GGUF
+      // layout via the torch wan_video adapter. The API serves only the entry matching the OS.
       "downloads": [
         {
           "provider": "huggingface",
-          "repo": "Wan-AI/Wan2.2-I2V-A14B",
+          "repo": "SceneWorks/wan2.2-i2v-a14b-mlx",
           "files": [],
           "platforms": ["macos"],
-          "estimatedSizeBytes": 126202610088
+          "estimatedSizeBytes": 69042107874
         },
         {
           "provider": "huggingface",
@@ -2164,7 +2180,7 @@
         }
       ],
       "paths": {
-        "model": "${HF_CACHE}/Wan-AI/Wan2.2-I2V-A14B"
+        "model": "${HF_CACHE}/SceneWorks/wan2.2-i2v-a14b-mlx"
       },
       "defaults": {
         "duration": 5,
@@ -2212,14 +2228,15 @@
         }
       },
       "mlx": {
-        // I2V-A14B has no published MLX repo; the native checkpoint is converted locally
-        // in-process by the Rust mlx-gen-wan converter (sc-3240, converter "wan_i2v_14b")
-        // into <data>/models/mlx/wan_2_2_i2v_14b (in_dim 36 image-concat, z16 VAE; dense
-        // bf16 by default). Its distill LoRA is applied at run time.
+        // Turnkey pre-converted dual-expert MLX snapshot on the SceneWorks HF org (sc-5600,
+        // epic 5594): dense bf16, self-contained (high/low-noise experts + UMT5 encoder + z16
+        // VAE + tokenizer; in_dim 36 image-concat), downloaded on first use — no in-app
+        // conversion. The worker resolves env override (SCENEWORKS_MLX_WAN14B_I2V_DIR) → local
+        // <data>/models/mlx/wan_2_2_i2v_14b (a local conversion supersedes) → this snapshot.
+        // Source Wan-AI/Wan2.2-I2V-A14B is Apache-2.0; converter "wan_i2v_14b" emits bf16
+        // (Q4/Q8 at load). Its distill LoRA is applied at run time.
         "minMemoryGb": 133,
-        "requiresConversion": true,
-        "converter": "wan_i2v_14b",
-        "convertSourceRepo": "Wan-AI/Wan2.2-I2V-A14B",
+        "repo": "SceneWorks/wan2.2-i2v-a14b-mlx",
         "limits": {
           "samplers": ["default"],
           "schedulers": ["default"]

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -1728,6 +1728,47 @@ mod tests {
         let _ = std::fs::remove_dir_all(&out);
     }
 
+    /// One-shot real-weight conversion harness for re-hosting (epic 5594). Runs the SAME
+    /// `convert_wan_native` + `copy_wan_umt5_tokenizer` as `run_model_convert_job`, writing the
+    /// assembled MLX dir to `SW_CONVERT_OUT` (a real, persistent dir — NOT a temp dir — so the
+    /// artifact survives for upload). Env-driven so it is not machine-specific. Dense bf16
+    /// (quant=None), matching the manifest default for the A14B Wan models. Run e.g.:
+    ///   SW_CONVERT_KIND=wan_i2v_14b SW_CONVERT_SRC=models--Wan-AI--Wan2.2-I2V-A14B \
+    ///   SW_CONVERT_OUT="$HOME/Library/Application Support/SceneWorks/data/models/mlx/wan_2_2_i2v_14b" \
+    ///   cargo test -p sceneworks-worker --lib -- --ignored --nocapture oneshot_convert_wan_to_data_dir
+    #[test]
+    #[ignore]
+    fn oneshot_convert_wan_to_data_dir() {
+        let kind = std::env::var("SW_CONVERT_KIND").expect("SW_CONVERT_KIND");
+        let src = std::env::var("SW_CONVERT_SRC").expect("SW_CONVERT_SRC");
+        let out = PathBuf::from(std::env::var("SW_CONVERT_OUT").expect("SW_CONVERT_OUT"));
+        let checkpoint = hf_snapshot(&src);
+        eprintln!(
+            "[oneshot] converting {kind} from {} -> {}",
+            checkpoint.display(),
+            out.display()
+        );
+        let _ = std::fs::remove_dir_all(&out);
+        convert_wan_native(&kind, &checkpoint, &out, None).expect("native Wan convert");
+        copy_wan_umt5_tokenizer(&checkpoint, &out).expect("copy UMT5 tokenizer");
+
+        let mut biggest = 0u64;
+        for entry in std::fs::read_dir(&out).expect("read out").flatten() {
+            let len = entry.metadata().map(|m| m.len()).unwrap_or(0);
+            biggest = biggest.max(len);
+            eprintln!("  {} ({len} bytes)", entry.file_name().to_string_lossy());
+        }
+        assert!(out.join("config.json").is_file(), "missing config.json");
+        assert!(
+            out.join("tokenizer.json").is_file(),
+            "missing tokenizer.json"
+        );
+        assert!(
+            biggest > 1_000_000_000,
+            "no multi-GB weight shard written — conversion produced a stub"
+        );
+    }
+
     /// Real-weights smoke for the native Rust/MLX LTX-2.3 converter (sc-3224 engine + sc-3240
     /// cutover) — the LTX path was never routed through the Rust job before. Runs the actual
     /// `convert_ltx_native` used by `run_model_convert_job` on the cached eros single-file + the base

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -1465,13 +1465,21 @@ fn resolve_wan_model_dir(
     _engine_id: &str,
 ) -> WorkerResult<PathBuf> {
     let (env, local_id, hf_repo): (&str, &str, Option<&str>) = match model {
-        "wan_2_2" => ("SCENEWORKS_MLX_WAN5B_DIR", "wan_2_2", None),
+        "wan_2_2" => (
+            "SCENEWORKS_MLX_WAN5B_DIR",
+            "wan_2_2",
+            Some("SceneWorks/wan2.2-ti2v-5b-mlx"),
+        ),
         "wan_2_2_t2v_14b" => (
             "SCENEWORKS_MLX_WAN14B_T2V_DIR",
             "wan_2_2_t2v_14b",
-            Some("AITRADER/Wan2.2-T2V-A14B-mlx-bf16"),
+            Some("SceneWorks/wan2.2-t2v-a14b-mlx"),
         ),
-        "wan_2_2_i2v_14b" => ("SCENEWORKS_MLX_WAN14B_I2V_DIR", "wan_2_2_i2v_14b", None),
+        "wan_2_2_i2v_14b" => (
+            "SCENEWORKS_MLX_WAN14B_I2V_DIR",
+            "wan_2_2_i2v_14b",
+            Some("SceneWorks/wan2.2-i2v-a14b-mlx"),
+        ),
         other => {
             return Err(WorkerError::InvalidPayload(format!(
                 "not a Wan model: {other}"


### PR DESCRIPTION
## What

Re-host the three Apache-2.0 Wan2.2 MLX models on the SceneWorks HF org and flip the manifest to download the pre-converted weights, instead of converting on each user's machine (or pulling a third-party mirror). Epic [5594](https://app.shortcut.com/trefry/epic/5594).

| Model | New SceneWorks repo | Was |
|---|---|---|
| `wan_2_2` (TI2V-5B) | [wan2.2-ti2v-5b-mlx](https://huggingface.co/SceneWorks/wan2.2-ti2v-5b-mlx) (24 GB) | source + in-app convert |
| `wan_2_2_i2v_14b` (A14B) | [wan2.2-i2v-a14b-mlx](https://huggingface.co/SceneWorks/wan2.2-i2v-a14b-mlx) (64 GB) | source + in-app convert |
| `wan_2_2_t2v_14b` (A14B) | [wan2.2-t2v-a14b-mlx](https://huggingface.co/SceneWorks/wan2.2-t2v-a14b-mlx) (64 GB) | third-party AITRADER mirror |

All public, Apache-2.0, with model cards; artifacts are bf16 (Q4/Q8 applied at load), byte-identical to the local conversions.

## How

- **`builtin.models.jsonc`**: macOS download → SceneWorks repo + `estimatedSizeBytes`; `paths.model`; `mlx.repo`; drop `requiresConversion`/`converter`/`convertSourceRepo`. `wan_2_2_t2v_14b` restructured to per-platform downloads (macOS = MLX, win/linux = diffusers) — which also fixes its macOS download path (the download job reads `downloads[]`, never `mlx.repo`). Windows/Linux torch entries untouched.
- **`video_jobs.rs`**: `resolve_wan_model_dir` gives each model its SceneWorks turnkey repo. Load precedence unchanged: env override → local conversion → turnkey download.
- **`models.rs`**: `mlx_catalog_status` counts a pre-existing local conversion as installed for turnkey models, so a `requiresConversion`→turnkey flip doesn't read as "missing" for existing users.
- **`model_jobs.rs`**: env-driven `#[ignore]` conversion harness (`oneshot_convert_wan_to_data_dir`) — runs the production `convert_wan_native` + tokenizer copy; used to produce the i2v/t2v artifacts and reusable for remaining epic models.

## Verification

- `cargo check` + `clippy` + `fmt` clean; readiness unit tests pass; no parity-snapshot impact.
- Published file sizes verified byte-identical to the local conversions.
- **Remaining acceptance (not in this PR):** real-weight clean-machine turnkey smoke per model (heavy; the A14B pair are `minMemoryGb: 133` vs a 128 GB Mac → bf16 inference is tight, a pre-existing constraint, not introduced here).

## Notes

- i2v's local dir was a config-only stub (a failed prior conversion) → freshly converted from native source. t2v converted from native source for provenance (vs mirroring AITRADER).
- Gotcha: don't overlap a heavy MLX conversion with a large upload — memory pressure caused a Metal GPU command-buffer timeout on the first t2v attempt; re-running the conversion alone succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
