### PR TITLE
sc-5681: bump worker mlx-gen pin to 891bee4 + scail2_14b minMemoryGb 48 → 96

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_distr 0.5.1",
  "safetensors 0.7.0",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12)",
  "serde_json",
  "thiserror 2.0.18",
 ]
@@ -3241,11 +3241,11 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a)",
  "thiserror 2.0.18",
  "tokenizers 0.21.4",
 ]
@@ -3253,7 +3253,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
 dependencies = [
  "image",
  "inventory",
@@ -3267,7 +3267,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3279,7 +3279,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3288,7 +3288,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3300,7 +3300,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3311,7 +3311,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3322,7 +3322,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3332,7 +3332,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
 dependencies = [
  "image",
  "inventory",
@@ -3344,7 +3344,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
 dependencies = [
  "image",
  "inventory",
@@ -3357,7 +3357,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
 dependencies = [
  "image",
  "inventory",
@@ -3369,7 +3369,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3380,7 +3380,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3392,7 +3392,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3402,7 +3402,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3411,7 +3411,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3420,7 +3420,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3432,7 +3432,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
 dependencies = [
  "image",
  "inventory",
@@ -3445,7 +3445,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3456,7 +3456,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3467,7 +3467,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3478,7 +3478,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
 dependencies = [
  "image",
  "inventory",
@@ -3492,7 +3492,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
 dependencies = [
  "image",
  "inventory",
@@ -5130,6 +5130,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sceneworks-gen-core"
+version = "0.1.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
+dependencies = [
+ "inventory",
+ "safetensors 0.4.5",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokenizers 0.21.4",
+]
+
+[[package]]
 name = "sceneworks-rust-api"
 version = "0.2.0"
 dependencies = [
@@ -5216,7 +5228,7 @@ dependencies = [
  "pmetal-mlx-rs",
  "reqwest 0.12.28",
  "sceneworks-core",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a)",
  "serde",
  "serde_json",
  "sha2",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2548,12 +2548,14 @@
         // Turnkey pre-converted MLX repo (no requiresConversion). The worker resolves
         // env override (SCENEWORKS_MLX_SCAIL2_DIR) → local <data>/models/mlx/scail2 →
         // this download-on-first-use snapshot, mirroring bernini.
-        // minMemoryGb is PROVISIONAL pending the real-size Mac measurement in sc-5445.
-        // Independent estimate: SCAIL-2 is a single Wan2.1-14B DiT (~1/3 of Bernini's
-        // dual-14B + 7B-planner stack, which needs 64) — Q4 weights ~8.4 GB; the 256²
-        // e2e smoke peaked 16.4 GB RSS (Metal-wired memory is not counted in RSS). 48
-        // is a conservative floor that still fits 64 GB-class Macs and gates out 32 GB.
-        "minMemoryGb": 48,
+        // minMemoryGb MEASURED under sc-5681 (mlx-gen #463). The real production bucket is
+        // 832x480/5s (81-frame segment): the full pipeline runs f32 DiT compute (bf16
+        // overflowed to NaN at that sequence length) and a temporal-tiled VAE decode, with a
+        // measured process footprint of ~76 GB (MLX-active peaks: preproc 13.5 / denoise 24.8 /
+        // decode 33.2 GB; the Metal VAE-decode conv scratch is ~2x the active). 76 GB exceeds
+        // 64, so 96 is the floor that fits with headroom (the earlier provisional 48 only ever
+        // ran the 256² smoke, which never exercised a real bucket).
+        "minMemoryGb": 96,
         "repo": "SceneWorks/scail2-mlx",
         "quantize": 4,
         "limits": {

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -70,7 +70,16 @@ sceneworks-core = { path = "../sceneworks-core" }
 # byte-identical). This is the lockstep the blocks ABOVE should have carried; sc-5491 closes it while
 # wiring the candle InstantID worker route. (Pre-merge of candle-gen #63 this points at the branch
 # commit; flip to the merged candle-gen `main` rev once #63 lands.)
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
+# Rev 891bee4 (mlx-gen #463-465, epic 5439 / sc-5681): makes high-res SCAIL-2 actually RUN — f32 DiT
+# compute (the bf16 path overflowed to NaN at L≳40k / 832x480·5s) + a temporal-tiled VAE decode (the
+# real 832x480 OOM was the *decode*, not the DiT — ~139GB un-tiled) + the shared mlx-gen-wan activation-
+# chunking layer (#463); plus combined-axis tiled-decode regression coverage (#464, sc-5690) and the
+# lightx2v lightning diff-patch LoRA (#465, sc-5684). gen-core BYTE-IDENTICAL 40063d5 -> 891bee4, mlx-rs
+# unchanged (44929a0). Bumps EVERY mlx-gen crate 40063d5 -> 891bee4 in lockstep. Pairs with scail2_14b
+# minMemoryGb 48 -> 96 (the measured 832x480/5s process footprint, 76GB). NB: reopens the candle-gen
+# gen-core skew sc-5491 closed (candle-gen b4f6c6f re-pins to 40063d5; no 891bee4-based candle rev exists
+# yet) — same catch-up-in-its-own-repo pattern, the default/CI graph (candle off) stays single-rev.
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -176,6 +185,14 @@ backend-candle = [
 # desktop packager (build-sidecar.mjs) has a dylib to stage and dev runs work.
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
+# Rev 891bee4 (mlx-gen #463-465, epic 5439 / sc-5681 + sc-5451/5686/5684): bumps EVERY mlx-gen crate
+# 40063d5 -> 891bee4 in lockstep (gen-core BYTE-IDENTICAL, mlx-rs unchanged 44929a0 — so MLX rebuilds
+# only the changed mlx-gen Rust layers). Carries the SCAIL-2 high-res fix (f32 DiT compute since bf16
+# overflowed to NaN at L≳40k + temporal-tiled VAE decode; #463/sc-5681), the inference-LoRA path
+# (#462/sc-5451) that scail2 worker routing already wires, tiled-decode regression coverage (#464),
+# and the lightx2v lightning diff-patch LoRA (#465). Pairs with scail2_14b minMemoryGb 48 -> 96 (the
+# measured 832x480/5s footprint). Full rationale: the gen-core block above. (The intervening 40063d5
+# entry was omitted from this block by #679 — covered here.)
 # Rev fa0f75b (mlx-gen main, merged PRs #453/#454/#455 + #456, epic 5439 / sc-5448): adds the full
 # **SCAIL-2** provider (`mlx-gen-scail2`, dep below) — a Wan2.1-14B I2V end-to-end character-animation /
 # cross-identity-replacement Generator self-registering as `scail2_14b` (reference character image +
@@ -338,7 +355,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -350,55 +367,55 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed
 # internal pin (the Lens engine PRs #407–#414 did not move it; nor did the seedvr2 engine #416/#419/
 # #421 or the softness PR #422, so the 1a97909 bump above leaves mlx-rs at 44929a0).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "44929a001ab8a8837403a71c65cf064224de0cdc" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -407,12 +424,12 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -421,7 +438,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -429,7 +446,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -440,7 +457,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4006
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -451,7 +468,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -466,7 +483,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d
 # converted in-memory at load (no Python); the precomputed neg-prompt embedding is bundled in-crate. No
 # LoRA/guidance/CFG (one-step). 3B fp16 only here — 7B (sc-5197) + int8 (sc-5198) are engine-side and
 # unwired. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -477,7 +494,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "400
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
 # Prompt-refine provider (sc-5552, the MLX twin of candle-gen-prompt-refine / sc-5500). An
 # inventory-registered `TextLlm` under id `prompt_refine` (`backend="mlx"`, `mac_only`): a native MLX
 # Llama-3.2-3B-Instruct that rewrites a user's prompt, replacing the Python `prompt_refine.py`
@@ -487,7 +504,7 @@ mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "400
 # textllm registered" trap). Weights = a stock Llama-3.2-3B-Instruct HF snapshot (config.json +
 # tokenizer.json + model-*.safetensors; default `huihui-ai/Llama-3.2-3B-Instruct-abliterated`). Same
 # git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
+mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
 # SCAIL-2 (zai-org) end-to-end character-animation provider (epic 5439, sc-5448). An inventory-registered
 # `Generator` under id `scail2_14b` (`Modality::Video`): a Wan2.1-14B I2V DiT that animates a reference
 # character with a driving video's motion (`video_mode == "replacement"` flips the cross-identity
@@ -499,7 +516,7 @@ mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev 
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "40063d565ed0827e4383cd4392841a0f1a733c12" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory


### PR DESCRIPTION
## What
Bumps the worker `mlx-gen` pin `40063d5 → 891bee4` (mlx-gen main, #463–465) and sets `scail2_14b minMemoryGb: 48 → 96`. This is the SceneWorks half of **sc-5681** — it lands the high-res SCAIL-2 fix in the worker.

## Why
mlx-gen #463 (sc-5681) makes the SCAIL-2 832×480/5s bucket actually run:
- **f32 DiT compute** — the bf16 path overflowed to NaN at L≳40k.
- **temporal-tiled VAE decode** — the real 832×480 OOM was the *decode* (~139 GB un-tiled), not the DiT.
- the shared `mlx-gen-wan` activation-chunking layer.

The pin also picks up #464 (combined-axis tiled-decode regression coverage, sc-5690) and #465 (lightx2v lightning diff-patch LoRA, sc-5684).

`minMemoryGb: 96` is **measured**: the full 832×480/5s pipeline runs at a **~76 GB process footprint** (MLX-active peaks preproc 13.5 / denoise 24.8 / decode 33.2 GB; the Metal decode conv scratch is ~2× the active). 76 GB > 64, so 96 is the floor that fits with headroom; the provisional 48 only ever ran the 256² smoke.

## Validation
- gen-core skew gate: single rev (`891bee4`) in the worker's default build graph.
- `cargo check -p sceneworks-worker`: clean at the new pin.
- gen-core BYTE-IDENTICAL `40063d5 → 891bee4`, mlx-rs unchanged (`44929a0`) → MLX rebuilds only the changed mlx-gen Rust layers.

## Note
candle-gen (`b4f6c6f`) still references gen-core `40063d5` (off in the default graph) → it catches up to `891bee4` in its own repo, same as prior mlx-gen bumps (documented in `Cargo.toml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)