### PR TITLE
feat(flux2): FLUX.2-dev T2I in SceneWorks — catalog + routing + convert (sc-5921)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_distr 0.5.1",
  "safetensors 0.7.0",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=32fdb34991b2945dc4af7d3d5b036239eac4ce81)",
  "serde_json",
  "thiserror 2.0.18",
 ]
@@ -3256,11 +3256,11 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=32fdb34991b2945dc4af7d3d5b036239eac4ce81#32fdb34991b2945dc4af7d3d5b036239eac4ce81"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c)",
  "thiserror 2.0.18",
  "tokenizers 0.21.4",
 ]
@@ -3268,7 +3268,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=32fdb34991b2945dc4af7d3d5b036239eac4ce81#32fdb34991b2945dc4af7d3d5b036239eac4ce81"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
 dependencies = [
  "image",
  "inventory",
@@ -3282,7 +3282,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=32fdb34991b2945dc4af7d3d5b036239eac4ce81#32fdb34991b2945dc4af7d3d5b036239eac4ce81"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3294,7 +3294,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=32fdb34991b2945dc4af7d3d5b036239eac4ce81#32fdb34991b2945dc4af7d3d5b036239eac4ce81"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3303,7 +3303,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=32fdb34991b2945dc4af7d3d5b036239eac4ce81#32fdb34991b2945dc4af7d3d5b036239eac4ce81"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3315,7 +3315,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=32fdb34991b2945dc4af7d3d5b036239eac4ce81#32fdb34991b2945dc4af7d3d5b036239eac4ce81"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3326,7 +3326,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=32fdb34991b2945dc4af7d3d5b036239eac4ce81#32fdb34991b2945dc4af7d3d5b036239eac4ce81"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3337,7 +3337,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=32fdb34991b2945dc4af7d3d5b036239eac4ce81#32fdb34991b2945dc4af7d3d5b036239eac4ce81"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3347,7 +3347,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=32fdb34991b2945dc4af7d3d5b036239eac4ce81#32fdb34991b2945dc4af7d3d5b036239eac4ce81"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
 dependencies = [
  "image",
  "inventory",
@@ -3359,7 +3359,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=32fdb34991b2945dc4af7d3d5b036239eac4ce81#32fdb34991b2945dc4af7d3d5b036239eac4ce81"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
 dependencies = [
  "image",
  "inventory",
@@ -3372,7 +3372,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=32fdb34991b2945dc4af7d3d5b036239eac4ce81#32fdb34991b2945dc4af7d3d5b036239eac4ce81"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
 dependencies = [
  "image",
  "inventory",
@@ -3384,7 +3384,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=32fdb34991b2945dc4af7d3d5b036239eac4ce81#32fdb34991b2945dc4af7d3d5b036239eac4ce81"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3395,7 +3395,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=32fdb34991b2945dc4af7d3d5b036239eac4ce81#32fdb34991b2945dc4af7d3d5b036239eac4ce81"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3407,7 +3407,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=32fdb34991b2945dc4af7d3d5b036239eac4ce81#32fdb34991b2945dc4af7d3d5b036239eac4ce81"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3417,7 +3417,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=32fdb34991b2945dc4af7d3d5b036239eac4ce81#32fdb34991b2945dc4af7d3d5b036239eac4ce81"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3426,7 +3426,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=32fdb34991b2945dc4af7d3d5b036239eac4ce81#32fdb34991b2945dc4af7d3d5b036239eac4ce81"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3435,7 +3435,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=32fdb34991b2945dc4af7d3d5b036239eac4ce81#32fdb34991b2945dc4af7d3d5b036239eac4ce81"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3447,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=32fdb34991b2945dc4af7d3d5b036239eac4ce81#32fdb34991b2945dc4af7d3d5b036239eac4ce81"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
 dependencies = [
  "image",
  "inventory",
@@ -3460,7 +3460,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=32fdb34991b2945dc4af7d3d5b036239eac4ce81#32fdb34991b2945dc4af7d3d5b036239eac4ce81"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3471,7 +3471,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=32fdb34991b2945dc4af7d3d5b036239eac4ce81#32fdb34991b2945dc4af7d3d5b036239eac4ce81"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3482,7 +3482,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=32fdb34991b2945dc4af7d3d5b036239eac4ce81#32fdb34991b2945dc4af7d3d5b036239eac4ce81"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3493,7 +3493,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=32fdb34991b2945dc4af7d3d5b036239eac4ce81#32fdb34991b2945dc4af7d3d5b036239eac4ce81"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
 dependencies = [
  "image",
  "inventory",
@@ -3507,7 +3507,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=32fdb34991b2945dc4af7d3d5b036239eac4ce81#32fdb34991b2945dc4af7d3d5b036239eac4ce81"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
 dependencies = [
  "image",
  "inventory",
@@ -5135,6 +5135,18 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
+dependencies = [
+ "inventory",
+ "safetensors 0.4.5",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokenizers 0.21.4",
+]
+
+[[package]]
+name = "sceneworks-gen-core"
+version = "0.1.0"
 source = "git+https://github.com/michaeltrefry/mlx-gen?rev=32fdb34991b2945dc4af7d3d5b036239eac4ce81#32fdb34991b2945dc4af7d3d5b036239eac4ce81"
 dependencies = [
  "inventory",
@@ -5232,7 +5244,7 @@ dependencies = [
  "pmetal-mlx-rs",
  "reqwest 0.12.28",
  "sceneworks-core",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c)",
  "serde",
  "serde_json",
  "sha2",

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -349,6 +349,35 @@ fn inject_converted_model_path_populates_modelpath_seam_once_converted() {
     });
     inject_converted_model_path(&mut turnkey, &data_dir);
     assert!(turnkey.get("modelPath").is_none());
+
+    // FLUX.2-dev (sc-5921) converts to a packed Q4 dir whose top level is SUBDIRS
+    // (transformer/ + text_encoder/, each with its own config.json) plus a symlinked
+    // model_index.json — there is NO top-level config.json. The catalog's "converted"
+    // detection keys on the top-level model_index.json, so the modelPath seam is still
+    // injected for dev's subdir layout.
+    let dev_entry = || {
+        json!({
+            "id": "flux2_dev",
+            "mlx": {
+                "requiresConversion": true,
+                "converter": "flux2_dev_quant",
+                "convertSourceRepo": "black-forest-labs/FLUX.2-dev"
+            }
+        })
+    };
+    let dev_converted = data_dir.join("models").join("mlx").join("flux2_dev");
+    std::fs::create_dir_all(dev_converted.join("transformer")).expect("create dev transformer");
+    std::fs::write(dev_converted.join("transformer").join("config.json"), "{}")
+        .expect("write dev transformer config");
+    // No top-level config.json — only the model_index.json marker.
+    std::fs::write(dev_converted.join("model_index.json"), "{}").expect("write dev model_index");
+    let mut entry = dev_entry();
+    inject_converted_model_path(&mut entry, &data_dir);
+    assert_eq!(
+        entry.get("modelPath").and_then(Value::as_str),
+        Some(dev_converted.display().to_string().as_str()),
+        "dev's subdir layout is detected via its top-level model_index.json marker"
+    );
 }
 
 fn write_test_safetensors(path: &std::path::Path) {

--- a/apps/web/public/prompt-guides/flux2-dev.md
+++ b/apps/web/public/prompt-guides/flux2-dev.md
@@ -1,0 +1,55 @@
+# FLUX.2 [dev] Prompt Guide
+
+## Best For
+
+The 32B Black Forest Labs FLUX.2 [dev] checkpoint — the high-fidelity flagship of the FLUX.2 family, ported natively to MLX (Apple Silicon only). A larger, sharper sibling of FLUX.2 [klein]: a Mistral-3 text encoder and a 48-layer flow transformer give it stronger prompt adherence, finer detail, and better text rendering than the 9B klein, at the cost of speed and memory. Guidance-distilled text-to-image; reference editing and LoRAs land separately.
+
+> **License:** FLUX [dev] Non-Commercial License v2.0 — gated Hugging Face download. Accept the license at the model card and add a Hugging Face token under Settings → Service credentials before downloading. The model is for non-commercial use; the images you generate are yours to use commercially.
+
+> **Hardware:** 128 GB Mac only. The dense weights are too large to quantize in memory, so the model is pre-quantized to Q4 on disk at install (a one-time conversion step after download). Generation peaks ~74 GB at 1024². macOS only.
+
+## Prompt Shape
+
+FLUX.2 [dev] reads a fluent natural-language description, not tag lists:
+
+`subject + setting + visual details + style + composition + lighting + any text`
+
+There is no negative prompt — FLUX.2 [dev] is guidance-distilled (embedded guidance, not classifier-free), so describe everything you DO want in the positive prompt.
+
+## Build The Prompt
+
+### Subject
+
+Describe the subject as if captioning a finished photo. Include type, action, position, and distinguishing features.
+
+Good: `a marine biologist examining a glowing jellyfish in a research lab tank`
+
+### Details
+
+Add material, texture, and atmosphere:
+
+- `brushed copper helmet`
+- `wet kelp glinting under fluorescents`
+- `late-afternoon golden light through high windows`
+
+### Style + Composition
+
+Pick concrete style cues (photo, illustration, render) and a composition (medium shot, low angle, etc.). [dev] handles photoreal and stylized equally well but doesn't infer them — say what you want. Its larger text encoder follows long, layered descriptions more faithfully than klein, so it rewards detail.
+
+### Text
+
+FLUX.2 [dev] renders longer, cleaner text than klein. Wrap exact strings in double quotes:
+
+`a vintage tea-tin labeled "Earl Grey No. 3"`
+
+## Defaults
+
+- Resolution: 1024×1024 (also 768×768, 1280×720, 720×1280)
+- Steps: 28 (24–50 is the useful range; 28 is the recommended trade-off)
+- Guidance: 4.0 (embedded distilled guidance — raise for tighter prompt adherence, lower for more variation)
+- Quantization: Q4 (pre-quantized on disk at install; required to fit in memory)
+
+## Sources
+
+- [FLUX.2 [dev] model card](https://huggingface.co/black-forest-labs/FLUX.2-dev)
+- [FLUX.2 announcement](https://bfl.ai/blog/flux-2)

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1108,6 +1108,77 @@
       }
     },
     {
+      "id": "flux2_dev",
+      "name": "FLUX.2 [dev]",
+      "family": "flux2-dev",
+      "type": "image",
+      // FLUX.2 [dev] (epic 5914) — the guidance-distilled 32B flagship, a SEPARATE
+      // model from klein: a Mistral3 text encoder (vs klein's Qwen3) + a 48/48/15360
+      // DiT, ported natively to mlx-gen (sc-5915/5916/5917/2365). MLX-only (no torch
+      // backend), Mac-only. T2I-only for now — the Pixtral edit/reference path is
+      // sc-5918/5919/5922. Shares the `mlx_flux2` adapter + the `flux2` engine.
+      "adapter": "mlx_flux2",
+      "capabilities": ["text_to_image"],
+      "macOnly": true,
+      "downloads": [
+        {
+          // Gated repo (FLUX [dev] Non-Commercial License v2.0). The repo ships BOTH
+          // the BFL single-file (flux2-dev.safetensors / ae.safetensors, ~60 GB) AND
+          // the diffusers tree; the native loader/converter reads ONLY the diffusers
+          // subdirs, so include just those (+ model_index.json) and skip the redundant
+          // ~60 GB single-file. ~113 GiB downloaded.
+          "provider": "huggingface",
+          "repo": "black-forest-labs/FLUX.2-dev",
+          "files": ["model_index.json", "transformer/*", "text_encoder/*", "vae/*", "tokenizer/*"],
+          "estimatedSizeBytes": 112823015150
+        }
+      ],
+      "defaults": {
+        // Guidance-distilled (embedded scalar, NOT true-CFG): ~28 steps (24–50 ok) at
+        // guidance 4.0 — the FLUX.1-dev pattern, no negative prompt. (sc-2365.)
+        "resolution": "1024x1024",
+        "steps": 28,
+        "guidanceScale": 4.0,
+        "count": 1
+      },
+      "limits": {
+        "resolutions": ["768x768", "1024x1024", "1280x720", "720x1280"],
+        "count": [1, 2]
+      },
+      // 32B DiT + ~24B Mistral TE. In-app Q4 *load* of the dense bf16 snapshot peaks
+      // ~105 GB (> the 128 GB ceiling), so the snapshot is pre-quantized to Q4 ON DISK
+      // by the install-time convert job (mlx.requiresConversion + the `flux2_dev_quant`
+      // converter, sc-5917): the offline quantize peaks ~34.5 GB. The worker then loads
+      // the packed dir (load `.quantize()` is a no-op on already-packed weights). Q4
+      // weights floor ~30 GB but generate is activation-bound — 1024²/28 peaks ~74 GB
+      // (sc-2365) — so minMemoryGb 96 (128 GB Macs only). The convert pre-quantizes
+      // transformer + text_encoder and symlinks the (identical-to-klein) VAE +
+      // tokenizer + model_index.json from the gated source snapshot.
+      "mlx": {
+        "minMemoryGb": 96,
+        "quantize": 4,
+        "requiresConversion": true,
+        "converter": "flux2_dev_quant",
+        "convertSourceRepo": "black-forest-labs/FLUX.2-dev"
+      },
+      "gated": true,
+      "credentialHost": "huggingface.co",
+      "licenseUrl": "https://huggingface.co/black-forest-labs/FLUX.2-dev",
+      "ui": {
+        "label": "FLUX.2 [dev]",
+        "description": "Black Forest Labs FLUX.2 [dev] — the 32B guidance-distilled flagship text-to-image model, ported natively to MLX (Apple Silicon only). A larger, higher-fidelity sibling of FLUX.2 [klein] with a Mistral-3 text encoder and a 48-layer flow transformer; runs ~28 steps at guidance 4.0. Pre-quantized to Q4 at install (the dense weights are too large to quantize in memory) and needs a 128 GB Mac (~74 GB peak at 1024²). Distributed under the FLUX [dev] Non-Commercial License (gated): accept the license at huggingface.co/black-forest-labs/FLUX.2-dev and add a Hugging Face token under Settings → Service credentials before downloading. Reference editing and LoRAs are coming separately.",
+        "recommendedFor": ["text_to_image"],
+        "promptGuide": {
+          "title": "FLUX.2 [dev] Prompt Guide",
+          "path": "/prompt-guides/flux2-dev.md",
+          "sources": [
+            { "label": "FLUX.2 [dev] model card", "url": "https://huggingface.co/black-forest-labs/FLUX.2-dev" },
+            { "label": "FLUX.2 announcement", "url": "https://bfl.ai/blog/flux-2" }
+          ]
+        }
+      }
+    },
+    {
       "id": "chroma1_hd",
       "name": "Chroma1-HD",
       "family": "chroma",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -2700,7 +2700,10 @@ fn classify_training_gap(payload: &Map<String, Value>) -> UnsupportedReason {
 /// (`flux2_klein_diffusers`, sc-3136). The default/absent converter is the Python mlx-video
 /// Wan/LTX path (sc-3491 / sc-3224).
 fn classify_convert_gap(payload: &Map<String, Value>) -> Result<(), UnsupportedReason> {
-    if payload.get("converter").and_then(Value::as_str) == Some("flux2_klein_diffusers") {
+    if matches!(
+        payload.get("converter").and_then(Value::as_str),
+        Some("flux2_klein_diffusers") | Some("flux2_dev_quant")
+    ) {
         return Ok(());
     }
     Err(UnsupportedReason::new(
@@ -3034,6 +3037,8 @@ const MLX_ROUTED_MODELS: &[&str] = &[
     "flux2_klein_9b",
     "flux2_klein_9b_kv",
     "flux2_klein_9b_true_v2",
+    // FLUX.2-dev (epic 5914) — MLX-only flagship, txt2img today (edit = sc-5919).
+    "flux2_dev",
     "sdxl",
     "realvisxl",
     // InstantID on RealVisXL (sc-3345): single-identity + the 11-view angle set route to the
@@ -3115,7 +3120,7 @@ fn image_request_mlx_eligible(model: &str, payload: &Map<String, Value>) -> bool
         | "qwen_image_edit_2509"
         | "qwen_image_edit_2511"
         | "qwen_image_edit_2511_lightning" => qwen_edit_mlx_eligible(payload),
-        "flux2_klein_9b" | "flux2_klein_9b_kv" | "flux2_klein_9b_true_v2" => {
+        "flux2_klein_9b" | "flux2_klein_9b_kv" | "flux2_klein_9b_true_v2" | "flux2_dev" => {
             flux2_mlx_eligible(payload)
         }
         "sdxl" | "realvisxl" => sdxl_mlx_eligible(payload),
@@ -3755,9 +3760,11 @@ fn pulid_flux_mlx_eligible(payload: &Map<String, Value>) -> bool {
         .is_some_and(|value| !value.trim().is_empty())
 }
 
-/// FLUX.2-klein MLX-routing conditions. FLUX.2-klein is an **MLX-only** family (no torch backend),
-/// so everything it does runs on MLX: txt2img (sc-3025), edit/reference + KV-cache + multi-reference
-/// (sc-3029), and — since epic 3641 (sc-3642/3643) — third-party LyCORIS via the core loader.
+/// FLUX.2 MLX-routing conditions, shared by klein and dev. FLUX.2 is an **MLX-only** family (no torch
+/// backend), so everything it does runs on MLX: klein txt2img (sc-3025), edit/reference + KV-cache +
+/// multi-reference (sc-3029), third-party LyCORIS via the core loader (epic 3641), and FLUX.2-dev
+/// txt2img (epic 5914 — dev's manifest advertises `text_to_image` only, so its edit/character modes
+/// are never offered until the Pixtral path lands in sc-5919).
 fn flux2_mlx_eligible(_payload: &Map<String, Value>) -> bool {
     true
 }

--- a/crates/sceneworks-core/src/lora_family.rs
+++ b/crates/sceneworks-core/src/lora_family.rs
@@ -836,11 +836,14 @@ pub const MAX_JOB_LORAS: usize = 3;
 /// (Python `EXTRA_COMPATIBLE_LORA_FAMILIES`). Chroma is FLUX.1-derived and shares
 /// Flux's block layout, so Flux LoRAs load on Chroma (one-directional). FLUX.2
 /// [klein]'s model family is `flux2-klein` but klein LoRAs are detected/declared
-/// as `flux2`, so a klein model must accept `flux2` LoRAs.
+/// as `flux2`, so a klein model must accept `flux2` LoRAs. FLUX.2-dev's family is
+/// `flux2-dev` (a separate model — Mistral3 TE + 48/48 DiT) but it shares the FLUX.2
+/// transformer layout, so dev LoRAs are likewise detected/declared as `flux2` (epic 5914;
+/// dev LoRA application is validated in sc-5920).
 fn extra_compatible_lora_families(normalized_family: &str) -> &'static [&'static str] {
     match normalized_family {
         "chroma" => &["flux"],
-        "flux2-klein" => &["flux2"],
+        "flux2-klein" | "flux2-dev" => &["flux2"],
         _ => &[],
     }
 }

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -2252,13 +2252,20 @@ fn mac_rust_supported_names_advanced_video_and_svd() {
 #[test]
 fn mac_rust_supported_convert_flux2_ok_else_python_gap() {
     let store = store("oracle-convert");
-    // The in-process Rust FLUX.2 converter is supported.
+    // The in-process Rust FLUX.2 converters are supported.
     let flux2 = job_of(
         &store,
         JobType::ModelConvert,
         json!({ "model": "flux2_klein_9b_true_v2", "converter": "flux2_klein_diffusers" }),
     );
     assert!(mac_rust_supported(&flux2).is_ok());
+    // FLUX.2-dev pre-quantization (sc-5921) is likewise an in-process Rust/MLX convert.
+    let flux2_dev = job_of(
+        &store,
+        JobType::ModelConvert,
+        json!({ "model": "flux2_dev", "converter": "flux2_dev_quant" }),
+    );
+    assert!(mac_rust_supported(&flux2_dev).is_ok());
     // The default/absent converter is the Python mlx-video Wan/LTX path → gap.
     let wan = job_of(&store, JobType::ModelConvert, json!({ "model": "wan_2_2" }));
     assert_eq!(
@@ -3935,11 +3942,13 @@ fn flux2_klein_variants_route_to_mlx_worker() {
     register_gpu_worker(&store, "worker-torch", "mps", image_caps());
     register_gpu_worker(&store, "worker-mlx", "mlx", image_caps());
 
-    // All three FLUX.2-klein txt2img variants (MLX-only family) route to the mlx worker.
+    // All three FLUX.2-klein txt2img variants + FLUX.2-dev (MLX-only family) route to the mlx
+    // worker (dev is txt2img-only today — epic 5914 / sc-5921).
     for model in [
         "flux2_klein_9b",
         "flux2_klein_9b_kv",
         "flux2_klein_9b_true_v2",
+        "flux2_dev",
     ] {
         let job = store
             .create_job(image_job_with(

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -93,7 +93,20 @@ sceneworks-core = { path = "../sceneworks-core" }
 # prompt-refine/joycaption Rust layers recompile). candle-gen still pins gen-core 27b0107 (byte-identical,
 # Windows/CUDA-only, no SAM3); its backend-candle skew lane is workflow_dispatch-only (not a PR gate), so
 # this PR doesn't break it — candle catches up in its own repo (tracked: sc-5905).
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32fdb34991b2945dc4af7d3d5b036239eac4ce81" }
+# Rev 154af37 (mlx-gen main, merged PRs #469/#470/#471/#472, epic 5914 / sc-5915/5916/5917/2365): bumps
+# EVERY mlx-gen crate 32fdb34 -> 154af37 in lockstep to bring the native FLUX.2-**dev** image model into
+# the registry (the `flux2_dev` engine id + `mlx_gen_flux2::quantize_flux2_dit`/`_text_encoder_dir`
+# pre-quant convert API the sc-5921 worker wiring calls). dev = a Mistral3 text encoder + a 48/48/15360
+# DiT (a SEPARATE model from klein), guidance-distilled (embedded scalar, not true-CFG). The gen-core
+# delta 32fdb34 -> 154af37 is exactly +27 lines in `tokenizer.rs` (the additive `ChatTemplate::
+# Flux2DevMistral` the dev TE renders) — mlx-rs is unchanged (44929a0), so the direct `mlx-rs` pin below
+# is unchanged and MLX core does not rebuild (only the flux2 + gen-core Rust layers recompile). The
+# DEFAULT skew gate (the PR gate, `check.yml`) is blind to candle-gen, so it stays single-rev/green at
+# 154af37. candle-gen still pins gen-core 32fdb34, so the `--features backend-candle` lane is skewed —
+# but that lane is workflow_dispatch-only (not a PR gate) and build-windows builds WITHOUT backend-candle,
+# so this PR is unaffected; candle catches up in its own repo (same deferral as the 32fdb34 bump above,
+# tracked: sc-5905).
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -378,7 +391,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32fdb34991b2945dc4af7d3d5b036239eac4ce81" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -390,55 +403,55 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32fdb34991b
 # internal pin (the Lens engine PRs #407–#414 did not move it; nor did the seedvr2 engine #416/#419/
 # #421 or the softness PR #422, so the 1a97909 bump above leaves mlx-rs at 44929a0).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "44929a001ab8a8837403a71c65cf064224de0cdc" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32fdb34991b2945dc4af7d3d5b036239eac4ce81" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32fdb34991b2945dc4af7d3d5b036239eac4ce81" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32fdb34991b2945dc4af7d3d5b036239eac4ce81" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32fdb34991b2945dc4af7d3d5b036239eac4ce81" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32fdb34991b2945dc4af7d3d5b036239eac4ce81" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32fdb34991b2945dc4af7d3d5b036239eac4ce81" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32fdb34991b2945dc4af7d3d5b036239eac4ce81" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32fdb34991b2945dc4af7d3d5b036239eac4ce81" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32fdb34991b2945dc4af7d3d5b036239eac4ce81" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32fdb34991b2945dc4af7d3d5b036239eac4ce81" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32fdb34991b2945dc4af7d3d5b036239eac4ce81" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32fdb34991b2945dc4af7d3d5b036239eac4ce81" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -447,12 +460,12 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32fdb3
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32fdb34991b2945dc4af7d3d5b036239eac4ce81" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32fdb34991b2945dc4af7d3d5b036239eac4ce81" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -461,7 +474,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32fdb3
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32fdb34991b2945dc4af7d3d5b036239eac4ce81" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -469,7 +482,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32fdb34991b2945dc4af7d3d5b036239eac4ce81" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -480,7 +493,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32fd
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32fdb34991b2945dc4af7d3d5b036239eac4ce81" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -491,7 +504,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32fdb
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32fdb34991b2945dc4af7d3d5b036239eac4ce81" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -506,7 +519,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32fdb3
 # converted in-memory at load (no Python); the precomputed neg-prompt embedding is bundled in-crate. No
 # LoRA/guidance/CFG (one-step). 3B fp16 only here — 7B (sc-5197) + int8 (sc-5198) are engine-side and
 # unwired. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32fdb34991b2945dc4af7d3d5b036239eac4ce81" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -517,7 +530,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32f
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32fdb34991b2945dc4af7d3d5b036239eac4ce81" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
 # Prompt-refine provider (sc-5552, the MLX twin of candle-gen-prompt-refine / sc-5500). An
 # inventory-registered `TextLlm` under id `prompt_refine` (`backend="mlx"`, `mac_only`): a native MLX
 # Llama-3.2-3B-Instruct that rewrites a user's prompt, replacing the Python `prompt_refine.py`
@@ -527,7 +540,7 @@ mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32f
 # textllm registered" trap). Weights = a stock Llama-3.2-3B-Instruct HF snapshot (config.json +
 # tokenizer.json + model-*.safetensors; default `huihui-ai/Llama-3.2-3B-Instruct-abliterated`). Same
 # git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32fdb34991b2945dc4af7d3d5b036239eac4ce81" }
+mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
 # SCAIL-2 (zai-org) end-to-end character-animation provider (epic 5439, sc-5448). An inventory-registered
 # `Generator` under id `scail2_14b` (`Modality::Video`): a Wan2.1-14B I2V DiT that animates a reference
 # character with a driving video's motion (`video_mode == "replacement"` flips the cross-identity
@@ -539,7 +552,7 @@ mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev 
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "32fdb34991b2945dc4af7d3d5b036239eac4ce81" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -169,6 +169,21 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
         default_guidance: 1.0,
         adapter_label: "mlx_flux2",
     },
+    // FLUX.2-dev (epic 5914) — the guidance-distilled 32B flagship. A SEPARATE engine
+    // model `flux2_dev` (Mistral3 TE + 48/48/15360 DiT), NOT a klein weight variant, so it
+    // maps to its own engine id. Embedded distilled guidance (FLUX.1-dev pattern, NOT
+    // true-CFG): the descriptor advertises `supports_guidance` but not negative prompt, so
+    // the engine takes the guidance scalar (default 4.0) over ~28 steps. Loaded from a
+    // pre-quantized Q4 dir assembled by the install-time `flux2_dev_quant` convert job
+    // (sc-5917 / sc-5921) — in-app Q4 load of the dense bf16 snapshot would peak ~105 GB.
+    ModelRow {
+        sceneworks_id: "flux2_dev",
+        engine_id: "flux2_dev",
+        default_repo: "black-forest-labs/FLUX.2-dev",
+        default_steps: 28,
+        default_guidance: 4.0,
+        adapter_label: "mlx_flux2",
+    },
     // SDXL (sc-3026) — U-Net, real CFG (negative prompt + guidance 7.0), 30 steps.
     // `sdxl` and the `realvisxl` finetune share the engine's single `sdxl` model
     // (identical arch), differing only in weights. Replaces the in-process

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -208,6 +208,16 @@ fn mlx_model_table_maps_known_families() {
         mlx_model("flux2_klein_9b_true_v2").unwrap().default_steps(),
         24
     );
+    // FLUX.2-dev (epic 5914): its OWN engine model (not a klein weight variant), embedded
+    // distilled guidance (guidance scalar, no negative prompt — like klein but ~28 steps /
+    // guidance 4.0). Shares the `mlx_flux2` adapter.
+    let dev = mlx_model("flux2_dev").unwrap();
+    assert_eq!(dev.engine_id(), "flux2_dev");
+    assert_eq!(dev.adapter_label(), "mlx_flux2");
+    assert_eq!(dev.default_repo(), "black-forest-labs/FLUX.2-dev");
+    assert_eq!(dev.default_steps(), 28);
+    assert_eq!(dev.default_guidance(), 4.0);
+    assert!(dev.supports_guidance() && !dev.supports_negative_prompt());
     // SDXL + the realvisxl finetune share the single `sdxl` engine model (real CFG).
     for id in ["sdxl", "realvisxl"] {
         let m = mlx_model(id).unwrap();
@@ -1180,6 +1190,26 @@ fn flux2_klein_9b_true_v2_real_weights_generates_one_image() {
     let dir = dirs_home()
         .join("Library/Application Support/SceneWorks/data/models/mlx/flux2_klein_9b_true_v2");
     smoke_generate_one("flux2_klein_9b_true_v2", dir, Some(1.0), None);
+}
+
+/// Real-weights smoke (sc-5921 / sc-5923 boundary): FLUX.2-dev (embedded guidance, ~28-step).
+/// Loads the install-time pre-quantized Q4 dir under the SceneWorks data dir
+/// (`models/mlx/flux2_dev`, assembled by the `flux2_dev_quant` convert job) via the
+/// `flux2_dev` engine id — proving the worker's `mlx_gen_flux2` force-link reaches the dev
+/// loader and that the packed snapshot loads + generates (the Q8 LoadSpec hint is a no-op on
+/// the already-packed weights). Needs a previously-converted dir + a 128 GB Metal device.
+/// `SCENEWORKS_FLUX2_DEV_DIR` overrides the dir. Run on demand:
+/// `cargo test -p sceneworks-worker --lib -- --ignored flux2_dev_real_weights`.
+#[cfg(target_os = "macos")]
+#[test]
+#[ignore = "needs a converted FLUX.2-dev Q4 dir + 128 GB Metal device"]
+fn flux2_dev_real_weights_generates_one_image() {
+    let dir = std::env::var("SCENEWORKS_FLUX2_DEV_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| {
+            dirs_home().join("Library/Application Support/SceneWorks/data/models/mlx/flux2_dev")
+        });
+    smoke_generate_one("flux2_dev", dir, Some(4.0), None);
 }
 
 /// Real-weights smoke: SDXL base (real CFG, guidance 7.0 + a negative prompt,

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -456,6 +456,69 @@ fn convert_ltx_native(
         .to_owned())
 }
 
+/// Native Rust/MLX FLUX.2-dev pre-quantization convert (sc-5921, epic 5914). FLUX.2-dev is too large
+/// to quantize in memory at load — the dense bf16 snapshot (60 GB DiT + 45 GB Mistral TE) peaks
+/// ~105 GB > the 128 GB ceiling — so the install-time convert pre-quantizes the DiT + text encoder to
+/// Q`bits` **on disk** (offline peak ~34.5 GB; MLX mmap-streams the source, sc-5917) and assembles a
+/// packed snapshot: real packed `transformer/` + `text_encoder/` dirs (each one safetensors + a
+/// `quantization` manifest in config.json) plus the unchanged VAE + tokenizer + `model_index.json`
+/// symlinked from the gated source (the VAE is byte-identical to klein's). The worker then loads the
+/// packed dir via the `modelPath` seam; the load-time `.quantize()` is a no-op on already-packed
+/// weights. Absolute symlinks survive the worker's temp→final atomic rename, and `model_index.json`
+/// doubles as the catalog's "converted" marker (`mlx_catalog_status` looks for a top-level
+/// config.json/model_index.json). Runs MLX, so macOS-only.
+#[cfg(target_os = "macos")]
+fn convert_flux2_dev_prequant(
+    source_dir: &Path,
+    out_dir: &Path,
+    bits: i32,
+    group_size: i32,
+) -> Result<(), String> {
+    // CARVE-OUT(epic 3720): backend-specific weight converter; not a registry contract.
+    std::fs::create_dir_all(out_dir).map_err(|error| error.to_string())?;
+    mlx_gen_flux2::quantize_flux2_dit(
+        &source_dir.join("transformer"),
+        &out_dir.join("transformer"),
+        bits,
+        group_size,
+    )
+    .map_err(|error| format!("quantize FLUX.2-dev transformer: {error}"))?;
+    mlx_gen_flux2::quantize_flux2_text_encoder_dir(
+        &source_dir.join("text_encoder"),
+        &out_dir.join("text_encoder"),
+        bits,
+        group_size,
+    )
+    .map_err(|error| format!("quantize FLUX.2-dev text encoder: {error}"))?;
+    for sub in ["vae", "tokenizer", "model_index.json"] {
+        let src = source_dir.join(sub);
+        if !src.exists() {
+            return Err(format!(
+                "FLUX.2-dev source is missing `{sub}` — expected the gated diffusers snapshot of \
+                 black-forest-labs/FLUX.2-dev (transformer/ text_encoder/ vae/ tokenizer/ \
+                 model_index.json)."
+            ));
+        }
+        let canonical = std::fs::canonicalize(&src).map_err(|error| error.to_string())?;
+        std::os::unix::fs::symlink(&canonical, out_dir.join(sub))
+            .map_err(|error| error.to_string())?;
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn convert_flux2_dev_prequant(
+    _source_dir: &Path,
+    _out_dir: &Path,
+    _bits: i32,
+    _group_size: i32,
+) -> Result<(), String> {
+    Err(
+        "FLUX.2-dev conversion requires macOS (mlx-gen-flux2); this model is macOS-only."
+            .to_owned(),
+    )
+}
+
 /// The base `Lightricks/LTX-2.3` latent upsampler the LTX loader hard-requires (emitted as
 /// `upsampler.safetensors` in the converted dir). Neither the eros nor the base single-file
 /// checkpoint bundles it, so the converter merges it from the base repo at convert time.
@@ -510,13 +573,21 @@ enum ConvertPlan {
         upscaler_dir: PathBuf,
         bits: i32,
     },
+    /// FLUX.2-dev gated diffusers snapshot → packed Q`bits` dir (sc-5921): pre-quantize the DiT +
+    /// Mistral text encoder on disk, symlink the unchanged VAE/tokenizer/model_index.json.
+    Flux2Dev {
+        source_dir: PathBuf,
+        bits: i32,
+        group_size: i32,
+    },
 }
 
 /// Convert a model's native checkpoint into the local MLX format on macOS/Apple Silicon, fully
 /// in-process via the linked `mlx-gen-*` converters (epic 2337). The native checkpoint must already
 /// be downloaded into the Hugging Face cache (via a model_download job). The converter is selected by
-/// the manifest `mlx.converter` discriminator: `flux2_klein_diffusers` (sc-3136) or `ltx_video`
-/// (mlx-gen-ltx) — the only models that still install via in-app conversion. The Python
+/// the manifest `mlx.converter` discriminator: `flux2_klein_diffusers` (sc-3136), `ltx_video`
+/// (mlx-gen-ltx), or `flux2_dev_quant` (FLUX.2-dev pre-quantization, sc-5921) — the models that
+/// install via in-app conversion. The Python
 /// `mlx_video.convert_wan` subprocess + `SCENEWORKS_PYTHON` wiring were retired here (sc-3240); the
 /// Wan2.2 converters were decommissioned once those models flipped to pre-converted SceneWorks
 /// downloads (sc-5603, epic 5594).
@@ -577,6 +648,7 @@ pub(crate) async fn run_model_convert_job(
     // `mlx_video.convert_wan` subprocess and its mlx-video venv were retired at this cutover.
     //   flux2_klein_diffusers          -> FLUX.2-klein single-file → diffusers dir (sc-3136)
     //   ltx_video                      -> single-file LTX-2.3 → split MLX dir (mlx-gen-ltx)
+    //   flux2_dev_quant                -> FLUX.2-dev diffusers snapshot → packed Q4 dir (sc-5921)
     let converter = optional_payload_string(&job.payload, "converter")
         .map(str::to_owned)
         .unwrap_or_default();
@@ -676,6 +748,23 @@ pub(crate) async fn run_model_convert_job(
                 bits,
             }
         }
+        "flux2_dev_quant" => {
+            // FLUX.2-dev is self-contained (its own VAE/tokenizer/TE in the snapshot), so the whole
+            // gated diffusers snapshot dir is the convert source — no single source file, no base
+            // repo. Q4 is mandatory (in-app Q4 load of the dense bf16 would peak ~105 GB), so default
+            // to Q4 / group-size 64 when the request omits them.
+            let bits = quantize_bits.map_or(4, |bits| bits as i32);
+            let group_size = job
+                .payload
+                .get("quantizeGroupSize")
+                .and_then(Value::as_u64)
+                .map_or(64, |group| group as i32);
+            ConvertPlan::Flux2Dev {
+                source_dir: checkpoint_dir.clone(),
+                bits,
+                group_size,
+            }
+        }
         "" => {
             fail_job(
                 api,
@@ -764,6 +853,16 @@ pub(crate) async fn run_model_convert_job(
         } => {
             tokio::task::spawn_blocking(move || {
                 convert_ltx_native(&source_file, &upscaler_dir, &temp, bits)
+            })
+            .await
+        }
+        ConvertPlan::Flux2Dev {
+            source_dir,
+            bits,
+            group_size,
+        } => {
+            tokio::task::spawn_blocking(move || {
+                convert_flux2_dev_prequant(&source_dir, &temp, bits, group_size)
             })
             .await
         }

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -664,6 +664,9 @@ fn model_table_rows_resolve_and_flags_match_descriptor() {
         ("flux2_klein_9b", true, false),
         ("flux2_klein_9b_kv", true, false),
         ("flux2_klein_9b_true_v2", true, false),
+        // FLUX.2-dev (epic 5914 / sc-5921): its own `flux2_dev` engine id, embedded distilled
+        // guidance (supports_guidance=true) with no negative prompt / true-CFG.
+        ("flux2_dev", true, false),
         ("sdxl", true, true),
         ("realvisxl", true, true),
         ("kolors", true, true),


### PR DESCRIPTION
**Epic 5914, slice B1 ([sc-5921](https://app.shortcut.com/trefry/story/5921)).** Wires the native mlx-gen **FLUX.2-dev** image model into SceneWorks end-to-end for **text-to-image**, making it selectable in Image Studio on Mac and dispatchable to the engine. The engine vertical (Mistral3 TE + 48/48/15360 DiT + embedded-guidance T2I pipeline, real-weight validated) merged in [mlx-gen #469–#472](https://github.com/michaeltrefry/mlx-gen/pull/472); this is the SceneWorks integration.

## What's wired
- **Manifest** (`builtin.models.jsonc`): `flux2_dev` entry — family `flux2-dev`, `mlx_flux2` adapter, `text_to_image` only (edit is sc-5919/5922), `mlx.quantize:4` + `minMemoryGb:96`, `requiresConversion` + the new `flux2_dev_quant` converter, gated BFL download **scoped to the diffusers subdirs (~113 GiB)** to skip the redundant ~60 GB root single-file, embedded-guidance defaults (28 steps / guidance 4.0). New prompt guide `flux2-dev.md`.
- **Worker** (`engines.rs`, `model_jobs.rs`): `MODEL_TABLE` row (`engine_id: flux2_dev`) + the `flux2_dev_quant` install-time convert job. It **pre-quantizes the DiT + Mistral TE to Q4 on disk** (`quantize_flux2_dit` / `quantize_flux2_text_encoder_dir`) and symlinks the unchanged `vae`/`tokenizer`/`model_index.json` — because in-app Q4 load of the dense bf16 snapshot peaks ~105 GB (> the 128 GB ceiling), while the offline prequant peaks ~34.5 GB. Txt2img routes through the generic `ImageRoute::Mlx` path; the load-time `.quantize()` is a verified no-op on already-packed weights.
- **Core** (`jobs_store.rs`, `lora_family.rs`): routes `flux2_dev` to the mlx worker, accepts the new converter in `classify_convert_gap`, maps the `flux2-dev` family → `flux2` LoRAs.
- **Catalog** (`models.rs`, existing mechanism): `inject_converted_model_path` injects the `modelPath` seam for dev's **subdir** converted layout via its top-level `model_index.json` marker (no root `config.json`). The gated-download cache-health check already tolerates the glob include-patterns.

## Why no turnkey re-host
FLUX.2-dev is gated + FLUX Non-Commercial — **redistribution is prohibited**, so a `SceneWorks/flux2-dev-mlx` turnkey is off the table (same posture as klein). The gated BFL download + on-disk convert is the only viable path.

## mlx-gen pin bump
Bumps the worker's mlx-gen pin `32fdb34` → `154af37` (PRs #469–472) to bring the `flux2_dev` engine id + the pre-quant convert API into the registry. **mlx-rs unchanged (`44929a0`)** so MLX core doesn't rebuild; the gen-core delta is +27 additive lines (`ChatTemplate::Flux2DevMistral`). The **default skew gate (the PR gate) stays single-rev** — it's blind to candle-gen. The `--features backend-candle` lane is skewed (candle-gen still pins gen-core `32fdb34`), but that lane is **workflow_dispatch-only (not a PR gate)** and build-windows builds without backend-candle, so this PR is unaffected; candle catches up in its own repo (same deferral as the `32fdb34` bump, tracked sc-5905).

## Validation (local, M5 Max 128 GB)
- `cargo test` green: worker lib **302 passed / 0 failed**, core **30 + integration** (flux2_dev routing + convert-gap), rust-api **114** (modelPath injection for dev's subdir layout).
- `cargo clippy --tests -- -D warnings` clean; `cargo fmt --check` clean; manifest JSONC parses.
- `mlx_model("flux2_dev").unwrap()` resolves through the linked registry (proves the force-link + descriptor registration); `flux2_edit_engine_id("flux2_dev")` is `None` (T2I-only).
- Real-weight worker e2e (`#[ignore]` `flux2_dev_real_weights`) is the sc-5923 validation boundary; the engine itself was real-weight validated in sc-2365 (1024²/28 coherent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)