### PR TITLE
Models UX overhaul: recommended infra, page reorg, built-in LoRA download, per-Studio gates

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -797,6 +797,10 @@ pub(crate) fn create_app_with_state(
         .route("/api/v1/loras", get(list_loras))
         .route("/api/v1/loras/:lora_id", delete(delete_lora))
         .route(
+            "/api/v1/loras/:lora_id/download",
+            post(create_lora_download_job),
+        )
+        .route(
             "/api/v1/loras/import",
             post(create_lora_import_job)
                 .layer(DefaultBodyLimit::max(MAX_LORA_MULTIPART_BODY_BYTES)),

--- a/apps/rust-api/src/loras.rs
+++ b/apps/rust-api/src/loras.rs
@@ -15,6 +15,111 @@ pub(crate) async fn list_loras(
     Ok(Json(items))
 }
 
+/// Explicitly download a catalog LoRA (built-in or user-global) whose source is a
+/// Hugging Face repo into the shared HF cache (sc-5944). Mirrors the model-download
+/// endpoint: the worker fetches the adapter file(s) into the cache the install-state
+/// probe (`lora_huggingface_cached_file`) reads, so the catalog row flips to
+/// "installed". Built-in LoRAs previously had no way to be fetched from the UI — they
+/// were only pulled on-demand at first generation.
+pub(crate) async fn create_lora_download_job(
+    State(state): State<AppState>,
+    Path(lora_id): Path<String>,
+    ApiJson(payload): ApiJson<ModelDownloadRequest>,
+) -> Result<(StatusCode, Json<JobSnapshot>), ApiError> {
+    let lora = lora_catalog(&state, None)
+        .await?
+        .into_iter()
+        .find(|item| item.get("id").and_then(Value::as_str) == Some(lora_id.as_str()))
+        .ok_or_else(|| ApiError {
+            status: StatusCode::NOT_FOUND,
+            detail: "LoRA not found".to_owned(),
+        })?;
+    if lora.get("installState").and_then(Value::as_str) == Some("installed") {
+        return Err(ApiError::bad_request("LoRA is already installed"));
+    }
+    let source = lora.get("source").and_then(Value::as_object);
+    let provider = source
+        .and_then(|source| source.get("provider"))
+        .or_else(|| lora.get("provider"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    if provider != Some("huggingface") {
+        return Err(ApiError::bad_request(
+            "LoRA does not define a Hugging Face download source",
+        ));
+    }
+    let repo = source
+        .and_then(|source| source.get("repo"))
+        .or_else(|| lora.get("repo"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| ApiError::bad_request("LoRA download source is missing a repo"))?
+        .to_owned();
+    // A single `file` or an explicit `files` list narrows the snapshot to the adapter
+    // weights; an empty list lets the worker fetch the (small) repo.
+    let mut files: Vec<String> = Vec::new();
+    if let Some(file) = source
+        .and_then(|source| source.get("file"))
+        .or_else(|| lora.get("file"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        files.push(file.to_owned());
+    }
+    if files.is_empty() {
+        if let Some(list) = source
+            .and_then(|source| source.get("files"))
+            .or_else(|| lora.get("files"))
+            .and_then(Value::as_array)
+        {
+            files.extend(
+                list.iter()
+                    .filter_map(Value::as_str)
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(str::to_owned),
+            );
+        }
+    }
+
+    let mut job_payload = JsonObject::new();
+    job_payload.insert("loraId".to_owned(), Value::String(lora_id.clone()));
+    job_payload.insert(
+        "loraName".to_owned(),
+        Value::String(
+            lora.get("name")
+                .and_then(Value::as_str)
+                .unwrap_or(&lora_id)
+                .to_owned(),
+        ),
+    );
+    job_payload.insert(
+        "provider".to_owned(),
+        Value::String("huggingface".to_owned()),
+    );
+    job_payload.insert("repo".to_owned(), Value::String(repo));
+    job_payload.insert("files".to_owned(), json!(files));
+    if let Some(family) = lora.get("family").and_then(Value::as_str) {
+        if !family.trim().is_empty() {
+            job_payload.insert("family".to_owned(), Value::String(family.to_owned()));
+        }
+    }
+
+    let job = create_generation_job(
+        state,
+        JobType::LoraDownload,
+        None,
+        None,
+        job_payload,
+        requested_gpu_or_auto(payload.requested_gpu),
+    )
+    .await?;
+    Ok((StatusCode::CREATED, Json(job)))
+}
+
 pub(crate) async fn delete_lora(
     State(state): State<AppState>,
     Path(lora_id): Path<String>,

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -3754,6 +3754,77 @@ async fn video_jobs_expand_recipe_presets_server_side() {
 }
 
 #[tokio::test]
+async fn lora_download_endpoint_queues_hf_download_for_builtin_lora() {
+    // sc-5944: built-in LoRAs gain an explicit Download (mirrors model download). A
+    // catalog LoRA with a Hugging Face source queues a `lora_download` job carrying the
+    // repo/file the worker fetches into the HF cache; a non-HF source or already-installed
+    // LoRA is rejected, and an unknown id is 404.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    std::fs::write(
+        config_dir.join("builtin.loras.jsonc"),
+        r#"
+            {
+              "schemaVersion": 1,
+              "loras": [
+                {
+                  "id": "ltx_ic_union",
+                  "name": "LTX IC Union",
+                  "family": "ltx-video",
+                  "compatibility": { "families": ["ltx-video"] },
+                  "source": {
+                    "provider": "huggingface",
+                    "repo": "Lightricks/LTX-2.3-IC",
+                    "file": "ic-union.safetensors"
+                  }
+                },
+                {
+                  "id": "local_only",
+                  "name": "Local Only",
+                  "family": "z-image",
+                  "compatibility": { "families": ["z-image"] },
+                  "source": { "provider": "local", "path": "loras/local.safetensors" }
+                }
+              ]
+            }
+            "#,
+    )
+    .expect("builtin loras writes");
+
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (status, job) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/loras/ltx_ic_union/download",
+        json!({ "requestedGpu": "auto" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(job["type"], "lora_download");
+    assert_eq!(job["payload"]["loraId"], "ltx_ic_union");
+    assert_eq!(job["payload"]["loraName"], "LTX IC Union");
+    assert_eq!(job["payload"]["provider"], "huggingface");
+    assert_eq!(job["payload"]["repo"], "Lightricks/LTX-2.3-IC");
+    assert_eq!(job["payload"]["files"][0], "ic-union.safetensors");
+    assert_eq!(job["payload"]["family"], "ltx-video");
+
+    // A LoRA whose source is not a Hugging Face repo can't be fetched this way.
+    let (status, _) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/loras/local_only/download",
+        json!({}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    // An unknown LoRA id is a 404.
+    let (status, _) = request(app, "POST", "/api/v1/loras/missing/download", json!({})).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
 async fn model_and_lora_routes_match_manifest_behavior() {
     std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
     let temp_dir = tempfile::tempdir().expect("temp dir creates");

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -684,6 +684,7 @@ export function App() {
     createModelImportJob,
     createLoraImportJob,
     createModelDownloadJob,
+    createLoraDownloadJob,
     createModelConvertJob,
   } = useModelsAndLoras({
     token,
@@ -1033,6 +1034,11 @@ export function App() {
       }
       if (job.status === "completed" && job.type === "model_download") {
         refreshDataRef.current?.();
+      }
+      // A completed built-in LoRA download (sc-5944) flips the catalog entry to
+      // installed; refresh models+loras so the Models row and any Studio gate update.
+      if (job.status === "completed" && job.type === "lora_download") {
+        refreshDataWithLoraOverlayRef.current?.(job.projectId ?? activeProjectRef.current?.id);
       }
       if (job.status === "completed" && job.type === "lora_import") {
         dismissNoticeKind("lora-import");
@@ -1765,6 +1771,7 @@ export function App() {
     deleteLora,
     deleteModel,
     createModelDownloadJob,
+    createLoraDownloadJob,
     createModelConvertJob,
     createLoraImportJob,
     createModelImportJob,
@@ -1833,7 +1840,7 @@ export function App() {
     recentVideoAssets, videoLocalJobs, imageLocalJobs, documentLocalJobs, studioLaunch,
     rememberLocalGenerationJob, personTracks, personReadiness, createPersonDetectionJob,
     createPersonTrackJob, saveTrackCorrections, imageModels, videoModels, models, macCapabilities,
-    loras, deleteLora, deleteModel, createModelDownloadJob, createModelConvertJob,
+    loras, deleteLora, deleteModel, createModelDownloadJob, createLoraDownloadJob, createModelConvertJob,
     createLoraImportJob, createModelImportJob, gpuOptions, requestedGpu, setRequestedGpu,
     presets, createPreset, updatePreset, deletePreset, duplicatePreset, token, authenticated,
     trainingDatasets, trainingDatasetsProjectId, trainingDatasetsError, loadingTrainingDatasets,

--- a/apps/web/src/components/ModelAvailabilityGate.jsx
+++ b/apps/web/src/components/ModelAvailabilityGate.jsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { WorkerProgressCard } from "./WorkerProgressCard.jsx";
+import { terminalStatuses } from "../constants.js";
+
+// Per-Studio model-availability gate (sc-5947). When a Studio has no installed model that
+// supports its functions, it renders this instead of its body: a short explanation plus the
+// screen's recommended models with an inline Download. A completed download refreshes the
+// catalog (App.jsx SSE handler), so `ready` flips and the Studio renders without a reload.
+//
+// Props:
+//   ready          — when true, render `children` (the Studio body) unchanged.
+//   title/description — gate copy.
+//   offers         — models to offer for download (downloadOffersFor in modelEligibility.js).
+//   downloadJobs   — model_download jobs, to show progress for an in-flight offer.
+//   onDownload(model) / onOpenModels() / onOpenQueue() / onCancelJob(job) — wired from context.
+function offerSizeText(model) {
+  if (!model?.downloadSizeLabel) {
+    return "Size unavailable";
+  }
+  return model.downloadSizeEstimated ? `~${model.downloadSizeLabel}` : model.downloadSizeLabel;
+}
+
+export function ModelAvailabilityGate({
+  ready,
+  title,
+  description,
+  offers = [],
+  downloadJobs = [],
+  onDownload,
+  onOpenModels,
+  onOpenQueue,
+  onCancelJob,
+  children,
+}) {
+  if (ready) {
+    return children;
+  }
+  const activeJobFor = (model) =>
+    downloadJobs.find((job) => job.payload?.modelId === model.id && !terminalStatuses.has(job.status));
+  return (
+    <section className="model-availability-gate">
+      <div className="model-availability-gate-card">
+        <div className="section-heading">
+          <p className="eyebrow">No supported model installed</p>
+          <h2>{title}</h2>
+        </div>
+        {description ? <p>{description}</p> : null}
+        {offers.length ? (
+          <div className="model-availability-offers">
+            {offers.map((model) => {
+              const job = activeJobFor(model);
+              return (
+                <article className="model-availability-offer" key={model.id}>
+                  <div className="model-availability-offer-head">
+                    <span>
+                      <strong>{model.name ?? model.id}</strong>
+                      <small>{offerSizeText(model)}</small>
+                    </span>
+                    <button
+                      disabled={!onDownload || Boolean(job)}
+                      onClick={() => onDownload?.(model)}
+                      type="button"
+                    >
+                      {job ? job.status : "Download"}
+                    </button>
+                  </div>
+                  {job ? (
+                    <WorkerProgressCard job={job} onCancel={onCancelJob} onOpenQueue={onOpenQueue} />
+                  ) : null}
+                </article>
+              );
+            })}
+          </div>
+        ) : (
+          <p className="empty-panel compact-panel">No downloadable model in the catalog supports this screen yet.</p>
+        )}
+        {onOpenModels ? (
+          <button className="model-availability-browse" onClick={onOpenModels} type="button">
+            Browse all models
+          </button>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/ModelAvailabilityGate.test.jsx
+++ b/apps/web/src/components/ModelAvailabilityGate.test.jsx
@@ -1,0 +1,83 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppContext } from "../context/AppContext.js";
+import { ModelAvailabilityGate } from "./ModelAvailabilityGate.jsx";
+
+describe("ModelAvailabilityGate", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  async function renderGate(props) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={{ workersById: new Map(), visibleWorkers: [] }}>
+          <ModelAvailabilityGate {...props} />
+        </AppContext.Provider>,
+      );
+    });
+  }
+
+  async function click(el) {
+    await act(async () => {
+      el.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+    });
+  }
+
+  it("renders children when ready", async () => {
+    await renderGate({ ready: true, children: <div className="studio-body">Studio</div> });
+    expect(container.querySelector(".studio-body")).toBeTruthy();
+    expect(container.querySelector(".model-availability-gate")).toBeNull();
+  });
+
+  it("offers recommended models for download when gated and queues on click", async () => {
+    const onDownload = vi.fn();
+    await renderGate({
+      ready: false,
+      title: "Image Studio needs a model",
+      offers: [{ id: "z_image_turbo", name: "Z-Image-Turbo", downloadSizeLabel: "30.6 GB", downloadSizeEstimated: true }],
+      downloadJobs: [],
+      onDownload,
+      onOpenModels: () => {},
+      children: <div className="studio-body">Studio</div>,
+    });
+    expect(container.querySelector(".studio-body")).toBeNull();
+    expect(container.textContent).toContain("Image Studio needs a model");
+    expect(container.textContent).toContain("~30.6 GB");
+    const downloadButton = [...container.querySelectorAll(".model-availability-offer button")].find(
+      (button) => button.textContent === "Download",
+    );
+    expect(downloadButton).toBeTruthy();
+    await click(downloadButton);
+    expect(onDownload).toHaveBeenCalledWith(expect.objectContaining({ id: "z_image_turbo" }));
+  });
+
+  it("shows progress and disables the button while an offer is downloading", async () => {
+    await renderGate({
+      ready: false,
+      title: "Video Studio needs a model",
+      offers: [{ id: "ltx_2_3", name: "LTX-2.3", downloadSizeLabel: "146 GB" }],
+      downloadJobs: [{ id: "j1", type: "model_download", status: "downloading", progress: 0.3, payload: { modelId: "ltx_2_3" } }],
+      onDownload: vi.fn(),
+      children: <div className="studio-body">Studio</div>,
+    });
+    const button = container.querySelector(".model-availability-offer button");
+    expect(button.disabled).toBe(true);
+    expect(button.textContent).toBe("downloading");
+  });
+});

--- a/apps/web/src/hooks/useModelsAndLoras.js
+++ b/apps/web/src/hooks/useModelsAndLoras.js
@@ -202,6 +202,27 @@ export function useModelsAndLoras({
     [token, setJobs, setError],
   );
 
+  // Built-in LoRA explicit download (sc-5944): queues a `lora_download` job that fetches
+  // the catalog LoRA's HF files into the cache, flipping its installState to "installed".
+  // Mirrors createModelDownloadJob.
+  const createLoraDownloadJob = useCallback(
+    async (lora) => {
+      try {
+        const job = await apiFetch(`/api/v1/loras/${encodeURIComponent(lora.id)}/download`, token, {
+          method: "POST",
+          body: JSON.stringify({ requestedGpu: "auto" }),
+        });
+        setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
+        setError("");
+        return job;
+      } catch (err) {
+        setError(err.message);
+        return null;
+      }
+    },
+    [token, setJobs, setError],
+  );
+
   return {
     models,
     setModels,
@@ -213,6 +234,7 @@ export function useModelsAndLoras({
     createModelImportJob,
     createLoraImportJob,
     createModelDownloadJob,
+    createLoraDownloadJob,
     createModelConvertJob,
   };
 }

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -439,6 +439,7 @@ describe("SceneWorks app shell", () => {
       id: "z_image_turbo",
       name: "Z-Image-Turbo",
       type: "image",
+      recommended: true,
       downloadable: true,
       installState: "missing",
       downloadSizeLabel: "30.6 GB",
@@ -471,6 +472,8 @@ describe("SceneWorks app shell", () => {
       id: "ltx_2_3",
       name: "LTX-2.3",
       type: "video",
+      recommended: true,
+      autoDownload: false,
       downloadable: true,
       installState: "missing",
       downloadSizeLabel: "146 GB",
@@ -508,16 +511,16 @@ describe("SceneWorks app shell", () => {
 
     const checkboxes = [...container.querySelectorAll("input[type=checkbox]")];
     // DOM order: image group (z_image_turbo, qwen_image[installed]), then video (wan_2_2, ltx_2_3).
-    expect(checkboxes[0].checked).toBe(true); // z_image_turbo — recommended, small enough to auto-select
+    expect(checkboxes[0].checked).toBe(true); // z_image_turbo — recommended, autoDownload not disabled
     expect(checkboxes[1].disabled).toBe(true); // qwen_image — installed, not selectable
     expect(checkboxes[2].checked).toBe(false); // wan_2_2 — not recommended
-    expect(checkboxes[3].checked).toBe(false); // ltx_2_3 — recommended but too large to auto-select (~146 GB)
+    expect(checkboxes[3].checked).toBe(false); // ltx_2_3 — recommended but autoDownload:false (~146 GB)
     // LTX-2.3 is still surfaced as recommended (badge) and shows its size so the choice is informed.
     expect(container.textContent).toContain("146 GB");
     expect(container.querySelectorAll(".setup-wizard-tag").length).toBe(2); // z_image_turbo + ltx_2_3
   });
 
-  it("auto-selects only the small recommended model, leaving huge ones opt-in", async () => {
+  it("auto-selects recommended models, leaving autoDownload:false ones opt-in", async () => {
     const props = renderWizard();
     await act(async () => {
       root.render(<SetupWizard {...props} />);
@@ -3721,6 +3724,37 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).not.toContain("No analysis yet");
   });
 
+  it("gates Image Studio behind a model download when no image model is present", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withImageStudioContext({
+          activeProject: { id: "project-1", name: "Noir" },
+          assets: [],
+          characters: [],
+          createImageJob: () => {},
+          deleteAsset: () => {},
+          purgeAsset: () => {},
+          gpuOptions: ["auto"],
+          imageModels: [],
+          latestAssets: [],
+          localJobs: [],
+          loras: [],
+          onPreview: () => {},
+          requestedGpu: "auto",
+          selectedAsset: null,
+          setRequestedGpu: () => {},
+          updateAssetStatus: () => {},
+        }),
+      );
+    });
+    await settle();
+    // The studio form is replaced by the availability gate.
+    expect(container.textContent).toContain("Image Studio needs an image model");
+    expect(container.querySelector(".model-availability-gate")).not.toBeNull();
+    expect(container.querySelector(".studio-shell")).toBeNull();
+  });
+
   it("keeps image generation in the studio and shows local progress", async () => {
     const createdJobs = [];
     global.fetch.mockImplementation((url, options = {}) => {
@@ -5036,7 +5070,7 @@ describe("SceneWorks app shell", () => {
     expect(field(panel(), "Name").value).toBe("");
     expect(container.textContent).toContain("LoRA imports");
     expect(container.textContent).toContain("detail_lora_1");
-    expect(container.textContent).not.toContain("No LoRAs in this view");
+    expect(container.textContent).not.toContain("No user LoRAs");
 
     await changeField(field(panel(), "Source URL"), "https://example.com/loras/two.safetensors");
     await act(async () => {
@@ -5124,7 +5158,7 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("LoRA imports");
     expect(container.textContent).toContain("broken_detail");
     expect(container.textContent).toContain("Adapter crashed");
-    expect(container.textContent).not.toContain("No LoRAs in this view");
+    expect(container.textContent).not.toContain("No user LoRAs");
   });
 
   it("hides failed Models LoRA imports superseded by a completed retry", async () => {
@@ -5165,7 +5199,7 @@ describe("SceneWorks app shell", () => {
 
     expect(container.textContent).not.toContain("LoRA manifestPath must target");
     expect(container.textContent).not.toContain("LoRA imports");
-    expect(container.textContent).toContain("No LoRAs in this view");
+    expect(container.textContent).toContain("No user LoRAs yet");
   });
 
   it("shows Models page LoRA import errors and resets the queueing state", async () => {
@@ -9151,6 +9185,35 @@ describe("SceneWorks app shell", () => {
     expect(purgeAsset).toHaveBeenCalledWith(trashedB);
     expect(purgeAsset).not.toHaveBeenCalledWith(active);
     confirm.mockRestore();
+  });
+
+  it("gates Document Studio behind a model download when no interleave model is present", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Noir" },
+            assets: [],
+            createInterleaveJob: () => {},
+            documentLocalJobs: [],
+            gpuOptions: ["auto"],
+            imageModels: [{ id: "z_image_turbo", name: "Z-Image", type: "image", capabilities: ["text_to_image"] }],
+            jobAction: () => {},
+            rememberLocalGenerationJob: () => {},
+            setActiveView: () => {},
+            requestedGpu: "auto",
+            setRequestedGpu: () => {},
+          },
+          <DocumentStudio />,
+        ),
+      );
+    });
+    await settle();
+    // An image model without interleave doesn't satisfy Document Studio → gate shows.
+    expect(container.textContent).toContain("Document Studio needs an interleave-capable model");
+    expect(container.querySelector(".model-availability-gate")).not.toBeNull();
+    expect(container.querySelector(".studio-form")).toBeNull();
   });
 
   it("DocumentStudio renders an interleaved document and submits a compose job", async () => {

--- a/apps/web/src/modelEligibility.js
+++ b/apps/web/src/modelEligibility.js
@@ -1,0 +1,111 @@
+// Shared per-screen model-eligibility predicates (sc-5946). Each Studio already
+// derived "can this model serve this screen?" inline; those predicates are lifted here
+// verbatim so the per-Studio availability gates and the screens themselves agree on
+// exactly which models qualify. Predicates are capability + Mac-gating only (no install
+// state) — callers layer installState via the helpers at the bottom.
+import { macModelBlock, macModelFeatureBlock, macVideoModeBlock } from "./macGating.js";
+
+// Image generation modes a model can serve (ImageStudio mode tabs).
+const IMAGE_MODES = ["text_to_image", "edit_image", "character_image", "style_variations"];
+
+// Video generation modes a model can advertise (VideoStudio modeOptions).
+export const VIDEO_MODES = [
+  "text_to_video",
+  "image_to_video",
+  "first_last_frame",
+  "extend_clip",
+  "video_bridge",
+  "replace_person",
+  "video_to_video",
+  "reference_to_video",
+  "reference_video_to_video",
+  "multi_video_to_video",
+  "ads2v",
+  "animate_character",
+];
+
+// Image Studio — mirrors ImageStudio.jsx `imageModelServesMode`. A model serves a mode
+// when it declares the capability and, under active Mac gating, that feature is MLX-routed
+// for it (the macModelFeatureBlock calls are no-ops off Mac).
+export function imageModelServesMode(model, mode, caps) {
+  const capabilities = model?.capabilities ?? [];
+  if (mode === "edit_image") {
+    return (
+      (capabilities.includes("edit_image") || capabilities.includes("image_edit")) &&
+      !macModelFeatureBlock(model, caps, "edit")
+    );
+  }
+  if (mode === "character_image") {
+    return capabilities.includes("character_image") && !macModelFeatureBlock(model, caps, "reference");
+  }
+  if (mode === "style_variations") {
+    return capabilities.includes("style_variations") && !macModelFeatureBlock(model, caps, "reference");
+  }
+  return capabilities.includes("text_to_image");
+}
+
+// Usable on Image Studio: an image-type model that isn't Mac-blocked and serves ≥1 mode.
+export function imageModelUsable(model, caps) {
+  return (
+    model?.type === "image" &&
+    !macModelBlock(model, caps) &&
+    IMAGE_MODES.some((mode) => imageModelServesMode(model, mode, caps))
+  );
+}
+
+// Video Studio — mirrors VideoStudio.jsx `modelServesMode`.
+export function videoModelServesMode(model, mode, caps) {
+  return Boolean(model?.capabilities?.includes(mode)) && !macVideoModeBlock(model, caps, mode);
+}
+
+// Usable on Video Studio: a video-type model that isn't Mac-blocked and serves ≥1 mode.
+export function videoModelUsable(model, caps) {
+  return (
+    model?.type === "video" &&
+    !macModelBlock(model, caps) &&
+    VIDEO_MODES.some((mode) => videoModelServesMode(model, mode, caps))
+  );
+}
+
+// Document Studio — mirrors DocumentStudio.jsx `modelSupportsInterleave` (SenseNova-U1).
+export function documentModelUsable(model, caps) {
+  return (
+    model?.type === "image" &&
+    !macModelBlock(model, caps) &&
+    Array.isArray(model?.capabilities) &&
+    model.capabilities.includes("interleave")
+  );
+}
+
+// Character Studio — mirrors CharacterStudio.jsx angle/pose predicates.
+export function angleModelUsable(model, caps) {
+  return !macModelBlock(model, caps) && Array.isArray(model?.ui?.viewAngles) && model.ui.viewAngles.length > 0;
+}
+
+export function poseModelUsable(model, caps) {
+  return !macModelBlock(model, caps) && Boolean(model?.ui?.poseLibrary);
+}
+
+// Character Studio needs Angles OR Poses support.
+export function characterModelUsable(model, caps) {
+  return angleModelUsable(model, caps) || poseModelUsable(model, caps);
+}
+
+// Does the user have ≥1 present (installed or incomplete) model usable on this screen?
+// Matches what the Studios' pickers actually offer (they source from models with
+// installState !== "missing"), so a screen is never gated while its picker still shows a
+// model. Only a fully-missing catalog gates the screen.
+export function hasUsableModelFor(models, predicate, caps) {
+  return (models ?? []).some((model) => model?.installState !== "missing" && predicate(model, caps));
+}
+
+// The models to OFFER for download when a screen is gated: catalog models usable on the
+// screen that aren't installed, recommended-first. Falls back to any eligible-but-not-
+// installed model so every screen has at least the models that would unlock it.
+export function downloadOffersFor(models, predicate, caps) {
+  const eligible = (models ?? []).filter(
+    (model) => model?.installState !== "installed" && predicate(model, caps),
+  );
+  const recommended = eligible.filter((model) => model?.recommended === true);
+  return recommended.length ? recommended : eligible;
+}

--- a/apps/web/src/modelEligibility.test.js
+++ b/apps/web/src/modelEligibility.test.js
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_MAC_CAPABILITIES } from "./macGating.js";
+import {
+  angleModelUsable,
+  characterModelUsable,
+  documentModelUsable,
+  downloadOffersFor,
+  hasUsableModelFor,
+  imageModelUsable,
+  poseModelUsable,
+  videoModelUsable,
+} from "./modelEligibility.js";
+
+const caps = DEFAULT_MAC_CAPABILITIES; // gating off → Mac blocks are no-ops
+
+describe("modelEligibility predicates", () => {
+  it("imageModelUsable matches image models serving a mode, rejects other types", () => {
+    expect(imageModelUsable({ type: "image", capabilities: ["text_to_image"] }, caps)).toBe(true);
+    expect(imageModelUsable({ type: "image", capabilities: ["edit_image"] }, caps)).toBe(true);
+    expect(imageModelUsable({ type: "image", capabilities: [] }, caps)).toBe(false);
+    expect(imageModelUsable({ type: "video", capabilities: ["text_to_image"] }, caps)).toBe(false);
+  });
+
+  it("videoModelUsable matches video models with a video capability", () => {
+    expect(videoModelUsable({ type: "video", capabilities: ["text_to_video"] }, caps)).toBe(true);
+    expect(videoModelUsable({ type: "video", capabilities: ["animate_character"] }, caps)).toBe(true);
+    expect(videoModelUsable({ type: "video", capabilities: [] }, caps)).toBe(false);
+    expect(videoModelUsable({ type: "image", capabilities: ["text_to_video"] }, caps)).toBe(false);
+  });
+
+  it("documentModelUsable requires an interleave-capable image model", () => {
+    expect(documentModelUsable({ type: "image", capabilities: ["interleave"] }, caps)).toBe(true);
+    expect(documentModelUsable({ type: "image", capabilities: ["text_to_image"] }, caps)).toBe(false);
+  });
+
+  it("angle/pose predicates read the ui flags", () => {
+    expect(angleModelUsable({ ui: { viewAngles: [{ id: "front" }] } }, caps)).toBe(true);
+    expect(angleModelUsable({ ui: { viewAngles: [] } }, caps)).toBe(false);
+    expect(poseModelUsable({ ui: { poseLibrary: true } }, caps)).toBe(true);
+    expect(poseModelUsable({ ui: {} }, caps)).toBe(false);
+    expect(characterModelUsable({ ui: { poseLibrary: true } }, caps)).toBe(true);
+    expect(characterModelUsable({ ui: { viewAngles: [{ id: "front" }] } }, caps)).toBe(true);
+    expect(characterModelUsable({ ui: {} }, caps)).toBe(false);
+  });
+
+  it("hasUsableModelFor counts present (installed/incomplete) models, not missing ones", () => {
+    const installed = { id: "b", type: "image", capabilities: ["text_to_image"], installState: "installed" };
+    const incomplete = { id: "c", type: "image", capabilities: ["text_to_image"], installState: "incomplete" };
+    const missing = { id: "a", type: "image", capabilities: ["text_to_image"], installState: "missing" };
+    expect(hasUsableModelFor([missing, installed], imageModelUsable, caps)).toBe(true);
+    expect(hasUsableModelFor([incomplete], imageModelUsable, caps)).toBe(true);
+    expect(hasUsableModelFor([missing], imageModelUsable, caps)).toBe(false);
+  });
+
+  it("downloadOffersFor prefers recommended, falls back to any eligible, skips installed", () => {
+    const models = [
+      { id: "rec", type: "image", capabilities: ["text_to_image"], installState: "missing", recommended: true },
+      { id: "plain", type: "image", capabilities: ["text_to_image"], installState: "missing" },
+      { id: "done", type: "image", capabilities: ["text_to_image"], installState: "installed", recommended: true },
+    ];
+    expect(downloadOffersFor(models, imageModelUsable, caps).map((m) => m.id)).toEqual(["rec"]);
+    // No recommended among eligible → fall back to all eligible (not installed).
+    const noRec = models.filter((m) => m.id === "plain");
+    expect(downloadOffersFor(noRec, imageModelUsable, caps).map((m) => m.id)).toEqual(["plain"]);
+  });
+});

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -15,6 +15,8 @@ import { assetMatchesCharacter } from "../components/DatasetAddDialog.jsx";
 import { extractFamilies } from "../presetUtils.js";
 import { loadStudioSettings, useStudioSettingsWriter } from "../hooks/useStudioSettings.js";
 import { useAppContext } from "../context/AppContext.js";
+import { ModelAvailabilityGate } from "../components/ModelAvailabilityGate.jsx";
+import { angleModelUsable, downloadOffersFor, poseModelUsable } from "../modelEligibility.js";
 import { DEFAULT_MAC_CAPABILITIES, macAvailableModels } from "../macGating.js";
 
 const characterTypes = [
@@ -58,6 +60,7 @@ export function CharacterStudio() {
     detachCharacterLora,
     createCharacterTestJob,
     createImageJob,
+    createModelDownloadJob,
     importAsset,
     imageLocalJobs,
     jobAction,
@@ -66,6 +69,8 @@ export function CharacterStudio() {
     deleteAsset,
     purgeAsset,
     imageModels,
+    models = [],
+    jobs = [],
     latestImageAssets,
     loras,
     setPreviewAsset,
@@ -85,6 +90,24 @@ export function CharacterStudio() {
     [imageModels, macCapabilities],
   );
   const onPreview = setPreviewAsset;
+  // Model-availability gate (sc-5947): the Angle Set and Pose Library generation tabs each
+  // need a model with ui.viewAngles / ui.poseLibrary (e.g. InstantID). Only those two tab
+  // panels are gated — character/asset management works without a generation model — so the
+  // gate shows recommended downloads in place of the panel, not the whole studio. Offers come
+  // from the full catalog (recommended-first); `ready` reads the screen's angle/pose pickers.
+  const angleOffers = useMemo(
+    () => downloadOffersFor(models, angleModelUsable, macCapabilities),
+    [models, macCapabilities],
+  );
+  const poseOffers = useMemo(
+    () => downloadOffersFor(models, poseModelUsable, macCapabilities),
+    [models, macCapabilities],
+  );
+  const modelDownloadJobs = useMemo(
+    () => (jobs ?? []).filter((job) => job.type === "model_download"),
+    [jobs],
+  );
+  const onOpenModels = () => setActiveView("Models");
   // Job callbacks for character generation cards (Angle Set / Pose Library).
   // jobAction may be missing in test contexts that wrap CharacterStudio with a
   // stub provider; guard so the buttons just no-op there.
@@ -576,6 +599,17 @@ export function CharacterStudio() {
               id="character-panel-angles"
               role="tabpanel"
             >
+              <ModelAvailabilityGate
+                ready={angleModels.length > 0}
+                title="Angle Set needs an angle-capable model"
+                description="Generating character angle sets needs a model like InstantID (RealVisXL). Download one to get started."
+                offers={angleOffers}
+                downloadJobs={modelDownloadJobs}
+                onDownload={createModelDownloadJob}
+                onOpenModels={onOpenModels}
+                onOpenQueue={onOpenCharacterJobQueue}
+                onCancelJob={onCancelCharacterJob}
+              >
               <CharacterAngleSet
                 addCharacterReference={addCharacterReference}
                 angleModel={angleModel}
@@ -595,6 +629,7 @@ export function CharacterStudio() {
                 rememberLocalGenerationJob={rememberLocalGenerationJob}
                 selectedCharacter={selectedCharacter}
               />
+              </ModelAvailabilityGate>
             </div>
 
             {/* Poses tab — Pose generation. */}
@@ -605,6 +640,17 @@ export function CharacterStudio() {
               id="character-panel-poses"
               role="tabpanel"
             >
+              <ModelAvailabilityGate
+                ready={poseModels.length > 0}
+                title="Pose Library needs a pose-capable model"
+                description="Generating character poses needs a model like InstantID (RealVisXL). Download one to get started."
+                offers={poseOffers}
+                downloadJobs={modelDownloadJobs}
+                onDownload={createModelDownloadJob}
+                onOpenModels={onOpenModels}
+                onOpenQueue={onOpenCharacterJobQueue}
+                onCancelJob={onCancelCharacterJob}
+              >
               <CharacterPoseLibrary
                 addCharacterReference={addCharacterReference}
                 approvedReferences={approvedReferences}
@@ -624,6 +670,7 @@ export function CharacterStudio() {
                 rememberLocalGenerationJob={rememberLocalGenerationJob}
                 selectedCharacter={selectedCharacter}
               />
+              </ModelAvailabilityGate>
             </div>
 
             {/* Test tab — Test Character form. */}

--- a/apps/web/src/screens/DocumentStudio.jsx
+++ b/apps/web/src/screens/DocumentStudio.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { AssetPickerField } from "../components/AssetPicker.jsx";
 import { DocumentView } from "../components/DocumentView.jsx";
+import { ModelAvailabilityGate } from "../components/ModelAvailabilityGate.jsx";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
 import {
   DEFAULT_INTERLEAVE_RESOLUTION,
@@ -8,6 +9,8 @@ import {
   INTERLEAVE_RESOLUTION_OPTIONS,
 } from "../constants.js";
 import { useAppContext } from "../context/AppContext.js";
+import { DEFAULT_MAC_CAPABILITIES } from "../macGating.js";
+import { documentModelUsable, downloadOffersFor } from "../modelEligibility.js";
 import { selectStackedJobs } from "./generationStudio.jsx";
 
 const MAX_IMAGES_DEFAULT = 6;
@@ -40,10 +43,14 @@ export function DocumentStudio() {
     activeProject,
     assets,
     createInterleaveJob,
+    createModelDownloadJob,
     documentLocalJobs = [],
     gpuOptions,
     imageModels,
+    jobs = [],
     jobAction,
+    macCapabilities = DEFAULT_MAC_CAPABILITIES,
+    models = [],
     rememberLocalGenerationJob,
     setActiveView,
     requestedGpu,
@@ -54,6 +61,17 @@ export function DocumentStudio() {
   const interleaveModels = useMemo(
     () => (imageModels ?? []).filter(modelSupportsInterleave),
     [imageModels],
+  );
+  // Model-availability gate (sc-5947): when no interleave-capable model is present, show the
+  // recommended downloads (SenseNova-U1) instead of the compose form. Offers are mac-aware.
+  const modelReady = interleaveModels.length > 0;
+  const modelOffers = useMemo(
+    () => downloadOffersFor(models, documentModelUsable, macCapabilities),
+    [models, macCapabilities],
+  );
+  const modelDownloadJobs = useMemo(
+    () => (jobs ?? []).filter((job) => job.type === "model_download"),
+    [jobs],
   );
   const [model, setModel] = useState("");
   const [prompt, setPrompt] = useState("");
@@ -112,13 +130,19 @@ export function DocumentStudio() {
   }
 
   return (
+    <ModelAvailabilityGate
+      ready={modelReady}
+      title="Document Studio needs an interleave-capable model"
+      description="Interleaved text-image documents need a model like SenseNova-U1. Download one to get started."
+      offers={modelOffers}
+      downloadJobs={modelDownloadJobs}
+      onDownload={createModelDownloadJob}
+      onOpenModels={() => setActiveView("Models")}
+      onOpenQueue={onOpenQueue}
+      onCancelJob={onCancelJob}
+    >
     <section className="main-surface document-studio">
       <form className="studio-form" onSubmit={submit}>
-        {interleaveModels.length ? null : (
-          <p className="empty-panel compact-panel">
-            Install a SenseNova-U1 model to generate interleaved text-image documents.
-          </p>
-        )}
         <label className="field">
           <span>Prompt</span>
           <textarea
@@ -230,5 +254,6 @@ export function DocumentStudio() {
         )}
       </section>
     </section>
+    </ModelAvailabilityGate>
   );
 }

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -83,6 +83,8 @@ import {
   useGenerationStudio,
 } from "./generationStudio.jsx";
 import { useAppContext } from "../context/AppContext.js";
+import { ModelAvailabilityGate } from "../components/ModelAvailabilityGate.jsx";
+import { downloadOffersFor, imageModelUsable } from "../modelEligibility.js";
 import { PROMPT_REFINE_MODEL_ID } from "../constants.js";
 import {
   DEFAULT_MAC_CAPABILITIES,
@@ -237,6 +239,7 @@ export function ImageStudio() {
     gpuOptions,
     imageModels,
     models = [],
+    jobs = [],
     importAsset,
     latestImageAssets,
     recentImageAssets,
@@ -484,6 +487,19 @@ export function ImageStudio() {
     [mode, modelsForMode],
   );
   const pickerModels = mode === "text_to_image" && availableModels.length === 0 ? macImageModels : availableModels;
+  // Model-availability gate (sc-5947): when the user has no mac-available image model at all,
+  // show recommended image-model downloads instead of the studio. `ready` matches the picker
+  // (which falls back to all macImageModels for the text tab); offers come from the full catalog
+  // via imageModelUsable, recommended-first.
+  const modelReady = macImageModels.length > 0;
+  const modelOffers = useMemo(
+    () => downloadOffersFor(models, imageModelUsable, macCapabilities),
+    [models, macCapabilities],
+  );
+  const modelDownloadJobs = useMemo(
+    () => (jobs ?? []).filter((job) => job.type === "model_download"),
+    [jobs],
+  );
   // When the mode change filters out the current model (e.g. Lens-Turbo is the
   // text default but isn't edit-capable), snap to the first available model so
   // the dropdown's displayed option matches the value actually submitted.
@@ -1053,6 +1069,17 @@ export function ImageStudio() {
     !selectedLoraValidationResult.ok;
 
   return (
+    <ModelAvailabilityGate
+      ready={modelReady}
+      title="Image Studio needs an image model"
+      description="Download a recommended image model to start generating."
+      offers={modelOffers}
+      downloadJobs={modelDownloadJobs}
+      onDownload={createModelDownloadJob}
+      onOpenModels={() => setActiveView("Models")}
+      onOpenQueue={onOpenQueue}
+      onCancelJob={onCancelJob}
+    >
     <section className="main-surface image-studio">
       <form className="studio-shell" onSubmit={submit}>
         <div className="surface-header hero studio-prompt-hero">
@@ -1612,5 +1639,6 @@ export function ImageStudio() {
         <PromptGuideModal guide={promptGuide} modelName={selectedModel?.name} onClose={() => setGuideOpen(false)} />
       ) : null}
     </section>
+    </ModelAvailabilityGate>
   );
 }

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -114,6 +114,13 @@ function capabilityLabel(capability) {
   return CAPABILITY_LABELS[capability] ?? String(capability).replaceAll("_", " ");
 }
 
+// Curated "getting started" models, flagged `recommended: true` in the catalog
+// (config/manifests/builtin.models.jsonc). Within each type section these float to a
+// "Recommended" subgroup; the rest collapse under "Additional Supported".
+function isRecommendedModel(model) {
+  return model.recommended === true;
+}
+
 // Group key for the family-organized LoRA list. A LoRA can list several compatible
 // families; we group under its primary one and bucket family-less entries under a
 // trailing "compatible" group.
@@ -198,6 +205,7 @@ export function ModelManagerScreen() {
     deleteLora: deleteLoraAction,
     deleteModel: deleteModelAction,
     createModelDownloadJob,
+    createLoraDownloadJob,
     createModelConvertJob,
     createLoraImportJob,
     createModelImportJob,
@@ -213,6 +221,7 @@ export function ModelManagerScreen() {
   const onDeleteLora = deleteLoraAction;
   const onDeleteModel = deleteModelAction;
   const onDownloadModel = createModelDownloadJob;
+  const onDownloadLora = createLoraDownloadJob;
   const onImportLora = createLoraImportJob;
   const onImportModel = createModelImportJob;
   const onOpenQueue = () => setActiveView("Queue");
@@ -334,6 +343,10 @@ export function ModelManagerScreen() {
 
   function convertJobsFor(model) {
     return jobs.filter((job) => job.type === "model_convert" && job.payload?.modelId === model.id);
+  }
+
+  function loraDownloadJobsFor(lora) {
+    return jobs.filter((job) => job.type === "lora_download" && job.payload?.loraId === lora.id);
   }
 
   async function importLora(event) {
@@ -491,11 +504,17 @@ export function ModelManagerScreen() {
     { type: "other", label: "Other Models", items: models.filter((model) => !knownModelTypes.has(model.type)) },
   ].filter((group) => group.items.length > 0);
 
-  // Visible LoRAs grouped by family for the family-organized list. The family
+  // LoRAs split into Built-In (catalog `scope: "builtin"`) and User (global/project)
+  // containers. Built-in entries are a flat list with a Download affordance; user
+  // entries keep the family-organized grouping below.
+  const builtinLoras = visibleLoras.filter((lora) => lora.scope === "builtin");
+  const userLoras = visibleLoras.filter((lora) => lora.scope !== "builtin");
+
+  // Visible user LoRAs grouped by family for the family-organized list. The family
   // dropdown still narrows `visibleLoras` upstream; when a specific family is
   // selected this collapses to a single group.
   const loraGroupMap = new Map();
-  visibleLoras.forEach((lora) => {
+  userLoras.forEach((lora) => {
     const key = loraGroupKey(lora) || "compatible";
     if (!loraGroupMap.has(key)) {
       loraGroupMap.set(key, []);
@@ -658,6 +677,11 @@ export function ModelManagerScreen() {
     const missing = lora.installState === "missing";
     const statusText = missing ? "unavailable" : installed ? "installed" : "pending";
     const deleteKey = `lora:${lora.scope ?? "global"}:${lora.id}`;
+    // Built-in LoRAs with a Hugging Face source can be fetched on demand (sc-5944) —
+    // user LoRAs are installed via the import form, so they get no Download affordance.
+    const hfSource = (lora.source?.provider ?? lora.provider) === "huggingface";
+    const canDownload = Boolean(onDownloadLora) && lora.scope === "builtin" && !installed && hfSource;
+    const downloadJob = loraDownloadJobsFor(lora).find((job) => !terminalStatuses.has(job.status));
     return (
       <article className={missing ? "lora-row warning" : "lora-row"} key={lora.id ?? lora.name}>
         <span>
@@ -665,14 +689,26 @@ export function ModelManagerScreen() {
           <small>{[lora.scope, lora.family ?? "compatible"].filter(Boolean).join(" | ")}</small>
         </span>
         <span className={installed ? "status-badge installed" : "status-badge"}>{statusText}</span>
-        <button
-          className="danger-action"
-          disabled={!onDeleteLora || lora.removable === false || deletingItem === deleteKey}
-          onClick={() => deleteLora(lora)}
-          type="button"
-        >
-          {lora.removable === false ? "Protected" : deletingItem === deleteKey ? "Deleting" : "Delete"}
-        </button>
+        <span className="lora-row-actions">
+          {canDownload ? (
+            <button disabled={Boolean(downloadJob)} onClick={() => onDownloadLora(lora)} type="button">
+              {downloadJob ? downloadJob.status : "Download"}
+            </button>
+          ) : null}
+          <button
+            className="danger-action"
+            disabled={!onDeleteLora || lora.removable === false || deletingItem === deleteKey}
+            onClick={() => deleteLora(lora)}
+            type="button"
+          >
+            {lora.removable === false ? "Protected" : deletingItem === deleteKey ? "Deleting" : "Delete"}
+          </button>
+        </span>
+        {downloadJob ? (
+          <div className="lora-row-progress">
+            <WorkerProgressCard job={downloadJob} onCancel={onCancelJob} onOpenQueue={onOpenQueue} />
+          </div>
+        ) : null}
       </article>
     );
   }
@@ -697,15 +733,41 @@ export function ModelManagerScreen() {
         </label>
       </div>
 
-      {modelGroups.map((group) => (
-        <section className="model-type-group" key={group.type}>
-          <div className="model-type-group-heading">
-            <h3>{group.label}</h3>
-            <span>{group.items.length}</span>
-          </div>
-          <div className="model-grid">{group.items.map((model) => renderModelCard(model))}</div>
-        </section>
-      ))}
+      {modelGroups.map((group) => {
+        const recommended = group.items.filter(isRecommendedModel);
+        const additional = group.items.filter((model) => !isRecommendedModel(model));
+        // Only split into Recommended / Additional Supported when both buckets exist;
+        // otherwise show a single grid so we never render an empty or redundant header.
+        const split = recommended.length > 0 && additional.length > 0;
+        return (
+          <details className="model-type-group" key={group.type} open>
+            <summary className="model-type-group-heading">
+              <h3>{group.label}</h3>
+              <span>{group.items.length}</span>
+            </summary>
+            {split ? (
+              <>
+                <div className="model-subgroup">
+                  <div className="model-subgroup-heading">
+                    <h4>Recommended Models</h4>
+                    <span>{recommended.length}</span>
+                  </div>
+                  <div className="model-grid">{recommended.map((model) => renderModelCard(model))}</div>
+                </div>
+                <details className="model-subgroup model-subgroup-additional">
+                  <summary className="model-subgroup-heading">
+                    <h4>Additional Supported Models</h4>
+                    <span>{additional.length}</span>
+                  </summary>
+                  <div className="model-grid">{additional.map((model) => renderModelCard(model))}</div>
+                </details>
+              </>
+            ) : (
+              <div className="model-grid">{group.items.map((model) => renderModelCard(model))}</div>
+            )}
+          </details>
+        );
+      })}
       {deleteMessage.text ? <p className={deleteMessage.tone === "success" ? "inline-success" : "inline-warning"}>{deleteMessage.text}</p> : null}
 
       <section className="model-import-panel-section">
@@ -831,6 +893,22 @@ export function ModelManagerScreen() {
           </div>
           <span>{loraCountText}</span>
         </div>
+
+        {builtinLoras.length ? (
+          <details className="lora-scope-group" open>
+            <summary className="lora-scope-group-heading">
+              <h3>Built-In LoRAs</h3>
+              <span>{builtinLoras.length}</span>
+            </summary>
+            <div className="lora-list">{builtinLoras.map((lora) => renderLoraRow(lora))}</div>
+          </details>
+        ) : null}
+
+        <details className="lora-scope-group" open>
+        <summary className="lora-scope-group-heading">
+          <h3>User LoRAs</h3>
+          <span>{userLoras.length}</span>
+        </summary>
         <form className="lora-import-panel models-import-panel" aria-label="Import LoRA" onSubmit={importLora}>
           <div>
             <strong>Import LoRA</strong>
@@ -993,7 +1071,7 @@ export function ModelManagerScreen() {
           </div>
         ) : null}
         {hiddenImportCount ? <p className="helper-copy">{hiddenImportCount} LoRA import{hiddenImportCount === 1 ? " is" : "s are"} hidden by this family filter.</p> : null}
-        {visibleLoras.length ? (
+        {userLoras.length ? (
           <div className="lora-family-groups">
             {loraGroups.map((group) => (
               <div className="lora-family-group" key={group.family}>
@@ -1006,10 +1084,11 @@ export function ModelManagerScreen() {
             ))}
           </div>
         ) : localLoraImportJobs.length ? null : loras.length && familyFilter !== "all" ? (
-          <div className="empty-panel compact-panel">No LoRAs match {familyFilter}</div>
+          <div className="empty-panel compact-panel">No user LoRAs match {familyFilter}</div>
         ) : (
-          <div className="empty-panel compact-panel">No LoRAs in this view</div>
+          <div className="empty-panel compact-panel">No user LoRAs yet — import one above.</div>
         )}
+        </details>
       </section>
     </section>
   );

--- a/apps/web/src/screens/ModelManagerScreen.test.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.test.jsx
@@ -343,18 +343,27 @@ describe("ModelManagerScreen type-grouped layout", () => {
     vi.restoreAllMocks();
   });
 
-  async function render({ models = [], loras = [], createModelDownloadJob = () => {} } = {}) {
+  async function render({
+    models = [],
+    loras = [],
+    jobs = [],
+    createModelDownloadJob = () => {},
+    createLoraDownloadJob = () => {},
+  } = {}) {
     const value = {
       activeProject: null,
-      jobs: [],
+      jobs,
       loras,
       models,
       presets: [],
+      workersById: new Map(),
+      visibleWorkers: [],
       jobAction: () => {},
       setActiveView: () => {},
       deleteLora: () => {},
       deleteModel: () => {},
       createModelDownloadJob,
+      createLoraDownloadJob,
       createModelConvertJob: () => {},
       createLoraImportJob: () => {},
       createModelImportJob: () => {},
@@ -394,6 +403,34 @@ describe("ModelManagerScreen type-grouped layout", () => {
   it("omits a type section when no model has that type", async () => {
     await render({ models: [MODELS[0]] });
     expect(groupHeadings()).toEqual(["Image Models"]);
+  });
+
+  it("splits a type into Recommended and a collapsed Additional Supported when both exist", async () => {
+    await render({
+      models: [
+        { id: "z_image_turbo", name: "Z-Image-Turbo", type: "image", family: "z-image", capabilities: ["text_to_image"], installState: "missing", recommended: true },
+        { id: "flux_dev", name: "FLUX.1 [dev]", type: "image", family: "flux", capabilities: ["text_to_image"], installState: "missing" },
+      ],
+    });
+    const imageGroup = container.querySelector(".model-type-group");
+    const recommendedGrid = imageGroup.querySelector(".model-subgroup .model-grid");
+    expect(imageGroup.textContent).toContain("Recommended Models");
+    expect(recommendedGrid.querySelectorAll(".model-card").length).toBe(1);
+    expect(recommendedGrid.textContent).toContain("Z-Image-Turbo");
+    const additional = imageGroup.querySelector(".model-subgroup-additional");
+    expect(additional.tagName).toBe("DETAILS");
+    expect(additional.open).toBe(false); // collapsed by default to cut clutter
+    expect(additional.textContent).toContain("Additional Supported Models");
+    expect(additional.querySelectorAll(".model-card").length).toBe(1);
+    expect(additional.textContent).toContain("FLUX.1 [dev]");
+  });
+
+  it("shows a single grid (no Recommended/Additional split) when a type has no recommended model", async () => {
+    await render({ models: [MODELS[0]] }); // fixture has no recommended flag
+    const imageGroup = container.querySelector(".model-type-group");
+    expect(imageGroup.textContent).not.toContain("Recommended Models");
+    expect(imageGroup.querySelector(".model-subgroup-additional")).toBeNull();
+    expect(imageGroup.querySelectorAll(".model-card").length).toBe(1);
   });
 
   it("describes each model's capabilities as chips on the card", async () => {
@@ -474,11 +511,104 @@ describe("ModelManagerScreen type-grouped layout", () => {
     await render({
       models: MODELS,
       loras: [
-        { id: "a", name: "Flux A", family: "flux", installState: "installed" },
-        { id: "x", name: "Loose", installState: "installed" },
+        { id: "a", name: "Flux A", family: "flux", scope: "global", installState: "installed" },
+        { id: "x", name: "Loose", scope: "global", installState: "installed" },
       ],
     });
     const families = [...container.querySelectorAll(".lora-family-group-heading h3")].map((h) => h.textContent);
     expect(families).toEqual(["flux", "Other / compatible"]);
+  });
+
+  it("separates built-in LoRAs from user LoRAs into their own sections", async () => {
+    await render({
+      models: MODELS,
+      loras: [
+        { id: "ltx_ic", name: "LTX IC", family: "ltx-video", scope: "builtin", installState: "missing" },
+        { id: "u1", name: "My LoRA", family: "flux", scope: "global", installState: "installed" },
+      ],
+    });
+    const scopeHeadings = [...container.querySelectorAll(".lora-scope-group-heading h3")].map((h) => h.textContent);
+    expect(scopeHeadings).toEqual(["Built-In LoRAs", "User LoRAs"]);
+    const builtin = [...container.querySelectorAll(".lora-scope-group")].find((group) =>
+      group.querySelector("h3")?.textContent === "Built-In LoRAs",
+    );
+    expect(builtin.querySelectorAll(".lora-row").length).toBe(1);
+    expect(builtin.textContent).toContain("LTX IC");
+    expect(builtin.textContent).not.toContain("My LoRA");
+    // The user LoRA is family-grouped inside the User section only.
+    const families = [...container.querySelectorAll(".lora-family-group-heading h3")].map((h) => h.textContent);
+    expect(families).toEqual(["flux"]);
+  });
+
+  function builtinSection() {
+    return [...container.querySelectorAll(".lora-scope-group")].find(
+      (group) => group.querySelector("h3")?.textContent === "Built-In LoRAs",
+    );
+  }
+
+  it("offers a Download button on a built-in HF LoRA and queues a download", async () => {
+    const createLoraDownloadJob = vi.fn();
+    await render({
+      models: MODELS,
+      createLoraDownloadJob,
+      loras: [
+        {
+          id: "ltx_ic",
+          name: "LTX IC",
+          family: "ltx-video",
+          scope: "builtin",
+          installState: "missing",
+          source: { provider: "huggingface", repo: "Lightricks/LTX-2.3-IC", file: "ic.safetensors" },
+        },
+      ],
+    });
+    const downloadButton = [...builtinSection().querySelectorAll(".lora-row-actions button")].find(
+      (button) => button.textContent === "Download",
+    );
+    expect(downloadButton).toBeTruthy();
+    await click(downloadButton);
+    expect(createLoraDownloadJob).toHaveBeenCalledWith(expect.objectContaining({ id: "ltx_ic" }));
+  });
+
+  it("shows progress and disables the button while a built-in LoRA download runs", async () => {
+    await render({
+      models: MODELS,
+      loras: [
+        {
+          id: "ltx_ic",
+          name: "LTX IC",
+          family: "ltx-video",
+          scope: "builtin",
+          installState: "missing",
+          source: { provider: "huggingface", repo: "r", file: "f" },
+        },
+      ],
+      jobs: [{ id: "j1", type: "lora_download", status: "downloading", progress: 0.4, payload: { loraId: "ltx_ic" } }],
+    });
+    const actionButton = builtinSection().querySelector(".lora-row-actions button");
+    expect(actionButton.disabled).toBe(true);
+    expect(actionButton.textContent).toBe("downloading");
+    expect(builtinSection().querySelector(".lora-row-progress")).toBeTruthy();
+  });
+
+  it("does not offer Download on a built-in LoRA without a Hugging Face source", async () => {
+    await render({
+      models: MODELS,
+      createLoraDownloadJob: vi.fn(),
+      loras: [
+        {
+          id: "local_builtin",
+          name: "Local Builtin",
+          family: "z-image",
+          scope: "builtin",
+          installState: "missing",
+          source: { provider: "local", path: "loras/x.safetensors" },
+        },
+      ],
+    });
+    const downloadButton = [...builtinSection().querySelectorAll(".lora-row-actions button")].find(
+      (button) => button.textContent === "Download",
+    );
+    expect(downloadButton).toBeUndefined();
   });
 });

--- a/apps/web/src/screens/SetupWizard.jsx
+++ b/apps/web/src/screens/SetupWizard.jsx
@@ -3,21 +3,21 @@ import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
 import { Logo } from "../components/Logo.jsx";
 import { terminalStatuses } from "../constants.js";
 
-// Models flagged "Recommended" in the wizard: the fast image target and LTX-2.3
-// as the headline video model. Anything not present in the live catalog is
-// silently ignored, so this stays correct as the catalog evolves.
-const RECOMMENDED_MODEL_IDS = new Set(["z_image_turbo", "ltx_2_3"]);
-// Recommended models are pre-checked — except very large ones (e.g. LTX-2.3 is
-// ~146 GB). Those stay recommended but unchecked so a new user opts into the big
-// download deliberately instead of having it auto-queued on first launch.
-const AUTO_SELECT_MAX_BYTES = 50 * 1024 * 1024 * 1024;
+// The curated "getting started" set is catalog-driven: a model is recommended when
+// its manifest entry carries `recommended: true` (config/manifests/builtin.models.jsonc).
+// Recommended models are pre-checked for download — unless the entry sets
+// `autoDownload: false` (e.g. LTX-2.3, ~146 GB), which keeps it badged-but-unchecked so
+// a new user opts into the big download deliberately instead of having it auto-queued.
+function isRecommended(model) {
+  return model.recommended === true;
+}
+
+function autoDownloadDisabled(model) {
+  return model.autoDownload === false;
+}
 
 function isDownloadable(model) {
   return model.downloadable !== false && Boolean(model.downloads?.[0]?.repo ?? model.repo);
-}
-
-function isHugeDownload(model) {
-  return typeof model.downloadSizeBytes === "number" && model.downloadSizeBytes > AUTO_SELECT_MAX_BYTES;
 }
 
 function downloadSizeText(model) {
@@ -34,14 +34,14 @@ function defaultSelection(models) {
         (model) =>
           isDownloadable(model) &&
           model.installState !== "installed" &&
-          RECOMMENDED_MODEL_IDS.has(model.id) &&
-          !isHugeDownload(model),
+          isRecommended(model) &&
+          !autoDownloadDisabled(model),
       )
       .map((model) => model.id),
   );
 }
 
-const TYPE_LABELS = { image: "Image models", video: "Video models" };
+const TYPE_LABELS = { image: "Image models", video: "Video models", utility: "Utility models" };
 
 export function SetupWizard({ models, jobs, onDownloadModel, onCreateProject, onComplete, onOpenQueue }) {
   const [step, setStep] = useState("models");
@@ -149,7 +149,7 @@ export function SetupWizard({ models, jobs, onDownloadModel, onCreateProject, on
                     {items.map((model) => {
                       const installed = model.installState === "installed";
                       const downloading = started.has(model.id) && !installed;
-                      const recommended = RECOMMENDED_MODEL_IDS.has(model.id);
+                      const recommended = isRecommended(model);
                       return (
                         <label className={`setup-wizard-model${installed ? " installed" : ""}`} key={model.id}>
                           <input

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useAppContext } from "../context/AppContext.js";
+import { ModelAvailabilityGate } from "../components/ModelAvailabilityGate.jsx";
+import { downloadOffersFor } from "../modelEligibility.js";
 import { DEFAULT_MAC_CAPABILITIES, macTrainingKernelBlocked } from "../macGating.js";
 import { API_BASE_URL } from "../api.js";
 import { assetCanRenderAsImage } from "../components/assetMedia.jsx";
@@ -458,6 +460,29 @@ export function TrainingStudio({ mode = "training" } = {}) {
   // Mac UI gating (sc-3486): a target whose kernel has no native mlx-gen Rust trainer
   // (kolors_lora / lens_lora) can't train on a gated Mac — disable it and snap off it.
   const macTargetBlocked = (target) => macTrainingKernelBlocked(macCapabilities, target?.kernel);
+  // Model-availability gate (sc-5947): training needs a trainable target whose base model is
+  // downloaded. A target's base counts as missing only when it's present in the catalog AND
+  // installState === "missing" (so a thin test context with no `models` stays ready, and a real
+  // install reads the true state). Only gated when targets exist but every trainable base is
+  // missing — a target-registry error keeps its own "registry unavailable" message.
+  const usableTrainingTargets = trainingTargets.filter((target) => !macTargetBlocked(target));
+  const trainingBaseMissing = (target) => {
+    const base = models.find((item) => item.id === target?.baseModel);
+    return Boolean(base) && base.installState === "missing";
+  };
+  const trainingReady =
+    usableTrainingTargets.length === 0 ||
+    usableTrainingTargets.some((target) => !trainingBaseMissing(target));
+  const trainingBaseIds = new Set(usableTrainingTargets.map((target) => target.baseModel).filter(Boolean));
+  const trainingOffers = useMemo(
+    () => downloadOffersFor(models, (item) => trainingBaseIds.has(item.id), macCapabilities),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [models, macCapabilities, [...trainingBaseIds].join("|")],
+  );
+  const trainingDownloadJobs = useMemo(
+    () => (jobs ?? []).filter((job) => job.type === "model_download"),
+    [jobs],
+  );
   const selectedTarget = useMemo(
     () => trainingTargets.find((target) => target.id === selectedTargetId) ?? firstTarget,
     [firstTarget, selectedTargetId, trainingTargets],
@@ -1031,6 +1056,16 @@ export function TrainingStudio({ mode = "training" } = {}) {
   }
 
   return (
+    <ModelAvailabilityGate
+      ready={trainingReady}
+      title="Training needs a trainable base model"
+      description="LoRA training needs a downloaded base model (e.g. Z-Image-Turbo or SDXL). Download one to get started."
+      offers={trainingOffers}
+      downloadJobs={trainingDownloadJobs}
+      onDownload={createModelDownloadJob}
+      onOpenModels={() => setActiveView("Models")}
+      onOpenQueue={() => setActiveView("Queue")}
+    >
     <section className="main-surface training-studio">
       <div className="training-studio-shell">
         <div className="training-summary-band">
@@ -1215,5 +1250,6 @@ export function TrainingStudio({ mode = "training" } = {}) {
         )}
       </div>
     </section>
+    </ModelAvailabilityGate>
   );
 }

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -81,6 +81,8 @@ import {
 } from "./generationStudio.jsx";
 import { ReplacePersonPanel } from "./ReplacePersonPanel.jsx";
 import { useAppContext } from "../context/AppContext.js";
+import { ModelAvailabilityGate } from "../components/ModelAvailabilityGate.jsx";
+import { downloadOffersFor, videoModelUsable } from "../modelEligibility.js";
 import { PROMPT_REFINE_MODEL_ID } from "../constants.js";
 import {
   DEFAULT_MAC_CAPABILITIES,
@@ -214,6 +216,19 @@ export function VideoStudio() {
   const modelServesMode = (item, value) =>
     Boolean(item?.capabilities?.includes(value)) && !macVideoModeBlock(item, macCapabilities, value);
   const modelsForMode = (value) => baseVideoModels.filter((item) => modelServesMode(item, value));
+  // Model-availability gate (sc-5947): when the user has no mac-available video model at all,
+  // show recommended video-model downloads instead of the studio. `ready` matches the picker
+  // (which falls back to all baseVideoModels); offers come from the full catalog via
+  // videoModelUsable, recommended-first.
+  const modelReady = baseVideoModels.length > 0;
+  const modelOffers = useMemo(
+    () => downloadOffersFor(models, videoModelUsable, macCapabilities),
+    [models, macCapabilities],
+  );
+  const modelDownloadJobs = useMemo(
+    () => (jobs ?? []).filter((job) => job.type === "model_download"),
+    [jobs],
+  );
   // Prompt guide for the selected model; fall back to the generic video guide
   // when a model declares none, so the button is always useful (sc-1817).
   const promptGuide = selectedModel?.ui?.promptGuide ?? {
@@ -874,6 +889,17 @@ export function VideoStudio() {
   }
 
   return (
+    <ModelAvailabilityGate
+      ready={modelReady}
+      title="Video Studio needs a video model"
+      description="Download a recommended video model to start generating."
+      offers={modelOffers}
+      downloadJobs={modelDownloadJobs}
+      onDownload={createModelDownloadJob}
+      onOpenModels={() => setActiveView("Models")}
+      onOpenQueue={onOpenQueue}
+      onCancelJob={onCancelJob}
+    >
     <section className="main-surface video-studio">
       <form className="studio-shell" onSubmit={submit}>
         <div className="surface-header hero studio-prompt-hero video-prompt-hero">
@@ -1686,5 +1712,6 @@ export function VideoStudio() {
         <PromptGuideModal guide={promptGuide} modelName={selectedModel?.name} onClose={() => setGuideOpen(false)} />
       ) : null}
     </section>
+    </ModelAvailabilityGate>
   );
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3490,6 +3490,95 @@ label {
   gap: 10px;
 }
 
+/* Collapsible model type sections + LoRA scope sections (sc-5943). The type group,
+   the "Additional Supported" subgroup, and the Built-In/User LoRA sections are native
+   <details>; we hide the default disclosure marker and draw our own rotating caret. */
+details.model-type-group,
+details.lora-scope-group,
+details.model-subgroup-additional {
+  display: grid;
+  gap: 12px;
+}
+
+details.model-type-group > summary,
+details.lora-scope-group > summary,
+details.model-subgroup-additional > summary {
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+}
+
+details.model-type-group > summary::-webkit-details-marker,
+details.lora-scope-group > summary::-webkit-details-marker,
+details.model-subgroup-additional > summary::-webkit-details-marker {
+  display: none;
+}
+
+summary.model-type-group-heading::before,
+summary.lora-scope-group-heading::before,
+.model-subgroup-additional > summary.model-subgroup-heading::before {
+  content: "▸";
+  font-size: 11px;
+  color: var(--text-faint);
+  transition: transform 0.15s ease;
+}
+
+details[open] > summary.model-type-group-heading::before,
+details[open] > summary.lora-scope-group-heading::before,
+.model-subgroup-additional[open] > summary.model-subgroup-heading::before {
+  transform: rotate(90deg);
+}
+
+.lora-scope-group + .lora-scope-group {
+  margin-top: var(--gap-3);
+}
+
+.lora-scope-group-heading {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--border);
+}
+
+.lora-scope-group-heading h3 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.lora-scope-group-heading > span {
+  font-size: 12px;
+  color: var(--text-faint);
+  font-variant-numeric: tabular-nums;
+}
+
+.model-subgroup {
+  display: grid;
+  gap: 10px;
+}
+
+.model-subgroup-heading {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.model-subgroup-heading h4 {
+  margin: 0;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.model-subgroup-heading > span {
+  font-size: 12px;
+  color: var(--text-faint);
+  font-variant-numeric: tabular-nums;
+}
+
 .model-card,
 .lora-panel,
 .lora-row,
@@ -3761,6 +3850,73 @@ label {
   gap: 12px;
   align-items: center;
   padding: 10px 12px;
+}
+
+/* Built-in LoRA Download + Delete share the third column; an active download's
+   progress card spans the full row below (sc-5944). */
+.lora-row-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.lora-row-progress {
+  grid-column: 1 / -1;
+}
+
+/* Per-Studio model-availability gate (sc-5947): shown in place of a Studio body when no
+   installed model supports it, offering the screen's recommended models for download. */
+.model-availability-gate {
+  display: grid;
+  place-items: center;
+  padding: var(--gap-4, 32px) var(--gap-3, 20px);
+  min-height: 320px;
+}
+
+.model-availability-gate-card {
+  width: min(560px, 100%);
+  display: grid;
+  gap: 16px;
+  padding: 24px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface);
+}
+
+.model-availability-offers {
+  display: grid;
+  gap: 12px;
+}
+
+.model-availability-offer {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--bg-2, var(--surface-2));
+}
+
+.model-availability-offer-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.model-availability-offer-head span {
+  display: grid;
+  gap: 2px;
+}
+
+.model-availability-offer-head small {
+  color: var(--text-faint);
+  font-variant-numeric: tabular-nums;
+}
+
+.model-availability-browse {
+  justify-self: start;
+  background: transparent;
 }
 
 .lora-row > span:first-child {

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -4,6 +4,11 @@
   "models": [
     {
       "id": "z_image_turbo",
+      // `recommended` flags the curated "getting started" set surfaced in the Setup
+      // Wizard, the Models page Recommended section, and per-Studio availability gates.
+      // `autoDownload: false` keeps a recommended model badged-but-unchecked in the
+      // wizard (used for very large downloads); absent => pre-checked.
+      "recommended": true,
       "name": "Z-Image-Turbo",
       "family": "z-image",
       "type": "image",
@@ -510,6 +515,7 @@
     },
     {
       "id": "sensenova_u1_8b",
+      "recommended": true,
       "name": "SenseNova-U1 8B",
       "family": "sensenova-u1",
       "type": "image",
@@ -1324,6 +1330,7 @@
     },
     {
       "id": "sdxl",
+      "recommended": true,
       "name": "Stable Diffusion XL",
       "family": "sdxl",
       "type": "image",
@@ -1468,6 +1475,7 @@
     },
     {
       "id": "instantid_realvisxl",
+      "recommended": true,
       "name": "InstantID (RealVisXL)",
       "family": "sdxl",
       "type": "image",
@@ -1675,6 +1683,10 @@
     },
     {
       "id": "ltx_2_3",
+      // Recommended headline video model, but ~146 GB — keep it badged yet unchecked in
+      // the wizard so the big download is a deliberate opt-in.
+      "recommended": true,
+      "autoDownload": false,
       "name": "LTX-2.3",
       "family": "ltx-video",
       "type": "video",
@@ -2587,6 +2599,7 @@
     },
     {
       "id": "real_esrgan",
+      "recommended": true,
       "name": "Real-ESRGAN Upscaler",
       "family": "real-esrgan",
       "type": "utility",
@@ -2725,6 +2738,7 @@
       // models) does not apply. `files: []` pulls the repo's own LICENSE.txt + USE_POLICY
       // (Llama community license) alongside the weights.
       "id": "prompt_refine_llama_3_2_3b",
+      "recommended": true,
       "name": "Prompt Refiner (Llama-3.2-3B)",
       "family": "prompt-refine",
       "type": "utility",

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -252,6 +252,10 @@ string_enum! {
         ModelImport => "model_import",
         ModelConvert => "model_convert",
         LoraImport => "lora_import",
+        // Explicit download of a built-in catalog LoRA into the Hugging Face cache
+        // (Models page, sc-5944) — mirrors model_download. Non-GPU; flips the catalog
+        // entry's installState to "installed" once the HF files land.
+        LoraDownload => "lora_download",
         LoraTrain => "lora_train",
         TrainingCaption => "training_caption",
         PromptRefine => "prompt_refine",
@@ -367,6 +371,9 @@ string_enum! {
         ModelImport => "model_import",
         ModelConvert => "model_convert",
         LoraImport => "lora_import",
+        // Built-in LoRA explicit download capability (sc-5944), advertised by the CPU
+        // utility worker alongside model_download / lora_import.
+        LoraDownload => "lora_download",
         LoraTrain => "lora_train",
         TrainingCaption => "training_caption",
         // Real (non-dry-run) LoRA training execution. Advertised separately from

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -43,6 +43,7 @@ pub const NON_GPU_JOB_TYPES: &[&str] = &[
     "model_import",
     "model_convert",
     "lora_import",
+    "lora_download",
 ];
 pub const MAX_JOB_ATTEMPTS: u32 = 5;
 
@@ -1573,6 +1574,14 @@ fn derive_job_title(job_type: &JobType, payload: &Map<String, Value>) -> Option<
                 Some(format!("LoRA Import — {subject}"))
             }
         }
+        JobType::LoraDownload => {
+            let subject = first_str(payload, &["loraName", "loraId", "repo"]).unwrap_or("");
+            if subject.is_empty() {
+                Some("LoRA Download".to_owned())
+            } else {
+                Some(format!("LoRA Download — {subject}"))
+            }
+        }
         JobType::PromptRefine => {
             let prompt = first_str(payload, &["prompt"]).unwrap_or("(empty prompt)");
             Some(format!("Prompt Refine — {}", truncate_prompt(prompt, 60)))
@@ -2016,6 +2025,7 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
         | JobType::ModelDownload
         | JobType::ModelImport
         | JobType::LoraImport
+        | JobType::LoraDownload
         | JobType::FrameExtract
         | JobType::TimelineExport
         | JobType::PromptRefine => Ok(()),

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -550,6 +550,9 @@ pub(crate) fn worker_capabilities_with_utility(
             WorkerCapability::ModelImport,
             WorkerCapability::ModelConvert,
             WorkerCapability::LoraImport,
+            // Explicit built-in LoRA download (sc-5944): fetches the catalog LoRA's HF
+            // repo/file into the shared HF cache, same as model_download.
+            WorkerCapability::LoraDownload,
             // Procedural detection/tracking is a preview only. Real, model-backed
             // PersonDetect/PersonTrack run on the macOS MLX worker (native
             // YOLO11/SAM2, epic 3482) or the Python GPU worker on Windows/Linux;

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -715,6 +715,9 @@ async fn run_utility_job(
         JobType::LoraImport => run_lora_import_job(api, settings, http_client, &job)
             .await
             .map_err(|error| ("LoRA import failed.", error)),
+        JobType::LoraDownload => run_lora_download_job(api, settings, http_client, &job)
+            .await
+            .map_err(|error| ("LoRA download failed.", error)),
         JobType::ModelImport => run_model_import_job(api, settings, http_client, &job)
             .await
             .map_err(|error| ("Model import failed.", error)),

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -188,6 +188,138 @@ pub(crate) async fn run_model_download_job(
     Ok(())
 }
 
+/// Download a built-in catalog LoRA's Hugging Face repo/file into the shared HF cache
+/// (sc-5944). Mirrors the `run_model_download_job` cache path but skips the model-only
+/// steps (family reconciliation, tokenizer overlay, install marker): a LoRA is a single
+/// adapter file. Landing it in the HF cache is exactly what the API's install-state probe
+/// (`lora_huggingface_cached_file`) and the engine's on-demand generation-time fetch read,
+/// so the catalog entry flips to "installed" on the next `/api/v1/loras` refresh.
+pub(crate) async fn run_lora_download_job(
+    api: &ApiClient,
+    settings: &Settings,
+    http_client: &reqwest::Client,
+    job: &JobSnapshot,
+) -> WorkerResult<()> {
+    let repo = match required_payload_string(&job.payload, "repo") {
+        Ok(repo) => repo,
+        Err(error) => {
+            fail_job(
+                api,
+                &job.id,
+                "LoRA download is missing a repository.",
+                Some(error.to_string()),
+            )
+            .await?;
+            return Ok(());
+        }
+    };
+    let files = payload_string_array(&job.payload, "files");
+    let revision = optional_payload_string(&job.payload, "revision").unwrap_or("main");
+
+    heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+    update_job(
+        api,
+        &job.id,
+        progress_payload(
+            JobStatus::Downloading,
+            ProgressStage::Downloading,
+            0.1,
+            &format!("Downloading LoRA {repo}: estimating size."),
+            None,
+            None,
+            None,
+        ),
+    )
+    .await?;
+    check_cancel(
+        api,
+        &job.id,
+        "LoRA download canceled before transfer started.",
+    )
+    .await?;
+
+    let repo_dir = huggingface_repo_cache_path(&settings.data_dir, repo).ok_or_else(|| {
+        WorkerError::InvalidPayload(format!(
+            "Unable to resolve Hugging Face cache path for {repo}."
+        ))
+    })?;
+    let snapshot =
+        HuggingFaceSnapshot::resolve(http_client, settings, repo, revision, &files).await?;
+    if let Some(total_bytes) = snapshot.total_bytes() {
+        update_job(
+            api,
+            &job.id,
+            progress_payload(
+                JobStatus::Downloading,
+                ProgressStage::Downloading,
+                0.1,
+                &format!(
+                    "Downloading LoRA {repo}: 0 B of {}.",
+                    format_bytes(total_bytes)
+                ),
+                None,
+                None,
+                None,
+            ),
+        )
+        .await?;
+    }
+
+    let mut progress = DownloadProgress::new(
+        repo,
+        directory_size(&repo_dir.join("blobs")).await,
+        snapshot.total_bytes(),
+        progress_report_interval(settings),
+    );
+    download_snapshot_into_cache(
+        &DownloadContext {
+            api,
+            client: http_client,
+            settings,
+            job_id: &job.id,
+            cancel_message: "LoRA download canceled by user.",
+            fresh_download: false,
+        },
+        &repo_dir,
+        revision,
+        &snapshot,
+        &mut progress,
+    )
+    .await?;
+    let cache_path = huggingface_snapshot_dir(&settings.data_dir, repo).unwrap_or(repo_dir);
+
+    let mut result = JsonObject::new();
+    result.insert(
+        "loraId".to_owned(),
+        job.payload.get("loraId").cloned().unwrap_or(Value::Null),
+    );
+    result.insert("repo".to_owned(), Value::String(repo.to_owned()));
+    result.insert(
+        "path".to_owned(),
+        Value::String(cache_path.display().to_string()),
+    );
+    result.insert(
+        "storage".to_owned(),
+        Value::String("huggingface_cache".to_owned()),
+    );
+    result.insert("completedAt".to_owned(), Value::String(now_rfc3339()));
+    update_job(
+        api,
+        &job.id,
+        progress_payload(
+            JobStatus::Completed,
+            ProgressStage::Completed,
+            1.0,
+            "LoRA download completed in the Hugging Face cache.",
+            None,
+            Some(result),
+            None,
+        ),
+    )
+    .await?;
+    Ok(())
+}
+
 /// Canonical upstream Kolors repo. Its snapshot ships only the ChatGLM3 **slow** SentencePiece
 /// tokenizer (`tokenizer.model`), NOT the fast `tokenizer.json` that the in-process Rust Kolors
 /// generator (sc-3875) and LoRA/LoKr trainer (sc-4732) require — both construct via


### PR DESCRIPTION
## Summary

Epic [5941](https://app.shortcut.com/trefry/epic/5941) — fixes the overcrowded Models page and turns "recommended models" into real infrastructure that also powers the Setup Wizard and a new per-Studio model-availability gate. Stories sc-5942 … sc-5948 (all Done).

### 1. Recommended-model catalog flag (sc-5942)
- Top-level `"recommended": true` on 7 curated entries in `config/manifests/builtin.models.jsonc` (Z-Image-Turbo, SDXL, LTX-2.3, Prompt Refiner, Real-ESRGAN, SenseNova-U1, InstantID); LTX-2.3 also `"autoDownload": false`. Flows to the frontend via the existing `list_models` JSON passthrough — no API change.
- **Setup Wizard** reads `model.recommended` and pre-checks unless `autoDownload === false`; the opaque `AUTO_SELECT_MAX_BYTES` (50 GB) heuristic is **removed** in favor of explicit curation.

### 2. Models page reorg (sc-5943)
- Type groups are collapsible `<details>`, each split into **Recommended** + a collapsed **Additional Supported**.
- LoRAs split into **Built-In** and **User** sections.

### 3. Built-in LoRA download (sc-5944 / sc-5945)
- New `lora_download` job type + `WorkerCapability` (`contracts.rs`, `jobs_store.rs`, `gpu.rs`), `run_lora_download_job` worker handler (mirrors model download → HF cache the install-state probe reads), `POST /api/v1/loras/:id/download`, and a **Download** button + progress on Built-In LoRA rows.

### 4. Per-Studio availability gates (sc-5946 / sc-5947)
- New reusable `ModelAvailabilityGate` + `modelEligibility.js` (predicates lifted verbatim from each screen). When a screen has no supporting model it shows that screen's recommended models for inline download and unlocks on completion (existing SSE refresh).
- Image / Video / Document / Training gate the screen; **Character gates only the Angles/Poses panels** so character/asset management stays accessible.

## Design notes for review
- **Character gating is per-panel, not screen-level** — flag if you'd prefer the whole screen.
- The wizard now pre-checks ~6 small recommended models on first launch (LTX-2.3 opts out); easy to flip more to `autoDownload: false`.

## Verification
- Web: **450/450** vitest (28 files), eslint 0 errors.
- Rust: full suite green; `cargo fmt` + `cargo clippy -D warnings` clean; +2 new endpoint tests.
- **Live browser e2e** (standalone rust-api + Vite): confirmed the Recommended/Additional split matches the curated list, the Built-In/User LoRA split + Download button, and — with an empty HF cache — the Image Studio gate (4 recommended download cards) and Training gate (target-based offers), while a model-present Video Studio correctly does not gate.
- Not run: real-weight built-in-LoRA download through the worker (live HF fetch); handler is a near-clone of the proven `run_model_download_job` and job creation is unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)