### PR TITLE
[codex] Fix epic 5719 bug backlog

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -1851,6 +1851,11 @@ fn validate_video_job(payload: &VideoJobRequest) -> Result<(), ApiError> {
             "referenceAssetIds must not contain blank ids",
         ));
     }
+    if payload.reference_asset_ids.len() > MAX_VIDEO_REFERENCE_ASSET_IDS {
+        return Err(ApiError::bad_request(format!(
+            "referenceAssetIds must contain at most {MAX_VIDEO_REFERENCE_ASSET_IDS} ids"
+        )));
+    }
     if payload
         .source_clip_asset_ids
         .iter()
@@ -1859,6 +1864,11 @@ fn validate_video_job(payload: &VideoJobRequest) -> Result<(), ApiError> {
         return Err(ApiError::bad_request(
             "sourceClipAssetIds must not contain blank ids",
         ));
+    }
+    if payload.source_clip_asset_ids.len() > MAX_VIDEO_SOURCE_CLIP_ASSET_IDS {
+        return Err(ApiError::bad_request(format!(
+            "sourceClipAssetIds must contain at most {MAX_VIDEO_SOURCE_CLIP_ASSET_IDS} ids"
+        )));
     }
     let duration = payload
         .duration
@@ -1945,6 +1955,8 @@ const MAX_IMAGE_DIMENSION: u32 = 4096;
 /// Upper bound for video width/height — a lower backstop than images, matching
 /// the cap enforced when validating a video job request.
 const MAX_VIDEO_DIMENSION: u32 = 1920;
+const MAX_VIDEO_REFERENCE_ASSET_IDS: usize = 8;
+const MAX_VIDEO_SOURCE_CLIP_ASSET_IDS: usize = 8;
 
 fn validate_dimension(value: u32, field: &'static str, max: u32) -> Result<(), ApiError> {
     if !(256..=max).contains(&value) {

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -9,6 +9,25 @@ const MODEL_SIZE_CACHE_LIMIT: usize = 64;
 // TTL window instead of one per catalog load (sc-4169).
 const MODEL_SIZE_NEGATIVE_TTL: Duration = Duration::from_secs(300);
 
+fn validate_huggingface_repo(repo: &str) -> Result<(), ApiError> {
+    let parts: Vec<_> = repo.trim().split('/').collect();
+    if parts.len() != 2
+        || parts.iter().any(|part| {
+            part.is_empty()
+                || part.starts_with('.')
+                || part.ends_with('.')
+                || !part.chars().all(|character| {
+                    character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | '.')
+                })
+        })
+    {
+        return Err(ApiError::bad_request(
+            "Hugging Face repo must be in owner/name form",
+        ));
+    }
+    Ok(())
+}
+
 #[derive(Debug, Default)]
 pub(crate) struct ModelSizeCache {
     entries: HashMap<ModelSizeCacheKey, CachedSizeEstimate>,
@@ -432,6 +451,9 @@ pub(crate) async fn queue_model_import_job(
     }
     if let Some(source_url) = payload.source_url.as_deref() {
         validate_source_url(source_url)?;
+    }
+    if let Some(repo) = payload.repo.as_deref() {
+        validate_huggingface_repo(repo)?;
     }
     let model_type = match payload.model_type.as_deref().map(str::trim) {
         Some(value) if !value.is_empty() => {

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -713,6 +713,7 @@ async fn worker_can_register_claim_and_complete_job_through_http() {
             "stage": "completed",
             "progress": 1,
             "message": "Done",
+            "workerId": "worker-1",
             "result": { "assetIds": ["asset-1"] }
         }),
     )
@@ -773,7 +774,7 @@ async fn progress_ticks_only_republish_queue_on_status_change() {
         app.clone(),
         "POST",
         &format!("/api/v1/jobs/{job_id}/progress"),
-        json!({ "status": "running", "stage": "running", "progress": 0.2, "message": "step" }),
+        json!({ "status": "running", "stage": "running", "progress": 0.2, "message": "step", "workerId": "worker-1" }),
     )
     .await;
 
@@ -785,7 +786,7 @@ async fn progress_ticks_only_republish_queue_on_status_change() {
         app.clone(),
         "POST",
         &format!("/api/v1/jobs/{job_id}/progress"),
-        json!({ "status": "running", "stage": "running", "progress": 0.6, "message": "step" }),
+        json!({ "status": "running", "stage": "running", "progress": 0.6, "message": "step", "workerId": "worker-1" }),
     )
     .await;
     let tick_events = drain_event_names(&mut events).await;
@@ -803,7 +804,7 @@ async fn progress_ticks_only_republish_queue_on_status_change() {
         app.clone(),
         "POST",
         &format!("/api/v1/jobs/{job_id}/progress"),
-        json!({ "status": "completed", "stage": "completed", "progress": 1, "message": "done" }),
+        json!({ "status": "completed", "stage": "completed", "progress": 1, "message": "done", "workerId": "worker-1" }),
     )
     .await;
     let done_events = drain_event_names(&mut events).await;
@@ -3096,6 +3097,22 @@ async fn bernini_video_modes_validate_required_media() {
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
 
+    // Reference id lists are bounded before the worker has to encode them.
+    let (status, _) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": "project-1",
+            "model": "bernini",
+            "mode": "reference_to_video",
+            "prompt": "the subject dances",
+            "referenceAssetIds": ["ref-1", "ref-2", "ref-3", "ref-4", "ref-5", "ref-6", "ref-7", "ref-8", "ref-9"]
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
     // A complete video_to_video request creates a base video_generate job that
     // carries the source clip.
     let (status, v2v_job) = request(
@@ -3165,6 +3182,22 @@ async fn bernini_video_modes_validate_required_media() {
             "mode": "multi_video_to_video",
             "prompt": "blend the takes",
             "sourceClipAssetIds": ["clip-a", "  "]
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    // Source clip lists are bounded before worker-side video conditioning.
+    let (status, _) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": "project-1",
+            "model": "bernini",
+            "mode": "multi_video_to_video",
+            "prompt": "blend the takes",
+            "sourceClipAssetIds": ["clip-1", "clip-2", "clip-3", "clip-4", "clip-5", "clip-6", "clip-7", "clip-8", "clip-9"]
         }),
     )
     .await;
@@ -4609,6 +4642,25 @@ async fn model_import_routes_handle_url_upload_and_family_detection() {
         .is_some_and(|value| value.contains("models/imports/custom_model")
             || value.contains("models\\imports\\custom_model")));
     assert!(url_job["payload"]["manifestEntry"].get("family").is_none());
+
+    // Repo imports must be owner/name, not arbitrary path-like strings.
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (bad_repo_status, bad_repo_error) = request(
+        app,
+        "POST",
+        "/api/v1/models/import",
+        json!({
+            "repo": "owner/nested/model",
+            "name": "Bad Repo",
+            "type": "image"
+        }),
+    )
+    .await;
+    assert_eq!(bad_repo_status, StatusCode::BAD_REQUEST);
+    assert!(bad_repo_error["detail"]
+        .as_str()
+        .unwrap_or("")
+        .contains("owner/name"));
 
     // Duplicate id is rejected with an actionable error.
     let app = create_app(test_settings(&temp_dir)).expect("app creates");

--- a/apps/web/src/components/assetMedia.jsx
+++ b/apps/web/src/components/assetMedia.jsx
@@ -6,7 +6,12 @@ export function assetUrl(asset) {
     return API_BASE_URL + asset.url;
   }
   if (asset?.projectId && asset?.file?.path) {
-    const normalizedPath = String(asset.file.path).replaceAll("\\", "/");
+    const normalizedPath = String(asset.file.path)
+      .replaceAll("\\", "/")
+      .split("/")
+      .filter(Boolean)
+      .map((segment) => encodeURIComponent(segment))
+      .join("/");
     return `${API_BASE_URL}/api/v1/projects/${asset.projectId}/files/${normalizedPath}`;
   }
   return "";

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App, ErrorBoundary, eventUrl } from "./main.jsx";
 import { AssetPickerField } from "./components/AssetPicker.jsx";
+import { assetUrl } from "./components/assetMedia.jsx";
 import { AssetDetail, FullscreenPreview } from "./components/assetPanels.jsx";
 import { liveElapsedSeconds } from "./formatting.js";
 import { dropUpscaledVariants, foldUpscaledAssetVariants, restrictFoldedToScope } from "./assetVariants.js";
@@ -395,6 +396,17 @@ describe("SceneWorks app shell", () => {
     });
     container.remove();
     vi.restoreAllMocks();
+  });
+
+  it("encodes fallback asset file path segments", () => {
+    const url = assetUrl({
+      projectId: "project-1",
+      file: { path: "assets\\images/final image #1?.png" },
+    });
+
+    expect(url).toBe(
+      "http://localhost:8000/api/v1/projects/project-1/files/assets/images/final%20image%20%231%3F.png",
+    );
   });
 
   it("shows a fallback instead of a blank screen when rendering fails", async () => {
@@ -9175,17 +9187,18 @@ describe("SceneWorks app shell", () => {
 
     // Submitting composes an interleave job with prompt, model, size, and max images.
     await changeField(container.querySelector("textarea"), "An illustrated guide to brewing tea");
+    await changeField(container.querySelector("input[type='number']"), "999");
     const submit = [...container.querySelectorAll("button")].find((button) =>
       button.textContent.includes("Compose document"),
     );
     await act(async () => {
-      submit.click();
+      submit.closest("form").dispatchEvent(new window.Event("submit", { bubbles: true, cancelable: true }));
     });
     expect(createInterleaveJob).toHaveBeenCalledTimes(1);
     const payload = createInterleaveJob.mock.calls[0][0];
     expect(payload.prompt).toBe("An illustrated guide to brewing tea");
     expect(payload.model).toBe("sensenova_u1_8b");
-    expect(payload.maxImages).toBe(6);
+    expect(payload.maxImages).toBe(10);
     expect(payload.width).toBe(2048);
     expect(payload.height).toBe(1152);
     // Unedited system prompt is not sent (worker uses its own default).

--- a/apps/web/src/screens/DocumentStudio.jsx
+++ b/apps/web/src/screens/DocumentStudio.jsx
@@ -27,6 +27,14 @@ function documentSegments(job) {
   return Array.isArray(segments) && segments.length ? segments : null;
 }
 
+function clampMaxImages(value) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return MAX_IMAGES_DEFAULT;
+  }
+  return Math.min(MAX_IMAGES_LIMIT, Math.max(1, Math.floor(parsed)));
+}
+
 export function DocumentStudio() {
   const {
     activeProject,
@@ -84,7 +92,7 @@ export function DocumentStudio() {
     const job = await createInterleaveJob({
       prompt: prompt.trim(),
       model: model || undefined,
-      maxImages: Number(maxImages) || MAX_IMAGES_DEFAULT,
+      maxImages: clampMaxImages(maxImages),
       width,
       height,
       sourceAssetIds,

--- a/crates/sceneworks-core/src/credentials.rs
+++ b/crates/sceneworks-core/src/credentials.rs
@@ -15,6 +15,8 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
+use crate::store_util::random_hex;
+
 /// Filename of the credential store within the config dir. Shared so the rust-api
 /// (writer) and the worker (reader) never drift.
 pub const CREDENTIALS_FILENAME: &str = "credentials.json";
@@ -114,7 +116,13 @@ impl CredentialFileStore {
         // the temp is created 0600 up front, closing the window where the token
         // was briefly world/group-readable between a plain write and the chmod
         // (sc-4268 / F-CORE-8).
-        let tmp_path = self.path.with_extension("json.tmp");
+        let extension = self
+            .path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .unwrap_or("json");
+        let token = random_hex(8).map_err(io::Error::other)?;
+        let tmp_path = self.path.with_extension(format!("{extension}.{token}.tmp"));
         write_secret_file(&tmp_path, body.as_bytes())?;
         std::fs::rename(&tmp_path, &self.path)?;
         // Backstop: re-assert 0600 on the final path in case it already existed

--- a/crates/sceneworks-core/src/hf_home.rs
+++ b/crates/sceneworks-core/src/hf_home.rs
@@ -12,6 +12,9 @@
 //! Compose already inject `HF_HOME`, so this only changes the env-less case.
 
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+static DEFAULT_HF_HOME: OnceLock<Option<PathBuf>> = OnceLock::new();
 
 /// The OS Hugging Face home, `~/.cache/huggingface` (the literal `~/.cache`, not
 /// the platform cache dir — matching huggingface_hub and `Path.home()/.cache/
@@ -43,6 +46,12 @@ pub fn default_huggingface_home(
 /// path it set, or `None` when it left the environment unchanged. Call once at
 /// binary startup, before any cache resolution or worker spawn.
 pub fn ensure_default_huggingface_home() -> Option<PathBuf> {
+    DEFAULT_HF_HOME
+        .get_or_init(default_huggingface_home_from_env)
+        .clone()
+}
+
+fn default_huggingface_home_from_env() -> Option<PathBuf> {
     let read = |key: &str| std::env::var(key).ok();
     let chosen = default_huggingface_home(
         read("HF_HUB_CACHE").as_deref(),

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -1116,8 +1116,10 @@ impl JobsStore {
                 status: current.status.as_str().to_owned(),
             });
         }
-        if let Some(reporter) = update.worker_id.as_deref() {
-            if current.worker_id.as_deref() != Some(reporter) {
+        match (update.worker_id.as_deref(), current.worker_id.as_deref()) {
+            (Some(reporter), Some(owner)) if reporter == owner => {}
+            (None, None) => {}
+            _ => {
                 return Err(JobsStoreError::NotJobOwner {
                     job_id: job_id.to_owned(),
                 });

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -1986,6 +1986,11 @@ impl ProjectStore {
             .and_then(Value::as_str)
             .unwrap_or_default()
             .to_owned();
+        if !media_rel.is_empty() && !is_safe_relative_path(&media_rel) {
+            return Err(ProjectStoreError::BadRequest(
+                "Asset media path must be project-relative".to_owned(),
+            ));
+        }
         let media_path = project_path.join(&media_rel);
         let status = asset
             .as_object_mut()
@@ -2801,10 +2806,21 @@ fn find_timeline_file(project_path: &Path, timeline_id: &str) -> ProjectStoreRes
         )
         .optional()?;
     if let Some(indexed_path) = indexed_path.as_deref() {
-        let path = project_path.join(indexed_path);
-        if path.exists() {
+        let path = if is_safe_relative_path(indexed_path) {
+            Some(project_path.join(indexed_path))
+        } else {
+            None
+        };
+        if let Some(path) = path.filter(|path| path.exists()) {
+            let project_root = project_path.canonicalize()?;
+            let canonical = path.canonicalize()?;
+            if !canonical.starts_with(&project_root) {
+                return Err(ProjectStoreError::BadRequest(
+                    "Timeline file path must stay inside the project".to_owned(),
+                ));
+            }
             return Ok(TimelineFile {
-                path,
+                path: canonical,
                 relative_path: indexed_path.to_owned(),
             });
         }
@@ -3541,11 +3557,11 @@ fn move_or_copy_file(source: &Path, destination: &Path) -> ProjectStoreResult<()
 #[cfg(test)]
 mod tests {
     use super::{
-        apply_project_migrations, build_generated_asset_sidecar, guess_mime_from_filename,
-        is_safe_relative_path, normalize_asset_tags, sniff_image_format, AssetScope,
-        CharacterCreateInput, CharacterLookInput, ProjectStore, ProjectStoreError, UploadAsset,
-        GLOBAL_KEYPOINTS_PROJECT_ID, GLOBAL_POSES_PROJECT_ID, PROJECT_FOLDERS,
-        PROJECT_SCHEMA_VERSION,
+        apply_project_migrations, build_generated_asset_sidecar, find_timeline_file,
+        guess_mime_from_filename, index_timeline, is_safe_relative_path, normalize_asset_tags,
+        sniff_image_format, AssetScope, CharacterCreateInput, CharacterLookInput, ProjectStore,
+        ProjectStoreError, UploadAsset, GLOBAL_KEYPOINTS_PROJECT_ID, GLOBAL_POSES_PROJECT_ID,
+        PROJECT_FOLDERS, PROJECT_SCHEMA_VERSION,
     };
     use rusqlite::Connection;
     use serde_json::{json, Value};
@@ -4416,6 +4432,74 @@ mod tests {
         ));
         // The traversal target is untouched.
         assert!(outside.join("victim.txt").exists());
+    }
+
+    #[test]
+    fn delete_asset_rejects_unsafe_sidecar_media_path() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Assets").expect("project creates");
+        let project_path = std::path::PathBuf::from(&project.path);
+        let image_dir = project_path.join("assets/images");
+        let outside = temp_dir.path().join("outside.png");
+        std::fs::write(&outside, b"outside").expect("outside media writes");
+        std::fs::write(
+            image_dir.join("unsafe.sceneworks.json"),
+            serde_json::to_string_pretty(&json!({
+                "id": "asset-unsafe",
+                "type": "image",
+                "displayName": "Unsafe",
+                "createdAt": "2026-06-15T00:00:00Z",
+                "file": {"path": outside.to_string_lossy()},
+                "status": {"favorite": false, "rating": 0, "rejected": false, "trashed": false}
+            }))
+            .expect("json"),
+        )
+        .expect("sidecar writes");
+
+        let error = store
+            .delete_asset(&project.id, "asset-unsafe")
+            .expect_err("unsafe media path rejected");
+        assert!(matches!(error, ProjectStoreError::BadRequest(_)));
+        assert!(outside.exists(), "delete must not move outside media");
+    }
+
+    #[test]
+    fn find_timeline_file_ignores_unsafe_indexed_path() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Timeline").expect("project creates");
+        let project_path = std::path::PathBuf::from(&project.path);
+        let timeline = json!({
+            "id": "timeline-1",
+            "name": "Main",
+            "aspectRatio": "16:9",
+            "width": 1280,
+            "height": 720,
+            "fps": 30,
+            "duration": 0.0,
+            "createdAt": "2026-06-15T00:00:00Z",
+            "updatedAt": "2026-06-15T00:00:00Z"
+        });
+        let safe_path = project_path
+            .join("timelines")
+            .join("main.sceneworks.timeline.json");
+        std::fs::write(
+            &safe_path,
+            serde_json::to_string_pretty(&timeline).expect("json"),
+        )
+        .expect("timeline writes");
+        index_timeline(&project_path, &timeline, "../outside.timeline.json").expect("index writes");
+
+        let found = find_timeline_file(&project_path, "timeline-1").expect("timeline found");
+        assert_eq!(
+            found.path.canonicalize().expect("canonical found path"),
+            safe_path.canonicalize().expect("canonical safe path")
+        );
+        assert_eq!(
+            found.relative_path,
+            "timelines/main.sceneworks.timeline.json"
+        );
     }
 
     // ---- Key Point Library (sc-4434) ---------------------------------------------------

--- a/crates/sceneworks-core/src/session_log.rs
+++ b/crates/sceneworks-core/src/session_log.rs
@@ -103,7 +103,8 @@ impl SessionLog {
             }
             let seq = guard.next_seq;
             guard.next_seq = guard.next_seq.saturating_add(1);
-            let entry = classify(source, line, seq);
+            let line = redact_secrets(line);
+            let entry = classify(source, &line, seq);
             guard.entries.push_back(entry);
             let capacity = guard.capacity;
             while guard.entries.len() > capacity {
@@ -151,6 +152,57 @@ impl SessionLog {
     pub fn next_seq(&self) -> u64 {
         self.inner.lock().expect("session log lock").next_seq
     }
+}
+
+fn redact_secrets(line: &str) -> String {
+    let line = redact_marker_value(
+        line.to_owned(),
+        "token=",
+        &['&', '"', '\'', ' ', '\t', '<', '>'],
+    );
+    let line = redact_marker_value(
+        line,
+        "access_token=",
+        &['&', '"', '\'', ' ', '\t', '<', '>'],
+    );
+    let line = redact_marker_value(line, "api_key=", &['&', '"', '\'', ' ', '\t', '<', '>']);
+    let line = redact_marker_value(line, "bearer ", &['"', '\'', ' ', '\t', '<', '>']);
+    redact_authorization_header(line)
+}
+
+fn redact_marker_value(mut output: String, marker: &str, terminators: &[char]) -> String {
+    let mut search_from = 0;
+    loop {
+        let lowered = output.to_ascii_lowercase();
+        let Some(relative_start) = lowered[search_from..].find(marker) else {
+            return output;
+        };
+        let start = search_from + relative_start;
+        let value_start = start + marker.len();
+        let value_end = output[value_start..]
+            .char_indices()
+            .find_map(|(index, character)| {
+                terminators
+                    .contains(&character)
+                    .then_some(value_start + index)
+            })
+            .unwrap_or(output.len());
+        if value_end == value_start {
+            return output;
+        }
+        output.replace_range(value_start..value_end, "[REDACTED]");
+        search_from = value_start + "[REDACTED]".len();
+    }
+}
+
+fn redact_authorization_header(mut output: String) -> String {
+    let lowered = output.to_ascii_lowercase();
+    let Some(start) = lowered.find("authorization:") else {
+        return output;
+    };
+    let value_start = start + "authorization:".len();
+    output.replace_range(value_start.., " [REDACTED]");
+    output
 }
 
 fn classify(source: &str, line: &str, seq: u64) -> LogEntry {
@@ -307,6 +359,39 @@ mod tests {
         assert_eq!(entries[1].raw, "second");
         assert_eq!(entries[0].seq, 0);
         assert_eq!(entries[1].seq, 1);
+    }
+
+    #[test]
+    fn redacts_secret_shapes_on_ingest() {
+        let log = SessionLog::with_capacity(16);
+        log.push_line(
+            "worker",
+            "fetch https://example.test/model?token=secret-value&x=1 Authorization: Bearer abc123",
+        );
+        log.push_line(
+            "api",
+            &json!({
+                "event": "download_started",
+                "url": "https://example.test/file?access_token=hidden",
+                "authorization": "Bearer nested-secret"
+            })
+            .to_string(),
+        );
+
+        let entries = log.query(&LogQuery::default());
+        assert!(entries[0].raw.contains("token=[REDACTED]&x=1"));
+        assert!(entries[0].raw.contains("Authorization: [REDACTED]"));
+        assert!(!entries[0].raw.contains("secret-value"));
+        assert!(entries[1].raw.contains("access_token=[REDACTED]"));
+        assert!(!entries[1].raw.contains("nested-secret"));
+        assert_eq!(
+            entries[1]
+                .event
+                .as_ref()
+                .and_then(|event| event.get("url"))
+                .and_then(Value::as_str),
+            Some("https://example.test/file?access_token=[REDACTED]")
+        );
     }
 
     #[test]

--- a/crates/sceneworks-core/src/training.rs
+++ b/crates/sceneworks-core/src/training.rs
@@ -27,6 +27,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::{json, Value};
 
 use crate::contracts::{string_enum, ContractNumber, ExtraFields, JsonObject};
+use crate::store_util::is_safe_relative_path;
 
 /// Schema version stamped on persisted training contracts.
 pub const TRAINING_CONTRACT_SCHEMA_VERSION: u32 = 1;
@@ -1632,17 +1633,19 @@ pub fn build_training_plan(
         .dataset
         .items
         .iter()
-        .map(|item| TrainingPlanItem {
-            image_path: resolve_item_path(input.dataset_root, &item.path),
-            caption: caption_with_trigger_words(
-                &item.caption.text,
-                &combined_trigger_words(&item.caption.trigger_words, &trigger_words),
-            ),
-            width: item.width,
-            height: item.height,
-            extra: ExtraFields::new(),
+        .map(|item| {
+            Ok(TrainingPlanItem {
+                image_path: resolve_item_path(input.dataset_root, &item.path)?,
+                caption: caption_with_trigger_words(
+                    &item.caption.text,
+                    &combined_trigger_words(&item.caption.trigger_words, &trigger_words),
+                ),
+                width: item.width,
+                height: item.height,
+                extra: ExtraFields::new(),
+            })
         })
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>, TrainingPlanError>>()?;
 
     let config_snapshot = match serde_json::to_value(&input.config) {
         Ok(Value::Object(map)) => map,
@@ -1739,12 +1742,20 @@ fn caption_with_trigger_words(caption: &str, trigger_words: &[String]) -> String
 /// using the host's path separator. Dataset item paths are stored POSIX-style
 /// (the store forbids backslashes), so joining the whole string would leave
 /// mixed separators on Windows; pushing each component normalizes them.
-fn resolve_item_path(dataset_root: &Path, relative_path: &str) -> String {
+fn resolve_item_path(
+    dataset_root: &Path,
+    relative_path: &str,
+) -> Result<String, TrainingPlanError> {
+    if !is_safe_relative_path(relative_path) {
+        return Err(TrainingPlanError::InvalidConfig(
+            "Dataset item path must be relative to the dataset root.".to_owned(),
+        ));
+    }
     let mut path = dataset_root.to_path_buf();
     for component in Path::new(relative_path).components() {
         path.push(component);
     }
-    path.display().to_string()
+    Ok(path.display().to_string())
 }
 
 fn validate_training_config(config: &TrainingConfig) -> Result<(), TrainingPlanError> {
@@ -1812,4 +1823,27 @@ fn validate_lr_scheduler(config: &TrainingConfig) -> Result<(), TrainingPlanErro
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_item_path_rejects_paths_outside_dataset_root() {
+        let root = Path::new("/dataset");
+
+        assert!(matches!(
+            resolve_item_path(root, "../outside.png"),
+            Err(TrainingPlanError::InvalidConfig(_))
+        ));
+        assert!(matches!(
+            resolve_item_path(root, "/absolute.png"),
+            Err(TrainingPlanError::InvalidConfig(_))
+        ));
+        assert_eq!(
+            resolve_item_path(root, "images/photo.png").expect("safe path"),
+            "/dataset/images/photo.png"
+        );
+    }
 }

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -87,7 +87,7 @@ fn job_lifecycle_create_claim_complete() {
                 peak_gpu_memory_pct: None,
                 peak_gpu_load_pct: None,
                 backend: None,
-                worker_id: None,
+                worker_id: Some("worker-1".to_owned()),
             },
         )
         .expect("progress updates");
@@ -124,7 +124,7 @@ fn progress_keeps_running_max_for_peak_gpu_meters() {
             peak_gpu_memory_pct: memory,
             peak_gpu_load_pct: load,
             backend: None,
-            worker_id: None,
+            worker_id: Some("worker-1".to_owned()),
         }
     }
 
@@ -218,7 +218,7 @@ fn progress_leaves_peaks_null_when_no_samples_arrive() {
         peak_gpu_memory_pct: None,
         peak_gpu_load_pct: None,
         backend: None,
-        worker_id: None,
+        worker_id: Some("worker-1".to_owned()),
     };
     for _ in 0..3 {
         store
@@ -1528,6 +1528,7 @@ fn image_edit_job_with(payload: Value, requested_gpu: &str) -> CreateJob {
 }
 
 fn complete_job(store: &JobsStore, job_id: &str) {
+    let worker_id = store.get_job(job_id).expect("job loads").worker_id;
     store
         .update_job_progress(
             job_id,
@@ -1542,7 +1543,7 @@ fn complete_job(store: &JobsStore, job_id: &str) {
                 peak_gpu_memory_pct: None,
                 peak_gpu_load_pct: None,
                 backend: None,
-                worker_id: None,
+                worker_id,
             },
         )
         .expect("job completes");
@@ -3895,7 +3896,7 @@ fn qwen_txt2img_and_strict_pose_route_to_mlx() {
                 peak_gpu_memory_pct: None,
                 peak_gpu_load_pct: None,
                 backend: None,
-                worker_id: None,
+                worker_id: Some("worker-mlx".to_owned()),
             },
         )
         .expect("txt2img job completes");
@@ -3966,7 +3967,7 @@ fn flux2_klein_variants_route_to_mlx_worker() {
                     peak_gpu_memory_pct: None,
                     peak_gpu_load_pct: None,
                     backend: None,
-                    worker_id: None,
+                    worker_id: Some("worker-mlx".to_owned()),
                 },
             )
             .expect("complete job");
@@ -4044,7 +4045,7 @@ fn sdxl_and_realvisxl_route_to_mlx_worker() {
                     peak_gpu_memory_pct: None,
                     peak_gpu_load_pct: None,
                     backend: None,
-                    worker_id: None,
+                    worker_id: Some("worker-mlx".to_owned()),
                 },
             )
             .expect("complete job");
@@ -4088,7 +4089,7 @@ fn sdxl_and_realvisxl_route_to_mlx_worker() {
                     peak_gpu_memory_pct: None,
                     peak_gpu_load_pct: None,
                     backend: None,
-                    worker_id: None,
+                    worker_id: Some("worker-mlx".to_owned()),
                 },
             )
             .expect("complete job");
@@ -4167,7 +4168,7 @@ fn image_detail_routes_to_mlx_worker() {
                     peak_gpu_memory_pct: None,
                     peak_gpu_load_pct: None,
                     backend: None,
-                    worker_id: None,
+                    worker_id: Some("worker-mlx".to_owned()),
                 },
             )
             .expect("complete detail job");
@@ -4366,7 +4367,7 @@ fn concurrent_claims_never_lock_and_stay_exactly_once() {
                                 peak_gpu_memory_pct: None,
                                 peak_gpu_load_pct: None,
                                 backend: None,
-                                worker_id: None,
+                                worker_id: Some(worker_id.clone()),
                             },
                         ) {
                             errors.lock().unwrap().push(error.to_string());
@@ -4484,9 +4485,7 @@ fn progress_cannot_resurrect_terminal_jobs() {
     assert_eq!(job.worker_id, None);
 }
 
-/// sc-4172 — a progress report that names a worker other than the job's owner
-/// is rejected; the owner's reports (and legacy reports with no worker id)
-/// still land.
+/// sc-4172 / sc-5751 — progress reports must name the claimed job's owner.
 #[test]
 fn progress_from_non_owner_worker_is_rejected() {
     fn running(worker_id: Option<&str>) -> ProgressUpdate {
@@ -4531,8 +4530,8 @@ fn progress_from_non_owner_worker_is_rejected() {
         .expect("owner report lands");
     assert_eq!(job.status, JobStatus::Running);
 
-    let job = store
+    let error = store
         .update_job_progress(&created.id, running(None))
-        .expect("legacy report without a worker id still lands");
-    assert_eq!(job.status, JobStatus::Running);
+        .expect_err("ownerless report on an owned job is rejected");
+    assert!(matches!(error, JobsStoreError::NotJobOwner { .. }));
 }

--- a/crates/sceneworks-worker/src/downloads.rs
+++ b/crates/sceneworks-worker/src/downloads.rs
@@ -54,6 +54,9 @@ pub(crate) async fn ensure_cached_file(
     all(target_os = "windows", feature = "backend-candle")
 ))]
 async fn remote_content_length(client: &reqwest::Client, url: &str) -> WorkerResult<Option<u64>> {
+    // `url` is built from trusted operator/runtime configuration
+    // (`Settings::huggingface_base_url`) plus validated HF path pieces. User-provided source URLs
+    // use the separate `download_source_url` path with SSRF checks.
     let response = match client.head(url).send().await {
         Ok(response) => response,
         Err(_) => return Ok(None),
@@ -184,6 +187,8 @@ pub(crate) fn snapshot_file_from_entry(
         download_url: format!(
             "{base_url}/{}/resolve/{}/{}",
             quote_path(repo),
+            // Revisions are pre-validated by `model_jobs::validate_hf_revision`;
+            // quote_path is the direct-download path's final URL-segment guard.
             quote_path(revision),
             quote_path(path)
         ),

--- a/crates/sceneworks-worker/src/generator_cache.rs
+++ b/crates/sceneworks-worker/src/generator_cache.rs
@@ -114,13 +114,12 @@ impl GeneratorCache {
             });
         }
 
-        let generator = self
-            .entry
-            .as_ref()
-            .expect("cache entry populated")
-            .generator
-            .as_ref();
-        run(generator)
+        let Some(entry) = self.entry.as_ref() else {
+            return Err(WorkerError::Engine(
+                "Generator cache entry missing after load.".to_owned(),
+            ));
+        };
+        run(entry.generator.as_ref())
     }
 }
 

--- a/crates/sceneworks-worker/src/image_jobs/pulid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/pulid.rs
@@ -201,6 +201,38 @@ fn pulid_weights_env_preset() -> Option<PulidWeights> {
     })
 }
 
+struct EnvRestore {
+    values: [(&'static str, Option<std::ffi::OsString>); 3],
+}
+
+impl Drop for EnvRestore {
+    fn drop(&mut self) {
+        for (key, value) in &self.values {
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+}
+
+fn set_pulid_weight_env(weights: &PulidWeights) -> EnvRestore {
+    let guard = EnvRestore {
+        values: [
+            ("PULID_FLUX_WEIGHTS", std::env::var_os("PULID_FLUX_WEIGHTS")),
+            ("PULID_EVA_WEIGHTS", std::env::var_os("PULID_EVA_WEIGHTS")),
+            (
+                "PULID_FACE_WEIGHTS_DIR",
+                std::env::var_os("PULID_FACE_WEIGHTS_DIR"),
+            ),
+        ],
+    };
+    std::env::set_var("PULID_FLUX_WEIGHTS", &weights.adapter);
+    std::env::set_var("PULID_EVA_WEIGHTS", &weights.eva);
+    std::env::set_var("PULID_FACE_WEIGHTS_DIR", &weights.face_dir);
+    guard
+}
+
 /// Resolve all PuLID-FLUX engine weight inputs, downloading the converted bundle + the PuLID
 /// adapter + the shared face stack on first use into ONE bundle dir (so it doubles as the engine's
 /// `PULID_FACE_WEIGHTS_DIR`). Resolution order: a fully-set env preset → a `SCENEWORKS_PULID_WEIGHTS`
@@ -315,12 +347,10 @@ async fn generate_pulid_flux_stream(
 
     let weights = ensure_pulid_weights(api, settings, job).await?;
     // Feed the engine's weight seam from the resolved cache paths (the `pulid_flux` loader resolves
-    // the PuLID adapter + EVA + face stack from these env vars). Stable per-worker paths, set right
-    // before the cached load; the generator cache serializes loads on its own thread, so the
-    // process-global vars are race-free for this single-threaded MLX path.
-    std::env::set_var("PULID_FLUX_WEIGHTS", &weights.adapter);
-    std::env::set_var("PULID_EVA_WEIGHTS", &weights.eva);
-    std::env::set_var("PULID_FACE_WEIGHTS_DIR", &weights.face_dir);
+    // the PuLID adapter + EVA + face stack from these env vars). Keep them scoped to this async job:
+    // the generator load happens inside the spawned stream task, so they must stay live through
+    // `consume_gen_events`, then `EnvRestore` removes/restores them before the next job.
+    let _pulid_env = set_pulid_weight_env(&weights);
 
     let steps = pulid_steps(request);
     let guidance = pulid_guidance(request);

--- a/crates/sceneworks-worker/src/kps_jobs.rs
+++ b/crates/sceneworks-worker/src/kps_jobs.rs
@@ -27,8 +27,8 @@ use serde_json::{json, Value};
 
 use crate::image_jobs::{ensure_scrfd_weights, load_reference_image};
 use crate::{
-    heartbeat, progress_payload, task_join_error, update_job, ApiClient, Settings, WorkerError,
-    WorkerResult,
+    heartbeat, normalize_app_managed_cache_path, progress_payload, task_join_error, update_job,
+    ApiClient, Settings, WorkerError, WorkerResult,
 };
 use sceneworks_core::contracts::{JobSnapshot, JobStatus, JsonObject, ProgressStage, WorkerStatus};
 use sceneworks_core::project_store::ProjectStore;
@@ -194,7 +194,9 @@ fn load_source_image(settings: &Settings, job: &JobSnapshot) -> WorkerResult<Ima
         // (the API's generic temp-file writer keeps no extension), so `image::open` — which
         // picks the codec from the extension — would reject a perfectly valid JPEG/PNG. Read
         // the bytes and let `load_from_memory` sniff the format from the magic bytes.
-        let bytes = std::fs::read(path).map_err(|error| {
+        let source_path =
+            normalize_app_managed_cache_path(settings, path, "pose-uploads", "kps sourcePath")?;
+        let bytes = std::fs::read(&source_path).map_err(|error| {
             WorkerError::InvalidPayload(format!("kps extraction source {path}: {error}"))
         })?;
         let decoded = image::load_from_memory(&bytes)

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -1328,6 +1328,25 @@ fn normalize_app_managed_path(
     ensure_path_under(path, &[data_dir], label)
 }
 
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub(crate) fn normalize_app_managed_cache_path(
+    settings: &Settings,
+    raw_path: &str,
+    cache_dir: &str,
+    label: &str,
+) -> WorkerResult<PathBuf> {
+    let raw_path = raw_path.trim();
+    if raw_path.is_empty() {
+        return Err(WorkerError::InvalidPayload(format!("{label} is required.")));
+    }
+    let root = settings.data_dir.join("cache").join(cache_dir);
+    let normalized_root = normalize_absolute_path(&root)?;
+    let canonical_root = normalize_existing_or_absolute(&root)?;
+    let normalized = normalize_absolute_path(Path::new(raw_path))?;
+    let resolved = normalize_existing_or_absolute(&normalized)?;
+    ensure_path_under(resolved, &[normalized_root, canonical_root], label)
+}
+
 /// A model's weights are a read-only source the rust-api resolves (e.g.
 /// `resolve_base_model_path`) from either the app data dir *or* the shared
 /// Hugging Face hub cache — the default `HF_HOME` the desktop injects points the

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -886,6 +886,9 @@ fn validate_hf_repo_id(repo: &str) -> WorkerResult<()> {
 }
 
 fn validate_hf_revision(revision: &str) -> WorkerResult<()> {
+    // Shared guard for both HF CLI (`--revision` is arg-isolated) and direct HTTP
+    // download (`downloads::quote_path` percent-encodes the revision in URLs).
+    // Keep leading slash / traversal rejection here so both paths fail closed.
     let parts = safe_hf_path_parts(revision, "Hugging Face revision")?;
     if !revision.chars().all(|character| {
         character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | '.' | '/')

--- a/crates/sceneworks-worker/src/pose_jobs.rs
+++ b/crates/sceneworks-worker/src/pose_jobs.rs
@@ -33,8 +33,8 @@ use serde_json::{json, Value};
 
 use crate::openpose_skeleton::{body_stickwidth, draw_wholebody, Keypoint};
 use crate::{
-    heartbeat, optional_payload_string, progress_payload, task_join_error, update_job, ApiClient,
-    Settings, WorkerError, WorkerResult,
+    heartbeat, normalize_app_managed_cache_path, optional_payload_string, progress_payload,
+    task_join_error, update_job, ApiClient, Settings, WorkerError, WorkerResult,
 };
 use sceneworks_core::contracts::{JobSnapshot, JobStatus, JsonObject, ProgressStage, WorkerStatus};
 use sceneworks_core::project_store::ProjectStore;
@@ -661,9 +661,10 @@ fn normalize_sources(payload: &JsonObject) -> Vec<JsonObject> {
 fn resolve_source(
     src: &JsonObject,
     store: &ProjectStore,
+    settings: &Settings,
     project_id: Option<&str>,
     project_path: Option<&Path>,
-) -> PoseSource {
+) -> WorkerResult<PoseSource> {
     let asset_id = src
         .get("assetId")
         .and_then(Value::as_str)
@@ -675,47 +676,57 @@ fn resolve_source(
     let temp = src.get("temp").and_then(Value::as_bool).unwrap_or(false);
     let raw = src.get("path").and_then(Value::as_str);
 
-    // explicit absolute path wins (spike/tests)
+    // Staged upload path, confined to the same pose-uploads cache cleaned up below.
     if let Some(raw) = raw {
         let abs = Path::new(raw);
-        if abs.is_absolute() && abs.exists() {
-            return PoseSource {
+        if abs.is_absolute() {
+            let path =
+                normalize_app_managed_cache_path(settings, raw, "pose-uploads", "pose sourcePath")?;
+            if path.exists() {
+                return Ok(PoseSource {
+                    asset_id,
+                    display_name,
+                    temp,
+                    path: Some(path),
+                });
+            }
+            return Ok(PoseSource {
                 asset_id,
                 display_name,
                 temp,
-                path: Some(abs.to_path_buf()),
-            };
+                path: None,
+            });
         }
     }
     // asset id resolved against the originating project (Create tab sends ids)
     if let (Some(id), Some(pid), Some(proj)) = (&asset_id, project_id, project_path) {
         if let Some(path) = resolve_asset_path(store, pid, id, proj) {
-            return PoseSource {
+            return Ok(PoseSource {
                 asset_id,
                 display_name,
                 temp,
                 path: Some(path),
-            };
+            });
         }
     }
     // project-relative path
     if let (Some(raw), Some(proj)) = (raw, project_path) {
         let candidate = proj.join(raw);
         if candidate.exists() {
-            return PoseSource {
+            return Ok(PoseSource {
                 asset_id,
                 display_name,
                 temp,
                 path: Some(candidate),
-            };
+            });
         }
     }
-    PoseSource {
+    Ok(PoseSource {
         asset_id,
         display_name,
         temp,
         path: raw.map(PathBuf::from),
-    }
+    })
 }
 
 fn resolve_asset_path(
@@ -787,8 +798,8 @@ pub(crate) async fn run_pose_detect_job(
 
     let resolved: Vec<PoseSource> = sources
         .iter()
-        .map(|s| resolve_source(s, &store, project_id, project_path.as_deref()))
-        .collect();
+        .map(|s| resolve_source(s, &store, settings, project_id, project_path.as_deref()))
+        .collect::<WorkerResult<_>>()?;
 
     update_job(
         api,

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -43,11 +43,12 @@ use super::supervisor::{
 use super::{
     allow_pattern_matches, bounded_tail, cancel_requested_peek, cleanup_uploaded_import_source,
     copy_lora_source, fresh_asset_id, import_lora_source_file_as, import_lora_source_path,
-    now_rfc3339, parse_credentials_env, resolve_model_convert_output, resolve_model_import_target,
-    safe_download_dir, safe_project_path, value_f64, wan_moe_pair_filenames,
-    write_model_install_marker, CredentialScheme, JsonObject, SafetensorsHeaderError, Settings,
-    WorkerCredential, WorkerError, DEFAULT_MAX_LORA_URL_BYTES, DEFAULT_MAX_MODEL_URL_BYTES,
-    DEFAULT_TRANSITION_DURATION_SECONDS, INSTALL_MARKER,
+    normalize_app_managed_cache_path, now_rfc3339, parse_credentials_env,
+    resolve_model_convert_output, resolve_model_import_target, safe_download_dir,
+    safe_project_path, value_f64, wan_moe_pair_filenames, write_model_install_marker,
+    CredentialScheme, JsonObject, SafetensorsHeaderError, Settings, WorkerCredential, WorkerError,
+    DEFAULT_MAX_LORA_URL_BYTES, DEFAULT_MAX_MODEL_URL_BYTES, DEFAULT_TRANSITION_DURATION_SECONDS,
+    INSTALL_MARKER,
 };
 
 fn write_safetensors_with_keys(path: &std::path::Path, keys: &[String]) {
@@ -149,10 +150,58 @@ fn hf_cli_download_inputs_reject_traversal_and_absolute_patterns() {
         assert!(matches!(error, WorkerError::InvalidPayload(_)));
     }
 
-    for revision in ["../main", "refs/heads/../main"] {
+    for revision in ["../main", "refs/heads/../main", "/refs/main"] {
         let error =
             validate_hf_cli_download_inputs("owner/model", revision, &["*.safetensors".to_owned()])
                 .expect_err("unsafe revision rejected");
+        assert!(matches!(error, WorkerError::InvalidPayload(_)));
+    }
+}
+
+#[test]
+fn app_managed_cache_path_rejects_escape_and_symlink_escape() {
+    let temp = tempdir().expect("temp dir");
+    let mut settings = Settings::from_env();
+    settings.data_dir = temp.path().join("data");
+    let uploads = settings.data_dir.join("cache").join("pose-uploads");
+    std::fs::create_dir_all(&uploads).expect("uploads dir");
+    let staged = uploads.join("upload.png");
+    std::fs::write(&staged, b"image").expect("staged file");
+
+    let accepted = normalize_app_managed_cache_path(
+        &settings,
+        staged.to_str().unwrap(),
+        "pose-uploads",
+        "sourcePath",
+    )
+    .expect("staged path accepted");
+    assert_eq!(
+        accepted,
+        staged.canonicalize().expect("canonical staged path")
+    );
+
+    let outside = temp.path().join("outside.png");
+    std::fs::write(&outside, b"not staged").expect("outside file");
+    let error = normalize_app_managed_cache_path(
+        &settings,
+        outside.to_str().unwrap(),
+        "pose-uploads",
+        "sourcePath",
+    )
+    .expect_err("outside path rejected");
+    assert!(matches!(error, WorkerError::InvalidPayload(_)));
+
+    #[cfg(unix)]
+    {
+        let link = uploads.join("link.png");
+        std::os::unix::fs::symlink(&outside, &link).expect("symlink");
+        let error = normalize_app_managed_cache_path(
+            &settings,
+            link.to_str().unwrap(),
+            "pose-uploads",
+            "sourcePath",
+        )
+        .expect_err("symlink escape rejected");
         assert!(matches!(error, WorkerError::InvalidPayload(_)));
     }
 }

--- a/crates/sceneworks-worker/src/upscale_jobs.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs.rs
@@ -56,6 +56,9 @@ use sceneworks_core::project_store::ProjectStore;
 
 const TILE_SIZE: usize = 512;
 const TILE_PAD: usize = 16;
+const MAX_UPSCALE_TARGET_DIMENSION: u32 = 8192;
+const MAX_UPSCALE_TARGET_PIXELS: u64 =
+    MAX_UPSCALE_TARGET_DIMENSION as u64 * MAX_UPSCALE_TARGET_DIMENSION as u64;
 const CANCEL_MESSAGE: &str = "Image upscale canceled by user.";
 
 /// SceneWorks-owned HuggingFace repo hosting the pre-exported ONNX (reproducible from
@@ -131,6 +134,19 @@ fn crop_to_chw(
     (data, cw, ch)
 }
 
+fn validate_upscale_target_dimensions(width: u32, height: u32) -> WorkerResult<()> {
+    let pixels = u64::from(width) * u64::from(height);
+    if width > MAX_UPSCALE_TARGET_DIMENSION
+        || height > MAX_UPSCALE_TARGET_DIMENSION
+        || pixels > MAX_UPSCALE_TARGET_PIXELS
+    {
+        return Err(WorkerError::InvalidPayload(format!(
+            "Upscale target {width}x{height} exceeds the {MAX_UPSCALE_TARGET_DIMENSION}px side / {MAX_UPSCALE_TARGET_PIXELS} pixel limit."
+        )));
+    }
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // onnxruntime upscaler (cached per-factor process-wide, like pose_jobs::DETECTOR)
 // ---------------------------------------------------------------------------
@@ -182,7 +198,17 @@ impl Upscaler {
         cancel: &CancelFlag,
     ) -> WorkerResult<RgbImage> {
         let (w, h) = (img.width() as usize, img.height() as usize);
-        let (ow, oh) = (w * factor, h * factor);
+        let ow = w
+            .checked_mul(factor)
+            .ok_or_else(|| WorkerError::InvalidPayload("upscale width overflow".to_owned()))?;
+        let oh = h
+            .checked_mul(factor)
+            .ok_or_else(|| WorkerError::InvalidPayload("upscale height overflow".to_owned()))?;
+        let ow_u32 = u32::try_from(ow)
+            .map_err(|_| WorkerError::InvalidPayload("upscale width overflow".to_owned()))?;
+        let oh_u32 = u32::try_from(oh)
+            .map_err(|_| WorkerError::InvalidPayload("upscale height overflow".to_owned()))?;
+        validate_upscale_target_dimensions(ow_u32, oh_u32)?;
         let mut output = vec![0u8; ow * oh * 3];
         for tl in tile_slices(w, h, TILE_SIZE) {
             if cancel.is_cancelled() {
@@ -449,6 +475,7 @@ async fn run_seedvr2_upscale(
     let (src_w, src_h) = (source.width(), source.height());
     let target_w = round_to_16(src_w.saturating_mul(u32::from(factor)));
     let target_h = round_to_16(src_h.saturating_mul(u32::from(factor)));
+    validate_upscale_target_dimensions(target_w, target_h)?;
     let image = GenImage {
         width: src_w,
         height: src_h,

--- a/crates/sceneworks-worker/src/upscale_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs/tests.rs
@@ -163,6 +163,19 @@ fn round_to_16_rounds_up_floored_at_16() {
 }
 
 #[test]
+fn upscale_target_dimensions_are_bounded_before_allocation() {
+    validate_upscale_target_dimensions(8192, 8192).expect("8k square accepted");
+    assert!(matches!(
+        validate_upscale_target_dimensions(8193, 1024),
+        Err(WorkerError::InvalidPayload(_))
+    ));
+    assert!(matches!(
+        validate_upscale_target_dimensions(8192, 8193),
+        Err(WorkerError::InvalidPayload(_))
+    ));
+}
+
+#[test]
 fn manifest_seedvr2_resource_extracts_overrides_and_defaults() {
     let entry = json!({
         "resources": {

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -248,8 +248,7 @@ pub(crate) async fn run_video_generate_job(
                 None,
             ),
             Err(_) => {
-                let engine_id =
-                    wan_engine_id(&request.model).expect("checked wan2_2_ti2v_5b above");
+                let engine_id = "wan2_2_ti2v_5b";
                 (
                     generate_wan(
                         api,

--- a/scripts/convert_scail2_dpo_lora.py
+++ b/scripts/convert_scail2_dpo_lora.py
@@ -51,7 +51,7 @@ _KEY = re.compile(
 
 
 def convert(src_pt: str, out_safetensors: str) -> None:
-    ckpt = torch.load(src_pt, map_location="cpu", weights_only=False)
+    ckpt = torch.load(src_pt, map_location="cpu", weights_only=True)
     # DeepSpeed wraps the trained params under "module"; tolerate a bare state dict too.
     sd = ckpt["module"] if isinstance(ckpt, dict) and "module" in ckpt else ckpt
 

--- a/tests/test_convert_scail2_dpo_lora.py
+++ b/tests/test_convert_scail2_dpo_lora.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+class FakeTensor:
+    shape = (1, 1)
+
+    def to(self, _dtype):
+        return self
+
+    def contiguous(self):
+        return self
+
+
+def load_converter(monkeypatch, saved):
+    def fake_load(*args, **kwargs):
+        saved["load"] = (args, kwargs)
+        return {
+            "module": {
+                "model.diffusion_model.transformer.layers.0.attention.dense.lora_layer.down.weight": FakeTensor(),
+                "model.diffusion_model.transformer.layers.0.attention.dense.lora_layer.up.weight": FakeTensor(),
+            }
+        }
+
+    fake_torch = types.SimpleNamespace(
+        bfloat16=object(),
+        load=fake_load,
+    )
+    fake_safetensors_torch = types.SimpleNamespace(
+        save_file=lambda out, path: saved.setdefault("save", (out, path))
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    monkeypatch.setitem(sys.modules, "safetensors", types.ModuleType("safetensors"))
+    monkeypatch.setitem(sys.modules, "safetensors.torch", fake_safetensors_torch)
+
+    script = Path(__file__).resolve().parents[1] / "scripts" / "convert_scail2_dpo_lora.py"
+    spec = importlib.util.spec_from_file_location("convert_scail2_dpo_lora_test", script)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_convert_scail2_dpo_lora_uses_restricted_torch_load(monkeypatch):
+    saved = {}
+    converter = load_converter(monkeypatch, saved)
+
+    converter.convert("input.pt", "out.safetensors")
+
+    _args, kwargs = saved["load"]
+    assert kwargs["map_location"] == "cpu"
+    assert kwargs["weights_only"] is True
+    out, path = saved["save"]
+    assert path == "out.safetensors"
+    assert sorted(out) == [
+        "blocks.0.self_attn.o.lora_down.weight",
+        "blocks.0.self_attn.o.lora_up.weight",
+    ]

--- a/tests/test_rust_api_contract_snapshots.py
+++ b/tests/test_rust_api_contract_snapshots.py
@@ -1505,6 +1505,7 @@ def test_job_state_transition_contracts(contract_runtimes):
                 "stage": "canceled",
                 "progress": 1,
                 "message": "Worker canceled the job before completion.",
+                "workerId": "parity-worker",
             },
         )
         for runtime in contract_runtimes


### PR DESCRIPTION
## Summary

Fixes the remaining bug-type stories in Shortcut epic 5719 across core, worker, API, web, and Python surfaces.

Key changes:
- Hardened path containment, job progress ownership, credential writes, session log redaction, training item paths, and timeline index recovery.
- Added worker guards for app-managed upload paths, upscale target bounds, generator cache missing entries, scoped PuLID env restoration, and documented HF download trust boundaries.
- Added API caps/validation for video asset-id lists and model import repo shape.
- Fixed web asset URL segment encoding and DocumentStudio maxImages clamping.
- Switched the SCAIL2 DPO LoRA converter to `torch.load(..., weights_only=True)` with regression coverage.

## Shortcut

All unfinished bug stories in epic 5719 were commented with validation evidence and moved to Done. A follow-up Shortcut search confirmed no unfinished bug stories remain in the epic.

## Validation

- `cargo test -p sceneworks-core`
- `npm --prefix apps/web test -- src/main.test.jsx`
- `"$HOME/Library/Application Support/SceneWorks/python/venv/bin/python" -m pytest tests/test_convert_scail2_dpo_lora.py tests/test_worker_lora_adapters.py -q`
- `cargo test -p sceneworks-rust-api bernini_video_modes_validate_required_media`
- `cargo test -p sceneworks-rust-api model_import_routes_handle_url_upload_and_family_detection`
- `cargo test -p sceneworks-worker upscale_target_dimensions_are_bounded_before_allocation`
- `cargo test -p sceneworks-worker app_managed_cache_path_rejects_escape_and_symlink_escape`
- `cargo test -p sceneworks-worker source_url_client_pins_dns_to_validated_address`
- `cargo test -p sceneworks-worker generator_cache`
- `cargo test -p sceneworks-worker hf_cli_download_inputs_reject_traversal_and_absolute_patterns`
- `cargo fmt --all -- --check`
- `git diff --check`
