### PR TITLE
Fix unused terminating_signal import on Windows candle clippy

### DIFF
--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -36,8 +36,13 @@ use super::model_jobs::{
     overlay_kolors_tokenizer, validate_hf_cli_download_inputs, DownloadFamilyCheck,
     HF_CLI_UTF8_ENV,
 };
+// `terminating_signal` is only exercised by a `#[cfg(unix)]` test (signal-death
+// attribution is uncatchable and only observable on Unix), so gate the import to
+// match — otherwise it is an unused import on Windows builds.
+#[cfg(unix)]
+use super::supervisor::terminating_signal;
 use super::supervisor::{
-    auto_worker_specs, child_environment, restart_exited_children_with_spawner, terminating_signal,
+    auto_worker_specs, child_environment, restart_exited_children_with_spawner,
     utility_worker_specs, SupervisedChild, WorkerSpec,
 };
 use super::{


### PR DESCRIPTION
## What changed

`crates/sceneworks-worker/src/tests.rs` imported `terminating_signal` unconditionally, but its only consumer — the `terminating_signal_distinguishes_signal_death_from_clean_exit` test — is gated `#[cfg(unix)]`. The import is now split into its own `#[cfg(unix)]` `use` to match its sole consumer, mirroring the existing `#[cfg(target_os = "macos")]` import of `mlx_gpu` in the same file.

## Why

On Windows the unix-gated test is compiled out, leaving the import dead, so:

```
cargo clippy -p sceneworks-worker --features backend-candle --all-targets -- -D warnings
```

fails with `unused import: terminating_signal` on the lib-test target. The `terminating_signal` function itself keeps both its `#[cfg(unix)]` and `#[cfg(not(unix))]` definitions, so **deleting** the import would have broken the non-candle build — gating it is the correct fix.

## Reviewer notes

- This is not caught by default parity CI, which builds **without** `backend-candle` and runs on Unix (where the import is live). It only bites local full-candle Windows clippy runs.
- Verified `clippy --all-targets -D warnings` passes on Windows **both** with and without `--features backend-candle` (candle build via VS2022 BuildTools MSVC 14.44 vcvars64 + `CUDA_COMPUTE_CAP=120`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)