### PR TITLE
sc-5716 + sc-5875: Text→Video tab first; default presets to None

### DIFF
--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -6502,6 +6502,11 @@ describe("SceneWorks app shell", () => {
       );
     });
 
+    // sc-5875: presets are opt-in — select it explicitly before its defaults apply.
+    await act(async () => {
+      [...container.querySelectorAll(".preset-chip")].find((chip) => chip.textContent.trim() === "Cinematic").click();
+    });
+
     expect(container.textContent).toContain("Cinematic");
     expect(container.textContent).toContain("Balanced cinematic color, contrast, and detail.");
     expect(container.textContent).toContain("Adds: cinematic lighting");
@@ -6699,6 +6704,15 @@ describe("SceneWorks app shell", () => {
     expect(railLabels).toEqual(expect.arrayContaining(["Model", "Variations", "Aspect"]));
     expect(container.querySelector(".prompt-input")).not.toBeNull();
     expect(container.querySelector(".preset-chips").textContent).toContain("None");
+    // sc-5875: a fresh studio defaults to None, so the preset's count (2) is NOT
+    // auto-applied — Variations shows the studio default (4) until a preset is picked.
+    expect(field(container, "Variations").value).toBe("4");
+
+    // Selecting the preset applies its defaults (count 2).
+    await act(async () => {
+      [...container.querySelectorAll(".preset-chip")].find((chip) => chip.textContent.trim() === "Cinematic").click();
+    });
+    await settle();
     expect(field(container, "Variations").value).toBe("2");
     expect(field(container, "GPU")).toBeUndefined();
     expect(container.textContent).not.toContain("LoRAs");
@@ -7446,6 +7460,11 @@ describe("SceneWorks app shell", () => {
       );
     });
 
+    // sc-5875: presets are opt-in — select it explicitly to exercise the managed-LoRA mismatch block.
+    await act(async () => {
+      [...container.querySelectorAll(".preset-chip")].find((chip) => chip.textContent.trim() === "Cinematic").click();
+    });
+
     const generate = [...container.querySelectorAll("button")].find((button) => button.textContent === "Generate");
     expect(container.textContent).toContain("Preset cannot run with Z-Image");
     expect(container.textContent).toContain("qwen_detail");
@@ -7527,6 +7546,12 @@ describe("SceneWorks app shell", () => {
     // to that tab to exercise the managed-LoRA mismatch surface.
     await act(async () => {
       [...container.querySelectorAll("button")].find((button) => button.textContent === "Image → Video").click();
+    });
+    await settle();
+
+    // sc-5875: presets are opt-in — select it explicitly to exercise the managed-LoRA mismatch block.
+    await act(async () => {
+      [...container.querySelectorAll(".preset-chip")].find((chip) => chip.textContent.trim() === "Dream Motion").click();
     });
     await settle();
 
@@ -7793,6 +7818,12 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("Qwen Detail");
     expect(container.textContent).not.toContain("Cinematic");
 
+    // sc-5875: presets are opt-in — select the Qwen preset; the model must stay on Qwen.
+    await act(async () => {
+      [...container.querySelectorAll(".preset-chip")].find((chip) => chip.textContent.trim() === "Qwen Detail").click();
+    });
+    await settle();
+
     await act(async () => {
       [...container.querySelectorAll("button")].find((button) => button.textContent === "Generate").click();
     });
@@ -8015,6 +8046,12 @@ describe("SceneWorks app shell", () => {
     // Video Studio opens on Text→Video (sc-5716); this preset targets image_to_video.
     await act(async () => {
       [...container.querySelectorAll("button")].find((button) => button.textContent === "Image → Video").click();
+    });
+    await settle();
+
+    // sc-5875: presets are opt-in — select it explicitly before its defaults apply.
+    await act(async () => {
+      [...container.querySelectorAll(".preset-chip")].find((chip) => chip.textContent.trim() === "Dream Motion").click();
     });
     await settle();
 

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -635,8 +635,9 @@ export function VideoStudio() {
   }, [mode, personTracks, personTrackId, sourceClipAssetId]);
 
   const modeOptions = [
-    ["image_to_video", "Image → Video"],
+    // Text→Video first, mirroring Image Studio (Text → Image first) and the default mode (sc-5716).
     ["text_to_video", "Text → Video"],
+    ["image_to_video", "Image → Video"],
     ["first_last_frame", "First → Last"],
     ["extend_clip", "Extend"],
     ["video_bridge", "Bridge"],

--- a/apps/web/src/screens/generationStudio.jsx
+++ b/apps/web/src/screens/generationStudio.jsx
@@ -137,12 +137,13 @@ export function useGenerationStudio({
     () => presets.filter((preset) => presetMatchesWorkflow(preset, mode) && presetMatchesModel(preset, selectedModel, models)),
     [mode, presets, selectedModel?.id, models],
   );
+  // sc-5875: presets are opt-in. With no explicit selection (fresh screen / None),
+  // resolve to no preset so an unchosen preset's LoRA/resolution/prompt are never
+  // silently applied. The dropdown's "None" and the applied config stay in agreement.
   const selectedPreset =
-    selectedPresetId === noPresetId
-      ? null
-      : selectedPresetId
-        ? availablePresets.find((preset) => preset.id === selectedPresetId) ?? null
-        : availablePresets[0] ?? null;
+    selectedPresetId && selectedPresetId !== noPresetId
+      ? availablePresets.find((preset) => preset.id === selectedPresetId) ?? null
+      : null;
   const presetPromptParts = buildPresetPromptParts(selectedPreset);
   const presetLoraDetails = buildPresetLoraDetails(selectedPreset, loras);
   const presetValidationResult = useMemo(


### PR DESCRIPTION
Two small, related Video/Image Studio fixes (epic 5391, MLX-port QA), web-only.

## sc-5716 — Text → Video tab is now the first button
Reopened follow-up: [PR #691](https://github.com/michaeltrefry/SceneWorks/pull/691) changed the *default-selected* mode to `text_to_video` but left the **visual tab order** unchanged (Image → Video still rendered first). This swaps the first two entries of `modeOptions` in `VideoStudio.jsx` so the tabs read, left-to-right, **"Text → Video"** then **"Image → Video"** — matching the default mode and Image Studio (Text → Image first). The rest of the tab order (First→Last, Extend, Bridge, Replace person, the Bernini/SCAIL-2 modes) is unchanged. No gating/snap/picker logic touched (that all shipped in #691).

## sc-5875 — Studios default to "None" instead of silently applying preset #1
The shared `useGenerationStudio` hook resolved an unset/None preset selection to `availablePresets[0]`, so a fresh studio applied the first preset's **LoRA / resolution / prompt** at submit while the dropdown still showed **"None"** (UI and applied config disagreed). This was the actual root cause behind sc-5873 ("T2V ignored my resolution" was really an auto-applied preset's 704×1280). Fix: an unset/None selection now resolves to **no preset**, so presets are opt-in and the dropdown always agrees with what's applied. Affects **both Image and Video studios**. The explicit-selection auto-reselect effect is unchanged — it early-returns on None, so it cannot reintroduce a first-preset default.

## Tests
- Updated the six `main.test.jsx` cases that relied on the old auto-apply behavior to **explicitly select** their preset (and one to assert the new None-by-default + select-applies path).
- `433` web tests pass; `eslint` clean (0 errors); `vite build` clean.

Web-only — no backend / manifest / parity-contract changes.

Stories: [sc-5716](https://app.shortcut.com/trefry/story/5716), [sc-5875](https://app.shortcut.com/trefry/story/5875)

🤖 Generated with [Claude Code](https://claude.com/claude-code)