### PR TITLE
sc-5872: wire candle FLUX XLabs IP-Adapter into the worker (flux_dev/schnell reference)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,9 +476,12 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
 dependencies = [
+ "candle-core",
  "candle-gen",
+ "candle-gen-sdxl",
+ "candle-nn",
  "candle-transformers",
  "inventory",
  "rand 0.9.4",
@@ -490,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -504,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -516,7 +519,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -527,7 +530,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -541,7 +544,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -554,7 +557,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -566,7 +569,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -577,7 +580,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -591,7 +594,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -609,7 +612,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -622,7 +625,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -633,7 +636,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -646,7 +649,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96#a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
 dependencies = [
  "candle-core",
  "candle-gen",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3272,6 +3272,14 @@ fn image_job_is_candle_eligible(job: &JobSnapshot) -> bool {
     if model == "kolors" && kolors_ipadapter_candle_eligible(&job.payload) {
         return true;
     }
+    // FLUX XLabs IP-Adapter reference conditioning (sc-5872, epic 5480): a `flux_dev`/`flux_schnell`
+    // model with a reference image is the same bespoke candle lane (`generate_candle_flux_ipadapter_\
+    // stream`), NOT txt2img — branch it out before the gate (which rejects `referenceAssetId`). Pure IP
+    // only; img2img/edit shapes stay on torch (sc-5487). Mirrors the worker's `flux_ipadapter_available`.
+    if matches!(model, "flux_dev" | "flux_schnell") && flux_ipadapter_candle_eligible(&job.payload)
+    {
+        return true;
+    }
     image_request_candle_eligible(model, &job.payload)
 }
 
@@ -3559,6 +3567,26 @@ fn sdxl_ipadapter_candle_eligible(payload: &Map<String, Value>) -> bool {
 /// agree on the lane boundary. Candle-only — the macOS Kolors IP path is the registry `Reference` route,
 /// not a separate candle-eligible gate.
 fn kolors_ipadapter_candle_eligible(payload: &Map<String, Value>) -> bool {
+    if payload.get("mode").and_then(Value::as_str) == Some("edit_image") {
+        return false;
+    }
+    let non_empty = |key: &str| {
+        payload
+            .get(key)
+            .and_then(Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty())
+    };
+    non_empty("referenceAssetId") && !non_empty("sourceAssetId") && !non_empty("maskAssetId")
+}
+
+/// FLUX XLabs IP-Adapter candle-routing conditions (sc-5872, epic 5480). The candle `IpAdapterFlux`
+/// provider serves PURE reference (image-prompt) conditioning on the `flux_dev`/`flux_schnell` families
+/// — the same payload shape as the SDXL/Kolors IP lanes: a `referenceAssetId` with NO img2img source /
+/// inpaint mask and NOT an `edit_image` (those advanced FLUX shapes are sc-5487, still torch). Mirrors
+/// the worker's `flux_ipadapter_available` gate (minus the local weight-resolve check) so the router and
+/// worker agree on the lane boundary. Candle-only — the macOS FLUX IP path is the registry `Reference`
+/// route (epic 3621), not a separate candle-eligible gate.
+fn flux_ipadapter_candle_eligible(payload: &Map<String, Value>) -> bool {
     if payload.get("mode").and_then(Value::as_str) == Some("edit_image") {
         return false;
     }
@@ -5362,6 +5390,32 @@ mod candle_routing_tests {
         }))));
         assert!(!kolors_ipadapter_candle_eligible(&object(json!({
             "model": "kolors", "referenceAssetId": "a", "maskAssetId": "m"
+        }))));
+    }
+
+    #[test]
+    fn flux_ipadapter_reference_jobs_route_to_candle() {
+        // A pure FLUX reference (XLabs IP-Adapter) job routes to the candle lane (sc-5872) via the
+        // bespoke branch, NOT the txt2img `image_request_candle_eligible` gate (which rejects
+        // `referenceAssetId`). Both variants.
+        for model in ["flux_dev", "flux_schnell"] {
+            let payload = json!({ "model": model, "referenceAssetId": "asset_1" });
+            assert!(flux_ipadapter_candle_eligible(&object(payload.clone())));
+            assert!(image_job_is_candle_eligible(&image_generate_job(payload)));
+        }
+        // No reference → plain txt2img routes via the txt2img gate instead.
+        assert!(!flux_ipadapter_candle_eligible(&object(
+            json!({ "model": "flux_dev" })
+        )));
+        // img2img / inpaint / edit shapes are NOT this lane (those are sc-5487, still torch).
+        assert!(!flux_ipadapter_candle_eligible(&object(json!({
+            "model": "flux_dev", "mode": "edit_image", "referenceAssetId": "a", "sourceAssetId": "s"
+        }))));
+        assert!(!flux_ipadapter_candle_eligible(&object(json!({
+            "model": "flux_dev", "referenceAssetId": "a", "sourceAssetId": "s"
+        }))));
+        assert!(!flux_ipadapter_candle_eligible(&object(json!({
+            "model": "flux_schnell", "referenceAssetId": "a", "maskAssetId": "m"
         }))));
     }
 }

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -643,38 +643,44 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "27b0
 # Wan-VACE controllable-video provider (`wan_vace`, epic 5481) the worker advanced-video lane routes
 # replace_person / extend_clip / video_bridge onto. #70 is SOURCE-ONLY and a89a595 is its ancestor, so
 # a5e6c4b still resolves gen-core `27b0107` == this worker's mlx-gen pin (single gen-core rev, no skew).
+#
+# sc-5872 (FLUX XLabs IP-Adapter) bumps the candle pin `a5e6c4b` -> `9fc7aa2` (candle-gen #71): ADDS the
+# candle FLUX XLabs IP-Adapter reference provider (`candle_gen_flux::IpAdapterFlux`, epic 5480) the worker
+# `flux_dev`/`flux_schnell` + `referenceAssetId` lane routes onto (image_jobs/flux_ipadapter.rs). #71 is
+# SOURCE-ONLY and a5e6c4b is its ancestor, so 9fc7aa2 still resolves gen-core `27b0107` == this worker's
+# mlx-gen pin (single gen-core rev, no skew). GPU-validated (cosine 0.82 vs 0.70).
 [target.'cfg(target_os = "windows")'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7aa2930525e76f2401beee6550cb9344766af", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7aa2930525e76f2401beee6550cb9344766af", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7aa2930525e76f2401beee6550cb9344766af", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7aa2930525e76f2401beee6550cb9344766af", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7aa2930525e76f2401beee6550cb9344766af", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7aa2930525e76f2401beee6550cb9344766af", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled`. Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7aa2930525e76f2401beee6550cb9344766af", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7aa2930525e76f2401beee6550cb9344766af", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7aa2930525e76f2401beee6550cb9344766af", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7aa2930525e76f2401beee6550cb9344766af", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -683,19 +689,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7aa2930525e76f2401beee6550cb9344766af", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7aa2930525e76f2401beee6550cb9344766af", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7aa2930525e76f2401beee6550cb9344766af", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -704,12 +710,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7aa2930525e76f2401beee6550cb9344766af", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7aa2930525e76f2401beee6550cb9344766af", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -717,7 +723,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5e6c4ba194dfb9e0058e7ef7fbb4c68c2542d96", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7aa2930525e76f2401beee6550cb9344766af", features = ["cuda"], optional = true }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -164,6 +164,14 @@ use candle_gen_sdxl::{IpAdapterSdxl, IpAdapterSdxlPaths, IpAdapterSdxlRequest};
 // (`image_jobs/kolors_ipadapter.rs`) drives.
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
 use candle_gen_kolors::{IpAdapterKolors, IpAdapterKolorsPaths, IpAdapterKolorsRequest};
+// FLUX XLabs IP-Adapter reference provider (sc-5872, epic 5480) — the candle (Windows/CUDA) FLUX sibling
+// of the SDXL/Kolors IP lanes, living in `candle-gen-flux` (the forked FLUX DiT with the per-double-block
+// XLabs seam + the pooled CLIP-ViT-L image encoder). Candle-only: macOS keeps the MLX FLUX XLabs IP path
+// (epic 3621, the registry `Reference` route). `candle_gen_flux` is already force-link anchored above (the
+// registered txt2img `flux1_*`); this is the named-type import the bespoke reference route
+// (`image_jobs/flux_ipadapter.rs`) drives.
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+use candle_gen_flux::{IpAdapterFlux, IpAdapterFluxPaths, IpAdapterFluxRequest};
 
 /// The stub adapter id recorded on generated assets (matches the contract fixture
 /// `tests/fixtures/rust_migration_contracts/sidecars/asset-image.sceneworks.json`).
@@ -472,6 +480,22 @@ pub(crate) async fn run_image_generate_job(
         // because `kolors` IS a candle txt2img id, so without this a reference job would be caught by
         // the txt2img branch and silently drop the reference (the SDXL IP reasoning, for Kolors).
         generate_candle_kolors_ipadapter_stream(
+            api,
+            settings,
+            job,
+            &plan,
+            &project_path,
+            backend,
+            &mut asset_writes,
+        )
+        .await?;
+        true
+    } else if settings.backend_candle_enabled && flux_ipadapter_available(&request, settings) {
+        // FLUX XLabs IP-Adapter reference conditioning (sc-5872) — checked BEFORE `is_candle_engine`
+        // because `flux_dev`/`flux_schnell` ARE candle txt2img ids, so without this a reference job
+        // would be caught by the txt2img branch and silently drop the reference (the SDXL/Kolors IP
+        // reasoning, for FLUX).
+        generate_candle_flux_ipadapter_stream(
             api,
             settings,
             job,
@@ -967,6 +991,11 @@ include!("image_jobs/sdxl_ipadapter.rs");
 // is a bespoke provider, so this is candle-exclusive.
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
 include!("image_jobs/kolors_ipadapter.rs");
+// FLUX XLabs IP-Adapter reference conditioning — the Windows/CUDA candle lane ONLY (sc-5872). macOS keeps
+// the MLX FLUX XLabs IP path (epic 3621, the registry `Reference` route); the candle `IpAdapterFlux` is a
+// bespoke provider, so this is candle-exclusive.
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+include!("image_jobs/flux_ipadapter.rs");
 #[cfg(target_os = "macos")]
 // PuLID-FLUX native routing.
 include!("image_jobs/pulid.rs");

--- a/crates/sceneworks-worker/src/image_jobs/flux_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux_ipadapter.rs
@@ -1,0 +1,356 @@
+// Candle (Windows/CUDA) FLUX XLabs IP-Adapter reference route (sc-5872, epic 5480) — reference-image
+// (identity) conditioning on FLUX.1 [dev]/[schnell] off-Mac via `candle_gen_flux::IpAdapterFlux`. The
+// FLUX sibling of the candle SDXL/Kolors IP-Adapter lanes (sdxl_ipadapter.rs / kolors_ipadapter.rs):
+// the pooled CLIP-ViT-L image embedding is projected (XLabs `ImageProjModel`) into image-prompt tokens
+// and injected as a decoupled cross-attention into the forked FLUX DiT's double blocks, denoised with
+// the FLUX flow-match schedule (a single distilled forward per step).
+//
+// **Candle-only.** macOS keeps the MLX FLUX XLabs IP path (epic 3621, the registry `Reference` route
+// the `flux1_*` generators handle via `with_ip_adapter`); the candle `IpAdapterFlux` is a bespoke
+// provider, so this whole file is gated to the Windows/CUDA candle build (the `include!` in
+// image_jobs.rs carries the cfg). It is `include!`d into the `image_jobs` module, so it shares that
+// module's imports (ImageRequest/Settings/WorkerResult/`advanced`/`load_reference_image`/
+// `huggingface_snapshot_dir`/`ensure_hf_cached_file`/`start_gen_stream`/… all in scope unqualified).
+
+/// The XLabs FLUX IP-Adapter repo + the single bundle file (`ip_adapter_proj_model` + the 19
+/// per-double-block K/V projectors). Same repo the MLX path uses (`base.rs` `FLUX_IP_ADAPTER_REPO`).
+const FLUX_IPADAPTER_ADAPTER_REPO: &str = "XLabs-AI/flux-ip-adapter";
+const FLUX_IPADAPTER_ADAPTER_FILE: &str = "ip_adapter.safetensors";
+/// The CLIP ViT-L/14 image encoder repo (the XLabs adapter conditions on `openai/clip-vit-large-patch14`
+/// pooled image embeds) + the weight file the provider's `resolve_image_encoder` looks for in the dir.
+const FLUX_IPADAPTER_ENCODER_REPO: &str = "openai/clip-vit-large-patch14";
+const FLUX_IPADAPTER_ENCODER_FILE: &str = "model.safetensors";
+/// Both repos ship the safetensors on `main` (unlike the Kolors `refs/pr/4`).
+const FLUX_IPADAPTER_REVISION: &str = "main";
+/// IP-Adapter scale default — the XLabs resemblance tier 0.7 (matches `base.rs` `FLUX_IP_SCALE`, the MLX
+/// path, and the candle `IpAdapterFlux::DEFAULT_IP_SCALE`).
+const FLUX_IPADAPTER_IP_SCALE: f32 = 0.7;
+/// The adapter/engine id recorded on candle FLUX IP-Adapter assets + telemetry (distinct from the
+/// txt2img `candle_flux` lane).
+const FLUX_IPADAPTER_ENGINE: &str = "candle_flux_ipadapter";
+
+/// Model ids the candle FLUX IP-Adapter route accepts (both variants — the forked DiT injects the same
+/// XLabs adapter for each; dev embeds the guidance scalar, schnell ignores it).
+fn is_flux_ipadapter_model(model: &str) -> bool {
+    matches!(model, "flux_dev" | "flux_schnell")
+}
+
+/// The black-forest-labs base repo when the manifest omits `repo` (variant-keyed).
+fn flux_ipadapter_default_repo(model: &str) -> &'static str {
+    match model {
+        "flux_schnell" => "black-forest-labs/FLUX.1-schnell",
+        _ => "black-forest-labs/FLUX.1-dev",
+    }
+}
+
+/// Distilled default step count (FLUX parity): schnell 4, dev 25.
+fn flux_ipadapter_default_steps(model: &str) -> u32 {
+    match model {
+        "flux_schnell" => 4,
+        _ => 25,
+    }
+}
+
+/// Default guidance: dev embeds 3.5; schnell is timestep-distilled (no guidance).
+fn flux_ipadapter_default_guidance(model: &str) -> f32 {
+    match model {
+        "flux_schnell" => 0.0,
+        _ => 3.5,
+    }
+}
+
+/// Resolve the FLUX base (BFL snapshot) for the IP-Adapter route: an explicit `modelPath` dir
+/// (advanced or manifest) wins, else the HF cache snapshot for the manifest `repo` (default
+/// `black-forest-labs/FLUX.1-{dev,schnell}` by variant). `None` means the base is not present locally,
+/// so the job is not candle-runnable (falls through to torch). Mirrors `resolve_kolors_ipadapter_base`.
+fn resolve_flux_ipadapter_base(
+    request: &ImageRequest,
+    settings: &Settings,
+) -> WorkerResult<Option<PathBuf>> {
+    if let Some(path) = request
+        .advanced
+        .get("modelPath")
+        .or_else(|| request.model_manifest_entry.get("modelPath"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+    {
+        return resolve_app_managed_model_dir(settings, &path, "FLUX IP-Adapter modelPath").map(Some);
+    }
+    let repo = request
+        .model_manifest_entry
+        .get("repo")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| flux_ipadapter_default_repo(&request.model));
+    Ok(huggingface_snapshot_dir(&settings.data_dir, repo))
+}
+
+/// True when this is a candle-eligible FLUX IP-Adapter job: a `flux_dev`/`flux_schnell` model with a
+/// reference image (and NOT an img2img/inpaint/edit shape — those are sc-5487) whose base resolves
+/// locally. Mirrors `jobs_store::flux_ipadapter_candle_eligible` so the worker and router agree.
+fn flux_ipadapter_available(request: &ImageRequest, settings: &Settings) -> bool {
+    is_flux_ipadapter_model(&request.model)
+        && request.mode != "edit_image"
+        && non_empty(&request.reference_asset_id)
+        && !non_empty(&request.source_asset_id)
+        && !non_empty(&request.mask_asset_id)
+        && matches!(resolve_flux_ipadapter_base(request, settings), Ok(Some(_)))
+}
+
+/// Resolve denoise steps: `advanced.steps` (clamped 1..=100) → manifest `steps` → variant default.
+fn flux_ipadapter_steps(request: &ImageRequest) -> u32 {
+    let parse = |value: &Value| {
+        value
+            .as_u64()
+            .or_else(|| value.as_str()?.trim().parse().ok())
+    };
+    request
+        .advanced
+        .get("steps")
+        .and_then(parse)
+        .or_else(|| request.model_manifest_entry.get("steps").and_then(parse))
+        .map(|steps| steps.clamp(1, 100) as u32)
+        .unwrap_or_else(|| flux_ipadapter_default_steps(&request.model))
+}
+
+/// Resolve guidance: `advanced.guidanceScale` → manifest `guidanceScale` → variant default, clamped.
+fn flux_ipadapter_guidance(request: &ImageRequest) -> f32 {
+    let manifest_default = request
+        .model_manifest_entry
+        .get("guidanceScale")
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .map(|value| value as f32)
+        .unwrap_or_else(|| flux_ipadapter_default_guidance(&request.model));
+    advanced::f32_clamped(
+        &request.advanced,
+        "guidanceScale",
+        manifest_default,
+        0.0..=30.0,
+    )
+}
+
+/// Resolve the XLabs adapter file + the CLIP-ViT-L encoder dir the `IpAdapterFlux` provider loads,
+/// downloading on first use. Resolution order for each: an env-pinned root (`SCENEWORKS_IPADAPTER_FLUX`,
+/// the validation-staging layout `<root>/ip_adapter.safetensors` + `<root>/image_encoder/`) → a
+/// whole-repo HF cache snapshot → download into the app cache. Returns `(adapter_file, encoder_dir)`
+/// (the latter is what [`IpAdapterFluxPaths::image_encoder`] wants — `resolve_image_encoder` finds
+/// `model.safetensors` inside).
+async fn ensure_flux_ipadapter_weights(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+) -> WorkerResult<(PathBuf, PathBuf)> {
+    // Env override: a staged dir laid out like the validation harness.
+    if let Ok(root) = std::env::var("SCENEWORKS_IPADAPTER_FLUX") {
+        let root = PathBuf::from(root);
+        let adapter = root.join(FLUX_IPADAPTER_ADAPTER_FILE);
+        let encoder = root.join("image_encoder");
+        if adapter.is_file() && encoder.join(FLUX_IPADAPTER_ENCODER_FILE).is_file() {
+            return Ok((adapter, encoder));
+        }
+    }
+
+    let client = reqwest::Client::new();
+    let context = DownloadContext {
+        api,
+        client: &client,
+        settings,
+        job_id: &job.id,
+        cancel_message: "FLUX IP-Adapter generation canceled while fetching weights.",
+        fresh_download: false,
+    };
+    let cache = settings.data_dir.join("cache").join("ipadapter-flux");
+
+    // XLabs adapter file: a whole-repo HF cache snapshot already carrying it, else download-on-first-use.
+    let adapter = match huggingface_snapshot_dir(&settings.data_dir, FLUX_IPADAPTER_ADAPTER_REPO)
+        .map(|snapshot| snapshot.join(FLUX_IPADAPTER_ADAPTER_FILE))
+        .filter(|file| file.is_file())
+    {
+        Some(file) => file,
+        None => {
+            let dst = cache.join(FLUX_IPADAPTER_ADAPTER_FILE);
+            ensure_hf_cached_file(
+                &context,
+                FLUX_IPADAPTER_ADAPTER_REPO,
+                FLUX_IPADAPTER_REVISION,
+                FLUX_IPADAPTER_ADAPTER_FILE,
+                &dst,
+            )
+            .await?;
+            dst
+        }
+    };
+
+    // CLIP-ViT-L encoder dir (must contain `model.safetensors`): the whole-repo snapshot, else download.
+    let encoder = match huggingface_snapshot_dir(&settings.data_dir, FLUX_IPADAPTER_ENCODER_REPO)
+        .filter(|snapshot| snapshot.join(FLUX_IPADAPTER_ENCODER_FILE).is_file())
+    {
+        Some(snapshot) => snapshot,
+        None => {
+            let dir = cache.join("image_encoder");
+            ensure_hf_cached_file(
+                &context,
+                FLUX_IPADAPTER_ENCODER_REPO,
+                FLUX_IPADAPTER_REVISION,
+                FLUX_IPADAPTER_ENCODER_FILE,
+                &dir.join(FLUX_IPADAPTER_ENCODER_FILE),
+            )
+            .await?;
+            dir
+        }
+    };
+
+    Ok((adapter, encoder))
+}
+
+/// Flat telemetry recorded on candle FLUX IP-Adapter assets (parity with the SDXL/Kolors recipe-key
+/// shape).
+fn flux_ipadapter_raw_settings(
+    request: &ImageRequest,
+    repo: &str,
+    steps: u32,
+    guidance: f32,
+    ip_scale: f32,
+) -> JsonObject {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("repo".to_owned(), Value::String(repo.to_owned()));
+    raw.insert("numInferenceSteps".to_owned(), json!(steps));
+    raw.insert("guidanceScale".to_owned(), json!(guidance));
+    raw.insert("ipAdapterScale".to_owned(), json!(ip_scale));
+    raw.insert(
+        "ipAdapterEngine".to_owned(),
+        Value::String(FLUX_IPADAPTER_ENGINE.to_owned()),
+    );
+    raw
+}
+
+/// Real candle FLUX IP-Adapter generation: resolve the reference + weights on the async side, then load
+/// the `IpAdapterFlux` provider once + generate each image on the blocking thread. `request.count`
+/// images, each its own seed; `generate` takes the per-job `CancelFlag` + a `Progress` callback, so
+/// streaming is per-step and cancellation is honoured mid-denoise — same contract as the SDXL/Kolors IP
+/// lanes.
+async fn generate_candle_flux_ipadapter_stream(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+    let flux_base = resolve_flux_ipadapter_base(request, settings)?.ok_or_else(|| {
+        WorkerError::InvalidPayload("FLUX IP-Adapter base (FLUX.1 snapshot) not found".to_owned())
+    })?;
+    let reference_id = request
+        .reference_asset_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload("FLUX IP-Adapter requires a reference image".to_owned())
+        })?;
+    let reference = load_reference_image(
+        &settings.data_dir,
+        &request.project_id,
+        reference_id,
+        project_path,
+    )?;
+    let (adapter_file, encoder_dir) = ensure_flux_ipadapter_weights(api, settings, job).await?;
+
+    let steps = flux_ipadapter_steps(request);
+    let guidance = flux_ipadapter_guidance(request);
+    let ip_scale = advanced::f32_clamped(
+        &request.advanced,
+        "ipAdapterScale",
+        FLUX_IPADAPTER_IP_SCALE,
+        0.0..=1.0,
+    );
+    let repo = request
+        .model_manifest_entry
+        .get("repo")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| flux_ipadapter_default_repo(&request.model))
+        .to_owned();
+    let raw_settings = flux_ipadapter_raw_settings(request, &repo, steps, guidance, ip_scale);
+
+    // Per-image work items: (seed, prompt) — `request.count` images at the reference identity.
+    let (width, height) = (request.width, request.height);
+    let work: Vec<(i64, String)> = (0..request.count as usize)
+        .map(|index| (resolve_seed(request, index), request.prompt.clone()))
+        .collect();
+    let total = work.len();
+
+    let (cancel, rx, blocking) = start_gen_stream(
+        job.id.clone(),
+        "flux_ipadapter",
+        0,
+        move || {
+            let paths = IpAdapterFluxPaths {
+                flux_base,
+                ip_adapter: adapter_file,
+                image_encoder: encoder_dir,
+            };
+            let model = IpAdapterFlux::load(&paths).map_err(|error| {
+                WorkerError::Engine(format!("FLUX IP-Adapter load failed: {error}"))
+            })?;
+            Ok((model, reference))
+        },
+        move |(model, reference), tx, cancel| {
+            // `IpAdapterFlux::generate` takes `&self` (the IP tokens live in a per-call injector, not on
+            // the DiT), so — unlike the SDXL/Kolors lanes — the per-item closure needs no `mut model`.
+            drive_gen_items(tx, work, move |_index, (seed, prompt), on_progress| {
+                if cancel.is_cancelled() {
+                    return Ok(None);
+                }
+                let req = IpAdapterFluxRequest {
+                    prompt,
+                    width,
+                    height,
+                    steps: steps as usize,
+                    guidance,
+                    ip_adapter_scale: ip_scale,
+                    seed: seed as u64,
+                    cancel: cancel.clone(),
+                };
+                let out = match model.generate(&req, &reference, &mut *on_progress) {
+                    Ok(out) => out,
+                    Err(_) if cancel.is_cancelled() => return Ok(None),
+                    Err(error) => {
+                        return Err(WorkerError::Engine(format!(
+                            "FLUX IP-Adapter generation failed: {error}"
+                        )));
+                    }
+                };
+                Ok(Some((seed, out.width, out.height, out.pixels)))
+            })
+        },
+    );
+
+    consume_gen_events(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        FLUX_IPADAPTER_ENGINE,
+        &raw_settings,
+        total,
+        rx,
+        cancel,
+        blocking,
+        asset_writes,
+    )
+    .await
+}


### PR DESCRIPTION
Routes `flux_dev`/`flux_schnell` + `referenceAssetId` jobs to the candle `IpAdapterFlux` provider off-Mac, finishing the reference-conditioning closure for the FLUX family (after SDXL [#690](https://github.com/michaeltrefry/SceneWorks/pull/690) + Kolors [#697](https://github.com/michaeltrefry/SceneWorks/pull/697)). The candle-gen provider landed in [candle-gen #71](https://github.com/michaeltrefry/candle-gen/pull/71), **GPU-validated** on the RTX PRO 6000 (CLIP cosine **0.82** with-IP vs **0.70** no-IP, Δ +0.12; visual ablation decisive; pre/mid cancel honored).

### What's here
- **NEW `crates/sceneworks-worker/src/image_jobs/flux_ipadapter.rs`** (`cfg(all(windows, backend-candle))`): `generate_candle_flux_ipadapter_stream` + `flux_ipadapter_available` + weight resolution. The FLUX base resolves via the manifest `repo` (default `black-forest-labs/FLUX.1-{dev,schnell}` by variant); the XLabs `ip_adapter.safetensors` + the CLIP-ViT-L `model.safetensors` resolve via env `SCENEWORKS_IPADAPTER_FLUX` → whole-repo HF snapshot → download-on-first-use. Pure-IP, `request.count` images, NO negative/img2img/edit (those are sc-5487). `generate` is `&self` (the IP tokens live in a per-call injector), so — unlike the SDXL/Kolors lanes — the drive closure needs no `mut model`. Defaults: ip scale 0.7, dev steps 25/guidance 3.5, schnell 4/0, engine `candle_flux_ipadapter`.
- **`image_jobs.rs`**: dispatch branch BEFORE `is_candle_engine` (`flux_dev`/`flux_schnell` ARE candle txt2img ids, so a reference job would otherwise hit txt2img and silently drop the reference) + the `candle_gen_flux::{IpAdapterFlux, …}` named import + the cfg-gated `include!`.
- **`jobs_store.rs`**: `flux_ipadapter_candle_eligible` (referenceAssetId + no source/mask + not edit_image, mirroring sdxl/kolors) + a `flux_dev`/`flux_schnell` branch in `image_job_is_candle_eligible` before the txt2img gate + a routing test.
- **Cargo re-pin** candle-gen `a5e6c4b` → `9fc7aa2` (#71 merge, 16 crates); mlx-gen stays `27b0107` (#71 is source-only, no mlx-gen bump). Skew gate resolves a single gen-core rev `27b0107`.

### Verification
- 26 `sceneworks-core` candle routing tests (incl. the new `flux_ipadapter_reference_jobs_route_to_candle`, both variants).
- Worker `--features backend-candle` build **links** (sm_120, MSVC 14.44) + `clippy -D warnings` clean (lib; the pre-existing `tests.rs:40 terminating_signal` `--all-targets` wart is not mine — same lane the SDXL/Kolors PRs used).
- `fmt` clean.

macOS keeps its MLX FLUX XLabs IP path (epic 3621); this is the Windows/CUDA candle lane only. Full FLUX chain: candle-gen #71 (provider + GPU validation) → this worker PR (route + re-pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)