### PR TITLE
refactor(web): remove redundant "Variations" tab from Image Studio (sc-5950)

### DIFF
--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -8418,7 +8418,7 @@ describe("SceneWorks app shell", () => {
         name: "Soft Morning",
         scope: "global",
         loras: [{ id: "global_detail", weight: 0.35 }],
-        modes: ["text_to_image", "character_image", "style_variations"],
+        modes: ["text_to_image", "character_image"],
       }),
     );
     expect(container.textContent).toContain("Ready");

--- a/apps/web/src/presetUtils.js
+++ b/apps/web/src/presetUtils.js
@@ -21,7 +21,7 @@ export function clearPresetDefault(setter, snapshots, key) {
 }
 
 export const defaultModesByWorkflow = {
-  text_to_image: ["text_to_image", "character_image", "style_variations"],
+  text_to_image: ["text_to_image", "character_image"],
   edit_image: ["edit_image"],
   image_to_video: ["image_to_video"],
   text_to_video: ["text_to_video"],
@@ -32,7 +32,6 @@ export const modeLabels = {
   text_to_image: "Text",
   edit_image: "Edit",
   character_image: "Character",
-  style_variations: "Variations",
   image_to_video: "Image Video",
   text_to_video: "Text Video",
   first_last_frame: "First/Last",
@@ -322,8 +321,8 @@ export function slugifyPresetId(value) {
 }
 
 // Map an active studio mode to the recipe workflow it persists under. Inverts
-// defaultModesByWorkflow, so character_image / style_variations both fold into
-// text_to_image (the only workflow whose modes include them).
+// defaultModesByWorkflow, so character_image folds into text_to_image (the only
+// workflow whose modes include it).
 export function workflowForMode(mode) {
   for (const [workflow, modes] of Object.entries(defaultModesByWorkflow)) {
     if (modes.includes(mode)) {

--- a/apps/web/src/presetUtils.test.jsx
+++ b/apps/web/src/presetUtils.test.jsx
@@ -44,10 +44,9 @@ describe("presetMatchesModel", () => {
 });
 
 describe("workflowForMode", () => {
-  it("folds character and variation modes into text_to_image", () => {
+  it("folds the character mode into text_to_image", () => {
     expect(workflowForMode("text_to_image")).toBe("text_to_image");
     expect(workflowForMode("character_image")).toBe("text_to_image");
-    expect(workflowForMode("style_variations")).toBe("text_to_image");
   });
 
   it("maps the single-mode workflows to themselves", () => {

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -161,8 +161,15 @@ function recipeResolution(recipe) {
   return typeof rawResolution === "string" && rawResolution.includes("x") ? rawResolution : null;
 }
 
+// Fold any mode the tabs no longer expose (a legacy `style_variations` snapshot,
+// an unknown value) back to text_to_image so a restored studio never lands on a
+// missing tab. style_variations was a no-op duplicate of text_to_image (sc-5950).
+function normalizeImageMode(mode) {
+  return IMAGE_MODES.includes(mode) ? mode : "text_to_image";
+}
+
 function recipeMode(recipe) {
-  return IMAGE_MODES.includes(recipe?.mode) ? recipe.mode : "text_to_image";
+  return normalizeImageMode(recipe?.mode);
 }
 
 function recipeLoraId(lora) {
@@ -284,7 +291,7 @@ export function ImageStudio() {
   const saved = useMemo(() => loadStudioSettings("image", activeProject?.id ?? null), [activeProject?.id]);
   const [sceneSuggestions] = useState(() => pickSuggestions(4));
   const [characterSuggestions] = useState(() => pickSuggestions(4, CHARACTER_SUGGESTION_POOL));
-  const [mode, setMode] = useState(saved.mode ?? "text_to_image");
+  const [mode, setMode] = useState(() => normalizeImageMode(saved.mode));
   const [prompt, setPrompt] = useState(saved.prompt ?? "A cinematic frame of a neon street at midnight");
   // True once the user types or picks a suggestion, so the character-mode default
   // prompt never clobbers their own wording. A restored prompt counts as edited so
@@ -468,9 +475,6 @@ export function ImageStudio() {
       // character's identity from one reference; gate the picker to them.
       return caps.includes("character_image") && !macModelFeatureBlock(item, macCapabilities, "reference");
     }
-    if (value === "style_variations") {
-      return caps.includes("style_variations") && !macModelFeatureBlock(item, macCapabilities, "reference");
-    }
     // text_to_image: only models that declare a real sourceless T2I path (sc-5549).
     // Without this gate the Text tab leaked edit-only models (run a degraded
     // sourceless edit) and reference-only identity models (MLX-ineligible without a
@@ -534,7 +538,7 @@ export function ImageStudio() {
   const macPoseBlock = macModelFeatureBlock(selectedModel, macCapabilities, "pose");
   const macActiveModeBlock = (() => {
     if (mode === "edit_image") return macEditBlock;
-    if (mode === "character_image" || mode === "style_variations") return macReferenceBlock;
+    if (mode === "character_image") return macReferenceBlock;
     return null;
   })();
   const macModeTabBlock = (value) => {
@@ -1089,7 +1093,6 @@ export function ImageStudio() {
                 ["text_to_image", "Text"],
                 ["edit_image", "Edit"],
                 ["character_image", "With character"],
-                ["style_variations", "Variations"],
               ].map(([value, label]) => {
                 const macBlock = macModeTabBlock(value);
                 return (

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -520,17 +520,6 @@ describe("ImageStudio model picker capability gating", () => {
     expect(options).not.toContain("character_only");
   });
 
-  it("Variations tab lists only style_variations models (sc-5549)", async () => {
-    await render(baseContext({ imageModels: [EDIT_ONLY, T2I, VARIATIONS, CHARACTER_ONLY] }));
-    await click([...container.querySelectorAll(".segmented-control button")].find((button) => button.textContent === "Variations"));
-
-    const options = modelOptionValues();
-    expect(options).toContain("variations_model");
-    expect(options).not.toContain("t2i_only"); // text_to_image but no style_variations
-    expect(options).not.toContain("edit_only");
-    expect(options).not.toContain("character_only");
-  });
-
   it("enables the Mac Edit tab when any available model supports edit mode (sc-5589)", async () => {
     await render(
       baseContext({


### PR DESCRIPTION
## What & why

The Image Studio **"Variations"** (`style_variations`) mode was a no-op duplicate of **Text → Image**: it sent identical conditioning (prompt / model / count / seed / dims / LoRAs only — no reference, source, or control) and **no worker or engine ever branched on the mode**, so it dispatched as plain text-to-image. It read like a distinct feature and was even Mac-gated like a reference feature, so it added confusion with zero behavior. Per [sc-5950](https://app.shortcut.com/trefry/story/5950), making it a *real* feature was explicitly declined, so the tab is dead and this UI cleanup is the whole job.

> The **"Variations" image-count control (1–8)** present in every tab is a separate, unrelated knob and is untouched.

## Changes (UI only)

- **Removed the tab** — dropped `["style_variations", "Variations"]` from the mode segmented-control. Image Studio now shows **Text / Edit / With character**.
- **Removed the dead arms** — the `style_variations` branch in `imageModelServesMode` (model-picker filter) and the `|| mode === "style_variations"` arm in `macActiveModeBlock` (Mac reference-gating).
- **`presetUtils.js`** — dropped `style_variations` from `defaultModesByWorkflow.text_to_image` and from `modeLabels`.
- **Graceful fallback** — added `normalizeImageMode()` (reused by `recipeMode`) so a legacy saved snapshot/preset with `mode === "style_variations"` opens as **Text → Image** rather than landing on a now-missing tab. The recipe-restore and preset-apply paths were already guarded by `IMAGE_MODES` (which never included `style_variations`).
- **Tests** — updated `presetUtils.test.jsx`, removed the now-dead "Variations tab" test in `ImageStudio.test.jsx`, and corrected the preset-save mode-array assertion in `main.test.jsx`.

## Deliberately out of scope (per the story)

The inert `capabilities: [..., "style_variations"]` declarations in `apps/web/src/constants.js` + `config/manifests/builtin.models.jsonc`, and the `ModelManagerScreen` capability label, are **left as-is** — harmless dead metadata. The story scopes stripping them (which would touch the parity contract snapshot + every manifest entry) as a separate optional follow-up.

## Acceptance / validation

- ✅ Image Studio shows Text / Edit / With character (no Variations tab).
- ✅ Presets/recipes saved as `style_variations` still load (as Text → Image).
- ✅ No `style_variations` job creatable from the UI.
- ✅ eslint `src`: 0 errors · full web suite **432/432 pass** · `vite build` clean.

## Reviewer notes

Live browser-preview was skipped intentionally: Image Studio only renders with a backend-supplied `AppContext`, so a bare `vite dev` stalls at the connect shell and can't exercise the tabs. The jsdom tests mount the **real** `ImageStudio` component and assert the segmented-control tab set directly — that is the authoritative check here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)