### PR TITLE
Tune Chroma Flash defaults for Mac MLX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_distr 0.5.1",
  "safetensors 0.7.0",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a)",
  "serde_json",
  "thiserror 2.0.18",
 ]
@@ -3241,11 +3241,11 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=27b010780afebc3a69f18dcb85667acb35b55e41#27b010780afebc3a69f18dcb85667acb35b55e41"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=27b010780afebc3a69f18dcb85667acb35b55e41)",
  "thiserror 2.0.18",
  "tokenizers 0.21.4",
 ]
@@ -3253,7 +3253,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=27b010780afebc3a69f18dcb85667acb35b55e41#27b010780afebc3a69f18dcb85667acb35b55e41"
 dependencies = [
  "image",
  "inventory",
@@ -3267,7 +3267,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=27b010780afebc3a69f18dcb85667acb35b55e41#27b010780afebc3a69f18dcb85667acb35b55e41"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3279,7 +3279,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=27b010780afebc3a69f18dcb85667acb35b55e41#27b010780afebc3a69f18dcb85667acb35b55e41"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3288,7 +3288,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=27b010780afebc3a69f18dcb85667acb35b55e41#27b010780afebc3a69f18dcb85667acb35b55e41"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3300,7 +3300,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=27b010780afebc3a69f18dcb85667acb35b55e41#27b010780afebc3a69f18dcb85667acb35b55e41"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3311,7 +3311,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=27b010780afebc3a69f18dcb85667acb35b55e41#27b010780afebc3a69f18dcb85667acb35b55e41"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3322,7 +3322,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=27b010780afebc3a69f18dcb85667acb35b55e41#27b010780afebc3a69f18dcb85667acb35b55e41"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3332,7 +3332,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=27b010780afebc3a69f18dcb85667acb35b55e41#27b010780afebc3a69f18dcb85667acb35b55e41"
 dependencies = [
  "image",
  "inventory",
@@ -3344,7 +3344,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=27b010780afebc3a69f18dcb85667acb35b55e41#27b010780afebc3a69f18dcb85667acb35b55e41"
 dependencies = [
  "image",
  "inventory",
@@ -3357,7 +3357,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=27b010780afebc3a69f18dcb85667acb35b55e41#27b010780afebc3a69f18dcb85667acb35b55e41"
 dependencies = [
  "image",
  "inventory",
@@ -3369,7 +3369,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=27b010780afebc3a69f18dcb85667acb35b55e41#27b010780afebc3a69f18dcb85667acb35b55e41"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3380,7 +3380,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=27b010780afebc3a69f18dcb85667acb35b55e41#27b010780afebc3a69f18dcb85667acb35b55e41"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3392,7 +3392,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=27b010780afebc3a69f18dcb85667acb35b55e41#27b010780afebc3a69f18dcb85667acb35b55e41"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3402,7 +3402,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=27b010780afebc3a69f18dcb85667acb35b55e41#27b010780afebc3a69f18dcb85667acb35b55e41"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3411,7 +3411,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=27b010780afebc3a69f18dcb85667acb35b55e41#27b010780afebc3a69f18dcb85667acb35b55e41"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3420,7 +3420,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=27b010780afebc3a69f18dcb85667acb35b55e41#27b010780afebc3a69f18dcb85667acb35b55e41"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3432,7 +3432,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=27b010780afebc3a69f18dcb85667acb35b55e41#27b010780afebc3a69f18dcb85667acb35b55e41"
 dependencies = [
  "image",
  "inventory",
@@ -3445,7 +3445,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=27b010780afebc3a69f18dcb85667acb35b55e41#27b010780afebc3a69f18dcb85667acb35b55e41"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3456,7 +3456,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=27b010780afebc3a69f18dcb85667acb35b55e41#27b010780afebc3a69f18dcb85667acb35b55e41"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3467,7 +3467,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=27b010780afebc3a69f18dcb85667acb35b55e41#27b010780afebc3a69f18dcb85667acb35b55e41"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3478,7 +3478,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=27b010780afebc3a69f18dcb85667acb35b55e41#27b010780afebc3a69f18dcb85667acb35b55e41"
 dependencies = [
  "image",
  "inventory",
@@ -3492,7 +3492,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=27b010780afebc3a69f18dcb85667acb35b55e41#27b010780afebc3a69f18dcb85667acb35b55e41"
 dependencies = [
  "image",
  "inventory",
@@ -3799,7 +3799,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5120,7 +5120,19 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#891bee46e7ec7d7a5b3074eaea183d2e87be9d2a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=27b010780afebc3a69f18dcb85667acb35b55e41#27b010780afebc3a69f18dcb85667acb35b55e41"
+dependencies = [
+ "inventory",
+ "safetensors 0.4.5",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokenizers 0.21.4",
+]
+
+[[package]]
+name = "sceneworks-gen-core"
+version = "0.1.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=891bee46e7ec7d7a5b3074eaea183d2e87be9d2a#27b010780afebc3a69f18dcb85667acb35b55e41"
 dependencies = [
  "inventory",
  "safetensors 0.4.5",
@@ -5216,7 +5228,7 @@ dependencies = [
  "pmetal-mlx-rs",
  "reqwest 0.12.28",
  "sceneworks-core",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=27b010780afebc3a69f18dcb85667acb35b55e41)",
  "serde",
  "serde_json",
  "sha2",

--- a/apps/web/public/prompt-guides/chroma1-base.md
+++ b/apps/web/public/prompt-guides/chroma1-base.md
@@ -8,7 +8,7 @@ A neutral, general-purpose text-to-image foundation and the recommended starting
 
 - **Chroma1-Base** — the neutral foundation. Pick it when you want a clean, un-opinionated base (e.g. as a LoRA training base) or general text-to-image without HD's high-resolution bias.
 - **Chroma1-HD** — the high-resolution tune. Best fidelity for finished images; the default for most generation.
-- **Chroma1-Flash** — the fast, CFG-baked variant (~8 steps, no negative prompt) for quick drafts.
+- **Chroma1-Flash** — the fast, CFG-baked variant (~12 Heun steps, no negative prompt) for quick drafts.
 
 All three share one worker adapter and the same prompt structure — only step count and guidance differ.
 

--- a/apps/web/public/prompt-guides/chroma1-flash.md
+++ b/apps/web/public/prompt-guides/chroma1-flash.md
@@ -6,7 +6,7 @@ Fast drafts and rapid iteration. Chroma1-Flash is the CFG-baked, low-step varian
 
 ## Choosing A Chroma1 Variant
 
-- **Chroma1-Flash** — fastest (~8 steps, CFG baked, **no negative prompt**). Use it for quick drafts and iteration.
+- **Chroma1-Flash** — fastest (~12 Heun steps, CFG baked, **no negative prompt**). Use it for quick drafts and iteration.
 - **Chroma1-HD** — the high-resolution tune with real CFG + negative prompt (~40 steps). Use it for finished images.
 - **Chroma1-Base** — the neutral foundation (real CFG, ~40 steps); the recommended base for finetuning.
 
@@ -18,7 +18,7 @@ Chroma was trained on rich natural-language captions (T5-XXL text encoder, no CL
 
 `subject + setting + visual details + style + composition + lighting + any text`
 
-Flash bakes CFG (guidance 1.0), so it does **not** use a negative prompt — put everything you want into the positive prompt. Recommended default: **~8 steps** with a Heun-friendly schedule.
+Flash bakes CFG (guidance 1.0), so it does **not** use a negative prompt — put everything you want into the positive prompt. Recommended default: **768x768, ~12 steps** with the Heun sampler.
 
 ## Build The Prompt
 
@@ -67,7 +67,7 @@ Chroma renders legible text — quote the exact words and describe the medium:
 ## Tips
 
 - Keep the prompt descriptive and positive; at guidance 1.0 there is no negative prompt.
-- ~8 steps is the sweet spot — more steps rarely help Flash. Heun / DPM++ SDE samplers do well at low step counts.
+- 768x768 at 12 Heun steps is the default quality/speed balance; 1024x1024 or 16-20 steps can improve some images at a higher render cost.
 - Use Flash to explore composition quickly, then re-render the keeper on Chroma1-HD for maximum quality.
 
 ## Example Prompts

--- a/apps/web/public/prompt-guides/chroma1-hd.md
+++ b/apps/web/public/prompt-guides/chroma1-hd.md
@@ -8,7 +8,7 @@ High-resolution, detail-rich text-to-image: photography, illustration, concept a
 
 - **Chroma1-HD** — the default. Best fidelity and the high-resolution sweet spot. Use it for finished images.
 - **Chroma1-Base** — the neutral foundation the family is finetuned from. Same engine and prompt shape as HD; pick it when you want a clean base (e.g. for LoRA training) or a slightly less HD-biased look.
-- **Chroma1-Flash** — the fast, CFG-baked variant (~8 steps, no negative prompt). Use it for quick drafts and iteration.
+- **Chroma1-Flash** — the fast, CFG-baked variant (~12 Heun steps, no negative prompt). Use it for quick drafts and iteration.
 
 HD, Base, and Flash share one worker adapter and the same prompt structure — only step count and guidance differ.
 

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -254,8 +254,14 @@ export const fallbackModels = [
     name: "Chroma1-Flash",
     type: "image",
     capabilities: ["text_to_image", "style_variations"],
+    defaults: { resolution: "768x768", steps: 12, guidanceScale: 1.0, sampler: "heun", scheduler: "default" },
+    limits: {
+      resolutions: ["768x768", "1024x1024", "1280x720", "720x1280"],
+      samplers: ["default", "euler", "heun"],
+      schedulers: ["default"],
+    },
     ui: {
-      description: "Chroma1-Flash — fast CFG-baked text-to-image, Apache-2.0 (commercial-safe). FLUX.1-schnell-derived 8.9B + T5-XXL; ~8-step generation, CFG disabled (guidance 1.0, no negative prompt). Large-VRAM GPU.",
+      description: "Chroma1-Flash — fast CFG-baked text-to-image, Apache-2.0 (commercial-safe). FLUX.1-schnell-derived 8.9B + T5-XXL; Heun ~12-step generation, CFG disabled (guidance 1.0, no negative prompt). Large-VRAM GPU.",
       promptGuide: { title: "Chroma1-Flash Prompt Guide", path: "/prompt-guides/chroma1-flash.md" },
     },
   },

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -117,6 +117,15 @@ function preferredOption(defaultValue, options) {
   return options.includes(defaultValue) ? defaultValue : options[0] ?? "default";
 }
 
+function preferredResolution(model, options) {
+  const modelDefault = model?.defaults?.resolution;
+  return options.includes(modelDefault)
+    ? modelDefault
+    : options.includes("1024x1024")
+      ? "1024x1024"
+      : options[0];
+}
+
 const UPSCALE_ENGINES = [
   { id: "real-esrgan", label: "Real-ESRGAN", factors: [2, 4] },
   // SeedVR2: native-MLX one-step diffusion upscaler (Mac-only, epic 4811 / sc-4815) with a
@@ -617,9 +626,10 @@ export function ImageStudio() {
     setSampler(preferredOption(samplerDefaultFromModel(selectedModel), samplerOptions));
     setScheduler(preferredOption(schedulerDefaultFromModel(selectedModel), schedulerOptions));
     setSchedulerShift(schedulerShiftDefaultFromModel(selectedModel));
+    setResolution(preferredResolution(selectedModel, resolutionOptions));
     setStepsOverride("");
     setGuidanceOverride("");
-  }, [model, samplerOptions, schedulerOptions, selectedModel]);
+  }, [model, resolutionOptions, samplerOptions, schedulerOptions, selectedModel]);
   // Snap the sampler / scheduler back to the model's declared default when the
   // current value is no longer in the menu (e.g. user switched to a sealed
   // model whose only option is "default"). Mirrors the resolution-snap effect.
@@ -642,14 +652,8 @@ export function ImageStudio() {
     if (resolutionOptions.includes(resolution)) {
       return;
     }
-    const modelDefault = selectedModel?.defaults?.resolution;
-    const preferred = resolutionOptions.includes(modelDefault)
-      ? modelDefault
-      : resolutionOptions.includes("1024x1024")
-        ? "1024x1024"
-        : resolutionOptions[0];
-    setResolution(preferred);
-  }, [resolutionOptions, resolution, selectedModel?.defaults?.resolution]);
+    setResolution(preferredResolution(selectedModel, resolutionOptions));
+  }, [resolutionOptions, resolution, selectedModel]);
   const {
     availablePresets,
     selectedPreset,

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -229,7 +229,7 @@ describe("ImageStudio advanced model defaults", () => {
             family: "qwen-image",
             capabilities: ["text_to_image"],
             defaults: {
-              resolution: "1024x1024",
+              resolution: "1536x1024",
               sampler: "unipc",
               scheduler: "shift",
               schedulerShift: 4.2,
@@ -270,7 +270,7 @@ describe("ImageStudio advanced model defaults", () => {
     const payload = createImageJob.mock.calls[0][0];
     expect(payload.model).toBe("qwen_image");
     expect(payload.advanced).toMatchObject({
-      resolution: "1024x1024",
+      resolution: "1536x1024",
       sampler: "unipc",
       scheduler: "shift",
       schedulerShift: 4.2,

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -505,8 +505,8 @@ MODEL_TARGETS = {
         "label": "Chroma1-Flash",
         "family": "chroma",
         "supportsEdit": False,
-        # CFG baked: ~8 steps, guidance 1.0 (CFG off, negative prompt ignored).
-        "steps": 8,
+        # CFG baked: Heun at ~12 steps, guidance 1.0 (CFG off, negative prompt ignored).
+        "steps": 12,
         "guidanceScale": 1.0,
         "maxSequenceLength": 512,
         "repo": "lodestones/Chroma1-Flash",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1225,14 +1225,19 @@
         "model": "${HF_CACHE}/lodestones/Chroma1-Flash"
       },
       "defaults": {
-        // CFG baked: ~8 steps, guidance 1.0 (CFG off, negative prompt ignored).
-        "resolution": "1024x1024",
-        "steps": 8,
+        // CFG baked: Heun at ~12 steps, guidance 1.0 (CFG off, negative prompt ignored).
+        // 768² is the quality/speed sweet spot for Flash; use HD/Base for polished 1024² renders.
+        "resolution": "768x768",
+        "steps": 12,
         "guidanceScale": 1.0,
+        "sampler": "heun",
+        "scheduler": "default",
         "count": 4
       },
       "limits": {
         "resolutions": ["768x768", "1024x1024", "1280x720", "720x1280"],
+        "samplers": ["default", "euler", "heun"],
+        "schedulers": ["default"],
         "count": [1, 2, 4]
       },
       "loraCompatibility": {
@@ -1244,7 +1249,7 @@
       },
       "ui": {
         "label": "Chroma1-Flash",
-        "description": "Lodestones Chroma1-Flash — fast CFG-baked text-to-image, Apache-2.0 (commercial-safe). FLUX.1-schnell-derived 8.9B transformer + T5-XXL text encoder (no CLIP); ~8-step generation with CFG disabled (guidance 1.0, negative prompt ignored). Needs a large-VRAM GPU.",
+        "description": "Lodestones Chroma1-Flash — fast CFG-baked text-to-image, Apache-2.0 (commercial-safe). FLUX.1-schnell-derived 8.9B transformer + T5-XXL text encoder (no CLIP); Heun ~12-step generation with CFG disabled (guidance 1.0, negative prompt ignored). Needs a large-VRAM GPU.",
         "recommendedFor": ["text_to_image", "style_variations"],
         "promptGuide": {
           "title": "Chroma1-Flash Prompt Guide",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -81,7 +81,10 @@ sceneworks-core = { path = "../sceneworks-core" }
 # rev existing yet); sc-5700 re-closes it below by re-pinning candle-gen b4f6c6f -> 0eeb926 (candle-gen
 # #64, which re-pins gen-core 40063d5 -> 891bee4) so `--features backend-candle --target all` resolves
 # the single rev 891bee4 again. (candle-gen #64 merged as 89b28dd — the merge commit.)
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
+# Rev 27b0107 (mlx-gen, sc-5392): adds Chroma Flash Heun sampling and makes Flash's native MLX default
+# 12 Heun steps. gen-core is unchanged; this is a Chroma-only quality bump to reduce Flash default
+# haze/speckling while keeping Euler available for parity tests and manual fallback.
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "27b010780afebc3a69f18dcb85667acb35b55e41" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -195,6 +198,8 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # and the lightx2v lightning diff-patch LoRA (#465). Pairs with scail2_14b minMemoryGb 48 -> 96 (the
 # measured 832x480/5s footprint). Full rationale: the gen-core block above. (The intervening 40063d5
 # entry was omitted from this block by #679 — covered here.)
+# Rev 27b0107 (mlx-gen, sc-5392): Chroma Flash Heun sampler/default quality bump; EVERY mlx-gen crate
+# moves 891bee4 -> 27b0107 in lockstep even though the code delta is Chroma-only.
 # Rev fa0f75b (mlx-gen main, merged PRs #453/#454/#455 + #456, epic 5439 / sc-5448): adds the full
 # **SCAIL-2** provider (`mlx-gen-scail2`, dep below) — a Wan2.1-14B I2V end-to-end character-animation /
 # cross-identity-replacement Generator self-registering as `scail2_14b` (reference character image +
@@ -357,7 +362,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "27b010780afebc3a69f18dcb85667acb35b55e41" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -369,55 +374,55 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7e
 # internal pin (the Lens engine PRs #407–#414 did not move it; nor did the seedvr2 engine #416/#419/
 # #421 or the softness PR #422, so the 1a97909 bump above leaves mlx-rs at 44929a0).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "44929a001ab8a8837403a71c65cf064224de0cdc" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "27b010780afebc3a69f18dcb85667acb35b55e41" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "27b010780afebc3a69f18dcb85667acb35b55e41" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "27b010780afebc3a69f18dcb85667acb35b55e41" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "27b010780afebc3a69f18dcb85667acb35b55e41" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "27b010780afebc3a69f18dcb85667acb35b55e41" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "27b010780afebc3a69f18dcb85667acb35b55e41" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "27b010780afebc3a69f18dcb85667acb35b55e41" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "27b010780afebc3a69f18dcb85667acb35b55e41" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "27b010780afebc3a69f18dcb85667acb35b55e41" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "27b010780afebc3a69f18dcb85667acb35b55e41" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "27b010780afebc3a69f18dcb85667acb35b55e41" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "27b010780afebc3a69f18dcb85667acb35b55e41" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -426,12 +431,12 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "27b010780afebc3a69f18dcb85667acb35b55e41" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "27b010780afebc3a69f18dcb85667acb35b55e41" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -440,7 +445,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "27b010780afebc3a69f18dcb85667acb35b55e41" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -448,7 +453,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "27b010780afebc3a69f18dcb85667acb35b55e41" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -459,7 +464,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891b
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "27b010780afebc3a69f18dcb85667acb35b55e41" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -470,7 +475,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891be
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "27b010780afebc3a69f18dcb85667acb35b55e41" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -485,7 +490,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee
 # converted in-memory at load (no Python); the precomputed neg-prompt embedding is bundled in-crate. No
 # LoRA/guidance/CFG (one-step). 3B fp16 only here — 7B (sc-5197) + int8 (sc-5198) are engine-side and
 # unwired. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "27b010780afebc3a69f18dcb85667acb35b55e41" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -496,7 +501,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "27b010780afebc3a69f18dcb85667acb35b55e41" }
 # Prompt-refine provider (sc-5552, the MLX twin of candle-gen-prompt-refine / sc-5500). An
 # inventory-registered `TextLlm` under id `prompt_refine` (`backend="mlx"`, `mac_only`): a native MLX
 # Llama-3.2-3B-Instruct that rewrites a user's prompt, replacing the Python `prompt_refine.py`
@@ -506,7 +511,7 @@ mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891
 # textllm registered" trap). Weights = a stock Llama-3.2-3B-Instruct HF snapshot (config.json +
 # tokenizer.json + model-*.safetensors; default `huihui-ai/Llama-3.2-3B-Instruct-abliterated`). Same
 # git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
+mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "27b010780afebc3a69f18dcb85667acb35b55e41" }
 # SCAIL-2 (zai-org) end-to-end character-animation provider (epic 5439, sc-5448). An inventory-registered
 # `Generator` under id `scail2_14b` (`Modality::Video`): a Wan2.1-14B I2V DiT that animates a reference
 # character with a driving video's motion (`video_mode == "replacement"` flips the cross-identity
@@ -518,7 +523,7 @@ mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev 
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "891bee46e7ec7d7a5b3074eaea183d2e87be9d2a" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "27b010780afebc3a69f18dcb85667acb35b55e41" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -228,14 +228,14 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
         default_guidance: 3.0,
         adapter_label: "mlx_chroma",
     },
-    // Flash is the few-step distilled checkpoint: ~8 steps, CFG baked toward 1.0 (single forward —
+    // Flash is the few-step distilled checkpoint: ~12 Heun steps, CFG baked toward 1.0 (single forward —
     // the negative prompt is effectively inert at true_cfg≈1). It shares the true-CFG descriptor,
     // so `true_cfg` still carries the scale (default 1.0).
     ModelRow {
         sceneworks_id: "chroma1_flash",
         engine_id: "chroma1_flash",
         default_repo: "lodestones/Chroma1-Flash",
-        default_steps: 8,
+        default_steps: 12,
         default_guidance: 1.0,
         adapter_label: "mlx_chroma",
     },

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -555,6 +555,9 @@ fn generate_one(
     negative_prompt: Option<String>,
     reference: Option<&(Image, f32)>,
     true_cfg: Option<f32>,
+    sampler: Option<&str>,
+    scheduler: Option<&str>,
+    scheduler_shift: Option<f32>,
     cancel: &CancelFlag,
     on_progress: &mut dyn FnMut(Progress),
 ) -> WorkerResult<(u32, u32, Vec<u8>)> {
@@ -575,6 +578,9 @@ fn generate_one(
         steps: Some(steps),
         guidance,
         true_cfg,
+        sampler: sampler.map(str::to_owned),
+        scheduler: scheduler.map(str::to_owned),
+        scheduler_shift,
         conditioning,
         cancel: cancel.clone(),
         ..Default::default()
@@ -817,6 +823,30 @@ async fn generate_stream(
     let (quant, quant_bits) = resolve_quant(request);
     let steps = resolve_steps(request, &model);
     let guidance = resolve_guidance(request, &model);
+    let sampler = request
+        .advanced
+        .get("sampler")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty() && *value != "default")
+        .map(str::to_owned);
+    let scheduler = request
+        .advanced
+        .get("scheduler")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty() && *value != "default")
+        .map(str::to_owned);
+    let scheduler_shift = request
+        .advanced
+        .get("schedulerShift")
+        .or_else(|| request.advanced.get("timestepShift"))
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .map(|value| value as f32);
     // True-CFG families (Chroma) carry the CFG scale in `true_cfg`, not `guidance` (which their
     // engine rejects); `None` for every other family. The recipe records the effective CFG knob.
     let model_true_cfg = resolve_true_cfg(request, &model);
@@ -936,6 +966,9 @@ async fn generate_stream(
                     negative_prompt.clone(),
                     identity_init.as_ref(),
                     true_cfg,
+                    sampler.as_deref(),
+                    scheduler.as_deref(),
+                    scheduler_shift,
                     &cancel,
                     on_progress,
                 )?;

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -874,6 +874,9 @@ fn smoke_generate_one(
         negative_prompt,
         None,
         None,
+        None,
+        None,
+        None,
         &cancel,
         &mut |p| {
             if let gen_core::Progress::Step { current, .. } = p {
@@ -1044,6 +1047,9 @@ fn lens_turbo_real_weights_bucket_resolution() {
         None,
         None,
         None,
+        None,
+        None,
+        None,
         &cancel,
         &mut |_p| {},
     )
@@ -1149,6 +1155,9 @@ fn kolors_real_weights_img2img_generates_one_image() {
         Some("blurry, low quality".to_owned()),
         Some(&(source, 0.6)),
         None,
+        None,
+        None,
+        None,
         &cancel,
         &mut |p| {
             if let gen_core::Progress::Step { current, .. } = p {
@@ -1194,6 +1203,9 @@ fn kolors_real_weights_ip_adapter_generates_one_image() {
         Some(5.0),
         Some("blurry, low quality".to_owned()),
         Some(&(reference, 0.6)),
+        None,
+        None,
+        None,
         None,
         &cancel,
         &mut |p| {
@@ -1523,6 +1535,9 @@ fn smoke_generate_one_true_cfg(
         negative_prompt,
         None,
         true_cfg,
+        None,
+        None,
+        None,
         &cancel,
         &mut |p| {
             if let gen_core::Progress::Step { current, .. } = p {
@@ -1708,6 +1723,9 @@ fn sc3031_ab_dump_txt2img() {
         steps,
         guidance,
         negative,
+        None,
+        None,
+        None,
         None,
         None,
         &cancel,

--- a/tests/test_worker_image_adapters.py
+++ b/tests/test_worker_image_adapters.py
@@ -1401,8 +1401,8 @@ def test_chroma_model_target_defaults():
     assert base["steps"] == 40
     assert base["guidanceScale"] == 3.0
     assert base["repo"] == "lodestones/Chroma1-Base"
-    # Flash: CFG baked off (~8 steps, guidance 1.0).
-    assert flash["steps"] == 8
+    # Flash: CFG baked off (~12 Heun steps, guidance 1.0).
+    assert flash["steps"] == 12
     assert flash["guidanceScale"] == 1.0
     assert flash["repo"] == "lodestones/Chroma1-Flash"
 
@@ -1424,7 +1424,7 @@ def test_chroma_num_inference_steps_default_and_override():
     flash = MODEL_TARGETS["chroma1_flash"]
     # Defaults come straight from the model target.
     assert adapter._num_inference_steps(SimpleNamespace(advanced={}), hd) == 40
-    assert adapter._num_inference_steps(SimpleNamespace(advanced={}), flash) == 8
+    assert adapter._num_inference_steps(SimpleNamespace(advanced={}), flash) == 12
     # Explicit override is honored and clamped to [1, 80].
     assert adapter._num_inference_steps(SimpleNamespace(advanced={"steps": 20}), hd) == 20
     assert adapter._num_inference_steps(SimpleNamespace(advanced={"steps": 999}), flash) == 80


### PR DESCRIPTION
## Summary
- pin mlx-gen to 27b0107 / PR #466 for Chroma Flash Heun sampling
- set Chroma1-Flash defaults to 768x768, 12 steps, sampler=heun, CFG 1.0
- forward sampler/scheduler fields through the shared Mac MLX image generation path
- reset Image Studio resolution on model switch so model-specific defaults actually apply
- update Chroma Flash prompt guide and fallback catalog copy

## Validation
- cargo test -p sceneworks-worker image_jobs::tests::chroma_flash_real_weights_generates_one_image -- --ignored --exact --nocapture
- SC3031 worker render: "A cinematic frame of a neon street at midnight", 768x768, 12 steps, sampler=heun, seed 424242 -> /tmp/sc5392/neon_sceneworks_heun_768.png
- npm test -- ImageStudio.test.jsx
- npm run lint (passes with existing warnings; 0 errors)
- git diff --check