### PR TITLE
sc-5445: refresh scail2-mlx snapshot size after shipping lean Q4 repo

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2479,9 +2479,9 @@
     // ViT-H/14 image tower; packed-token conditioning with auto-generated color-coded
     // segmentation masks (the worker paints them from native SAM3 — no user masks).
     // macOS-only native MLX (mlx-gen-scail2, engine id "scail2_14b"); no Torch path.
-    // Distributed the SceneWorks/*-mlx turnkey way: the converted bf16 snapshot is
-    // published as `SceneWorks/scail2-mlx`, downloaded on first use (engine quantizes
-    // Q4 at load). This entry covers the standalone `animate_character` mode (sc-5447 /
+    // Distributed the SceneWorks/*-mlx turnkey way: a pre-quantized Q4 snapshot is
+    // published as `SceneWorks/scail2-mlx` (sc-5445), downloaded on first use. This entry
+    // covers the standalone `animate_character` mode (sc-5447 /
     // sc-5448) AND cross-identity `replace_person` (sc-5452 — the SAME engine with
     // replace_flag=true, offered as the higher-quality backend behind the existing
     // person-track replacement pipeline). LoRA refinement under sc-5451 — not declared
@@ -2502,12 +2502,12 @@
           "repo": "SceneWorks/scail2-mlx",
           "files": [],
           "platforms": ["macos"],
-          // Pre-converted MLX snapshot (bf16 DiT + stock Wan2.1 VAE / umt5-xxl +
-          // open-CLIP ViT-H/14 visual tower). PROVISIONAL size: the published repo
-          // still carries the redundant raw torch pickles (~15 GB) alongside the
-          // loadable safetensors; sc-5445 prunes them at ship-time, dropping this to
-          // ~34 GB. Self-contained — no Wan base needed at runtime. Q4 default at load.
-          "estimatedSizeBytes": 48440000000
+          // Pre-converted, pre-quantized MLX snapshot: Q4-packed DiT (~8.9 GB) + stock
+          // Wan2.1 VAE / umt5-xxl + open-CLIP ViT-H/14 visual tower + Bias-Aware DPO LoRA.
+          // Self-contained — no Wan base needed at runtime. Size MEASURED from the HF tree
+          // after sc-5445 shipped the lean Q4 repo (the redundant raw torch pickles —
+          // ~14.4 GB — were pruned; the loaders use only the safetensors).
+          "estimatedSizeBytes": 25241936201
         }
       ],
       "paths": {


### PR DESCRIPTION
The `SceneWorks/scail2-mlx` HF repo was published as a **lean pre-quantized Q4 snapshot** (sc-5445, commit [`35d6df7`](https://huggingface.co/SceneWorks/scail2-mlx/commit/35d6df79b14d6fb2a9a29bb611abb6c21baa2c08)): the DiT was swapped bf16 → Q4 packed (32.8 → 8.9 GB) and the ~14.4 GB redundant raw torch pickles (`Wan2.1_VAE.pth`, `umt5-xxl/models_t5_…pth`, `models_clip_…onlyvisual.pth`) were pruned. The repo is now **25.24 GB** (was 48.4 GB), public, MIT/permissive.

This refreshes the manifest to match:
- `estimatedSizeBytes` 48,440,000,000 → **25,241,936,201** (measured from the HF tree).
- Updates the stale download comment ("bf16 DiT … quantize-at-load … prune-to-~34 GB") to the shipped pre-quantized-Q4 state.

`minMemoryGb: 96` is **unchanged** — already measured under sc-5681 (mlx-gen #463), and independently reproduced here (832×480 / 5 s full segment ran at ~70 GB peak on the Q4 snapshot + current engine, no OOM). No code, no pin change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)