### PR TITLE
sc-5495: re-pin candle-gen → candle LTX synchronized audio (worker)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -519,7 +519,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -530,7 +530,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -557,7 +557,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -569,7 +569,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -580,7 +580,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -594,7 +594,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -612,7 +612,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -625,7 +625,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -636,7 +636,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -649,7 +649,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fc7aa2930525e76f2401beee6550cb9344766af#9fc7aa2930525e76f2401beee6550cb9344766af"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
 dependencies = [
  "candle-core",
  "candle-gen",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -649,38 +649,51 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "27b0
 # `flux_dev`/`flux_schnell` + `referenceAssetId` lane routes onto (image_jobs/flux_ipadapter.rs). #71 is
 # SOURCE-ONLY and a5e6c4b is its ancestor, so 9fc7aa2 still resolves gen-core `27b0107` == this worker's
 # mlx-gen pin (single gen-core rev, no skew). GPU-validated (cosine 0.82 vs 0.70).
+#
+# sc-5495 (LTX synchronized audio) bumps the candle pin `9fc7aa2` -> `7c7550d` (candle-gen #73 + #74):
+# #73 EXTENDS the candle `ltx_2_3_distilled` provider from T2V-only to the full AudioVideo path — the
+# audio VAE decoder + BigVGAN/BWE vocoder + the dual-modal AvDiT (48 blocks: audio stack @2048 +
+# bidirectional cross-modal attention) + the audio text head + the joint A/V denoise — so the candle LTX
+# engine now returns `GenerationOutput::Video { audio: Some(track) }` (a synchronized 48 kHz stereo
+# track) which the worker's existing decode/mux path (sc-3035) AAC-muxes with zero further worker code.
+# #74 fixes the vocoder core key prefix (the dense ckpt nests it `vocoder.vocoder.*`) + adds the GPU
+# harness. Both are SOURCE-ONLY at gen-core `27b0107` (== this worker's mlx-gen pin; 9fc7aa2 is their
+# ancestor) so 7c7550d still resolves exactly ONE gen-core rev, no skew. GPU-validated on RTX PRO 6000:
+# coherent on-prompt video + a 48 kHz stereo audio track of matching duration. ALL candle deps MUST
+# share this rev.
 [target.'cfg(target_os = "windows")'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7aa2930525e76f2401beee6550cb9344766af", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c7550d12281faae5e92a4b2acc5cf37dd5c1f55", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7aa2930525e76f2401beee6550cb9344766af", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7aa2930525e76f2401beee6550cb9344766af", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7aa2930525e76f2401beee6550cb9344766af", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7aa2930525e76f2401beee6550cb9344766af", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c7550d12281faae5e92a4b2acc5cf37dd5c1f55", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c7550d12281faae5e92a4b2acc5cf37dd5c1f55", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c7550d12281faae5e92a4b2acc5cf37dd5c1f55", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c7550d12281faae5e92a4b2acc5cf37dd5c1f55", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7aa2930525e76f2401beee6550cb9344766af", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c7550d12281faae5e92a4b2acc5cf37dd5c1f55", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
-# extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled`. Force-linked in video_jobs.rs
+# extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
+# synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7aa2930525e76f2401beee6550cb9344766af", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7aa2930525e76f2401beee6550cb9344766af", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c7550d12281faae5e92a4b2acc5cf37dd5c1f55", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c7550d12281faae5e92a4b2acc5cf37dd5c1f55", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7aa2930525e76f2401beee6550cb9344766af", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c7550d12281faae5e92a4b2acc5cf37dd5c1f55", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7aa2930525e76f2401beee6550cb9344766af", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c7550d12281faae5e92a4b2acc5cf37dd5c1f55", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -689,19 +702,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7aa2930525e76f2401beee6550cb9344766af", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c7550d12281faae5e92a4b2acc5cf37dd5c1f55", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7aa2930525e76f2401beee6550cb9344766af", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c7550d12281faae5e92a4b2acc5cf37dd5c1f55", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7aa2930525e76f2401beee6550cb9344766af", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c7550d12281faae5e92a4b2acc5cf37dd5c1f55", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -710,12 +723,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7aa2930525e76f2401beee6550cb9344766af", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c7550d12281faae5e92a4b2acc5cf37dd5c1f55", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7aa2930525e76f2401beee6550cb9344766af", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c7550d12281faae5e92a4b2acc5cf37dd5c1f55", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -723,7 +736,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7a
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fc7aa2930525e76f2401beee6550cb9344766af", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c7550d12281faae5e92a4b2acc5cf37dd5c1f55", features = ["cuda"], optional = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Worker side of **sc-5495** (epic 5481). Re-pins the worker's candle-gen deps `9fc7aa2` → `7c7550d`, lighting up **synchronized audio** on the candle (Windows/CUDA) LTX lane.

## What this does
candle-gen [#73](https://github.com/michaeltrefry/candle-gen/pull/73) (+ [#74](https://github.com/michaeltrefry/candle-gen/pull/74) vocoder fix) extended the candle `ltx_2_3_distilled` provider from T2V-only to the full **AudioVideo** path — audio VAE + BigVGAN/BWE vocoder + the dual-modal AvDiT (48 blocks: audio stack + bidirectional cross-modal attention) + the audio text head + the joint A/V denoise. The engine now returns `GenerationOutput::Video { audio: Some(track) }` (a synchronized 48 kHz stereo track).

**Zero worker code change:** the worker's shared video driver already maps `audio` → `DecodedVideo.audio` and the encode pipeline AAC-muxes it (built for the MLX LTX path, sc-3035). So the candle lane produces audio purely from the re-pin.

## Skew + builds
- gen-core skew gate green: candle-gen #73/#74 are source-only at gen-core `27b0107` (== this worker's mlx-gen pin; `9fc7aa2` is their ancestor), so `7c7550d` resolves exactly ONE gen-core rev.
- `cargo check -p sceneworks-worker` (default) + `--features backend-candle` (CUDA, sm_120) both green.

## GPU-validated (upstream, RTX PRO 6000)
512×320 × 25f × 24fps "a dog barking in a sunlit garden" → coherent photorealistic on-prompt video with motion + a **48 kHz stereo audio track of matching duration** (1.01 s ↔ 1.04 s), non-degenerate, no NaN.

## eros (deferred, checkpoint-gated)
`ltx_2_3_eros` stays on the Python torch worker. The candle provider **supports** eros (checkpoint-agnostic — same architecture), but the existing eros checkpoint is the MLX-bundle format the candle provider can't read, and the router has no torch fallback once a job is claimed by the candle worker. So eros→candle is gated on a **dense eros checkpoint** being available — a small follow-up that activates when one is provided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)