### PR TITLE
sc-5494: wire candle worker video lane for Wan-VACE modes (replace/extend/bridge)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -490,7 +490,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -504,7 +504,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -527,7 +527,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -541,7 +541,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -554,7 +554,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -566,7 +566,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -577,7 +577,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -591,7 +591,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -609,7 +609,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -622,7 +622,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -633,7 +633,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -646,7 +646,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a89a595664fec9f03e4eaeb17db59de505b45290#a89a595664fec9f03e4eaeb17db59de505b45290"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
 dependencies = [
  "candle-core",
  "candle-gen",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3370,22 +3370,26 @@ const CANDLE_VIDEO_ROUTED_MODELS: &[&str] = &[
 /// `sourceAssetId` — the inverse of the txt2video-only gate the 5B / T2V-14B / ltx ids use.
 const CANDLE_VIDEO_I2V_ROUTED_MODELS: &[&str] = &["wan_2_2_i2v_14b", "svd"];
 
-/// Does this video job belong on the candle video lane (sc-5097 txt2video; sc-5175 adds the Wan2.2
-/// 14B I2V image→video)? The candle wan/ltx providers drive plain text-to-video, plus the 14B I2V's
-/// single source-image conditioning — but no first-last-frame / extend / bridge / replace (the
-/// advanced job types), no reference/mask conditioning, and no LoRAs. Every other shape must fall back
-/// to the Python torch worker, so the candle worker refuses it here. The per-model shape gate is
-/// [`video_request_candle_eligible`].
+/// Does this video job belong on the candle video lane? The candle wan/ltx providers drive plain
+/// text-to-video, the 14B I2V's single source-image conditioning (sc-5175), SVD image→video (sc-5493),
+/// **and** the Wan-VACE advanced modes — replace_person / extend / bridge (sc-5494, the `PersonReplace`
+/// / `VideoExtend` / `VideoBridge` job types → the candle `wan_vace` engine). Every other shape
+/// (reference/mask/first-last-frame conditioning, LoRAs, SCAIL-2 replace) must fall back to the Python
+/// torch worker, so the candle worker refuses it here. The per-model shape gates are
+/// [`video_request_candle_eligible`] (base) and [`video_request_candle_vace_eligible`] (VACE modes).
 fn video_job_is_candle_eligible(job: &JobSnapshot) -> bool {
-    // Only the base `video_generate` job type — the advanced types (VideoExtend/VideoBridge/
-    // PersonReplace) are conditioned modes the candle lane doesn't serve.
-    if !matches!(job.job_type, JobType::VideoGenerate) {
-        return false;
-    }
     let Some(model) = job.payload.get("model").and_then(Value::as_str) else {
         return false;
     };
-    video_request_candle_eligible(model, &job.payload)
+    match job.job_type {
+        // The base txt2video / image→video lane (sc-5097 / sc-5175 / sc-5493).
+        JobType::VideoGenerate => video_request_candle_eligible(model, &job.payload),
+        // The Wan-VACE advanced modes (sc-5494): replace_person / extend_clip / video_bridge.
+        JobType::PersonReplace | JobType::VideoExtend | JobType::VideoBridge => {
+            video_request_candle_vace_eligible(model, &job.payload, &job.job_type)
+        }
+        _ => false,
+    }
 }
 
 /// Per-model candle txt2video-eligibility, factored out so the routing tests can probe it with
@@ -3434,6 +3438,68 @@ fn video_request_candle_eligible(model: &str, payload: &Map<String, Value>) -> b
         return false;
     }
     // On-the-fly quantization → torch (the candle video providers are dense; sc-5099).
+    if candle_request_wants_quant(payload) {
+        return false;
+    }
+    true
+}
+
+/// The candle video models eligible for the Wan-VACE advanced modes (sc-5494). These route to the
+/// single candle `wan_vace` engine regardless of the user's wan pick. The SCAIL-2 person-replace
+/// backend is MLX-only, so `scail2_*` is deliberately absent (those stay on the torch / mac worker).
+const CANDLE_VIDEO_VACE_MODELS: &[&str] = &["wan_2_2", "wan_2_2_t2v_14b", "wan_2_2_i2v_14b"];
+
+/// Candle Wan-VACE eligibility for the advanced video job types (sc-5494): `PersonReplace`
+/// (replace_person), `VideoExtend` (extend_clip), `VideoBridge` (video_bridge). Routes to the candle
+/// `wan_vace` engine when the model is VACE-capable and the per-mode source assets are present. LoRA /
+/// on-the-fly quant are not in the candle video lane (the VACE provider rejects them). Factored out so
+/// the routing tests can probe it with synthetic payloads (parity with [`video_request_candle_eligible`]).
+fn video_request_candle_vace_eligible(
+    model: &str,
+    payload: &Map<String, Value>,
+    job_type: &JobType,
+) -> bool {
+    if !CANDLE_VIDEO_VACE_MODELS.contains(&model) {
+        return false;
+    }
+    let has_nonempty_id = |key: &str| {
+        payload
+            .get(key)
+            .and_then(Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty())
+    };
+    match job_type {
+        // replace_person: the source control clip + the tracked person + the character references.
+        JobType::PersonReplace => {
+            if !has_nonempty_id("sourceClipAssetId")
+                || !has_nonempty_id("personTrackId")
+                || !has_nonempty_id("characterId")
+            {
+                return false;
+            }
+        }
+        // extend_clip: the source clip whose tail anchors the continuation.
+        JobType::VideoExtend => {
+            if !has_nonempty_id("sourceClipAssetId") {
+                return false;
+            }
+        }
+        // video_bridge: both clips (the left tail + the right head) are pinned around the gap.
+        JobType::VideoBridge => {
+            if !has_nonempty_id("sourceClipAssetId") || !has_nonempty_id("bridgeRightClipAssetId") {
+                return false;
+            }
+        }
+        _ => return false,
+    }
+    // LoRAs / on-the-fly quant are not in the candle video lane (the VACE provider rejects them).
+    if payload
+        .get("loras")
+        .and_then(Value::as_array)
+        .is_some_and(|loras| !loras.is_empty())
+    {
+        return false;
+    }
     if candle_request_wants_quant(payload) {
         return false;
     }
@@ -4897,6 +4963,70 @@ mod candle_routing_tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn candle_vace_modes_eligible_with_required_assets() {
+        // replace_person (PersonReplace): needs the source clip + person track + character.
+        assert!(video_request_candle_vace_eligible(
+            "wan_2_2",
+            &object(json!({
+                "sourceClipAssetId": "clip_1",
+                "personTrackId": "track_1",
+                "characterId": "char_1"
+            })),
+            &JobType::PersonReplace
+        ));
+        // extend_clip (VideoExtend): needs a source clip.
+        assert!(video_request_candle_vace_eligible(
+            "wan_2_2_t2v_14b",
+            &object(json!({ "sourceClipAssetId": "clip_1" })),
+            &JobType::VideoExtend
+        ));
+        // video_bridge (VideoBridge): needs both clips.
+        assert!(video_request_candle_vace_eligible(
+            "wan_2_2_i2v_14b",
+            &object(json!({ "sourceClipAssetId": "l", "bridgeRightClipAssetId": "r" })),
+            &JobType::VideoBridge
+        ));
+    }
+
+    #[test]
+    fn candle_vace_modes_fall_back_without_assets_or_for_unsupported_models() {
+        // Missing required assets → torch.
+        assert!(!video_request_candle_vace_eligible(
+            "wan_2_2",
+            &object(json!({ "sourceClipAssetId": "clip_1" })), // no personTrackId / characterId
+            &JobType::PersonReplace
+        ));
+        assert!(!video_request_candle_vace_eligible(
+            "wan_2_2",
+            &object(json!({ "sourceClipAssetId": "l" })), // bridge needs the right clip too
+            &JobType::VideoBridge
+        ));
+        // SCAIL-2 (MLX-only) is not a candle VACE model → torch.
+        assert!(!video_request_candle_vace_eligible(
+            "scail2_14b",
+            &object(json!({ "sourceClipAssetId": "c", "personTrackId": "t", "characterId": "ch" })),
+            &JobType::PersonReplace
+        ));
+        // A LoRA shape → torch (the candle VACE provider advertises no adapters).
+        assert!(!video_request_candle_vace_eligible(
+            "wan_2_2",
+            &object(json!({
+                "sourceClipAssetId": "c",
+                "personTrackId": "t",
+                "characterId": "ch",
+                "loras": [{ "name": "x" }]
+            })),
+            &JobType::PersonReplace
+        ));
+        // A non-VACE job type is never VACE-eligible (the base txt2video gate handles VideoGenerate).
+        assert!(!video_request_candle_vace_eligible(
+            "wan_2_2",
+            &object(json!({ "sourceClipAssetId": "c", "personTrackId": "t", "characterId": "ch" })),
+            &JobType::VideoGenerate
+        ));
     }
 
     #[test]

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -638,36 +638,43 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "27b0
 # is a behavior-neutral source-pin-only re-pin of `sceneworks-gen-core` + testkit to 27b0107. a89a595 now
 # resolves gen-core `27b0107` == this worker's mlx-gen pin, so the `--features backend-candle` graph
 # resolves exactly ONE gen-core rev again. ALL candle deps MUST share this rev.
+#
+# sc-5494 (Wan-VACE) bumps the candle pin `a89a595` -> `a5e6c4b` (candle-gen #70): ADDS the candle
+# Wan-VACE controllable-video provider (`wan_vace`, epic 5481) the worker advanced-video lane routes
+# replace_person / extend_clip / video_bridge onto. #70 is SOURCE-ONLY and a89a595 is its ancestor, so
+# a5e6c4b still resolves gen-core `27b0107` == this worker's mlx-gen pin (single gen-core rev, no skew).
 [target.'cfg(target_os = "windows")'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a595664fec9f03e4eaeb17db59de505b45290", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a595664fec9f03e4eaeb17db59de505b45290", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a595664fec9f03e4eaeb17db59de505b45290", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a595664fec9f03e4eaeb17db59de505b45290", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a595664fec9f03e4eaeb17db59de505b45290", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a595664fec9f03e4eaeb17db59de505b45290", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
-# `wan2_2_ti2v_5b`; ltx registers `ltx_2_3_distilled` (txt2video first slice — no conditioning/audio/
-# LoRA/quant). Force-linked in video_jobs.rs (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a595664fec9f03e4eaeb17db59de505b45290", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a595664fec9f03e4eaeb17db59de505b45290", features = ["cuda"], optional = true }
+# `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
+# Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
+# extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled`. Force-linked in video_jobs.rs
+# (`use candle_gen_<x> as _;`). Same rev as the others.
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a595664fec9f03e4eaeb17db59de505b45290", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a595664fec9f03e4eaeb17db59de505b45290", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -676,19 +683,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a595664fec9f03e4eaeb17db59de505b45290", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a595664fec9f03e4eaeb17db59de505b45290", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a595664fec9f03e4eaeb17db59de505b45290", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -697,12 +704,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a595664fec9f03e4eaeb17db59de505b45290", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a595664fec9f03e4eaeb17db59de505b45290", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -710,7 +717,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a5
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a89a595664fec9f03e4eaeb17db59de505b45290", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96", features = ["cuda"], optional = true }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -84,7 +84,10 @@ use candle_gen_ltx as _;
 use candle_gen_svd as _;
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
 use candle_gen_wan as _;
-#[cfg(any(target_os = "macos", all(target_os = "windows", feature = "backend-candle")))]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 use sceneworks_core::character_store::CharacterStore;
 // Frame-count stride coercion (Wan needs frames ≡ 1 mod 4; LTX snaps to 8k+1) — used by the MLX path
 // and the candle entry (sc-5097).
@@ -1909,7 +1912,10 @@ fn resolve_wan_conditioning(
 }
 
 /// Which boundary frame of a source clip to extract for Wan-native clip conditioning (sc-3357).
-#[cfg(any(target_os = "macos", all(target_os = "windows", feature = "backend-candle")))]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum ClipFramePosition {
     /// The clip's first decoded frame (the right-side clip's head for `video_bridge`).

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -47,10 +47,16 @@ use gen_core::{
     AdapterSpec, CancelFlag, Conditioning, GenerationOutput, GenerationRequest, Generator,
     LoadSpec, Precision, Progress, Quant, WeightsSource,
 };
-// MLX-only contract types (LoRA classification, MoE experts, ControlNet/VACE conditioning, Wan-VACE
-// replacement) — the candle txt2video first slice uses none of these.
+// MLX-only contract types (LoRA classification, MoE experts) — the candle video lane uses none of these.
 #[cfg(target_os = "macos")]
-use gen_core::{AdapterKind, Image, MoeExpert, ReplacementMode};
+use gen_core::{AdapterKind, MoeExpert};
+// VACE conditioning + replacement types are shared by the MLX Wan-VACE path and the candle Wan-VACE
+// lane (sc-5494), so they are available on both the macos and windows+backend-candle builds.
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
+use gen_core::{Image, ReplacementMode};
 #[cfg(target_os = "macos")]
 use mlx_gen_ltx as _;
 #[cfg(target_os = "macos")]
@@ -78,7 +84,7 @@ use candle_gen_ltx as _;
 use candle_gen_svd as _;
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
 use candle_gen_wan as _;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", all(target_os = "windows", feature = "backend-candle")))]
 use sceneworks_core::character_store::CharacterStore;
 // Frame-count stride coercion (Wan needs frames ≡ 1 mod 4; LTX snaps to 8k+1) — used by the MLX path
 // and the candle entry (sc-5097).
@@ -395,19 +401,53 @@ pub(crate) async fn run_video_generate_job(
     // off → routing unchanged until parity). Conditioning shapes never reach here — the router's
     // `video_job_is_candle_eligible` confines the candle worker to txt2video.
     #[cfg(all(target_os = "windows", feature = "backend-candle"))]
-    let (decoded, adapter, raw_settings, replacement_status) =
-        if settings.backend_candle_enabled && is_candle_video_engine(&request.model) {
-            let (decoded, adapter, raw_settings) =
-                generate_candle_video(api, settings, job, &request, &project_path, backend).await?;
-            (decoded, adapter, raw_settings, None::<Value>)
-        } else {
-            (
-                generate_stub_video(&request, seed),
-                STUB_ADAPTER,
-                stub_raw_settings(&request),
-                None::<Value>,
-            )
-        };
+    let (decoded, adapter, raw_settings, replacement_status) = if settings.backend_candle_enabled
+        && request.mode == "replace_person"
+    {
+        // Candle Wan-VACE person replacement (sc-5494) — the candle equivalent of the MLX `wan_vace`
+        // path. The router (`video_request_candle_eligible`) already confirmed the candle-VACE model +
+        // the source clip + person track before this job reached the candle worker; `generate_candle_
+        // wan_vace` resolves-or-errors loudly (a person-replace must never silently degrade to a stub).
+        let (decoded, status) =
+            generate_candle_wan_vace(api, settings, job, &request, &project_path, backend).await?;
+        (
+            decoded,
+            CANDLE_WAN_VACE_ADAPTER,
+            wan_vace_raw_settings(&request),
+            Some(status),
+        )
+    } else if settings.backend_candle_enabled
+        && matches!(request.mode.as_str(), "extend_clip" | "video_bridge")
+    {
+        // Candle Wan-VACE extend/bridge (sc-5494): real source frames pinned at the kept positions +
+        // a generated span (the candle equivalent of the MLX `generate_wan_vace_extend_bridge`).
+        let decoded = generate_candle_wan_vace_extend_bridge(
+            api,
+            settings,
+            job,
+            &request,
+            &project_path,
+            backend,
+        )
+        .await?;
+        (
+            decoded,
+            CANDLE_WAN_VACE_ADAPTER,
+            wan_vace_extend_raw_settings(&request),
+            None::<Value>,
+        )
+    } else if settings.backend_candle_enabled && is_candle_video_engine(&request.model) {
+        let (decoded, adapter, raw_settings) =
+            generate_candle_video(api, settings, job, &request, &project_path, backend).await?;
+        (decoded, adapter, raw_settings, None::<Value>)
+    } else {
+        (
+            generate_stub_video(&request, seed),
+            STUB_ADAPTER,
+            stub_raw_settings(&request),
+            None::<Value>,
+        )
+    };
     #[cfg(not(any(
         target_os = "macos",
         all(target_os = "windows", feature = "backend-candle")
@@ -1869,7 +1909,7 @@ fn resolve_wan_conditioning(
 }
 
 /// Which boundary frame of a source clip to extract for Wan-native clip conditioning (sc-3357).
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", all(target_os = "windows", feature = "backend-candle")))]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum ClipFramePosition {
     /// The clip's first decoded frame (the right-side clip's head for `video_bridge`).
@@ -2663,6 +2703,17 @@ const CANDLE_LTX_REPO: &str = "Lightricks/LTX-2.3";
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
 const CANDLE_LTX_GEMMA_REPO: &str = "google/gemma-3-12b-it";
 
+/// Per-asset adapter id for the candle Wan-VACE controllable-video lane (sc-5494) — the candle sibling
+/// of the MLX `mlx_wan_vace` label.
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+const CANDLE_WAN_VACE_ADAPTER: &str = "candle_wan_vace";
+
+/// The diffusers Wan2.1-VACE-14B snapshot the candle `wan_vace` provider reads (`transformer/` +
+/// `text_encoder/` + `vae/` + `tokenizer/`). Overridable via `SCENEWORKS_CANDLE_WAN_VACE_DIR`. The 14B
+/// repo matches the provider's `WanVaceConfig::vace_14b` dims (dim 5120, 40 layers).
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+const CANDLE_WAN_VACE_REPO: &str = "Wan-AI/Wan2.1-VACE-14B-diffusers";
+
 /// SceneWorks video model id → candle registry engine id, or `None` for an id the candle video lane
 /// does not serve. Note ltx maps to `ltx_2_3_distilled` (the candle provider's id), not the MLX
 /// `ltx_2_3`. Covers the base txt2video ids (5B + ltx) plus the Wan2.2 **14B** dual-expert MoE pair
@@ -2909,6 +2960,196 @@ async fn generate_candle_video(
     let raw_settings = candle_video_raw_settings(request, &repo);
     let decoded = generate_video(api, settings, job, backend, input).await?;
     Ok((decoded, adapter, raw_settings))
+}
+
+/// Resolve the candle Wan-VACE diffusers snapshot dir (sc-5494): `SCENEWORKS_CANDLE_WAN_VACE_DIR`
+/// override (when it holds a `transformer/config.json`), else the HF [`CANDLE_WAN_VACE_REPO`] snapshot.
+/// Errors loudly when absent (no stub fallback — a missing VACE checkpoint surfaces a re-download error).
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+fn resolve_candle_wan_vace_model_dir(settings: &Settings) -> WorkerResult<PathBuf> {
+    if let Ok(dir) = std::env::var("SCENEWORKS_CANDLE_WAN_VACE_DIR") {
+        let path = PathBuf::from(dir.trim());
+        if path.join("transformer").join("config.json").is_file() {
+            return Ok(path);
+        }
+    }
+    candle_video_snapshot_dir(settings, CANDLE_WAN_VACE_REPO)
+}
+
+/// Windows/CUDA candle Wan-VACE `replace_person` (sc-5494): the candle sibling of the MLX
+/// [`generate_wan_vace`]. Resolves the diffusers VACE snapshot, extracts the source-clip control frames,
+/// builds the per-frame person mask from the saved track + the character references, and runs the
+/// `wan_vace` engine. Person detect/track/segment stays upstream (the masks are pre-saved); the
+/// conditioning builders are shared with the MLX path. No quant / LoRA (the candle VACE provider rejects
+/// them). Returns the decoded clip + the honest `replacementStatus`.
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+async fn generate_candle_wan_vace(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &VideoRequest,
+    project_path: &Path,
+    backend: &str,
+) -> WorkerResult<(DecodedVideo, Value)> {
+    let model_dir = resolve_candle_wan_vace_model_dir(settings)?;
+    let track_id = request.person_track_id.as_deref().ok_or_else(|| {
+        WorkerError::InvalidPayload(
+            "replace_person requires a person track (personTrackId).".to_owned(),
+        )
+    })?;
+    let track = ProjectStore::new(settings.data_dir.clone(), "worker")
+        .get_person_track(&request.project_id, track_id)
+        .map_err(|error| {
+            WorkerError::InvalidPayload(format!("person track {track_id}: {error}"))
+        })?;
+
+    let frame_count = wan_frame_count(request.raw_frame_count()) as usize;
+    let frames =
+        load_source_video_frames(api, settings, job, request, project_path, frame_count).await?;
+    let (masks, mask_mode) = crate::person_replace::person_track_masks(
+        project_path,
+        &track,
+        request.width,
+        request.height,
+        frames.len(),
+    )?;
+    let references = resolve_character_references(settings, request, project_path)?;
+    let reference_count = references.len();
+    let frame_total = frames.len();
+
+    let masking_strength = advanced::f32(&request.advanced, "maskingStrength", 1.0);
+    let conditioning = build_vace_conditioning(
+        frames,
+        masks,
+        references,
+        masking_strength,
+        replacement_mode_from(&request.replacement_mode),
+    )?;
+    let negative_prompt = {
+        let trimmed = request.negative_prompt.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_owned())
+    };
+    let input = VideoGenInput {
+        engine_id: "wan_vace",
+        model_dir,
+        conditioning,
+        prompt: request.prompt.clone(),
+        negative_prompt,
+        width: request.width,
+        height: request.height,
+        frames: frame_count as u32,
+        fps: request.fps,
+        steps: advanced_opt_u32(request, "steps"),
+        guidance: advanced_opt_f32(request, "guidanceScale"),
+        seed: resolve_video_seed(request) as u64,
+        control_scale: Some(advanced::f32(&request.advanced, "conditioningScale", 1.0)),
+        ..VideoGenInput::default()
+    };
+    let decoded = generate_video(api, settings, job, backend, input).await?;
+    let status = replacement_status_value(
+        &track,
+        track_id,
+        mask_mode,
+        masking_strength,
+        reference_count,
+        frame_total,
+        CANDLE_WAN_VACE_ADAPTER,
+    );
+    Ok((decoded, status))
+}
+
+/// Windows/CUDA candle Wan-VACE `extend_clip` / `video_bridge` (sc-5494): the candle sibling of the MLX
+/// [`generate_wan_vace_extend_bridge`]. Loads the real source-clip anchor frames (the left clip's tail
+/// for extend; both clips' boundaries for bridge), builds the source-at-kept-positions + generated-span
+/// ControlClip, and runs the `wan_vace` engine. No reference images, no quant / LoRA.
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+async fn generate_candle_wan_vace_extend_bridge(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &VideoRequest,
+    project_path: &Path,
+    backend: &str,
+) -> WorkerResult<DecodedVideo> {
+    let model_dir = resolve_candle_wan_vace_model_dir(settings)?;
+    let frame_count = wan_frame_count(request.raw_frame_count()) as usize;
+    let anchor = extend_anchor_frames(request, frame_count);
+    let left_id = request.source_clip_asset_id.as_deref().ok_or_else(|| {
+        WorkerError::InvalidPayload(format!(
+            "{} requires a source clip (sourceClipAssetId).",
+            request.mode.replace('_', " ")
+        ))
+    })?;
+    let left_anchor = load_clip_anchor_frames(
+        api,
+        settings,
+        job,
+        &request.project_id,
+        project_path,
+        left_id,
+        request.width,
+        request.height,
+        anchor,
+        ClipFramePosition::Last,
+    )
+    .await?;
+    let right_anchor = if request.mode == "video_bridge" {
+        let right_id = request
+            .bridge_right_clip_asset_id
+            .as_deref()
+            .ok_or_else(|| {
+                WorkerError::InvalidPayload(
+                    "video_bridge requires a right-side source clip (bridgeRightClipAssetId)."
+                        .to_owned(),
+                )
+            })?;
+        Some(
+            load_clip_anchor_frames(
+                api,
+                settings,
+                job,
+                &request.project_id,
+                project_path,
+                right_id,
+                request.width,
+                request.height,
+                anchor,
+                ClipFramePosition::First,
+            )
+            .await?,
+        )
+    } else {
+        None
+    };
+    let conditioning = build_extend_bridge_vace_conditioning(
+        request,
+        request.width,
+        request.height,
+        frame_count,
+        left_anchor,
+        right_anchor,
+    )?;
+    let negative_prompt = {
+        let trimmed = request.negative_prompt.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_owned())
+    };
+    let input = VideoGenInput {
+        engine_id: "wan_vace",
+        model_dir,
+        conditioning,
+        prompt: request.prompt.clone(),
+        negative_prompt,
+        width: request.width,
+        height: request.height,
+        frames: frame_count as u32,
+        fps: request.fps,
+        steps: advanced_opt_u32(request, "steps"),
+        guidance: advanced_opt_f32(request, "guidanceScale"),
+        seed: resolve_video_seed(request) as u64,
+        control_scale: Some(advanced::f32(&request.advanced, "conditioningScale", 1.0)),
+        ..VideoGenInput::default()
+    };
+    generate_video(api, settings, job, backend, input).await
 }
 
 /// Resolve a Wan request into a [`VideoGenInput`] and run it (sc-3034).
@@ -4077,7 +4318,10 @@ fn build_video_clip_conditioning(
 /// Resolve an asset id to its on-disk media file path (the source clip mp4), mirroring the asset
 /// lookup in [`load_reference_image`] but returning the path for ffmpeg frame extraction (the
 /// Rust equivalent of the torch `source_asset_media_path`).
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn resolve_clip_media_path(
     settings: &Settings,
     project_id: &str,
@@ -4656,12 +4900,18 @@ const WAN_VACE_ADAPTER: &str = "mlx_wan_vace";
 /// background (`0x12110f` = RGB 18,17,15) so the box masks (rasterized from the same
 /// normalized boxes at W×H) stay aligned with the control frames through the engine's
 /// identity-resize preprocess.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 const FRAME_PAD_COLOR: &str = "0x12110f";
 
 /// Raw-settings recorded on a real Wan-VACE asset (`advanced` knobs + the real-inference
 /// markers; the engine id is `wan_vace`, not the user-picked replace-capable model).
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn wan_vace_raw_settings(request: &VideoRequest) -> Value {
     let mut raw = request.advanced.clone();
     raw.insert("realModelInference".to_owned(), Value::Bool(true));
@@ -4679,7 +4929,10 @@ fn wan_vace_raw_settings(request: &VideoRequest) -> Value {
 }
 
 /// SceneWorks `replacementMode` string → engine [`ReplacementMode`] (default FaceOnly).
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn replacement_mode_from(value: &str) -> ReplacementMode {
     match value {
         "full_person_keep_outfit" => ReplacementMode::FullPersonKeepOutfit,
@@ -4759,7 +5012,10 @@ fn resolve_wan_vace_model_dir(settings: &Settings) -> WorkerResult<PathBuf> {
 /// `FRAME_PAD_COLOR`), evenly resampled across the clip — the new shared frame-extraction
 /// helper (Python `load_source_video_frames`; also the seam extend/bridge will reuse). The
 /// frames are the (un-neutralized) Wan-VACE control video; the engine masks them.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 async fn load_source_video_frames(
     api: &ApiClient,
     settings: &Settings,
@@ -4829,7 +5085,10 @@ async fn load_source_video_frames(
 /// Collect the extracted PNG frames in `work_dir`, resample them to `count` evenly-spaced
 /// indices (Python `evenly_spaced_indices` — the same arithmetic as the mask resample), and
 /// decode the selected frames to engine [`Image`]s. Blocking IO/decoding runs off the runtime.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 async fn select_extracted_frames(work_dir: PathBuf, count: usize) -> WorkerResult<Vec<Image>> {
     tokio::task::spawn_blocking(move || -> WorkerResult<Vec<Image>> {
         let mut paths: Vec<PathBuf> = std::fs::read_dir(&work_dir)?
@@ -4856,7 +5115,10 @@ async fn select_extracted_frames(work_dir: PathBuf, count: usize) -> WorkerResul
 /// `character_reference_images`): the selected look's `approvedReferenceIds`, else the
 /// character's approved `references`. Errors when none are readable (the torch
 /// `_validate_inputs` parity). The engine cover-fits each to the output size.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn resolve_character_references(
     settings: &Settings,
     request: &VideoRequest,
@@ -4919,7 +5181,10 @@ fn resolve_character_references(
 }
 
 /// Convert an `image::RgbImage` (the rasterized mask) to an engine [`Image`].
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn rgb_image_to_engine(image: image::RgbImage) -> Image {
     Image {
         width: image.width(),
@@ -4931,7 +5196,10 @@ fn rgb_image_to_engine(image: image::RgbImage) -> Image {
 /// Build the Wan-VACE conditioning: one [`Conditioning::ControlClip`] (source frames + the
 /// per-frame person mask; the engine neutralizes the masked region) plus one
 /// [`Conditioning::Reference`] per character reference image.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn build_vace_conditioning(
     frames: Vec<Image>,
     masks: Vec<image::RgbImage>,
@@ -4966,7 +5234,10 @@ fn build_vace_conditioning(
 
 /// The honest `replacementStatus` recorded on the asset fact (mirrors the torch
 /// `replacement_status`); the API folds it into the video sidecar's normalizedSettings.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn replacement_status_value(
     track: &Value,
     track_id: &str,
@@ -5119,7 +5390,10 @@ async fn generate_wan_vace(
 /// Mid-gray (≈0 after the engine's `2·x/255 − 1` normalization) control frame for the
 /// to-generate span: a neutral `reactive = video·mask` signal so the masked region is generated
 /// freely from the kept frames + prompt, never biased toward a frozen filler image.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn neutral_control_frame(width: u32, height: u32) -> Image {
     Image {
         width,
@@ -5130,7 +5404,10 @@ fn neutral_control_frame(width: u32, height: u32) -> Image {
 
 /// A solid W×H mask (`0` = keep the control frame, `255` = regenerate; the engine binarizes at
 /// 0.5), matching the `image::RgbImage` form `person_track_masks` produces for replace_person.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn solid_mask(width: u32, height: u32, value: u8) -> image::RgbImage {
     image::RgbImage::from_pixel(width, height, image::Rgb([value, value, value]))
 }
@@ -5139,7 +5416,10 @@ fn solid_mask(width: u32, height: u32, value: u8) -> image::RgbImage {
 /// truer continuity but fewer freely-generated frames. Overridable via advanced `motionAnchorFrames`
 /// (per side); defaults to ~⅓ of the output budget (split across the two boundaries for bridge), and
 /// is clamped so at least 5 frames (one z16 chunk) are left to generate.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn extend_anchor_frames(request: &VideoRequest, frame_count: usize) -> usize {
     let per_side = if request.mode == "video_bridge" { 2 } else { 1 };
     let max_total = frame_count.saturating_sub(5).max(1);
@@ -5162,7 +5442,10 @@ fn extend_anchor_frames(request: &VideoRequest, frame_count: usize) -> usize {
 /// engine [`Image`]s, in temporal order (sc-3812). Unlike [`load_source_video_frames`] — which
 /// resamples the *whole* clip evenly — this keeps *consecutive* real frames so the model sees the
 /// clip's actual motion velocity at the boundary. Decodes only the kept subset (`decode_png_image`).
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 #[allow(clippy::too_many_arguments)]
 async fn load_clip_anchor_frames(
     api: &ApiClient,
@@ -5215,7 +5498,10 @@ async fn load_clip_anchor_frames(
 
 /// Pick the head/tail `count` consecutive PNGs from `work_dir` (sorted) and decode them to engine
 /// [`Image`]s, preserving temporal order. Fewer available than `count` ⇒ all of them (short clip).
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 async fn select_anchor_frames(
     work_dir: PathBuf,
     count: usize,
@@ -5244,7 +5530,10 @@ async fn select_anchor_frames(
 }
 
 /// Decode one RGB PNG into an engine [`Image`] (shared by the resample + anchor frame selectors).
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn decode_png_image(path: &Path) -> WorkerResult<Image> {
     let decoded = image::open(path)
         .map_err(|error| {
@@ -5265,7 +5554,10 @@ fn decode_png_image(path: &Path) -> WorkerResult<Image> {
 /// control clip is `frame_count` long (`1 + 4·k`, the engine's z16-chunk constraint) with no
 /// reference images. `masking_strength`/`mode` are inert in the WanVACE mask math (carried for the
 /// shared [`Conditioning::ControlClip`] contract), so they take the neutral defaults.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn build_extend_bridge_vace_conditioning(
     request: &VideoRequest,
     width: u32,
@@ -5337,7 +5629,10 @@ fn build_extend_bridge_vace_conditioning(
 /// markers, recording the actual engine (`wan_vace`) and `fidelityTier` so the substitution under the
 /// user's `wan_2_2` pick is an inspectable fact (sc-3812). Unlike [`wan_vace_raw_settings`] there is
 /// no `replacementMode` (these modes are not person-replacement).
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn wan_vace_extend_raw_settings(request: &VideoRequest) -> Value {
     let mut raw = request.advanced.clone();
     raw.insert("realModelInference".to_owned(), Value::Bool(true));


### PR DESCRIPTION
Routes the advanced Wan video modes — **replace_person**, **extend_clip**, **video_bridge** — to the candle `wan_vace` engine on the Windows/CUDA worker, the off-Mac sibling of the MLX Wan-VACE path. Completes epic [5481](https://app.shortcut.com/trefry/epic/5481) Phase-4 story [sc-5494](https://app.shortcut.com/trefry/story/5494) (the candle-gen provider landed in [candle-gen #70](https://github.com/michaeltrefry/candle-gen/pull/70)).

## Worker (`video_jobs.rs`)
- **Widen the shared VACE conditioning/frame helpers** from `#[cfg(macos)]` to `any(macos, windows+backend-candle)`: `build_vace_conditioning`, `build_extend_bridge_vace_conditioning`, `load_source_video_frames`/`select_extracted_frames`, `load_clip_anchor_frames`/`select_anchor_frames`/`decode_png_image`, `resolve_clip_media_path`, `resolve_character_references`, `replacement_mode_from`, `neutral_control_frame`/`solid_mask`/`extend_anchor_frames`, `rgb_image_to_engine`, `FRAME_PAD_COLOR`, the raw-settings/status JSON builders, and the `Image`/`ReplacementMode`/`CharacterStore`/`ClipFramePosition` imports. `person_track_masks` was already cross-platform (reads pre-saved track masks — no segmentation at gen time).
- **Add the candle path:** `CANDLE_WAN_VACE_ADAPTER` / `CANDLE_WAN_VACE_REPO` (Wan2.1-VACE-14B diffusers), `resolve_candle_wan_vace_model_dir` (HF snapshot + `SCENEWORKS_CANDLE_WAN_VACE_DIR` override), `generate_candle_wan_vace` (replace_person) and `generate_candle_wan_vace_extend_bridge` — mirror the MLX generators but resolve the diffusers VACE snapshot and drop quant/adapters (the candle VACE provider rejects them).
- **Dispatch** the three modes to the candle engine in the Windows `backend-candle` block of `run_video_generate_job`, before the txt2video/i2v `is_candle_video_engine` check.

## Router (`sceneworks-core` `jobs_store.rs`)
- `video_job_is_candle_eligible` now branches by job type: `VideoGenerate` keeps the base txt2video/i2v gate; `PersonReplace` / `VideoExtend` / `VideoBridge` route via the new `video_request_candle_vace_eligible` (model in `CANDLE_VIDEO_VACE_MODELS` = the wan models — SCAIL-2 is MLX-only and excluded — plus the per-mode source assets present, no LoRA/quant). **+2 routing tests.**

## Cargo
- Re-pin all candle-gen-* `a89a595` → `a5e6c4b` (candle-gen #70 merged; adds the `wan_vace` provider). `a89a595` is an ancestor of `a5e6c4b`, both resolve gen-core `27b0107` == this worker's mlx-gen pin → the backend-candle graph stays a single gen-core rev (no skew).

## Validation
`cargo check -p sceneworks-worker` (default) + `-p sceneworks-core`, the 25 candle-routing tests (incl. 2 new VACE), `fmt`, and the **Windows+CUDA `cargo check --features backend-candle`** (sm_120, vcvars 14.44) — all green. The Windows+CUDA build also compiles the VACE provider against gen-core `27b0107` for the first time.

**Follow-up:** RTX PRO 6000 e2e VACE validation (replace_person / extend / bridge) vs the torch/mlx reference — needs the diffusers Wan2.1-VACE-14B checkpoint in the HF cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)