### PR TITLE
sc-5491: re-pin worker candle-gen 89b28dd -> 0c8b9ac (#65 InstantID CFG fixes)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89b28dd5f499ff61d44e51d3260e4b8cb225f834#89b28dd5f499ff61d44e51d3260e4b8cb225f834"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0c8b9ac87fc993f4dab2263e0628d2742bf0b012#0c8b9ac87fc993f4dab2263e0628d2742bf0b012"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89b28dd5f499ff61d44e51d3260e4b8cb225f834#89b28dd5f499ff61d44e51d3260e4b8cb225f834"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0c8b9ac87fc993f4dab2263e0628d2742bf0b012#0c8b9ac87fc993f4dab2263e0628d2742bf0b012"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89b28dd5f499ff61d44e51d3260e4b8cb225f834#89b28dd5f499ff61d44e51d3260e4b8cb225f834"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0c8b9ac87fc993f4dab2263e0628d2742bf0b012#0c8b9ac87fc993f4dab2263e0628d2742bf0b012"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89b28dd5f499ff61d44e51d3260e4b8cb225f834#89b28dd5f499ff61d44e51d3260e4b8cb225f834"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0c8b9ac87fc993f4dab2263e0628d2742bf0b012#0c8b9ac87fc993f4dab2263e0628d2742bf0b012"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -490,7 +490,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89b28dd5f499ff61d44e51d3260e4b8cb225f834#89b28dd5f499ff61d44e51d3260e4b8cb225f834"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0c8b9ac87fc993f4dab2263e0628d2742bf0b012#0c8b9ac87fc993f4dab2263e0628d2742bf0b012"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -504,7 +504,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89b28dd5f499ff61d44e51d3260e4b8cb225f834#89b28dd5f499ff61d44e51d3260e4b8cb225f834"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0c8b9ac87fc993f4dab2263e0628d2742bf0b012#0c8b9ac87fc993f4dab2263e0628d2742bf0b012"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89b28dd5f499ff61d44e51d3260e4b8cb225f834#89b28dd5f499ff61d44e51d3260e4b8cb225f834"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0c8b9ac87fc993f4dab2263e0628d2742bf0b012#0c8b9ac87fc993f4dab2263e0628d2742bf0b012"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -527,7 +527,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89b28dd5f499ff61d44e51d3260e4b8cb225f834#89b28dd5f499ff61d44e51d3260e4b8cb225f834"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0c8b9ac87fc993f4dab2263e0628d2742bf0b012#0c8b9ac87fc993f4dab2263e0628d2742bf0b012"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -540,7 +540,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89b28dd5f499ff61d44e51d3260e4b8cb225f834#89b28dd5f499ff61d44e51d3260e4b8cb225f834"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0c8b9ac87fc993f4dab2263e0628d2742bf0b012#0c8b9ac87fc993f4dab2263e0628d2742bf0b012"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -553,7 +553,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89b28dd5f499ff61d44e51d3260e4b8cb225f834#89b28dd5f499ff61d44e51d3260e4b8cb225f834"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0c8b9ac87fc993f4dab2263e0628d2742bf0b012#0c8b9ac87fc993f4dab2263e0628d2742bf0b012"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -565,7 +565,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89b28dd5f499ff61d44e51d3260e4b8cb225f834#89b28dd5f499ff61d44e51d3260e4b8cb225f834"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0c8b9ac87fc993f4dab2263e0628d2742bf0b012#0c8b9ac87fc993f4dab2263e0628d2742bf0b012"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -576,7 +576,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89b28dd5f499ff61d44e51d3260e4b8cb225f834#89b28dd5f499ff61d44e51d3260e4b8cb225f834"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0c8b9ac87fc993f4dab2263e0628d2742bf0b012#0c8b9ac87fc993f4dab2263e0628d2742bf0b012"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -590,7 +590,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89b28dd5f499ff61d44e51d3260e4b8cb225f834#89b28dd5f499ff61d44e51d3260e4b8cb225f834"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0c8b9ac87fc993f4dab2263e0628d2742bf0b012#0c8b9ac87fc993f4dab2263e0628d2742bf0b012"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -608,7 +608,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89b28dd5f499ff61d44e51d3260e4b8cb225f834#89b28dd5f499ff61d44e51d3260e4b8cb225f834"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0c8b9ac87fc993f4dab2263e0628d2742bf0b012#0c8b9ac87fc993f4dab2263e0628d2742bf0b012"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -621,7 +621,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89b28dd5f499ff61d44e51d3260e4b8cb225f834#89b28dd5f499ff61d44e51d3260e4b8cb225f834"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0c8b9ac87fc993f4dab2263e0628d2742bf0b012#0c8b9ac87fc993f4dab2263e0628d2742bf0b012"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -634,7 +634,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89b28dd5f499ff61d44e51d3260e4b8cb225f834#89b28dd5f499ff61d44e51d3260e4b8cb225f834"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0c8b9ac87fc993f4dab2263e0628d2742bf0b012#0c8b9ac87fc993f4dab2263e0628d2742bf0b012"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -7337,7 +7337,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -587,30 +587,42 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891b
 # #57 moved its `sceneworks-gen-core` `fa0f75b` -> `d3ec5e5`, so this worker's mlx-gen + gen-core pins
 # are bumped to `d3ec5e5` in LOCKSTEP (above) to keep the candle lane on ONE gen-core rev. ALL candle
 # deps MUST share this rev.
+#
+# sc-5491 bumps the candle pin `89b28dd` -> `0c8b9ac` (candle-gen main HEAD, #65): picks up the candle
+# InstantID CFG-inference FIXES that Phase 5 real-weight GPU validation surfaced — (1) the dual-CLIP
+# conditioner ran candle's STOCK `ClipTextTransformer` on a batch-2 `[neg, prompt]` tensor, but candle's
+# CLIP causal mask only broadcasts onto the per-head scores at batch 1; (2) the IP-Adapter K/V install
+# walked down->mid->up instead of the diffusers `attn_processors` order down->up->mid, dropping a 640-dim
+# K/V pair onto a 1280-dim block. Both made EVERY CFG InstantID generation crash, so the candle InstantID
+# provider wired below (#61) was runtime-broken from #61 until #65. candle-gen #65 KEEPS
+# `sceneworks-gen-core` at `891bee4` (== this worker's mlx-gen pin), so there is NO mlx-gen bump and the
+# `--features backend-candle` graph still resolves exactly ONE gen-core rev. ALL candle deps MUST share
+# this rev. Re-validated on RTX PRO 6000 against gen-core 891bee4: ArcFace identity cosine 0.87 / angle
+# 0.89 / pose 0.58, pre- + mid-denoise cancel honored.
 [target.'cfg(target_os = "windows")'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89b28dd5f499ff61d44e51d3260e4b8cb225f834", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0c8b9ac87fc993f4dab2263e0628d2742bf0b012", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89b28dd5f499ff61d44e51d3260e4b8cb225f834", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89b28dd5f499ff61d44e51d3260e4b8cb225f834", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89b28dd5f499ff61d44e51d3260e4b8cb225f834", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89b28dd5f499ff61d44e51d3260e4b8cb225f834", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0c8b9ac87fc993f4dab2263e0628d2742bf0b012", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0c8b9ac87fc993f4dab2263e0628d2742bf0b012", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0c8b9ac87fc993f4dab2263e0628d2742bf0b012", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0c8b9ac87fc993f4dab2263e0628d2742bf0b012", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89b28dd5f499ff61d44e51d3260e4b8cb225f834", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0c8b9ac87fc993f4dab2263e0628d2742bf0b012", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b`; ltx registers `ltx_2_3_distilled` (txt2video first slice — no conditioning/audio/
 # LoRA/quant). Force-linked in video_jobs.rs (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89b28dd5f499ff61d44e51d3260e4b8cb225f834", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89b28dd5f499ff61d44e51d3260e4b8cb225f834", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0c8b9ac87fc993f4dab2263e0628d2742bf0b012", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0c8b9ac87fc993f4dab2263e0628d2742bf0b012", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89b28dd5f499ff61d44e51d3260e4b8cb225f834", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0c8b9ac87fc993f4dab2263e0628d2742bf0b012", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -619,19 +631,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89b28dd5f499ff61d44e51d3260e4b8cb225f834", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0c8b9ac87fc993f4dab2263e0628d2742bf0b012", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89b28dd5f499ff61d44e51d3260e4b8cb225f834", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0c8b9ac87fc993f4dab2263e0628d2742bf0b012", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89b28dd5f499ff61d44e51d3260e4b8cb225f834", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0c8b9ac87fc993f4dab2263e0628d2742bf0b012", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -640,20 +652,20 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89b28dd5f499ff61d44e51d3260e4b8cb225f834", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0c8b9ac87fc993f4dab2263e0628d2742bf0b012", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89b28dd5f499ff61d44e51d3260e4b8cb225f834", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0c8b9ac87fc993f4dab2263e0628d2742bf0b012", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
 # `generate_instantid_stream`, composing candle-gen-sdxl (the IP-Adapter / IdentityNet ControlNet /
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
-# build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 24c89c9, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89b28dd5f499ff61d44e51d3260e4b8cb225f834", features = ["cuda"], optional = true }
+# build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0c8b9ac87fc993f4dab2263e0628d2742bf0b012", features = ["cuda"], optional = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

Re-pins the worker's candle-gen `89b28dd → 0c8b9ac` (candle-gen main HEAD, [#65](https://github.com/michaeltrefry/candle-gen/pull/65)) to pick up the candle InstantID **CFG-inference fixes** that Phase 5 real-weight GPU validation surfaced. The candle InstantID provider ([candle-gen #61](https://github.com/michaeltrefry/candle-gen/pull/61), wired into the worker in #682) had two CFG-only bugs that made **every** real InstantID generation crash — so the off-Mac candle InstantID lane has been runtime-broken from #61 until now:

1. **CLIP batched forward** — `SdxlConditioner::encode` ran candle-transformers' stock `ClipTextTransformer` on a batch-2 `[negative, prompt]` tensor, but candle's CLIP causal mask `[B,S,S]` only broadcasts onto the per-head scores `[B,H,S,S]` at B==1. → `broadcast_add lhs [2,12,77,77] rhs [2,77,77]`.
2. **IP-Adapter install walk order** — the cross-attn walk was `down → mid → up`, but diffusers `attn_processors` (which numbers the saved `ip_adapter.{n}` K/V pairs) is `down → up → mid` (mid last). A 640-dim K/V pair landed on a 1280-dim block. → `matmul lhs [40,1024,64] rhs [40,32,16]`.

Both are fixed in candle-gen #65 (already merged to candle-gen main).

## Skew

candle-gen `0c8b9ac` keeps `sceneworks-gen-core` at `891bee4` — identical to this worker's mlx-gen pin — so **there is no mlx-gen bump**, and the `--features backend-candle` graph still resolves exactly one gen-core rev:

```
scripts/check-gen-core-skew.sh --features backend-candle
OK: exactly one sceneworks-gen-core ... rev=891bee4
```

Cargo.toml change is the 15 candle-gen rev pins + the lockstep history comment (and a stale `gen-core 24c89c9` comment corrected to `891bee4`); Cargo.lock follows.

## Validation

- Worker links clean: `cargo build -p sceneworks-worker --features backend-candle` (CUDA, sm_120).
- Re-validated the candle InstantID stack end-to-end on an RTX PRO 6000 against gen-core `891bee4` (RealVisXL_V5.0 + InstantX/InstantID + the instantid-mlx bundle + xinsir OpenPose):

| Mode | ArcFace cosine (ref ↔ generated) |
|---|---|
| Identity | 0.870 |
| AngleSet (front) | 0.894 |
| PoseSet (front) | 0.582 |
| Cancel (pre / mid-denoise) | `Err(Canceled)` both |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
