### PR TITLE
build: automatic version bumping via npm version (sc-6012)

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sceneworks/web",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sceneworks/web",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "konva": "^9.3.22",
         "react": "18.3.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sceneworks/web",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite --host 0.0.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "api:build:embedded": "npm run web:build && cargo build -p sceneworks-rust-api --release --features embed-web",
     "api:build:embedded:candle": "npm run web:build && cargo build -p sceneworks-rust-api --release --features embed-web,backend-candle",
     "tauri:dev": "npm --prefix apps/desktop run dev",
-    "tauri:build": "npm --prefix apps/desktop run build"
+    "tauri:build": "npm --prefix apps/desktop run build",
+    "version": "node scripts/sync-version.mjs && git add apps/desktop/tauri.conf.json apps/desktop/package.json apps/desktop/package-lock.json apps/web/package.json apps/web/package-lock.json"
   },
   "engines": {
     "node": ">=20"

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+// Propagate the version to every file Tauri + npm read, so one `npm version` at
+// the repo root bumps the whole product atomically. Wired as the root
+// package.json `version` lifecycle script: npm bumps the root package.json first,
+// then runs this (before the version commit), so the synced files land in the
+// SAME commit + tag — the git tag can never drift from the shipped version.
+//
+//   npm version 0.3.0        # bump everything -> one commit "0.3.0" -> tag v0.3.0
+//   git push --follow-tags   # triggers .github/workflows/release.yml
+//
+// tauri.conf.json's `version` names the bundled .app / DMG (the artifact-critical
+// field). The sub-package versions are bumped with `npm version` so each
+// package.json AND its package-lock.json stay in lockstep — a mismatch can fail
+// the `npm ci` the release workflow runs.
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+// `npm version` already wrote the new version into the root package.json; mirror it.
+const version = JSON.parse(
+  readFileSync(join(repoRoot, "package.json"), "utf8"),
+).version;
+if (!version) {
+  console.error("sync-version: no version in root package.json");
+  process.exit(1);
+}
+
+// Sub-packages with lockfiles: use `npm version` so package.json AND
+// package-lock.json move together. --allow-same-version makes an already-aligned
+// package a no-op (idempotent re-runs).
+for (const dir of ["apps/desktop", "apps/web"]) {
+  execFileSync(
+    "npm",
+    ["version", version, "--no-git-tag-version", "--allow-same-version"],
+    { cwd: join(repoRoot, dir), stdio: "inherit" },
+  );
+}
+
+// tauri.conf.json has no lockfile — surgical replace of the first `"version": "…"`
+// to preserve exact formatting (no JSON reparse/reformat churn).
+const conf = join(repoRoot, "apps", "desktop", "tauri.conf.json");
+const before = readFileSync(conf, "utf8");
+const after = before.replace(/"version":\s*"[^"]*"/, `"version": "${version}"`);
+if (after === before) {
+  console.error('sync-version: no "version" field found in tauri.conf.json');
+  process.exit(1);
+}
+writeFileSync(conf, after);
+
+console.log(
+  `sync-version: apps/desktop + apps/web + tauri.conf.json synced to ${version}`,
+);


### PR DESCRIPTION
Resolves the version-drift gotcha surfaced in sc-5930 (task sc-6012): the release version lived in **4 files**, and `apps/web` had already drifted to `0.1.0` while everything else was `0.2.0`. Now one command bumps them all atomically, and the git tag is created *from* the bump so it can't disagree with the shipped artifact.

## Change

- **`scripts/sync-version.mjs`** — propagates the root `version` to `apps/desktop` + `apps/web` via `npm version --no-git-tag-version` (keeps each `package.json` **and** its `package-lock.json` in lockstep — a mismatch can fail the `npm ci` the release workflow runs), and to `tauri.conf.json` via a surgical regex (no lockfile; its `version` names the DMG/.app).
- **`package.json`** — a `version` lifecycle hook runs the sync and stages the files, so they land in the version commit.
- Realigns **`apps/web` 0.1.0 → 0.2.0** (the existing drift — exactly what this prevents).

## New release flow

```
npm version 0.3.0          # one commit "0.3.0" + tag v0.3.0
git push --follow-tags     # triggers .github/workflows/release.yml
```

## Verified

Ran `npm version 0.2.1` on this branch → a **single commit** touching all 6 version files (`package.json`, `tauri.conf.json`, and both sub-packages' `package.json` + `package-lock.json`), every file reading `0.2.1`, plus tag `v0.2.1`; then reverted the test. Confirmed it updates the lockfiles' version too — which a hand-edit would silently miss and break `npm ci`.

Makes the sc-6012 tag/conf-version guard unnecessary by construction.

Story: sc-5930 (task sc-6012).

🤖 Generated with [Claude Code](https://claude.com/claude-code)