### PR TITLE
sc-5495: route ltx_2_3_eros → candle (eros variant)

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3369,12 +3369,15 @@ fn candle_request_wants_quant(payload: &Map<String, Value>) -> bool {
 /// (→ candle `wan2_2_ti2v_5b`) and `ltx_2_3` (→ candle `ltx_2_3_distilled`) (epic 5095, sc-5097),
 /// plus the Wan2.2 **14B** MoE pair `wan_2_2_t2v_14b` (text-only) and `wan_2_2_i2v_14b` (image→video)
 /// (sc-5175), plus `svd` (→ candle `svd_xt`, image→video, sc-5493 / epic 5481). Mirrors the worker's
-/// `video_jobs::candle_video_engine_id`. `ltx_2_3_eros` still has no candle provider; every conditioned
-/// mode (first_last_frame / extend / bridge / replace) + LoRA stays on the Python torch worker. Note
-/// the 14B I2V and SVD are image→video, NOT txt2video — see [`CANDLE_VIDEO_I2V_ROUTED_MODELS`].
+/// `video_jobs::candle_video_engine_id`. `ltx_2_3_eros` (sc-5495) now routes to candle for plain
+/// text-to-video too — it's a full dense LTX-2.3 fine-tune → the same `ltx_2_3_distilled` engine, just
+/// its own weights repo; every conditioned mode (first_last_frame / extend / bridge / replace) + LoRA
+/// still stays on the Python torch worker. Note the 14B I2V and SVD are image→video, NOT txt2video —
+/// see [`CANDLE_VIDEO_I2V_ROUTED_MODELS`].
 const CANDLE_VIDEO_ROUTED_MODELS: &[&str] = &[
     "wan_2_2",
     "ltx_2_3",
+    "ltx_2_3_eros",
     "wan_2_2_t2v_14b",
     "wan_2_2_i2v_14b",
     "svd",
@@ -4984,14 +4987,30 @@ mod candle_routing_tests {
 
     #[test]
     fn non_candle_video_models_and_conditioned_shapes_fall_back() {
-        // Models with no candle video provider stay on torch even for text_to_video (`ltx_2_3_eros`
-        // is still torch-only; SVD now has a candle provider but is image→video, covered below).
+        // `ltx_2_3_eros` now routes to candle for plain text_to_video (sc-5495 — it's a full dense
+        // LTX-2.3 fine-tune on the `ltx_2_3_distilled` engine), but any conditioned eros shape stays on
+        // the Python torch worker (the candle LTX lane is txt2video-only).
         assert!(
-            !video_request_candle_eligible(
+            video_request_candle_eligible(
                 "ltx_2_3_eros",
                 &object(json!({ "mode": "text_to_video" }))
             ),
-            "ltx_2_3_eros must fall back to the Python worker"
+            "ltx_2_3_eros text_to_video must route to the candle lane"
+        );
+        assert!(
+            !video_request_candle_eligible(
+                "ltx_2_3_eros",
+                &object(json!({ "mode": "first_last_frame" }))
+            ),
+            "a conditioned ltx_2_3_eros shape must fall back to the Python worker"
+        );
+        // A genuinely non-candle video model stays on torch.
+        assert!(
+            !video_request_candle_eligible(
+                "some_unported_model",
+                &object(json!({ "mode": "text_to_video" }))
+            ),
+            "an unported model must fall back to the Python worker"
         );
         // A txt2video model in any conditioned shape (default/i2v mode, a source, or a LoRA) → torch.
         let cases = [
@@ -5124,12 +5143,16 @@ mod candle_routing_tests {
                 "candle worker should claim {model} image_to_video"
             );
         }
-        // Refuses a non-candle video model (ltx_2_3_eros has no candle provider), a conditioned (i2v)
-        // shape on a txt2video model, an image→video model (svd) in a txt2video shape, and the 14B I2V
-        // in a txt2video shape (both are image→video only).
-        assert!(!worker_supports_job(
+        // Claims `ltx_2_3_eros` text_to_video (sc-5495 — the candle LTX engine serves the eros fine-tune
+        // too). Refuses an unported model, a conditioned (i2v) shape on a txt2video model, an image→video
+        // model (svd) in a txt2video shape, and the 14B I2V in a txt2video shape (both image→video only).
+        assert!(worker_supports_job(
             &candle,
             &video_generate_job(json!({ "model": "ltx_2_3_eros", "mode": "text_to_video" }))
+        ));
+        assert!(!worker_supports_job(
+            &candle,
+            &video_generate_job(json!({ "model": "some_unported_model", "mode": "text_to_video" }))
         ));
         assert!(!worker_supports_job(
             &candle,

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -2706,6 +2706,10 @@ const CANDLE_WAN_T2V_14B_REPO: &str = "Wan-AI/Wan2.2-T2V-A14B-Diffusers";
 const CANDLE_WAN_I2V_14B_REPO: &str = "Wan-AI/Wan2.2-I2V-A14B-Diffusers";
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
 const CANDLE_LTX_REPO: &str = "Lightricks/LTX-2.3";
+// The `ltx_2_3_eros` weights repo (sc-5495): a full dense LTX-2.3 fine-tune (the candle provider
+// loads its `10Eros_v1_bf16.safetensors` like the base; same architecture, same Gemma encoder).
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+const CANDLE_LTX_EROS_REPO: &str = "TenStrip/LTX2.3-10Eros";
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
 const CANDLE_LTX_GEMMA_REPO: &str = "google/gemma-3-12b-it";
 
@@ -2724,14 +2728,17 @@ const CANDLE_WAN_VACE_REPO: &str = "Wan-AI/Wan2.1-VACE-14B-diffusers";
 /// does not serve. Note ltx maps to `ltx_2_3_distilled` (the candle provider's id), not the MLX
 /// `ltx_2_3`. Covers the base txt2video ids (5B + ltx) plus the Wan2.2 **14B** dual-expert MoE pair
 /// (sc-5174 / sc-5175): `wan_2_2_t2v_14b` (text→video) and `wan_2_2_i2v_14b` (image→video), plus `svd`
-/// (image→video, sc-5493 / epic 5481). `ltx_2_3_eros` has no candle provider yet and stays on torch.
+/// (image→video, sc-5493 / epic 5481). `ltx_2_3_eros` (sc-5495) maps to the same `ltx_2_3_distilled`
+/// engine as the base — it's a full dense LTX-2.3 fine-tune — differing only in the weights repo.
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
 fn candle_video_engine_id(model: &str) -> Option<&'static str> {
     match model {
         "wan_2_2" => Some("wan2_2_ti2v_5b"),
         "wan_2_2_t2v_14b" => Some("wan2_2_t2v_14b"),
         "wan_2_2_i2v_14b" => Some("wan2_2_i2v_14b"),
-        "ltx_2_3" => Some("ltx_2_3_distilled"),
+        // Base + eros both load the one candle LTX-2.3 engine (the eros merge is a full dense LTX-2.3
+        // checkpoint, sc-5495); they differ only in the weights repo (see `candle_video_repo`).
+        "ltx_2_3" | "ltx_2_3_eros" => Some("ltx_2_3_distilled"),
         // SVD-XT image→video (sc-5493 / epic 5481): the candle-gen-svd provider's `svd_xt` engine.
         "svd" => Some("svd_xt"),
         _ => None,
@@ -2767,8 +2774,9 @@ fn candle_video_default_repo(engine_id: &str) -> &'static str {
     }
 }
 
-/// The candle weights repo for a video engine: the manifest `repo` wins, else the candle default repo
-/// for the engine.
+/// The candle weights repo for a video engine: the manifest `repo` wins, else `ltx_2_3_eros` selects
+/// its own fine-tune repo (it shares the `ltx_2_3_distilled` engine id with the base), else the candle
+/// default repo for the engine.
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
 fn candle_video_repo(request: &VideoRequest, engine_id: &str) -> String {
     request
@@ -2777,8 +2785,14 @@ fn candle_video_repo(request: &VideoRequest, engine_id: &str) -> String {
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| candle_video_default_repo(engine_id))
-        .to_owned()
+        .map(str::to_owned)
+        .unwrap_or_else(|| {
+            if request.model == "ltx_2_3_eros" {
+                CANDLE_LTX_EROS_REPO.to_owned()
+            } else {
+                candle_video_default_repo(engine_id).to_owned()
+            }
+        })
 }
 
 /// Resolve the candle weights snapshot dir for `repo`. Errors loudly (no procedural-stub fallback)


### PR DESCRIPTION
The final piece of **sc-5495** — routes the **`ltx_2_3_eros`** variant onto the candle (Windows/CUDA) LTX lane. Pairs with the provider's eros checkpoint-selector fix (candle-gen [#76](https://github.com/michaeltrefry/candle-gen/pull/76), merged → `c3a6413`).

## What this does
The eros merge [TenStrip/LTX2.3-10Eros](https://huggingface.co/TenStrip/LTX2.3-10Eros) ships a **full dense LTX-2.3 checkpoint** (`10Eros_v1_bf16.safetensors` — identical structure to the base), so the candle LTX engine serves it like the base, differing only in the weights repo.

- **video_jobs.rs:** `candle_video_engine_id` `ltx_2_3_eros` → `ltx_2_3_distilled` (same engine — reuses the Gemma-3-12B encoder + the AudioVideo path, so **eros gets synchronized audio too**); `CANDLE_LTX_EROS_REPO = "TenStrip/LTX2.3-10Eros"`, selected in `candle_video_repo` when `model == ltx_2_3_eros` (manifest `repo` still wins).
- **jobs_store.rs:** `ltx_2_3_eros` added to `CANDLE_VIDEO_ROUTED_MODELS` for plain **text-to-video** only (conditioned eros modes + LoRA stay on the Python torch worker). Updated the two routing tests.
- **Cargo.toml:** re-pin candle-gen `7c7550d` → `c3a6413` (the merged #76). Source-only at gen-core `27b0107` (== mlx-gen pin) — skew gate green.

## Verification
core check + candle-eligibility router tests + default `cargo check -p sceneworks-worker` + `--features backend-candle` (CUDA, sm_120) all green.

**GPU-validated (RTX PRO 6000):** the eros checkpoint loads (the provider's selector picks `10Eros_v1_bf16.safetensors` over the fp8 variants) and generates 25 coherent on-prompt frames ("a person walking along a beach at sunset") + a synchronized 48 kHz stereo audio track of matching duration (1.01 s), non-degenerate.

*(Pre-existing, unrelated: `training::tests::resolve_item_path_rejects_paths_outside_dataset_root` fails on Windows — a `\` vs `/` path-separator test in training.rs I didn't touch.)*

This closes out sc-5495: synchronized audio **and** the eros variant, both on the candle lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)