### PR TITLE
sc-5686: wire SCAIL-2 LoRA into the worker (+ DPO converter)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3219,11 +3219,11 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5)",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12)",
  "thiserror 2.0.18",
  "tokenizers 0.21.4",
 ]
@@ -3231,7 +3231,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
 dependencies = [
  "image",
  "inventory",
@@ -3245,7 +3245,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3257,7 +3257,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3266,7 +3266,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3278,7 +3278,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3289,7 +3289,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3300,7 +3300,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3310,7 +3310,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
 dependencies = [
  "image",
  "inventory",
@@ -3322,7 +3322,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
 dependencies = [
  "image",
  "inventory",
@@ -3335,7 +3335,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
 dependencies = [
  "image",
  "inventory",
@@ -3347,7 +3347,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3358,7 +3358,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3370,7 +3370,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3380,7 +3380,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3389,7 +3389,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3398,7 +3398,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3410,7 +3410,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
 dependencies = [
  "image",
  "inventory",
@@ -3423,7 +3423,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3434,7 +3434,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3445,7 +3445,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3456,7 +3456,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
 dependencies = [
  "image",
  "inventory",
@@ -3470,7 +3470,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
 dependencies = [
  "image",
  "inventory",
@@ -5098,7 +5098,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5#24c89c90476279a4e47533202111ca19e40a46d5"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
 dependencies = [
  "inventory",
  "safetensors 0.4.5",
@@ -5205,7 +5205,7 @@ dependencies = [
  "pmetal-mlx-rs",
  "reqwest 0.12.28",
  "sceneworks-core",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=24c89c90476279a4e47533202111ca19e40a46d5)",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12)",
  "serde",
  "serde_json",
  "sha2",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2533,10 +2533,14 @@
         "schedulers": ["default"]
       },
       "loraCompatibility": {
-        // The Bias-Aware DPO refinement LoRA + general LoRA are wired in sc-5451; the
-        // engine descriptor currently reports supports_lora: false.
+        // SCAIL-2 LoRA is wired (sc-5451, mlx-gen #462): the engine descriptor reports
+        // supports_lora/supports_lokr and installs a standard lora_down/up adapter as a
+        // forward-time residual over the Q4 base; the worker routes request.loras via
+        // resolve_scail2_adapters (sc-5686). Covers the bundled Bias-Aware DPO quality
+        // (enhance) LoRA and user scail2-family LoRAs. (A lightx2v diff-patch "lightning"
+        // LoRA is rejected by the engine today — sc-5684.)
         "families": ["scail2"],
-        "types": []
+        "types": ["style", "motion", "character", "enhance"]
       },
       "mlx": {
         // Turnkey pre-converted MLX repo (no requiresConversion). The worker resolves

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -53,7 +53,14 @@ sceneworks-core = { path = "../sceneworks-core" }
 # surface is otherwise unchanged → skew gate stays green at one rev. mlx-rs unchanged (44929a0);
 # candle-gen unaffected (gen-core change is additive; the backend-candle lane still resolves the same
 # single gen-core rev). NB: bumps EVERY mlx-gen crate d3ec5e5 -> 24c89c9 in lockstep.
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
+# Rev 40063d5 (mlx-gen #462, sc-5451 / sc-5686): SCAIL-2 inference LoRA path — scail2_14b now advertises
+# supports_lora/supports_lokr and installs a standard lora_down/up (PEFT/diffusers/kohya/LoKr) LoRA as
+# forward-time residuals over the Q4/Q8 base via the family-agnostic apply_adapters_strict; a lightx2v
+# diff-patch file is rejected loudly (sc-5684). PURE mlx-gen-scail2 Rust change (the 24c89c9 -> 40063d5
+# range is #460 sc-5637 smokes + #461 sc-5445 Q4 + #462 sc-5451) — gen-core BYTE-IDENTICAL, mlx-rs
+# unchanged (44929a0), candle-gen unaffected → skew gate stays green at one rev. Bumps EVERY mlx-gen
+# crate 24c89c9 -> 40063d5 in lockstep (sc-5686 worker LoRA wiring).
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -315,7 +322,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -327,55 +334,55 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476
 # internal pin (the Lens engine PRs #407–#414 did not move it; nor did the seedvr2 engine #416/#419/
 # #421 or the softness PR #422, so the 1a97909 bump above leaves mlx-rs at 44929a0).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "44929a001ab8a8837403a71c65cf064224de0cdc" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -384,12 +391,12 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -398,7 +405,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -406,7 +413,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "2
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -417,7 +424,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c8
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -428,7 +435,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -443,7 +450,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c
 # converted in-memory at load (no Python); the precomputed neg-prompt embedding is bundled in-crate. No
 # LoRA/guidance/CFG (one-step). 3B fp16 only here — 7B (sc-5197) + int8 (sc-5198) are engine-side and
 # unwired. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -454,7 +461,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
 # Prompt-refine provider (sc-5552, the MLX twin of candle-gen-prompt-refine / sc-5500). An
 # inventory-registered `TextLlm` under id `prompt_refine` (`backend="mlx"`, `mac_only`): a native MLX
 # Llama-3.2-3B-Instruct that rewrites a user's prompt, replacing the Python `prompt_refine.py`
@@ -464,7 +471,7 @@ mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c
 # textllm registered" trap). Weights = a stock Llama-3.2-3B-Instruct HF snapshot (config.json +
 # tokenizer.json + model-*.safetensors; default `huihui-ai/Llama-3.2-3B-Instruct-abliterated`). Same
 # git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
+mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
 # SCAIL-2 (zai-org) end-to-end character-animation provider (epic 5439, sc-5448). An inventory-registered
 # `Generator` under id `scail2_14b` (`Modality::Video`): a Wan2.1-14B I2V DiT that animates a reference
 # character with a driving video's motion (`video_mode == "replacement"` flips the cross-identity
@@ -476,7 +483,7 @@ mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev 
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "24c89c90476279a4e47533202111ca19e40a46d5" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -1770,6 +1770,39 @@ fn resolve_wan_vace_adapters(request: &VideoRequest) -> WorkerResult<Vec<Adapter
     Ok(specs)
 }
 
+/// Build the adapter specs for a SCAIL-2 generation (sc-5451 inference LoRA path, mlx-gen #462).
+/// SCAIL-2 is a single **dense** Wan2.1-14B-I2V transformer — like Wan-VACE, no Lightning distill and
+/// no MoE high/low experts — so every LoRA is applied shared with `moe_expert: None`. The engine
+/// installs a standard `lora_down/up` (PEFT/diffusers/kohya/LoKr) adapter as a forward-time residual
+/// over the (Q4/Q8) base; `classify_adapter` tags SceneWorks peft LoKr as `Lokr` and everything else
+/// (incl. third-party LyCORIS) as `Lora`. This carries both a user-selected SCAIL-2 LoRA and the
+/// bundled Bias-Aware DPO quality LoRA (both surface through `request.loras`). A lightx2v diff-patch
+/// "lightning" LoRA is rejected by the engine today (sc-5684).
+#[cfg(target_os = "macos")]
+fn resolve_scail2_adapters(request: &VideoRequest) -> WorkerResult<Vec<AdapterSpec>> {
+    if request.loras.len() > MAX_JOB_LORAS {
+        return Err(WorkerError::InvalidPayload(format!(
+            "Generation supports at most {MAX_JOB_LORAS} LoRAs per job."
+        )));
+    }
+    let mut specs: Vec<AdapterSpec> = Vec::new();
+    for lora in &request.loras {
+        let path = lora_path(lora).ok_or_else(|| {
+            WorkerError::InvalidPayload("LoRA is missing a usable path.".to_owned())
+        })?;
+        let file = resolve_lora_file(path)?;
+        let kind = classify_adapter(&file)?;
+        specs.push(AdapterSpec {
+            path: file,
+            scale: lora_scale(lora),
+            kind,
+            pass_scales: None,
+            moe_expert: None,
+        });
+    }
+    Ok(specs)
+}
+
 /// The first-frame conditioning for a Wan generation: required for I2V-14B, optional for
 /// the TI2V-5B (present → image-conditioned mask-blend, absent → pure T2V), and ignored
 /// by the T2V-14B (text-only). Loads `source_asset_id` to an in-memory RGB8 image.
@@ -3279,8 +3312,10 @@ async fn resolve_scail2_conditioning(
 /// Real MLX SCAIL-2 generation (epic 5439 / sc-5448): build the `VideoGenInput` and run the shared
 /// `generate_video` path. The SceneWorks mode resolves to the engine `video_mode` task
 /// ([`scail2_engine_video_mode`]) and the source media into the SAM3-painted conditioning
-/// ([`resolve_scail2_conditioning`]). No LoRA (the engine reports `supports_lora=false`, sc-5451);
-/// steps/guidance stay at the engine defaults. Frame count uses the Wan 1-mod-4 stride coercion (the
+/// ([`resolve_scail2_conditioning`]). A user-selected SCAIL-2 LoRA and the bundled Bias-Aware DPO
+/// quality LoRA install as forward-time residuals over the Q4 base ([`resolve_scail2_adapters`],
+/// sc-5451 / mlx-gen #462); steps/guidance stay at the engine defaults. Frame count uses the Wan
+/// 1-mod-4 stride coercion (the
 /// renderer is Wan2.1); the engine stitches > 81-frame clips into overlapping segments internally.
 #[cfg(target_os = "macos")]
 async fn generate_scail2(
@@ -3311,6 +3346,7 @@ async fn generate_scail2(
         fps: request.fps,
         seed: resolve_video_seed(request) as u64,
         video_mode: Some(scail2_engine_video_mode(&request.mode).to_owned()),
+        adapters: resolve_scail2_adapters(request)?,
         ..VideoGenInput::default()
     };
     generate_video(api, settings, job, backend, input).await
@@ -6631,6 +6667,49 @@ mod tests {
         let over = request(json!({ "projectId": "p", "loras": many }));
         assert!(matches!(
             resolve_wan_vace_adapters(&over),
+            Err(WorkerError::InvalidPayload(_))
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// SCAIL-2 is single-dense like Wan-VACE (sc-5451/sc-5686): each user LoRA/LoKr (and the bundled
+    /// Bias-Aware DPO LoRA, which arrives the same way) resolves to one shared spec with
+    /// `moe_expert: None` and no `pass_scales`, the kind set by the file's metadata, scale from
+    /// `weight`; over the per-job cap is a clear payload error.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn scail2_adapters_are_single_dense() {
+        let dir = std::env::temp_dir().join(format!("sw_scail2_lora_{}", Uuid::new_v4().simple()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let plain = dir.join("dpo.safetensors");
+        let lokr = dir.join("char.safetensors");
+        write_lora_fixture(&plain, None);
+        write_lora_fixture(&lokr, Some("lokr"));
+
+        let req = request(json!({
+            "projectId": "p",
+            "loras": [
+                { "path": plain.to_string_lossy(), "weight": 1.0 },
+                { "path": lokr.to_string_lossy(), "weight": 0.7 },
+            ],
+        }));
+        let specs = resolve_scail2_adapters(&req).expect("resolve scail2 adapters");
+        assert_eq!(specs.len(), 2);
+        assert_eq!(specs[0].path, plain);
+        assert_eq!(specs[0].kind, AdapterKind::Lora);
+        assert!((specs[0].scale - 1.0).abs() < 1e-6);
+        assert!(specs[0].moe_expert.is_none(), "SCAIL-2 is single-dense");
+        assert!(specs[0].pass_scales.is_none());
+        assert_eq!(specs[1].kind, AdapterKind::Lokr);
+        assert!((specs[1].scale - 0.7).abs() < 1e-6);
+        assert!(specs[1].moe_expert.is_none());
+
+        let many: Vec<Value> = (0..MAX_JOB_LORAS + 1)
+            .map(|_| json!({ "path": plain.to_string_lossy() }))
+            .collect();
+        let over = request(json!({ "projectId": "p", "loras": many }));
+        assert!(matches!(
+            resolve_scail2_adapters(&over),
             Err(WorkerError::InvalidPayload(_))
         ));
         let _ = std::fs::remove_dir_all(&dir);

--- a/scripts/convert_scail2_dpo_lora.py
+++ b/scripts/convert_scail2_dpo_lora.py
@@ -1,0 +1,81 @@
+"""sc-5451 / sc-5686: convert SCAIL-2's Bias-Aware DPO LoRA to an engine-loadable safetensors.
+
+zai-org/SCAIL-2 ships its Bias-Aware DPO refinement LoRA as `model/bias-aware-dpo-lora.pt`
+(in `SceneWorks/scail2-mlx` and the upstream HF snapshot). That file is a **DeepSpeed/SAT**
+(SwissArmyTransformer) checkpoint — the LoRA state lives under the top-level `["module"]` key with
+SAT module names and `.lora_layer[.{idx}].{down,up}.weight` factors — which the native MLX engine's
+LoRA loader (which reads a `.safetensors` of standard `lora_down`/`lora_up` factors named for the
+inference `SCAIL2Model` modules) cannot consume directly.
+
+This converts it to `scail2-dpo-lora.safetensors`: a plain rank-128 LoRA whose keys are the inference
+module names the engine resolves (`blocks.N.{self_attn,cross_attn}.{q,k,v,o}`, `blocks.N.ffn.{0,2}`),
+with the SAT fused projections split out per sub-LoRA index (`query_key_value.lora_layer.{0,1,2}` =
+q/k/v; `key_value.lora_layer.{0,1}` = k/v; `dense` = the output proj `o`; `mlp.dense_h_to_4h`/`4h_to_h`
+= `ffn.0`/`ffn.2`). The mapping is a pure rename — the per-projection sub-LoRAs are already separate,
+and the dims confirm it (e.g. `mlp.dense_h_to_4h` down[128,5120]/up[13824,128] == SCAIL-2's
+`ffn.0` [13824,5120]). NO diff-patch tensors (unlike the lightx2v lightning LoRAs, sc-5684).
+
+The output applies through the family-agnostic engine loader (`apply_adapters_strict`) as a forward-time
+residual over the Q4 base — validated 2026-06-14 on a 128 GB Mac (400 modules matched, 16-frame
+generation, CFG-on). Host the result alongside the model in `SceneWorks/scail2-mlx` and catalog it in
+`config/manifests/builtin.loras.jsonc`.
+
+Usage:
+    python scripts/convert_scail2_dpo_lora.py <bias-aware-dpo-lora.pt> <scail2-dpo-lora.safetensors>
+"""
+
+import re
+import sys
+
+import torch
+from safetensors.torch import save_file
+
+# SAT (SwissArmyTransformer) module → inference `SCAIL2Model` module. The fused `query_key_value` /
+# `key_value` projections carry one `lora_layer.{idx}` per split (q/k/v, k/v); the rest are bare.
+SAT_TO_INFERENCE = {
+    "attention.query_key_value.lora_layer.0": "self_attn.q",
+    "attention.query_key_value.lora_layer.1": "self_attn.k",
+    "attention.query_key_value.lora_layer.2": "self_attn.v",
+    "attention.dense.lora_layer": "self_attn.o",
+    "cross_attention.query.lora_layer": "cross_attn.q",
+    "cross_attention.key_value.lora_layer.0": "cross_attn.k",
+    "cross_attention.key_value.lora_layer.1": "cross_attn.v",
+    "cross_attention.dense.lora_layer": "cross_attn.o",
+    "mlp.dense_h_to_4h.lora_layer": "ffn.0",
+    "mlp.dense_4h_to_h.lora_layer": "ffn.2",
+}
+
+_KEY = re.compile(
+    r"^model\.diffusion_model\.transformer\.layers\.(\d+)\.(.+)\.(down|up)\.weight$"
+)
+
+
+def convert(src_pt: str, out_safetensors: str) -> None:
+    ckpt = torch.load(src_pt, map_location="cpu", weights_only=False)
+    # DeepSpeed wraps the trained params under "module"; tolerate a bare state dict too.
+    sd = ckpt["module"] if isinstance(ckpt, dict) and "module" in ckpt else ckpt
+
+    out: dict[str, torch.Tensor] = {}
+    for key, value in sd.items():
+        if not hasattr(value, "shape"):
+            continue  # DeepSpeed RNG/optimizer bookkeeping
+        m = _KEY.match(key)
+        if not m:
+            raise SystemExit(f"unexpected SAT LoRA key (not a layer down/up factor): {key}")
+        layer, sat_module, factor = m.group(1), m.group(2), m.group(3)
+        inference_module = SAT_TO_INFERENCE.get(sat_module)
+        if inference_module is None:
+            raise SystemExit(f"unmapped SAT module '{sat_module}' (key {key})")
+        new_factor = "lora_down" if factor == "down" else "lora_up"
+        out_key = f"blocks.{layer}.{inference_module}.{new_factor}.weight"
+        out[out_key] = value.to(torch.bfloat16).contiguous()
+
+    save_file(out, out_safetensors)
+    pairs = len(out) // 2
+    print(f"converted {len(out)} tensors → {pairs} LoRA pairs → {out_safetensors}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        raise SystemExit(__doc__)
+    convert(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
Exposes the SCAIL-2 inference LoRA path (mlx-gen [#462](https://github.com/michaeltrefry/mlx-gen/pull/462) / sc-5451) in SceneWorks. **Blocked-by sc-5451 (now merged).**

## What
- **Pin bump**: all 24 mlx-gen crate revs `44db818 → 40063d5` (the #462 merge). gen-core is byte-identical and mlx-rs is unchanged (`44929a0`), so the gen-core **skew gate stays green at one rev**; the `Cargo.lock` diff is purely the rev bump (no dep churn).
- **Worker** (`crates/sceneworks-worker/src/video_jobs.rs`): new `resolve_scail2_adapters` (mirrors `resolve_wan_vace_adapters` — SCAIL-2 is a single **dense** Wan2.1-14B-I2V transformer: no MoE, no `pass_scales`), wired into `generate_scail2`'s `VideoGenInput`. Drops the stale `// No LoRA … supports_lora=false` comment. Carries a user-selected scail2-family LoRA **and** the bundled Bias-Aware DPO LoRA (both arrive via `request.loras`). New `scail2_adapters_are_single_dense` unit test.
- **Manifest** (`config/manifests/builtin.models.jsonc`): `scail2_14b` `loraCompatibility.types = [style, motion, character, enhance]` so the LoRA picker surfaces for SCAIL-2.
- **`scripts/convert_scail2_dpo_lora.py`**: the shipped `bias-aware-dpo-lora.pt` is a **DeepSpeed/SAT** checkpoint (LoRA under `["module"]`, fused `query_key_value`/`key_value` projections already split into per-projection `lora_layer.{idx}` sub-LoRAs, SAT module names). The converter renames it to an inference-named `scail2-dpo-lora.safetensors` (400 LoRA pairs; the dims confirm the mapping, e.g. `mlp.dense_h_to_4h` → SCAIL-2 `ffn.0`). Clean low-rank LoRA, no diff-patch.

## Validation (128 GB Mac)
- gen-core skew gate green (one resolution at `40063d5`).
- `cargo clippy -p sceneworks-worker -- -D warnings` + `cargo fmt --check` clean.
- 291 worker lib tests pass (incl. the new resolver test).
- The **converted DPO LoRA** applies via the engine over Q4 end-to-end (400 modules matched, CFG-on, 16 frames) — proving the worker→engine LoRA path.

## Remaining for the full DPO *bundle* (tracked in sc-5686, needs a call from you)
The LoRA **mechanism** is fully wired here — a scail2-family LoRA selected in the standard LoRA picker now flows to the engine. To ship the **bundled** Bias-Aware DPO as a one-click quality toggle, the converted `scail2-dpo-lora.safetensors` (~0.6 GB) needs **hosting** — recommend adding it to `SceneWorks/scail2-mlx` (the raw `.pt` already ships there; the converted file rides the existing download) — plus a `builtin.loras.jsonc` catalog entry and (optionally) a dedicated toggle. I held the HF upload for your go-ahead since it's an outward-facing publish to the private, pre-public-flip model repo.

Lightning (lightx2v) as a *speed* toggle rides the same plumbing but is **blocked on sc-5684** (engine rejects its diff-patch format).

Part of epic 5439. Do not merge — leaving the merge to Michael.

🤖 Generated with [Claude Code](https://claude.com/claude-code)