### PR TITLE
fix(sc-5891): stop eager keychain reads at launch; lazy credential socket on macOS

### DIFF
--- a/apps/desktop/src/cred_ipc.rs
+++ b/apps/desktop/src/cred_ipc.rs
@@ -1,0 +1,167 @@
+//! On-demand download-credential socket for the macOS desktop (sc-5891).
+//!
+//! The desktop is the only process that can read the OS keychain. Reading it
+//! eagerly at worker spawn (to inject `HF_TOKEN`/`SCENEWORKS_CREDENTIALS`) is what
+//! prompted for the keychain password at every launch. Instead this module hosts a
+//! tiny Unix-domain-socket server in the desktop process: the MLX worker is given
+//! the socket path + a per-launch token, and pulls a host's secret from here the
+//! first time a download actually needs it. The keychain is therefore read lazily —
+//! the single prompt happens at download time, not at launch — and the result is
+//! cached for the rest of the desktop session so worker restarts don't re-prompt.
+//!
+//! Security: the socket is created `0600` (same-user only) and the worker must
+//! present the per-launch token. Only credentials recorded in `settings.json`
+//! metadata are ever read (`settings::resolve_credential_secret` gates on that), so
+//! an install with nothing stored never causes a keychain touch.
+
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use crate::settings::{self, CredentialScheme};
+
+/// Cached, already-resolved secret for a host, so repeat pulls (a multi-file gated
+/// download, or a worker restart within this session) don't re-read the keychain.
+#[derive(Clone)]
+struct CachedSecret {
+    token: String,
+    scheme: &'static str,
+}
+
+type CredCache = Arc<Mutex<HashMap<String, CachedSecret>>>;
+
+/// Handle to the running credential socket, stored in `Managed` so the MLX worker
+/// spawn site can inject the socket path/token and the credential commands can
+/// invalidate the cache.
+pub struct CredIpc {
+    pub socket: PathBuf,
+    pub token: String,
+    cache: CredCache,
+}
+
+impl CredIpc {
+    /// Drop a host's cached secret so a later pull re-reads the keychain — used when
+    /// the user updates or removes that credential mid-session (revocation must take
+    /// effect without an app restart).
+    pub fn invalidate(&self, host: &str) {
+        let host = host.trim().to_ascii_lowercase();
+        if let Ok(mut cache) = self.cache.lock() {
+            cache.remove(&host);
+        }
+    }
+}
+
+fn scheme_str(scheme: CredentialScheme) -> &'static str {
+    match scheme {
+        CredentialScheme::Bearer => "bearer",
+        CredentialScheme::Query => "query",
+    }
+}
+
+/// A per-launch random token (hex). Defense-in-depth on top of the socket's `0600`
+/// same-user restriction. Falls back to a process/time-derived value if
+/// `/dev/urandom` is somehow unreadable — the file-mode is the real guard.
+fn random_token() -> String {
+    use std::io::Read;
+    let mut bytes = [0u8; 24];
+    if std::fs::File::open("/dev/urandom")
+        .and_then(|mut file| file.read_exact(&mut bytes))
+        .is_ok()
+    {
+        return bytes.iter().map(|byte| format!("{byte:02x}")).collect();
+    }
+    format!(
+        "{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|elapsed| elapsed.as_nanos())
+            .unwrap_or_default()
+    )
+}
+
+/// Bind the credential socket and spawn its server thread. Returns the handle to
+/// store in `Managed`, or `None` if the socket couldn't be created (the worker then
+/// simply gets no credentials — a gated download fails with a clear auth error
+/// rather than the app prompting at launch).
+pub fn start(socket: PathBuf) -> Option<CredIpc> {
+    // Remove any stale socket from a prior (crashed) launch so bind succeeds.
+    let _ = std::fs::remove_file(&socket);
+    if let Some(parent) = socket.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let listener = match UnixListener::bind(&socket) {
+        Ok(listener) => listener,
+        Err(_) => return None,
+    };
+    // Restrict to the current user; the per-launch token is the second factor.
+    let _ = std::fs::set_permissions(&socket, std::fs::Permissions::from_mode(0o600));
+
+    let token = random_token();
+    let cache: CredCache = Arc::new(Mutex::new(HashMap::new()));
+    let server_token = token.clone();
+    let server_cache = Arc::clone(&cache);
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(stream) = stream else { continue };
+            handle_connection(stream, &server_token, &server_cache);
+        }
+    });
+    Some(CredIpc {
+        socket,
+        token,
+        cache,
+    })
+}
+
+/// Serve one request: read `"<token> <host>\n"`, validate the token, then reply with
+/// `{ "token": "...", "scheme": "bearer" | "query" }` for a recorded+present host, or
+/// `ERR` otherwise. One request per connection; the worker opens a fresh connection
+/// each time.
+fn handle_connection(stream: UnixStream, token: &str, cache: &CredCache) {
+    let mut reader = BufReader::new(stream);
+    let mut line = String::new();
+    if reader.read_line(&mut line).is_err() {
+        return;
+    }
+    let mut parts = line.trim().splitn(2, ' ');
+    let presented = parts.next().unwrap_or_default();
+    let host = parts.next().unwrap_or_default().trim().to_ascii_lowercase();
+    let response = if presented != token || host.is_empty() {
+        "ERR".to_owned()
+    } else {
+        resolve(&host, cache).unwrap_or_else(|| "ERR".to_owned())
+    };
+    let mut stream = reader.into_inner();
+    let _ = stream.write_all(response.as_bytes());
+    let _ = stream.flush();
+}
+
+/// The cached or freshly-read secret for `host`, serialized as the response JSON.
+/// Only recorded+present credentials resolve; the keychain read happens here (lazy),
+/// and a successful read is cached. Absent secrets are not cached, so adding a
+/// credential later this session works without restarting the server.
+fn resolve(host: &str, cache: &CredCache) -> Option<String> {
+    if let Some(cached) = cache.lock().ok().and_then(|cache| cache.get(host).cloned()) {
+        return Some(response_json(&cached.token, cached.scheme));
+    }
+    let (token, scheme) = settings::resolve_credential_secret(host)?;
+    let scheme = scheme_str(scheme);
+    if let Ok(mut cache) = cache.lock() {
+        cache.insert(
+            host.to_owned(),
+            CachedSecret {
+                token: token.clone(),
+                scheme,
+            },
+        );
+    }
+    Some(response_json(&token, scheme))
+}
+
+fn response_json(token: &str, scheme: &str) -> String {
+    serde_json::json!({ "token": token, "scheme": scheme }).to_string()
+}

--- a/apps/desktop/src/main.rs
+++ b/apps/desktop/src/main.rs
@@ -1,6 +1,10 @@
 // Hide the extra console window on Windows in release builds.
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+// On-demand keychain credential socket for the MLX worker (sc-5891). macOS-only:
+// it replaces the eager spawn-time keychain reads that prompted at every launch.
+#[cfg(target_os = "macos")]
+mod cred_ipc;
 mod settings;
 mod setup;
 

--- a/apps/desktop/src/settings.rs
+++ b/apps/desktop/src/settings.rs
@@ -12,8 +12,11 @@ use tauri_plugin_dialog::DialogExt;
 use crate::setup::{app_support_dir, default_data_dir, shared_huggingface_home, Managed};
 
 const KEYRING_SERVICE: &str = "SceneWorks";
-/// Pre-migration account that held the single Hugging Face token. Kept only for
-/// one-time migration into the host-keyed store (and as a read fallback).
+/// Pre-migration account that held the single Hugging Face token. Retained only so
+/// `delete_credential` can also clear it when the user removes Hugging Face — it is
+/// never *read* on a startup/spawn path, because probing it unconditionally is an
+/// unguarded keychain touch (and macOS prompt) on installs that have no token
+/// recorded (sc-5891).
 const HF_TOKEN_ACCOUNT: &str = "huggingface_token";
 /// Host of the migrated Hugging Face credential.
 const HF_HOST: &str = "huggingface.co";
@@ -104,6 +107,9 @@ fn remove_credential_meta(settings: &mut AppSettings, host: &str) -> bool {
     settings.credentials.len() != before
 }
 
+// Gates the eager-push HF read below; on macOS that path is replaced by the lazy
+// credential socket (sc-5891), so this is only reached off macOS (and in tests).
+#[cfg_attr(target_os = "macos", allow(dead_code))]
 fn hf_credential_recorded(settings: &AppSettings) -> bool {
     settings
         .credentials
@@ -111,46 +117,17 @@ fn hf_credential_recorded(settings: &AppSettings) -> bool {
         .any(|entry| entry.host == HF_HOST)
 }
 
-/// One-time move of the legacy single HF token into the host-keyed store as a
-/// `huggingface.co` credential. Idempotent: a no-op once a `huggingface.co`
-/// credential is recorded. Returns true when it migrated so the caller persists.
-fn migrate_legacy_hf_token(settings: &mut AppSettings) -> bool {
-    if hf_credential_recorded(settings) {
-        return false;
-    }
-    let Some(token) = keyring::Entry::new(KEYRING_SERVICE, HF_TOKEN_ACCOUNT)
-        .ok()
-        .and_then(|entry| entry.get_password().ok())
-        .map(|token| token.trim().to_owned())
-        .filter(|token| !token.is_empty())
-    else {
-        return false;
-    };
-    match keyring::Entry::new(KEYRING_SERVICE, &cred_account(HF_HOST)) {
-        Ok(entry) if entry.set_password(&token).is_ok() => {}
-        _ => return false,
-    }
-    // Drop the legacy entry so the token isn't stored twice; best-effort.
-    if let Ok(legacy) = keyring::Entry::new(KEYRING_SERVICE, HF_TOKEN_ACCOUNT) {
-        let _ = legacy.delete_credential();
-    }
-    settings.credentials.push(CredentialMeta {
-        host: HF_HOST.to_owned(),
-        label: "Hugging Face".to_owned(),
-        scheme: CredentialScheme::Bearer,
-    });
-    true
-}
-
-/// Load settings, running the one-time HF-token migration and persisting it if it
-/// fired.
-fn load_settings_migrated() -> AppSettings {
-    let mut settings = load_settings();
-    if migrate_legacy_hf_token(&mut settings) {
-        let _ = save_settings(&settings);
-    }
-    settings
-}
+// NOTE (sc-5891): there used to be a startup `migrate_legacy_hf_token` here that
+// moved the pre-host-keyed single token (`huggingface_token` account) into the
+// `cred:huggingface.co` store. It had to probe the legacy keychain entry to do so,
+// and the only signal that such a token might exist *is* the keychain itself — the
+// pre-migration `settings.json` recorded nothing about it. That unconditional probe
+// is exactly the unguarded keychain touch (and macOS password prompt) this story
+// removes, so the startup auto-migration is gone: a fresh/no-token install must
+// never touch the keychain. Any install that launched a build after the host-keyed
+// store landed already auto-migrated (the migration was idempotent and ran at
+// startup); the rare install that skipped every such build can re-add its Hugging
+// Face token once in Settings.
 
 #[derive(Default, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -198,24 +175,64 @@ fn save_settings(settings: &AppSettings) -> Result<(), String> {
     std::fs::write(&path, body).map_err(|error| error.to_string())
 }
 
-/// Hugging Face token for injecting `HF_TOKEN` into the worker. Prefers the
-/// host-keyed `huggingface.co` credential, falling back to the pre-migration
-/// `huggingface_token` account so a not-yet-migrated install still authenticates.
+/// Hugging Face token for injecting `HF_TOKEN` into the worker, from the host-keyed
+/// `huggingface.co` credential. Gated on the non-secret `settings.json` metadata
+/// first: if no `huggingface.co` credential is recorded, returns `None` *without
+/// constructing a `keyring::Entry` or calling `get_password()`*, so a no-token
+/// install never touches the OS keychain (and never triggers a macOS password
+/// prompt). The pre-migration `huggingface_token` fallback was removed for the same
+/// reason — it probed the keychain unconditionally (sc-5891).
+///
+/// macOS no longer uses this eager push at all — the MLX worker pulls credentials
+/// lazily from the desktop credential socket (`cred_ipc`) — so it's compiled but
+/// uncalled there (the Python/candle spawn sites on other platforms still use it).
+#[cfg_attr(target_os = "macos", allow(dead_code))]
 pub fn read_hf_token() -> Option<String> {
-    read_credential_secret(HF_HOST).or_else(|| {
-        keyring::Entry::new(KEYRING_SERVICE, HF_TOKEN_ACCOUNT)
-            .ok()
-            .and_then(|entry| entry.get_password().ok())
-            .map(|token| token.trim().to_owned())
-            .filter(|token| !token.is_empty())
-    })
+    if !hf_credential_recorded(&load_settings()) {
+        return None;
+    }
+    read_credential_secret(HF_HOST)
+}
+
+/// The non-secret hosts that have a credential recorded, handed to the MLX worker so
+/// it knows which hosts it may request from the credential socket (sc-5891). Reads
+/// `settings.json` metadata only — no keychain access — so an empty list (nothing
+/// recorded) keeps the worker from ever asking, hence no keychain touch.
+#[cfg(target_os = "macos")]
+pub fn recorded_credential_hosts() -> Vec<String> {
+    load_settings()
+        .credentials
+        .into_iter()
+        .map(|meta| meta.host)
+        .collect()
+}
+
+/// The secret token + scheme for a single recorded host, for the on-demand
+/// credential socket to serve when a worker download actually needs it (sc-5891).
+/// Gated on the non-secret `settings.json` metadata: if the host isn't recorded this
+/// returns `None` without reading the keychain. This is the single *lazy* keychain
+/// read that replaces the eager spawn-time reads on macOS.
+#[cfg(target_os = "macos")]
+pub fn resolve_credential_secret(host: &str) -> Option<(String, CredentialScheme)> {
+    let host = host.trim().to_ascii_lowercase();
+    let settings = load_settings();
+    let meta = settings
+        .credentials
+        .iter()
+        .find(|entry| entry.host == host)?;
+    let token = read_credential_secret(&host)?;
+    Some((token, meta.scheme))
 }
 
 /// All stored credentials serialized as the worker's `SCENEWORKS_CREDENTIALS` JSON
 /// map (`{ host: { token, scheme } }`), reading each secret from the keychain.
 /// `None` when no credentials are stored. Injected into the worker at spawn.
+///
+/// macOS uses the lazy credential socket (`cred_ipc`) instead, so this is compiled
+/// but uncalled there (the Python/candle spawn sites on other platforms use it).
+#[cfg_attr(target_os = "macos", allow(dead_code))]
 pub fn credentials_env_json() -> Option<String> {
-    let settings = load_settings_migrated();
+    let settings = load_settings();
     let mut map = serde_json::Map::new();
     for meta in &settings.credentials {
         if let Some(token) = read_credential_secret(&meta.host) {
@@ -386,7 +403,7 @@ fn validate_reveal_target(path: &str) -> Result<PathBuf, String> {
         return Err("A path is required.".to_owned());
     }
     let target = std::fs::canonicalize(target).map_err(|error| error.to_string())?;
-    let settings = load_settings_migrated();
+    let settings = load_settings();
     let roots = [
         settings
             .data_dir
@@ -416,7 +433,7 @@ fn validate_reveal_target(path: &str) -> Result<PathBuf, String> {
 /// whether the secret is present in the keychain. Never returns the token itself.
 #[tauri::command]
 pub fn list_credentials() -> Vec<CredentialStatus> {
-    load_settings_migrated()
+    load_settings()
         .credentials
         .into_iter()
         .map(|meta| {
@@ -435,6 +452,7 @@ pub fn list_credentials() -> Vec<CredentialStatus> {
 /// non-secret metadata. The token is write-only — it is never read back to the UI.
 #[tauri::command]
 pub fn set_credential(
+    app: AppHandle,
     host: String,
     label: String,
     scheme: CredentialScheme,
@@ -464,18 +482,21 @@ pub fn set_credential(
     upsert_credential_meta(
         &mut settings,
         CredentialMeta {
-            host,
+            host: host.clone(),
             label,
             scheme,
         },
     );
     save_settings(&settings)?;
+    // Drop any cached secret for this host so the worker pulls the new token on its
+    // next download without an app restart (sc-5891).
+    crate::setup::invalidate_credential_cache(&app, &host);
     Ok(list_credentials())
 }
 
 /// Remove a host's credential from the keychain and drop its metadata.
 #[tauri::command]
-pub fn delete_credential(host: String) -> Result<Vec<CredentialStatus>, String> {
+pub fn delete_credential(app: AppHandle, host: String) -> Result<Vec<CredentialStatus>, String> {
     let host = normalize_host(&host);
     if let Ok(entry) = keyring::Entry::new(KEYRING_SERVICE, &cred_account(&host)) {
         match entry.delete_credential() {
@@ -493,6 +514,9 @@ pub fn delete_credential(host: String) -> Result<Vec<CredentialStatus>, String> 
     let mut settings = load_settings();
     remove_credential_meta(&mut settings, &host);
     save_settings(&settings)?;
+    // Drop the cached secret so a revoked credential stops being served by the
+    // credential socket without an app restart (sc-5891).
+    crate::setup::invalidate_credential_cache(&app, &host);
     Ok(list_credentials())
 }
 
@@ -635,19 +659,17 @@ mod tests {
         assert!(!remove_credential_meta(&mut settings, HF_HOST));
     }
 
+    /// sc-5891: the spawn-time credential gate must short-circuit on the non-secret
+    /// metadata before any `keyring::Entry`/`get_password()` is constructed, so a
+    /// no-credential install never touches the OS keychain. `hf_credential_recorded`
+    /// is that gate for `read_hf_token`; an empty `credentials` list is likewise the
+    /// gate for `credentials_env_json` (its loop body — the only `read_credential_secret`
+    /// site — never runs). This headless test asserts the gate predicate without
+    /// touching the keychain (which `read_hf_token` itself would, once past the gate).
     #[test]
-    fn migration_is_skipped_once_hf_is_recorded() {
-        let mut settings = AppSettings::default();
-        upsert_credential_meta(
-            &mut settings,
-            CredentialMeta {
-                host: HF_HOST.to_owned(),
-                label: "Hugging Face".to_owned(),
-                scheme: CredentialScheme::Bearer,
-            },
-        );
-        // With HF already recorded, migration short-circuits before any keychain
-        // access, so this is safe to run in a headless test.
-        assert!(!migrate_legacy_hf_token(&mut settings));
+    fn no_recorded_credential_means_no_keychain_gate() {
+        let settings = AppSettings::default();
+        assert!(!hf_credential_recorded(&settings));
+        assert!(settings.credentials.is_empty());
     }
 }

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -79,6 +79,12 @@ pub struct Managed {
     /// alongside the Python torch worker (Wave A). Only populated on the Windows
     /// candle build.
     pub candle_worker: Mutex<Option<CommandChild>>,
+    /// On-demand keychain credential socket served to the MLX worker (sc-5891).
+    /// Started once before the worker spawns; the worker pulls a host's secret from
+    /// it the first time a download needs auth, so the keychain is read lazily
+    /// instead of eagerly at launch. macOS-only.
+    #[cfg(target_os = "macos")]
+    pub cred_ipc: Mutex<Option<crate::cred_ipc::CredIpc>>,
     /// OS-assigned API port, discovered from the sidecar's startup line.
     api_port: Mutex<Option<u16>>,
     /// PIDs of the spawned sidecars, persisted to disk so an unclean exit
@@ -1026,6 +1032,11 @@ fn gate_window(app: AppHandle) {
                         // MLX-eligible image/video jobs on the in-process Rust mlx-gen
                         // engine. Any MLX-ineligible job fails `mlx_unsupported` /
                         // `mlx_unavailable` (never MPS) per `Settings.mlx_required`.
+                        //
+                        // Start the on-demand credential socket first (sc-5891) so the
+                        // worker can pull a recorded keychain secret lazily at download
+                        // time instead of us reading it eagerly here at launch.
+                        ensure_cred_ipc(&app);
                         supervise_mlx_worker(app, port);
                     }
                     #[cfg(not(target_os = "macos"))]
@@ -1210,6 +1221,52 @@ fn supervise_worker(app: AppHandle, api_port: u16) {
     });
 }
 
+/// Start the on-demand credential socket (sc-5891) once and stash it in `Managed`.
+/// The MLX worker is handed its socket path + token at spawn and pulls a recorded
+/// keychain secret from it the first time a download needs auth — so the keychain is
+/// read lazily, not eagerly at launch. Idempotent; a start failure is logged and the
+/// worker simply gets no credentials (a gated download then fails with an auth error
+/// rather than the app prompting at launch).
+#[cfg(target_os = "macos")]
+fn ensure_cred_ipc(app: &AppHandle) {
+    let managed = app.state::<Managed>();
+    let mut slot = managed.cred_ipc.lock().expect("cred_ipc lock");
+    if slot.is_some() {
+        return;
+    }
+    let socket = app_support_dir().join("cred-ipc.sock");
+    match crate::cred_ipc::start(socket) {
+        Some(handle) => *slot = Some(handle),
+        None => append_log(
+            &logs_dir().join("mlx-worker.log"),
+            "[desktop] credential socket failed to start; gated downloads will need a re-entered token\n",
+        ),
+    }
+}
+
+/// Drop a host's cached secret from the credential socket (sc-5891) so a later pull
+/// re-reads the keychain. Called when the user updates or removes a credential, so a
+/// revoked/changed token stops being served without an app restart. No-op off macOS
+/// (no socket there).
+pub fn invalidate_credential_cache(app: &AppHandle, host: &str) {
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(ipc) = app
+            .state::<Managed>()
+            .cred_ipc
+            .lock()
+            .expect("cred_ipc lock")
+            .as_ref()
+        {
+            ipc.invalidate(host);
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (app, host);
+    }
+}
+
 /// Spawn and supervise the Apple-Silicon MLX GPU worker (sc-3289): the same
 /// `sceneworks-api` sidecar binary re-launched in worker mode
 /// (`SCENEWORKS_WORKER_ONLY=1`) with `SCENEWORKS_GPU_ID=mlx`, so MLX-eligible
@@ -1283,11 +1340,27 @@ fn supervise_mlx_worker(app: AppHandle, api_port: u16) {
             if let Some(ort_dylib) = resolve_bundled_onnxruntime(&app) {
                 command = command.env("ORT_DYLIB_PATH", ort_dylib);
             }
-            if let Some(token) = crate::settings::read_hf_token() {
-                command = command.env("HF_TOKEN", token);
-            }
-            if let Some(credentials) = crate::settings::credentials_env_json() {
-                command = command.env("SCENEWORKS_CREDENTIALS", credentials);
+            // Lazy credentials (sc-5891): instead of reading the keychain here and
+            // injecting HF_TOKEN/SCENEWORKS_CREDENTIALS (which prompted at launch),
+            // hand the worker the credential socket + token + the NON-secret list of
+            // recorded hosts. The worker pulls a secret only when a download for a
+            // recorded host needs it, so nothing-recorded ⇒ no socket call ⇒ no
+            // keychain touch. Credential changes still take effect on worker restart.
+            {
+                let managed = app.state::<Managed>();
+                let guard = managed.cred_ipc.lock().expect("cred_ipc lock");
+                if let Some(ipc) = guard.as_ref() {
+                    command = command
+                        .env(
+                            "SCENEWORKS_CRED_IPC_SOCKET",
+                            ipc.socket.to_string_lossy().to_string(),
+                        )
+                        .env("SCENEWORKS_CRED_IPC_TOKEN", &ipc.token);
+                    let hosts = crate::settings::recorded_credential_hosts().join(",");
+                    if !hosts.is_empty() {
+                        command = command.env("SCENEWORKS_CREDENTIAL_HOSTS", hosts);
+                    }
+                }
             }
             let spawned = command.spawn();
             let (mut events, child) = match spawned {

--- a/crates/sceneworks-worker/src/credentials_ipc.rs
+++ b/crates/sceneworks-worker/src/credentials_ipc.rs
@@ -1,0 +1,271 @@
+//! Lazy, on-demand download-credential resolution for the macOS desktop build
+//! (sc-5891).
+//!
+//! On macOS the desktop app is the only process that can read the OS keychain, and
+//! reading it eagerly at worker spawn (to inject `HF_TOKEN`/`SCENEWORKS_CREDENTIALS`)
+//! is what triggered a keychain-password prompt at every launch. Instead the desktop
+//! runs a tiny Unix-domain-socket credential server and injects only its socket path
+//! (`SCENEWORKS_CRED_IPC_SOCKET`), a per-launch token (`SCENEWORKS_CRED_IPC_TOKEN`),
+//! and the *non-secret* list of hosts that have a credential recorded
+//! (`SCENEWORKS_CREDENTIAL_HOSTS`). This module pulls a host's secret from that
+//! socket the first time a download actually needs it — so the single keychain prompt
+//! happens then, not at launch — caching it per process for the rest of the session.
+//!
+//! Off the desktop (server/Docker, the Windows candle worker) none of the
+//! `SCENEWORKS_CRED_IPC_*` env vars are set, so the resolver is inert and the worker
+//! keeps using the eager env/file-store credentials exactly as before. The socket
+//! pull itself is `cfg(unix)`; on other targets it compiles to a no-op (the desktop
+//! that injects the env vars only exists on macOS anyway).
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use tokio::sync::Mutex;
+
+use crate::{credential_for_host, Settings, WorkerCredential};
+// Only the `cfg(unix)` response parser (and its tests) name the scheme enum; gating
+// the import keeps the Windows build free of an unused-import warning.
+#[cfg(unix)]
+use crate::CredentialScheme;
+
+/// Path of the desktop credential socket (macOS desktop only).
+const ENV_SOCKET: &str = "SCENEWORKS_CRED_IPC_SOCKET";
+/// Per-launch shared token the worker presents to the socket (defense-in-depth on
+/// top of the socket file's `0600` same-user restriction).
+const ENV_TOKEN: &str = "SCENEWORKS_CRED_IPC_TOKEN";
+/// Comma-separated, non-secret list of hosts that have a credential recorded in the
+/// desktop keychain. The worker only ever asks the socket for hosts in this list, so
+/// an install with nothing recorded never causes a keychain touch — the
+/// no-credential invariant holds end to end.
+const ENV_HOSTS: &str = "SCENEWORKS_CREDENTIAL_HOSTS";
+
+struct IpcConfig {
+    // Read only by the `cfg(unix)` socket pull; off unix the desktop never injects
+    // these, so the fields are constructed-but-unread there.
+    #[cfg_attr(not(unix), allow(dead_code))]
+    socket: std::path::PathBuf,
+    #[cfg_attr(not(unix), allow(dead_code))]
+    token: String,
+    recorded_hosts: Vec<String>,
+}
+
+impl IpcConfig {
+    fn from_env() -> Option<Self> {
+        let socket = std::env::var(ENV_SOCKET)
+            .ok()
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty())
+            .map(std::path::PathBuf::from)?;
+        let token = std::env::var(ENV_TOKEN)
+            .unwrap_or_default()
+            .trim()
+            .to_owned();
+        let recorded_hosts = std::env::var(ENV_HOSTS)
+            .unwrap_or_default()
+            .split(',')
+            .map(|host| host.trim().to_ascii_lowercase())
+            .filter(|host| !host.is_empty())
+            .collect();
+        Some(Self {
+            socket,
+            token,
+            recorded_hosts,
+        })
+    }
+
+    fn has_host(&self, host: &str) -> bool {
+        self.recorded_hosts.iter().any(|recorded| recorded == host)
+    }
+}
+
+struct Resolver {
+    /// `None` off the macOS desktop (no `SCENEWORKS_CRED_IPC_SOCKET`), making every
+    /// lazy pull a no-op so the static env/file-store path is used unchanged.
+    config: Option<IpcConfig>,
+    /// Per-process cache of pulled secrets, so a multi-file gated download — and any
+    /// worker restart within the same desktop session (the desktop server caches
+    /// too) — prompts at most once.
+    cache: Mutex<HashMap<String, WorkerCredential>>,
+}
+
+impl Resolver {
+    fn from_env() -> Self {
+        Self {
+            config: IpcConfig::from_env(),
+            cache: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+static RESOLVER: OnceLock<Resolver> = OnceLock::new();
+
+fn resolver() -> &'static Resolver {
+    RESOLVER.get_or_init(Resolver::from_env)
+}
+
+/// The download credential for `host`: the statically-injected env/file-store
+/// credential first (server/Docker, the Windows candle worker), else — on the macOS
+/// desktop — a lazy pull from the desktop credential socket (cached per process).
+/// `None` when no credential is available for the host.
+pub(crate) async fn resolve_credential_for_host(
+    settings: &Settings,
+    host: &str,
+) -> Option<WorkerCredential> {
+    let host = host.trim().to_ascii_lowercase();
+    if host.is_empty() {
+        return None;
+    }
+    if let Some(credential) = credential_for_host(settings, &host) {
+        return Some(credential.clone());
+    }
+    fetch_via_ipc(&host).await
+}
+
+/// The Hugging Face token for authenticating gated HF downloads: the operator/env
+/// `HF_TOKEN` first (server/Docker, Windows), else the recorded `huggingface.co`
+/// credential pulled lazily from the desktop socket.
+pub(crate) async fn resolve_hf_token(settings: &Settings) -> Option<String> {
+    if let Some(token) = &settings.huggingface_token {
+        return Some(token.clone());
+    }
+    resolve_credential_for_host(settings, "huggingface.co")
+        .await
+        .map(|credential| credential.token)
+}
+
+async fn fetch_via_ipc(host: &str) -> Option<WorkerCredential> {
+    let resolver = resolver();
+    let config = resolver.config.as_ref()?;
+    // Only ask for hosts the desktop says are recorded — never trigger a keychain
+    // touch for something that isn't stored.
+    if !config.has_host(host) {
+        return None;
+    }
+    if let Some(credential) = resolver.cache.lock().await.get(host).cloned() {
+        return Some(credential);
+    }
+    let credential = request_credential(config, host).await?;
+    resolver
+        .cache
+        .lock()
+        .await
+        .insert(host.to_owned(), credential.clone());
+    Some(credential)
+}
+
+/// Parse the socket's response line into a credential. The server replies with a
+/// `{ "token": "...", "scheme": "bearer" | "query" }` JSON object, or `ERR`/empty
+/// when the host has no secret. Only the `cfg(unix)` pull (and its tests) parse
+/// responses.
+#[cfg(unix)]
+fn parse_response(host: &str, body: &str) -> Option<WorkerCredential> {
+    let body = body.trim();
+    if body.is_empty() || body == "ERR" {
+        return None;
+    }
+    #[derive(serde::Deserialize)]
+    struct Response {
+        token: String,
+        #[serde(default)]
+        scheme: Option<String>,
+    }
+    let response: Response = serde_json::from_str(body).ok()?;
+    let token = response.token.trim().to_owned();
+    if token.is_empty() {
+        return None;
+    }
+    let scheme = match response.scheme.as_deref() {
+        Some("query") => CredentialScheme::Query,
+        _ => CredentialScheme::Bearer,
+    };
+    Some(WorkerCredential {
+        host: host.to_owned(),
+        token,
+        scheme,
+    })
+}
+
+#[cfg(unix)]
+async fn request_credential(config: &IpcConfig, host: &str) -> Option<WorkerCredential> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::UnixStream;
+
+    let mut stream = UnixStream::connect(&config.socket).await.ok()?;
+    // One request line: "<token> <host>\n". The server reads the line, replies, and
+    // closes, so reading to EOF yields the full response.
+    let request = format!("{} {}\n", config.token, host);
+    stream.write_all(request.as_bytes()).await.ok()?;
+    let _ = stream.shutdown().await;
+    let mut response = String::new();
+    stream.read_to_string(&mut response).await.ok()?;
+    parse_response(host, &response)
+}
+
+#[cfg(not(unix))]
+async fn request_credential(_config: &IpcConfig, _host: &str) -> Option<WorkerCredential> {
+    None
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::UnixListener;
+
+    #[test]
+    fn parse_response_reads_token_and_scheme() {
+        let bearer = parse_response("huggingface.co", r#"{"token":"  hf_x ","scheme":"bearer"}"#)
+            .expect("bearer");
+        assert_eq!(bearer.token, "hf_x");
+        assert_eq!(bearer.scheme, CredentialScheme::Bearer);
+
+        let query =
+            parse_response("civitai.com", r#"{"token":"k","scheme":"query"}"#).expect("query");
+        assert_eq!(query.scheme, CredentialScheme::Query);
+
+        // Unknown/missing scheme defaults to bearer.
+        assert_eq!(
+            parse_response("h", r#"{"token":"k"}"#).unwrap().scheme,
+            CredentialScheme::Bearer
+        );
+        // Sentinels / empties yield nothing.
+        assert!(parse_response("h", "ERR").is_none());
+        assert!(parse_response("h", "").is_none());
+        assert!(parse_response("h", r#"{"token":"  "}"#).is_none());
+    }
+
+    /// End-to-end wire test of the socket pull against a one-shot fake server: the
+    /// worker sends "<token> <host>\n" and parses the JSON reply.
+    #[tokio::test]
+    async fn request_credential_round_trips_over_uds() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket = dir.path().join("cred.sock");
+        let listener = UnixListener::bind(&socket).expect("bind");
+
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept");
+            let mut request = String::new();
+            stream
+                .read_to_string(&mut request)
+                .await
+                .expect("read request");
+            assert_eq!(request.trim(), "tok huggingface.co");
+            stream
+                .write_all(br#"{"token":"hf_secret","scheme":"bearer"}"#)
+                .await
+                .expect("write response");
+        });
+
+        let config = IpcConfig {
+            socket,
+            token: "tok".to_owned(),
+            recorded_hosts: vec!["huggingface.co".to_owned()],
+        };
+        let credential = request_credential(&config, "huggingface.co")
+            .await
+            .expect("credential");
+        assert_eq!(credential.token, "hf_secret");
+        assert_eq!(credential.scheme, CredentialScheme::Bearer);
+        server.await.expect("server task");
+    }
+}

--- a/crates/sceneworks-worker/src/downloads.rs
+++ b/crates/sceneworks-worker/src/downloads.rs
@@ -136,6 +136,7 @@ impl HuggingFaceSnapshot {
             quote_path(revision)
         );
         let payload = with_hf_auth(settings, client.get(tree_url))
+            .await
             .send()
             .await?
             .error_for_status()?
@@ -237,7 +238,7 @@ async fn download_file(
         if existing_bytes > 0 {
             request = request.header(header::RANGE, format!("bytes={existing_bytes}-"));
         }
-        let response = with_hf_auth(context.settings, request).send().await?;
+        let response = with_hf_auth(context.settings, request).await.send().await?;
         let status = response.status();
         if status == StatusCode::RANGE_NOT_SATISFIABLE && existing_bytes > 0 {
             if let Some(expected) = expected_size {
@@ -421,6 +422,7 @@ pub(crate) async fn download_snapshot_into_cache(
     for file in &snapshot.files {
         check_download_cancel(context).await?;
         let head = with_hf_auth(context.settings, meta_client.head(&file.download_url))
+            .await
             .send()
             .await?;
         if commit.is_none() {
@@ -575,9 +577,15 @@ pub(crate) async fn download_source_url(
 
     // Attach a stored credential matching the source host. Bearer tokens ride an
     // Authorization header (dropped on cross-host redirects below); query tokens
-    // are baked into the request URL and never carried onto a redirect target.
-    let credential = credential_for_host(context.settings, url.host_str().unwrap_or_default());
-    let request_url = match credential {
+    // are baked into the request URL and never carried onto a redirect target. The
+    // secret is resolved lazily (env/file-store, or the macOS desktop socket on
+    // first use) so a no-credential install never touches the keychain (sc-5891).
+    let credential = crate::credentials_ipc::resolve_credential_for_host(
+        context.settings,
+        url.host_str().unwrap_or_default(),
+    )
+    .await;
+    let request_url = match &credential {
         Some(cred) if cred.scheme == CredentialScheme::Query => {
             let mut authed = url.clone();
             authed.query_pairs_mut().append_pair("token", &cred.token);
@@ -585,7 +593,7 @@ pub(crate) async fn download_source_url(
         }
         _ => source_url.to_owned(),
     };
-    let bearer = match credential {
+    let bearer = match &credential {
         Some(cred) if cred.scheme == CredentialScheme::Bearer => Some(cred.token.as_str()),
         _ => None,
     };

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -45,6 +45,10 @@ use uuid::Uuid;
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 mod advanced;
 mod api_client;
+// Lazy, on-demand download-credential pull from the macOS desktop credential socket
+// (sc-5891). Compiles on all targets; the socket I/O is `cfg(unix)` and inert unless
+// the desktop injects `SCENEWORKS_CRED_IPC_*`, so server/Docker/Windows are unaffected.
+mod credentials_ipc;
 // Backend-neutral generator load/run cache (epic 3720, sc-3724). Typed entirely against
 // `gen_core::*` (no tensor types leak), so it links on ALL targets — the production load seam
 // (`with_cached_generator`) is reached only from the macOS image/video paths, but the all-targets
@@ -1842,8 +1846,14 @@ async fn existing_download_bytes(path: &Path, expected_size: Option<u64>) -> Wor
     Ok(existing)
 }
 
-fn with_hf_auth(settings: &Settings, request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
-    match &settings.huggingface_token {
+async fn with_hf_auth(
+    settings: &Settings,
+    request: reqwest::RequestBuilder,
+) -> reqwest::RequestBuilder {
+    // Resolves the HF token lazily: the env `HF_TOKEN` (server/Docker/Windows) or,
+    // on the macOS desktop, a one-time pull of the recorded `huggingface.co`
+    // credential from the desktop socket (sc-5891). `None` ⇒ unauthenticated.
+    match credentials_ipc::resolve_hf_token(settings).await {
         Some(token) => request.bearer_auth(token),
         None => request,
     }

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -764,7 +764,10 @@ pub(crate) async fn download_model_with_hf_cli(
         .stdout(Stdio::null())
         .stderr(Stdio::piped());
     configure_hf_cli_environment(&mut command);
-    if let Some(token) = &settings.huggingface_token {
+    // Resolve the HF token lazily (env, or a one-time pull of the recorded
+    // `huggingface.co` keychain credential from the desktop socket on macOS) so the
+    // keychain is read only when a download actually needs it (sc-5891).
+    if let Some(token) = crate::credentials_ipc::resolve_hf_token(settings).await {
         command.env("HF_TOKEN", token);
     }
     for pattern in files {


### PR DESCRIPTION
Fixes [sc-5891](https://app.shortcut.com/trefry/story/5891). On the Mac desktop the app prompted for the keychain password at **every launch** because the desktop read credentials **eagerly at worker spawn** to inject `HF_TOKEN`/`SCENEWORKS_CREDENTIALS`. Credentials are only needed to authenticate **gated downloads**, so this moves from eager push to lazy pull and gates every keychain access on non-secret `settings.json` metadata first.

## Topology that shaped the fix
The desktop (Tauri) is the only process that can read the OS keychain; the worker + API talk over one-way HTTP and there is no reverse channel. On macOS the only worker spawned is the MLX worker (`supervise_mlx_worker`); the Python (`cfg(not macos)`) and candle (`cfg windows`) workers keep eager push since Windows Credential Manager doesn't prompt. So this is a **macOS-only** change to one spawn site + a desktop-hosted credential socket + a worker-side lazy fetch that's inert off macOS.

## Part 1 — gate (closes "zero recorded ⇒ zero keychain access")
- `read_hf_token()` short-circuits on `hf_credential_recorded()` before constructing any `keyring::Entry`, and the unconditional legacy `huggingface_token` `get_password()` fallback is removed.
- The startup `migrate_legacy_hf_token` probe is removed: the pre-host-keyed era stored the token keychain-only with **no** `settings.json` marker (verified at `dd3f3ab^`), so auto-migration is fundamentally incompatible with not touching the keychain on a no-token install. A legacy single-token install that skipped every build since the host-keyed store re-adds its token once in Settings.

## Part 2 — lazy pull (no launch prompt even with a credential recorded)
- **`apps/desktop/src/cred_ipc.rs`** (new, macOS-only): a `0600` Unix-domain-socket credential server with a per-launch token. It reads the keychain only on request (gated `settings::resolve_credential_secret`), so the single prompt happens at download time, and caches results so worker restarts don't re-prompt.
- The MLX spawn site injects `SCENEWORKS_CRED_IPC_SOCKET`/`_TOKEN` + the non-secret `SCENEWORKS_CREDENTIAL_HOSTS` instead of the secrets; nothing recorded ⇒ the worker never asks ⇒ the keychain is never touched.
- **`crates/sceneworks-worker/src/credentials_ipc.rs`** (new): a process-global resolver (no `Settings` struct change) that uses the static env/file-store credentials first then lazily pulls from the socket (`cfg(unix)`; inert elsewhere) for recorded hosts only, cached per session. `with_hf_auth` is now async; the HF-CLI token, the three `with_hf_auth` sites, and the one `credential_for_host` prod site route through it.
- `set_credential`/`delete_credential` invalidate the desktop cache so a changed/revoked token takes effect without an app restart.

## Acceptance mapping
- **A** — no keychain access at launch (only the non-secret host list is read).
- **B** — nothing recorded ⇒ empty `SCENEWORKS_CREDENTIAL_HOSTS` ⇒ worker never asks ⇒ keychain never touched.
- **C** — first gated download triggers the one keychain read/prompt, cached after.
- **D** — desktop-side cache means worker restarts re-pull from cache, no re-prompt unless a gated download is in flight.

**Deliberate nuance:** resolution is lazy-at-first-use, not fetch-on-401, so a token-recorded user whose *first* download of a session is public sees that one prompt (cached after); public-only users have no token recorded and never prompt. Fetch-on-401 was deferred as not worth the retry logic on the SSRF-sensitive download/redirect paths.

## Verification
- `cargo check` / `clippy -D warnings` / `fmt --check` clean for `sceneworks-desktop` and `sceneworks-worker`.
- `sceneworks-worker`: 302 tests pass (+2 new — response parse + UDS round-trip). `sceneworks-desktop`: 4 tests pass.
- **Not verifiable headlessly:** the actual keychain-prompt behavior needs a running Mac build (clean launch with token stored = no prompt; first gated download = one prompt; restart = no re-prompt). `build-windows` CI is the check on the `cfg(unix)`/`cfg(not(unix))` gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)