### PR TITLE
[codex] Fix medium review bugs

### DIFF
--- a/apps/desktop/src/settings.rs
+++ b/apps/desktop/src/settings.rs
@@ -366,7 +366,7 @@ pub async fn choose_data_dir(app: AppHandle) -> Option<String> {
 
 #[tauri::command]
 pub fn reveal_in_os(path: String) -> Result<(), String> {
-    let target = PathBuf::from(&path);
+    let target = validate_reveal_target(&path)?;
     let result = if cfg!(target_os = "macos") {
         Command::new("open").arg("-R").arg(&target).status()
     } else if cfg!(target_os = "windows") {
@@ -378,6 +378,38 @@ pub fn reveal_in_os(path: String) -> Result<(), String> {
         Command::new("xdg-open").arg(dir).status()
     };
     result.map(|_| ()).map_err(|error| error.to_string())
+}
+
+fn validate_reveal_target(path: &str) -> Result<PathBuf, String> {
+    let target = path.trim();
+    if target.is_empty() {
+        return Err("A path is required.".to_owned());
+    }
+    let target = std::fs::canonicalize(target).map_err(|error| error.to_string())?;
+    let settings = load_settings_migrated();
+    let roots = [
+        settings
+            .data_dir
+            .as_deref()
+            .map(PathBuf::from)
+            .unwrap_or_else(default_data_dir),
+        settings
+            .hf_home
+            .as_deref()
+            .map(PathBuf::from)
+            .unwrap_or_else(shared_huggingface_home),
+    ];
+    let roots = roots
+        .iter()
+        .filter_map(|root| std::fs::canonicalize(root).ok())
+        .collect::<Vec<_>>();
+    if roots.iter().any(|root| target.starts_with(root)) {
+        return Ok(target);
+    }
+    Err(
+        "Can only reveal files inside the SceneWorks data directory or Hugging Face cache."
+            .to_owned(),
+    )
 }
 
 /// Enumerate stored credentials for the Settings screen: host, label, scheme, and

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -85,6 +85,32 @@ function isInterleaveJob(job) {
   return job.type === "image_interleave";
 }
 
+function parseSseJson(event, label) {
+  try {
+    return JSON.parse(event.data);
+  } catch (err) {
+    console.warn(`Ignoring malformed ${label} SSE event`, err);
+    return null;
+  }
+}
+
+function abortableDelay(ms, signal) {
+  if (signal?.aborted) {
+    return Promise.reject(new DOMException("Aborted", "AbortError"));
+  }
+  return new Promise((resolve, reject) => {
+    const timer = window.setTimeout(resolve, ms);
+    signal?.addEventListener(
+      "abort",
+      () => {
+        window.clearTimeout(timer);
+        reject(new DOMException("Aborted", "AbortError"));
+      },
+      { once: true },
+    );
+  });
+}
+
 // sc-4198: notice kind for a job-failure banner. LoRA import/train failures get
 // their own kind so the matching job's later completion dismisses exactly that
 // banner (replacing the old "lora import:"/"lora training:" startsWith protocol);
@@ -540,6 +566,15 @@ export function App() {
   const activeViewRef = useRef(activeView);
   const localGenerationJobIdsRef = useRef(localGenerationJobIds);
   const generatedAssetRefreshesRef = useRef(new Map());
+  const refreshDataRef = useRef(null);
+  const refreshAssetsRef = useRef(null);
+  const refreshCharactersRef = useRef(null);
+  const refreshLorasRef = useRef(null);
+  const refreshPresetsRef = useRef(null);
+  const refreshTrainingDatasetsRef = useRef(null);
+  const refreshPersonTracksRef = useRef(null);
+  const refreshTimelinesRef = useRef(null);
+  const refreshDataWithLoraOverlayRef = useRef(null);
   // A screen (the Image Editor, sc-2434) can register a guard that runs before a
   // user-initiated navigation leaves it — e.g. to confirm discarding unsaved edits.
   // Programmatic setActiveView calls (post-generation hops) deliberately bypass it.
@@ -916,7 +951,7 @@ export function App() {
     if (!authenticated) {
       return;
     }
-    refreshData();
+    refreshDataRef.current?.();
   }, [authenticated, token]);
 
   useEffect(() => {
@@ -939,13 +974,13 @@ export function App() {
     // loads so a slow response can't overwrite the newly-selected project's data.
     const controller = new AbortController();
     const { signal } = controller;
-    refreshAssets(activeProject.id, { signal });
-    refreshCharacters(activeProject.id, { signal });
-    refreshLoras(activeProject.id, { signal });
-    refreshPresets(activeProject.id, { signal });
-    refreshTrainingDatasets(activeProject.id, { signal });
-    refreshPersonTracks(activeProject.id, { signal });
-    refreshTimelines(activeProject.id, { signal });
+    refreshAssetsRef.current?.(activeProject.id, { signal });
+    refreshCharactersRef.current?.(activeProject.id, { signal });
+    refreshLorasRef.current?.(activeProject.id, { signal });
+    refreshPresetsRef.current?.(activeProject.id, { signal });
+    refreshTrainingDatasetsRef.current?.(activeProject.id, { signal });
+    refreshPersonTracksRef.current?.(activeProject.id, { signal });
+    refreshTimelinesRef.current?.(activeProject.id, { signal });
     return () => controller.abort();
   }, [activeProject?.id, authenticated, token]);
 
@@ -960,7 +995,10 @@ export function App() {
     let closed = false;
 
     function handleJobUpdated(event) {
-      const job = JSON.parse(event.data);
+      const job = parseSseJson(event, "job");
+      if (!job) {
+        return;
+      }
       const hasGeneratedAssets = Boolean(job.result?.generationSetId || job.result?.assetIds?.length || job.result?.assets?.length);
       const resultAssetCount = generatedResultAssetCount(job);
       const generationSetId = job.result?.generationSetId ?? "";
@@ -981,31 +1019,31 @@ export function App() {
           generationSetId: generationSetId || previousRefresh.generationSetId,
         });
         if (shouldRefreshGeneratedAssets) {
-          refreshAssets(job.projectId);
+          refreshAssetsRef.current?.(job.projectId);
         }
       }
       if (job.status === "completed" && hasGeneratedAssets) {
         enqueueTimelineGenerationApply(job);
       }
       if (job.status === "completed" && job.projectId && job.type === "person_track") {
-        refreshPersonTracks(job.projectId);
+        refreshPersonTracksRef.current?.(job.projectId);
       }
       if (job.status === "completed" && job.projectId && job.type === "person_detect") {
-        refreshAssets(job.projectId);
+        refreshAssetsRef.current?.(job.projectId);
       }
       if (job.status === "completed" && job.type === "model_download") {
-        refreshData();
+        refreshDataRef.current?.();
       }
       if (job.status === "completed" && job.type === "lora_import") {
         dismissNoticeKind("lora-import");
-        refreshDataWithLoraOverlay(job.projectId ?? activeProjectRef.current?.id);
+        refreshDataWithLoraOverlayRef.current?.(job.projectId ?? activeProjectRef.current?.id);
       }
       if (job.status === "completed" && job.type === "lora_train" && job.payload?.dryRun === false) {
         if (job.result?.loraRegistered === false) {
           pushNotice("lora-train", `lora training: ${job.result?.loraRegistrationError ?? "Completed training but could not register the LoRA."}`);
         } else {
           dismissNoticeKind("lora-train");
-          refreshDataWithLoraOverlay(job.projectId ?? activeProjectRef.current?.id);
+          refreshDataWithLoraOverlayRef.current?.(job.projectId ?? activeProjectRef.current?.id);
         }
       }
       if (job.status === "failed" && !hasVisibleLocalFailure(job)) {
@@ -1014,12 +1052,18 @@ export function App() {
     }
 
     function handleWorkerUpdated(event) {
-      const worker = JSON.parse(event.data);
+      const worker = parseSseJson(event, "worker");
+      if (!worker) {
+        return;
+      }
       setWorkers((items) => [worker, ...items.filter((item) => item.id !== worker.id)].sort(sortWorkers));
     }
 
     function handleQueueUpdated(event) {
-      const summary = JSON.parse(event.data);
+      const summary = parseSseJson(event, "queue");
+      if (!summary) {
+        return;
+      }
       setQueueSummary(summary);
       if (Array.isArray(summary.workers)) {
         setWorkers(summary.workers.sort(sortWorkers));
@@ -1166,6 +1210,16 @@ export function App() {
       .catch(() => {});
   }
 
+  refreshDataRef.current = refreshData;
+  refreshAssetsRef.current = refreshAssets;
+  refreshCharactersRef.current = refreshCharacters;
+  refreshLorasRef.current = refreshLoras;
+  refreshPresetsRef.current = refreshPresets;
+  refreshTrainingDatasetsRef.current = refreshTrainingDatasets;
+  refreshPersonTracksRef.current = refreshPersonTracks;
+  refreshTimelinesRef.current = refreshTimelines;
+  refreshDataWithLoraOverlayRef.current = refreshDataWithLoraOverlay;
+
 
   function saveToken(event) {
     event.preventDefault();
@@ -1294,9 +1348,10 @@ export function App() {
   // independent (no activeProject gate); throws on failure so the studio can surface
   // the message inline without clobbering the original prompt.
   const refinePrompt = useCallback(
-    async ({ prompt, modelId, workflow, guide }) => {
+    async ({ prompt, modelId, workflow, guide, signal }) => {
       const created = await apiFetch("/api/v1/prompts/refine", token, {
         method: "POST",
+        signal,
         body: JSON.stringify({ prompt, modelId, workflow, guide }),
       });
       const jobId = created?.id;
@@ -1305,8 +1360,8 @@ export function App() {
       }
       const deadline = Date.now() + 120000;
       while (Date.now() < deadline) {
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-        const job = await apiFetch(`/api/v1/jobs/${jobId}`, token);
+        await abortableDelay(1000, signal);
+        const job = await apiFetch(`/api/v1/jobs/${jobId}`, token, { signal });
         if (job.status === "completed") {
           const refined = job.result?.refinedPrompt;
           if (!refined) {

--- a/apps/web/src/components/RefinePrompt.test.jsx
+++ b/apps/web/src/components/RefinePrompt.test.jsx
@@ -66,12 +66,13 @@ describe("RefinePromptControl", () => {
     await settle();
 
     // Sent the prompt + model + workflow + fetched guide; original not yet applied.
-    expect(refinePrompt).toHaveBeenCalledWith({
+    expect(refinePrompt).toHaveBeenCalledWith(expect.objectContaining({
       prompt: "neon street",
       modelId: "z_image_turbo",
       workflow: "image",
       guide: "# Guide\n\nWrite vividly.",
-    });
+      signal: expect.any(AbortSignal),
+    }));
     expect(onApply).not.toHaveBeenCalled();
     expect(container.querySelector(".refine-review-text").textContent).toBe("A vivid neon street at midnight, cinematic.");
 
@@ -128,7 +129,13 @@ describe("RefinePromptControl", () => {
     });
     await settle();
 
-    expect(refinePrompt).toHaveBeenCalledWith({ prompt: "dog", modelId: "z", workflow: "video", guide: "" });
+    expect(refinePrompt).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: "dog",
+      modelId: "z",
+      workflow: "video",
+      guide: "",
+      signal: expect.any(AbortSignal),
+    }));
     expect(container.querySelector(".refine-review-text").textContent).toBe("rewritten");
   });
 

--- a/apps/web/src/components/RefinePromptControl.jsx
+++ b/apps/web/src/components/RefinePromptControl.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Icon } from "./Icons.jsx";
 
 // Humanize a byte count to a "7.2 GB" label; null when the size is unknown.
@@ -44,6 +44,7 @@ export function RefinePromptControl({
   const [refined, setRefined] = useState("");
   const [error, setError] = useState("");
   const [downloadRequested, setDownloadRequested] = useState(false);
+  const refineControllerRef = useRef(null);
 
   const trimmed = (prompt ?? "").trim();
   const busy = status === "loading";
@@ -62,7 +63,18 @@ export function RefinePromptControl({
     }
   }, [installState, downloadRequested]);
 
+  useEffect(
+    () => () => {
+      refineControllerRef.current?.abort();
+    },
+    [],
+  );
+
   async function handleRefine() {
+    refineControllerRef.current?.abort();
+    const controller = new AbortController();
+    refineControllerRef.current = controller;
+    const { signal } = controller;
     setStatus("loading");
     setError("");
     try {
@@ -71,18 +83,31 @@ export function RefinePromptControl({
       let guide = "";
       if (guidePath) {
         try {
-          const response = await fetch(guidePath);
+          const response = await fetch(guidePath, { signal });
           if (response.ok) guide = await response.text();
-        } catch {
+        } catch (err) {
+          if (err?.name === "AbortError") {
+            return;
+          }
           guide = "";
         }
       }
-      const result = await refinePrompt({ prompt: trimmed, modelId, workflow, guide });
+      const result = await refinePrompt({ prompt: trimmed, modelId, workflow, guide, signal });
+      if (signal.aborted) {
+        return;
+      }
       setRefined(result);
       setStatus("review");
     } catch (err) {
+      if (err?.name === "AbortError") {
+        return;
+      }
       setError(err?.message || "Prompt refinement failed.");
       setStatus("error");
+    } finally {
+      if (refineControllerRef.current === controller) {
+        refineControllerRef.current = null;
+      }
     }
   }
 

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -9587,12 +9587,13 @@ describe("refine my prompt (sc-2041)", () => {
     });
     await settle();
 
-    expect(refinePrompt).toHaveBeenCalledWith({
+    expect(refinePrompt).toHaveBeenCalledWith(expect.objectContaining({
       prompt: "A cinematic frame of a neon street at midnight",
       modelId: "z_image_turbo",
       workflow: "image",
       guide: "# Guide\n\nWrite vividly.",
-    });
+      signal: expect.any(AbortSignal),
+    }));
     expect(container.querySelector(".refine-review-text").textContent).toBe("A cinematic neon street at midnight, rain-slick.");
     // Original prompt unchanged until the user applies.
     expect(container.querySelector(".prompt-input").value).toBe("A cinematic frame of a neon street at midnight");

--- a/apps/web/src/screens/generationStudio.jsx
+++ b/apps/web/src/screens/generationStudio.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Icon } from "../components/Icons.jsx";
 import { terminalStatuses } from "../jobTypes.js";
 import {
@@ -25,6 +25,10 @@ export function onPromptKeyDown(event) {
 function jobCreatedMs(job) {
   const parsed = Date.parse(job?.createdAt ?? "");
   return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function completedAnchorMs(job) {
+  return Date.parse(job.completedAt ?? job.updatedAt ?? "");
 }
 
 // Pick the runs that belong in a studio's live stack from the tracked set, shared
@@ -119,7 +123,7 @@ export function useGenerationStudio({
     if (!models.some((item) => item.id === model)) {
       setModel(models[0]?.id ?? fallbackModelId);
     }
-  }, [models, model]);
+  }, [models, model, setModel, fallbackModelId]);
 
   // Drop a character selection that's no longer in the catalog.
   useEffect(() => {
@@ -127,7 +131,7 @@ export function useGenerationStudio({
       setCharacterId("");
       setCharacterLookId("");
     }
-  }, [characters, characterId]);
+  }, [characters, characterId, setCharacterId, setCharacterLookId]);
 
   const availablePresets = useMemo(
     () => presets.filter((preset) => presetMatchesWorkflow(preset, mode) && presetMatchesModel(preset, selectedModel, models)),
@@ -157,22 +161,18 @@ export function useGenerationStudio({
     }
   }, [availablePresets, selectedPresetId, selectedPreset]);
 
-  function resultVisible(job) {
+  const resultVisible = useCallback((job) => {
     if (job.result?.generationSetId) {
       return latestAssets.some((asset) => asset.generationSetId === job.result.generationSetId);
     }
     const assetIds = job.result?.assetIds ?? [];
     return assetIds.length > 0 && assetIds.every((id) => assets.some((asset) => asset.id === id));
-  }
+  }, [assets, latestAssets]);
 
-  function completedAnchorMs(job) {
-    return Date.parse(job.completedAt ?? job.updatedAt ?? "");
-  }
-
-  function completedWaitExpired(job, nowMs = Date.now()) {
+  const completedWaitExpired = useCallback((job, nowMs = Date.now()) => {
     const anchorMs = completedAnchorMs(job);
     return Number.isFinite(anchorMs) && nowMs - anchorMs > completedResultFallbackMs;
-  }
+  }, []);
 
   // A completed job's assets can lag its SSE result by a beat; keep the progress
   // card until the asset renders or the fallback window expires, re-checking on a
@@ -194,14 +194,14 @@ export function useGenerationStudio({
     );
     const timer = window.setTimeout(() => setResultFallbackTick((value) => value + 1), nextDelay + 50);
     return () => window.clearTimeout(timer);
-  }, [assets, latestAssets, trackedLocalJobs, resultFallbackTick]);
+  }, [trackedLocalJobs, resultVisible, completedWaitExpired, resultFallbackTick]);
 
   // The visible stack (see selectStackedJobs). A lone completed run collapses once
   // its batch renders in the latest-batch grid or the SSE-lag window expires, so a
   // stale progress card never lingers.
   const localJobs = useMemo(
     () => selectStackedJobs(trackedLocalJobs, (job) => resultVisible(job) || completedWaitExpired(job)),
-    [assets, latestAssets, trackedLocalJobs, resultFallbackTick],
+    [trackedLocalJobs, resultVisible, completedWaitExpired, resultFallbackTick],
   );
 
   // ---- LoRA selection (sc-4196: shared by Image + Video studios) ----

--- a/crates/sceneworks-core/src/character_store.rs
+++ b/crates/sceneworks-core/src/character_store.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::time::UNIX_EPOCH;
+use std::time::{Duration, UNIX_EPOCH};
 
 use rusqlite::{params, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
@@ -1016,6 +1016,7 @@ fn purge_character_on_connection(
 fn connect_project_db(project_path: &Path) -> ProjectStoreResult<Connection> {
     fs::create_dir_all(project_path)?;
     let connection = Connection::open(project_path.join("project.db"))?;
+    connection.busy_timeout(Duration::from_millis(5000))?;
     apply_project_migrations(&connection)?;
     Ok(connection)
 }

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -358,6 +358,10 @@ impl JobsStore {
         let mut connection = self.connect()?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let interrupted = self.list_jobs_by_status_on_connection(&transaction, ACTIVE_STATUSES)?;
+        let interrupted_ids = interrupted
+            .iter()
+            .map(|job| job.id.clone())
+            .collect::<Vec<_>>();
         let now = utc_now();
         transaction.execute(
             &format!(
@@ -380,8 +384,12 @@ impl JobsStore {
             "update workers set status = 'offline', current_job_id = null where status != 'offline'",
             [],
         )?;
+        let updated_jobs = interrupted_ids
+            .iter()
+            .map(|job_id| self.get_job_on_connection(&transaction, job_id))
+            .collect::<JobsStoreResult<Vec<_>>>()?;
         transaction.commit()?;
-        Ok(interrupted)
+        Ok(updated_jobs)
     }
 
     pub fn create_job(&self, request: CreateJob) -> JobsStoreResult<JobSnapshot> {

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use parking_lot::{Mutex, ReentrantMutexGuard};
 use rusqlite::{params, Connection, OptionalExtension};
@@ -2880,7 +2881,9 @@ fn write_project_file(
 
 fn connect_project_db(project_path: &Path) -> ProjectStoreResult<Connection> {
     fs::create_dir_all(project_path)?;
-    Ok(Connection::open(project_path.join("project.db"))?)
+    let connection = Connection::open(project_path.join("project.db"))?;
+    connection.busy_timeout(Duration::from_millis(5000))?;
+    Ok(connection)
 }
 
 /// Assemble the on-disk asset sidecar from the worker-reported flat facts. Rust

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1028,6 +1028,37 @@ fn idle_heartbeat_interrupts_previous_heartbeated_job() {
 }
 
 #[test]
+fn startup_interrupt_returns_post_update_job_snapshots() {
+    let store = store("startup-interrupt-post-update");
+    register_image_worker(&store);
+    let created = store
+        .create_job(image_job(Map::new()))
+        .expect("job creates");
+    let claimed = store
+        .claim_next_job("worker-1")
+        .expect("claim succeeds")
+        .expect("job claimed");
+    assert_eq!(claimed.id, created.id);
+    assert_eq!(claimed.status, JobStatus::Preparing);
+
+    let interrupted = store
+        .mark_interrupted_on_startup()
+        .expect("startup interrupt succeeds");
+    let persisted = store.get_job(&created.id).expect("job loads");
+    let worker = store.get_worker("worker-1").expect("worker loads");
+
+    assert_eq!(interrupted.len(), 1);
+    assert_eq!(interrupted[0].id, created.id);
+    assert_eq!(interrupted[0].status, JobStatus::Interrupted);
+    assert_eq!(interrupted[0].stage, ProgressStage::Interrupted);
+    assert_eq!(interrupted[0].worker_id, None);
+    assert_eq!(persisted.status, JobStatus::Interrupted);
+    assert_eq!(persisted.stage, ProgressStage::Interrupted);
+    assert_eq!(worker.status, WorkerStatus::Offline);
+    assert_eq!(worker.current_job_id, None);
+}
+
+#[test]
 fn signal_death_fails_active_job_with_attributed_error() {
     // sc-4881: a worker hard-killed by SIGKILL/OOM can't report its own death, so
     // the supervisor attributes it. The worker's active job must become a real

--- a/crates/sceneworks-worker/src/downloads.rs
+++ b/crates/sceneworks-worker/src/downloads.rs
@@ -370,7 +370,7 @@ pub(crate) async fn download_snapshot(
 ) -> WorkerResult<()> {
     tokio::fs::create_dir_all(target_dir).await?;
     for file in &snapshot.files {
-        check_cancel(context.api, context.job_id, context.cancel_message).await?;
+        check_download_cancel(context).await?;
         let target_path = safe_join(target_dir, &file.path)?;
         if let Some(parent) = target_path.parent() {
             tokio::fs::create_dir_all(parent).await?;
@@ -414,7 +414,7 @@ pub(crate) async fn download_snapshot_into_cache(
     let mut placements: Vec<(String, String)> = Vec::with_capacity(snapshot.files.len());
 
     for file in &snapshot.files {
-        check_cancel(context.api, context.job_id, context.cancel_message).await?;
+        check_download_cancel(context).await?;
         let head = with_hf_auth(context.settings, meta_client.head(&file.download_url))
             .send()
             .await?;
@@ -601,6 +601,7 @@ pub(crate) async fn download_source_url(
     let mut response = send_source_url_with_redirects(
         context.settings,
         &request_url,
+        &client,
         bearer,
         range_header.as_deref(),
     )
@@ -659,7 +660,7 @@ pub(crate) async fn download_source_url(
                 let Some(chunk) = chunk? else {
                     break;
                 };
-                check_cancel(context.api, context.job_id, context.cancel_message).await?;
+                check_download_cancel(context).await?;
                 output.write_all(&chunk).await?;
                 progress.record_transferred(u64::try_from(chunk.len()).unwrap_or(u64::MAX));
                 if progress.downloaded_bytes() > max_bytes {
@@ -715,6 +716,7 @@ pub(crate) fn credential_for_host<'a>(
 async fn send_source_url_with_redirects(
     settings: &Settings,
     initial_url: &str,
+    initial_client: &reqwest::Client,
     bearer: Option<&str>,
     range_header: Option<&str>,
 ) -> WorkerResult<reqwest::Response> {
@@ -723,8 +725,8 @@ async fn send_source_url_with_redirects(
         .ok()
         .and_then(|url| url.host_str().map(str::to_ascii_lowercase));
     let mut bearer = bearer.map(str::to_owned);
+    let mut client = initial_client.clone();
     for _ in 0..=MAX_SOURCE_URL_REDIRECTS {
-        let client = source_url_client_for_request(settings, &current_url).await?;
         let mut request = client.get(&current_url);
         if let Some(token) = &bearer {
             request = request.bearer_auth(token);
@@ -762,6 +764,7 @@ async fn send_source_url_with_redirects(
         }
         current_host = next_host;
         current_url = next.to_string();
+        client = source_url_client_for_url(settings, &next).await?;
     }
     Err(WorkerError::InvalidPayload(
         "sourceUrl exceeded the redirect limit".to_owned(),
@@ -878,7 +881,15 @@ pub(crate) async fn report_download_progress(
     )
     .await?;
     update_job(context.api, context.job_id, progress.payload()).await?;
-    check_cancel(context.api, context.job_id, context.cancel_message).await
+    check_download_cancel(context).await
+}
+
+async fn check_download_cancel(context: &DownloadContext<'_>) -> WorkerResult<()> {
+    if cancel_requested_peek(context.api, context.job_id).await {
+        mark_job_canceled(context.api, context.job_id, context.cancel_message).await?;
+        return Err(WorkerError::Canceled(context.cancel_message.to_owned()));
+    }
+    Ok(())
 }
 
 pub(crate) struct DownloadProgress<'a> {

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -779,7 +779,7 @@ async fn run_utility_job(
         }
     };
     if matches!(job.job_type, JobType::LoraImport | JobType::ModelImport) {
-        let _ = cleanup_uploaded_import_source(&job.payload).await;
+        let _ = cleanup_uploaded_import_source(settings, &job.payload).await;
     }
     if let Err((message, error)) = result {
         match error {
@@ -903,22 +903,27 @@ async fn fail_job(
 async fn check_cancel(api: &ApiClient, job_id: &str, message: &str) -> WorkerResult<()> {
     let job: JobSnapshot = api.get_json(&format!("/api/v1/jobs/{job_id}")).await?;
     if job.cancel_requested {
-        update_job(
-            api,
-            job_id,
-            progress_payload(
-                JobStatus::Canceled,
-                ProgressStage::Canceled,
-                1.0,
-                message,
-                None,
-                None,
-                None,
-            ),
-        )
-        .await?;
+        mark_job_canceled(api, job_id, message).await?;
         return Err(WorkerError::Canceled(message.to_owned()));
     }
+    Ok(())
+}
+
+async fn mark_job_canceled(api: &ApiClient, job_id: &str, message: &str) -> WorkerResult<()> {
+    update_job(
+        api,
+        job_id,
+        progress_payload(
+            JobStatus::Canceled,
+            ProgressStage::Canceled,
+            1.0,
+            message,
+            None,
+            None,
+            None,
+        ),
+    )
+    .await?;
     Ok(())
 }
 
@@ -1238,17 +1243,30 @@ fn payload_bool(payload: &JsonObject, field: &str) -> bool {
     payload.get(field).and_then(Value::as_bool).unwrap_or(false)
 }
 
-async fn cleanup_uploaded_import_source(payload: &JsonObject) -> WorkerResult<()> {
+async fn cleanup_uploaded_import_source(
+    settings: &Settings,
+    payload: &JsonObject,
+) -> WorkerResult<()> {
     if !payload_bool(payload, "uploadedSourcePath") {
         return Ok(());
     }
     let Some(source_path) = optional_payload_string(payload, "sourcePath") else {
         return Ok(());
     };
-    let source_path = PathBuf::from(source_path);
+    let source_path = normalize_absolute_path(Path::new(source_path))?;
+    let allowed_roots = [
+        normalize_absolute_path(&settings.data_dir.join("cache").join("lora-uploads"))?,
+        normalize_absolute_path(&settings.data_dir.join("cache").join("model-uploads"))?,
+    ];
+    let source_path = ensure_path_under(source_path, &allowed_roots, "Uploaded sourcePath")?;
     let _ = tokio::fs::remove_file(&source_path).await;
     if let Some(parent) = source_path.parent() {
-        let _ = tokio::fs::remove_dir(parent).await;
+        if allowed_roots
+            .iter()
+            .any(|root| parent.starts_with(root) && parent != root)
+        {
+            let _ = tokio::fs::remove_dir(parent).await;
+        }
     }
     Ok(())
 }

--- a/crates/sceneworks-worker/src/media_jobs.rs
+++ b/crates/sceneworks-worker/src/media_jobs.rs
@@ -2240,10 +2240,11 @@ pub(crate) async fn run_ffmpeg(
                 status = child.wait() => break status?,
                 _ = interval.tick() => {
                     heartbeat(context.api, context.settings, WorkerStatus::Busy, Some(context.job_id)).await?;
-                    if let Err(error) = check_cancel(context.api, context.job_id, context.cancel_message).await {
+                    if cancel_requested_peek(context.api, context.job_id).await {
                         let _ = child.kill().await;
                         let _ = child.wait().await;
-                        return Err(error);
+                        mark_job_canceled(context.api, context.job_id, context.cancel_message).await?;
+                        return Err(WorkerError::Canceled(context.cancel_message.to_owned()));
                     }
                 }
             }

--- a/crates/sceneworks-worker/src/person_segment_sam3.rs
+++ b/crates/sceneworks-worker/src/person_segment_sam3.rs
@@ -212,7 +212,11 @@ fn select_object(outputs: &[VideoFrameOutput], anchors: &[Option<BoxNorm>]) -> O
     // Deterministic tie-break on the object id (BTree-like) so repeated runs agree.
     score
         .into_iter()
-        .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap().then(b.0.cmp(&a.0)))
+        .max_by(|a, b| {
+            a.1.partial_cmp(&b.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(b.0.cmp(&a.0))
+        })
         .map(|(oid, _)| oid)
 }
 

--- a/crates/sceneworks-worker/src/pose_jobs.rs
+++ b/crates/sceneworks-worker/src/pose_jobs.rs
@@ -489,7 +489,11 @@ fn detect_batch(
     images: Vec<Option<PathBuf>>,
 ) -> WorkerResult<(Vec<Option<RawSource>>, &'static str)> {
     let cell = DETECTOR.get_or_init(|| Mutex::new(None));
-    let mut guard = cell.lock().expect("pose detector mutex poisoned");
+    let mut guard = cell.lock().unwrap_or_else(|poisoned| {
+        let mut guard = poisoned.into_inner();
+        *guard = None;
+        guard
+    });
     if guard.is_none() {
         *guard = Some(Detector::load(&det_path, &pose_path)?);
     }

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -874,7 +874,9 @@ async fn lora_file_and_directory_import_preserve_copy_semantics() {
 #[tokio::test]
 async fn uploaded_lora_source_cleanup_removes_staged_file_and_parent() {
     let temp = tempdir().expect("tempdir creates");
-    let upload_dir = temp.path().join("upload-1");
+    let mut settings = test_settings("http://127.0.0.1:9".to_owned(), None);
+    settings.data_dir = temp.path().join("data");
+    let upload_dir = settings.data_dir.join("cache/lora-uploads/upload-1");
     tokio::fs::create_dir_all(&upload_dir).await.unwrap();
     let source_file = upload_dir.join("detail.safetensors");
     tokio::fs::write(&source_file, b"lora").await.unwrap();
@@ -885,10 +887,34 @@ async fn uploaded_lora_source_cleanup_removes_staged_file_and_parent() {
     );
     payload.insert("uploadedSourcePath".to_owned(), json!(true));
 
-    cleanup_uploaded_import_source(&payload).await.unwrap();
+    cleanup_uploaded_import_source(&settings, &payload)
+        .await
+        .unwrap();
 
     assert!(!source_file.exists());
     assert!(!upload_dir.exists());
+}
+
+#[tokio::test]
+async fn uploaded_lora_source_cleanup_rejects_paths_outside_upload_cache() {
+    let temp = tempdir().expect("tempdir creates");
+    let mut settings = test_settings("http://127.0.0.1:9".to_owned(), None);
+    settings.data_dir = temp.path().join("data");
+    let outside_file = temp.path().join("outside.safetensors");
+    tokio::fs::write(&outside_file, b"lora").await.unwrap();
+    let mut payload = serde_json::Map::new();
+    payload.insert(
+        "sourcePath".to_owned(),
+        json!(outside_file.display().to_string()),
+    );
+    payload.insert("uploadedSourcePath".to_owned(), json!(true));
+
+    let error = cleanup_uploaded_import_source(&settings, &payload)
+        .await
+        .expect_err("outside path is rejected");
+
+    assert!(matches!(error, WorkerError::InvalidPayload(_)));
+    assert!(outside_file.exists());
 }
 
 #[tokio::test]

--- a/crates/sceneworks-worker/src/upscale_jobs.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs.rs
@@ -37,7 +37,8 @@ use std::sync::{Mutex, OnceLock};
 use crate::downloads::{ensure_hf_cached_file, DownloadContext};
 use crate::generator_cache::with_cached_generator;
 use gen_core::{
-    Conditioning, GenerationOutput, GenerationRequest, Image as GenImage, LoadSpec, WeightsSource,
+    CancelFlag, Conditioning, GenerationOutput, GenerationRequest, Image as GenImage, LoadSpec,
+    WeightsSource,
 };
 use image::RgbImage;
 use ort::execution_providers::CoreMLExecutionProvider;
@@ -46,14 +47,16 @@ use ort::value::Tensor;
 use serde_json::{json, Value};
 
 use crate::{
-    fresh_asset_id, heartbeat, now_rfc3339, progress_payload, task_join_error, update_job,
-    ApiClient, Settings, WorkerError, WorkerResult,
+    cancel_requested_peek, fresh_asset_id, heartbeat, mark_job_canceled, now_rfc3339,
+    progress_payload, progress_report_interval, task_join_error, update_job, ApiClient, Settings,
+    WorkerError, WorkerResult,
 };
 use sceneworks_core::contracts::{JobSnapshot, JobStatus, JsonObject, ProgressStage, WorkerStatus};
 use sceneworks_core::project_store::ProjectStore;
 
 const TILE_SIZE: usize = 512;
 const TILE_PAD: usize = 16;
+const CANCEL_MESSAGE: &str = "Image upscale canceled by user.";
 
 /// SceneWorks-owned HuggingFace repo hosting the pre-exported ONNX (reproducible from
 /// `scripts/spikes/sc3489_export_reference.py`). Public; downloaded on first use,
@@ -172,11 +175,19 @@ impl Upscaler {
 
     /// Tiled x`factor` upscale of one RGB image → an upscaled RGB image. Tiling +
     /// crop/place is a verbatim port of `upscalers.py:_run_tiled`.
-    fn upscale(&mut self, img: &RgbImage, factor: usize) -> WorkerResult<RgbImage> {
+    fn upscale(
+        &mut self,
+        img: &RgbImage,
+        factor: usize,
+        cancel: &CancelFlag,
+    ) -> WorkerResult<RgbImage> {
         let (w, h) = (img.width() as usize, img.height() as usize);
         let (ow, oh) = (w * factor, h * factor);
         let mut output = vec![0u8; ow * oh * 3];
         for tl in tile_slices(w, h, TILE_SIZE) {
+            if cancel.is_cancelled() {
+                return Err(WorkerError::Canceled(CANCEL_MESSAGE.to_owned()));
+            }
             let cx0 = tl.x0.saturating_sub(TILE_PAD);
             let cy0 = tl.y0.saturating_sub(TILE_PAD);
             let cx1 = (tl.x1 + TILE_PAD).min(w);
@@ -214,7 +225,12 @@ impl Upscaler {
 /// Blocking upscale: load+cache the factor's session (amortising the CoreML graph
 /// compile across a batch), run it. All `ort` objects live inside this closure and
 /// never cross an await (mirrors `pose_jobs::detect_batch`).
-fn upscale_blocking(onnx_path: PathBuf, factor: u8, img: RgbImage) -> WorkerResult<RgbImage> {
+fn upscale_blocking(
+    onnx_path: PathBuf,
+    factor: u8,
+    img: RgbImage,
+    cancel: CancelFlag,
+) -> WorkerResult<RgbImage> {
     use std::collections::hash_map::Entry;
     let cell = UPSCALERS.get_or_init(|| Mutex::new(HashMap::new()));
     // Recover from a poisoned lock rather than panicking every subsequent job: if a
@@ -230,7 +246,7 @@ fn upscale_blocking(onnx_path: PathBuf, factor: u8, img: RgbImage) -> WorkerResu
         Entry::Occupied(e) => e.into_mut(),
         Entry::Vacant(e) => e.insert(Upscaler::load(&onnx_path)?),
     };
-    upscaler.upscale(&img, factor as usize)
+    upscaler.upscale(&img, factor as usize, &cancel)
 }
 
 // ---------------------------------------------------------------------------
@@ -424,10 +440,11 @@ async fn ensure_seedvr2_checkpoint(
 /// (0..1) is the optional `--softness` pre-blur; `seed` makes the generative result reproducible.
 async fn run_seedvr2_upscale(
     dir: PathBuf,
-    source: &RgbImage,
+    source: RgbImage,
     factor: u8,
     softness: f32,
     seed: u64,
+    cancel: CancelFlag,
 ) -> WorkerResult<RgbImage> {
     let (src_w, src_h) = (source.width(), source.height());
     let target_w = round_to_16(src_w.saturating_mul(u32::from(factor)));
@@ -453,6 +470,7 @@ async fn run_seedvr2_upscale(
                     image,
                     strength: None,
                 }],
+                cancel: cancel.clone(),
                 ..Default::default()
             };
             let output = generator
@@ -477,6 +495,54 @@ async fn run_seedvr2_upscale(
         },
     )
     .await
+}
+
+async fn run_upscale_with_heartbeat<R>(
+    api: &ApiClient,
+    settings: &Settings,
+    job_id: &str,
+    cancel: CancelFlag,
+    mut task: tokio::task::JoinHandle<WorkerResult<R>>,
+) -> WorkerResult<R>
+where
+    R: Send + 'static,
+{
+    let mut canceled = false;
+    let mut interval = tokio::time::interval(progress_report_interval(settings));
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        tokio::select! {
+            result = &mut task => {
+                let value = result.map_err(|error| task_join_error("upscale task", error))??;
+                if canceled {
+                    mark_job_canceled(api, job_id, CANCEL_MESSAGE).await?;
+                    return Err(WorkerError::Canceled(CANCEL_MESSAGE.to_owned()));
+                }
+                return Ok(value);
+            }
+            _ = interval.tick() => {
+                heartbeat(api, settings, WorkerStatus::Busy, Some(job_id)).await?;
+                if !canceled && cancel_requested_peek(api, job_id).await {
+                    cancel.cancel();
+                    canceled = true;
+                    update_job(
+                        api,
+                        job_id,
+                        progress_payload(
+                            JobStatus::Running,
+                            ProgressStage::Running,
+                            0.45,
+                            "Canceling image upscale.",
+                            None,
+                            None,
+                            None,
+                        ),
+                    )
+                    .await?;
+                }
+            }
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -638,7 +704,18 @@ pub(crate) async fn run_image_upscale_job(
             ),
         )
         .await?;
-        run_seedvr2_upscale(dir, &source_image, factor, softness, seed).await?
+        let cancel = CancelFlag::new();
+        let seed_source = source_image.clone();
+        run_upscale_with_heartbeat(
+            api,
+            settings,
+            &job.id,
+            cancel.clone(),
+            tokio::spawn(async move {
+                run_seedvr2_upscale(dir, seed_source, factor, softness, seed, cancel).await
+            }),
+        )
+        .await?
     } else {
         update_job(
             api,
@@ -671,9 +748,17 @@ pub(crate) async fn run_image_upscale_job(
             ),
         )
         .await?;
-        tokio::task::spawn_blocking(move || upscale_blocking(onnx_path, factor, source_image))
-            .await
-            .map_err(|error| task_join_error("upscale task", error))??
+        let cancel = CancelFlag::new();
+        run_upscale_with_heartbeat(
+            api,
+            settings,
+            &job.id,
+            cancel.clone(),
+            tokio::task::spawn_blocking(move || {
+                upscale_blocking(onnx_path, factor, source_image, cancel)
+            }),
+        )
+        .await?
     };
     let (out_w, out_h) = (upscaled.width(), upscaled.height());
 

--- a/crates/sceneworks-worker/src/upscale_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs/tests.rs
@@ -229,13 +229,13 @@ async fn seedvr2_upscale_real_weight_smoke() {
     for (x, y, pixel) in img.enumerate_pixels_mut() {
         *pixel = Rgb([(x * 5) as u8, (y * 7) as u8, ((x + y) * 3 % 256) as u8]);
     }
-    let faithful = run_seedvr2_upscale(dir.clone(), &img, 2, 0.0, 7)
+    let faithful = run_seedvr2_upscale(dir.clone(), img.clone(), 2, 0.0, 7, CancelFlag::new())
         .await
         .expect("seedvr2 upscale (softness 0)");
     assert_eq!((faithful.width(), faithful.height()), (96, 64));
 
     // The softness request field must reach the engine: a heavily-softened run changes the result.
-    let softened = run_seedvr2_upscale(dir, &img, 2, 0.8, 7)
+    let softened = run_seedvr2_upscale(dir, img, 2, 0.8, 7, CancelFlag::new())
         .await
         .expect("seedvr2 upscale (softness 0.8)");
     assert_eq!((softened.width(), softened.height()), (96, 64));

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -2578,16 +2578,13 @@ async fn generate_video(
         // leaks until the worker is restarted by the supervisor.
         eprintln!(
             "rust_worker_video_abandoned: job={} engine={log_engine_id} did not respond to \
-             cancellation within {}s — abandoning the wedged task",
+             cancellation within {}s — exiting the worker so the supervisor can recover the \
+             wedged GPU task",
             job.id,
             VIDEO_STALL_GRACE.as_secs()
         );
         blocking.abort();
-        return Err(WorkerError::Engine(format!(
-            "Video generation stalled: no progress for {}s and the GPU job did not respond to \
-             cancellation. The job was abandoned; the worker may need to restart to free the GPU.",
-            stall_timeout.as_secs()
-        )));
+        std::process::exit(70);
     }
     let result = blocking
         .await


### PR DESCRIPTION
## Summary

Fixes all Medium (`[Med]`) bug findings from Shortcut epic 5719 that were assigned as bug stories.

## Changes

- Hardened Rust worker crash/cancel paths:
  - pose detector mutex poison recovery
  - NaN-safe SAM3 object selection
  - image upscale heartbeat/cancel polling for Real-ESRGAN and SeedVR2
  - deferred terminal cancel for downloads/ffmpeg until work has actually stopped
  - worker process exit on abandoned wedged video generation so the supervisor can recover
- Closed path and SSRF gaps:
  - confined uploaded import cleanup to staged upload roots
  - reused the same pinned source-url client for HEAD and initial GET
  - confined desktop `reveal_in_os` to SceneWorks data/HF cache roots
- Fixed core job/database behavior:
  - startup interrupt returns post-update job snapshots
  - project DB openers use a 5s SQLite busy timeout
- Fixed web lifecycle bugs:
  - guarded SSE JSON parsing
  - live refresh refs for long-lived App/SSE handlers
  - abortable prompt refinement polling
  - corrected `useGenerationStudio` dependency/memo wiring

## Shortcut

Completed Medium bug stories: sc-5724, sc-5725, sc-5726, sc-5727, sc-5728, sc-5729, sc-5730, sc-5731, sc-5732, sc-5733, sc-5736, sc-5737, sc-5738, sc-5741.

## Validation

- `cargo check -p sceneworks-worker -p sceneworks-core`
- `cargo test -p sceneworks-worker uploaded_lora_source_cleanup -- --nocapture`
- `cargo test -p sceneworks-worker cancel_peek_reports_confirmed_cancel_without_posting -- --nocapture`
- `cargo test -p sceneworks-worker begin_video_cancel_trips_flag_and_stays_non_terminal -- --nocapture`
- `cargo test -p sceneworks-worker select_object_picks_the_id_overlapping_the_anchor -- --nocapture`
- `cargo test -p sceneworks-core startup_interrupt_returns_post_update_job_snapshots -- --nocapture`
- `npm run check`
- `npm run check:compose`
- `npm --prefix apps/web run build`
- `npm --prefix apps/web run test -- RefinePrompt --run`
- `npm --prefix apps/web run test -- main --run`
- `git diff --check`

Blocked/known:

- `cargo check -p sceneworks-desktop` is blocked in this worktree because Tauri's build script requires missing packaging artifact `apps/desktop/binaries/sceneworks-api-aarch64-apple-darwin`.
- `npm ci` reported 4 high-severity advisories in the existing web dependency tree; this PR does not change dependency versions.
