### PR TITLE
sc-5716: gate Video Studio mode tabs on mode availability (un-trap Replace Person)

### DIFF
--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -7511,6 +7511,13 @@ describe("SceneWorks app shell", () => {
       );
     });
 
+    // Video Studio opens on Text→Video (sc-5716); this preset targets image_to_video, so switch
+    // to that tab to exercise the managed-LoRA mismatch surface.
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Image → Video").click();
+    });
+    await settle();
+
     const generate = [...container.querySelectorAll("button")].find((button) => button.textContent === "Render clip");
     expect(container.textContent).toContain("Preset cannot run with LTX");
     expect(container.textContent).toContain("wan_motion");
@@ -7648,6 +7655,13 @@ describe("SceneWorks app shell", () => {
         ),
       );
     });
+
+    // Video Studio opens on Text→Video (sc-5716); this LTX model is image_to_video-only, so switch
+    // to that tab before exercising the LoRA picker + submit.
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Image → Video").click();
+    });
+    await settle();
 
     await act(async () => {
       [...container.querySelectorAll("button")].find((button) => button.textContent === "Advanced").click();
@@ -7986,6 +8000,12 @@ describe("SceneWorks app shell", () => {
     });
     await settle();
 
+    // Video Studio opens on Text→Video (sc-5716); this preset targets image_to_video.
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Image → Video").click();
+    });
+    await settle();
+
     expect(container.textContent).toContain("Dream Motion");
     expect(container.textContent).toContain("Soft camera motion.");
     expect(container.textContent).toContain("Adds: smooth camera motion");
@@ -8064,6 +8084,12 @@ describe("SceneWorks app shell", () => {
     });
     await settle();
 
+    // Video Studio opens on Text→Video (sc-5716); SVD is image_to_video-only, so switch tabs.
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Image → Video").click();
+    });
+    await settle();
+
     // The prompt field advertises that no prompt is needed for promptless models.
     const promptField = container.querySelector("textarea[aria-label='Prompt']");
     expect(promptField.placeholder).toContain("No prompt needed");
@@ -8128,6 +8154,13 @@ describe("SceneWorks app shell", () => {
           <VideoStudio />,
         ),
       );
+    });
+    await settle();
+
+    // Video Studio opens on Text→Video (sc-5716); enter Image→Video to filter the image_to_video
+    // presets, then the test walks Text→Video and a model switch as before.
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Image → Video").click();
     });
     await settle();
 
@@ -8208,6 +8241,13 @@ describe("SceneWorks app shell", () => {
           <VideoStudio />,
         ),
       );
+    });
+    await settle();
+
+    // Video Studio opens on Text→Video (sc-5716); these presets target image_to_video /
+    // first_last_frame, so enter Image→Video to surface them.
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Image → Video").click();
     });
     await settle();
 

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -79,13 +79,14 @@ import {
   SavePresetPanel,
   useGenerationStudio,
 } from "./generationStudio.jsx";
-import { ReplacePersonPanel, findReplacementModel } from "./ReplacePersonPanel.jsx";
+import { ReplacePersonPanel } from "./ReplacePersonPanel.jsx";
 import { useAppContext } from "../context/AppContext.js";
 import { PROMPT_REFINE_MODEL_ID } from "../constants.js";
 import {
   DEFAULT_MAC_CAPABILITIES,
   macAvailableModels,
   macBlockedModels,
+  macGatingActive,
   macVideoModeBlock,
 } from "../macGating.js";
 import { loadStudioSettings, useStudioSettingsWriter } from "../hooks/useStudioSettings.js";
@@ -176,7 +177,9 @@ export function VideoStudio() {
   const [motion, setMotion] = useState(saved.motion ?? "slow push-in");
   const imageAssets = assets.filter((asset) => asset.type === "image" || asset.type === "frame");
   const videoAssets = assets.filter((asset) => asset.type === "video");
-  const [mode, setMode] = useState(saved.mode ?? "image_to_video");
+  // Open on Text→Video for parity with Image Studio's Text→Image default and the
+  // launch-request fallback below (sc-5716); the prior image_to_video default was the odd one out.
+  const [mode, setMode] = useState(saved.mode ?? "text_to_video");
   const [prompt, setPrompt] = useState(saved.prompt ?? "Camera slowly pushes in while the scene comes alive");
   const [quality, setQuality] = useState(saved.quality ?? "balanced");
   const [ltxPipeline, setLtxPipeline] = useState(saved.ltxPipeline ?? "auto");
@@ -201,6 +204,16 @@ export function VideoStudio() {
     }
   }, [macVideoModels, model]);
   const selectedModel = videoModels.find((item) => item.id === model) ?? videoModels[0];
+  // Models gated on the selected tab, not tabs on the selected model (sc-5716). A model "serves" a
+  // mode when it declares the capability AND, under active Mac gating, that mode is MLX-routed for
+  // it (`macVideoModeBlock` is a no-op off-Mac, so there this is pure capability). The mode tabs,
+  // the model picker, and the snap-on-mode-switch effect all derive from this so the user is never
+  // trapped on a mode whose model can't serve the others.
+  const macGating = macGatingActive(macCapabilities);
+  const baseVideoModels = macVideoModels.length ? macVideoModels : videoModels;
+  const modelServesMode = (item, value) =>
+    Boolean(item?.capabilities?.includes(value)) && !macVideoModeBlock(item, macCapabilities, value);
+  const modelsForMode = (value) => baseVideoModels.filter((item) => modelServesMode(item, value));
   // Prompt guide for the selected model; fall back to the generic video guide
   // when a model declares none, so the button is always useful (sc-1817).
   const promptGuide = selectedModel?.ui?.promptGuide ?? {
@@ -504,28 +517,23 @@ export function VideoStudio() {
     if (match) setResolution(match);
   }, [i2vSourceAssetId, mode, selectedModel?.id, assets]);
 
+  // Models are gated on the selected tab (sc-5716): when the active mode isn't served by the current
+  // model, snap to the first model that serves it so the user can always leave a mode. Generalizes
+  // the old per-mode snaps (replace_person → first replace-capable model; animate_character →
+  // scail2_14b) to every mode, including the Bernini editing/reference modes. A no-op when the
+  // current model already serves the mode (e.g. an LTX image_to_video → text_to_video switch) or
+  // when no model serves it (a reduced catalog) — there's nothing to snap to.
   useEffect(() => {
-    if (mode !== "replace_person" || supportsMode) {
+    if (modelServesMode(selectedModel, mode)) {
       return;
     }
-    const replacementModel = findReplacementModel(videoModels);
-    if (replacementModel) {
-      setModel(replacementModel.id);
+    const fallback = modelsForMode(mode)[0];
+    if (fallback && fallback.id !== model) {
+      setModel(fallback.id);
     }
-  }, [mode, supportsMode, videoModels]);
-
-  // SCAIL-2 character animation (sc-5449): like replace_person, animate_character runs only on the
-  // model that advertises the capability (scail2_14b). Auto-switch to it when the user picks the
-  // mode on a model that can't serve it, so the mode is usable without first hunting for the model.
-  useEffect(() => {
-    if (mode !== "animate_character" || supportsMode) {
-      return;
-    }
-    const animateModel = videoModels.find((item) => item.capabilities?.includes("animate_character"));
-    if (animateModel) {
-      setModel(animateModel.id);
-    }
-  }, [mode, supportsMode, videoModels]);
+    // modelServesMode / modelsForMode close over videoModels + macCapabilities, captured below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode, model, selectedModel, videoModels, macCapabilities]);
 
   // When restoring a snapshot, the saved length/fps/quality/resolution/negativePrompt
   // already reflect the user's last state — skip the one preset-default pass that fires
@@ -647,12 +655,14 @@ export function VideoStudio() {
     // capabilities include it (today: scail2_14b); the same per-model gating as the others.
     ["animate_character", "Animate character"],
   ];
-  // Mac UI gating (sc-3486, sc-3773): every video mode is disabled per-model via the selected
-  // model's `macSupport.features.videoModes` — FLF on the non-Keyframe Wan MoE engines,
-  // replace_person on non-replace models, and the LTX IC-LoRA clip-conditioning modes
-  // (extend_clip / video_bridge) on non-LTX models. On LTX, extend/bridge stay enabled because
-  // the in-process Rust worker serves them, so the old coarse global flag is gone.
-  const macVideoModeBlockFor = (value) => macVideoModeBlock(selectedModel, macCapabilities, value);
+  // Mac UI gating (sc-3486, sc-3773, sc-5716): mode tabs are gated at the MODE level, not on the
+  // selected model. A tab is disabled only under active Mac gating when NO available model serves
+  // the mode (mode-level availability across `macVideoModels`) — never on the selected model's
+  // `videoModes`, which used to trap the user on replace_person / animate_character with no way
+  // back. Off-Mac `macGating` is false so tabs are never disabled here. The active tab is always
+  // left enabled so a reduced catalog can't strand you on a disabled tab. `macVideoModeBlock` still
+  // gates the in-mode model picker + submit (via `modelsForMode` / `supportsMode`).
+  const macModeTabBlocked = (value) => macGating && modelsForMode(value).length === 0;
   const matchingTracks = personTracks.filter((track) => track.sourceAssetId === sourceClipAssetId);
   const latestDetectionJob = jobs
     .filter(
@@ -869,15 +879,17 @@ export function VideoStudio() {
           <div className="prompt-hero-top">
             <div className="segmented-control mode-control" role="tablist" aria-label="Video mode">
               {modeOptions.map(([value, label]) => {
-                const macBlock = macVideoModeBlockFor(value);
+                // Disabled only when no available model serves this mode on Mac — and never the
+                // active tab, so the user can always switch away (sc-5716).
+                const blocked = value !== mode && macModeTabBlocked(value);
                 return (
                   <button
                     className={mode === value ? "active" : ""}
                     key={value}
                     onClick={() => setMode(value)}
                     type="button"
-                    disabled={Boolean(macBlock)}
-                    title={macBlock ? macBlock.text : undefined}
+                    disabled={blocked}
+                    title={blocked ? "No installed model supports this mode on macOS." : undefined}
                   >
                     {label}
                   </button>
@@ -1261,7 +1273,10 @@ export function VideoStudio() {
               <label>
                 Model
                 <select onChange={(event) => setModel(event.target.value)} value={model}>
-                  {(macVideoModels.length ? macVideoModels : videoModels).map((item) => (
+                  {/* Models gated on the selected tab (sc-5716): show only models that serve the
+                      active mode, falling back to the full available list if none do (a reduced
+                      catalog) so the picker is never empty. */}
+                  {(modelsForMode(mode).length ? modelsForMode(mode) : baseVideoModels).map((item) => (
                     <option key={item.id} value={item.id}>
                       {item.name}
                     </option>

--- a/apps/web/src/screens/VideoStudio.test.jsx
+++ b/apps/web/src/screens/VideoStudio.test.jsx
@@ -118,7 +118,7 @@ describe("VideoStudio Save as Preset", () => {
     await act(async () => {});
   }
 
-  it("snapshots the video config into an image_to_video preset without the seed", async () => {
+  it("snapshots the video config into a text_to_video preset without the seed", async () => {
     const context = baseContext();
     await render(context);
 
@@ -129,11 +129,12 @@ describe("VideoStudio Save as Preset", () => {
 
     expect(context.createPreset).toHaveBeenCalledTimes(1);
     const payload = context.createPreset.mock.calls[0][0];
+    // Video Studio now opens on Text→Video (sc-5716), matching Image Studio's Text→Image default.
     expect(payload).toMatchObject({
       id: "push_in",
       name: "Push In",
       scope: "project",
-      workflow: "image_to_video",
+      workflow: "text_to_video",
       model: "ltx_2_3",
     });
     expect(payload.defaults.prompt).toBe("Camera slowly pushes in while the scene comes alive");
@@ -628,5 +629,163 @@ describe("VideoStudio SCAIL-2 character animation + replacement backend", () => 
       el.textContent.includes("Replacement engine"),
     );
     expect(engineLabel).toBeFalsy();
+  });
+});
+
+// sc-5716: under active Mac gating, mode tabs must be gated on mode availability (does any model
+// serve it), not on the selected model — otherwise switching to a model-specific mode (Replace
+// person / Animate character) snapped to a model whose other modes were disabled and trapped the
+// user. These render the studio in MLX-required mode with per-model `macSupport.features.videoModes`.
+describe("VideoStudio Mac mode gating (sc-5716)", () => {
+  let container;
+  let root;
+
+  // Every UI mode, so each Mac model can declare an explicit per-mode boolean (mirrors the API's
+  // `macSupport.features.videoModes`, populated for every VIDEO_UI_MODE on a Mac-routed model).
+  const ALL_VIDEO_MODES = [
+    "image_to_video",
+    "text_to_video",
+    "first_last_frame",
+    "extend_clip",
+    "video_bridge",
+    "replace_person",
+    "video_to_video",
+    "reference_to_video",
+    "reference_video_to_video",
+    "multi_video_to_video",
+    "ads2v",
+    "animate_character",
+  ];
+
+  // A Mac-routed model: `capabilities` = the modes it serves, and `macSupport.features.videoModes`
+  // sets those true and every other mode false (the MLX-eligibility the API computes per model).
+  const macModel = (id, name, served) => ({
+    id,
+    name,
+    type: "video",
+    family: id,
+    capabilities: served,
+    defaults: { duration: 5, resolution: "832x480", fps: 16 },
+    limits: { durations: [3, 4, 5], fps: [16], resolutions: ["832x480", "480x832"] },
+    quantization: {},
+    loraCompatibility: {},
+    ui: {},
+    macSupport: {
+      supported: true,
+      features: {
+        videoModes: Object.fromEntries(ALL_VIDEO_MODES.map((m) => [m, served.includes(m)])),
+      },
+    },
+  });
+
+  const MAC_CAPS = {
+    macGatingActive: true,
+    platform: "darwin",
+    notAvailableLabel: "Not available on Mac (Rust/MLX only)",
+    features: {},
+    training: { supportedKernels: [], lokrOnWanSupported: false },
+  };
+
+  // Wan serves t2v / i2v / replace; SCAIL-2 serves only animate_character + replace (the trap model).
+  const WAN = macModel("wan_2_2", "Wan 2.2", ["image_to_video", "text_to_video", "replace_person"]);
+  const SCAIL2 = macModel("scail2_14b", "SCAIL-2", ["animate_character", "replace_person"]);
+
+  const clip = { id: "vid_src", type: "video", projectId: "project_1", displayName: "Driving Clip" };
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <VideoStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  const modeButton = (label) => buttonWithText(container.querySelector(".mode-control"), label);
+  const modelSelect = () =>
+    [...container.querySelectorAll(".render-rail label")]
+      .find((el) => el.textContent.trim().startsWith("Model"))
+      ?.querySelector("select");
+
+  it("does not trap the user after switching to a model-specific mode", async () => {
+    const context = baseContext({
+      videoModels: [WAN, SCAIL2],
+      assets: [clip],
+      macCapabilities: MAC_CAPS,
+    });
+    await render(context);
+
+    // Opens on Text→Video, served by Wan — the picker reflects the selected model.
+    expect(modelSelect().value).toBe("wan_2_2");
+
+    // Switch to Animate character → snaps the model to SCAIL-2 (the only model that serves it).
+    await click(modeButton("Animate character"));
+    expect(modelSelect().value).toBe("scail2_14b");
+
+    // The bug: with SCAIL-2 selected, every other tab used to be disabled with no way back.
+    // Now Text→Video / Image→Video stay enabled because Wan serves them.
+    expect(modeButton("Text → Video").disabled).toBe(false);
+    expect(modeButton("Image → Video").disabled).toBe(false);
+
+    // And leaving the mode snaps back to a model that serves the target mode.
+    await click(modeButton("Text → Video"));
+    expect(modeButton("Text → Video").className).toContain("active");
+    expect(modelSelect().value).toBe("wan_2_2");
+  });
+
+  it("disables a mode tab only when no available model serves it", async () => {
+    const context = baseContext({
+      videoModels: [SCAIL2],
+      assets: [clip],
+      macCapabilities: MAC_CAPS,
+    });
+    await render(context);
+
+    // Only SCAIL-2 is installed (animate_character + replace_person). Enter animate_character so it
+    // isn't the active tab being checked, then assert the unserved modes are disabled.
+    await click(modeButton("Animate character"));
+    expect(modeButton("Animate character").disabled).toBe(false);
+    expect(modeButton("Replace person").disabled).toBe(false);
+    expect(modeButton("Text → Video").disabled).toBe(true);
+    expect(modeButton("Image → Video").disabled).toBe(true);
+    expect(modeButton("Video → Video").disabled).toBe(true);
+  });
+
+  it("filters the model picker to models that serve the active mode", async () => {
+    const context = baseContext({
+      videoModels: [WAN, SCAIL2],
+      assets: [clip],
+      macCapabilities: MAC_CAPS,
+    });
+    await render(context);
+
+    // Text→Video: only Wan serves it.
+    expect([...modelSelect().options].map((o) => o.value)).toEqual(["wan_2_2"]);
+
+    // Animate character: only SCAIL-2 serves it.
+    await click(modeButton("Animate character"));
+    expect([...modelSelect().options].map((o) => o.value)).toEqual(["scail2_14b"]);
+
+    // Replace person: both backends serve it.
+    await click(modeButton("Replace person"));
+    expect([...modelSelect().options].map((o) => o.value)).toEqual(
+      expect.arrayContaining(["wan_2_2", "scail2_14b"]),
+    );
   });
 });


### PR DESCRIPTION
Fixes [sc-5716](https://app.shortcut.com/trefry/story/5716). Video-Studio instance of the inverted mode/capability-gating anti-pattern (sibling of [sc-5589](https://app.shortcut.com/trefry/story/5589)).

## Problem
On a Mac in MLX-required mode, each mode tab was `disabled` based on the **currently-selected model's** `macSupport.features.videoModes`, while the model `<select>` listed **every** model regardless of mode — the inverse of correct. Switching to **Replace person** / **Animate character** fired a snap to a model that can't serve the other modes, disabling every other tab and **trapping the user with no way back** (the snap-to-a-supporting-model logic existed only for those two modes). Mac-only, because `macVideoModeBlock` short-circuits to "not blocked" unless gating is active.

Secondary: Video Studio opened on **Image→Video**, inconsistent with Image Studio's **Text→Image**.

## Fix (web-only — no backend / manifest / parity-contract changes)
- **Tabs gated at the mode level**: a tab disables only under active Mac gating when **no** available model serves the mode (`modelsForMode(value).length === 0`), and **never the active tab**, so a reduced catalog can't strand you. Off-Mac gating is inactive → tabs are never disabled (existing behavior preserved).
- **Generalized the model snap**: collapsed the two `replace_person` / `animate_character` effects into one that snaps the model to a serving one on **any** mode switch the current model can't serve — so you can always leave a mode.
- **Model picker filtered by the active mode** (models gated on the tab; falls back to the full available list if none serve it so the picker is never empty).
- **Default mode** `image_to_video` → `text_to_video`, matching Image Studio and the existing launch-request fallback.
- `macVideoModeBlock` / `supportsMode` retained as the in-mode picker + submit guard.

## Tests
- New `VideoStudio Mac mode gating (sc-5716)` suite (injects `macGatingActive: true` + per-model `videoModes`): trap-escape, mode-level tab disabling, and picker filtering.
- Updated the preset-default test (now a `text_to_video` preset) and the 6 full-app-shell video tests that implicitly opened on image_to_video (each now enters Image→Video, the mode it actually exercises).
- `npm test` → **430 passed**; `npm run lint` → **0 errors**; `npm run build` → clean.

## Verification note
The Mac-gated trap is only reachable under `SCENEWORKS_MLX_REQUIRED` (per-model `videoModes` + a live MLX worker), so a backend-less dev preview can't exercise it — off-Mac all tabs are always enabled and there is no trap. Coverage is via the injected-capability unit tests that mount the real component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)