### PR TITLE
ci(release): generate-notes changelog + bump actions to v5 (sc-5938)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,9 +43,9 @@ jobs:
       APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
       APPLE_API_KEY_PATH: ${{ secrets.APPLE_API_KEY_PATH }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
 
@@ -71,7 +71,9 @@ jobs:
         run: node apps/desktop/scripts/staple-dmg.mjs
 
       # Create a DRAFT release with the already-stapled DMG attached (review before
-      # publishing). Tags with a pre-release suffix (e.g. v1.2.3-rc.1) are marked
+      # publishing). The body is a fixed install blurb followed by auto-generated
+      # notes (--generate-notes appends a changelog of merged PRs since the last
+      # release). Tags with a pre-release suffix (e.g. v1.2.3-rc.1) are marked
       # prerelease. The tag name goes through an env var, not inline `${{ }}`, to
       # avoid script-injection from the ref.
       - name: Draft GitHub Release with the stapled DMG
@@ -86,7 +88,7 @@ jobs:
             echo "No DMG produced under target/release/bundle/dmg/" >&2
             exit 1
           fi
-          args=(--draft --title "SceneWorks $TAG"
+          args=(--draft --generate-notes --title "SceneWorks $TAG"
                 --notes "Signed & notarized macOS build (Apple Silicon, macOS 26.2+). Open the DMG and drag SceneWorks to Applications.")
           case "$TAG" in *-*) args+=(--prerelease) ;; esac
           gh release create "$TAG" "${args[@]}" "${dmgs[0]}"


### PR DESCRIPTION
The last two minor items on sc-5930.

## Changes (release.yml only)

1. **Auto changelog (sc-5938):** `gh release create` now passes `--generate-notes`, so the release body = the fixed install blurb **followed by** an auto-generated changelog of merged PRs since the last release.
2. **Node-20 deprecation:** `actions/checkout@v4 → @v5`, `actions/setup-node@v4 → @v5` (GitHub is moving JS action runtimes to Node 24; the prior run was green but threw the deprecation annotation).

## Scope

Confined to `release.yml`. The other workflows (`check.yml`, `desktop-*.yml`, `macos-mlx.yml`) carry the same `@v4` deprecation — left for a separate sweep, out of scope here.

## Verification

Low-risk: `--generate-notes` is a documented `gh` flag; the action bumps would fail **fast** at the checkout/setup-node steps (first ~30s) if the runner couldn't run Node-24 actions. A full test-tag run can confirm end-to-end — happy to drive one, but it ties up the nax runner for a full build, so I'm flagging rather than auto-running.

Story: sc-5930 (task sc-5938) + the Node-20 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)