### PR TITLE
fix(training): host-separator-agnostic resolve_item_path unit test (Windows)

### DIFF
--- a/crates/sceneworks-core/src/training.rs
+++ b/crates/sceneworks-core/src/training.rs
@@ -1841,9 +1841,16 @@ mod tests {
             resolve_item_path(root, "/absolute.png"),
             Err(TrainingPlanError::InvalidConfig(_))
         ));
+        // A safe relative path resolves under the dataset root using the host separator (the plan is
+        // built + consumed on the same machine). Build the expectation the same way so the assertion
+        // holds on Windows too — a hardcoded `/dataset/images/photo.png` only matches on `/`-sep hosts.
+        let mut expected = root.to_path_buf();
+        for component in Path::new("images/photo.png").components() {
+            expected.push(component);
+        }
         assert_eq!(
             resolve_item_path(root, "images/photo.png").expect("safe path"),
-            "/dataset/images/photo.png"
+            expected.display().to_string()
         );
     }
 }


### PR DESCRIPTION
A pre-existing Windows-only unit-test failure surfaced while validating sc-5495 (unrelated to that work).

`training::tests::resolve_item_path_rejects_paths_outside_dataset_root` hardcoded the expected resolved path as `/dataset/images/photo.png`, which only matches on `/`-separator hosts. On Windows `resolve_item_path` (correctly) joins with the host separator → `/dataset\images\photo.png`, so the assertion failed:

```
assertion `left == right` failed
  left: "/dataset\images\photo.png"
 right: "/dataset/images/photo.png"
```

The host-separator behavior is intended: the training plan is built and consumed by the Python kernel on the **same machine**, and the contract test (`tests/training_contracts.rs`) already documents it — *"Item paths resolve under the dataset root with the host separator."* So this fixes the **test**, not the function: it now builds the expectation the same way the function (and the contract test) do, so it holds on every platform. **No runtime behavior change.**

All 190 `sceneworks-core` lib tests pass (was 189 + 1 failing on Windows); fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)