### PR TITLE
Fix code review high path containment gaps

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -269,6 +269,13 @@ fn should_warn_open_bind(access_token: &str, ip: std::net::IpAddr) -> bool {
     access_token.trim().is_empty() && !ip.is_loopback()
 }
 
+// sc-5720 (API-001): an operator may knowingly opt into an unauthenticated wider
+// bind (e.g. a trusted-network deployment that fronts its own auth) by setting
+// `SCENEWORKS_ALLOW_OPEN_BIND=1`. Pure + tested alongside `should_warn_open_bind`.
+fn open_bind_override_enabled(value: &str) -> bool {
+    matches!(value.trim(), "1" | "true" | "TRUE" | "yes" | "YES")
+}
+
 fn json_rejection_response(rejection: JsonRejection) -> Response {
     let detail = match rejection {
         JsonRejection::JsonDataError(error) => error.body_text(),
@@ -302,16 +309,28 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
     }
     let settings = Settings::from_env();
     let address: SocketAddr = format!("{}:{}", settings.host, settings.port).parse()?;
-    // sc-4201 (F-API-1): a non-loopback bind with no access token serves every
-    // endpoint — file reads, credential writes, job creation, large uploads — to the
-    // whole network without authentication. The default is now loopback; warn loudly
-    // when an operator opts into a wider bind (e.g. Docker's 0.0.0.0) without a token.
+    // sc-4201 (F-API-1) / sc-5720 (API-001): a non-loopback bind with no access token
+    // serves every endpoint — file reads, credential writes, job creation, large
+    // uploads — to the whole network without authentication. The default is loopback;
+    // refuse to start on an open bind without a token unless the operator explicitly
+    // opts in with SCENEWORKS_ALLOW_OPEN_BIND=1 (then warn loudly instead).
     if should_warn_open_bind(&settings.access_token, address.ip()) {
-        eprintln!(
-            "WARNING: SceneWorks API is binding to {address} with no SCENEWORKS_ACCESS_TOKEN set — \
-             every endpoint is reachable without authentication from the network. Set \
-             SCENEWORKS_ACCESS_TOKEN, or bind to 127.0.0.1, before exposing this beyond a trusted host."
-        );
+        let override_raw = std::env::var("SCENEWORKS_ALLOW_OPEN_BIND").unwrap_or_default();
+        if open_bind_override_enabled(&override_raw) {
+            eprintln!(
+                "WARNING: SceneWorks API is binding to {address} with no SCENEWORKS_ACCESS_TOKEN set — \
+                 every endpoint is reachable without authentication from the network. Proceeding \
+                 because SCENEWORKS_ALLOW_OPEN_BIND is set; ensure this host is on a trusted network."
+            );
+        } else {
+            return Err(format!(
+                "Refusing to bind to {address} with no SCENEWORKS_ACCESS_TOKEN set: every endpoint \
+                 would be reachable without authentication from the network. Set \
+                 SCENEWORKS_ACCESS_TOKEN, bind to 127.0.0.1, or set SCENEWORKS_ALLOW_OPEN_BIND=1 to \
+                 override (only on a trusted network)."
+            )
+            .into());
+        }
     }
     let run_utility_inprocess = settings.run_utility_inprocess;
     let app = create_app(settings)?;

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -5,10 +5,11 @@ use super::workers::person_readiness_from_workers;
 use super::{
     create_app, create_app_with_state, huggingface_repo_cache_path, inject_converted_model_path,
     inprocess_worker_gpu_id, lora_artifact_paths, merge_model_manifest_entry, mlx_catalog_status,
-    safe_download_dir, serialize_job_lora, should_warn_open_bind, strip_jsonc_comments,
-    sweep_stale_asset_uploads_before, sweep_stale_lora_uploads_before, Settings, WorkerCapability,
-    WorkerSnapshot, WorkerStatus, API_MANAGED_MANIFEST_HEADER, DEFAULT_API_HOST, EVENT_BUFFER_SIZE,
-    HEARTBEAT_SSE_DATA, HEARTBEAT_SSE_WIRE, TEST_MAX_LORA_UPLOAD_BYTES,
+    open_bind_override_enabled, safe_download_dir, serialize_job_lora, should_warn_open_bind,
+    strip_jsonc_comments, sweep_stale_asset_uploads_before, sweep_stale_lora_uploads_before,
+    Settings, WorkerCapability, WorkerSnapshot, WorkerStatus, API_MANAGED_MANIFEST_HEADER,
+    DEFAULT_API_HOST, EVENT_BUFFER_SIZE, HEARTBEAT_SSE_DATA, HEARTBEAT_SSE_WIRE,
+    TEST_MAX_LORA_UPLOAD_BYTES,
 };
 use axum::body::{to_bytes, Body};
 use axum::http::{Request, StatusCode};
@@ -37,6 +38,21 @@ fn warns_only_on_open_bind_without_token() {
     assert!(!should_warn_open_bind("secret", v4("0.0.0.0")));
     assert!(!should_warn_open_bind("", v4("127.0.0.1")));
     assert!(!should_warn_open_bind("", "::1".parse().unwrap()));
+}
+
+#[test]
+fn open_bind_override_only_for_explicit_optin() {
+    // sc-5720 (API-001): the override that lets an unauthenticated open bind start
+    // must require an explicit affirmative value; anything else keeps the refusal.
+    for value in ["1", "true", "TRUE", "yes", "YES", " 1 "] {
+        assert!(open_bind_override_enabled(value), "{value:?} should opt in");
+    }
+    for value in ["", "0", "false", "no", "off", "2", "enable"] {
+        assert!(
+            !open_bind_override_enabled(value),
+            "{value:?} must not opt in"
+        );
+    }
 }
 
 #[test]

--- a/apps/worker/scene_worker/lora_adapters.py
+++ b/apps/worker/scene_worker/lora_adapters.py
@@ -4,11 +4,12 @@ from dataclasses import dataclass
 import hashlib
 import importlib
 import json
+import os
 import re
 from pathlib import Path
 from typing import Any
 
-from .hf_cache import huggingface_repo_cache_path
+from .hf_cache import huggingface_cache_roots, huggingface_repo_cache_path
 
 
 # Keep in sync with packages/schemas/recipe-preset.schema.json and the Rust
@@ -680,12 +681,59 @@ def set_adapter_weights_on_module(
         raise
 
 
+def _lora_allowed_roots() -> list[Path]:
+    """App-managed roots a payload-supplied LoRA path may resolve under (sc-5723 /
+    WKA-002): the app data dir plus every Hugging Face hub cache root. Installed
+    LoRAs live under ``<data>/...`` and HF-cached adapters under a hub cache; a
+    payload path outside all of these is rejected so the worker can't be pointed at
+    an arbitrary host file. Resolved from the environment (``SCENEWORKS_DATA_DIR`` +
+    ``huggingface_cache_roots``) since this chokepoint has no ``settings`` handle."""
+
+    roots: list[Path] = []
+    data_dir = os.getenv("SCENEWORKS_DATA_DIR", "data")
+    try:
+        roots.append(Path(data_dir).expanduser().resolve())
+    except OSError:
+        pass
+    for root in huggingface_cache_roots(None):
+        try:
+            roots.append(Path(root).expanduser().resolve())
+        except OSError:
+            continue
+    return roots
+
+
+def _confine_lora_path(path: Path) -> Path:
+    """Reject a payload-supplied LoRA path that escapes every app-managed root
+    (sc-5723 / WKA-002). ``resolve()`` collapses ``..`` and symlinks first so the
+    containment check can't be bypassed."""
+
+    try:
+        resolved = path.expanduser().resolve()
+    except OSError as exc:
+        raise RuntimeError(f"Invalid LoRA path: {path}") from exc
+    roots = _lora_allowed_roots()
+    for root in roots:
+        try:
+            resolved.relative_to(root)
+            return resolved
+        except ValueError:
+            continue
+    allowed = ", ".join(str(root) for root in roots)
+    raise RuntimeError(
+        f"LoRA path must be inside an app-managed directory ({allowed}): {path}"
+    )
+
+
 def lora_path(lora: dict[str, Any]) -> Path | None:
     source = lora.get("source") if isinstance(lora.get("source"), dict) else {}
     value = lora.get("installedPath") or lora.get("sourcePath") or lora.get("path") or source.get("path")
     if not value:
         return huggingface_cached_lora_path(lora)
-    path = Path(str(value)).expanduser()
+    # The path is attacker-controllable payload; confine it to an app-managed root
+    # before any on-disk use (sc-5723 / WKA-002). The HF-cache fallback below is
+    # already root-confined by huggingface_repo_cache_path.
+    path = _confine_lora_path(Path(str(value)))
     if path.exists():
         return resolve_lora_file(path, lora)
     return huggingface_cached_lora_path(lora) or path

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -1262,6 +1262,16 @@ impl ProjectStore {
             .ok_or_else(|| {
                 ProjectStoreError::BadRequest("generated asset fact missing mediaPath".to_owned())
             })?;
+        // mediaPath comes from the worker result fact and is joined into the project
+        // path below for sidecar/dir writes; reject traversal/absolute paths before any
+        // create_dir_all/write so the worker->API boundary can't write outside the
+        // project root (sc-5721 / CORE-002->F). Mirrors the is_safe_relative_path guard
+        // used at every other path-from-outside site in this store.
+        if !is_safe_relative_path(media_rel) {
+            return Err(ProjectStoreError::BadRequest(
+                "Invalid media path".to_owned(),
+            ));
+        }
         let asset_id = fact.get("assetId").and_then(Value::as_str).ok_or_else(|| {
             ProjectStoreError::BadRequest("generated asset fact missing assetId".to_owned())
         })?;
@@ -3818,6 +3828,78 @@ mod tests {
             json!(false)
         );
         assert_eq!(asset["lineage"]["jobId"], json!("job-1"));
+    }
+
+    /// sc-5721 (CORE-002→F): `persist_generated_asset` joins the worker-supplied
+    /// `mediaPath` into the project tree and `create_dir_all`/`write`s a sidecar there,
+    /// so a traversal or absolute path must be rejected before any filesystem write —
+    /// the worker→API boundary must not write outside the project root. A normal
+    /// relative path is still accepted.
+    #[test]
+    fn persist_generated_asset_rejects_unsafe_media_path() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Boundary").expect("project creates");
+
+        let fact_with = |media_path: &str| {
+            json!({
+                "assetId": "asset_safe1",
+                "mediaPath": media_path,
+                "mimeType": "image/png",
+                "width": 64,
+                "height": 64,
+                "model": "z_image_turbo",
+                "adapter": "z_image_diffusers",
+                "prompt": "x",
+                "loras": [],
+            })
+        };
+
+        for unsafe_path in [
+            "../../../../tmp/escape.png",
+            "/etc/passwd",
+            "assets/../../escape.png",
+        ] {
+            let result = store.persist_generated_asset(
+                &project.id,
+                "job-1",
+                "genset_x",
+                &fact_with(unsafe_path),
+            );
+            assert!(
+                matches!(result, Err(ProjectStoreError::BadRequest(_))),
+                "expected {unsafe_path:?} to be rejected, got {result:?}"
+            );
+        }
+
+        // A normal project-relative path is still accepted and written under the project.
+        let safe_fact = json!({
+            "assetId": "asset_safe1",
+            "mediaPath": "assets/images/genset_x/asset_safe1.png",
+            "mimeType": "image/png",
+            "width": 64,
+            "height": 64,
+            "normalizedWidth": 64,
+            "normalizedHeight": 64,
+            "count": 1,
+            "family": "z-image",
+            "seed": 1,
+            "index": 0,
+            "displayName": "safe #1",
+            "createdAt": "2026-06-15T00:00:00Z",
+            "mode": "text_to_image",
+            "model": "z_image_turbo",
+            "adapter": "z_image_diffusers",
+            "prompt": "x",
+            "negativePrompt": "",
+            "loras": [],
+            "stylePreset": "none",
+            "rawAdapterSettings": {"steps": 8},
+        });
+        let safe = store
+            .persist_generated_asset(&project.id, "job-1", "genset_x", &safe_fact)
+            .expect("safe media path persists");
+        assert_eq!(safe["id"], json!("asset_safe1"));
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -345,7 +345,7 @@ pub(crate) fn classify_adapter(file: &Path) -> WorkerResult<AdapterKind> {
     target_os = "macos",
     all(target_os = "windows", feature = "backend-candle")
 ))]
-fn resolve_adapters(request: &ImageRequest) -> WorkerResult<Vec<AdapterSpec>> {
+fn resolve_adapters(request: &ImageRequest, settings: &Settings) -> WorkerResult<Vec<AdapterSpec>> {
     if request.loras.len() > MAX_JOB_LORAS {
         return Err(WorkerError::InvalidPayload(format!(
             "Generation supports at most {MAX_JOB_LORAS} LoRAs per job."
@@ -353,9 +353,12 @@ fn resolve_adapters(request: &ImageRequest) -> WorkerResult<Vec<AdapterSpec>> {
     }
     let mut specs = Vec::with_capacity(request.loras.len());
     for lora in &request.loras {
-        let path = lora_path(lora).ok_or_else(|| {
+        let raw = lora_path(lora).ok_or_else(|| {
             WorkerError::InvalidPayload("LoRA is missing a usable path.".to_owned())
         })?;
+        // The path is attacker-controllable payload; confine it to an app-managed
+        // root before any on-disk use (sc-5723 / WKA-002).
+        let path = crate::normalize_app_managed_lora_path(settings, &raw)?;
         let file = if path.is_dir() {
             first_safetensors_path(&path).ok_or_else(|| {
                 WorkerError::InvalidPayload(format!(
@@ -818,7 +821,7 @@ async fn generate_stream(
     // engine rejects); `None` for every other family. The recipe records the effective CFG knob.
     let model_true_cfg = resolve_true_cfg(request, &model);
     let negative_prompt = resolve_negative_prompt(request, &model);
-    let adapters = resolve_adapters(request)?;
+    let adapters = resolve_adapters(request, settings)?;
     let repo = model_repo(request, &model);
     let raw_settings = mlx_raw_settings(
         request,
@@ -1094,7 +1097,7 @@ async fn generate_candle_stream(
         (None, None)
     };
     let adapters = if model.supports_adapters() {
-        resolve_adapters(request)?
+        resolve_adapters(request, settings)?
     } else {
         Vec::new()
     };

--- a/crates/sceneworks-worker/src/image_jobs/flux2.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2.rs
@@ -259,7 +259,7 @@ async fn generate_flux2_edit_stream(
     let (quant, quant_bits) = resolve_quant(request);
     let steps = resolve_steps(request, &model);
     let guidance = resolve_guidance(request, &model);
-    let adapters = resolve_adapters(request)?;
+    let adapters = resolve_adapters(request, settings)?;
     let repo = model_repo(request, &model);
     let adapter_label = model.adapter_label();
 

--- a/crates/sceneworks-worker/src/image_jobs/kolors.rs
+++ b/crates/sceneworks-worker/src/image_jobs/kolors.rs
@@ -324,7 +324,7 @@ async fn generate_kolors_control_stream(
     let control_scale = kolors_pose_control_scale(request);
     let ip_scale =
         advanced::f32_clamped(&request.advanced, "ipAdapterScale", KOLORS_IP_SCALE, 0.0..=1.0);
-    let adapters = resolve_adapters(request)?;
+    let adapters = resolve_adapters(request, settings)?;
     let repo = model_repo(request, &kolors);
     let poses = parse_poses(request);
     let count = poses.len();

--- a/crates/sceneworks-worker/src/image_jobs/qwen.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen.rs
@@ -154,7 +154,7 @@ async fn generate_qwen_control_stream(
     let guidance = resolve_guidance(request, &qwen).unwrap_or(qwen.default_guidance());
     let negative_prompt = resolve_negative_prompt(request, &qwen);
     let control_scale = resolve_control_scale(request);
-    let adapters = resolve_adapters(request)?;
+    let adapters = resolve_adapters(request, settings)?;
     let repo = model_repo(request, &qwen);
     let poses = parse_poses(request);
     let count = poses.len();
@@ -533,7 +533,7 @@ async fn generate_qwen_edit_stream(
             ensure_distill_lora_cached(api, settings, job, distill.repo, distill.file).await?;
         adapters.push(AdapterSpec::new(path, 1.0, AdapterKind::Lora));
     }
-    adapters.extend(resolve_adapters(request)?);
+    adapters.extend(resolve_adapters(request, settings)?);
     let repo = model_repo(request, &model);
     let adapter_label = model.adapter_label();
 

--- a/crates/sceneworks-worker/src/image_jobs/sdxl.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl.rs
@@ -217,7 +217,7 @@ async fn generate_sdxl_advanced_stream(
     let steps = resolve_steps(request, &model);
     let guidance = resolve_guidance(request, &model);
     let negative_prompt = resolve_negative_prompt(request, &model);
-    let adapters = resolve_adapters(request)?;
+    let adapters = resolve_adapters(request, settings)?;
     let repo = model_repo(request, &model);
     let adapter_label = model.adapter_label();
     let (width, height) = (request.width, request.height);

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -1694,7 +1694,7 @@ fn sc3031_ab_dump_txt2img() {
     let weights = resolve_weights_dir(&req, &settings)
         .expect("weights resolve")
         .expect("weights in HF cache");
-    let adapters = resolve_adapters(&req).expect("adapters");
+    let adapters = resolve_adapters(&req, &settings).expect("adapters");
     let seed = resolve_seed(&req, 0);
     let generator = load_engine(model.engine_id(), weights, quant, adapters, None).expect("load");
 
@@ -1751,7 +1751,7 @@ fn sc3031_ab_dump_pose() {
     let zimage = mlx_model("z_image_turbo").expect("z-image model row");
     let steps = resolve_steps(&req, &zimage);
     let control_scale = resolve_control_scale(&req);
-    let adapters = resolve_adapters(&req).expect("adapters");
+    let adapters = resolve_adapters(&req, &settings).expect("adapters");
     let seed = resolve_seed(&req, 0);
 
     let pose = parse_poses(&req)

--- a/crates/sceneworks-worker/src/image_jobs/zimage.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage.rs
@@ -215,7 +215,7 @@ async fn generate_zimage_control_stream(
         .ok_or_else(|| WorkerError::InvalidPayload("z-image model row missing".to_owned()))?;
     let steps = resolve_steps(request, &zimage);
     let control_scale = resolve_control_scale(request);
-    let adapters = resolve_adapters(request)?;
+    let adapters = resolve_adapters(request, settings)?;
     let repo = model_repo(request, &zimage);
     let poses = parse_poses(request);
     let count = poses.len();

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -1334,6 +1334,42 @@ fn normalize_app_managed_model_path(
     ensure_path_under(path, &[data_dir, hf_cache], label)
 }
 
+/// Confine a LoRA adapter path taken from a job payload to an app-managed root
+/// (sc-5723 / WKA-002). The path arrives untrusted (`installedPath`/`sourcePath`/
+/// `path`/`source.path` on a LoRA spec) and is loaded as adapter weights, so —
+/// like every other on-disk model input — it must resolve under the app data dir
+/// or the shared Hugging Face hub cache (installed LoRAs live in `<data>/loras` or
+/// a project tree under `<data>`; HF-cached adapters live in the hub cache).
+/// Without this a crafted payload could point a LoRA at any `.safetensors` on the
+/// host, giving the worker an arbitrary-file read primitive across the API boundary.
+/// Mirrors `normalize_app_managed_model_path` (model weights share the same roots).
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub(crate) fn normalize_app_managed_lora_path(
+    settings: &Settings,
+    path: &Path,
+) -> WorkerResult<PathBuf> {
+    let data_dir = normalized_data_dir(settings)?;
+    let canonical_data_dir = normalize_existing_or_absolute(&settings.data_dir)?;
+    let hf_cache = normalize_absolute_path(&huggingface_hub_cache_dir(&settings.data_dir))?;
+    let canonical_hf_cache =
+        normalize_existing_or_absolute(&huggingface_hub_cache_dir(&settings.data_dir))?;
+    let normalized = normalize_absolute_path(path)?;
+    let resolved = normalize_existing_or_absolute(&normalized)?;
+    ensure_path_under(
+        resolved,
+        &[data_dir, canonical_data_dir, hf_cache, canonical_hf_cache],
+        "LoRA path",
+    )
+}
+
+fn normalize_existing_or_absolute(path: &Path) -> WorkerResult<PathBuf> {
+    match std::fs::canonicalize(path) {
+        Ok(canonical) => normalize_absolute_path(&canonical),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => normalize_absolute_path(path),
+        Err(error) => Err(error.into()),
+    }
+}
+
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 fn looks_like_huggingface_repo(value: &str) -> bool {
     let value = value.trim();

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -2083,6 +2083,38 @@ fn model_destinations_are_constrained_to_data_models() {
     assert!(convert_error.to_string().contains("data/models"));
 }
 
+#[cfg(unix)]
+#[test]
+fn lora_paths_resolve_symlinks_before_root_check() {
+    let temp = tempdir().expect("tempdir creates");
+    let data_dir = temp.path().join("data");
+    let lora_dir = data_dir.join("loras");
+    let outside_dir = temp.path().join("outside");
+    std::fs::create_dir_all(&lora_dir).expect("lora dir creates");
+    std::fs::create_dir_all(&outside_dir).expect("outside dir creates");
+
+    let mut settings = test_settings("http://127.0.0.1".to_owned(), None);
+    settings.data_dir = data_dir.clone();
+
+    let safe = lora_dir.join("safe.safetensors");
+    std::fs::write(&safe, b"safe").expect("safe lora writes");
+    let normalized =
+        super::normalize_app_managed_lora_path(&settings, &safe).expect("safe lora accepted");
+    assert_eq!(
+        normalized,
+        safe.canonicalize().expect("safe lora canonicalizes")
+    );
+
+    let outside = outside_dir.join("escape.safetensors");
+    std::fs::write(&outside, b"outside").expect("outside lora writes");
+    let link = lora_dir.join("escape-link.safetensors");
+    std::os::unix::fs::symlink(&outside, &link).expect("symlink creates");
+
+    let error = super::normalize_app_managed_lora_path(&settings, &link)
+        .expect_err("symlink target outside managed roots rejects");
+    assert!(error.to_string().contains("LoRA path must be inside"));
+}
+
 #[tokio::test]
 async fn ffmpeg_runner_surfaces_bounded_stderr_from_failing_process() {
     let args = if cfg!(windows) {

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -368,7 +368,7 @@ pub(crate) async fn run_video_generate_job(
             scail2_raw_settings(
                 &request,
                 scail2_adapters_have_lightning(
-                    &resolve_scail2_adapters(&request).unwrap_or_default(),
+                    &resolve_scail2_adapters(settings, &request).unwrap_or_default(),
                 ),
             ),
             None,
@@ -1645,8 +1645,11 @@ fn wan_moe_low_noise_sibling(primary: &Path) -> Option<PathBuf> {
 }
 
 /// Resolve a LoRA spec's file (a directory → its first `.safetensors`), verifying it exists.
+/// The `path` originates from attacker-controllable job payload, so it is first confined to an
+/// app-managed root (sc-5723 / WKA-002) before any on-disk use.
 #[cfg(target_os = "macos")]
-fn resolve_lora_file(path: PathBuf) -> WorkerResult<PathBuf> {
+fn resolve_lora_file(settings: &Settings, path: PathBuf) -> WorkerResult<PathBuf> {
+    let path = crate::normalize_app_managed_lora_path(settings, &path)?;
     let file = if path.is_dir() {
         first_safetensors_path(&path).ok_or_else(|| {
             WorkerError::InvalidPayload(format!(
@@ -1711,7 +1714,7 @@ fn resolve_wan_adapters(
         let path = lora_path(lora).ok_or_else(|| {
             WorkerError::InvalidPayload("LoRA is missing a usable path.".to_owned())
         })?;
-        let file = resolve_lora_file(path)?;
+        let file = resolve_lora_file(settings, path)?;
         let kind = classify_adapter(&file)?;
         let scale = lora_scale(lora);
         match (is_moe, wan_moe_low_noise_sibling(&file)) {
@@ -1754,7 +1757,10 @@ fn moe_adapter(path: PathBuf, scale: f32, kind: AdapterKind, expert: MoeExpert) 
 /// tags SceneWorks peft LoKr as `Lokr` and everything else (incl. third-party LyCORIS LoHa / non-peft
 /// LoKr) as `Lora`, which the engine then detects + merges by key sniff (epic 3641).
 #[cfg(target_os = "macos")]
-fn resolve_wan_vace_adapters(request: &VideoRequest) -> WorkerResult<Vec<AdapterSpec>> {
+fn resolve_wan_vace_adapters(
+    settings: &Settings,
+    request: &VideoRequest,
+) -> WorkerResult<Vec<AdapterSpec>> {
     if request.loras.len() > MAX_JOB_LORAS {
         return Err(WorkerError::InvalidPayload(format!(
             "Generation supports at most {MAX_JOB_LORAS} LoRAs per job."
@@ -1765,7 +1771,7 @@ fn resolve_wan_vace_adapters(request: &VideoRequest) -> WorkerResult<Vec<Adapter
         let path = lora_path(lora).ok_or_else(|| {
             WorkerError::InvalidPayload("LoRA is missing a usable path.".to_owned())
         })?;
-        let file = resolve_lora_file(path)?;
+        let file = resolve_lora_file(settings, path)?;
         let kind = classify_adapter(&file)?;
         specs.push(AdapterSpec {
             path: file,
@@ -1788,7 +1794,10 @@ fn resolve_wan_vace_adapters(request: &VideoRequest) -> WorkerResult<Vec<Adapter
 /// "lightning" LoRA installs via the engine's in-place diff-patch merge (sc-5684); selecting it makes
 /// the worker apply the step-distill recipe (`scail2_sampling`, sc-5700).
 #[cfg(target_os = "macos")]
-fn resolve_scail2_adapters(request: &VideoRequest) -> WorkerResult<Vec<AdapterSpec>> {
+fn resolve_scail2_adapters(
+    settings: &Settings,
+    request: &VideoRequest,
+) -> WorkerResult<Vec<AdapterSpec>> {
     if request.loras.len() > MAX_JOB_LORAS {
         return Err(WorkerError::InvalidPayload(format!(
             "Generation supports at most {MAX_JOB_LORAS} LoRAs per job."
@@ -1799,7 +1808,7 @@ fn resolve_scail2_adapters(request: &VideoRequest) -> WorkerResult<Vec<AdapterSp
         let path = lora_path(lora).ok_or_else(|| {
             WorkerError::InvalidPayload("LoRA is missing a usable path.".to_owned())
         })?;
-        let file = resolve_lora_file(path)?;
+        let file = resolve_lora_file(settings, path)?;
         let kind = classify_adapter(&file)?;
         specs.push(AdapterSpec {
             path: file,
@@ -3408,7 +3417,7 @@ async fn generate_scail2(
     // Selecting a lightx2v diff-patch "lightning" LoRA flips the worker to the step-distill recipe
     // (8 steps, CFG off, shift 1.0) so the toggle yields the speedup; otherwise steps/guidance/shift
     // stay `None` and the engine's quality defaults stand (sc-5700).
-    let adapters = resolve_scail2_adapters(request)?;
+    let adapters = resolve_scail2_adapters(settings, request)?;
     let (steps, guidance, scheduler_shift) =
         scail2_sampling(request, scail2_adapters_have_lightning(&adapters));
     let input = VideoGenInput {
@@ -3799,7 +3808,10 @@ async fn ensure_ltx_q8_present(
 /// per-stage schedule is parity-plus). No distill/Lightning prepend — the 2-stage distill
 /// is baked into the checkpoint. peft LoKr allowed (engine residual), LyCORIS rejected.
 #[cfg(target_os = "macos")]
-fn resolve_ltx_adapters(request: &VideoRequest) -> WorkerResult<Vec<AdapterSpec>> {
+fn resolve_ltx_adapters(
+    settings: &Settings,
+    request: &VideoRequest,
+) -> WorkerResult<Vec<AdapterSpec>> {
     if request.loras.len() > MAX_JOB_LORAS {
         return Err(WorkerError::InvalidPayload(format!(
             "Generation supports at most {MAX_JOB_LORAS} LoRAs per job."
@@ -3810,7 +3822,7 @@ fn resolve_ltx_adapters(request: &VideoRequest) -> WorkerResult<Vec<AdapterSpec>
         let path = lora_path(lora).ok_or_else(|| {
             WorkerError::InvalidPayload("LoRA is missing a usable path.".to_owned())
         })?;
-        let file = resolve_lora_file(path)?;
+        let file = resolve_lora_file(settings, path)?;
         let kind = classify_adapter(&file)?;
         specs.push(AdapterSpec::new(file, lora_scale(lora), kind));
     }
@@ -4273,7 +4285,7 @@ async fn generate_ltx(
         engine_id,
         model_dir,
         quant: None,
-        adapters: resolve_ltx_adapters(request)?,
+        adapters: resolve_ltx_adapters(settings, request)?,
         conditioning,
         prompt: request.prompt.clone(),
         negative_prompt: None,
@@ -4710,7 +4722,7 @@ async fn load_source_video_frames(
         .ok_or_else(|| {
             WorkerError::InvalidPayload(format!("source clip {asset_id} has no media path"))
         })?;
-    let media_path = project_path.join(rel);
+    let media_path = crate::safe_project_path(project_path, rel)?;
     if !tokio::fs::try_exists(&media_path).await? {
         return Err(WorkerError::InvalidPayload(format!(
             "source clip file is missing: {}",
@@ -5001,7 +5013,7 @@ async fn generate_wan_vace(
         engine_id: "wan_vace",
         model_dir,
         quant: resolve_wan_quant(request),
-        adapters: resolve_wan_vace_adapters(request)?,
+        adapters: resolve_wan_vace_adapters(settings, request)?,
         conditioning,
         prompt: request.prompt.clone(),
         negative_prompt,
@@ -5372,7 +5384,7 @@ async fn generate_wan_vace_extend_bridge(
         engine_id: "wan_vace",
         model_dir,
         quant: resolve_wan_quant(request),
-        adapters: resolve_wan_vace_adapters(request)?,
+        adapters: resolve_wan_vace_adapters(settings, request)?,
         conditioning,
         prompt: request.prompt.clone(),
         negative_prompt,
@@ -6824,7 +6836,13 @@ mod tests {
                 { "path": lokr.to_string_lossy(), "weight": 0.9 },
             ],
         }));
-        let specs = resolve_wan_vace_adapters(&req).expect("resolve vace adapters");
+        // sc-5723: LoRA paths are confined to the app data dir, so point data_dir at
+        // the fixture dir the temp LoRAs live in.
+        let settings = Settings {
+            data_dir: dir.clone(),
+            ..Settings::from_env()
+        };
+        let specs = resolve_wan_vace_adapters(&settings, &req).expect("resolve vace adapters");
         assert_eq!(specs.len(), 2);
         assert_eq!(specs[0].path, plain);
         assert_eq!(specs[0].kind, AdapterKind::Lora);
@@ -6841,10 +6859,47 @@ mod tests {
             .collect();
         let over = request(json!({ "projectId": "p", "loras": many }));
         assert!(matches!(
-            resolve_wan_vace_adapters(&over),
+            resolve_wan_vace_adapters(&settings, &over),
             Err(WorkerError::InvalidPayload(_))
         ));
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// sc-5723 (WKA-002): a LoRA path from the (attacker-controllable) payload that
+    /// resolves outside every app-managed root is rejected before the file is opened —
+    /// the worker must not be pointed at an arbitrary host `.safetensors`. The fixture
+    /// lives in a sibling temp dir that is NOT under the configured `data_dir`.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn lora_path_outside_app_managed_root_is_rejected() {
+        let data_dir =
+            std::env::temp_dir().join(format!("sw_lora_data_{}", Uuid::new_v4().simple()));
+        let outside =
+            std::env::temp_dir().join(format!("sw_lora_evil_{}", Uuid::new_v4().simple()));
+        std::fs::create_dir_all(&data_dir).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        let evil = outside.join("evil.safetensors");
+        write_lora_fixture(&evil, None);
+
+        let settings = Settings {
+            data_dir: data_dir.clone(),
+            ..Settings::from_env()
+        };
+        let req = request(json!({
+            "projectId": "p",
+            "loras": [ { "path": evil.to_string_lossy(), "weight": 0.5 } ],
+        }));
+        // The HF cache roots are env-derived; this temp path is under neither, so it
+        // must be refused. (Guard against the host's real HF cache happening to be a
+        // parent — vanishingly unlikely for a fresh uuid temp dir.)
+        let result = resolve_wan_vace_adapters(&settings, &req);
+        assert!(
+            matches!(result, Err(WorkerError::InvalidPayload(_))),
+            "expected out-of-root LoRA to be rejected, got {result:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&data_dir);
+        let _ = std::fs::remove_dir_all(&outside);
     }
 
     /// SCAIL-2 is single-dense like Wan-VACE (sc-5451/sc-5686): each user LoRA/LoKr (and the bundled
@@ -6868,7 +6923,13 @@ mod tests {
                 { "path": lokr.to_string_lossy(), "weight": 0.7 },
             ],
         }));
-        let specs = resolve_scail2_adapters(&req).expect("resolve scail2 adapters");
+        // sc-5723: LoRA paths are confined to the app data dir, so point data_dir at
+        // the fixture dir the temp LoRAs live in.
+        let settings = Settings {
+            data_dir: dir.clone(),
+            ..Settings::from_env()
+        };
+        let specs = resolve_scail2_adapters(&settings, &req).expect("resolve scail2 adapters");
         assert_eq!(specs.len(), 2);
         assert_eq!(specs[0].path, plain);
         assert_eq!(specs[0].kind, AdapterKind::Lora);
@@ -6884,7 +6945,7 @@ mod tests {
             .collect();
         let over = request(json!({ "projectId": "p", "loras": many }));
         assert!(matches!(
-            resolve_scail2_adapters(&over),
+            resolve_scail2_adapters(&settings, &over),
             Err(WorkerError::InvalidPayload(_))
         ));
         let _ = std::fs::remove_dir_all(&dir);
@@ -7379,7 +7440,8 @@ mod tests {
         assert!(advanced::bool(&req.advanced, "enhancePrompt"));
         assert!(!advanced::bool(&req.advanced, "useUncensoredEnhancer"));
         // LTX adapters: a plain user LoRA is uniform (no per-pass schedule, no moe tag).
-        let none = resolve_ltx_adapters(&req).unwrap();
+        let settings = Settings::from_env();
+        let none = resolve_ltx_adapters(&settings, &req).unwrap();
         assert!(none.is_empty());
     }
 

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -6844,7 +6844,7 @@ mod tests {
         };
         let specs = resolve_wan_vace_adapters(&settings, &req).expect("resolve vace adapters");
         assert_eq!(specs.len(), 2);
-        assert_eq!(specs[0].path, plain);
+        assert_eq!(specs[0].path, plain.canonicalize().unwrap());
         assert_eq!(specs[0].kind, AdapterKind::Lora);
         assert!((specs[0].scale - 0.5).abs() < 1e-6);
         assert!(specs[0].moe_expert.is_none(), "VACE is single-dense");
@@ -6931,7 +6931,7 @@ mod tests {
         };
         let specs = resolve_scail2_adapters(&settings, &req).expect("resolve scail2 adapters");
         assert_eq!(specs.len(), 2);
-        assert_eq!(specs[0].path, plain);
+        assert_eq!(specs[0].path, plain.canonicalize().unwrap());
         assert_eq!(specs[0].kind, AdapterKind::Lora);
         assert!((specs[0].scale - 1.0).abs() < 1e-6);
         assert!(specs[0].moe_expert.is_none(), "SCAIL-2 is single-dense");

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       SCENEWORKS_CONFIG_DIR: /sceneworks/config
       SCENEWORKS_JOBS_DB_PATH: /sceneworks/data/cache/jobs.db
       SCENEWORKS_ACCESS_TOKEN: ${SCENEWORKS_ACCESS_TOKEN:-}
+      SCENEWORKS_ALLOW_OPEN_BIND: ${SCENEWORKS_ALLOW_OPEN_BIND:-}
       SCENEWORKS_CORS_ORIGINS: ${SCENEWORKS_CORS_ORIGINS:-http://localhost:5173,http://127.0.0.1:5173,http://localhost:5174,http://127.0.0.1:5174,http://localhost:5175,http://127.0.0.1:5175,http://localhost:5176,http://127.0.0.1:5176}
       SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE: ${SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE:-1}
       HF_HOME: ${SCENEWORKS_HF_HOME:-/sceneworks/data/cache/huggingface}

--- a/scripts/check-docker-api-runtime.mjs
+++ b/scripts/check-docker-api-runtime.mjs
@@ -18,6 +18,9 @@ const env = {
   SCENEWORKS_API_PORT: port,
   SCENEWORKS_DATA_BIND: tempData,
   SCENEWORKS_CONFIG_BIND: path.resolve("config"),
+  // This smoke intentionally exercises the Docker API container's wider in-container
+  // bind through a host-loopback published port, without provisioning auth.
+  SCENEWORKS_ALLOW_OPEN_BIND: "1",
   SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE:
     process.env.SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE || "1",
   // Run the container as this (host) user so the api isn't root and the files it

--- a/scripts/check-scaffold.mjs
+++ b/scripts/check-scaffold.mjs
@@ -233,6 +233,7 @@ await assertContains("docker-compose.yml", "NVIDIA_VISIBLE_DEVICES");
 await assertContains("docker-compose.yml", "dockerfile: docker/rust.Dockerfile");
 await assertContains("docker-compose.yml", "SCENEWORKS_RUST_WORKER_GPU_ID:-cpu");
 await assertContains("docker-compose.yml", "/sceneworks/data/cache/jobs.db");
+await assertContains("docker-compose.yml", "SCENEWORKS_ALLOW_OPEN_BIND");
 await assertContains(".env.example", "SCENEWORKS_RUST_WORKER_GPU_ID=cpu");
 await assertContains("docker/rust.Dockerfile", "sceneworks-rust-api");
 await assertContains("README.md", "SCENEWORKS_ACCESS_TOKEN");

--- a/tests/test_worker_lora_adapters.py
+++ b/tests/test_worker_lora_adapters.py
@@ -2,6 +2,11 @@ from __future__ import annotations
 
 from worker_runtime_shared import *
 
+@pytest.fixture(autouse=True)
+def managed_lora_data_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("SCENEWORKS_DATA_DIR", str(tmp_path))
+
+
 def test_cpu_worker_does_not_advertise_lora_train():
     capabilities = worker_capabilities({"id": "cpu", "name": "CPU", "capabilities": ["placeholder", "cpu"]})
 
@@ -504,6 +509,16 @@ def test_lora_specs_fail_before_inference_for_missing_or_excess_loras(tmp_path):
     many = [{"id": f"lora_{index}", "installedPath": str(missing)} for index in range(4)]
     with pytest.raises(RuntimeError, match="at most 3 LoRAs"):
         normalize_lora_specs(many)
+
+
+def test_lora_specs_reject_outside_app_managed_root(tmp_path):
+    outside = tmp_path.parent / f"{tmp_path.name}-outside" / "evil.safetensors"
+    outside.parent.mkdir()
+    outside.write_bytes(b"lora")
+
+    with pytest.raises(RuntimeError, match="inside an app-managed directory"):
+        normalize_lora_specs([{"id": "evil", "installedPath": str(outside)}])
+
 
 def test_lora_specs_resolve_installed_directory_to_safetensors_file(tmp_path):
     # Installed LoRAs are stored as a directory and the Rust API reports the
@@ -1053,4 +1068,3 @@ def test_wan_backend_save_lora_lokr_routes_to_write_lokr_adapter(tmp_path, monke
     assert captured["file_name"] == "motion.safetensors"
     assert captured["kwargs"] == save_kwargs
     assert output_path == str(tmp_path / "motion.safetensors")
-

--- a/tests/test_worker_video_adapters.py
+++ b/tests/test_worker_video_adapters.py
@@ -1041,6 +1041,7 @@ def test_native_ltx_mocked_run_writes_scene_video_asset(monkeypatch, tmp_path):
     project_path = tmp_path / "project"
     data_dir.mkdir()
     project_path.mkdir()
+    monkeypatch.setenv("SCENEWORKS_DATA_DIR", str(data_dir))
     (data_dir / "recent-projects.json").write_text(
         json.dumps([{"id": "project-1", "path": str(project_path)}]),
         encoding="utf-8",
@@ -1090,6 +1091,7 @@ def test_native_ltx_text_to_video_uses_ltx_pipeline_and_writes_mp4(monkeypatch, 
     project_path = tmp_path / "project"
     data_dir.mkdir()
     project_path.mkdir()
+    monkeypatch.setenv("SCENEWORKS_DATA_DIR", str(data_dir))
     (data_dir / "recent-projects.json").write_text(
         json.dumps([{"id": "project-1", "path": str(project_path)}]),
         encoding="utf-8",
@@ -1262,6 +1264,7 @@ def test_native_ltx_image_to_video_passes_source_image_conditioning(monkeypatch,
     project_path = tmp_path / "project"
     data_dir.mkdir()
     project_path.mkdir()
+    monkeypatch.setenv("SCENEWORKS_DATA_DIR", str(data_dir))
     (data_dir / "recent-projects.json").write_text(
         json.dumps([{"id": "project-1", "path": str(project_path)}]),
         encoding="utf-8",
@@ -1275,7 +1278,9 @@ def test_native_ltx_image_to_video_passes_source_image_conditioning(monkeypatch,
     )
     checkpoint, spatial, lora, gemma = write_native_ltx_resource_files(tmp_path)
     manifest_entry = write_native_ltx_manifest(config_dir, checkpoint=checkpoint, spatial=spatial, lora=lora, gemma=gemma)
-    ic_lora = tmp_path / "identity-control.safetensors"
+    lora_dir = data_dir / "loras"
+    lora_dir.mkdir()
+    ic_lora = lora_dir / "identity-control.safetensors"
     ic_lora.write_bytes(b"ic-lora")
     calls = {"run": None, "encode": None}
 
@@ -1390,6 +1395,7 @@ def test_native_ltx_image_to_video_falls_back_without_ic_lora(monkeypatch, tmp_p
     project_path = tmp_path / "project"
     data_dir.mkdir()
     project_path.mkdir()
+    monkeypatch.setenv("SCENEWORKS_DATA_DIR", str(data_dir))
     (data_dir / "recent-projects.json").write_text(
         json.dumps([{"id": "project-1", "path": str(project_path)}]),
         encoding="utf-8",
@@ -1403,7 +1409,9 @@ def test_native_ltx_image_to_video_falls_back_without_ic_lora(monkeypatch, tmp_p
     )
     checkpoint, spatial, lora, gemma = write_native_ltx_resource_files(tmp_path)
     manifest_entry = write_native_ltx_manifest(config_dir, checkpoint=checkpoint, spatial=spatial, lora=lora, gemma=gemma)
-    style_lora = tmp_path / "cinematic-style.safetensors"
+    lora_dir = data_dir / "loras"
+    lora_dir.mkdir()
+    style_lora = lora_dir / "cinematic-style.safetensors"
     style_lora.write_bytes(b"style-lora")
     calls = {"init": None, "run": None}
 
@@ -1517,6 +1525,7 @@ def test_native_ltx_extend_clip_uses_ic_lora_video_conditioning(monkeypatch, tmp
     project_path = tmp_path / "project"
     data_dir.mkdir()
     project_path.mkdir()
+    monkeypatch.setenv("SCENEWORKS_DATA_DIR", str(data_dir))
     (data_dir / "recent-projects.json").write_text(
         json.dumps([{"id": "project-1", "path": str(project_path)}]),
         encoding="utf-8",
@@ -1530,7 +1539,9 @@ def test_native_ltx_extend_clip_uses_ic_lora_video_conditioning(monkeypatch, tmp
     )
     checkpoint, spatial, lora, gemma = write_native_ltx_resource_files(tmp_path)
     manifest_entry = write_native_ltx_manifest(config_dir, checkpoint=checkpoint, spatial=spatial, lora=lora, gemma=gemma)
-    ic_lora = tmp_path / "identity-control.safetensors"
+    lora_dir = data_dir / "loras"
+    lora_dir.mkdir()
+    ic_lora = lora_dir / "identity-control.safetensors"
     ic_lora.write_bytes(b"ic-lora")
     calls = {"init": None, "run": None, "encode": None}
 


### PR DESCRIPTION
## Summary
- Refuse unauthenticated non-loopback API binds unless an explicit open-bind override is set
- Reject unsafe generated-asset and source-video paths before joining them into project roots
- Confine Rust and Python LoRA adapter payload paths to app-managed roots, including symlink-target checks for Rust
- Add focused regression coverage for the high findings from Shortcut epic 5719

## Shortcut
- https://app.shortcut.com/trefry/epic/5719
- https://app.shortcut.com/trefry/story/5720
- https://app.shortcut.com/trefry/story/5721
- https://app.shortcut.com/trefry/story/5722
- https://app.shortcut.com/trefry/story/5723

## Validation
- cargo fmt
- git diff --check
- cargo test -p sceneworks-worker lora_paths_resolve_symlinks_before_root_check -- --nocapture
- ~/Library/Application\ Support/SceneWorks/python/venv/bin/python -m pytest tests/test_worker_lora_adapters.py -q