### PR TITLE
build(desktop): DMG-staple tooling + scaffold tag-triggered release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,74 @@
+name: Release (desktop)
+
+# SCAFFOLD / STARTING POINT — sc-5930. Builds, signs, notarizes, staples, and
+# publishes a DRAFT GitHub Release of the macOS desktop app when a `v*` tag is
+# pushed. Only runs on a version tag or manual dispatch — never on push/PR.
+#
+# NOT YET WIRED: a tag push will fail at the signing/notarization step until the
+# following are available on the self-hosted `nax` runner (or as repo secrets):
+#   APPLE_SIGNING_IDENTITY  e.g. "Developer ID Application: Michael Trefry (R2526H7YN9)"
+#   APPLE_API_ISSUER        App Store Connect API issuer UUID
+#   APPLE_API_KEY           App Store Connect API key id
+#   APPLE_API_KEY_PATH      path to the .p8 key on the runner (or write from a secret)
+# The Developer ID cert is ALREADY in the nax runner's login keychain, so the
+# base64 APPLE_CERTIFICATE -> temp-keychain import that ephemeral runners need is
+# NOT required here. Build prerequisites on the runner (root npm deps for the
+# embedded web/api build invoked by tauri.conf beforeBuildCommand, Rust toolchain)
+# still need validation. Verify end-to-end with a throwaway tag (e.g. v0.0.0-rc.1)
+# before relying on this. See sc-5930.
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: write # create releases + upload assets
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  macos:
+    # Self-hosted macOS 26.2 runner: GitHub-hosted images can't build at that
+    # deployment target (see macos-mlx.yml). Same-repo only — never run fork code.
+    if: ${{ github.repository == 'michaeltrefry/SceneWorks' }}
+    runs-on: [self-hosted, macOS, ARM64, nax]
+    env:
+      APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+      APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+      APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+      APPLE_API_KEY_PATH: ${{ secrets.APPLE_API_KEY_PATH }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      # Build the signed + notarized .app + DMG and create a DRAFT release with the
+      # asset attached. tauri-action runs the tauri.conf beforeBuildCommand, which
+      # stages the sidecar + web UI and applies the nested-binary pre-signing from
+      # PR #715.
+      - name: Build, sign, notarize & draft-release
+        uses: tauri-apps/tauri-action@v0
+        with:
+          projectPath: apps/desktop
+          tagName: ${{ github.ref_name }}
+          releaseName: SceneWorks ${{ github.ref_name }}
+          releaseDraft: true
+          # TODO(sc-5930): wire the release body / changelog source.
+
+      # tauri-action staples the .app but not the wrapping .dmg, and uploads the
+      # un-stapled DMG. Staple the DMG (shared script) and replace the release asset
+      # so the downloaded file verifies offline.
+      - name: Staple the DMG and replace the release asset
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node apps/desktop/scripts/staple-dmg.mjs
+          shopt -s nullglob
+          dmgs=(target/release/bundle/dmg/*.dmg)
+          gh release upload "${{ github.ref_name }}" "${dmgs[0]}" --clobber

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -5,7 +5,8 @@
   "description": "SceneWorks desktop shell (Tauri).",
   "scripts": {
     "dev": "tauri dev",
-    "build": "tauri build"
+    "build": "tauri build",
+    "release:mac": "tauri build && node scripts/staple-dmg.mjs"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2"

--- a/apps/desktop/scripts/staple-dmg.mjs
+++ b/apps/desktop/scripts/staple-dmg.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// Notarize + staple the macOS DMG. Tauri notarizes and staples the inner .app but
+// leaves the wrapping .dmg without its own notarization ticket, so a freshly
+// downloaded DMG can't be Gatekeeper-verified offline. This submits the DMG
+// container itself to the notary and staples the returned ticket to it.
+//
+// Used by `npm run release:mac` (build then staple) and by the CI release
+// workflow (.github/workflows/release.yml), so stapling has a single source of
+// truth. No-op off macOS and when notary credentials are absent, so it never
+// slows or breaks ordinary/dev builds (mirrors the env-gated codesign in
+// build-sidecar.mjs).
+//
+// Credentials = App Store Connect API key (the same env Tauri uses to notarize):
+//   APPLE_API_ISSUER     issuer UUID
+//   APPLE_API_KEY        key id
+//   APPLE_API_KEY_PATH   path to the .p8 key file
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import process from "node:process";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const desktopDir = resolve(scriptDir, ".."); // apps/desktop
+const repoRoot = resolve(desktopDir, "..", ".."); // repository root
+
+if (process.platform !== "darwin") {
+  console.log("staple-dmg: not macOS — nothing to do");
+  process.exit(0);
+}
+
+const { APPLE_API_ISSUER, APPLE_API_KEY, APPLE_API_KEY_PATH } = process.env;
+if (!APPLE_API_ISSUER || !APPLE_API_KEY || !APPLE_API_KEY_PATH) {
+  console.log(
+    "staple-dmg: notary credentials not set " +
+      "(APPLE_API_ISSUER / APPLE_API_KEY / APPLE_API_KEY_PATH) — skipping",
+  );
+  process.exit(0);
+}
+
+// Locate the built DMG(s) under the Tauri bundle dir (normally one per build).
+const dmgDir = join(repoRoot, "target", "release", "bundle", "dmg");
+const dmgs = existsSync(dmgDir)
+  ? readdirSync(dmgDir).filter((f) => f.endsWith(".dmg"))
+  : [];
+if (dmgs.length === 0) {
+  console.error(
+    `staple-dmg: no .dmg found in ${dmgDir} — run a release build first`,
+  );
+  process.exit(1);
+}
+if (dmgs.length > 1) {
+  console.warn(
+    `staple-dmg: multiple DMGs present, stapling all: ${dmgs.join(", ")}`,
+  );
+}
+
+function xcrun(args) {
+  console.log(`> xcrun ${args.join(" ")}`);
+  execFileSync("xcrun", args, { stdio: "inherit" });
+}
+
+for (const name of dmgs) {
+  const dmg = join(dmgDir, name);
+  xcrun([
+    "notarytool",
+    "submit",
+    dmg,
+    "--key",
+    APPLE_API_KEY_PATH,
+    "--key-id",
+    APPLE_API_KEY,
+    "--issuer",
+    APPLE_API_ISSUER,
+    "--wait",
+  ]);
+  xcrun(["stapler", "staple", dmg]);
+  xcrun(["stapler", "validate", dmg]);
+  console.log(`staple-dmg: stapled ${dmg}`);
+}


### PR DESCRIPTION
Follow-up to the signing work in #715. Two related pieces of desktop release tooling.

## 1. DMG notarize + staple tooling (sc-5933) — complete

Tauri notarizes + staples the inner `.app` but leaves the wrapping `.dmg` without its own ticket (`xcrun stapler validate <dmg>` → "does not have a ticket stapled"), so a freshly downloaded DMG can't be verified **offline**.

- `apps/desktop/scripts/staple-dmg.mjs` — notarize + staple + validate the built DMG. **Gated**: no-op off macOS and when notary creds (`APPLE_API_ISSUER`/`APPLE_API_KEY`/`APPLE_API_KEY_PATH`) are absent, so dev builds are unchanged (mirrors the env-gated codesign in `build-sidecar.mjs`).
- `apps/desktop/package.json` → `release:mac` = `tauri build && node scripts/staple-dmg.mjs`.

Verified: stapling `SceneWorks_0.2.0_aarch64.dmg` with this logic → `stapler validate` passes (used it to staple the `v0.2.0` artifact).

## 2. CI release workflow scaffold (sc-5930) — starting point, NOT yet live

`.github/workflows/release.yml`: on a `v*` tag, build + sign + notarize via `tauri-action`, create a **draft** release, then staple the DMG (reusing `staple-dmg.mjs`) and replace the asset.

⚠️ **Scaffold** — won't work until repo/runner secrets are wired and it's verified with a throwaway tag (tracked in sc-5930). Triggers on tag/`workflow_dispatch` only (never push/PR), so it can't run on this PR. Uses the same self-hosted `[self-hosted, macOS, ARM64, nax]` runner as `macos-mlx.yml`.

## Notes

- `actionlint` flags the custom `nax` runner label as "unknown" — the same pre-existing warning `macos-mlx.yml` already has (no repo `actionlint` config); not a real error.

Stories: sc-5933 (staple tooling, complete) · sc-5930 (CI pipeline, scaffold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)