### PR TITLE
sc-5488: route candle Kolors IP-Adapter-Plus reference jobs off-Mac

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f28528497e92b9335b44567bf99c3603f38034a2#f28528497e92b9335b44567bf99c3603f38034a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f28528497e92b9335b44567bf99c3603f38034a2#f28528497e92b9335b44567bf99c3603f38034a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f28528497e92b9335b44567bf99c3603f38034a2#f28528497e92b9335b44567bf99c3603f38034a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f28528497e92b9335b44567bf99c3603f38034a2#f28528497e92b9335b44567bf99c3603f38034a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -490,7 +490,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f28528497e92b9335b44567bf99c3603f38034a2#f28528497e92b9335b44567bf99c3603f38034a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -504,7 +504,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f28528497e92b9335b44567bf99c3603f38034a2#f28528497e92b9335b44567bf99c3603f38034a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f28528497e92b9335b44567bf99c3603f38034a2#f28528497e92b9335b44567bf99c3603f38034a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -527,9 +527,10 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f28528497e92b9335b44567bf99c3603f38034a2#f28528497e92b9335b44567bf99c3603f38034a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
 dependencies = [
  "candle-gen",
+ "candle-gen-sdxl",
  "candle-transformers",
  "inventory",
  "rand 0.9.4",
@@ -540,7 +541,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f28528497e92b9335b44567bf99c3603f38034a2#f28528497e92b9335b44567bf99c3603f38034a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -553,7 +554,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f28528497e92b9335b44567bf99c3603f38034a2#f28528497e92b9335b44567bf99c3603f38034a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -565,7 +566,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f28528497e92b9335b44567bf99c3603f38034a2#f28528497e92b9335b44567bf99c3603f38034a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -576,7 +577,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f28528497e92b9335b44567bf99c3603f38034a2#f28528497e92b9335b44567bf99c3603f38034a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -590,7 +591,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f28528497e92b9335b44567bf99c3603f38034a2#f28528497e92b9335b44567bf99c3603f38034a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -608,7 +609,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f28528497e92b9335b44567bf99c3603f38034a2#f28528497e92b9335b44567bf99c3603f38034a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -621,7 +622,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f28528497e92b9335b44567bf99c3603f38034a2#f28528497e92b9335b44567bf99c3603f38034a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -634,7 +635,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f28528497e92b9335b44567bf99c3603f38034a2#f28528497e92b9335b44567bf99c3603f38034a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
 dependencies = [
  "candle-core",
  "candle-gen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -444,7 +444,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_distr 0.5.1",
  "safetensors 0.7.0",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a)",
+ "sceneworks-gen-core",
  "serde_json",
  "thiserror 2.0.18",
 ]
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -490,7 +490,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -504,7 +504,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -527,7 +527,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -541,7 +541,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -554,7 +554,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -566,7 +566,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -577,7 +577,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -591,7 +591,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -609,7 +609,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -622,7 +622,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -633,7 +633,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -646,7 +646,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a8c61740ab3de5c65cf6598be0fe2f4817de035#7a8c61740ab3de5c65cf6598be0fe2f4817de035"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -3257,7 +3257,7 @@ source = "git+https://github.com/michaeltrefry/mlx-gen?rev=27b010780afebc3a69f18
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=27b010780afebc3a69f18dcb85667acb35b55e41)",
+ "sceneworks-gen-core",
  "thiserror 2.0.18",
  "tokenizers 0.21.4",
 ]
@@ -5142,18 +5142,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sceneworks-gen-core"
-version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#27b010780afebc3a69f18dcb85667acb35b55e41"
-dependencies = [
- "inventory",
- "safetensors 0.4.5",
- "serde_json",
- "thiserror 2.0.18",
- "tokenizers 0.21.4",
-]
-
-[[package]]
 name = "sceneworks-rust-api"
 version = "0.2.0"
 dependencies = [
@@ -5241,7 +5229,7 @@ dependencies = [
  "pmetal-mlx-rs",
  "reqwest 0.12.28",
  "sceneworks-core",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=27b010780afebc3a69f18dcb85667acb35b55e41)",
+ "sceneworks-gen-core",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3265,6 +3265,13 @@ fn image_job_is_candle_eligible(job: &JobSnapshot) -> bool {
     if matches!(model, "sdxl" | "realvisxl") && sdxl_ipadapter_candle_eligible(&job.payload) {
         return true;
     }
+    // Kolors IP-Adapter-Plus reference conditioning (sc-5488, epic 5480): the `kolors` family with a
+    // reference image is the same bespoke candle lane (`generate_candle_kolors_ipadapter_stream`), NOT
+    // txt2img — branch it out before the gate (which rejects `referenceAssetId`). Pure IP only;
+    // img2img/edit shapes stay on torch (sc-5487). Mirrors the worker's `kolors_ipadapter_available`.
+    if model == "kolors" && kolors_ipadapter_candle_eligible(&job.payload) {
+        return true;
+    }
     image_request_candle_eligible(model, &job.payload)
 }
 
@@ -3460,6 +3467,26 @@ fn instantid_candle_eligible(payload: &Map<String, Value>) -> bool {
 /// MLX `IpAdapterSdxl` (the MLX SDXL IP path is the registry `SdxlSubMode::Ip`), so this has no
 /// `*_mlx_eligible` sibling.
 fn sdxl_ipadapter_candle_eligible(payload: &Map<String, Value>) -> bool {
+    if payload.get("mode").and_then(Value::as_str) == Some("edit_image") {
+        return false;
+    }
+    let non_empty = |key: &str| {
+        payload
+            .get(key)
+            .and_then(Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty())
+    };
+    non_empty("referenceAssetId") && !non_empty("sourceAssetId") && !non_empty("maskAssetId")
+}
+
+/// Kolors IP-Adapter-Plus candle-routing conditions (sc-5488, epic 5480). The candle `IpAdapterKolors`
+/// provider serves PURE reference (image-prompt) conditioning on the `kolors` family — the same payload
+/// shape as the SDXL IP lane: a `referenceAssetId` with NO img2img source / inpaint mask and NOT an
+/// `edit_image` (those advanced Kolors shapes are sc-5487, still torch). Mirrors the worker's
+/// `kolors_ipadapter_available` gate (minus the local weight-resolve check) so the router and worker
+/// agree on the lane boundary. Candle-only — the macOS Kolors IP path is the registry `Reference` route,
+/// not a separate candle-eligible gate.
+fn kolors_ipadapter_candle_eligible(payload: &Map<String, Value>) -> bool {
     if payload.get("mode").and_then(Value::as_str) == Some("edit_image") {
         return false;
     }
@@ -5161,6 +5188,29 @@ mod candle_routing_tests {
         }))));
         assert!(!sdxl_ipadapter_candle_eligible(&object(json!({
             "model": "sdxl", "referenceAssetId": "a", "maskAssetId": "m"
+        }))));
+    }
+
+    #[test]
+    fn kolors_ipadapter_reference_jobs_route_to_candle() {
+        // A pure Kolors reference (IP-Adapter) job routes to the candle lane (sc-5488) via the bespoke
+        // branch, NOT the txt2img `image_request_candle_eligible` gate (which rejects `referenceAssetId`).
+        let payload = json!({ "model": "kolors", "referenceAssetId": "asset_1" });
+        assert!(kolors_ipadapter_candle_eligible(&object(payload.clone())));
+        assert!(image_job_is_candle_eligible(&image_generate_job(payload)));
+        // No reference → plain txt2img routes via the txt2img gate instead.
+        assert!(!kolors_ipadapter_candle_eligible(&object(
+            json!({ "model": "kolors" })
+        )));
+        // img2img / inpaint / edit shapes are NOT this lane (those are sc-5487, still torch).
+        assert!(!kolors_ipadapter_candle_eligible(&object(json!({
+            "model": "kolors", "mode": "edit_image", "referenceAssetId": "a", "sourceAssetId": "s"
+        }))));
+        assert!(!kolors_ipadapter_candle_eligible(&object(json!({
+            "model": "kolors", "referenceAssetId": "a", "sourceAssetId": "s"
+        }))));
+        assert!(!kolors_ipadapter_candle_eligible(&object(json!({
+            "model": "kolors", "referenceAssetId": "a", "maskAssetId": "m"
         }))));
     }
 }

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -626,42 +626,48 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "27b0
 # from candle-gen-sdxl + ChatGLM3 conditioning / leading-Euler denoise on the vendored SDXL IP UNet) that
 # the worker's bespoke `generate_candle_kolors_ipadapter_stream` drives for off-Mac Kolors reference
 # (image-prompt) conditioning — closing the `referenceAssetId`->torch deferral for the kolors family.
-# Both candle-gen #66/#68 are SOURCE-ONLY (KEEP `sceneworks-gen-core` at `891bee4` == this worker's
-# mlx-gen pin), so NO mlx-gen bump and the `--features backend-candle` graph still resolves exactly ONE
-# gen-core rev. GPU-validated on RTX PRO 6000: Kolors IP CLIP-feature cosine 0.978 (with IP) vs 0.933 (no
-# IP), pre- + mid-denoise cancel honored; the SVD UNet runs f32 (fp16 overflows to NaN in the deep
-# spatio-temporal UNet; native-res fp16+f32-upcast is the sc-5493 GPU follow-up). ALL candle deps MUST
-# share this rev.
+# Both candle-gen #66/#68 are SOURCE-ONLY at gen-core `891bee4`. GPU-validated on RTX PRO 6000: Kolors IP
+# CLIP-feature cosine 0.978 (with IP) vs 0.933 (no IP), pre- + mid-denoise cancel honored; the SVD UNet
+# runs f32 (fp16 overflows to NaN in the deep spatio-temporal UNet; native-res fp16+f32-upcast is the
+# sc-5493 GPU follow-up).
+#
+# sc-5488 then re-pins the candle pin `7a8c617` -> `a89a595` (candle-gen #69): main bumped its mlx-gen pin
+# `891bee4` -> `27b0107` ("Add Heun sampler default for Chroma Flash", #698's MLX side) which skewed the
+# backend-candle graph (candle-gen still resolved gen-core 891bee4 while mlx-gen is 27b0107 — two gen-core
+# revs). gen-core is BYTE-IDENTICAL 891bee4..27b0107 (the bump is pure mlx-gen-chroma sampler work), so #69
+# is a behavior-neutral source-pin-only re-pin of `sceneworks-gen-core` + testkit to 27b0107. a89a595 now
+# resolves gen-core `27b0107` == this worker's mlx-gen pin, so the `--features backend-candle` graph
+# resolves exactly ONE gen-core rev again. ALL candle deps MUST share this rev.
 [target.'cfg(target_os = "windows")'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a8c61740ab3de5c65cf6598be0fe2f4817de035", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a595664fec9f03e4eaeb17db59de505b45290", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a8c61740ab3de5c65cf6598be0fe2f4817de035", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a8c61740ab3de5c65cf6598be0fe2f4817de035", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a8c61740ab3de5c65cf6598be0fe2f4817de035", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a8c61740ab3de5c65cf6598be0fe2f4817de035", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a595664fec9f03e4eaeb17db59de505b45290", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a595664fec9f03e4eaeb17db59de505b45290", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a595664fec9f03e4eaeb17db59de505b45290", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a595664fec9f03e4eaeb17db59de505b45290", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a8c61740ab3de5c65cf6598be0fe2f4817de035", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a595664fec9f03e4eaeb17db59de505b45290", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b`; ltx registers `ltx_2_3_distilled` (txt2video first slice — no conditioning/audio/
 # LoRA/quant). Force-linked in video_jobs.rs (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a8c61740ab3de5c65cf6598be0fe2f4817de035", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a8c61740ab3de5c65cf6598be0fe2f4817de035", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a595664fec9f03e4eaeb17db59de505b45290", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a595664fec9f03e4eaeb17db59de505b45290", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a8c61740ab3de5c65cf6598be0fe2f4817de035", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a595664fec9f03e4eaeb17db59de505b45290", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a8c61740ab3de5c65cf6598be0fe2f4817de035", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a595664fec9f03e4eaeb17db59de505b45290", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -670,19 +676,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a8c61740ab3de5c65cf6598be0fe2f4817de035", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a595664fec9f03e4eaeb17db59de505b45290", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a8c61740ab3de5c65cf6598be0fe2f4817de035", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a595664fec9f03e4eaeb17db59de505b45290", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a8c61740ab3de5c65cf6598be0fe2f4817de035", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a595664fec9f03e4eaeb17db59de505b45290", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -691,12 +697,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a8c61740ab3de5c65cf6598be0fe2f4817de035", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a595664fec9f03e4eaeb17db59de505b45290", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a8c61740ab3de5c65cf6598be0fe2f4817de035", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a595664fec9f03e4eaeb17db59de505b45290", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -704,7 +710,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a8c6
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a8c61740ab3de5c65cf6598be0fe2f4817de035", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a595664fec9f03e4eaeb17db59de505b45290", features = ["cuda"], optional = true }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -610,30 +610,41 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891b
 # this worker's mlx-gen pin), so NO mlx-gen bump and the `--features backend-candle` graph still resolves
 # exactly ONE gen-core rev. GPU-validated on RTX PRO 6000: CLIP-feature cosine 0.94 (with IP) vs 0.70
 # (no IP), pre- + mid-denoise cancel honored. ALL candle deps MUST share this rev.
+#
+# sc-5488 (Kolors slice) bumps the candle pin `f285284` -> `7a8c617` (candle-gen main HEAD, #68): LINKS
+# the candle Kolors IP-Adapter-Plus provider (`candle_gen_kolors::IpAdapterKolors` — the CLIP ViT-L/14-336
+# image encoder + the `kolors_plus` Resampler reused from candle-gen-sdxl + the Kolors ChatGLM3 conditioning
+# / leading-Euler denoise on the vendored SDXL IP UNet) that the worker's bespoke
+# `generate_candle_kolors_ipadapter_stream` drives for off-Mac Kolors reference (image-prompt)
+# conditioning — closing the `referenceAssetId`->torch deferral for the kolors family. candle-gen #68 is
+# SOURCE-ONLY (KEEPS `sceneworks-gen-core` at `891bee4` == this worker's mlx-gen pin), so NO mlx-gen bump
+# and the `--features backend-candle` graph still resolves exactly ONE gen-core rev. GPU-validated on RTX
+# PRO 6000: CLIP-feature cosine 0.978 (with IP) vs 0.933 (no IP), pre- + mid-denoise cancel honored. ALL
+# candle deps MUST share this rev.
 [target.'cfg(target_os = "windows")'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f28528497e92b9335b44567bf99c3603f38034a2", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a8c61740ab3de5c65cf6598be0fe2f4817de035", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f28528497e92b9335b44567bf99c3603f38034a2", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f28528497e92b9335b44567bf99c3603f38034a2", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f28528497e92b9335b44567bf99c3603f38034a2", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f28528497e92b9335b44567bf99c3603f38034a2", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a8c61740ab3de5c65cf6598be0fe2f4817de035", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a8c61740ab3de5c65cf6598be0fe2f4817de035", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a8c61740ab3de5c65cf6598be0fe2f4817de035", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a8c61740ab3de5c65cf6598be0fe2f4817de035", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f28528497e92b9335b44567bf99c3603f38034a2", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a8c61740ab3de5c65cf6598be0fe2f4817de035", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b`; ltx registers `ltx_2_3_distilled` (txt2video first slice — no conditioning/audio/
 # LoRA/quant). Force-linked in video_jobs.rs (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f28528497e92b9335b44567bf99c3603f38034a2", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f28528497e92b9335b44567bf99c3603f38034a2", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a8c61740ab3de5c65cf6598be0fe2f4817de035", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a8c61740ab3de5c65cf6598be0fe2f4817de035", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f28528497e92b9335b44567bf99c3603f38034a2", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a8c61740ab3de5c65cf6598be0fe2f4817de035", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -642,19 +653,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f28528497e92b9335b44567bf99c3603f38034a2", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a8c61740ab3de5c65cf6598be0fe2f4817de035", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f28528497e92b9335b44567bf99c3603f38034a2", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a8c61740ab3de5c65cf6598be0fe2f4817de035", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f28528497e92b9335b44567bf99c3603f38034a2", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a8c61740ab3de5c65cf6598be0fe2f4817de035", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -663,12 +674,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f28528497e92b9335b44567bf99c3603f38034a2", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a8c61740ab3de5c65cf6598be0fe2f4817de035", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f28528497e92b9335b44567bf99c3603f38034a2", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a8c61740ab3de5c65cf6598be0fe2f4817de035", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -676,7 +687,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2852
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f28528497e92b9335b44567bf99c3603f38034a2", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a8c61740ab3de5c65cf6598be0fe2f4817de035", features = ["cuda"], optional = true }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -155,6 +155,15 @@ use candle_gen_instantid::{
 // named-type import the bespoke reference route (`image_jobs/sdxl_ipadapter.rs`) drives.
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
 use candle_gen_sdxl::{IpAdapterSdxl, IpAdapterSdxlPaths, IpAdapterSdxlRequest};
+// Kolors IP-Adapter-Plus reference provider (sc-5488, epic 5480) — the candle (Windows/CUDA) Kolors
+// sibling of the SDXL IP lane, living in `candle-gen-kolors` (it reuses candle-gen-sdxl's vendored IP
+// UNet + the CLIP ViT-L/14-336 image encoder, with the Kolors ChatGLM3 conditioning + leading-Euler
+// sampler). Candle-only: macOS keeps the MLX Kolors IP path (the registry `Reference` route), so these
+// named types resolve only off-Mac. `candle_gen_kolors` is already force-link anchored above (the
+// registered txt2img `kolors`); this is the named-type import the bespoke reference route
+// (`image_jobs/kolors_ipadapter.rs`) drives.
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+use candle_gen_kolors::{IpAdapterKolors, IpAdapterKolorsPaths, IpAdapterKolorsRequest};
 
 /// The stub adapter id recorded on generated assets (matches the contract fixture
 /// `tests/fixtures/rust_migration_contracts/sidecars/asset-image.sceneworks.json`).
@@ -448,6 +457,21 @@ pub(crate) async fn run_image_generate_job(
         // because `sdxl`/`realvisxl` ARE candle txt2img ids, so without this a reference job would be
         // caught by the txt2img branch and silently drop the reference.
         generate_candle_sdxl_ipadapter_stream(
+            api,
+            settings,
+            job,
+            &plan,
+            &project_path,
+            backend,
+            &mut asset_writes,
+        )
+        .await?;
+        true
+    } else if settings.backend_candle_enabled && kolors_ipadapter_available(&request, settings) {
+        // Kolors IP-Adapter-Plus reference conditioning (sc-5488) — checked BEFORE `is_candle_engine`
+        // because `kolors` IS a candle txt2img id, so without this a reference job would be caught by
+        // the txt2img branch and silently drop the reference (the SDXL IP reasoning, for Kolors).
+        generate_candle_kolors_ipadapter_stream(
             api,
             settings,
             job,
@@ -938,6 +962,11 @@ include!("image_jobs/instantid.rs");
 // candle-exclusive.
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
 include!("image_jobs/sdxl_ipadapter.rs");
+// Kolors IP-Adapter-Plus reference conditioning — the Windows/CUDA candle lane ONLY (sc-5488). macOS
+// keeps the MLX Kolors IP path (kolors.rs, the registry `Reference` route); the candle `IpAdapterKolors`
+// is a bespoke provider, so this is candle-exclusive.
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+include!("image_jobs/kolors_ipadapter.rs");
 #[cfg(target_os = "macos")]
 // PuLID-FLUX native routing.
 include!("image_jobs/pulid.rs");

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -1164,6 +1164,12 @@ async fn generate_candle_stream(
                     negative_prompt.clone(),
                     None,
                     true_cfg,
+                    // The candle txt2img families don't advertise sampler/scheduler selection (each uses
+                    // its family default), so no override is forwarded — matching this path's behavior
+                    // before sc-5392 added those params to `generate_one` for the macOS Chroma path.
+                    None,
+                    None,
+                    None,
                     &cancel,
                     on_progress,
                 )?;

--- a/crates/sceneworks-worker/src/image_jobs/kolors_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/kolors_ipadapter.rs
@@ -1,0 +1,327 @@
+// Candle (Windows/CUDA) Kolors IP-Adapter-Plus reference route (sc-5488, epic 5480) — reference-image
+// (identity) conditioning on Kolors off-Mac via `candle_gen_kolors::IpAdapterKolors`. The Kolors sibling
+// of the candle SDXL IP-Adapter lane (sdxl_ipadapter.rs): CLIP ViT-L/14-336 image tokens injected into
+// the vendored SDXL UNet alongside the encoder_hid_proj-projected ChatGLM3 text path, denoised with the
+// Kolors leading-Euler sampler.
+//
+// **Candle-only.** macOS keeps the MLX Kolors IP path (the `Reference` conditioning the registry
+// `kolors` generator handles once `with_ip_adapter` installs the K/V — kolors.rs, sc-4767); the candle
+// `IpAdapterKolors` is a bespoke provider, so this whole file is gated to the Windows/CUDA candle build
+// (the `include!` in image_jobs.rs carries the cfg). It is `include!`d into the `image_jobs` module, so
+// it shares that module's imports (ImageRequest/Settings/WorkerResult/`advanced`/`load_reference_image`/
+// `huggingface_snapshot_dir`/`ensure_hf_cached_file`/`start_gen_stream`/… all in scope unqualified).
+
+/// The Kolors IP-Adapter-Plus repo (CLIP ViT-L/14-336 `image_encoder/` + the `image_proj` Resampler +
+/// `ip_adapter.*` K/V). Same repo the MLX path uses (`kolors.rs` `KOLORS_IP_ADAPTER_REPO`).
+const KOLORS_IPADAPTER_REPO: &str = "Kwai-Kolors/Kolors-IP-Adapter-Plus";
+/// The repo revision carrying the **safetensors** (`refs/pr/4`): the repo's `main` ships only `.bin`
+/// (a torch pickle candle can't read); PR-4 adds `ip_adapter_plus_general.safetensors` +
+/// `image_encoder/model.safetensors`. The torch/MLX download flow uses this same rev.
+const KOLORS_IPADAPTER_REVISION: &str = "refs/pr/4";
+/// The IP-Adapter-Plus bundle file (root of the snapshot).
+const KOLORS_IPADAPTER_BUNDLE: &str = "ip_adapter_plus_general.safetensors";
+/// The CLIP ViT-L/14-336 image-encoder files inside the repo (config + weights).
+const KOLORS_IPADAPTER_ENCODER_SRC: [&str; 2] = [
+    "image_encoder/config.json",
+    "image_encoder/model.safetensors",
+];
+/// IP-Adapter scale default — the torch `KolorsDiffusersAdapter._ip_adapter_scale` 0.6 (matches the MLX
+/// path's `KOLORS_IP_SCALE`, and the candle `IpAdapterKolors::DEFAULT_IP_ADAPTER_SCALE`).
+const KOLORS_IPADAPTER_IP_SCALE: f32 = 0.6;
+/// Denoise steps default (Kolors production — diffusers `KolorsPipeline`).
+const KOLORS_IPADAPTER_DEFAULT_STEPS: u32 = 50;
+/// CFG default (Kolors production guidance).
+const KOLORS_IPADAPTER_DEFAULT_GUIDANCE: f32 = 5.0;
+/// The Kolors base diffusers repo when the manifest omits `repo`.
+const KOLORS_IPADAPTER_DEFAULT_REPO: &str = "Kwai-Kolors/Kolors-diffusers";
+/// The adapter/engine id recorded on candle Kolors IP-Adapter assets + telemetry (distinct from the
+/// txt2img `candle_kolors` lane).
+const KOLORS_IPADAPTER_ENGINE: &str = "candle_kolors_ipadapter";
+
+/// Model ids the candle Kolors IP-Adapter route accepts.
+fn is_kolors_ipadapter_model(model: &str) -> bool {
+    model == "kolors"
+}
+
+/// Resolve the Kolors base (diffusers) snapshot for the IP-Adapter route: an explicit `modelPath` dir
+/// (advanced or manifest) wins, else the HF cache snapshot for the manifest `repo` (default
+/// `Kwai-Kolors/Kolors-diffusers`). `None` means the base is not present locally, so the job is not
+/// candle-runnable (falls through to torch). Mirrors `resolve_sdxl_ipadapter_base`.
+fn resolve_kolors_ipadapter_base(
+    request: &ImageRequest,
+    settings: &Settings,
+) -> WorkerResult<Option<PathBuf>> {
+    if let Some(path) = request
+        .advanced
+        .get("modelPath")
+        .or_else(|| request.model_manifest_entry.get("modelPath"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+    {
+        return resolve_app_managed_model_dir(settings, &path, "Kolors IP-Adapter modelPath").map(Some);
+    }
+    let repo = request
+        .model_manifest_entry
+        .get("repo")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(KOLORS_IPADAPTER_DEFAULT_REPO);
+    Ok(huggingface_snapshot_dir(&settings.data_dir, repo))
+}
+
+/// True when this is a candle-eligible Kolors IP-Adapter job: the `kolors` model with a reference image
+/// (and NOT an img2img/inpaint/edit shape — those are sc-5487) whose base resolves locally. Mirrors
+/// `jobs_store::kolors_ipadapter_candle_eligible` so the worker and router agree.
+fn kolors_ipadapter_available(request: &ImageRequest, settings: &Settings) -> bool {
+    is_kolors_ipadapter_model(&request.model)
+        && request.mode != "edit_image"
+        && non_empty(&request.reference_asset_id)
+        && !non_empty(&request.source_asset_id)
+        && !non_empty(&request.mask_asset_id)
+        && matches!(resolve_kolors_ipadapter_base(request, settings), Ok(Some(_)))
+}
+
+/// Resolve denoise steps: `advanced.steps` (clamped 1..=80) → manifest `steps` → default (50).
+fn kolors_ipadapter_steps(request: &ImageRequest) -> u32 {
+    let parse = |value: &Value| {
+        value
+            .as_u64()
+            .or_else(|| value.as_str()?.trim().parse().ok())
+    };
+    request
+        .advanced
+        .get("steps")
+        .and_then(parse)
+        .or_else(|| request.model_manifest_entry.get("steps").and_then(parse))
+        .map(|steps| steps.clamp(1, 80) as u32)
+        .unwrap_or(KOLORS_IPADAPTER_DEFAULT_STEPS)
+}
+
+/// Resolve guidance: `advanced.guidanceScale` → manifest `guidanceScale` → default (5.0), clamped.
+fn kolors_ipadapter_guidance(request: &ImageRequest) -> f32 {
+    let manifest_default = request
+        .model_manifest_entry
+        .get("guidanceScale")
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .map(|value| value as f32)
+        .unwrap_or(KOLORS_IPADAPTER_DEFAULT_GUIDANCE);
+    advanced::f32_clamped(
+        &request.advanced,
+        "guidanceScale",
+        manifest_default,
+        0.0..=30.0,
+    )
+}
+
+/// Resolve the Kolors IP-Adapter-Plus snapshot **directory** (`image_encoder/` + the bundle file) the
+/// `IpAdapterKolors` provider loads, downloading from `Kwai-Kolors/Kolors-IP-Adapter-Plus` **@
+/// `refs/pr/4`** on first use. Resolution order: an env-pinned root (pre-staged, the validation path) →
+/// a whole-repo HF cache snapshot → download the bundle + encoder into the app cache. Returns the dir
+/// (what [`IpAdapterKolorsPaths::ip_adapter`] wants).
+async fn ensure_kolors_ipadapter_weights(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+) -> WorkerResult<PathBuf> {
+    let has_layout = |dir: &Path| {
+        dir.join(KOLORS_IPADAPTER_BUNDLE).is_file()
+            && dir.join("image_encoder").join("model.safetensors").is_file()
+    };
+    // Env override: a directory laid out like the snapshot, pre-staged for local validation.
+    if let Ok(root) = std::env::var("SCENEWORKS_IPADAPTER_KOLORS") {
+        let root = PathBuf::from(root);
+        if has_layout(&root) {
+            return Ok(root);
+        }
+    }
+    // Whole-repo HF cache snapshot already present (the model-download flow staged it at refs/pr/4).
+    if let Some(snapshot) = huggingface_snapshot_dir(&settings.data_dir, KOLORS_IPADAPTER_REPO) {
+        if has_layout(&snapshot) {
+            return Ok(snapshot);
+        }
+    }
+    // Download-on-first-use into the app cache (the snapshot layout: bundle at root + image_encoder/).
+    let client = reqwest::Client::new();
+    let context = DownloadContext {
+        api,
+        client: &client,
+        settings,
+        job_id: &job.id,
+        cancel_message: "Kolors IP-Adapter generation canceled while fetching weights.",
+        fresh_download: false,
+    };
+    let cache = settings.data_dir.join("cache").join("ipadapter-kolors");
+    ensure_hf_cached_file(
+        &context,
+        KOLORS_IPADAPTER_REPO,
+        KOLORS_IPADAPTER_REVISION,
+        KOLORS_IPADAPTER_BUNDLE,
+        &cache.join(KOLORS_IPADAPTER_BUNDLE),
+    )
+    .await?;
+    for source in KOLORS_IPADAPTER_ENCODER_SRC {
+        let name = source.rsplit('/').next().unwrap_or(source);
+        ensure_hf_cached_file(
+            &context,
+            KOLORS_IPADAPTER_REPO,
+            KOLORS_IPADAPTER_REVISION,
+            source,
+            &cache.join("image_encoder").join(name),
+        )
+        .await?;
+    }
+    Ok(cache)
+}
+
+/// Flat telemetry recorded on candle Kolors IP-Adapter assets (parity with the SDXL/InstantID recipe-key
+/// shape).
+fn kolors_ipadapter_raw_settings(
+    request: &ImageRequest,
+    repo: &str,
+    steps: u32,
+    guidance: f32,
+    ip_scale: f32,
+) -> JsonObject {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("repo".to_owned(), Value::String(repo.to_owned()));
+    raw.insert("numInferenceSteps".to_owned(), json!(steps));
+    raw.insert("guidanceScale".to_owned(), json!(guidance));
+    raw.insert("ipAdapterScale".to_owned(), json!(ip_scale));
+    raw.insert(
+        "ipAdapterEngine".to_owned(),
+        Value::String(KOLORS_IPADAPTER_ENGINE.to_owned()),
+    );
+    raw
+}
+
+/// Real candle Kolors IP-Adapter generation: resolve the reference + weights on the async side, then
+/// load the `IpAdapterKolors` provider once + generate each image on the blocking thread. `request.count`
+/// images, each its own seed; `generate` takes the per-job `CancelFlag` + a `Progress` callback, so
+/// streaming is per-step and cancellation is honoured mid-denoise — same contract as the SDXL IP lane.
+async fn generate_candle_kolors_ipadapter_stream(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+    let kolors_base = resolve_kolors_ipadapter_base(request, settings)?.ok_or_else(|| {
+        WorkerError::InvalidPayload("Kolors IP-Adapter base (Kolors-diffusers) not found".to_owned())
+    })?;
+    let reference_id = request
+        .reference_asset_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload("Kolors IP-Adapter requires a reference image".to_owned())
+        })?;
+    let reference = load_reference_image(
+        &settings.data_dir,
+        &request.project_id,
+        reference_id,
+        project_path,
+    )?;
+    let ip_adapter = ensure_kolors_ipadapter_weights(api, settings, job).await?;
+
+    let steps = kolors_ipadapter_steps(request);
+    let guidance = kolors_ipadapter_guidance(request);
+    let ip_scale = advanced::f32_clamped(
+        &request.advanced,
+        "ipAdapterScale",
+        KOLORS_IPADAPTER_IP_SCALE,
+        0.0..=1.0,
+    );
+    let repo = request
+        .model_manifest_entry
+        .get("repo")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(KOLORS_IPADAPTER_DEFAULT_REPO)
+        .to_owned();
+    let raw_settings = kolors_ipadapter_raw_settings(request, &repo, steps, guidance, ip_scale);
+
+    // Per-image work items: (seed, prompt) — `request.count` images at the reference identity.
+    let (width, height) = (request.width, request.height);
+    let work: Vec<(i64, String)> = (0..request.count as usize)
+        .map(|index| (resolve_seed(request, index), request.prompt.clone()))
+        .collect();
+    let total = work.len();
+    let negative_prompt = request.negative_prompt.clone();
+
+    let (cancel, rx, blocking) = start_gen_stream(
+        job.id.clone(),
+        "kolors_ipadapter",
+        0,
+        move || {
+            let paths = IpAdapterKolorsPaths {
+                kolors_base,
+                ip_adapter,
+            };
+            let model = IpAdapterKolors::load(&paths).map_err(|error| {
+                WorkerError::Engine(format!("Kolors IP-Adapter load failed: {error}"))
+            })?;
+            Ok((model, reference))
+        },
+        move |(model, reference), tx, cancel| {
+            // `IpAdapterKolors::generate` takes `&mut self` (it sets the IP image tokens on the UNet
+            // before the denoise), so the per-item closure mutates `model`.
+            let mut model = model;
+            drive_gen_items(tx, work, move |_index, (seed, prompt), on_progress| {
+                if cancel.is_cancelled() {
+                    return Ok(None);
+                }
+                let req = IpAdapterKolorsRequest {
+                    prompt,
+                    negative: negative_prompt.clone(),
+                    width,
+                    height,
+                    steps: steps as usize,
+                    guidance,
+                    ip_adapter_scale: ip_scale,
+                    seed: seed as u64,
+                    cancel: cancel.clone(),
+                };
+                let out = match model.generate(&req, &reference, &mut *on_progress) {
+                    Ok(out) => out,
+                    Err(_) if cancel.is_cancelled() => return Ok(None),
+                    Err(error) => {
+                        return Err(WorkerError::Engine(format!(
+                            "Kolors IP-Adapter generation failed: {error}"
+                        )));
+                    }
+                };
+                Ok(Some((seed, out.width, out.height, out.pixels)))
+            })
+        },
+    );
+
+    consume_gen_events(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        KOLORS_IPADAPTER_ENGINE,
+        &raw_settings,
+        total,
+        rx,
+        cancel,
+        blocking,
+        asset_writes,
+    )
+    .await
+}


### PR DESCRIPTION
Wires the candle `IpAdapterKolors` provider ([candle-gen#68](https://github.com/michaeltrefry/candle-gen/pull/68), merged + GPU-validated) into the worker as a bespoke Windows/CUDA route, **closing the `referenceAssetId → torch` deferral for the kolors family**. The Kolors sibling of the SDXL IP route ([#690](https://github.com/michaeltrefry/SceneWorks/pull/690)) — candle-only and fully cfg-gated (`all(target_os = "windows", feature = "backend-candle")`); macOS keeps the MLX Kolors IP path (the registry `Reference` route in `kolors.rs`).

### Changes
- **`crates/sceneworks-worker/src/image_jobs/kolors_ipadapter.rs`** (new) — `generate_candle_kolors_ipadapter_stream` + `kolors_ipadapter_available` + weight resolution. Mirrors the SDXL IP stream (`start_gen_stream` → `drive_gen_items` → `consume_gen_events`, per-step progress + mid-denoise cancel), pure-IP denoise, `request.count` images. Base = `Kolors-diffusers` via the manifest `repo`; the `Kwai-Kolors/Kolors-IP-Adapter-Plus` snapshot (`image_encoder/` + `ip_adapter_plus_general.safetensors`) via an env override (`SCENEWORKS_IPADAPTER_KOLORS`) → HF cache snapshot → download-on-first-use **at `refs/pr/4`** (the safetensors revision — the repo's `main` ships `.bin`, which candle can't read).
- **`image_jobs.rs`** — dispatch branch **before** `is_candle_engine` (`kolors` *is* a candle txt2img id, so a reference job would otherwise be caught by the txt2img branch and silently drop the reference) + the `IpAdapterKolors` types import + the cfg-gated `include!`.
- **`jobs_store.rs`** — `kolors_ipadapter_candle_eligible` (pure reference: `referenceAssetId`, no `sourceAssetId`/`maskAssetId`, not `edit_image` — those img2img/inpaint/edit shapes are **sc-5487**, still torch) + a branch in `image_job_is_candle_eligible` before the txt2img gate + a routing test.
- **Cargo** — re-pin candle-gen `f285284 → 7a8c617` (#68). #68 is **source-only** in candle-gen, so `sceneworks-gen-core` stays `891bee4` (== this worker's mlx-gen pin): **no mlx-gen bump**, skew gate single-rev. (`candle-gen-kolors` was already a worker dep from the Kolors txt2img wiring.)

### Verification
- sc-4482 skew gate: **exactly one** `sceneworks-gen-core` (`891bee4`) in the `--features backend-candle` graph.
- `sceneworks-core` routing tests green (`kolors_ipadapter_reference_jobs_route_to_candle`, + the 22 existing).
- `cargo build` + `cargo clippy -p sceneworks-worker --features backend-candle -- -D warnings` clean (sm_120, MSVC 14.44); `cargo fmt` clean.
- The candle Kolors IP-Adapter math is GPU-validated upstream (#68): CLIP-feature cosine **0.978** (with IP) vs **0.933** (no IP), Δ +0.045; visually the with-IP output resembles the reference (glasses, hair, hoodie, office) while no-IP is a generic portrait; cancel honored.

### Follow-up
A deployed-worker GPU smoke (a real `referenceAssetId` job → candle) is the remaining end-to-end check — the same pattern as the SDXL/InstantID worker routes. The remaining sc-5488 family is **FLUX XLabs** (recommended as its own story — candle FLUX has no IP-injection seam).

🤖 Generated with [Claude Code](https://claude.com/claude-code)