### PR TITLE
sc-5637: re-pin mlx-gen to merged main rev (24c89c9)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3219,11 +3219,11 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=44db8184106d70be88cd8661f018d4371ac9c0cf#44db8184106d70be88cd8661f018d4371ac9c0cf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=44db8184106d70be88cd8661f018d4371ac9c0cf)",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5)",
  "thiserror 2.0.18",
  "tokenizers 0.21.4",
 ]
@@ -3231,7 +3231,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=44db8184106d70be88cd8661f018d4371ac9c0cf#44db8184106d70be88cd8661f018d4371ac9c0cf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
 dependencies = [
  "image",
  "inventory",
@@ -3245,7 +3245,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=44db8184106d70be88cd8661f018d4371ac9c0cf#44db8184106d70be88cd8661f018d4371ac9c0cf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3257,7 +3257,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=44db8184106d70be88cd8661f018d4371ac9c0cf#44db8184106d70be88cd8661f018d4371ac9c0cf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3266,7 +3266,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=44db8184106d70be88cd8661f018d4371ac9c0cf#44db8184106d70be88cd8661f018d4371ac9c0cf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3278,7 +3278,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=44db8184106d70be88cd8661f018d4371ac9c0cf#44db8184106d70be88cd8661f018d4371ac9c0cf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3289,7 +3289,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=44db8184106d70be88cd8661f018d4371ac9c0cf#44db8184106d70be88cd8661f018d4371ac9c0cf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3300,7 +3300,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=44db8184106d70be88cd8661f018d4371ac9c0cf#44db8184106d70be88cd8661f018d4371ac9c0cf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3310,7 +3310,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=44db8184106d70be88cd8661f018d4371ac9c0cf#44db8184106d70be88cd8661f018d4371ac9c0cf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
 dependencies = [
  "image",
  "inventory",
@@ -3322,7 +3322,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=44db8184106d70be88cd8661f018d4371ac9c0cf#44db8184106d70be88cd8661f018d4371ac9c0cf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
 dependencies = [
  "image",
  "inventory",
@@ -3335,7 +3335,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=44db8184106d70be88cd8661f018d4371ac9c0cf#44db8184106d70be88cd8661f018d4371ac9c0cf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
 dependencies = [
  "image",
  "inventory",
@@ -3347,7 +3347,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=44db8184106d70be88cd8661f018d4371ac9c0cf#44db8184106d70be88cd8661f018d4371ac9c0cf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3358,7 +3358,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=44db8184106d70be88cd8661f018d4371ac9c0cf#44db8184106d70be88cd8661f018d4371ac9c0cf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3370,7 +3370,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=44db8184106d70be88cd8661f018d4371ac9c0cf#44db8184106d70be88cd8661f018d4371ac9c0cf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3380,7 +3380,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=44db8184106d70be88cd8661f018d4371ac9c0cf#44db8184106d70be88cd8661f018d4371ac9c0cf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3389,7 +3389,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=44db8184106d70be88cd8661f018d4371ac9c0cf#44db8184106d70be88cd8661f018d4371ac9c0cf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3398,7 +3398,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=44db8184106d70be88cd8661f018d4371ac9c0cf#44db8184106d70be88cd8661f018d4371ac9c0cf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3410,7 +3410,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=44db8184106d70be88cd8661f018d4371ac9c0cf#44db8184106d70be88cd8661f018d4371ac9c0cf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
 dependencies = [
  "image",
  "inventory",
@@ -3423,7 +3423,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=44db8184106d70be88cd8661f018d4371ac9c0cf#44db8184106d70be88cd8661f018d4371ac9c0cf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3434,7 +3434,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=44db8184106d70be88cd8661f018d4371ac9c0cf#44db8184106d70be88cd8661f018d4371ac9c0cf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3445,7 +3445,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=44db8184106d70be88cd8661f018d4371ac9c0cf#44db8184106d70be88cd8661f018d4371ac9c0cf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3456,7 +3456,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=44db8184106d70be88cd8661f018d4371ac9c0cf#44db8184106d70be88cd8661f018d4371ac9c0cf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
 dependencies = [
  "image",
  "inventory",
@@ -3470,7 +3470,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=44db8184106d70be88cd8661f018d4371ac9c0cf#44db8184106d70be88cd8661f018d4371ac9c0cf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
 dependencies = [
  "image",
  "inventory",
@@ -5098,7 +5098,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=44db8184106d70be88cd8661f018d4371ac9c0cf#44db8184106d70be88cd8661f018d4371ac9c0cf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
 dependencies = [
  "inventory",
  "safetensors 0.4.5",
@@ -5205,7 +5205,7 @@ dependencies = [
  "pmetal-mlx-rs",
  "reqwest 0.12.28",
  "sceneworks-core",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=44db8184106d70be88cd8661f018d4371ac9c0cf)",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5)",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -42,7 +42,8 @@ sceneworks-core = { path = "../sceneworks-core" }
 # the worker's import surface is unchanged → skew gate stays green at one rev. The candle-gen pin in the
 # macOS block is re-pinned in LOCKSTEP to candle-gen d3ec5e5 (#57, carried by sc-5501's dbe5560 bump) so
 # the `--features backend-candle` lane resolves the same single gen-core rev. mlx-rs unchanged (44929a0).
-# Rev 44db818 (mlx-gen branch claude/sc-5637-training-samples, sc-5637): adds training PREVIEW SAMPLES.
+# Rev 24c89c9 (mlx-gen main, merged PR #459, sc-5637): adds training PREVIEW SAMPLES. Re-pin from the
+# pre-merge branch rev 44db818 to the merged `main` rev (byte-identical content; merge-commit SHA).
 # gen-core `TrainingConfig` gains `sample_every`/`sample_prompts`/`sample_steps`/`sample_guidance_scale`
 # (default sample_every:0 ⇒ off) and `TrainingProgress` gains an additive `Sample { step, index, total,
 # prompt, image }` variant; ALL SIX native trainers (z-image/sdxl/kolors/lens image + wan/ltx video)
@@ -51,8 +52,8 @@ sceneworks-core = { path = "../sceneworks-core" }
 # (training_jobs.rs). PURELY ADDITIVE to gen-core (new fields + new enum variant), so the worker import
 # surface is otherwise unchanged → skew gate stays green at one rev. mlx-rs unchanged (44929a0);
 # candle-gen unaffected (gen-core change is additive; the backend-candle lane still resolves the same
-# single gen-core rev). NB: bumps EVERY mlx-gen crate d3ec5e5 -> 44db818 in lockstep.
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "44db8184106d70be88cd8661f018d4371ac9c0cf" }
+# single gen-core rev). NB: bumps EVERY mlx-gen crate d3ec5e5 -> 24c89c9 in lockstep.
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -314,7 +315,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "44db8184106d70be88cd8661f018d4371ac9c0cf" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -326,55 +327,55 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "44db8184106
 # internal pin (the Lens engine PRs #407–#414 did not move it; nor did the seedvr2 engine #416/#419/
 # #421 or the softness PR #422, so the 1a97909 bump above leaves mlx-rs at 44929a0).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "44929a001ab8a8837403a71c65cf064224de0cdc" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "44db8184106d70be88cd8661f018d4371ac9c0cf" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "44db8184106d70be88cd8661f018d4371ac9c0cf" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "44db8184106d70be88cd8661f018d4371ac9c0cf" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "44db8184106d70be88cd8661f018d4371ac9c0cf" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "44db8184106d70be88cd8661f018d4371ac9c0cf" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "44db8184106d70be88cd8661f018d4371ac9c0cf" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "44db8184106d70be88cd8661f018d4371ac9c0cf" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "44db8184106d70be88cd8661f018d4371ac9c0cf" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "44db8184106d70be88cd8661f018d4371ac9c0cf" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "44db8184106d70be88cd8661f018d4371ac9c0cf" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "44db8184106d70be88cd8661f018d4371ac9c0cf" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "44db8184106d70be88cd8661f018d4371ac9c0cf" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -383,12 +384,12 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "44db81
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "44db8184106d70be88cd8661f018d4371ac9c0cf" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "44db8184106d70be88cd8661f018d4371ac9c0cf" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -397,7 +398,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "44db81
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "44db8184106d70be88cd8661f018d4371ac9c0cf" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -405,7 +406,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "44db8184106d70be88cd8661f018d4371ac9c0cf" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -416,7 +417,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "44db
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "44db8184106d70be88cd8661f018d4371ac9c0cf" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -427,7 +428,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "44db8
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "44db8184106d70be88cd8661f018d4371ac9c0cf" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -442,7 +443,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "44db81
 # converted in-memory at load (no Python); the precomputed neg-prompt embedding is bundled in-crate. No
 # LoRA/guidance/CFG (one-step). 3B fp16 only here — 7B (sc-5197) + int8 (sc-5198) are engine-side and
 # unwired. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "44db8184106d70be88cd8661f018d4371ac9c0cf" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -453,7 +454,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "44d
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "44db8184106d70be88cd8661f018d4371ac9c0cf" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
 # Prompt-refine provider (sc-5552, the MLX twin of candle-gen-prompt-refine / sc-5500). An
 # inventory-registered `TextLlm` under id `prompt_refine` (`backend="mlx"`, `mac_only`): a native MLX
 # Llama-3.2-3B-Instruct that rewrites a user's prompt, replacing the Python `prompt_refine.py`
@@ -463,7 +464,7 @@ mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "44d
 # textllm registered" trap). Weights = a stock Llama-3.2-3B-Instruct HF snapshot (config.json +
 # tokenizer.json + model-*.safetensors; default `huihui-ai/Llama-3.2-3B-Instruct-abliterated`). Same
 # git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "44db8184106d70be88cd8661f018d4371ac9c0cf" }
+mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
 # SCAIL-2 (zai-org) end-to-end character-animation provider (epic 5439, sc-5448). An inventory-registered
 # `Generator` under id `scail2_14b` (`Modality::Video`): a Wan2.1-14B I2V DiT that animates a reference
 # character with a driving video's motion (`video_mode == "replacement"` flips the cross-identity
@@ -475,7 +476,7 @@ mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev 
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "44db8184106d70be88cd8661f018d4371ac9c0cf" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory


### PR DESCRIPTION
Follow-up to #676: that PR pinned the pre-merge branch rev `44db818`; this bumps the worker's mlx-gen/gen-core pin to the merged `main` rev `24c89c9` (merge of mlx-gen #459) so it tracks a main-history commit, not a feature-branch tip. Byte-identical content. Skew gate stays green at one rev (all 24 mlx-gen-* deps + the direct gen-core dep in lockstep); mlx-rs unchanged (44929a0). `cargo check -p sceneworks-worker` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)