### PR TITLE
sc-5686: catalog the SCAIL-2 Bias-Aware DPO LoRA

### DIFF
--- a/config/manifests/builtin.loras.jsonc
+++ b/config/manifests/builtin.loras.jsonc
@@ -61,6 +61,23 @@
         "repo": "Lightricks/LTX-2.3-22b-IC-LoRA-LipDub",
         "file": "ltx-2.3-22b-ic-lora-lipdub-0.9.safetensors"
       }
+    },
+    {
+      // SCAIL-2 Bias-Aware DPO refinement LoRA (sc-5451 / sc-5686). A plain rank-128 low-rank LoRA
+      // (NOT an IC-LoRA) converted from zai-org's DeepSpeed/SAT `bias-aware-dpo-lora.pt` to the
+      // inference module names via scripts/convert_scail2_dpo_lora.py; the engine installs it as a
+      // forward-time residual over the Q4 base. Downloaded on demand when selected for a scail2 job.
+      "id": "scail2_dpo_quality",
+      "name": "SCAIL-2 Bias-Aware DPO (quality)",
+      "family": "scail2",
+      "triggerWords": [],
+      "compatibility": { "families": ["scail2"] },
+      "defaultWeight": 1.0,
+      "source": {
+        "provider": "huggingface",
+        "repo": "SceneWorks/scail2-dpo-lora",
+        "file": "scail2-dpo-lora.safetensors"
+      }
     }
   ]
 }


### PR DESCRIPTION
Completes the SCAIL-2 DPO **bundle** on top of the merged worker wiring ([#679](https://github.com/michaeltrefry/SceneWorks/pull/679)).

## What
Adds the **Bias-Aware DPO** quality LoRA to `config/manifests/builtin.loras.jsonc`:
```jsonc
{ "id": "scail2_dpo_quality", "name": "SCAIL-2 Bias-Aware DPO (quality)", "family": "scail2",
  "triggerWords": [], "compatibility": { "families": ["scail2"] }, "defaultWeight": 1.0,
  "source": { "provider": "huggingface", "repo": "SceneWorks/scail2-dpo-lora",
              "file": "scail2-dpo-lora.safetensors" } }
```

- Sourced from the new **public** [`SceneWorks/scail2-dpo-lora`](https://huggingface.co/SceneWorks/scail2-dpo-lora) HF repo (apache-2.0) — the inference-named conversion of zai-org's DeepSpeed/SAT `bias-aware-dpo-lora.pt` produced by `scripts/convert_scail2_dpo_lora.py` (rank 128, 400 LoRA pairs, bf16, ~1.2 GB).
- `family: scail2` / `compatibility.families: ["scail2"]` matches `scail2_14b`'s `loraCompatibility.families` (set in #679), so the LoRA picker surfaces it for SCAIL-2 jobs and it **downloads on demand** when selected (matching the LTX IC-LoRA pattern — not bundled into the base model download). The worker's `resolve_scail2_adapters` then routes it to the engine as a forward-time residual over the Q4 base.
- Plain refinement LoRA → `icLora`/`conditioningRole` correctly omitted (the consuming code defaults them falsy).

## Validation
- `builtin.loras.jsonc` parses; the entry round-trips the `LoraManifestEntry` serde contract.
- `cargo test -p sceneworks-core --test contract_roundtrip` (7) + `sceneworks-rust-api` lora (16) + manifest (9) tests green.
- The underlying weights were already validated applying via the engine over Q4 end-to-end (400 modules, CFG-on).

With this, the **end-to-end DPO quality toggle is live**: select "SCAIL-2 Bias-Aware DPO (quality)" in the LoRA picker on a SCAIL-2 job → it downloads → routes to the engine. A *dedicated* one-click toggle affordance (beyond the standard picker) remains optional polish.

Part of epic 5439 / sc-5686. Do not merge — leaving the merge to Michael.

🤖 Generated with [Claude Code](https://claude.com/claude-code)