### PR TITLE
build(desktop): sign nested macOS bundle binaries for Developer ID notarization

### DIFF
--- a/apps/desktop/Entitlements.plist
+++ b/apps/desktop/Entitlements.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <!-- WKWebView / Tauri IPC -->
+        <key>com.apple.security.network.client</key><true/>
+        <key>com.apple.security.network.server</key><true/>
+        <!-- The worker dlopens onnxruntime + spawns uv/python that load unsigned dylibs -->
+        <key>com.apple.security.cs.disable-library-validation</key><true/>
+        <!-- setup.rs sets ORT_DYLIB_PATH and friends; needed if any DYLD_* is used for subprocesses -->
+        <key>com.apple.security.cs.allow-dyld-environment-variables</key><true/>
+    </dict>
+</plist>

--- a/apps/desktop/scripts/build-sidecar.mjs
+++ b/apps/desktop/scripts/build-sidecar.mjs
@@ -10,6 +10,7 @@ import {
   writeFileSync,
   existsSync,
   readdirSync,
+  readFileSync,
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -39,6 +40,43 @@ if (!triple) {
   process.exit(1);
 }
 const exe = triple.includes("windows") ? ".exe" : "";
+
+// Sign a nested Mach-O for notarization. Tauri signs the .app and the externalBin
+// sidecars (sceneworks-api, uv), but NOT the extra binaries we drop into the
+// bundle's Resources/ (the static ffmpeg, the onnxruntime dylib). Apple's notary
+// service rejects any nested binary that lacks a Developer ID signature, a secure
+// timestamp, or (for executables) hardened runtime — so sign them inside-out here,
+// before Tauri seals the bundle. No-op unless an identity is configured (the same
+// identity Tauri uses for the .app), so plain dev builds are unchanged. The
+// identity comes from the APPLE_SIGNING_IDENTITY env var (CI/headless) OR, as a
+// fallback, bundle.macOS.signingIdentity in tauri.conf.json — because
+// beforeBuildCommand runs before Tauri signs and does NOT inherit the conf value
+// as an env var, so a local `tauri build` that sets the identity only in the conf
+// would otherwise skip pre-signing and fail notarization on the nested binaries.
+// execFileSync (not the shell `run` above) so the identity's spaces/parens in
+// "Developer ID Application: Name (TEAMID)" don't need quoting.
+function readConfSigningIdentity() {
+  try {
+    const conf = JSON.parse(
+      readFileSync(join(desktopDir, "tauri.conf.json"), "utf8"),
+    );
+    return conf?.bundle?.macOS?.signingIdentity || "";
+  } catch {
+    return "";
+  }
+}
+const signingIdentity =
+  process.env.APPLE_SIGNING_IDENTITY || readConfSigningIdentity();
+function codesignForNotarization(file) {
+  if (!signingIdentity || !triple.includes("apple-darwin")) return;
+  console.log(`> codesign --force --options runtime --timestamp "${file}"`);
+  execFileSync(
+    "codesign",
+    ["--force", "--sign", signingIdentity, "--options", "runtime", "--timestamp", file],
+    { stdio: "inherit" },
+  );
+  console.log(`build-sidecar: codesigned ${file} for notarization`);
+}
 
 // Build the web bundle + API binary with the embedded UI (single source of
 // truth for the embedded build). Empty VITE_API_BASE_URL makes the embedded UI
@@ -94,6 +132,7 @@ if (triple.includes("apple-darwin")) {
   const py = process.env.PYTHON || "python3";
   run(py, ["apps/desktop/scripts/stage-onnxruntime.py", dylibDest]);
   console.log(`build-sidecar: staged ${dylibDest}`);
+  codesignForNotarization(dylibDest);
   // onnxruntime is MIT — ship its license text + notice next to the dylib so the
   // MIT "include the copyright + permission notice" requirement is satisfied at
   // the distribution level (mirrors the ffmpeg GPLv3 §6 staging below). Source of
@@ -130,6 +169,7 @@ if (triple.includes("apple-darwin")) {
   const py = process.env.PYTHON || "python3";
   run(py, ["apps/desktop/scripts/stage-ffmpeg.py", ffmpegDest]);
   console.log(`build-sidecar: staged ${ffmpegDest}`);
+  codesignForNotarization(ffmpegDest);
   // The bundled ffmpeg is GPLv3 — ship its license text + written source offer
   // next to the binary so the distribution satisfies GPLv3 §6 (sc-3767). Source
   // of truth: apps/desktop/licenses/ffmpeg/ (tracked).

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -42,7 +42,9 @@
       "icons/icon.ico"
     ],
     "macOS": {
-      "minimumSystemVersion": "26.2"
+      "minimumSystemVersion": "26.2",
+      "entitlements": "Entitlements.plist",
+      "signingIdentity": "Developer ID Application: Michael Trefry (R2526H7YN9)"
     },
     "windows": {
       "webviewInstallMode": {


### PR DESCRIPTION
## Problem

`tauri build` was failing notarization. Apple's notary log flagged two binaries:

- `Contents/Resources/ffmpeg/ffmpeg` — not signed with a valid Developer ID cert, no secure timestamp, hardened runtime not enabled
- `Contents/Resources/onnxruntime/libonnxruntime.dylib` — not signed with a valid Developer ID cert, no secure timestamp

Root cause: Tauri signs the `.app`, the main binary, and the `externalBin` sidecars (`sceneworks-api`, `uv`) — but **not** arbitrary Mach-O files staged into `Contents/Resources/`. The bundled static **ffmpeg** and **libonnxruntime.dylib** reached the notary service unsigned.

## Fix

`apps/desktop/scripts/build-sidecar.mjs` now codesigns each nested Resources binary **inside-out**, right after staging, with `--sign <identity> --options runtime --timestamp` (covers all three error classes: Developer ID cert, secure timestamp, hardened runtime).

- Identity comes from `APPLE_SIGNING_IDENTITY`, falling back to `bundle.macOS.signingIdentity` in `tauri.conf.json`. The fallback matters because `beforeBuildCommand` runs *before* Tauri signs and does **not** inherit the conf value as an env var — so a local build that configures the identity only in the conf would otherwise silently skip pre-signing.
- No-op off macOS and when no identity is configured, so `tauri dev` / unsigned builds are unchanged.

Also adds the Developer ID signing config itself:

- **`apps/desktop/Entitlements.plist`** — hardened-runtime entitlements: `network.client`/`network.server` (WKWebView + Tauri IPC), `disable-library-validation` and `allow-dyld-environment-variables` (the worker `dlopen`s onnxruntime and spawns `uv`/python subprocesses that load unsigned dylibs).
- **`tauri.conf.json`** `bundle.macOS` — `entitlements` + `signingIdentity`.

## Verification

End-to-end signed → notarized → stapled `SceneWorks.app` build now passes Apple notarization (`status: Accepted`). Confirmed on macOS with the App Store Connect API-key notarization flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)