### PR TITLE
sc-5489: wire candle Qwen-Image strict-pose ControlNet into the worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3d6496505f0bc6e10c7be7b6eeb2654ca5e94310#3d6496505f0bc6e10c7be7b6eeb2654ca5e94310"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3d6496505f0bc6e10c7be7b6eeb2654ca5e94310#3d6496505f0bc6e10c7be7b6eeb2654ca5e94310"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3d6496505f0bc6e10c7be7b6eeb2654ca5e94310#3d6496505f0bc6e10c7be7b6eeb2654ca5e94310"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3d6496505f0bc6e10c7be7b6eeb2654ca5e94310#3d6496505f0bc6e10c7be7b6eeb2654ca5e94310"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3d6496505f0bc6e10c7be7b6eeb2654ca5e94310#3d6496505f0bc6e10c7be7b6eeb2654ca5e94310"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3d6496505f0bc6e10c7be7b6eeb2654ca5e94310#3d6496505f0bc6e10c7be7b6eeb2654ca5e94310"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -519,7 +519,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3d6496505f0bc6e10c7be7b6eeb2654ca5e94310#3d6496505f0bc6e10c7be7b6eeb2654ca5e94310"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -530,7 +530,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3d6496505f0bc6e10c7be7b6eeb2654ca5e94310#3d6496505f0bc6e10c7be7b6eeb2654ca5e94310"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3d6496505f0bc6e10c7be7b6eeb2654ca5e94310#3d6496505f0bc6e10c7be7b6eeb2654ca5e94310"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -557,7 +557,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3d6496505f0bc6e10c7be7b6eeb2654ca5e94310#3d6496505f0bc6e10c7be7b6eeb2654ca5e94310"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -569,7 +569,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3d6496505f0bc6e10c7be7b6eeb2654ca5e94310#3d6496505f0bc6e10c7be7b6eeb2654ca5e94310"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -580,7 +580,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3d6496505f0bc6e10c7be7b6eeb2654ca5e94310#3d6496505f0bc6e10c7be7b6eeb2654ca5e94310"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -594,7 +594,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3d6496505f0bc6e10c7be7b6eeb2654ca5e94310#3d6496505f0bc6e10c7be7b6eeb2654ca5e94310"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -612,7 +612,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3d6496505f0bc6e10c7be7b6eeb2654ca5e94310#3d6496505f0bc6e10c7be7b6eeb2654ca5e94310"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -625,7 +625,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3d6496505f0bc6e10c7be7b6eeb2654ca5e94310#3d6496505f0bc6e10c7be7b6eeb2654ca5e94310"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -636,7 +636,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3d6496505f0bc6e10c7be7b6eeb2654ca5e94310#3d6496505f0bc6e10c7be7b6eeb2654ca5e94310"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -649,7 +649,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c7550d12281faae5e92a4b2acc5cf37dd5c1f55#7c7550d12281faae5e92a4b2acc5cf37dd5c1f55"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3d6496505f0bc6e10c7be7b6eeb2654ca5e94310#3d6496505f0bc6e10c7be7b6eeb2654ca5e94310"
 dependencies = [
  "candle-core",
  "candle-gen",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3280,6 +3280,14 @@ fn image_job_is_candle_eligible(job: &JobSnapshot) -> bool {
     {
         return true;
     }
+    // Qwen-Image strict-pose ControlNet (sc-5489, epic 5480): `qwen_image` + `advanced.poses` is a
+    // bespoke candle lane (`generate_candle_qwen_control_stream`), NOT txt2img — the
+    // `image_request_candle_eligible` gate below DEFERS any `advanced.poses` job to torch. Branch it out
+    // first so `qwen_image` pose jobs reach candle, while the other families' pose jobs (z_image /
+    // kolors / sdxl) stay on torch until their slices land. Mirrors the worker's `qwen_control_available`.
+    if model == "qwen_image" && qwen_control_candle_eligible(&job.payload) {
+        return true;
+    }
     image_request_candle_eligible(model, &job.payload)
 }
 
@@ -3597,6 +3605,25 @@ fn flux_ipadapter_candle_eligible(payload: &Map<String, Value>) -> bool {
             .is_some_and(|value| !value.trim().is_empty())
     };
     non_empty("referenceAssetId") && !non_empty("sourceAssetId") && !non_empty("maskAssetId")
+}
+
+/// Qwen-Image strict-pose ControlNet candle-routing conditions (sc-5489, epic 5480). The candle
+/// `QwenControl` provider serves `qwen_image` + a non-empty object `advanced.poses` (one image per pose,
+/// each conditioned on a DWPose skeleton), NOT an `edit_image`. A `referenceAssetId`, if present, is
+/// ignored (identity comes from a character LoRA on the base, mirroring the MLX/torch
+/// `QwenImageControlNetPipeline`). Mirrors the worker's `qwen_control_available` gate (minus the local
+/// weight-resolve check) so the router and worker agree. Candle-only — the macOS path is the registry
+/// `qwen_image_control` generator, not a separate candle-eligible gate.
+fn qwen_control_candle_eligible(payload: &Map<String, Value>) -> bool {
+    if payload.get("mode").and_then(Value::as_str) == Some("edit_image") {
+        return false;
+    }
+    payload
+        .get("advanced")
+        .and_then(Value::as_object)
+        .and_then(|advanced| advanced.get("poses"))
+        .and_then(Value::as_array)
+        .is_some_and(|poses| !poses.is_empty())
 }
 
 /// PuLID-FLUX (`pulid_flux_dev`) MLX-routing conditions (sc-3344). The native `mlx-gen-pulid`
@@ -4837,10 +4864,23 @@ mod candle_routing_tests {
                 "sourceAssetId": "asset_1"
             }))
         ));
+        // sc-5489: `qwen_image` + `advanced.poses` IS now a candle lane (the bespoke strict-pose
+        // ControlNet route), so the candle worker claims it (was deferred to torch before this slice).
+        assert!(
+            worker_supports_job(
+                &candle,
+                &image_generate_job(json!({
+                    "model": "qwen_image",
+                    "advanced": { "poses": [{ "id": "pose_1" }] }
+                }))
+            ),
+            "candle worker should claim qwen_image strict-pose (sc-5489)"
+        );
+        // A DIFFERENT family's pose job still defers to torch (its slice hasn't landed).
         assert!(!worker_supports_job(
             &candle,
             &image_generate_job(json!({
-                "model": "qwen_image",
+                "model": "z_image_turbo",
                 "advanced": { "poses": [{ "id": "pose_1" }] }
             }))
         ));
@@ -5416,6 +5456,32 @@ mod candle_routing_tests {
         }))));
         assert!(!flux_ipadapter_candle_eligible(&object(json!({
             "model": "flux_schnell", "referenceAssetId": "a", "maskAssetId": "m"
+        }))));
+    }
+
+    #[test]
+    fn qwen_control_pose_jobs_route_to_candle() {
+        // qwen_image + advanced.poses routes to the candle strict-pose lane (sc-5489) via the bespoke
+        // branch, NOT the txt2img gate (which DEFERS any advanced.poses job to torch).
+        let payload =
+            json!({ "model": "qwen_image", "advanced": { "poses": [{ "keypoints": [] }] } });
+        assert!(qwen_control_candle_eligible(&object(payload.clone())));
+        assert!(image_job_is_candle_eligible(&image_generate_job(payload)));
+        // No poses (or empty) → plain txt2img routes via the txt2img gate instead.
+        assert!(!qwen_control_candle_eligible(&object(
+            json!({ "model": "qwen_image" })
+        )));
+        assert!(!qwen_control_candle_eligible(&object(json!({
+            "model": "qwen_image", "advanced": { "poses": [] }
+        }))));
+        // edit_image with poses is NOT this lane.
+        assert!(!qwen_control_candle_eligible(&object(json!({
+            "model": "qwen_image", "mode": "edit_image", "advanced": { "poses": [{}] }
+        }))));
+        // A DIFFERENT model with poses still defers to torch (z_image/kolors/sdxl slices not landed) —
+        // the qwen branch is specific; the txt2img gate's has_poses deferral still applies to them.
+        assert!(!image_job_is_candle_eligible(&image_generate_job(json!({
+            "model": "z_image_turbo", "advanced": { "poses": [{}] }
         }))));
     }
 }

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -661,39 +661,46 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "27b0
 # ancestor) so 7c7550d still resolves exactly ONE gen-core rev, no skew. GPU-validated on RTX PRO 6000:
 # coherent on-prompt video + a 48 kHz stereo audio track of matching duration. ALL candle deps MUST
 # share this rev.
+#
+# sc-5489 (Qwen-Image ControlNet / strict pose) bumps the candle pin `7c7550d` -> `3d64965` (candle-gen
+# #75): ADDS the candle Qwen-Image strict-pose ControlNet provider (`candle_gen_qwen_image::QwenControl`
+# — the InstantX Qwen-Image-ControlNet-Union branch + the VAE encoder for the pose skeleton) the worker
+# `qwen_image` + `advanced.poses` lane routes onto (image_jobs/qwen_control.rs). #75 is SOURCE-ONLY and
+# 7c7550d is its ancestor, so 3d64965 still resolves gen-core `27b0107` == this worker's mlx-gen pin
+# (single gen-core rev, no skew). GPU-validated (the generated person follows the pose skeleton).
 [target.'cfg(target_os = "windows")'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c7550d12281faae5e92a4b2acc5cf37dd5c1f55", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3d6496505f0bc6e10c7be7b6eeb2654ca5e94310", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c7550d12281faae5e92a4b2acc5cf37dd5c1f55", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c7550d12281faae5e92a4b2acc5cf37dd5c1f55", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c7550d12281faae5e92a4b2acc5cf37dd5c1f55", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c7550d12281faae5e92a4b2acc5cf37dd5c1f55", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3d6496505f0bc6e10c7be7b6eeb2654ca5e94310", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3d6496505f0bc6e10c7be7b6eeb2654ca5e94310", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3d6496505f0bc6e10c7be7b6eeb2654ca5e94310", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3d6496505f0bc6e10c7be7b6eeb2654ca5e94310", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c7550d12281faae5e92a4b2acc5cf37dd5c1f55", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3d6496505f0bc6e10c7be7b6eeb2654ca5e94310", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c7550d12281faae5e92a4b2acc5cf37dd5c1f55", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c7550d12281faae5e92a4b2acc5cf37dd5c1f55", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3d6496505f0bc6e10c7be7b6eeb2654ca5e94310", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3d6496505f0bc6e10c7be7b6eeb2654ca5e94310", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c7550d12281faae5e92a4b2acc5cf37dd5c1f55", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3d6496505f0bc6e10c7be7b6eeb2654ca5e94310", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c7550d12281faae5e92a4b2acc5cf37dd5c1f55", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3d6496505f0bc6e10c7be7b6eeb2654ca5e94310", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -702,19 +709,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c7550d12281faae5e92a4b2acc5cf37dd5c1f55", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3d6496505f0bc6e10c7be7b6eeb2654ca5e94310", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c7550d12281faae5e92a4b2acc5cf37dd5c1f55", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3d6496505f0bc6e10c7be7b6eeb2654ca5e94310", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c7550d12281faae5e92a4b2acc5cf37dd5c1f55", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3d6496505f0bc6e10c7be7b6eeb2654ca5e94310", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -723,12 +730,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c7550d12281faae5e92a4b2acc5cf37dd5c1f55", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3d6496505f0bc6e10c7be7b6eeb2654ca5e94310", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c7550d12281faae5e92a4b2acc5cf37dd5c1f55", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3d6496505f0bc6e10c7be7b6eeb2654ca5e94310", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -736,7 +743,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c755
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c7550d12281faae5e92a4b2acc5cf37dd5c1f55", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3d6496505f0bc6e10c7be7b6eeb2654ca5e94310", features = ["cuda"], optional = true }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -172,6 +172,13 @@ use candle_gen_kolors::{IpAdapterKolors, IpAdapterKolorsPaths, IpAdapterKolorsRe
 // (`image_jobs/flux_ipadapter.rs`) drives.
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
 use candle_gen_flux::{IpAdapterFlux, IpAdapterFluxPaths, IpAdapterFluxRequest};
+// Qwen-Image ControlNet (strict pose) provider (sc-5489, epic 5480) — the candle (Windows/CUDA)
+// strict-pose lane (the first candle ControlNet family beyond the InstantID SDXL path). Candle-only:
+// macOS keeps the MLX `qwen_image_control` registry generator. `candle_gen_qwen_image` is already a
+// force-link anchor (`use candle_gen_qwen_image as _;`) from the Qwen txt2img wiring; this is the
+// named-type import the bespoke pose route (`image_jobs/qwen_control.rs`) drives.
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+use candle_gen_qwen_image::{QwenControl, QwenControlPaths, QwenControlRequest};
 
 /// The stub adapter id recorded on generated assets (matches the contract fixture
 /// `tests/fixtures/rust_migration_contracts/sidecars/asset-image.sceneworks.json`).
@@ -496,6 +503,21 @@ pub(crate) async fn run_image_generate_job(
         // would be caught by the txt2img branch and silently drop the reference (the SDXL/Kolors IP
         // reasoning, for FLUX).
         generate_candle_flux_ipadapter_stream(
+            api,
+            settings,
+            job,
+            &plan,
+            &project_path,
+            backend,
+            &mut asset_writes,
+        )
+        .await?;
+        true
+    } else if settings.backend_candle_enabled && qwen_control_available(&request, settings) {
+        // Qwen-Image strict-pose ControlNet (sc-5489) — checked BEFORE `is_candle_engine` because
+        // `qwen_image` IS a candle txt2img id, so without this a `advanced.poses` job would be caught
+        // by the txt2img branch and silently drop the poses (the IP-Adapter reasoning, for poses).
+        generate_candle_qwen_control_stream(
             api,
             settings,
             job,
@@ -996,6 +1018,10 @@ include!("image_jobs/kolors_ipadapter.rs");
 // bespoke provider, so this is candle-exclusive.
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
 include!("image_jobs/flux_ipadapter.rs");
+// Qwen-Image ControlNet (strict pose) — the Windows/CUDA candle lane ONLY (sc-5489). macOS keeps the
+// MLX `qwen_image_control` registry generator; the candle `QwenControl` is a bespoke provider.
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+include!("image_jobs/qwen_control.rs");
 #[cfg(target_os = "macos")]
 // PuLID-FLUX native routing.
 include!("image_jobs/pulid.rs");

--- a/crates/sceneworks-worker/src/image_jobs/qwen_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_control.rs
@@ -1,0 +1,310 @@
+// Candle (Windows/CUDA) Qwen-Image ControlNet (strict pose) route (sc-5489, epic 5480) — `qwen_image`
+// + `advanced.poses` off-Mac via `candle_gen_qwen_image::QwenControl`. The candle sibling of the MLX
+// Qwen strict-pose path (qwen.rs `generate_qwen_control_stream`): one image per pose, each conditioned
+// on a full DWPose skeleton (rendered cross-platform by `openpose_skeleton::draw_wholebody`) fed to the
+// InstantX Qwen-Image-ControlNet-Union branch.
+//
+// **Candle-only.** macOS keeps the MLX `qwen_image_control` registry generator; the candle `QwenControl`
+// is a bespoke provider, so this whole file is gated to the Windows/CUDA candle build (the `include!` in
+// image_jobs.rs carries the cfg). It is `include!`d into the `image_jobs` module, so it shares that
+// module's imports (`parse_poses`/`Settings`/`WorkerResult`/`huggingface_snapshot_dir`/
+// `ensure_hf_cached_file`/`start_gen_stream`/… all in scope unqualified).
+
+/// Default InstantX Qwen-Image-ControlNet-Union weights (Apache-2.0, DWPose-trained) — same repo/file
+/// the MLX path uses (`qwen.rs` `QWEN_CONTROL_REPO`/`QWEN_CONTROL_FILE`).
+const QWEN_CONTROL_REPO: &str = "InstantX/Qwen-Image-ControlNet-Union";
+const QWEN_CONTROL_FILE: &str = "diffusion_pytorch_model.safetensors";
+/// The Qwen-Image base diffusers repo when the manifest omits `repo`.
+const QWEN_CONTROL_DEFAULT_REPO: &str = "Qwen/Qwen-Image";
+/// ControlNet conditioning-scale default (the strict-pose tier).
+const QWEN_CONTROL_DEFAULT_SCALE: f32 = 1.0;
+/// Denoise-steps default (Qwen-Image production).
+const QWEN_CONTROL_DEFAULT_STEPS: u32 = 30;
+/// CFG default.
+const QWEN_CONTROL_DEFAULT_GUIDANCE: f32 = 4.0;
+/// The adapter/engine id recorded on candle Qwen control assets (distinct from the txt2img
+/// `candle_qwen` lane).
+const QWEN_CONTROL_ENGINE: &str = "candle_qwen_control";
+
+/// Model ids the candle Qwen ControlNet route accepts.
+fn is_qwen_control_model(model: &str) -> bool {
+    model == "qwen_image"
+}
+
+/// Resolve the Qwen-Image base (diffusers) snapshot: an explicit `modelPath` (advanced or manifest) →
+/// the HF cache snapshot for the manifest `repo` (default `Qwen/Qwen-Image`). `None` ⇒ not present
+/// locally (the job is not candle-runnable, falls through to torch). Mirrors
+/// `resolve_kolors_ipadapter_base`.
+fn resolve_qwen_control_base(
+    request: &ImageRequest,
+    settings: &Settings,
+) -> WorkerResult<Option<PathBuf>> {
+    if let Some(path) = request
+        .advanced
+        .get("modelPath")
+        .or_else(|| request.model_manifest_entry.get("modelPath"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+    {
+        return resolve_app_managed_model_dir(settings, &path, "Qwen control modelPath").map(Some);
+    }
+    let repo = request
+        .model_manifest_entry
+        .get("repo")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(QWEN_CONTROL_DEFAULT_REPO);
+    Ok(huggingface_snapshot_dir(&settings.data_dir, repo))
+}
+
+/// True when this is a candle-eligible Qwen strict-pose job: `qwen_image` with a non-empty
+/// `advanced.poses`, not edit mode, whose base resolves locally. Mirrors
+/// `jobs_store::qwen_control_candle_eligible` so the worker and router agree.
+fn qwen_control_available(request: &ImageRequest, settings: &Settings) -> bool {
+    is_qwen_control_model(&request.model)
+        && request.mode != "edit_image"
+        && !pose_entries(request).is_empty()
+        && matches!(resolve_qwen_control_base(request, settings), Ok(Some(_)))
+}
+
+/// Resolve denoise steps: `advanced.steps` (clamped 1..=100) → manifest `steps` → default (30).
+fn qwen_control_steps(request: &ImageRequest) -> u32 {
+    let parse = |value: &Value| {
+        value
+            .as_u64()
+            .or_else(|| value.as_str()?.trim().parse().ok())
+    };
+    request
+        .advanced
+        .get("steps")
+        .and_then(parse)
+        .or_else(|| request.model_manifest_entry.get("steps").and_then(parse))
+        .map(|steps| steps.clamp(1, 100) as u32)
+        .unwrap_or(QWEN_CONTROL_DEFAULT_STEPS)
+}
+
+/// Resolve guidance: `advanced.guidanceScale` → manifest `guidanceScale` → default (4.0), clamped.
+fn qwen_control_guidance(request: &ImageRequest) -> f32 {
+    let manifest_default = request
+        .model_manifest_entry
+        .get("guidanceScale")
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .map(|value| value as f32)
+        .unwrap_or(QWEN_CONTROL_DEFAULT_GUIDANCE);
+    advanced::f32_clamped(
+        &request.advanced,
+        "guidanceScale",
+        manifest_default,
+        0.0..=30.0,
+    )
+}
+
+/// The (repo, filename) of the ControlNet weights — `advanced.controlWeights.{repo,filename}` overrides,
+/// else the InstantX Union default (parity with the MLX `resolve_control_weights_for`).
+fn qwen_control_repo_file(request: &ImageRequest) -> (String, String) {
+    let cw = request.advanced.get("controlWeights").and_then(Value::as_object);
+    let pick = |key: &str, default: &str| {
+        cw.and_then(|m| m.get(key))
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+            .unwrap_or(default)
+            .to_owned()
+    };
+    (
+        pick("repo", QWEN_CONTROL_REPO),
+        pick("filename", QWEN_CONTROL_FILE),
+    )
+}
+
+/// Resolve the InstantX ControlNet weight **file** the `QwenControl` provider loads, downloading on
+/// first use. Order: an env-pinned file (`SCENEWORKS_CONTROLNET_QWEN`) → a whole-repo HF cache snapshot
+/// → download into the app cache.
+async fn ensure_qwen_control_weights(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &ImageRequest,
+) -> WorkerResult<PathBuf> {
+    let (repo, file) = qwen_control_repo_file(request);
+    if let Ok(p) = std::env::var("SCENEWORKS_CONTROLNET_QWEN") {
+        let p = PathBuf::from(p);
+        if p.is_file() {
+            return Ok(p);
+        }
+    }
+    if let Some(snapshot) = huggingface_snapshot_dir(&settings.data_dir, &repo) {
+        let f = snapshot.join(&file);
+        if f.is_file() {
+            return Ok(f);
+        }
+    }
+    let client = reqwest::Client::new();
+    let context = DownloadContext {
+        api,
+        client: &client,
+        settings,
+        job_id: &job.id,
+        cancel_message: "Qwen strict-pose generation canceled while fetching control weights.",
+        fresh_download: false,
+    };
+    let dst = settings
+        .data_dir
+        .join("cache")
+        .join("controlnet-qwen")
+        .join(&file);
+    ensure_hf_cached_file(&context, &repo, "main", &file, &dst).await?;
+    Ok(dst)
+}
+
+/// Flat telemetry recorded on candle Qwen control assets.
+fn qwen_control_raw_settings(
+    request: &ImageRequest,
+    repo: &str,
+    steps: u32,
+    guidance: f32,
+    control_scale: f32,
+    pose_count: usize,
+) -> JsonObject {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("repo".to_owned(), Value::String(repo.to_owned()));
+    raw.insert("numInferenceSteps".to_owned(), json!(steps));
+    raw.insert("guidanceScale".to_owned(), json!(guidance));
+    raw.insert("controlScale".to_owned(), json!(control_scale));
+    raw.insert("poseCount".to_owned(), json!(pose_count));
+    raw.insert(
+        "controlEngine".to_owned(),
+        Value::String(QWEN_CONTROL_ENGINE.to_owned()),
+    );
+    raw
+}
+
+/// Real candle Qwen strict-pose generation: one image per pose, each conditioned on a full DWPose
+/// skeleton. The provider loads once on the blocking thread; each pose renders its skeleton + generates.
+/// `generate` takes the per-job `CancelFlag` + a `Progress` callback (per-step streaming + mid-denoise
+/// cancel), the same contract as the IP-Adapter lanes.
+async fn generate_candle_qwen_control_stream(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+    let qwen_base = resolve_qwen_control_base(request, settings)?
+        .ok_or_else(|| WorkerError::InvalidPayload("Qwen-Image base weights not found".to_owned()))?;
+    let controlnet = ensure_qwen_control_weights(api, settings, job, request).await?;
+
+    let steps = qwen_control_steps(request);
+    let guidance = qwen_control_guidance(request);
+    let control_scale = advanced::f32_clamped(
+        &request.advanced,
+        "controlScale",
+        QWEN_CONTROL_DEFAULT_SCALE,
+        0.0..=2.0,
+    );
+    let repo = request
+        .model_manifest_entry
+        .get("repo")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(QWEN_CONTROL_DEFAULT_REPO)
+        .to_owned();
+
+    let poses = parse_poses(request);
+    let pose_count = poses.len();
+    let raw_settings =
+        qwen_control_raw_settings(request, &repo, steps, guidance, control_scale, pose_count);
+
+    let (width, height) = (request.width, request.height);
+    let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
+    // One shared seed across the pose set (the MLX `_generate_pose_set` convention).
+    let seed = resolve_seed(request, 0);
+    let prompt = request.prompt.clone();
+    let negative = request.negative_prompt.clone();
+
+    let (cancel, rx, blocking) = start_gen_stream(
+        job.id.clone(),
+        "qwen_control",
+        0,
+        move || {
+            let paths = QwenControlPaths {
+                qwen_base,
+                controlnet,
+            };
+            let model = QwenControl::load(&paths).map_err(|error| {
+                WorkerError::Engine(format!("Qwen strict-pose control load failed: {error}"))
+            })?;
+            Ok((model, poses))
+        },
+        move |(model, poses), tx, cancel| {
+            drive_gen_items(tx, poses, move |_index, pose, on_progress| {
+                if cancel.is_cancelled() {
+                    return Ok(None);
+                }
+                let skeleton = crate::openpose_skeleton::draw_wholebody(
+                    width,
+                    height,
+                    &pose.keypoints,
+                    pose.hands.as_deref(),
+                    pose.face.as_deref(),
+                    stickwidth,
+                );
+                let control = Image {
+                    width,
+                    height,
+                    pixels: skeleton.into_raw(),
+                };
+                let req = QwenControlRequest {
+                    prompt: prompt.clone(),
+                    negative: negative.clone(),
+                    width,
+                    height,
+                    steps: steps as usize,
+                    guidance,
+                    control_scale,
+                    seed: seed as u64,
+                    cancel: cancel.clone(),
+                };
+                let out = match model.generate(&req, &control, &mut *on_progress) {
+                    Ok(out) => out,
+                    Err(_) if cancel.is_cancelled() => return Ok(None),
+                    Err(error) => {
+                        return Err(WorkerError::Engine(format!(
+                            "Qwen strict-pose generation failed: {error}"
+                        )));
+                    }
+                };
+                Ok(Some((seed, out.width, out.height, out.pixels)))
+            })
+        },
+    );
+
+    consume_gen_events(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        QWEN_CONTROL_ENGINE,
+        &raw_settings,
+        pose_count,
+        rx,
+        cancel,
+        blocking,
+        asset_writes,
+    )
+    .await
+}


### PR DESCRIPTION
Routes `qwen_image` + `advanced.poses` jobs to the candle `QwenControl` provider off-Mac, removing the `advanced.poses → torch` deferral for the Qwen family — the first candle strict-pose lane ([sc-5489](https://app.shortcut.com/trefry/story/5489); SDXL OpenPose already ships via the InstantID lane). The candle-gen provider landed in [candle-gen #75](https://github.com/michaeltrefry/candle-gen/pull/75), **GPU-validated** (the generated person follows the pose skeleton).

### What's here
- **NEW `crates/sceneworks-worker/src/image_jobs/qwen_control.rs`** (`cfg(all(windows, backend-candle))`): `generate_candle_qwen_control_stream` + `qwen_control_available` + weight resolution. **One image per pose** — each pose renders a full DWPose skeleton via the cross-platform `openpose_skeleton::draw_wholebody`, which the provider VAE-encodes. Base via the manifest `repo` (default `Qwen/Qwen-Image`); the InstantX `Qwen-Image-ControlNet-Union` `diffusion_pytorch_model.safetensors` via env `SCENEWORKS_CONTROLNET_QWEN` / `advanced.controlWeights.{repo,filename}` → whole-repo HF snapshot → download-on-first-use. control scale 1.0 (clamp 0..2), steps 30, guidance 4.0, engine `candle_qwen_control`. `generate` is `&self`.
- **`image_jobs.rs`**: dispatch branch BEFORE `is_candle_engine` (`qwen_image` IS a candle txt2img id, so a pose job would otherwise hit txt2img and silently drop the poses) + the `candle_gen_qwen_image::{QwenControl, …}` named import (already a force-link anchor) + the cfg-gated `include!`.
- **`jobs_store.rs`**: `qwen_control_candle_eligible` (`qwen_image` + non-empty `advanced.poses`, not `edit_image`) + a branch in `image_job_is_candle_eligible` **before** the `image_request_candle_eligible` pose-deferral, so `qwen_image` pose jobs reach candle while `z_image`/`kolors`/`sdxl` pose jobs stay on torch until their slices land. + a routing test (and updated the worker-claims test — qwen poses are now claimed).
- **Cargo re-pin** candle-gen `7c7550d` → `3d64965` (#75, 16 crates); mlx-gen stays `27b0107` (#75 source-only → single gen-core rev `27b0107`, no skew, no treadmill).

### Verification
- 27 `sceneworks-core` candle routing tests (incl. the new `qwen_control_pose_jobs_route_to_candle`, and the cross-check that a *different* family's pose job still defers to torch).
- Worker `--features backend-candle` build **links** (sm_120, MSVC 14.44) + `clippy -D warnings` clean (lib; the pre-existing `tests.rs` `--all-targets` wart is not mine).
- `fmt` clean.

macOS keeps its MLX `qwen_image_control` registry generator; this is the Windows/CUDA candle lane only. Full Qwen chain: candle-gen #75 (provider + GPU validation) → this worker PR (route + re-pin). Kolors + Z-Image strict-pose remain (their own slices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)