### PR TITLE
sc-5972: harden parity Docker smoke against intermittent Node exit-13

### DIFF
--- a/scripts/check-docker-api-runtime.mjs
+++ b/scripts/check-docker-api-runtime.mjs
@@ -9,32 +9,8 @@ const runtime = "rust";
 const port = process.env.SCENEWORKS_API_PORT || "18000";
 const projectName = "sceneworks-rust-api-check";
 const compose = ["compose", "-p", projectName];
-const tempRoot = await mkdtemp(path.join(os.tmpdir(), "sceneworks-rust-api-"));
-const tempData = path.join(tempRoot, "data");
-await mkdir(path.join(tempData, "cache"), { recursive: true });
 
-const env = {
-  ...process.env,
-  SCENEWORKS_API_PORT: port,
-  SCENEWORKS_DATA_BIND: tempData,
-  SCENEWORKS_CONFIG_BIND: path.resolve("config"),
-  // This smoke intentionally exercises the Docker API container's wider in-container
-  // bind through a host-loopback published port, without provisioning auth.
-  SCENEWORKS_ALLOW_OPEN_BIND: "1",
-  SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE:
-    process.env.SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE || "1",
-  // Run the container as this (host) user so the api isn't root and the files it
-  // seeds into the bind-mounted data dir stay owned by the runner (sc-4285 /
-  // F-INFRA-10), matching the compose `user:` default.
-  ...(typeof process.getuid === "function"
-    ? {
-        SCENEWORKS_UID: String(process.getuid()),
-        SCENEWORKS_GID: String(process.getgid()),
-      }
-    : {}),
-};
-
-function runDocker(args) {
+function runDocker(args, env) {
   return new Promise((resolve, reject) => {
     const child = spawn("docker", args, { env, stdio: "inherit", shell: false });
     child.on("error", reject);
@@ -72,35 +48,79 @@ async function waitForHealth() {
   throw new Error(`SceneWorks ${runtime} API did not become healthy: ${lastError}`);
 }
 
-try {
-  await runDocker([...compose, "up", "--build", "-d", "api"]).catch((error) => {
-    // The health check below is the real gate (it polls for 120s and fails if the
-    // container is not serving), so a spurious non-zero `up` is tolerated rather than
-    // aborting before we ever probe the container.
-    console.error(`compose up reported: ${error.message} (continuing to health check)`);
-  });
-  // Surface the container's boot logs AND keep an active handle across the detached
-  // up -> health-poll transition. Without this, `docker compose up -d` (stdio inherited,
-  // the container owned by the daemon) can momentarily drain Node's event loop and exit
-  // 13 ("unsettled top-level await") before waitForHealth's first request registers a
-  // socket — an intermittent CI flake unrelated to the API (the container is healthy).
-  await runDocker([...compose, "logs", "--no-color", "api"]).catch(() => {});
-  await waitForHealth();
-} finally {
-  // The api service runs as root in the container, so anything it seeds into the
-  // bind-mounted data dir is root-owned — notably data/projects/global-poses.sceneworks,
-  // the global pose store the API creates on boot (apps/rust-api ensure_global_poses_project).
-  // The host CI user then can't remove those files (EACCES on rmdir; fs.rm's `force`
-  // ignores ENOENT, not EACCES). Delete the root-owned tree from inside a one-off root
-  // container first. Scope it to data/projects so we never touch the Hugging Face cache
-  // bind-mounted under data/cache/huggingface.
-  await runDocker([
-    ...compose, "run", "--rm", "--no-deps", "--entrypoint", "rm", "api", "-rf", "/sceneworks/data/projects",
-  ]).catch((error) => {
-    console.error(error.message);
-  });
-  await runDocker([...compose, "down", "--remove-orphans"]).catch((error) => {
-    console.error(error.message);
-  });
-  await rm(tempRoot, { recursive: true, force: true });
+async function main() {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "sceneworks-rust-api-"));
+  const tempData = path.join(tempRoot, "data");
+  await mkdir(path.join(tempData, "cache"), { recursive: true });
+
+  const env = {
+    ...process.env,
+    SCENEWORKS_API_PORT: port,
+    SCENEWORKS_DATA_BIND: tempData,
+    SCENEWORKS_CONFIG_BIND: path.resolve("config"),
+    // This smoke intentionally exercises the Docker API container's wider in-container
+    // bind through a host-loopback published port, without provisioning auth.
+    SCENEWORKS_ALLOW_OPEN_BIND: "1",
+    SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE:
+      process.env.SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE || "1",
+    // Run the container as this (host) user so the api isn't root and the files it
+    // seeds into the bind-mounted data dir stay owned by the runner (sc-4285 /
+    // F-INFRA-10), matching the compose `user:` default.
+    ...(typeof process.getuid === "function"
+      ? {
+          SCENEWORKS_UID: String(process.getuid()),
+          SCENEWORKS_GID: String(process.getgid()),
+        }
+      : {}),
+  };
+
+  // Keep-alive: a ref'd timer guarantees the event loop always has an active handle
+  // for the whole run. `docker compose up -d` detaches (the container is owned by the
+  // daemon and the CLI child exits quickly), so between the detached `up` finishing and
+  // waitForHealth's first `fetch()` registering a socket, Node can momentarily have zero
+  // active handles. Combined with running off the module top level (main() below, not a
+  // top-level await), this closes both routes to the intermittent exit-13 CI flake
+  // ("unsettled top-level await") seen while the container is in fact healthy. Cleared in
+  // `finally` so the process can exit normally once the smoke completes.
+  const keepAlive = setInterval(() => {}, 1000);
+
+  try {
+    await runDocker([...compose, "up", "--build", "-d", "api"], env).catch((error) => {
+      // The health check below is the real gate (it polls for 120s and fails if the
+      // container is not serving), so a spurious non-zero `up` is tolerated rather than
+      // aborting before we ever probe the container.
+      console.error(`compose up reported: ${error.message} (continuing to health check)`);
+    });
+    // Surface the container's boot logs so a genuine CI failure has the API banner/errors
+    // in the run output. (This is no longer load-bearing for exit-13 avoidance — the
+    // keepAlive handle and main() wrapper cover that — it's purely diagnostic now.)
+    await runDocker([...compose, "logs", "--no-color", "api"], env).catch(() => {});
+    await waitForHealth();
+  } finally {
+    // The api service runs as root in the container, so anything it seeds into the
+    // bind-mounted data dir is root-owned — notably data/projects/global-poses.sceneworks,
+    // the global pose store the API creates on boot (apps/rust-api ensure_global_poses_project).
+    // The host CI user then can't remove those files (EACCES on rmdir; fs.rm's `force`
+    // ignores ENOENT, not EACCES). Delete the root-owned tree from inside a one-off root
+    // container first. Scope it to data/projects so we never touch the Hugging Face cache
+    // bind-mounted under data/cache/huggingface.
+    await runDocker([
+      ...compose, "run", "--rm", "--no-deps", "--entrypoint", "rm", "api", "-rf", "/sceneworks/data/projects",
+    ], env).catch((error) => {
+      console.error(error.message);
+    });
+    await runDocker([...compose, "down", "--remove-orphans"], env).catch((error) => {
+      console.error(error.message);
+    });
+    await rm(tempRoot, { recursive: true, force: true });
+    clearInterval(keepAlive);
+  }
 }
+
+main().catch((error) => {
+  // A genuine failure (unhealthy container hitting the 120s waitForHealth deadline,
+  // an unexpected throw, etc.) surfaces as a normal rejection here and exits non-zero —
+  // not via Node's top-level-await exit-13 path.
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

The `parity` CI lane (`npm run check:docker:rust-api` → `scripts/check-docker-api-runtime.mjs`) intermittently failed with Node **exit code 13** ("unsettled top-level await") immediately after the API container started — *before* the health probe ran. It's a harness/timing flake, not an API or product defect: seen red on a pure `apps/web` PR (#719, which can't touch the Rust API container) and on `main` (merge `a81e7eb`), while neighboring commits passed. ([sc-5972](https://app.shortcut.com/trefry/story/5972))

## Root cause

`docker compose up --build -d api` detaches — the container is owned by the daemon and the `docker` CLI child exits quickly. Between `up`/`logs` finishing and `waitForHealth`'s first `fetch()` registering a socket handle, Node's event loop could momentarily have **zero active handles while a top-level await was still pending** → Node bails with exit 13. The existing non-`-f` `docker compose logs` bridge also returns immediately, so the zero-handle window wasn't reliably closed.

## Fix (both recommended mitigations — test-harness only)

- **Removed all top-level await** — the whole body (including the `mkdtemp`/`mkdir` setup, which were also top-level awaits) is wrapped in `async function main()`, invoked as `main().catch((e) => { console.error(e); process.exitCode = 1; })`. With no top-level await, Node's exit-13 path can't trigger; a real failure surfaces as a normal rejection → non-zero exit.
- **Ref'd keep-alive handle** — `setInterval(() => {}, 1000)` spans the whole run, `clearInterval` as the last line of `finally`, so the event loop always has an active handle through the `up` → first-`fetch()` window.
- `docker compose logs` is **retained but re-commented**: no longer load-bearing for exit-13 avoidance, kept purely to surface the container boot banner in CI for diagnosing genuine failures.
- `runDocker` now takes `env` as a parameter, since `env` moved inside `main()`.

No product/runtime code changes.

## Verification

Docker daemon wasn't running locally and the real smoke builds the full Linux Rust-API container, so the authoritative green/red is the `parity` CI lane on this PR. Confirmed deterministically here:

- `node --check` clean.
- OLD pattern `await new Promise(() => {})` → reproduces `exit 13` ("Detected unsettled top-level await").
- NEW `main()` wrapper around the same never-settling await → `exit 0` (exit-13 route gone).
- Throw inside `main()` → `exit 1` — a genuinely unhealthy container still fails the check; the 120s `waitForHealth` deadline path is unchanged.
- Ref'd `setInterval` keeps the loop alive until cleared, then clean `exit 0`.

## Acceptance

- [x] `parity` can no longer exit 13 in the up→health-poll window (no top-level await + ref'd handle).
- [x] A genuinely unhealthy container still fails the check (120s `waitForHealth` deadline → exit 1).
- [ ] Stable green across several `parity` CI runs — verified by this PR's checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)