### PR TITLE
sc-5489: wire candle Z-Image Fun-ControlNet strict-pose into the worker + re-pin candle-gen #79

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f459ab973d31dfa363770f8cb37b0ec02a77936c#f459ab973d31dfa363770f8cb37b0ec02a77936c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f459ab973d31dfa363770f8cb37b0ec02a77936c#f459ab973d31dfa363770f8cb37b0ec02a77936c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f459ab973d31dfa363770f8cb37b0ec02a77936c#f459ab973d31dfa363770f8cb37b0ec02a77936c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f459ab973d31dfa363770f8cb37b0ec02a77936c#f459ab973d31dfa363770f8cb37b0ec02a77936c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f459ab973d31dfa363770f8cb37b0ec02a77936c#f459ab973d31dfa363770f8cb37b0ec02a77936c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f459ab973d31dfa363770f8cb37b0ec02a77936c#f459ab973d31dfa363770f8cb37b0ec02a77936c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -519,7 +519,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f459ab973d31dfa363770f8cb37b0ec02a77936c#f459ab973d31dfa363770f8cb37b0ec02a77936c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -530,7 +530,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f459ab973d31dfa363770f8cb37b0ec02a77936c#f459ab973d31dfa363770f8cb37b0ec02a77936c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f459ab973d31dfa363770f8cb37b0ec02a77936c#f459ab973d31dfa363770f8cb37b0ec02a77936c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -557,7 +557,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f459ab973d31dfa363770f8cb37b0ec02a77936c#f459ab973d31dfa363770f8cb37b0ec02a77936c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -569,7 +569,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f459ab973d31dfa363770f8cb37b0ec02a77936c#f459ab973d31dfa363770f8cb37b0ec02a77936c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -580,7 +580,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f459ab973d31dfa363770f8cb37b0ec02a77936c#f459ab973d31dfa363770f8cb37b0ec02a77936c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -594,7 +594,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f459ab973d31dfa363770f8cb37b0ec02a77936c#f459ab973d31dfa363770f8cb37b0ec02a77936c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -612,7 +612,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f459ab973d31dfa363770f8cb37b0ec02a77936c#f459ab973d31dfa363770f8cb37b0ec02a77936c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -625,7 +625,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f459ab973d31dfa363770f8cb37b0ec02a77936c#f459ab973d31dfa363770f8cb37b0ec02a77936c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -636,7 +636,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f459ab973d31dfa363770f8cb37b0ec02a77936c#f459ab973d31dfa363770f8cb37b0ec02a77936c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -649,7 +649,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f459ab973d31dfa363770f8cb37b0ec02a77936c#f459ab973d31dfa363770f8cb37b0ec02a77936c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
 dependencies = [
  "candle-core",
  "candle-gen",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3283,8 +3283,9 @@ fn image_job_is_candle_eligible(job: &JobSnapshot) -> bool {
     // Qwen-Image strict-pose ControlNet (sc-5489, epic 5480): `qwen_image` + `advanced.poses` is a
     // bespoke candle lane (`generate_candle_qwen_control_stream`), NOT txt2img — the
     // `image_request_candle_eligible` gate below DEFERS any `advanced.poses` job to torch. Branch it out
-    // first so `qwen_image` pose jobs reach candle, while the other families' pose jobs (z_image /
-    // kolors / sdxl) stay on torch until their slices land. Mirrors the worker's `qwen_control_available`.
+    // first so `qwen_image` pose jobs reach candle (the kolors / z_image families follow below — all three
+    // strict-pose families are now wired; plain-sdxl pose has no product route). Mirrors the worker's
+    // `qwen_control_available`.
     if model == "qwen_image" && qwen_control_candle_eligible(&job.payload) {
         return true;
     }
@@ -3295,6 +3296,14 @@ fn image_job_is_candle_eligible(job: &JobSnapshot) -> bool {
     // the `kolors_ipadapter_candle_eligible` branch above, so it reaches here. Mirrors the worker's
     // `kolors_control_available`.
     if model == "kolors" && kolors_control_candle_eligible(&job.payload) {
+        return true;
+    }
+    // Z-Image strict-pose Fun-ControlNet (sc-5489, epic 5480): `z_image_turbo` + `advanced.poses` is the
+    // bespoke candle lane (`generate_candle_zimage_control_stream`), NOT txt2img — the `image_request_\
+    // candle_eligible` gate below DEFERS any `advanced.poses` job to torch. Branch it out first (the
+    // Qwen/Kolors-control reasoning, for the last strict-pose family). Mirrors the worker's
+    // `zimage_control_available`. With this all three control families (qwen / kolors / z_image) are wired.
+    if model == "z_image_turbo" && zimage_control_candle_eligible(&job.payload) {
         return true;
     }
     image_request_candle_eligible(model, &job.payload)
@@ -3645,6 +3654,24 @@ fn qwen_control_candle_eligible(payload: &Map<String, Value>) -> bool {
 /// the call site. Mirrors the worker's `kolors_control_available` gate (minus the local weight-resolve
 /// check) so the router and worker agree. Candle-only — the macOS path is the MLX Kolors ControlNet.
 fn kolors_control_candle_eligible(payload: &Map<String, Value>) -> bool {
+    if payload.get("mode").and_then(Value::as_str) == Some("edit_image") {
+        return false;
+    }
+    payload
+        .get("advanced")
+        .and_then(Value::as_object)
+        .and_then(|advanced| advanced.get("poses"))
+        .and_then(Value::as_array)
+        .is_some_and(|poses| !poses.is_empty())
+}
+
+/// Z-Image strict-pose Fun-ControlNet candle-routing conditions (sc-5489, epic 5480). The candle
+/// `ZImageControl` provider serves `z_image_turbo` + a non-empty `advanced.poses` (one image per pose,
+/// each conditioned on a DWPose skeleton via the VACE-style `Z-Image-Turbo-Fun-Controlnet-Union-2.1`
+/// branch), NOT an `edit_image`. Same shape as the qwen/kolors gates — the model gate (`z_image_turbo`)
+/// is applied at the call site. Mirrors the worker's `zimage_control_available`. Candle-only — the macOS
+/// path is the MLX `z_image_turbo_control` registry generator.
+fn zimage_control_candle_eligible(payload: &Map<String, Value>) -> bool {
     if payload.get("mode").and_then(Value::as_str) == Some("edit_image") {
         return false;
     }
@@ -4918,11 +4945,24 @@ mod candle_routing_tests {
             ),
             "candle worker should claim kolors strict-pose (sc-5489)"
         );
-        // A DIFFERENT family's pose job still defers to torch (its slice hasn't landed).
+        // sc-5489: `z_image_turbo` + `advanced.poses` is the LAST strict-pose family wired (the VACE
+        // Fun-ControlNet route) — all three (qwen / kolors / z_image) are candle lanes now.
+        assert!(
+            worker_supports_job(
+                &candle,
+                &image_generate_job(json!({
+                    "model": "z_image_turbo",
+                    "advanced": { "poses": [{ "id": "pose_1" }] }
+                }))
+            ),
+            "candle worker should claim z_image_turbo strict-pose (sc-5489)"
+        );
+        // Plain `sdxl` + poses still defers to torch — there is no plain-SDXL pose product route (the
+        // SDXL identity-pose surface ships via the InstantID lane, `instantid_realvisxl`, not here).
         assert!(!worker_supports_job(
             &candle,
             &image_generate_job(json!({
-                "model": "z_image_turbo",
+                "model": "sdxl",
                 "advanced": { "poses": [{ "id": "pose_1" }] }
             }))
         ));
@@ -5540,10 +5580,11 @@ mod candle_routing_tests {
         assert!(!qwen_control_candle_eligible(&object(json!({
             "model": "qwen_image", "mode": "edit_image", "advanced": { "poses": [{}] }
         }))));
-        // A DIFFERENT not-yet-ported model with poses still defers to torch (the z_image / sdxl slices
-        // are not landed) — the qwen branch is specific; the txt2img gate's has_poses deferral applies.
+        // Plain `sdxl` + poses still defers to torch (no plain-SDXL pose product route — SDXL pose ships
+        // via the InstantID lane) — the qwen branch is specific; the txt2img gate's has_poses deferral
+        // applies. (z_image_turbo + poses IS a candle lane now — see `zimage_control_pose_jobs_*`.)
         assert!(!image_job_is_candle_eligible(&image_generate_job(json!({
-            "model": "z_image_turbo", "advanced": { "poses": [{}] }
+            "model": "sdxl", "advanced": { "poses": [{}] }
         }))));
     }
 
@@ -5568,6 +5609,27 @@ mod candle_routing_tests {
         // A kolors reference job (no poses) still routes via the IP-Adapter branch, not this one.
         assert!(!kolors_control_candle_eligible(&object(json!({
             "model": "kolors", "referenceAssetId": "asset_1"
+        }))));
+    }
+
+    #[test]
+    fn zimage_control_pose_jobs_route_to_candle() {
+        // z_image_turbo + advanced.poses routes to the candle VACE strict-pose lane (sc-5489, the last
+        // family) via the bespoke branch, NOT the txt2img gate (which DEFERS any advanced.poses to torch).
+        let payload =
+            json!({ "model": "z_image_turbo", "advanced": { "poses": [{ "keypoints": [] }] } });
+        assert!(zimage_control_candle_eligible(&object(payload.clone())));
+        assert!(image_job_is_candle_eligible(&image_generate_job(payload)));
+        // No poses (or empty) → plain txt2img routes via the txt2img gate instead.
+        assert!(!zimage_control_candle_eligible(&object(
+            json!({ "model": "z_image_turbo" })
+        )));
+        assert!(!zimage_control_candle_eligible(&object(json!({
+            "model": "z_image_turbo", "advanced": { "poses": [] }
+        }))));
+        // edit_image with poses is NOT this lane.
+        assert!(!zimage_control_candle_eligible(&object(json!({
+            "model": "z_image_turbo", "mode": "edit_image", "advanced": { "poses": [{}] }
         }))));
     }
 }

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -696,39 +696,47 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32fd
 # `advanced.poses` lane routes onto (image_jobs/kolors_control.rs). #78 is SOURCE-ONLY off `a610664` (its
 # parent), so f459ab9 still resolves gen-core `32fdb34` == this worker's mlx-gen pin (single gen-core rev,
 # no skew). ALL candle deps MUST share this rev.
+#
+# sc-5489 (Z-Image Fun-ControlNet / strict pose — the LAST family) bumps the candle pin `f459ab9` ->
+# `864aa0c` (candle-gen #79): ADDS the candle Z-Image strict-pose provider
+# (`candle_gen_z_image::ZImageControl` — VACE-style dual-injection on the vendored Z-Image DiT, the
+# `alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1` branch) the worker `z_image_turbo` +
+# `advanced.poses` lane routes onto (image_jobs/zimage_control.rs). #79 is SOURCE-ONLY off `f459ab9` (its
+# parent), so 864aa0c still resolves gen-core `32fdb34` == this worker's mlx-gen pin (single gen-core rev,
+# no skew). With this all three candle strict-pose families (qwen / kolors / z_image) are wired.
 [target.'cfg(target_os = "windows")'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f459ab973d31dfa363770f8cb37b0ec02a77936c", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa0c705c82763db388a04664705129e692c5f", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f459ab973d31dfa363770f8cb37b0ec02a77936c", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f459ab973d31dfa363770f8cb37b0ec02a77936c", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f459ab973d31dfa363770f8cb37b0ec02a77936c", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f459ab973d31dfa363770f8cb37b0ec02a77936c", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa0c705c82763db388a04664705129e692c5f", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa0c705c82763db388a04664705129e692c5f", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa0c705c82763db388a04664705129e692c5f", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa0c705c82763db388a04664705129e692c5f", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f459ab973d31dfa363770f8cb37b0ec02a77936c", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa0c705c82763db388a04664705129e692c5f", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f459ab973d31dfa363770f8cb37b0ec02a77936c", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f459ab973d31dfa363770f8cb37b0ec02a77936c", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa0c705c82763db388a04664705129e692c5f", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa0c705c82763db388a04664705129e692c5f", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f459ab973d31dfa363770f8cb37b0ec02a77936c", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa0c705c82763db388a04664705129e692c5f", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f459ab973d31dfa363770f8cb37b0ec02a77936c", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa0c705c82763db388a04664705129e692c5f", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -737,19 +745,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f459ab973d31dfa363770f8cb37b0ec02a77936c", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa0c705c82763db388a04664705129e692c5f", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f459ab973d31dfa363770f8cb37b0ec02a77936c", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa0c705c82763db388a04664705129e692c5f", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f459ab973d31dfa363770f8cb37b0ec02a77936c", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa0c705c82763db388a04664705129e692c5f", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -758,12 +766,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f459ab973d31dfa363770f8cb37b0ec02a77936c", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa0c705c82763db388a04664705129e692c5f", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f459ab973d31dfa363770f8cb37b0ec02a77936c", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa0c705c82763db388a04664705129e692c5f", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -771,7 +779,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f459a
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f459ab973d31dfa363770f8cb37b0ec02a77936c", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa0c705c82763db388a04664705129e692c5f", features = ["cuda"], optional = true }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -187,6 +187,14 @@ use candle_gen_qwen_image::{QwenControl, QwenControlPaths, QwenControlRequest};
 // (`image_jobs/kolors_control.rs`) drives.
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
 use candle_gen_kolors::{KolorsControl, KolorsControlPaths, KolorsControlRequest};
+// Z-Image Fun-ControlNet (strict pose) provider (sc-5489, epic 5480) — the candle (Windows/CUDA)
+// Z-Image sibling of the Qwen/Kolors strict-pose lanes, living in `candle-gen-z-image` (the VACE-style
+// dual-injection control on the vendored DiT). Candle-only: macOS keeps the MLX `z_image_turbo_control`
+// registry generator. `candle_gen_z_image` is already force-link anchored above (the registered txt2img
+// `z_image_turbo`); this is the named-type import the bespoke pose route (`image_jobs/zimage_control.rs`)
+// drives.
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+use candle_gen_z_image::{ZImageControl, ZImageControlPaths, ZImageControlRequest};
 
 /// The stub adapter id recorded on generated assets (matches the contract fixture
 /// `tests/fixtures/rust_migration_contracts/sidecars/asset-image.sceneworks.json`).
@@ -541,6 +549,22 @@ pub(crate) async fn run_image_generate_job(
         // IS a candle txt2img id, so without this a `advanced.poses` job would be caught by the txt2img
         // branch and silently drop the poses (the Qwen-control reasoning, for the Kolors family).
         generate_candle_kolors_control_stream(
+            api,
+            settings,
+            job,
+            &plan,
+            &project_path,
+            backend,
+            &mut asset_writes,
+        )
+        .await?;
+        true
+    } else if settings.backend_candle_enabled && zimage_control_available(&request, settings) {
+        // Z-Image strict-pose Fun-ControlNet (sc-5489) — checked BEFORE `is_candle_engine` because
+        // `z_image_turbo` IS a candle txt2img id, so without this a `advanced.poses` job would be caught
+        // by the txt2img branch and silently drop the poses (the Qwen/Kolors-control reasoning, for the
+        // Z-Image family — the last of the three strict-pose families).
+        generate_candle_zimage_control_stream(
             api,
             settings,
             job,
@@ -1049,6 +1073,10 @@ include!("image_jobs/qwen_control.rs");
 // Kolors ControlNet path; the candle `KolorsControl` is a bespoke provider.
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
 include!("image_jobs/kolors_control.rs");
+// Z-Image Fun-ControlNet (strict pose) — the Windows/CUDA candle lane ONLY (sc-5489). macOS keeps the
+// MLX `z_image_turbo_control` registry generator; the candle `ZImageControl` is a bespoke provider.
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+include!("image_jobs/zimage_control.rs");
 #[cfg(target_os = "macos")]
 // PuLID-FLUX native routing.
 include!("image_jobs/pulid.rs");

--- a/crates/sceneworks-worker/src/image_jobs/zimage_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage_control.rs
@@ -1,0 +1,280 @@
+// Candle (Windows/CUDA) Z-Image Fun-ControlNet (strict pose) route (sc-5489, epic 5480) —
+// `z_image_turbo` + `advanced.poses` off-Mac via `candle_gen_z_image::ZImageControl`. The LAST family
+// of the sc-5489 3-family ControlNet port (after Qwen + Kolors). The candle sibling of the MLX Z-Image
+// strict-pose path (zimage.rs `generate_zimage_control_stream`): one image per pose, each conditioned
+// on a full DWPose skeleton (rendered cross-platform by `openpose_skeleton::draw_wholebody`) fed to the
+// VACE-style `alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1` branch.
+//
+// **Candle-only.** macOS keeps the MLX `z_image_turbo_control` registry generator (zimage.rs); the
+// candle `ZImageControl` is a bespoke provider, so this whole file is gated to the Windows/CUDA candle
+// build (the `include!` in image_jobs.rs carries the cfg). It is `include!`d into the `image_jobs`
+// module, so it shares that module's imports (`parse_poses`/`pose_entries`/`Settings`/`WorkerResult`/
+// `huggingface_snapshot_dir`/`ensure_hf_cached_file`/`start_gen_stream`/… all in scope unqualified).
+
+/// Default Fun-Controlnet-Union weights — the **8-step** variant the MLX path uses (zimage.rs
+/// `ZIMAGE_CONTROL_FILE`); the candle `ZImageControl::generate` runs the matching 8-step schedule.
+const ZIMAGE_CTRL_REPO: &str = "alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1";
+const ZIMAGE_CTRL_FILE: &str = "Z-Image-Turbo-Fun-Controlnet-Union-2.1-8steps.safetensors";
+/// The Z-Image base diffusers repo when the manifest omits `repo`.
+const ZIMAGE_CTRL_DEFAULT_REPO: &str = "Tongyi-MAI/Z-Image-Turbo";
+/// ControlNet conditioning-scale default (the strict-pose tier).
+const ZIMAGE_CTRL_DEFAULT_SCALE: f32 = 1.0;
+/// Denoise-steps default — the 8-step Fun-ControlNet variant (vs the 4-step distilled txt2img).
+const ZIMAGE_CTRL_DEFAULT_STEPS: u32 = 8;
+/// The adapter/engine id recorded on candle Z-Image control assets (distinct from the txt2img
+/// `candle_z_image`/`candle_zimage` lane).
+const ZIMAGE_CTRL_ENGINE: &str = "candle_zimage_control";
+
+/// Model ids the candle Z-Image ControlNet route accepts.
+fn is_zimage_control_model(model: &str) -> bool {
+    model == "z_image_turbo"
+}
+
+/// Resolve the Z-Image base (diffusers) snapshot: an explicit `modelPath` (advanced or manifest) → the
+/// HF cache snapshot for the manifest `repo` (default `Tongyi-MAI/Z-Image-Turbo`). `None` ⇒ not present
+/// locally (the job is not candle-runnable, falls through to torch). Mirrors `resolve_kolors_control_base`.
+fn resolve_zimage_control_base(
+    request: &ImageRequest,
+    settings: &Settings,
+) -> WorkerResult<Option<PathBuf>> {
+    if let Some(path) = request
+        .advanced
+        .get("modelPath")
+        .or_else(|| request.model_manifest_entry.get("modelPath"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+    {
+        return resolve_app_managed_model_dir(settings, &path, "Z-Image control modelPath").map(Some);
+    }
+    let repo = request
+        .model_manifest_entry
+        .get("repo")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(ZIMAGE_CTRL_DEFAULT_REPO);
+    Ok(huggingface_snapshot_dir(&settings.data_dir, repo))
+}
+
+/// True when this is a candle-eligible Z-Image strict-pose job: `z_image_turbo` with a non-empty
+/// `advanced.poses`, not edit mode, whose base resolves locally. Mirrors
+/// `jobs_store::zimage_control_candle_eligible` so the worker and router agree.
+fn zimage_control_available(request: &ImageRequest, settings: &Settings) -> bool {
+    is_zimage_control_model(&request.model)
+        && request.mode != "edit_image"
+        && !pose_entries(request).is_empty()
+        && matches!(resolve_zimage_control_base(request, settings), Ok(Some(_)))
+}
+
+/// Resolve denoise steps: `advanced.steps` (clamped 1..=50) → manifest `steps` → default (8).
+fn zimage_control_steps(request: &ImageRequest) -> u32 {
+    let parse = |value: &Value| {
+        value
+            .as_u64()
+            .or_else(|| value.as_str()?.trim().parse().ok())
+    };
+    request
+        .advanced
+        .get("steps")
+        .and_then(parse)
+        .or_else(|| request.model_manifest_entry.get("steps").and_then(parse))
+        .map(|steps| steps.clamp(1, 50) as u32)
+        .unwrap_or(ZIMAGE_CTRL_DEFAULT_STEPS)
+}
+
+/// The (repo, filename) of the ControlNet weights — `advanced.controlWeights.{repo,filename}` overrides,
+/// else the Fun-Controlnet-Union 8-step default (parity with the MLX `resolve_control_weights`).
+fn zimage_control_repo_file(request: &ImageRequest) -> (String, String) {
+    let cw = request.advanced.get("controlWeights").and_then(Value::as_object);
+    let pick = |key: &str, default: &str| {
+        cw.and_then(|m| m.get(key))
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+            .unwrap_or(default)
+            .to_owned()
+    };
+    (
+        pick("repo", ZIMAGE_CTRL_REPO),
+        pick("filename", ZIMAGE_CTRL_FILE),
+    )
+}
+
+/// Resolve the Fun-Controlnet-Union weight **file** the `ZImageControl` provider loads, downloading on
+/// first use. Order: an env-pinned file (`SCENEWORKS_CONTROLNET_ZIMAGE`) → a whole-repo HF cache
+/// snapshot → download into the app cache. Mirrors `ensure_kolors_control_weights`.
+async fn ensure_zimage_control_weights(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &ImageRequest,
+) -> WorkerResult<PathBuf> {
+    let (repo, file) = zimage_control_repo_file(request);
+    if let Ok(p) = std::env::var("SCENEWORKS_CONTROLNET_ZIMAGE") {
+        let p = PathBuf::from(p);
+        if p.is_file() {
+            return Ok(p);
+        }
+    }
+    if let Some(snapshot) = huggingface_snapshot_dir(&settings.data_dir, &repo) {
+        let f = snapshot.join(&file);
+        if f.is_file() {
+            return Ok(f);
+        }
+    }
+    let client = reqwest::Client::new();
+    let context = DownloadContext {
+        api,
+        client: &client,
+        settings,
+        job_id: &job.id,
+        cancel_message: "Z-Image strict-pose generation canceled while fetching control weights.",
+        fresh_download: false,
+    };
+    let dst = settings
+        .data_dir
+        .join("cache")
+        .join("controlnet-zimage")
+        .join(&file);
+    ensure_hf_cached_file(&context, &repo, "main", &file, &dst).await?;
+    Ok(dst)
+}
+
+/// Flat telemetry recorded on candle Z-Image control assets. No guidance — Z-Image-Turbo is
+/// guidance-distilled.
+fn zimage_control_raw_settings(
+    request: &ImageRequest,
+    repo: &str,
+    steps: u32,
+    control_scale: f32,
+    pose_count: usize,
+) -> JsonObject {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("repo".to_owned(), Value::String(repo.to_owned()));
+    raw.insert("numInferenceSteps".to_owned(), json!(steps));
+    raw.insert("controlScale".to_owned(), json!(control_scale));
+    raw.insert("poseCount".to_owned(), json!(pose_count));
+    raw.insert(
+        "controlEngine".to_owned(),
+        Value::String(ZIMAGE_CTRL_ENGINE.to_owned()),
+    );
+    raw
+}
+
+/// Real candle Z-Image strict-pose generation: one image per pose, each conditioned on a full DWPose
+/// skeleton. The provider loads once on the blocking thread; each pose renders its skeleton + generates.
+/// Z-Image-Turbo is distilled (no CFG / negative prompt), so the request carries no guidance.
+/// `ZImageControl::generate` takes `&self`, so the per-item closure does not need `&mut`.
+async fn generate_candle_zimage_control_stream(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+    let base = resolve_zimage_control_base(request, settings)?.ok_or_else(|| {
+        WorkerError::InvalidPayload("Z-Image base (Z-Image-Turbo) weights not found".to_owned())
+    })?;
+    let controlnet = ensure_zimage_control_weights(api, settings, job, request).await?;
+
+    let steps = zimage_control_steps(request);
+    let control_scale = advanced::f32_clamped(
+        &request.advanced,
+        "controlScale",
+        ZIMAGE_CTRL_DEFAULT_SCALE,
+        0.0..=2.0,
+    );
+    let repo = request
+        .model_manifest_entry
+        .get("repo")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(ZIMAGE_CTRL_DEFAULT_REPO)
+        .to_owned();
+
+    let poses = parse_poses(request);
+    let pose_count = poses.len();
+    let raw_settings = zimage_control_raw_settings(request, &repo, steps, control_scale, pose_count);
+
+    let (width, height) = (request.width, request.height);
+    let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
+    // One shared seed across the pose set (the MLX `_generate_pose_set` convention).
+    let seed = resolve_seed(request, 0);
+    let prompt = request.prompt.clone();
+
+    let (cancel, rx, blocking) = start_gen_stream(
+        job.id.clone(),
+        "zimage_control",
+        0,
+        move || {
+            let paths = ZImageControlPaths { base, control: controlnet };
+            let model = ZImageControl::load(&paths).map_err(|error| {
+                WorkerError::Engine(format!("Z-Image strict-pose control load failed: {error}"))
+            })?;
+            Ok((model, poses))
+        },
+        move |(model, poses), tx, cancel| {
+            drive_gen_items(tx, poses, move |_index, pose, on_progress| {
+                if cancel.is_cancelled() {
+                    return Ok(None);
+                }
+                let skeleton = crate::openpose_skeleton::draw_wholebody(
+                    width,
+                    height,
+                    &pose.keypoints,
+                    pose.hands.as_deref(),
+                    pose.face.as_deref(),
+                    stickwidth,
+                );
+                let control = Image {
+                    width,
+                    height,
+                    pixels: skeleton.into_raw(),
+                };
+                let req = ZImageControlRequest {
+                    prompt: prompt.clone(),
+                    width,
+                    height,
+                    steps: steps as usize,
+                    control_scale,
+                    seed: seed as u64,
+                    cancel: cancel.clone(),
+                };
+                let out = match model.generate(&req, &control, &mut *on_progress) {
+                    Ok(out) => out,
+                    Err(_) if cancel.is_cancelled() => return Ok(None),
+                    Err(error) => {
+                        return Err(WorkerError::Engine(format!(
+                            "Z-Image strict-pose generation failed: {error}"
+                        )));
+                    }
+                };
+                Ok(Some((seed, out.width, out.height, out.pixels)))
+            })
+        },
+    );
+
+    consume_gen_events(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        ZIMAGE_CTRL_ENGINE,
+        &raw_settings,
+        pose_count,
+        rx,
+        cancel,
+        blocking,
+        asset_writes,
+    )
+    .await
+}


### PR DESCRIPTION
The worker half of the **Z-Image** strict-pose slice — the **LAST** of sc-5489's three ControlNet families ([candle-gen#79](https://github.com/michaeltrefry/candle-gen/pull/79) landed the `ZImageControl` provider). `z_image_turbo` + `advanced.poses` now routes off-Mac to the candle VACE Fun-ControlNet lane (the qwen/kolors-control sibling); macOS keeps the MLX `z_image_turbo_control` registry generator.

## Worker
- **`image_jobs/zimage_control.rs`** (new): `generate_candle_zimage_control_stream` + `zimage_control_available`. One image per pose, each conditioned on a DWPose skeleton rendered cross-platform by `openpose_skeleton::draw_wholebody` and fed to `candle_gen_z_image::ZImageControl`. Base default `Tongyi-MAI/Z-Image-Turbo` (manifest `repo`/`modelPath` override); control weights via env `SCENEWORKS_CONTROLNET_ZIMAGE` / `advanced.controlWeights.{repo,filename}` → HF snapshot → download-on-first-use the **8-step** Fun-Controlnet-Union variant (`alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1` — the file the MLX path uses) @ `main`. steps 8 (clamp 1..50), **no guidance** (Z-Image-Turbo is distilled), `controlScale` 1.0 (clamp 0..2), engine `candle_zimage_control`; shared seed across the pose set; `ZImageControl::generate` is `&self`.
- **`image_jobs.rs`**: cfg-gated `use candle_gen_z_image::{ZImageControl, ...}`, a dispatch branch (`zimage_control_available`) after the kolors_control branch and **before** `is_candle_engine`, and the cfg-gated `include!`.
- **`jobs_store.rs`**: `zimage_control_candle_eligible` + a `model == "z_image_turbo"` branch in `image_job_is_candle_eligible` before the txt2img gate. Routing test `zimage_control_pose_jobs_route_to_candle`. **Flipped** the existing `z_image_turbo`+poses "still defers" assertions (in the qwen routing test + `candle_worker_claims_txt2img_but_refuses_unsupported_shapes`) — z_image now **claimed**; the "different family still defers" cross-check switched to plain `sdxl`+poses (no plain-SDXL pose product route — SDXL pose ships via the InstantID lane).

## Re-pin
Worker candle-gen `f459ab9` → `864aa0c` (16 crates, candle-gen #79). Source-only off `f459ab9`, so gen-core stays `32fdb34` == the worker's mlx-gen pin → single gen-core rev, **no skew**.

## Verified
`sceneworks-core` jobs_store tests (52) pass; worker `build` + `clippy -p sceneworks-worker --features backend-candle` + core clippy + `fmt` clean (RTX PRO 6000, sm_120). Real-weight GPU smoke is the deploy follow-up (candle-gen #79's `#[ignore]`'d `control_validate` harness).

**With this, sc-5489 is feature-complete** — all four families have candle strict-pose lanes off-Mac (SDXL via InstantID; Qwen, Kolors, Z-Image via their providers, provider+worker pairs all merged/merging). Epic 5480.