### PR TITLE
Fix Mac Image Studio edit tab gating

### DIFF
--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ImageEditSourcePickerField } from "../components/AssetPicker.jsx";
 import { AssetCard } from "../components/assetPanels.jsx";
 import { AssetMedia } from "../components/assetMedia.jsx";
@@ -88,6 +88,7 @@ import {
   DEFAULT_MAC_CAPABILITIES,
   macAvailableModels,
   macBlockedModels,
+  macGatingActive,
   macModelFeatureBlock,
   macUpscaleEngineBlocked,
 } from "../macGating.js";
@@ -441,38 +442,47 @@ export function ImageStudio() {
     () => macBlockedModels(imageModels, macCapabilities),
     [imageModels, macCapabilities],
   );
-  const availableModels = useMemo(
-    () =>
-      macImageModels.filter((item) => {
-        const caps = item.capabilities ?? [];
-        if (mode === "edit_image") {
-          return caps.includes("edit_image") || caps.includes("image_edit");
-        }
-        if (mode === "character_image") {
-          // Only models with a reference-image (IP-Adapter) engine can preserve a
-          // character's identity from one reference; gate the picker to them.
-          return caps.includes("character_image");
-        }
-        if (mode === "style_variations") {
-          return caps.includes("style_variations");
-        }
-        // text_to_image: only models that declare a real sourceless T2I path (sc-5549).
-        // Without this gate the Text tab leaked edit-only models (run a degraded
-        // sourceless edit) and reference-only identity models (MLX-ineligible without a
-        // reference → strand on "Waiting for an available worker"); both classes lack
-        // text_to_image. Mirrors the per-capability gating the other three modes use.
-        return caps.includes("text_to_image");
-      }),
-    [macImageModels, mode],
+  const macGating = macGatingActive(macCapabilities);
+  const imageModelServesMode = useCallback((item, value) => {
+    const caps = item?.capabilities ?? [];
+    if (value === "edit_image") {
+      return (
+        (caps.includes("edit_image") || caps.includes("image_edit")) &&
+        !macModelFeatureBlock(item, macCapabilities, "edit")
+      );
+    }
+    if (value === "character_image") {
+      // Only models with a reference-image (IP-Adapter) engine can preserve a
+      // character's identity from one reference; gate the picker to them.
+      return caps.includes("character_image") && !macModelFeatureBlock(item, macCapabilities, "reference");
+    }
+    if (value === "style_variations") {
+      return caps.includes("style_variations") && !macModelFeatureBlock(item, macCapabilities, "reference");
+    }
+    // text_to_image: only models that declare a real sourceless T2I path (sc-5549).
+    // Without this gate the Text tab leaked edit-only models (run a degraded
+    // sourceless edit) and reference-only identity models (MLX-ineligible without a
+    // reference → strand on "Waiting for an available worker"); both classes lack
+    // text_to_image. Mirrors the per-capability gating the other three modes use.
+    return caps.includes("text_to_image");
+  }, [macCapabilities]);
+  const modelsForMode = useCallback(
+    (value) => macImageModels.filter((item) => imageModelServesMode(item, value)),
+    [imageModelServesMode, macImageModels],
   );
+  const availableModels = useMemo(
+    () => modelsForMode(mode),
+    [mode, modelsForMode],
+  );
+  const pickerModels = mode === "text_to_image" && availableModels.length === 0 ? macImageModels : availableModels;
   // When the mode change filters out the current model (e.g. Lens-Turbo is the
   // text default but isn't edit-capable), snap to the first available model so
   // the dropdown's displayed option matches the value actually submitted.
   useEffect(() => {
-    if (availableModels.length && !availableModels.some((item) => item.id === model)) {
-      setModel(availableModels[0].id);
+    if (pickerModels.length && !pickerModels.some((item) => item.id === model)) {
+      setModel(pickerModels[0].id);
     }
-  }, [availableModels, model]);
+  }, [pickerModels, model]);
   const selectedModel = imageModels.find((item) => item.id === model);
   // Prompt guide for the selected model; fall back to the generic image guide
   // when a model declares none, so the button is always useful (sc-1817).
@@ -497,10 +507,17 @@ export function ImageStudio() {
   const macEditBlock = macModelFeatureBlock(selectedModel, macCapabilities, "edit");
   const macReferenceBlock = macModelFeatureBlock(selectedModel, macCapabilities, "reference");
   const macPoseBlock = macModelFeatureBlock(selectedModel, macCapabilities, "pose");
-  const macModeBlock = (value) => {
-    if (value === "edit_image") return macEditBlock;
-    if (value === "character_image" || value === "style_variations") return macReferenceBlock;
+  const macActiveModeBlock = (() => {
+    if (mode === "edit_image") return macEditBlock;
+    if (mode === "character_image" || mode === "style_variations") return macReferenceBlock;
     return null;
+  })();
+  const macModeTabBlock = (value) => {
+    if (!macGating || value === mode || modelsForMode(value).length) return null;
+    return {
+      blocked: true,
+      text: "No available Mac model supports this mode.",
+    };
   };
   // Variation slider spec (FLUX / Qwen). When declared, the model exposes a
   // trueCfgScale knob alongside (FLUX) or instead of (Qwen, via hideReferenceStrength)
@@ -1027,6 +1044,7 @@ export function ImageStudio() {
     !activeProject ||
     !prompt.trim() ||
     (mode === "character_image" && !characterId) ||
+    Boolean(macActiveModeBlock) ||
     !presetValidationResult.ok ||
     !selectedLoraValidationResult.ok;
 
@@ -1042,7 +1060,7 @@ export function ImageStudio() {
                 ["character_image", "With character"],
                 ["style_variations", "Variations"],
               ].map(([value, label]) => {
-                const macBlock = macModeBlock(value);
+                const macBlock = macModeTabBlock(value);
                 return (
                   <button
                     className={mode === value ? "active" : ""}
@@ -1345,13 +1363,14 @@ export function ImageStudio() {
             <label>
               Model
               <select onChange={(event) => setModel(event.target.value)} value={model}>
-                {(availableModels.length ? availableModels : macImageModels).map((item) => (
+                {pickerModels.map((item) => (
                   <option key={item.id} value={item.id}>
                     {item.name}
                   </option>
                 ))}
               </select>
             </label>
+            {macActiveModeBlock ? <p className="mac-gating-note">{macActiveModeBlock.text}</p> : null}
             {macHiddenImageModels.length ? (
               <p className="mac-gating-note">
                 {macHiddenImageModels.length} model

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -477,8 +477,38 @@ describe("ImageStudio model picker capability gating", () => {
   };
   const EDIT_ONLY = { ...Z_IMAGE, id: "edit_only", name: "Edit Only", capabilities: ["edit_image", "image_to_image"] };
   const CHARACTER_ONLY = { ...Z_IMAGE, id: "character_only", name: "Character Only", capabilities: ["character_image"] };
+  const MAC_CAPS = {
+    macGatingActive: true,
+    platform: "darwin",
+    notAvailableLabel: "Not available on Mac (Rust/MLX only)",
+    features: {},
+    training: { supportedKernels: [], lokrOnWanSupported: false },
+  };
+  const LENS_TURBO = {
+    ...Z_IMAGE,
+    id: "lens_turbo",
+    name: "Lens-Turbo",
+    capabilities: ["text_to_image"],
+    macSupport: { supported: true, features: { edit: false, reference: false } },
+  };
+  const QWEN_EDIT = {
+    ...Z_IMAGE,
+    id: "qwen_image_edit",
+    name: "Qwen Image Edit",
+    capabilities: ["edit_image"],
+    macSupport: { supported: true, features: { edit: true, reference: false } },
+  };
+  const TORCH_ONLY_EDIT = {
+    ...Z_IMAGE,
+    id: "torch_only_edit",
+    name: "Torch-only Edit",
+    capabilities: ["edit_image"],
+    macSupport: { supported: true, features: { edit: false, reference: false } },
+  };
 
   const modelOptionValues = () => [...field(container, "Model").options].map((option) => option.value);
+  const modeButton = (label) =>
+    [...container.querySelectorAll(".segmented-control button")].find((button) => button.textContent === label);
 
   it("Text tab lists only text_to_image models, excluding edit-only and character-only (sc-5549)", async () => {
     await render(baseContext({ imageModels: [EDIT_ONLY, T2I, VARIATIONS, CHARACTER_ONLY] }));
@@ -499,5 +529,36 @@ describe("ImageStudio model picker capability gating", () => {
     expect(options).not.toContain("t2i_only"); // text_to_image but no style_variations
     expect(options).not.toContain("edit_only");
     expect(options).not.toContain("character_only");
+  });
+
+  it("enables the Mac Edit tab when any available model supports edit mode (sc-5589)", async () => {
+    await render(
+      baseContext({
+        imageModels: [LENS_TURBO, TORCH_ONLY_EDIT, QWEN_EDIT],
+        macCapabilities: MAC_CAPS,
+      }),
+    );
+
+    expect(field(container, "Model").value).toBe("lens_turbo");
+    expect(modeButton("Edit").disabled).toBe(false);
+
+    await click(modeButton("Edit"));
+    await act(async () => {});
+
+    expect(modeButton("Edit").className).toContain("active");
+    expect(field(container, "Model").value).toBe("qwen_image_edit");
+    expect(modelOptionValues()).toEqual(["qwen_image_edit"]);
+  });
+
+  it("disables the Mac Edit tab when no available model supports edit mode", async () => {
+    await render(
+      baseContext({
+        imageModels: [LENS_TURBO, TORCH_ONLY_EDIT],
+        macCapabilities: MAC_CAPS,
+      }),
+    );
+
+    expect(modeButton("Edit").disabled).toBe(true);
+    expect(modeButton("Edit").title).toBe("No available Mac model supports this mode.");
   });
 });


### PR DESCRIPTION
## Summary
- Gate Image Studio Mac mode tabs on mode-level availability across Mac-available models instead of the currently selected model.
- Keep edit/reference model picker choices limited to models whose per-feature Mac support is MLX-compatible.
- Add regression coverage for the Lens-Turbo default plus an available Qwen edit model, and for the no-edit-model case.

## Root Cause
The Edit tab was disabled using the selected model's `macSupport.features.edit` value. On Mac, the default Lens-Turbo text model reports `edit: false`, so the tab was greyed out even when another installed model could serve `edit_image` through MLX. The existing snap-to-edit-model effect could only run after entering edit mode, so users were trapped outside the tab.

## Validation
- `npm --prefix apps/web test -- ImageStudio.test.jsx`
- `npm --prefix apps/web run lint` (passes with existing warning baseline: 52 warnings, 0 errors)

Shortcut: sc-5589
