### PR TITLE
sc-5700: bundle the SCAIL-2 lightx2v lightning speed toggle (+ candle-gen lockstep)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0eeb9262fb38a17ca0735443663cbdb64164945b#0eeb9262fb38a17ca0735443663cbdb64164945b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89b28dd5f499ff61d44e51d3260e4b8cb225f834#89b28dd5f499ff61d44e51d3260e4b8cb225f834"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0eeb9262fb38a17ca0735443663cbdb64164945b#0eeb9262fb38a17ca0735443663cbdb64164945b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89b28dd5f499ff61d44e51d3260e4b8cb225f834#89b28dd5f499ff61d44e51d3260e4b8cb225f834"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0eeb9262fb38a17ca0735443663cbdb64164945b#0eeb9262fb38a17ca0735443663cbdb64164945b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89b28dd5f499ff61d44e51d3260e4b8cb225f834#89b28dd5f499ff61d44e51d3260e4b8cb225f834"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0eeb9262fb38a17ca0735443663cbdb64164945b#0eeb9262fb38a17ca0735443663cbdb64164945b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89b28dd5f499ff61d44e51d3260e4b8cb225f834#89b28dd5f499ff61d44e51d3260e4b8cb225f834"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -490,7 +490,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0eeb9262fb38a17ca0735443663cbdb64164945b#0eeb9262fb38a17ca0735443663cbdb64164945b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89b28dd5f499ff61d44e51d3260e4b8cb225f834#89b28dd5f499ff61d44e51d3260e4b8cb225f834"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -504,7 +504,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0eeb9262fb38a17ca0735443663cbdb64164945b#0eeb9262fb38a17ca0735443663cbdb64164945b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89b28dd5f499ff61d44e51d3260e4b8cb225f834#89b28dd5f499ff61d44e51d3260e4b8cb225f834"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0eeb9262fb38a17ca0735443663cbdb64164945b#0eeb9262fb38a17ca0735443663cbdb64164945b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89b28dd5f499ff61d44e51d3260e4b8cb225f834#89b28dd5f499ff61d44e51d3260e4b8cb225f834"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -527,7 +527,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0eeb9262fb38a17ca0735443663cbdb64164945b#0eeb9262fb38a17ca0735443663cbdb64164945b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89b28dd5f499ff61d44e51d3260e4b8cb225f834#89b28dd5f499ff61d44e51d3260e4b8cb225f834"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -540,7 +540,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0eeb9262fb38a17ca0735443663cbdb64164945b#0eeb9262fb38a17ca0735443663cbdb64164945b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89b28dd5f499ff61d44e51d3260e4b8cb225f834#89b28dd5f499ff61d44e51d3260e4b8cb225f834"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -553,7 +553,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0eeb9262fb38a17ca0735443663cbdb64164945b#0eeb9262fb38a17ca0735443663cbdb64164945b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89b28dd5f499ff61d44e51d3260e4b8cb225f834#89b28dd5f499ff61d44e51d3260e4b8cb225f834"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -565,7 +565,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0eeb9262fb38a17ca0735443663cbdb64164945b#0eeb9262fb38a17ca0735443663cbdb64164945b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89b28dd5f499ff61d44e51d3260e4b8cb225f834#89b28dd5f499ff61d44e51d3260e4b8cb225f834"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -576,7 +576,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0eeb9262fb38a17ca0735443663cbdb64164945b#0eeb9262fb38a17ca0735443663cbdb64164945b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89b28dd5f499ff61d44e51d3260e4b8cb225f834#89b28dd5f499ff61d44e51d3260e4b8cb225f834"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -590,7 +590,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0eeb9262fb38a17ca0735443663cbdb64164945b#0eeb9262fb38a17ca0735443663cbdb64164945b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89b28dd5f499ff61d44e51d3260e4b8cb225f834#89b28dd5f499ff61d44e51d3260e4b8cb225f834"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -608,7 +608,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0eeb9262fb38a17ca0735443663cbdb64164945b#0eeb9262fb38a17ca0735443663cbdb64164945b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89b28dd5f499ff61d44e51d3260e4b8cb225f834#89b28dd5f499ff61d44e51d3260e4b8cb225f834"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -621,7 +621,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0eeb9262fb38a17ca0735443663cbdb64164945b#0eeb9262fb38a17ca0735443663cbdb64164945b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89b28dd5f499ff61d44e51d3260e4b8cb225f834#89b28dd5f499ff61d44e51d3260e4b8cb225f834"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -634,7 +634,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0eeb9262fb38a17ca0735443663cbdb64164945b#0eeb9262fb38a17ca0735443663cbdb64164945b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89b28dd5f499ff61d44e51d3260e4b8cb225f834#89b28dd5f499ff61d44e51d3260e4b8cb225f834"
 dependencies = [
  "candle-core",
  "candle-gen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b4f6c6faf8ce38fe0d9ff5f551283a573560115b#b4f6c6faf8ce38fe0d9ff5f551283a573560115b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0eeb9262fb38a17ca0735443663cbdb64164945b#0eeb9262fb38a17ca0735443663cbdb64164945b"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -444,7 +444,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_distr 0.5.1",
  "safetensors 0.7.0",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12)",
+ "sceneworks-gen-core",
  "serde_json",
  "thiserror 2.0.18",
 ]
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b4f6c6faf8ce38fe0d9ff5f551283a573560115b#b4f6c6faf8ce38fe0d9ff5f551283a573560115b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0eeb9262fb38a17ca0735443663cbdb64164945b#0eeb9262fb38a17ca0735443663cbdb64164945b"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b4f6c6faf8ce38fe0d9ff5f551283a573560115b#b4f6c6faf8ce38fe0d9ff5f551283a573560115b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0eeb9262fb38a17ca0735443663cbdb64164945b#0eeb9262fb38a17ca0735443663cbdb64164945b"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b4f6c6faf8ce38fe0d9ff5f551283a573560115b#b4f6c6faf8ce38fe0d9ff5f551283a573560115b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0eeb9262fb38a17ca0735443663cbdb64164945b#0eeb9262fb38a17ca0735443663cbdb64164945b"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -490,7 +490,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b4f6c6faf8ce38fe0d9ff5f551283a573560115b#b4f6c6faf8ce38fe0d9ff5f551283a573560115b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0eeb9262fb38a17ca0735443663cbdb64164945b#0eeb9262fb38a17ca0735443663cbdb64164945b"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -504,7 +504,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b4f6c6faf8ce38fe0d9ff5f551283a573560115b#b4f6c6faf8ce38fe0d9ff5f551283a573560115b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0eeb9262fb38a17ca0735443663cbdb64164945b#0eeb9262fb38a17ca0735443663cbdb64164945b"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b4f6c6faf8ce38fe0d9ff5f551283a573560115b#b4f6c6faf8ce38fe0d9ff5f551283a573560115b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0eeb9262fb38a17ca0735443663cbdb64164945b#0eeb9262fb38a17ca0735443663cbdb64164945b"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -527,7 +527,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b4f6c6faf8ce38fe0d9ff5f551283a573560115b#b4f6c6faf8ce38fe0d9ff5f551283a573560115b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0eeb9262fb38a17ca0735443663cbdb64164945b#0eeb9262fb38a17ca0735443663cbdb64164945b"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -540,7 +540,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b4f6c6faf8ce38fe0d9ff5f551283a573560115b#b4f6c6faf8ce38fe0d9ff5f551283a573560115b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0eeb9262fb38a17ca0735443663cbdb64164945b#0eeb9262fb38a17ca0735443663cbdb64164945b"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -553,7 +553,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b4f6c6faf8ce38fe0d9ff5f551283a573560115b#b4f6c6faf8ce38fe0d9ff5f551283a573560115b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0eeb9262fb38a17ca0735443663cbdb64164945b#0eeb9262fb38a17ca0735443663cbdb64164945b"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -565,7 +565,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b4f6c6faf8ce38fe0d9ff5f551283a573560115b#b4f6c6faf8ce38fe0d9ff5f551283a573560115b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0eeb9262fb38a17ca0735443663cbdb64164945b#0eeb9262fb38a17ca0735443663cbdb64164945b"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -576,7 +576,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b4f6c6faf8ce38fe0d9ff5f551283a573560115b#b4f6c6faf8ce38fe0d9ff5f551283a573560115b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0eeb9262fb38a17ca0735443663cbdb64164945b#0eeb9262fb38a17ca0735443663cbdb64164945b"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -590,7 +590,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b4f6c6faf8ce38fe0d9ff5f551283a573560115b#b4f6c6faf8ce38fe0d9ff5f551283a573560115b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0eeb9262fb38a17ca0735443663cbdb64164945b#0eeb9262fb38a17ca0735443663cbdb64164945b"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -608,7 +608,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b4f6c6faf8ce38fe0d9ff5f551283a573560115b#b4f6c6faf8ce38fe0d9ff5f551283a573560115b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0eeb9262fb38a17ca0735443663cbdb64164945b#0eeb9262fb38a17ca0735443663cbdb64164945b"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -621,7 +621,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b4f6c6faf8ce38fe0d9ff5f551283a573560115b#b4f6c6faf8ce38fe0d9ff5f551283a573560115b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0eeb9262fb38a17ca0735443663cbdb64164945b#0eeb9262fb38a17ca0735443663cbdb64164945b"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -634,7 +634,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b4f6c6faf8ce38fe0d9ff5f551283a573560115b#b4f6c6faf8ce38fe0d9ff5f551283a573560115b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0eeb9262fb38a17ca0735443663cbdb64164945b#0eeb9262fb38a17ca0735443663cbdb64164945b"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -3245,7 +3245,7 @@ source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b307
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a)",
+ "sceneworks-gen-core",
  "thiserror 2.0.18",
  "tokenizers 0.21.4",
 ]
@@ -5120,18 +5120,6 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=40063d565ed0827e4383cd4392841a0f1a733c12#40063d565ed0827e4383cd4392841a0f1a733c12"
-dependencies = [
- "inventory",
- "safetensors 0.4.5",
- "serde_json",
- "thiserror 2.0.18",
- "tokenizers 0.21.4",
-]
-
-[[package]]
-name = "sceneworks-gen-core"
-version = "0.1.0"
 source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
 dependencies = [
  "inventory",
@@ -5228,7 +5216,7 @@ dependencies = [
  "pmetal-mlx-rs",
  "reqwest 0.12.28",
  "sceneworks-core",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a)",
+ "sceneworks-gen-core",
  "serde",
  "serde_json",
  "sha2",

--- a/config/manifests/builtin.loras.jsonc
+++ b/config/manifests/builtin.loras.jsonc
@@ -78,6 +78,29 @@
         "repo": "SceneWorks/scail2-dpo-lora",
         "file": "scail2-dpo-lora.safetensors"
       }
+    },
+    {
+      // SCAIL-2 lightx2v lightning SPEED toggle (sc-5684 / sc-5700). The cross-architecture
+      // step-distill ("lightning") LoRA from lightx2v's Wan2.1-I2V-14B repo (Apache-2.0): a hybrid
+      // diff-patch file (full-rank .diff/.diff_b on the norms/biases/head + low-rank lora_down/up on
+      // the dim-5120 projections). The engine installs it via an in-place dense merge that handles
+      // the diff patches and deliberately skips the cross-arch in_dim-36 `patch_embedding` (mlx-gen
+      // #465); selecting it makes the worker auto-apply the step-distill recipe — 8 steps, CFG off
+      // (guidance 1.0), scheduler shift 1.0 — for ~10× fewer DiT passes (minutes → near-sub-minute).
+      // Referenced directly from lightx2v's HF repo (no re-host); downloaded on demand. Requires the
+      // DENSE bf16 snapshot (the in-place merge can't fold into pre-quantized weights) — the published
+      // SceneWorks/scail2-mlx snapshot is bf16 + load-time Q4, which satisfies this.
+      "id": "scail2_lightning",
+      "name": "SCAIL-2 Lightning (8-step, fast)",
+      "family": "scail2",
+      "triggerWords": [],
+      "compatibility": { "families": ["scail2"] },
+      "defaultWeight": 1.0,
+      "source": {
+        "provider": "huggingface",
+        "repo": "lightx2v/Wan2.1-I2V-14B-480P-StepDistill-CfgDistill-Lightx2v",
+        "file": "loras/Wan21_I2V_14B_lightx2v_cfg_step_distill_lora_rank64.safetensors"
+      }
     }
   ]
 }

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2539,8 +2539,10 @@
         // supports_lora/supports_lokr and installs a standard lora_down/up adapter as a
         // forward-time residual over the Q4 base; the worker routes request.loras via
         // resolve_scail2_adapters (sc-5686). Covers the bundled Bias-Aware DPO quality
-        // (enhance) LoRA and user scail2-family LoRAs. (A lightx2v diff-patch "lightning"
-        // LoRA is rejected by the engine today — sc-5684.)
+        // (enhance) LoRA and user scail2-family LoRAs. The lightx2v diff-patch "lightning"
+        // LoRA (sc-5684, mlx-gen #465) installs via the engine's in-place diff-patch merge
+        // and is bundled as the `scail2_lightning` speed toggle (sc-5700, builtin.loras.jsonc)
+        // — selecting it auto-applies the 8-step / CFG-off recipe.
         "families": ["scail2"],
         "types": ["style", "motion", "character", "enhance"]
       },

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -76,9 +76,12 @@ sceneworks-core = { path = "../sceneworks-core" }
 # chunking layer (#463); plus combined-axis tiled-decode regression coverage (#464, sc-5690) and the
 # lightx2v lightning diff-patch LoRA (#465, sc-5684). gen-core BYTE-IDENTICAL 40063d5 -> 891bee4, mlx-rs
 # unchanged (44929a0). Bumps EVERY mlx-gen crate 40063d5 -> 891bee4 in lockstep. Pairs with scail2_14b
-# minMemoryGb 48 -> 96 (the measured 832x480/5s process footprint, 76GB). NB: reopens the candle-gen
-# gen-core skew sc-5491 closed (candle-gen b4f6c6f re-pins to 40063d5; no 891bee4-based candle rev exists
-# yet) — same catch-up-in-its-own-repo pattern, the default/CI graph (candle off) stays single-rev.
+# minMemoryGb 48 -> 96 (the measured 832x480/5s process footprint, 76GB). #683 briefly reopened the
+# gen-core skew sc-5491 closed (it left candle-gen at b4f6c6f / gen-core 40063d5, no 891bee4-based candle
+# rev existing yet); sc-5700 re-closes it below by re-pinning candle-gen b4f6c6f -> 0eeb926 (candle-gen
+# #64, which re-pins gen-core 40063d5 -> 891bee4) so `--features backend-candle --target all` resolves
+# the single rev 891bee4 again. (Pre-merge of candle-gen #64 this pins the branch commit; flip to the
+# merge commit once it lands.)
 sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -586,29 +589,29 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891b
 # are bumped to `d3ec5e5` in LOCKSTEP (above) to keep the candle lane on ONE gen-core rev. ALL candle
 # deps MUST share this rev.
 [target.'cfg(target_os = "windows")'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b4f6c6faf8ce38fe0d9ff5f551283a573560115b", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0eeb9262fb38a17ca0735443663cbdb64164945b", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b4f6c6faf8ce38fe0d9ff5f551283a573560115b", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b4f6c6faf8ce38fe0d9ff5f551283a573560115b", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b4f6c6faf8ce38fe0d9ff5f551283a573560115b", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b4f6c6faf8ce38fe0d9ff5f551283a573560115b", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0eeb9262fb38a17ca0735443663cbdb64164945b", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0eeb9262fb38a17ca0735443663cbdb64164945b", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0eeb9262fb38a17ca0735443663cbdb64164945b", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0eeb9262fb38a17ca0735443663cbdb64164945b", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b4f6c6faf8ce38fe0d9ff5f551283a573560115b", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0eeb9262fb38a17ca0735443663cbdb64164945b", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b`; ltx registers `ltx_2_3_distilled` (txt2video first slice — no conditioning/audio/
 # LoRA/quant). Force-linked in video_jobs.rs (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b4f6c6faf8ce38fe0d9ff5f551283a573560115b", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b4f6c6faf8ce38fe0d9ff5f551283a573560115b", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0eeb9262fb38a17ca0735443663cbdb64164945b", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0eeb9262fb38a17ca0735443663cbdb64164945b", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b4f6c6faf8ce38fe0d9ff5f551283a573560115b", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0eeb9262fb38a17ca0735443663cbdb64164945b", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -617,19 +620,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b4f6c6faf8ce38fe0d9ff5f551283a573560115b", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0eeb9262fb38a17ca0735443663cbdb64164945b", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b4f6c6faf8ce38fe0d9ff5f551283a573560115b", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0eeb9262fb38a17ca0735443663cbdb64164945b", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b4f6c6faf8ce38fe0d9ff5f551283a573560115b", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0eeb9262fb38a17ca0735443663cbdb64164945b", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -638,12 +641,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b4f6c6faf8ce38fe0d9ff5f551283a573560115b", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0eeb9262fb38a17ca0735443663cbdb64164945b", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b4f6c6faf8ce38fe0d9ff5f551283a573560115b", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0eeb9262fb38a17ca0735443663cbdb64164945b", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -651,7 +654,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b4f6c
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 24c89c9, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b4f6c6faf8ce38fe0d9ff5f551283a573560115b", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0eeb9262fb38a17ca0735443663cbdb64164945b", features = ["cuda"], optional = true }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -80,8 +80,7 @@ sceneworks-core = { path = "../sceneworks-core" }
 # gen-core skew sc-5491 closed (it left candle-gen at b4f6c6f / gen-core 40063d5, no 891bee4-based candle
 # rev existing yet); sc-5700 re-closes it below by re-pinning candle-gen b4f6c6f -> 0eeb926 (candle-gen
 # #64, which re-pins gen-core 40063d5 -> 891bee4) so `--features backend-candle --target all` resolves
-# the single rev 891bee4 again. (Pre-merge of candle-gen #64 this pins the branch commit; flip to the
-# merge commit once it lands.)
+# the single rev 891bee4 again. (candle-gen #64 merged as 89b28dd — the merge commit.)
 sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -589,29 +588,29 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891b
 # are bumped to `d3ec5e5` in LOCKSTEP (above) to keep the candle lane on ONE gen-core rev. ALL candle
 # deps MUST share this rev.
 [target.'cfg(target_os = "windows")'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0eeb9262fb38a17ca0735443663cbdb64164945b", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89b28dd5f499ff61d44e51d3260e4b8cb225f834", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0eeb9262fb38a17ca0735443663cbdb64164945b", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0eeb9262fb38a17ca0735443663cbdb64164945b", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0eeb9262fb38a17ca0735443663cbdb64164945b", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0eeb9262fb38a17ca0735443663cbdb64164945b", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89b28dd5f499ff61d44e51d3260e4b8cb225f834", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89b28dd5f499ff61d44e51d3260e4b8cb225f834", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89b28dd5f499ff61d44e51d3260e4b8cb225f834", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89b28dd5f499ff61d44e51d3260e4b8cb225f834", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0eeb9262fb38a17ca0735443663cbdb64164945b", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89b28dd5f499ff61d44e51d3260e4b8cb225f834", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b`; ltx registers `ltx_2_3_distilled` (txt2video first slice — no conditioning/audio/
 # LoRA/quant). Force-linked in video_jobs.rs (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0eeb9262fb38a17ca0735443663cbdb64164945b", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0eeb9262fb38a17ca0735443663cbdb64164945b", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89b28dd5f499ff61d44e51d3260e4b8cb225f834", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89b28dd5f499ff61d44e51d3260e4b8cb225f834", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0eeb9262fb38a17ca0735443663cbdb64164945b", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89b28dd5f499ff61d44e51d3260e4b8cb225f834", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -620,19 +619,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0eeb9262fb38a17ca0735443663cbdb64164945b", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89b28dd5f499ff61d44e51d3260e4b8cb225f834", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0eeb9262fb38a17ca0735443663cbdb64164945b", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89b28dd5f499ff61d44e51d3260e4b8cb225f834", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0eeb9262fb38a17ca0735443663cbdb64164945b", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89b28dd5f499ff61d44e51d3260e4b8cb225f834", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -641,12 +640,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0eeb9262fb38a17ca0735443663cbdb64164945b", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89b28dd5f499ff61d44e51d3260e4b8cb225f834", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0eeb9262fb38a17ca0735443663cbdb64164945b", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89b28dd5f499ff61d44e51d3260e4b8cb225f834", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -654,7 +653,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0eeb9
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 24c89c9, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0eeb9262fb38a17ca0735443663cbdb64164945b", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89b28dd5f499ff61d44e51d3260e4b8cb225f834", features = ["cuda"], optional = true }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -206,9 +206,10 @@ pub(crate) async fn run_video_generate_job(
             )
             .await?;
             (
+                // The replace_person path doesn't resolve user LoRAs (sc-5452), so no lightning recipe.
                 decoded,
                 SCAIL2_ADAPTER,
-                scail2_raw_settings(&request),
+                scail2_raw_settings(&request, false),
                 Some(status),
             )
         } else {
@@ -362,7 +363,14 @@ pub(crate) async fn run_video_generate_job(
             )
             .await?,
             SCAIL2_ADAPTER,
-            scail2_raw_settings(&request),
+            // Best-effort lightning detection for the asset's effective-recipe record (the adapter
+            // file is already resolved by generate_scail2 above; re-reading its header is cheap).
+            scail2_raw_settings(
+                &request,
+                scail2_adapters_have_lightning(
+                    &resolve_scail2_adapters(&request).unwrap_or_default(),
+                ),
+            ),
             None,
         )
     } else {
@@ -1777,7 +1785,8 @@ fn resolve_wan_vace_adapters(request: &VideoRequest) -> WorkerResult<Vec<Adapter
 /// over the (Q4/Q8) base; `classify_adapter` tags SceneWorks peft LoKr as `Lokr` and everything else
 /// (incl. third-party LyCORIS) as `Lora`. This carries both a user-selected SCAIL-2 LoRA and the
 /// bundled Bias-Aware DPO quality LoRA (both surface through `request.loras`). A lightx2v diff-patch
-/// "lightning" LoRA is rejected by the engine today (sc-5684).
+/// "lightning" LoRA installs via the engine's in-place diff-patch merge (sc-5684); selecting it makes
+/// the worker apply the step-distill recipe (`scail2_sampling`, sc-5700).
 #[cfg(target_os = "macos")]
 fn resolve_scail2_adapters(request: &VideoRequest) -> WorkerResult<Vec<AdapterSpec>> {
     if request.loras.len() > MAX_JOB_LORAS {
@@ -2117,6 +2126,48 @@ fn wan_sampling(engine_id: &str, request: &VideoRequest) -> (Option<u32>, Option
     (steps, guidance)
 }
 
+/// The lightx2v lightning step-distill recipe (sc-5684 / sc-5700): 8 steps, CFG off, scheduler shift 1.
+#[cfg(target_os = "macos")]
+const SCAIL2_LIGHTNING_STEPS: u32 = 8;
+#[cfg(target_os = "macos")]
+const SCAIL2_LIGHTNING_GUIDANCE: f32 = 1.0;
+#[cfg(target_os = "macos")]
+const SCAIL2_LIGHTNING_SHIFT: f32 = 1.0;
+
+/// SCAIL-2 sampling recipe `(steps, guidance, scheduler_shift)`. When a lightx2v diff-patch
+/// "lightning" LoRA is selected (`lightning`), apply the step-distill recipe so the toggle yields the
+/// ~10× fewer-DiT-passes speedup: CFG off (guidance 1.0 → the engine short-circuits to a single DiT
+/// forward per step) and scheduler shift 1.0 are the lightning invariants (forced), and the step count
+/// defaults to 8 but honors an explicit user `advanced.steps` override. Without a lightning LoRA, return
+/// all-`None` so the engine's quality defaults (40 steps, guide 5.0, shift 5.0) stand exactly as before
+/// — this path is unchanged. The chosen knobs are recorded as `effective*` in [`scail2_raw_settings`]
+/// so what actually ran is inspectable on the asset (mirrors [`wan_raw_settings`]).
+#[cfg(target_os = "macos")]
+fn scail2_sampling(
+    request: &VideoRequest,
+    lightning: bool,
+) -> (Option<u32>, Option<f32>, Option<f32>) {
+    if !lightning {
+        return (None, None, None);
+    }
+    (
+        advanced_opt_u32(request, "steps").or(Some(SCAIL2_LIGHTNING_STEPS)),
+        Some(SCAIL2_LIGHTNING_GUIDANCE),
+        Some(SCAIL2_LIGHTNING_SHIFT),
+    )
+}
+
+/// `true` if any resolved adapter is a lightx2v diff-patch ("lightning") LoRA — the engine's own
+/// detector (a file carrying full-rank `.diff`/`.diff_b` tensors), so the recipe keys off the actual
+/// format, not a catalog id or filename. A file that can't be read is treated as non-lightning (the
+/// engine surfaces the real load error downstream).
+#[cfg(target_os = "macos")]
+fn scail2_adapters_have_lightning(adapters: &[AdapterSpec]) -> bool {
+    adapters
+        .iter()
+        .any(|a| mlx_gen_scail2::has_diff_patch_keys(&a.path).unwrap_or(false))
+}
+
 /// The resolved inputs for one video generation (engine load + request build), shared by
 /// Wan (sc-3034) and LTX (sc-3035) — split out so the engine call is unit-testable on real
 /// weights without the API/job plumbing. The LTX-only knobs (`video_mode` no_audio,
@@ -2139,6 +2190,9 @@ struct VideoGenInput {
     fps: u32,
     steps: Option<u32>,
     guidance: Option<f32>,
+    /// Flow-matching scheduler shift (`req.scheduler_shift`); `None` ⇒ the engine default. Set by the
+    /// SCAIL-2 lightning recipe (shift 1.0, sc-5700); the other models leave it at the engine default.
+    scheduler_shift: Option<f32>,
     seed: u64,
     /// Per-request control-clip conditioning scale (Wan-VACE `conditioning_scale`, sc-3441 /
     /// sc-3521); `None` ⇒ the engine default (1.0). Unused by the non-control paths.
@@ -2179,6 +2233,7 @@ impl Default for VideoGenInput {
             fps: 0,
             steps: None,
             guidance: None,
+            scheduler_shift: None,
             seed: 0,
             control_scale: None,
             video_mode: None,
@@ -2234,6 +2289,7 @@ fn run_loaded_video_generation(
         fps: Some(input.fps),
         steps: input.steps,
         guidance: input.guidance,
+        scheduler_shift: input.scheduler_shift,
         seed: Some(input.seed),
         conditioning: input.conditioning,
         control_scale: input.control_scale,
@@ -3161,9 +3217,12 @@ fn resolve_scail2_quant(request: &VideoRequest) -> Option<Quant> {
     }
 }
 
-/// Raw-settings recorded on a real MLX SCAIL-2 asset (mirrors `bernini_raw_settings`).
+/// Raw-settings recorded on a real MLX SCAIL-2 asset (mirrors `bernini_raw_settings`). When the
+/// lightx2v lightning LoRA is applied (`lightning`, sc-5700), records the effective step-distill recipe
+/// the worker dispatched — so the chosen steps/CFG/shift is inspectable on the asset, not silent
+/// (mirrors `wan_raw_settings`).
 #[cfg(target_os = "macos")]
-fn scail2_raw_settings(request: &VideoRequest) -> Value {
+fn scail2_raw_settings(request: &VideoRequest, lightning: bool) -> Value {
     let mut raw = request.advanced.clone();
     raw.insert("realModelInference".to_owned(), Value::Bool(true));
     raw.insert("model".to_owned(), Value::String(request.model.clone()));
@@ -3174,6 +3233,19 @@ fn scail2_raw_settings(request: &VideoRequest) -> Value {
         "scail2Task".to_owned(),
         Value::String(scail2_engine_video_mode(&request.mode).to_owned()),
     );
+    if lightning {
+        let (steps, guidance, shift) = scail2_sampling(request, true);
+        raw.insert("scail2Lightning".to_owned(), Value::Bool(true));
+        if let Some(steps) = steps {
+            raw.insert("effectiveSteps".to_owned(), json!(steps));
+        }
+        if let Some(guidance) = guidance {
+            raw.insert("effectiveGuidanceScale".to_owned(), json!(guidance));
+        }
+        if let Some(shift) = shift {
+            raw.insert("effectiveSchedulerShift".to_owned(), json!(shift));
+        }
+    }
     Value::Object(raw)
 }
 
@@ -3333,6 +3405,12 @@ async fn generate_scail2(
     };
     let conditioning =
         resolve_scail2_conditioning(api, settings, job, request, project_path).await?;
+    // Selecting a lightx2v diff-patch "lightning" LoRA flips the worker to the step-distill recipe
+    // (8 steps, CFG off, shift 1.0) so the toggle yields the speedup; otherwise steps/guidance/shift
+    // stay `None` and the engine's quality defaults stand (sc-5700).
+    let adapters = resolve_scail2_adapters(request)?;
+    let (steps, guidance, scheduler_shift) =
+        scail2_sampling(request, scail2_adapters_have_lightning(&adapters));
     let input = VideoGenInput {
         engine_id,
         model_dir: resolve_scail2_model_dir(settings)?,
@@ -3344,9 +3422,12 @@ async fn generate_scail2(
         height: request.height,
         frames: wan_frame_count(request.raw_frame_count()),
         fps: request.fps,
+        steps,
+        guidance,
+        scheduler_shift,
         seed: resolve_video_seed(request) as u64,
         video_mode: Some(scail2_engine_video_mode(&request.mode).to_owned()),
-        adapters: resolve_scail2_adapters(request)?,
+        adapters,
         ..VideoGenInput::default()
     };
     generate_video(api, settings, job, backend, input).await
@@ -6301,7 +6382,7 @@ mod tests {
                 "fps": 16,
                 "advanced": { "mlxQuantize": 4, "userKnob": "keep-me" }
             }));
-            let raw = scail2_raw_settings(&req);
+            let raw = scail2_raw_settings(&req, false);
             (raw, req)
         };
         let (raw, req) = raw_for("animate_character");
@@ -6312,9 +6393,49 @@ mod tests {
         assert_eq!(raw["frameCount"], json!(req.frame_count()));
         assert_eq!(raw["scail2Task"], json!("animation"));
         assert_eq!(raw["userKnob"], json!("keep-me"));
+        // No lightning LoRA ⇒ no effective-recipe override recorded (engine quality defaults stand).
+        assert!(raw.get("scail2Lightning").is_none());
+        assert!(raw.get("effectiveSteps").is_none());
         // replace_person resolves to the replacement task (flips the engine replace_flag).
         let (raw_replace, _) = raw_for("replace_person");
         assert_eq!(raw_replace["scail2Task"], json!("replacement"));
+    }
+
+    /// The lightx2v lightning toggle (sc-5700): selecting a diff-patch LoRA applies the step-distill
+    /// recipe — 8 steps, CFG off (guidance 1.0), scheduler shift 1.0 — with an explicit user step
+    /// count still honored, and the effective recipe is recorded on the asset. Without lightning the
+    /// sampling is all-`None` (the engine's quality defaults stand, unchanged).
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn scail2_lightning_recipe_overrides_sampling_and_records() {
+        let req = request(json!({
+            "projectId": "p", "model": "scail2_14b", "mode": "animate_character",
+            "duration": 5, "fps": 16, "advanced": {}
+        }));
+        // Non-lightning: untouched (engine defaults).
+        assert_eq!(scail2_sampling(&req, false), (None, None, None));
+        // Lightning: CFG off + shift 1.0 forced, steps default 8.
+        assert_eq!(
+            scail2_sampling(&req, true),
+            (Some(8), Some(1.0), Some(1.0)),
+            "lightning applies the 8-step CFG-off recipe"
+        );
+        // An explicit user step count is honored; CFG/shift stay forced.
+        let req_steps = request(json!({
+            "projectId": "p", "model": "scail2_14b", "mode": "animate_character",
+            "duration": 5, "fps": 16, "advanced": { "steps": 4 }
+        }));
+        assert_eq!(
+            scail2_sampling(&req_steps, true),
+            (Some(4), Some(1.0), Some(1.0))
+        );
+        // The effective recipe is recorded for observability when lightning is active.
+        let raw = scail2_raw_settings(&req, true);
+        let raw = raw.as_object().unwrap();
+        assert_eq!(raw["scail2Lightning"], json!(true));
+        assert_eq!(raw["effectiveSteps"], json!(8));
+        assert_eq!(raw["effectiveGuidanceScale"], json!(1.0));
+        assert_eq!(raw["effectiveSchedulerShift"], json!(1.0));
     }
 
     /// SCAIL-2 conditioning resolution fails loudly BEFORE any IO when its required media is missing


### PR DESCRIPTION
The SceneWorks user-facing half of the lightx2v **lightning** speed lever. The engine landed in sc-5684 ([mlx-gen #465](https://github.com/michaeltrefry/mlx-gen/pull/465)); #683 (sc-5681) already moved the worker to the `891bee4` pin. This adds the catalog + recipe so a user can actually pick it, and re-closes a gen-core lockstep #683 reopened.

## What

**Lightning bundle (sc-5700)**
- `builtin.loras.jsonc`: new `scail2_lightning` LoRA entry pointing **directly** at lightx2v's Apache-2.0 `Wan2.1-I2V-14B-480P-StepDistill-CfgDistill-Lightx2v` repo (no re-host), downloaded on demand. The engine installs its diff-patch tensors via the sc-5684 in-place dense merge.
- `video_jobs.rs`: `scail2_sampling` — when a diff-patch ("lightning") LoRA is among the resolved adapters (detected by the engine's own `mlx_gen_scail2::has_diff_patch_keys`, not a catalog id/filename), the worker applies the step-distill recipe: **8 steps, CFG off** (guidance 1.0 → the engine short-circuits to a single DiT forward/step), **scheduler shift 1.0**. An explicit user step count is honored; CFG/shift are the lightning invariants. Without a lightning LoRA, sampling stays all-`None` and the engine's quality defaults are unchanged. Plumbs `scheduler_shift` through `VideoGenInput → GenerationRequest`, and records the effective recipe (`effectiveSteps`/`GuidanceScale`/`SchedulerShift` + `scail2Lightning`) on the asset (mirrors `wan_raw_settings`). Wired into `animate_character` (`generate_scail2`); the `replace_person` path doesn't resolve user LoRAs (sc-5452), so it's deliberately untouched.
- `builtin.models.jsonc`: refreshed the `loraCompatibility` comment (lightning supported + bundled).

**candle-gen lockstep (restores sc-5491)**
- #683 bumped mlx-gen→`891bee4` but left candle-gen at `b4f6c6f` (gen-core `40063d5`), briefly reopening the `--features backend-candle --target all` two-gen-core-rev skew. Re-pin candle-gen → `0eeb926` ([candle-gen #64](https://github.com/michaeltrefry/candle-gen/pull/64), a mechanical gen-core `40063d5→891bee4` re-pin — byte-identical public surface) so **both** the default graph and the candle lane resolve the single rev `891bee4` again. Pre-merge of #64 this pins the branch commit.

## Constraint
The diff-patch merge needs the **dense bf16** snapshot (it can't fold into pre-quantized weights); the published `SceneWorks/scail2-mlx` snapshot is bf16 + load-time Q4, which satisfies it. If sc-5445 later publishes a pre-quantized default, the lightning path must keep resolving a dense base (noted on sc-5700/sc-5445).

## Validation
`cargo check` / `clippy -Dwarnings` / `fmt` clean; 295 worker lib tests (new `scail2_lightning_recipe_overrides_sampling_and_records`); skew gate green on **both** the default graph and `--target all`. The engine merge + lightning recipe were validated real-weight in sc-5684 (730/530 deltas merged, 16-frame video in 19.5s at the 8-step recipe). A full worker→engine e2e on the dense snapshot is the remaining manual check.

Depends on: [candle-gen #64](https://github.com/michaeltrefry/candle-gen/pull/64) (pinned pre-merge). Engine: sc-5684 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)