### PR TITLE
sc-5488: route candle SDXL IP-Adapter-Plus reference jobs off-Mac

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0c8b9ac87fc993f4dab2263e0628d2742bf0b012#0c8b9ac87fc993f4dab2263e0628d2742bf0b012"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f28528497e92b9335b44567bf99c3603f38034a2#f28528497e92b9335b44567bf99c3603f38034a2"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0c8b9ac87fc993f4dab2263e0628d2742bf0b012#0c8b9ac87fc993f4dab2263e0628d2742bf0b012"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f28528497e92b9335b44567bf99c3603f38034a2#f28528497e92b9335b44567bf99c3603f38034a2"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0c8b9ac87fc993f4dab2263e0628d2742bf0b012#0c8b9ac87fc993f4dab2263e0628d2742bf0b012"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f28528497e92b9335b44567bf99c3603f38034a2#f28528497e92b9335b44567bf99c3603f38034a2"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0c8b9ac87fc993f4dab2263e0628d2742bf0b012#0c8b9ac87fc993f4dab2263e0628d2742bf0b012"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f28528497e92b9335b44567bf99c3603f38034a2#f28528497e92b9335b44567bf99c3603f38034a2"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -490,7 +490,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0c8b9ac87fc993f4dab2263e0628d2742bf0b012#0c8b9ac87fc993f4dab2263e0628d2742bf0b012"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f28528497e92b9335b44567bf99c3603f38034a2#f28528497e92b9335b44567bf99c3603f38034a2"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -504,7 +504,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0c8b9ac87fc993f4dab2263e0628d2742bf0b012#0c8b9ac87fc993f4dab2263e0628d2742bf0b012"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f28528497e92b9335b44567bf99c3603f38034a2#f28528497e92b9335b44567bf99c3603f38034a2"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0c8b9ac87fc993f4dab2263e0628d2742bf0b012#0c8b9ac87fc993f4dab2263e0628d2742bf0b012"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f28528497e92b9335b44567bf99c3603f38034a2#f28528497e92b9335b44567bf99c3603f38034a2"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -527,7 +527,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0c8b9ac87fc993f4dab2263e0628d2742bf0b012#0c8b9ac87fc993f4dab2263e0628d2742bf0b012"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f28528497e92b9335b44567bf99c3603f38034a2#f28528497e92b9335b44567bf99c3603f38034a2"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -540,7 +540,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0c8b9ac87fc993f4dab2263e0628d2742bf0b012#0c8b9ac87fc993f4dab2263e0628d2742bf0b012"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f28528497e92b9335b44567bf99c3603f38034a2#f28528497e92b9335b44567bf99c3603f38034a2"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -553,7 +553,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0c8b9ac87fc993f4dab2263e0628d2742bf0b012#0c8b9ac87fc993f4dab2263e0628d2742bf0b012"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f28528497e92b9335b44567bf99c3603f38034a2#f28528497e92b9335b44567bf99c3603f38034a2"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -565,7 +565,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0c8b9ac87fc993f4dab2263e0628d2742bf0b012#0c8b9ac87fc993f4dab2263e0628d2742bf0b012"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f28528497e92b9335b44567bf99c3603f38034a2#f28528497e92b9335b44567bf99c3603f38034a2"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -576,7 +576,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0c8b9ac87fc993f4dab2263e0628d2742bf0b012#0c8b9ac87fc993f4dab2263e0628d2742bf0b012"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f28528497e92b9335b44567bf99c3603f38034a2#f28528497e92b9335b44567bf99c3603f38034a2"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -590,7 +590,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0c8b9ac87fc993f4dab2263e0628d2742bf0b012#0c8b9ac87fc993f4dab2263e0628d2742bf0b012"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f28528497e92b9335b44567bf99c3603f38034a2#f28528497e92b9335b44567bf99c3603f38034a2"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -608,7 +608,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0c8b9ac87fc993f4dab2263e0628d2742bf0b012#0c8b9ac87fc993f4dab2263e0628d2742bf0b012"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f28528497e92b9335b44567bf99c3603f38034a2#f28528497e92b9335b44567bf99c3603f38034a2"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -621,7 +621,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0c8b9ac87fc993f4dab2263e0628d2742bf0b012#0c8b9ac87fc993f4dab2263e0628d2742bf0b012"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f28528497e92b9335b44567bf99c3603f38034a2#f28528497e92b9335b44567bf99c3603f38034a2"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -634,7 +634,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0c8b9ac87fc993f4dab2263e0628d2742bf0b012#0c8b9ac87fc993f4dab2263e0628d2742bf0b012"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f28528497e92b9335b44567bf99c3603f38034a2#f28528497e92b9335b44567bf99c3603f38034a2"
 dependencies = [
  "candle-core",
  "candle-gen",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3210,6 +3210,14 @@ fn image_job_is_candle_eligible(job: &JobSnapshot) -> bool {
     if model == "instantid_realvisxl" {
         return instantid_candle_eligible(&job.payload);
     }
+    // SDXL IP-Adapter-Plus reference conditioning (sc-5488, epic 5480): an sdxl-family model with a
+    // reference image is a bespoke candle lane (`generate_candle_sdxl_ipadapter_stream`), NOT txt2img —
+    // the `image_request_candle_eligible` gate below rejects `referenceAssetId`. Branch it out first
+    // (pure IP only; img2img/inpaint/edit shapes stay on torch — those are sc-5487). Mirrors the
+    // worker's `sdxl_ipadapter_available` gate.
+    if matches!(model, "sdxl" | "realvisxl") && sdxl_ipadapter_candle_eligible(&job.payload) {
+        return true;
+    }
     image_request_candle_eligible(model, &job.payload)
 }
 
@@ -3395,6 +3403,26 @@ fn instantid_mlx_eligible(payload: &Map<String, Value>) -> bool {
 /// Mirrors the candle worker's `instantid_available` gate so the router and worker agree.
 fn instantid_candle_eligible(payload: &Map<String, Value>) -> bool {
     instantid_mlx_eligible(payload)
+}
+
+/// SDXL IP-Adapter-Plus candle-routing conditions (sc-5488, epic 5480). The candle `IpAdapterSdxl`
+/// provider serves PURE reference (image-prompt) conditioning on the sdxl family: a `referenceAssetId`
+/// with NO img2img source / inpaint mask and NOT an `edit_image` (those advanced SDXL shapes are
+/// sc-5487, still torch). Mirrors the worker's `sdxl_ipadapter_available` gate (minus the local
+/// weight-resolve check) so the router and worker agree on the lane boundary. Candle-only — there is no
+/// MLX `IpAdapterSdxl` (the MLX SDXL IP path is the registry `SdxlSubMode::Ip`), so this has no
+/// `*_mlx_eligible` sibling.
+fn sdxl_ipadapter_candle_eligible(payload: &Map<String, Value>) -> bool {
+    if payload.get("mode").and_then(Value::as_str) == Some("edit_image") {
+        return false;
+    }
+    let non_empty = |key: &str| {
+        payload
+            .get(key)
+            .and_then(Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty())
+    };
+    non_empty("referenceAssetId") && !non_empty("sourceAssetId") && !non_empty("maskAssetId")
 }
 
 /// PuLID-FLUX (`pulid_flux_dev`) MLX-routing conditions (sc-3344). The native `mlx-gen-pulid`
@@ -4998,6 +5026,32 @@ mod candle_routing_tests {
             "model": "instantid_realvisxl",
             "mode": "text_to_image",
             "referenceAssetId": "asset_1"
+        }))));
+    }
+
+    #[test]
+    fn sdxl_ipadapter_reference_jobs_route_to_candle() {
+        // A pure SDXL/RealVisXL reference (IP-Adapter) job routes to the candle lane (sc-5488) via the
+        // bespoke branch, NOT the txt2img `image_request_candle_eligible` gate (which rejects
+        // `referenceAssetId`).
+        for model in ["sdxl", "realvisxl"] {
+            let payload = json!({ "model": model, "referenceAssetId": "asset_1" });
+            assert!(sdxl_ipadapter_candle_eligible(&object(payload.clone())));
+            assert!(image_job_is_candle_eligible(&image_generate_job(payload)));
+        }
+        // No reference → not an IP-Adapter job (plain txt2img routes via the txt2img gate instead).
+        assert!(!sdxl_ipadapter_candle_eligible(&object(
+            json!({ "model": "sdxl" })
+        )));
+        // img2img / inpaint / edit shapes are NOT this lane (those are sc-5487, still torch).
+        assert!(!sdxl_ipadapter_candle_eligible(&object(json!({
+            "model": "sdxl", "mode": "edit_image", "referenceAssetId": "a", "sourceAssetId": "s"
+        }))));
+        assert!(!sdxl_ipadapter_candle_eligible(&object(json!({
+            "model": "sdxl", "referenceAssetId": "a", "sourceAssetId": "s"
+        }))));
+        assert!(!sdxl_ipadapter_candle_eligible(&object(json!({
+            "model": "sdxl", "referenceAssetId": "a", "maskAssetId": "m"
         }))));
     }
 }

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -599,30 +599,41 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891b
 # `--features backend-candle` graph still resolves exactly ONE gen-core rev. ALL candle deps MUST share
 # this rev. Re-validated on RTX PRO 6000 against gen-core 891bee4: ArcFace identity cosine 0.87 / angle
 # 0.89 / pose 0.58, pre- + mid-denoise cancel honored.
+#
+# sc-5488 bumps the candle pin `0c8b9ac` -> `f285284` (candle-gen main HEAD, #67): LINKS the candle SDXL
+# IP-Adapter-Plus provider (`candle_gen_sdxl::IpAdapterSdxl` — the new CLIP ViT-H image encoder + the
+# IP-Adapter Resampler + a pure-IP denoise) that the worker's bespoke `generate_candle_sdxl_ipadapter_
+# stream` drives for off-Mac SDXL/RealVisXL reference (image-prompt) conditioning — closing the
+# `referenceAssetId`->torch deferral for the sdxl family. Also carries the `Weights::from_file`
+# int-buffer (I64 `position_ids`) cast fix Phase-5 GPU validation surfaced (the int->f16 cast kernel
+# isn't compiled on sm_120). candle-gen #67 is SOURCE-ONLY (KEEPS `sceneworks-gen-core` at `891bee4` ==
+# this worker's mlx-gen pin), so NO mlx-gen bump and the `--features backend-candle` graph still resolves
+# exactly ONE gen-core rev. GPU-validated on RTX PRO 6000: CLIP-feature cosine 0.94 (with IP) vs 0.70
+# (no IP), pre- + mid-denoise cancel honored. ALL candle deps MUST share this rev.
 [target.'cfg(target_os = "windows")'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0c8b9ac87fc993f4dab2263e0628d2742bf0b012", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f28528497e92b9335b44567bf99c3603f38034a2", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0c8b9ac87fc993f4dab2263e0628d2742bf0b012", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0c8b9ac87fc993f4dab2263e0628d2742bf0b012", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0c8b9ac87fc993f4dab2263e0628d2742bf0b012", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0c8b9ac87fc993f4dab2263e0628d2742bf0b012", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f28528497e92b9335b44567bf99c3603f38034a2", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f28528497e92b9335b44567bf99c3603f38034a2", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f28528497e92b9335b44567bf99c3603f38034a2", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f28528497e92b9335b44567bf99c3603f38034a2", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0c8b9ac87fc993f4dab2263e0628d2742bf0b012", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f28528497e92b9335b44567bf99c3603f38034a2", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b`; ltx registers `ltx_2_3_distilled` (txt2video first slice — no conditioning/audio/
 # LoRA/quant). Force-linked in video_jobs.rs (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0c8b9ac87fc993f4dab2263e0628d2742bf0b012", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0c8b9ac87fc993f4dab2263e0628d2742bf0b012", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f28528497e92b9335b44567bf99c3603f38034a2", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f28528497e92b9335b44567bf99c3603f38034a2", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0c8b9ac87fc993f4dab2263e0628d2742bf0b012", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f28528497e92b9335b44567bf99c3603f38034a2", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -631,19 +642,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0c8b9ac87fc993f4dab2263e0628d2742bf0b012", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f28528497e92b9335b44567bf99c3603f38034a2", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0c8b9ac87fc993f4dab2263e0628d2742bf0b012", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f28528497e92b9335b44567bf99c3603f38034a2", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0c8b9ac87fc993f4dab2263e0628d2742bf0b012", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f28528497e92b9335b44567bf99c3603f38034a2", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -652,12 +663,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0c8b9ac87fc993f4dab2263e0628d2742bf0b012", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f28528497e92b9335b44567bf99c3603f38034a2", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0c8b9ac87fc993f4dab2263e0628d2742bf0b012", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f28528497e92b9335b44567bf99c3603f38034a2", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -665,7 +676,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0c8b9
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0c8b9ac87fc993f4dab2263e0628d2742bf0b012", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f28528497e92b9335b44567bf99c3603f38034a2", features = ["cuda"], optional = true }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -147,6 +147,14 @@ use mlx_gen_instantid::{
 use candle_gen_instantid::{
     BodyPoint, InstantId, InstantIdPaths, InstantIdRequest, FACE_RESTORE_PROMPT,
 };
+// SDXL IP-Adapter-Plus reference provider (sc-5488, epic 5480) — the candle (Windows/CUDA) reference-
+// conditioning sibling of the InstantID lane, living in `candle-gen-sdxl` (it composes that crate's
+// IP-Adapter Resampler + the new CLIP ViT-H image encoder + a pure-IP denoise). Candle-only: macOS keeps
+// the MLX SDXL IP path (the registry `SdxlSubMode::Ip`), so these named types resolve only off-Mac.
+// `candle_gen_sdxl` is already force-link anchored above (the registered txt2img `sdxl`); this is the
+// named-type import the bespoke reference route (`image_jobs/sdxl_ipadapter.rs`) drives.
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+use candle_gen_sdxl::{IpAdapterSdxl, IpAdapterSdxlPaths, IpAdapterSdxlRequest};
 
 /// The stub adapter id recorded on generated assets (matches the contract fixture
 /// `tests/fixtures/rust_migration_contracts/sidecars/asset-image.sceneworks.json`).
@@ -425,6 +433,21 @@ pub(crate) async fn run_image_generate_job(
     #[cfg(all(target_os = "windows", feature = "backend-candle"))]
     let handled = if settings.backend_candle_enabled && instantid_available(&request, settings) {
         generate_instantid_stream(
+            api,
+            settings,
+            job,
+            &plan,
+            &project_path,
+            backend,
+            &mut asset_writes,
+        )
+        .await?;
+        true
+    } else if settings.backend_candle_enabled && sdxl_ipadapter_available(&request, settings) {
+        // SDXL IP-Adapter-Plus reference conditioning (sc-5488) — checked BEFORE `is_candle_engine`
+        // because `sdxl`/`realvisxl` ARE candle txt2img ids, so without this a reference job would be
+        // caught by the txt2img branch and silently drop the reference.
+        generate_candle_sdxl_ipadapter_stream(
             api,
             settings,
             job,
@@ -910,6 +933,11 @@ include!("image_jobs/kolors.rs");
     all(target_os = "windows", feature = "backend-candle")
 ))]
 include!("image_jobs/instantid.rs");
+// SDXL IP-Adapter-Plus reference conditioning — the Windows/CUDA candle lane ONLY (sc-5488). macOS keeps
+// the MLX SDXL IP path (sdxl.rs `SdxlSubMode::Ip`); there is no MLX `IpAdapterSdxl`, so this is
+// candle-exclusive.
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+include!("image_jobs/sdxl_ipadapter.rs");
 #[cfg(target_os = "macos")]
 // PuLID-FLUX native routing.
 include!("image_jobs/pulid.rs");

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
@@ -1,0 +1,331 @@
+// Candle (Windows/CUDA) SDXL IP-Adapter-Plus reference route (sc-5488, epic 5480) — reference-image
+// (identity) conditioning on SDXL/RealVisXL off-Mac via `candle_gen_sdxl::IpAdapterSdxl`. The
+// reference-conditioning sibling of the candle InstantID lane (instantid.rs), but plain SDXL: no face
+// stack, no IdentityNet/OpenPose ControlNet — just the CLIP ViT-H image tokens → pure-IP denoise.
+//
+// **Candle-only.** macOS keeps the MLX SDXL IP path (the registry `SdxlSubMode::Ip` in sdxl.rs); there
+// is no MLX `IpAdapterSdxl`, so this whole file is gated to the Windows/CUDA candle build (the
+// `include!` in image_jobs.rs carries the cfg). It is `include!`d into the `image_jobs` module, so it
+// shares that module's imports (ImageRequest/Settings/WorkerResult/`advanced`/`load_reference_image`/
+// `huggingface_snapshot_dir`/`ensure_hf_cached_file`/`start_gen_stream`/… all in scope unqualified).
+
+/// h94 IP-Adapter repo (the ViT-H encoder + the plus/plus-face SDXL weights), matching the MLX SDXL IP
+/// path's `SDXL_IP_ADAPTER_REPO`.
+const SDXL_IPADAPTER_REPO: &str = "h94/IP-Adapter";
+/// The IP-Adapter-Plus (ViT-H) bundle inside the repo (`image_proj` Resampler + `ip_adapter.*` K/V).
+const SDXL_IPADAPTER_BUNDLE_SRC: &str = "sdxl_models/ip-adapter-plus_sdxl_vit-h.safetensors";
+/// The CLIP ViT-H image-encoder files inside the repo (config + weights).
+const SDXL_IPADAPTER_ENCODER_SRC: [&str; 2] = [
+    "models/image_encoder/config.json",
+    "models/image_encoder/model.safetensors",
+];
+/// IP-Adapter scale default — torch plus parity (matches the MLX SDXL path's `SDXL_IP_SCALE`).
+const SDXL_IPADAPTER_IP_SCALE: f32 = 0.7;
+/// Denoise steps default (SDXL production).
+const SDXL_IPADAPTER_DEFAULT_STEPS: u32 = 30;
+/// CFG default — the reference-conditioned envelope validated on GPU (sc-5488); base SDXL uses ~7.
+const SDXL_IPADAPTER_DEFAULT_GUIDANCE: f32 = 5.0;
+/// The adapter/engine id recorded on candle SDXL IP-Adapter assets + telemetry (distinct from the
+/// txt2img `candle_sdxl` and the `candle_instantid` lanes).
+const SDXL_IPADAPTER_ENGINE: &str = "candle_sdxl_ipadapter";
+
+/// SDXL model ids the candle IP-Adapter route accepts (the txt2img-eligible SDXL family).
+fn is_sdxl_ipadapter_model(model: &str) -> bool {
+    matches!(model, "sdxl" | "realvisxl")
+}
+
+/// Default SDXL base repo for a model id when the manifest omits `repo`.
+fn sdxl_ipadapter_default_repo(model: &str) -> &'static str {
+    match model {
+        "realvisxl" => "SG161222/RealVisXL_V5.0",
+        _ => "stabilityai/stable-diffusion-xl-base-1.0",
+    }
+}
+
+/// Resolve the SDXL base snapshot for the IP-Adapter route: an explicit `modelPath` dir (advanced or
+/// manifest) wins, else the HF cache snapshot for the manifest `repo` (default by model id). `None`
+/// means the base is not present locally, so the job is not candle-runnable (falls through to torch).
+fn resolve_sdxl_ipadapter_base(
+    request: &ImageRequest,
+    settings: &Settings,
+) -> WorkerResult<Option<PathBuf>> {
+    if let Some(path) = request
+        .advanced
+        .get("modelPath")
+        .or_else(|| request.model_manifest_entry.get("modelPath"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+    {
+        return resolve_app_managed_model_dir(settings, &path, "SDXL IP-Adapter modelPath").map(Some);
+    }
+    let repo = request
+        .model_manifest_entry
+        .get("repo")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| sdxl_ipadapter_default_repo(&request.model));
+    Ok(huggingface_snapshot_dir(&settings.data_dir, repo))
+}
+
+/// True when this is a candle-eligible SDXL IP-Adapter job: an sdxl-family model with a reference image
+/// (and NOT an img2img/inpaint/edit shape — those advanced SDXL modes are sc-5487) whose base resolves
+/// locally. Mirrors `jobs_store::sdxl_ipadapter_candle_eligible` so the worker and router agree.
+fn sdxl_ipadapter_available(request: &ImageRequest, settings: &Settings) -> bool {
+    is_sdxl_ipadapter_model(&request.model)
+        && request.mode != "edit_image"
+        && non_empty(&request.reference_asset_id)
+        && !non_empty(&request.source_asset_id)
+        && !non_empty(&request.mask_asset_id)
+        && matches!(resolve_sdxl_ipadapter_base(request, settings), Ok(Some(_)))
+}
+
+/// Resolve denoise steps: `advanced.steps` (clamped 1..=80) → manifest `steps` → default (30).
+fn sdxl_ipadapter_steps(request: &ImageRequest) -> u32 {
+    let parse = |value: &Value| {
+        value
+            .as_u64()
+            .or_else(|| value.as_str()?.trim().parse().ok())
+    };
+    request
+        .advanced
+        .get("steps")
+        .and_then(parse)
+        .or_else(|| request.model_manifest_entry.get("steps").and_then(parse))
+        .map(|steps| steps.clamp(1, 80) as u32)
+        .unwrap_or(SDXL_IPADAPTER_DEFAULT_STEPS)
+}
+
+/// Resolve guidance: `advanced.guidanceScale` → manifest `guidanceScale` → the reference-tuned default
+/// (5.0), clamped to a sane CFG range.
+fn sdxl_ipadapter_guidance(request: &ImageRequest) -> f32 {
+    let manifest_default = request
+        .model_manifest_entry
+        .get("guidanceScale")
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .map(|value| value as f32)
+        .unwrap_or(SDXL_IPADAPTER_DEFAULT_GUIDANCE);
+    advanced::f32_clamped(
+        &request.advanced,
+        "guidanceScale",
+        manifest_default,
+        0.0..=30.0,
+    )
+}
+
+/// Resolve the IP-Adapter bundle file + the CLIP ViT-H image-encoder dir, downloading from
+/// `h94/IP-Adapter` on first use. Resolution order: an env-pinned root (pre-staged, the validation
+/// path) → a whole-repo HF cache snapshot → download the bundle + encoder into the app cache. Returns
+/// `(bundle_file, image_encoder_dir)` — what [`IpAdapterSdxlPaths`] wants.
+async fn ensure_sdxl_ipadapter_weights(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+) -> WorkerResult<(PathBuf, PathBuf)> {
+    // Env override: a directory laid out like the h94 repo (or its HF snapshot), pre-staged for local
+    // validation (`SCENEWORKS_IPADAPTER_SDXL`).
+    if let Ok(root) = std::env::var("SCENEWORKS_IPADAPTER_SDXL") {
+        let root = PathBuf::from(root);
+        let bundle = root.join("sdxl_models").join("ip-adapter-plus_sdxl_vit-h.safetensors");
+        let encoder = root.join("models").join("image_encoder");
+        if bundle.is_file() && encoder.is_dir() {
+            return Ok((bundle, encoder));
+        }
+    }
+    // Whole-repo HF cache snapshot already present (the model-download flow staged it).
+    if let Some(snapshot) = huggingface_snapshot_dir(&settings.data_dir, SDXL_IPADAPTER_REPO) {
+        let bundle = snapshot
+            .join("sdxl_models")
+            .join("ip-adapter-plus_sdxl_vit-h.safetensors");
+        let encoder = snapshot.join("models").join("image_encoder");
+        if bundle.is_file() && encoder.join("model.safetensors").is_file() {
+            return Ok((bundle, encoder));
+        }
+    }
+    // Download-on-first-use into the app cache (flat dest, nested source — the InstantID bundle pattern).
+    let client = reqwest::Client::new();
+    let context = DownloadContext {
+        api,
+        client: &client,
+        settings,
+        job_id: &job.id,
+        cancel_message: "SDXL IP-Adapter generation canceled while fetching weights.",
+        fresh_download: false,
+    };
+    let cache = settings.data_dir.join("cache").join("ipadapter-sdxl");
+    let bundle = ensure_hf_cached_file(
+        &context,
+        SDXL_IPADAPTER_REPO,
+        "main",
+        SDXL_IPADAPTER_BUNDLE_SRC,
+        &cache.join("ip-adapter-plus_sdxl_vit-h.safetensors"),
+    )
+    .await?;
+    let encoder = cache.join("image_encoder");
+    for source in SDXL_IPADAPTER_ENCODER_SRC {
+        let name = source.rsplit('/').next().unwrap_or(source);
+        ensure_hf_cached_file(
+            &context,
+            SDXL_IPADAPTER_REPO,
+            "main",
+            source,
+            &encoder.join(name),
+        )
+        .await?;
+    }
+    Ok((bundle, encoder))
+}
+
+/// Flat telemetry recorded on candle SDXL IP-Adapter assets (parity with the InstantID/`mlx_raw_settings`
+/// recipe-key shape).
+fn sdxl_ipadapter_raw_settings(
+    request: &ImageRequest,
+    repo: &str,
+    steps: u32,
+    guidance: f32,
+    ip_scale: f32,
+) -> JsonObject {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("repo".to_owned(), Value::String(repo.to_owned()));
+    raw.insert("numInferenceSteps".to_owned(), json!(steps));
+    raw.insert("guidanceScale".to_owned(), json!(guidance));
+    raw.insert("ipAdapterScale".to_owned(), json!(ip_scale));
+    raw.insert(
+        "ipAdapterEngine".to_owned(),
+        Value::String(SDXL_IPADAPTER_ENGINE.to_owned()),
+    );
+    raw
+}
+
+/// Real candle SDXL IP-Adapter generation: resolve the reference + weights on the async side, then load
+/// the `IpAdapterSdxl` provider once + generate each image on the blocking thread. `request.count`
+/// images, each its own seed; the engine `generate` takes the per-job `CancelFlag` + a `Progress`
+/// callback, so streaming is per-step and cancellation is honoured mid-denoise — same contract as the
+/// registry families + the InstantID lane. Reuses [`consume_gen_events`] for the asset writes.
+async fn generate_candle_sdxl_ipadapter_stream(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+    let sdxl_base = resolve_sdxl_ipadapter_base(request, settings)?.ok_or_else(|| {
+        WorkerError::InvalidPayload("SDXL IP-Adapter base (SDXL/RealVisXL) not found".to_owned())
+    })?;
+    let reference_id = request
+        .reference_asset_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload("SDXL IP-Adapter requires a reference image".to_owned())
+        })?;
+    let reference = load_reference_image(
+        &settings.data_dir,
+        &request.project_id,
+        reference_id,
+        project_path,
+    )?;
+    let (ip_bundle, image_encoder) = ensure_sdxl_ipadapter_weights(api, settings, job).await?;
+
+    let steps = sdxl_ipadapter_steps(request);
+    let guidance = sdxl_ipadapter_guidance(request);
+    let ip_scale = advanced::f32_clamped(
+        &request.advanced,
+        "ipAdapterScale",
+        SDXL_IPADAPTER_IP_SCALE,
+        0.0..=1.0,
+    );
+    let repo = request
+        .model_manifest_entry
+        .get("repo")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| sdxl_ipadapter_default_repo(&request.model))
+        .to_owned();
+    let raw_settings = sdxl_ipadapter_raw_settings(request, &repo, steps, guidance, ip_scale);
+
+    // Per-image work items: (seed, prompt) — `request.count` images at the reference identity.
+    let (width, height) = (request.width, request.height);
+    let work: Vec<(i64, String)> = (0..request.count as usize)
+        .map(|index| (resolve_seed(request, index), request.prompt.clone()))
+        .collect();
+    let total = work.len();
+    let negative_prompt = request.negative_prompt.clone();
+
+    let (cancel, rx, blocking) = start_gen_stream(
+        job.id.clone(),
+        "sdxl_ipadapter",
+        0,
+        move || {
+            let paths = IpAdapterSdxlPaths {
+                sdxl_base,
+                ip_adapter: ip_bundle,
+                image_encoder,
+            };
+            let model = IpAdapterSdxl::load(&paths).map_err(|error| {
+                WorkerError::Engine(format!("SDXL IP-Adapter load failed: {error}"))
+            })?;
+            Ok((model, reference))
+        },
+        move |(model, reference), tx, cancel| {
+            // `IpAdapterSdxl::generate` takes `&mut self` (it sets the IP image tokens on the UNet before
+            // the denoise), so the per-item closure mutates `model`.
+            let mut model = model;
+            drive_gen_items(tx, work, move |_index, (seed, prompt), on_progress| {
+                if cancel.is_cancelled() {
+                    return Ok(None);
+                }
+                let req = IpAdapterSdxlRequest {
+                    prompt,
+                    negative: negative_prompt.clone(),
+                    width,
+                    height,
+                    steps: steps as usize,
+                    guidance,
+                    ip_adapter_scale: ip_scale,
+                    seed: seed as u64,
+                    cancel: cancel.clone(),
+                };
+                let out = match model.generate(&req, &reference, &mut *on_progress) {
+                    Ok(out) => out,
+                    Err(_) if cancel.is_cancelled() => return Ok(None),
+                    Err(error) => {
+                        return Err(WorkerError::Engine(format!(
+                            "SDXL IP-Adapter generation failed: {error}"
+                        )));
+                    }
+                };
+                Ok(Some((seed, out.width, out.height, out.pixels)))
+            })
+        },
+    );
+
+    consume_gen_events(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        SDXL_IPADAPTER_ENGINE,
+        &raw_settings,
+        total,
+        rx,
+        cancel,
+        blocking,
+        asset_writes,
+    )
+    .await
+}


### PR DESCRIPTION
## sc-5488 — worker: route candle SDXL IP-Adapter-Plus reference jobs off-Mac

Wires the candle `IpAdapterSdxl` provider ([candle-gen#67](https://github.com/michaeltrefry/candle-gen/pull/67), merged) into the worker as a bespoke Windows/CUDA route, **closing the `referenceAssetId → torch` deferral for the sdxl family**. The off-Mac sibling of the macOS MLX SDXL IP path (registry `SdxlSubMode::Ip`) — but since there is no MLX `IpAdapterSdxl`, this route is **candle-only and fully cfg-gated** (`all(target_os = "windows", feature = "backend-candle")`).

### Changes
- **`crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs`** (new) — `generate_candle_sdxl_ipadapter_stream` + `sdxl_ipadapter_available` + weight resolution. Mirrors the InstantID stream (`start_gen_stream` → `drive_gen_items` → `consume_gen_events`, per-step progress + mid-denoise cancel), **minus** the face stack / IdentityNet / OpenPose — pure-IP denoise, `request.count` images. Weights: SDXL base via the manifest `repo`; the `h94/IP-Adapter` ViT-H bundle + `image_encoder` via an env override (`SCENEWORKS_IPADAPTER_SDXL`) → HF cache snapshot → download-on-first-use.
- **`image_jobs.rs`** — dispatch branch **before** `is_candle_engine` (`sdxl`/`realvisxl` *are* candle txt2img ids, so a reference job would otherwise be caught by the txt2img branch and silently drop the reference) + the `IpAdapterSdxl` types import + the cfg-gated `include!`.
- **`jobs_store.rs`** — `sdxl_ipadapter_candle_eligible` (pure reference: `referenceAssetId`, no `sourceAssetId`/`maskAssetId`, not `edit_image` — those img2img/inpaint/edit shapes are **sc-5487**, still torch) + a branch in `image_job_is_candle_eligible` before the txt2img gate + a routing test.
- **Cargo** — re-pin candle-gen `0c8b9ac → f285284` (#67). #67 is **source-only** in candle-gen, so `sceneworks-gen-core` stays `891bee4` (== this worker's mlx-gen pin): **no mlx-gen bump**, skew gate single-rev.

### Verification
- sc-4482 skew gate: **exactly one** `sceneworks-gen-core` (`891bee4`) in the `--features backend-candle` graph.
- `sceneworks-core` routing test green (`sdxl_ipadapter_reference_jobs_route_to_candle`); `clippy -p sceneworks-core --all-targets -- -D warnings` clean.
- `cargo build` + `cargo clippy -p sceneworks-worker --features backend-candle -- -D warnings` clean (sm_120, MSVC 14.44); `cargo fmt --all` clean.
- The candle SDXL IP-Adapter math is GPU-validated upstream (#67): CLIP-feature cosine **0.94** (with IP) vs **0.70** (no IP), cancel honored.

### Follow-up
A deployed-worker GPU smoke (a real `referenceAssetId` job → candle) is the remaining end-to-end check — the same pattern as the InstantID worker route (#682). Remaining sc-5488 families: **Kolors** (ViT-L/14-336) and **FLUX XLabs** (recommended as its own story).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
