### PR TITLE
sc-5679: lean macOS LTX-2.3 default download (q4+gemma) + on-demand Q8 fetch

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1683,12 +1683,14 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/ltx-2.3-mlx",
-          "files": [],
+          // Lean default (sc-5679): LTX-2.3 MLX `q4/` (~20.5 GB) + the `gemma/` gemma-3-12b-it-bf16
+          // text encoder (~26.4 GB). The `q8/` subdir (~29.7 GB, higher quality) is NOT pulled here;
+          // the worker fetches it on demand the first time a job opts into Q8 (advanced
+          // mlxQuantize: 8) — see ensure_ltx_q8_present / resolve_ltx_model_dir in video_jobs.rs.
+          // No separate gemma download — the worker points the engine at gemma/ via $LTX_GEMMA_DIR.
+          "files": ["q4/*", "gemma/*"],
           "platforms": ["macos"],
-          // Self-contained bundle: LTX-2.3 MLX `q4/` (default, ~20.5 GB) + `q8/` (opt-in via
-          // advanced mlxQuantize: 8, ~29.7 GB) + the `gemma/` gemma-3-12b-it-bf16 text encoder
-          // (~26.4 GB). No separate gemma download — the worker points the engine at gemma/.
-          "estimatedSizeBytes": 76624310084
+          "estimatedSizeBytes": 46895585378
         },
         {
           "provider": "huggingface",

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -3527,6 +3527,18 @@ fn ltx_dir_is_complete(dir: &Path) -> bool {
     .all(|file| dir.join(file).is_file())
 }
 
+/// Whether the request opts into the higher-quality Q8 LTX checkpoint (`advanced.mlxQuantize: 8`,
+/// accepted as int or string). The default is Q4 (sc-5608).
+#[cfg(target_os = "macos")]
+fn ltx_wants_q8(request: &VideoRequest) -> bool {
+    request
+        .advanced
+        .get("mlxQuantize")
+        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()))
+        .map(|bits| bits >= 8)
+        .unwrap_or(false)
+}
+
 /// Pick the engine-complete `q4/`/`q8/` checkpoint subdir of a SceneWorks LTX bundle `root`,
 /// preferring the requested quant (sc-5608). Returns the first **complete** ([`ltx_dir_is_complete`])
 /// subdir — so a partially-downloaded bundle falls through rather than half-loading — or `None`.
@@ -3563,12 +3575,7 @@ fn resolve_ltx_model_dir(settings: &Settings, request: &VideoRequest) -> WorkerR
             return Ok(path);
         }
     }
-    let wants_q8 = request
-        .advanced
-        .get("mlxQuantize")
-        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()))
-        .map(|bits| bits >= 8)
-        .unwrap_or(false);
+    let wants_q8 = ltx_wants_q8(request);
     let candidates: &[&str] = if eros {
         &["ltx_2_3_eros"]
     } else if wants_q8 {
@@ -3624,6 +3631,50 @@ fn ensure_bundled_ltx_gemma_dir(model_dir: &Path) {
     if let Some(gemma) = bundled_ltx_gemma_dir(model_dir) {
         std::env::set_var("LTX_GEMMA_DIR", gemma);
     }
+}
+
+/// On-demand fetch of the bundle's `q8/` subdir (sc-5679). The macOS default download is lean
+/// (`q4/` + `gemma/`); when a job opts into Q8 ([`ltx_wants_q8`]) and the bundle's `q8/` isn't already
+/// complete, pull just `q8/*` from [`LTX_BUNDLE_REPO`] into the HF cache so [`resolve_ltx_model_dir`]
+/// can load it. Base model only (eros has its own single-dir conversion). No-op when Q8 isn't
+/// requested, the bundle snapshot isn't downloaded yet (resolve surfaces the clear "download the
+/// bundle" error), or `q8/` is already present. Fails loud on a real download error — fast, before
+/// any compute; a missing `hf` CLI leaves `q8/` absent so resolve gracefully falls back to Q4.
+/// Mirrors the eros [`ensure_ltx_upscaler_cached`] on-demand fetch.
+#[cfg(target_os = "macos")]
+async fn ensure_ltx_q8_present(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &VideoRequest,
+) -> WorkerResult<()> {
+    if request.model == "ltx_2_3_eros" || !ltx_wants_q8(request) {
+        return Ok(());
+    }
+    let Some(root) = huggingface_snapshot_dir(&settings.data_dir, LTX_BUNDLE_REPO) else {
+        return Ok(());
+    };
+    if ltx_dir_is_complete(&root.join("q8")) {
+        return Ok(());
+    }
+    let scratch = settings
+        .data_dir
+        .join("cache")
+        .join(format!(".ltx-q8-fetch-{}", job.id));
+    tokio::fs::create_dir_all(&scratch).await?;
+    let files = vec!["q8/*".to_owned()];
+    let result = crate::model_jobs::download_model_with_hf_cli(
+        api,
+        settings,
+        job,
+        LTX_BUNDLE_REPO,
+        "main",
+        &files,
+        &scratch,
+    )
+    .await;
+    let _ = tokio::fs::remove_dir_all(&scratch).await;
+    result.map(|_| ())
 }
 
 /// User LoRAs for an LTX generation (sc-3035): each at a uniform per-pass strength
@@ -4094,6 +4145,9 @@ async fn generate_ltx(
         }
         _ => resolve_ltx_conditioning(settings, request, project_path)?,
     };
+    // The macOS default download is lean (q4 + gemma); a Q8 job fetches the bundle's q8/ on demand
+    // before resolving (sc-5679). No-op unless Q8 is requested and q8/ is absent.
+    ensure_ltx_q8_present(api, settings, job, request).await?;
     let model_dir = resolve_ltx_model_dir(settings, request)?;
     // When the resolved dir is the SceneWorks bundle subdir, its sibling `gemma/` is the text
     // encoder — point the engine at it (sc-5608) before load. No-op for legacy/local conversions.
@@ -6864,6 +6918,22 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&root);
         let _ = std::fs::remove_dir_all(&bare);
+    }
+
+    /// Q8 opt-in detection (sc-5679): `advanced.mlxQuantize: 8` (int or string) → true; absent / Q4
+    /// → false. Drives both the resolve quant preference and the on-demand q8 fetch.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn ltx_wants_q8_reads_mlx_quantize() {
+        let with = |adv: Value| {
+            request(json!({ "projectId": "p", "model": "ltx_2_3", "prompt": "x", "advanced": adv }))
+        };
+        assert!(ltx_wants_q8(&with(json!({ "mlxQuantize": 8 }))));
+        assert!(ltx_wants_q8(&with(json!({ "mlxQuantize": "8" }))));
+        assert!(!ltx_wants_q8(&with(json!({ "mlxQuantize": 4 }))));
+        assert!(!ltx_wants_q8(&request(
+            json!({ "projectId": "p", "model": "ltx_2_3", "prompt": "x" })
+        )));
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
## What

Follow-up to [sc-5608](https://app.shortcut.com/trefry/story/5608) (the `SceneWorks/ltx-2.3-mlx` flip, [#678](https://github.com/michaeltrefry/SceneWorks/pull/678)). That flip pulled the **whole ~76 GB** bundle on macOS so the Q8 opt-in needed no extra fetch. This makes the default **lean** while keeping **both options** available: default = q4 + gemma; Q8 fetched on demand.

## Changes

**Manifest** (`builtin.models.jsonc`, `ltx_2_3` macOS download)
- `files: []` → `["q4/*", "gemma/*"]` — default download is now **~46.9 GB** (q4 ~20.5 + gemma ~26.4); the `q8/` subdir (~29.7 GB) is no longer pulled up front. `estimatedSizeBytes` updated.

**Worker** (`video_jobs.rs`)
- Extracted `ltx_wants_q8(request)` (reads `advanced.mlxQuantize: 8`, int or string).
- New `ensure_ltx_q8_present` — for the base model, when Q8 is requested and the bundle's `q8/` isn't already complete, fetches `q8/*` via the existing `download_model_with_hf_cli` (the same `--include` mechanism as the eros upscaler). Wired into `generate_ltx` **before** `resolve_ltx_model_dir` (which already prefers q8→q4). Fails fast on a real fetch error (before any compute); a missing `hf` CLI leaves q8 absent so resolve gracefully falls back to Q4.
- Unit test for `ltx_wants_q8`; the existing `ltx_bundle_subdir` test already covers q8-preferred selection.

## Why this is safe
- `files[]` flow as `hf download --include <pattern>` (worker) and the rust-api catalog size estimate matches via `glob::Pattern` (`download_size_from_siblings` → `allow_pattern_matches`) — both verified. `validate_hf_include_pattern` allows `*`. The bundle's `q4/` and `gemma/` are flat dirs, so `q4/*` + `gemma/*` match exactly the needed files.

## Verification
- `cargo fmt` / `check` / `clippy --all-targets -D warnings` clean.
- **293 worker + 8 rust-api manifest/catalog + LTX unit tests** green (incl. new `ltx_wants_q8`).
- The lean **q4+gemma path is already smoke-validated** end-to-end (sc-5608 used these exact patterns and the q4 T2V+audio smoke passed).
- The on-demand fetch mechanism was confirmed live — an interrupted `--include "q8/*"` run pulled 6/7 q8 files before it was stopped. A full q8 *generation* smoke was intentionally skipped (disk pressure; q8 is the same engine/format as q4, differing only in quant bits read from `split_model.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)