### PR TITLE
sc-5492: wire the candle PuLID-FLUX worker route (pulid_flux_dev off-Mac)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -444,7 +444,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_distr 0.5.1",
  "safetensors 0.7.0",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=32fdb34991b2945dc4af7d3d5b036239eac4ce81)",
+ "sceneworks-gen-core",
  "serde_json",
  "thiserror 2.0.18",
 ]
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -519,7 +519,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -530,7 +530,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -557,7 +557,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -569,7 +569,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -578,9 +578,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "candle-gen-pulid"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+dependencies = [
+ "candle-core",
+ "candle-gen",
+ "candle-gen-face",
+ "candle-gen-flux",
+ "candle-gen-sdxl",
+ "candle-nn",
+ "candle-transformers",
+ "rand 0.9.4",
+ "rand_distr 0.5.1",
+ "serde_json",
+]
+
+[[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -594,7 +611,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -612,7 +629,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -625,7 +642,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -636,7 +653,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -649,7 +666,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=864aa0c705c82763db388a04664705129e692c5f#864aa0c705c82763db388a04664705129e692c5f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -3260,7 +3277,7 @@ source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552a
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c)",
+ "sceneworks-gen-core",
  "thiserror 2.0.18",
  "tokenizers 0.21.4",
 ]
@@ -5145,18 +5162,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sceneworks-gen-core"
-version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=32fdb34991b2945dc4af7d3d5b036239eac4ce81#32fdb34991b2945dc4af7d3d5b036239eac4ce81"
-dependencies = [
- "inventory",
- "safetensors 0.4.5",
- "serde_json",
- "thiserror 2.0.18",
- "tokenizers 0.21.4",
-]
-
-[[package]]
 name = "sceneworks-rust-api"
 version = "0.2.0"
 dependencies = [
@@ -5205,6 +5210,7 @@ dependencies = [
  "candle-gen-lens",
  "candle-gen-ltx",
  "candle-gen-prompt-refine",
+ "candle-gen-pulid",
  "candle-gen-qwen-image",
  "candle-gen-sdxl",
  "candle-gen-sensenova",
@@ -5244,7 +5250,7 @@ dependencies = [
  "pmetal-mlx-rs",
  "reqwest 0.12.28",
  "sceneworks-core",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c)",
+ "sceneworks-gen-core",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3321,6 +3321,15 @@ fn image_job_is_candle_eligible(job: &JobSnapshot) -> bool {
     if model == "z_image_turbo" && zimage_control_candle_eligible(&job.payload) {
         return true;
     }
+    // PuLID-FLUX face identity (sc-5492, epic 5480): `pulid_flux_dev` is a distinct model id (not a
+    // candle txt2img id), so the `image_request_candle_eligible` gate below would reject it; the candle
+    // `candle-gen-pulid` provider serves it via a bespoke `generate_candle_pulid_stream` lane (the
+    // off-Mac sibling of the macOS `pulid_flux` registry route). Branch it out, returning eligibility
+    // directly — a non-character / reference-less job returns false → falls back to torch/MLX. Mirrors
+    // the worker's `pulid_candle_available`.
+    if model == "pulid_flux_dev" {
+        return pulid_flux_candle_eligible(&job.payload);
+    }
     image_request_candle_eligible(model, &job.payload)
 }
 
@@ -3581,6 +3590,16 @@ fn instantid_mlx_eligible(payload: &Map<String, Value>) -> bool {
 /// Mirrors the candle worker's `instantid_available` gate so the router and worker agree.
 fn instantid_candle_eligible(payload: &Map<String, Value>) -> bool {
     instantid_mlx_eligible(payload)
+}
+
+/// PuLID-FLUX candle-routing conditions (sc-5492, epic 5480). The candle `candle-gen-pulid` provider is
+/// the off-Mac sibling of `mlx-gen-pulid` and serves the IDENTICAL surface (a `character_image` job with
+/// a reference face → the PuLID identity injection on FLUX.1-dev), so the gate is the same as
+/// [`pulid_flux_mlx_eligible`]. Mirrors the candle worker's `pulid_candle_available` gate so the router
+/// and worker agree. `pulid_flux_dev` is a distinct model id (not `flux_dev`), so this never collides
+/// with the FLUX XLabs IP-Adapter lane.
+fn pulid_flux_candle_eligible(payload: &Map<String, Value>) -> bool {
+    pulid_flux_mlx_eligible(payload)
 }
 
 /// SDXL IP-Adapter-Plus candle-routing conditions (sc-5488, epic 5480). The candle `IpAdapterSdxl`
@@ -5706,6 +5725,34 @@ mod candle_routing_tests {
         }))));
         assert!(!flux_ipadapter_candle_eligible(&object(json!({
             "model": "flux_schnell", "referenceAssetId": "a", "maskAssetId": "m"
+        }))));
+    }
+
+    #[test]
+    fn pulid_flux_character_jobs_route_to_candle_off_mac() {
+        // The candle PuLID-FLUX provider (sc-5492) serves the SAME surface as the MLX path off-Mac, so
+        // a `pulid_flux_dev` character_image + referenceAssetId job is candle-eligible via the bespoke
+        // `image_job_is_candle_eligible` branch, NOT the txt2img-only `image_request_candle_eligible`
+        // gate (which rejects `referenceAssetId`, which PuLID requires). The distinct `pulid_flux_dev`
+        // model id cleanly disambiguates it from the FLUX XLabs IP-Adapter lane (`flux_dev`).
+        let payload = json!({
+            "model": "pulid_flux_dev",
+            "mode": "character_image",
+            "referenceAssetId": "asset_1",
+        });
+        assert!(pulid_flux_candle_eligible(&object(payload.clone())));
+        assert!(image_job_is_candle_eligible(&image_generate_job(payload)));
+
+        // No reference face → not candle-eligible (mirrors the MLX gate).
+        assert!(!image_job_is_candle_eligible(&image_generate_job(json!({
+            "model": "pulid_flux_dev",
+            "mode": "character_image"
+        }))));
+        // Non-character mode → not candle-eligible (PuLID is a character flow).
+        assert!(!image_job_is_candle_eligible(&image_generate_job(json!({
+            "model": "pulid_flux_dev",
+            "mode": "text_to_image",
+            "referenceAssetId": "asset_1"
         }))));
     }
 

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -196,6 +196,12 @@ backend-candle = [
     # NOT an inventory-registered `Generator`, so the worker `generate_instantid_stream` path calls it
     # directly off-Mac — retiring the Python `_vendor/instantid`.
     "dep:candle-gen-instantid",
+    # sc-5492 (epic 5480): the candle PuLID-FLUX face-identity provider — the Windows/CUDA sibling of
+    # `mlx-gen-pulid`, composing candle-gen-flux (the forked FLUX DiT + post-block injector seam) +
+    # candle-gen-face (SCRFD/ArcFace + BiSeNet) + the EVA02-CLIP tower / IDFormer / 20 CA modules. A
+    # bespoke provider referenced by name (`PulidFlux::load`), NOT inventory-registered, so the worker
+    # `generate_candle_pulid_stream` path calls it directly off-Mac — retiring the torch PuLID adapter.
+    "dep:candle-gen-pulid",
 ]
 
 [target.'cfg(target_os = "macos")'.dependencies]
@@ -718,38 +724,38 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154a
 # parent), so 864aa0c still resolves gen-core `32fdb34` == this worker's mlx-gen pin (single gen-core rev,
 # no skew). With this all three candle strict-pose families (qwen / kolors / z_image) are wired.
 [target.'cfg(target_os = "windows")'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa0c705c82763db388a04664705129e692c5f", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa0c705c82763db388a04664705129e692c5f", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa0c705c82763db388a04664705129e692c5f", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa0c705c82763db388a04664705129e692c5f", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa0c705c82763db388a04664705129e692c5f", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa0c705c82763db388a04664705129e692c5f", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa0c705c82763db388a04664705129e692c5f", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa0c705c82763db388a04664705129e692c5f", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa0c705c82763db388a04664705129e692c5f", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa0c705c82763db388a04664705129e692c5f", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -758,19 +764,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa0c705c82763db388a04664705129e692c5f", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa0c705c82763db388a04664705129e692c5f", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa0c705c82763db388a04664705129e692c5f", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -779,12 +785,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa0c705c82763db388a04664705129e692c5f", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa0c705c82763db388a04664705129e692c5f", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -792,7 +798,16 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "864aa0c705c82763db388a04664705129e692c5f", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+# Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
+# `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
+# registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
+# `generate_candle_pulid_stream`, composing candle-gen-flux (the forked FLUX DiT + its post-block
+# `DitImageInjector` seam) + candle-gen-face (SCRFD/ArcFace + BiSeNet `face_features_image`) + the
+# EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
+# candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
+# build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 154af37, matching mlx-gen).
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -195,6 +195,15 @@ use candle_gen_kolors::{KolorsControl, KolorsControlPaths, KolorsControlRequest}
 // drives.
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
 use candle_gen_z_image::{ZImageControl, ZImageControlPaths, ZImageControlRequest};
+// PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the candle (Windows/CUDA) sibling of the
+// macOS `pulid_flux` registry generator, living in `candle-gen-pulid` (the EVA02-CLIP tower + IDFormer
+// + the 20 PerceiverAttentionCA modules injected into the forked FLUX DiT via the post-block
+// `DitImageInjector` seam, composing the gen-core FaceEmbedder + the BiSeNet `face_features_image`).
+// Candle-only: macOS keeps the inventory-registered `pulid_flux` MLX generator; the candle `PulidFlux`
+// is a bespoke provider referenced BY NAME (like `InstantId`), so no `as _;` anchor is needed — this is
+// the named-type import the bespoke route (`image_jobs/pulid_candle.rs`) drives.
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+use candle_gen_pulid::{PulidFlux, PulidFluxPaths, PulidFluxRequest};
 
 /// The stub adapter id recorded on generated assets (matches the contract fixture
 /// `tests/fixtures/rust_migration_contracts/sidecars/asset-image.sceneworks.json`).
@@ -519,6 +528,23 @@ pub(crate) async fn run_image_generate_job(
         // would be caught by the txt2img branch and silently drop the reference (the SDXL/Kolors IP
         // reasoning, for FLUX).
         generate_candle_flux_ipadapter_stream(
+            api,
+            settings,
+            job,
+            &plan,
+            &project_path,
+            backend,
+            &mut asset_writes,
+        )
+        .await?;
+        true
+    } else if settings.backend_candle_enabled && pulid_candle_available(&request, settings) {
+        // PuLID-FLUX face identity (sc-5492) — `pulid_flux_dev` is its OWN model id (not a candle
+        // txt2img id), so it would never be caught by the `is_candle_engine` branch below; routed here
+        // (grouped with the reference/identity lanes) to the bespoke candle `PulidFlux` stream. The
+        // distinct model id cleanly disambiguates it from the FLUX XLabs IP-Adapter lane above (both
+        // condition on a reference image, but that lane is `flux_dev`/`flux_schnell`).
+        generate_candle_pulid_stream(
             api,
             settings,
             job,
@@ -1098,6 +1124,11 @@ include!("image_jobs/kolors_control.rs");
 // MLX `z_image_turbo_control` registry generator; the candle `ZImageControl` is a bespoke provider.
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
 include!("image_jobs/zimage_control.rs");
+// PuLID-FLUX face identity — the Windows/CUDA candle lane ONLY (sc-5492). macOS keeps the
+// inventory-registered `pulid_flux` MLX generator (image_jobs/pulid.rs); the candle `PulidFlux` is a
+// bespoke provider, so this file is candle-gated and distinct from the macOS route.
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+include!("image_jobs/pulid_candle.rs");
 #[cfg(target_os = "macos")]
 // PuLID-FLUX native routing.
 include!("image_jobs/pulid.rs");

--- a/crates/sceneworks-worker/src/image_jobs/pulid_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/pulid_candle.rs
@@ -1,0 +1,357 @@
+// Candle (Windows/CUDA) PuLID-FLUX face-identity route (sc-5492, epic 5480) — identity-preserving
+// `character_image` generation on FLUX.1-dev off-Mac via `candle_gen_pulid::PulidFlux`. The candle
+// sibling of the macOS `pulid_flux` registry route (image_jobs/pulid.rs): the reference face →
+// SCRFD/ArcFace + BiSeNet `face_features_image` → EVA02-CLIP tower → IDFormer → 20 PerceiverAttentionCA
+// modules injected into the FLUX DiT, denoised with the FLUX flow-match schedule (a single distilled
+// forward per step).
+//
+// **Candle-only.** macOS keeps the inventory-registered `pulid_flux` MLX generator (it rides the
+// shared `start_cached_gen_stream` registry path with an env-var weight seam); the candle `PulidFlux`
+// is a bespoke provider taking explicit weight paths, so this whole file is gated to the Windows/CUDA
+// candle build (the `include!` in image_jobs.rs carries the cfg). It is `include!`d into the
+// `image_jobs` module, so it shares that module's imports (ImageRequest/Settings/WorkerResult/`advanced`/
+// `load_reference_image`/`huggingface_snapshot_dir`/`ensure_hf_cached_file`/`start_gen_stream`/… all in
+// scope unqualified). Distinct model id `pulid_flux_dev` (not `flux_dev`) cleanly disambiguates this
+// from the FLUX XLabs IP-Adapter lane (flux_ipadapter.rs).
+
+/// SceneWorks model id for native PuLID-FLUX (FLUX.1-dev backbone + PuLID injection).
+const PULID_CANDLE_MODEL: &str = "pulid_flux_dev";
+/// FLUX.1-dev backbone repo when the manifest omits `repo` (the same default the MLX route uses).
+const PULID_CANDLE_FLUX_REPO: &str = "black-forest-labs/FLUX.1-dev";
+/// The PuLID-FLUX adapter (IDFormer + the 20 PerceiverAttention CA blocks). Public repo.
+const PULID_CANDLE_ADAPTER_REPO: &str = "guozinan/PuLID";
+const PULID_CANDLE_ADAPTER_FILE: &str = "pulid_flux_v0.9.1.safetensors";
+/// The converted-weights bundle (the EVA02-CLIP-L-336 tower + the BiSeNet face-parsing net) — the SAME
+/// `SceneWorks/pulid-flux-mlx` repo the MLX route downloads (the candle EVA/BiSeNet loaders read the
+/// identical mlx-converted layout: OHWI conv, bare keys).
+const PULID_CANDLE_MLX_REPO: &str = "SceneWorks/pulid-flux-mlx";
+const PULID_CANDLE_EVA_FILE: &str = "eva02_clip_l_336.safetensors";
+const PULID_CANDLE_BISENET_FILE: &str = "bisenet_parsing.safetensors";
+/// The SCRFD detector + ArcFace embedder: the SAME converted files InstantID ships (reused from
+/// `SceneWorks/instantid-mlx`); only EVA + BiSeNet + the PuLID adapter are PuLID-specific.
+const PULID_CANDLE_FACE_REPO: &str = "SceneWorks/instantid-mlx";
+const PULID_CANDLE_SCRFD_FILE: &str = "scrfd_10g.safetensors";
+const PULID_CANDLE_ARCFACE_FILE: &str = "arcface_iresnet100.safetensors";
+/// Both bundle repos ship the safetensors on `main`.
+const PULID_CANDLE_REVISION: &str = "main";
+
+/// Torch/MLX-parity defaults (the `pulid_flux_dev` "photoreal" preset): 30 steps at guidance 4.0,
+/// id_weight 1.0.
+const PULID_CANDLE_DEFAULT_STEPS: u32 = 30;
+const PULID_CANDLE_DEFAULT_GUIDANCE: f32 = 4.0;
+const PULID_CANDLE_DEFAULT_ID_WEIGHT: f32 = 1.0;
+/// The adapter/engine id recorded on candle PuLID-FLUX assets + telemetry (distinct from the macOS
+/// `mlx_pulid_flux` label and the txt2img `candle_flux` lane).
+const PULID_CANDLE_ENGINE: &str = "candle_pulid_flux";
+
+/// Resolve the FLUX.1-dev backbone snapshot for candle PuLID-FLUX: an explicit `modelPath` dir
+/// (advanced or manifest) wins, else the HF cache snapshot for the manifest `repo` (default
+/// FLUX.1-dev). `None` means the base is not present locally, so the job is not candle-runnable (falls
+/// through to torch). Mirrors `resolve_flux_ipadapter_base` / the MLX `resolve_pulid_flux_base`.
+fn resolve_pulid_candle_base(
+    request: &ImageRequest,
+    settings: &Settings,
+) -> WorkerResult<Option<PathBuf>> {
+    if let Some(path) = request
+        .advanced
+        .get("modelPath")
+        .or_else(|| request.model_manifest_entry.get("modelPath"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+    {
+        return resolve_app_managed_model_dir(settings, &path, "PuLID-FLUX modelPath").map(Some);
+    }
+    let repo = request
+        .model_manifest_entry
+        .get("repo")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(PULID_CANDLE_FLUX_REPO);
+    Ok(huggingface_snapshot_dir(&settings.data_dir, repo))
+}
+
+/// True when this is a candle-eligible PuLID-FLUX job: the `pulid_flux_dev` model in `character_image`
+/// mode with a reference face whose FLUX.1-dev base resolves locally. Mirrors
+/// `jobs_store::pulid_flux_candle_eligible` so the router and worker agree (and the MLX
+/// `pulid_flux_available`). PuLID-FLUX is text-to-image-with-a-face only — no `edit_image`.
+fn pulid_candle_available(request: &ImageRequest, settings: &Settings) -> bool {
+    request.model == PULID_CANDLE_MODEL
+        && request.mode == "character_image"
+        && non_empty(&request.reference_asset_id)
+        && matches!(resolve_pulid_candle_base(request, settings), Ok(Some(_)))
+}
+
+/// Resolve PuLID denoise steps: `advanced.steps` (clamped 1..=80) → manifest `steps` → 30.
+fn pulid_candle_steps(request: &ImageRequest) -> u32 {
+    let parse = |value: &Value| {
+        value
+            .as_u64()
+            .or_else(|| value.as_str()?.trim().parse().ok())
+    };
+    request
+        .advanced
+        .get("steps")
+        .and_then(parse)
+        .or_else(|| request.model_manifest_entry.get("steps").and_then(parse))
+        .map(|steps| steps.clamp(1, 80) as u32)
+        .unwrap_or(PULID_CANDLE_DEFAULT_STEPS)
+}
+
+/// Resolve PuLID guidance: `advanced.guidanceScale` → manifest `guidanceScale` → 4.0 (the FLUX.1-dev
+/// guidance-distilled CFG the distilled single forward consumes).
+fn pulid_candle_guidance(request: &ImageRequest) -> f32 {
+    let manifest_default = request
+        .model_manifest_entry
+        .get("guidanceScale")
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .map(|value| value as f32)
+        .unwrap_or(PULID_CANDLE_DEFAULT_GUIDANCE);
+    advanced::f32_clamped(&request.advanced, "guidanceScale", manifest_default, 0.0..=30.0)
+}
+
+/// The PuLID identity-strength knob → the provider's `id_weight` (0.0 = the no-id ablation = plain
+/// FLUX). Torch/MLX clamp band 0.0–3.0 (the upstream gradio slider), default 1.0.
+fn pulid_candle_id_weight(request: &ImageRequest) -> f32 {
+    advanced::f32_clamped(
+        &request.advanced,
+        "idWeight",
+        PULID_CANDLE_DEFAULT_ID_WEIGHT,
+        0.0..=3.0,
+    )
+}
+
+/// Resolve the PuLID adapter file + the EVA tower file + the native face-stack dir the `PulidFlux`
+/// provider loads, downloading on first use into ONE bundle dir (so it doubles as the provider's
+/// `face_dir`: `candle_gen_face::load_with_parser_on` reads `scrfd_10g` + `arcface_iresnet100` +
+/// `bisenet_parsing` from it by name, ignoring the adapter/EVA files alongside). Resolution: a
+/// `SCENEWORKS_PULID_WEIGHTS` pre-staged bundle dir (all five files present) → a whole-repo HF cache
+/// snapshot per file → download-on-first-use into the app cache. Returns `(adapter, eva, face_dir)`.
+async fn ensure_pulid_candle_weights(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+) -> WorkerResult<(PathBuf, PathBuf, PathBuf)> {
+    // Env override: a pre-staged bundle dir holding all five loose files (the validation layout).
+    if let Ok(root) = std::env::var("SCENEWORKS_PULID_WEIGHTS") {
+        let root = PathBuf::from(root);
+        let adapter = root.join(PULID_CANDLE_ADAPTER_FILE);
+        let eva = root.join(PULID_CANDLE_EVA_FILE);
+        if adapter.is_file()
+            && eva.is_file()
+            && root.join(PULID_CANDLE_SCRFD_FILE).is_file()
+            && root.join(PULID_CANDLE_ARCFACE_FILE).is_file()
+            && root.join(PULID_CANDLE_BISENET_FILE).is_file()
+        {
+            return Ok((adapter, eva, root));
+        }
+    }
+
+    let client = reqwest::Client::new();
+    let context = DownloadContext {
+        api,
+        client: &client,
+        settings,
+        job_id: &job.id,
+        cancel_message: "PuLID-FLUX generation canceled while fetching weights.",
+        fresh_download: false,
+    };
+    // One bundle dir holds every loose file (it IS the provider's face_dir).
+    let bundle = settings.data_dir.join("cache").join("pulid-flux");
+
+    // Resolve one bundle file: a whole-repo HF cache snapshot already carrying it, else download into
+    // `bundle` on first use.
+    async fn resolve_one(
+        context: &DownloadContext<'_>,
+        settings: &Settings,
+        repo: &str,
+        file: &str,
+        bundle: &Path,
+    ) -> WorkerResult<PathBuf> {
+        if let Some(snapshot) = huggingface_snapshot_dir(&settings.data_dir, repo)
+            .map(|snapshot| snapshot.join(file))
+            .filter(|path| path.is_file())
+        {
+            return Ok(snapshot);
+        }
+        let dst = bundle.join(file);
+        ensure_hf_cached_file(context, repo, PULID_CANDLE_REVISION, file, &dst).await?;
+        Ok(dst)
+    }
+
+    // PuLID adapter (public guozinan/PuLID) + EVA (SceneWorks bundle). These may resolve to a separate
+    // whole-repo snapshot, so keep their resolved paths (NOT assumed to be in `bundle`).
+    let adapter = resolve_one(
+        &context,
+        settings,
+        PULID_CANDLE_ADAPTER_REPO,
+        PULID_CANDLE_ADAPTER_FILE,
+        &bundle,
+    )
+    .await?;
+    let eva = resolve_one(
+        &context,
+        settings,
+        PULID_CANDLE_MLX_REPO,
+        PULID_CANDLE_EVA_FILE,
+        &bundle,
+    )
+    .await?;
+    // The three face-stack files MUST land together in `bundle` (the provider's face_dir), so download
+    // each straight into it rather than accepting a scattered whole-repo snapshot.
+    for (repo, file) in [
+        (PULID_CANDLE_FACE_REPO, PULID_CANDLE_SCRFD_FILE),
+        (PULID_CANDLE_FACE_REPO, PULID_CANDLE_ARCFACE_FILE),
+        (PULID_CANDLE_MLX_REPO, PULID_CANDLE_BISENET_FILE),
+    ] {
+        ensure_hf_cached_file(&context, repo, PULID_CANDLE_REVISION, file, &bundle.join(file)).await?;
+    }
+
+    Ok((adapter, eva, bundle))
+}
+
+/// Flat telemetry recorded on candle PuLID-FLUX assets (parity with the MLX `pulidFlux` recipe keys).
+fn pulid_candle_raw_settings(
+    request: &ImageRequest,
+    repo: &str,
+    steps: u32,
+    guidance: f32,
+    id_weight: f32,
+) -> JsonObject {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("repo".to_owned(), Value::String(repo.to_owned()));
+    raw.insert("pulidFlux".to_owned(), Value::Bool(true));
+    raw.insert("numInferenceSteps".to_owned(), json!(steps));
+    raw.insert("guidanceScale".to_owned(), json!(guidance));
+    raw.insert("idWeight".to_owned(), json!(id_weight));
+    raw.insert(
+        "pulidFluxEngine".to_owned(),
+        Value::String(PULID_CANDLE_ENGINE.to_owned()),
+    );
+    raw
+}
+
+/// Real candle PuLID-FLUX generation: resolve the reference + weights on the async side, then load the
+/// `PulidFlux` provider once + generate each image on the blocking thread. `request.count` images, each
+/// its own seed; `idWeight` rides the provider's `id_weight`. `generate` takes `&self` (the id_embedding
+/// and CA injector are built per call), so — like the FLUX IP lane — the per-item closure needs no
+/// `mut`. Reuses the shared streaming seam (`consume_gen_events`) so step/cancel/asset behavior matches
+/// every other candle family.
+async fn generate_candle_pulid_stream(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+    let flux_base = resolve_pulid_candle_base(request, settings)?.ok_or_else(|| {
+        WorkerError::InvalidPayload("PuLID-FLUX base (FLUX.1-dev) not found".to_owned())
+    })?;
+    let reference_id = request
+        .reference_asset_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload("PuLID-FLUX requires a reference face image".to_owned())
+        })?;
+    let reference = load_reference_image(
+        &settings.data_dir,
+        &request.project_id,
+        reference_id,
+        project_path,
+    )?;
+    let (adapter, eva, face_dir) = ensure_pulid_candle_weights(api, settings, job).await?;
+
+    let steps = pulid_candle_steps(request);
+    let guidance = pulid_candle_guidance(request);
+    let id_weight = pulid_candle_id_weight(request);
+    let repo = request
+        .model_manifest_entry
+        .get("repo")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(PULID_CANDLE_FLUX_REPO)
+        .to_owned();
+    let raw_settings = pulid_candle_raw_settings(request, &repo, steps, guidance, id_weight);
+
+    // Per-image work items: (seed, prompt) — `request.count` images at the reference identity.
+    let (width, height) = (request.width, request.height);
+    let work: Vec<(i64, String)> = (0..request.count as usize)
+        .map(|index| (resolve_seed(request, index), request.prompt.clone()))
+        .collect();
+    let total = work.len();
+
+    let (cancel, rx, blocking) = start_gen_stream(
+        job.id.clone(),
+        "pulid_flux",
+        0,
+        move || {
+            let paths = PulidFluxPaths {
+                flux_base,
+                pulid_weights: adapter,
+                eva_weights: eva,
+                face_dir,
+            };
+            let model = PulidFlux::load(&paths).map_err(|error| {
+                WorkerError::Engine(format!("PuLID-FLUX load failed: {error}"))
+            })?;
+            Ok((model, reference))
+        },
+        move |(model, reference), tx, cancel| {
+            drive_gen_items(tx, work, move |_index, (seed, prompt), on_progress| {
+                if cancel.is_cancelled() {
+                    return Ok(None);
+                }
+                let req = PulidFluxRequest {
+                    prompt,
+                    width,
+                    height,
+                    steps: steps as usize,
+                    guidance,
+                    id_weight,
+                    seed: seed as u64,
+                    cancel: cancel.clone(),
+                };
+                let out = match model.generate(&req, &reference, &mut *on_progress) {
+                    Ok(out) => out,
+                    Err(_) if cancel.is_cancelled() => return Ok(None),
+                    Err(error) => {
+                        return Err(WorkerError::Engine(format!(
+                            "PuLID-FLUX generation failed: {error}"
+                        )));
+                    }
+                };
+                Ok(Some((seed, out.width, out.height, out.pixels)))
+            })
+        },
+    );
+
+    consume_gen_events(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        PULID_CANDLE_ENGINE,
+        &raw_settings,
+        total,
+        rx,
+        cancel,
+        blocking,
+        asset_writes,
+    )
+    .await
+}


### PR DESCRIPTION
Wires the candle PuLID-FLUX provider ([candle-gen #83](https://github.com/michaeltrefry/candle-gen/pull/83), GPU-validated — ArcFace identity cosine **0.84**) into the SceneWorks worker, so `pulid_flux_dev` runs off-Mac (the bespoke sibling of the macOS `pulid_flux` registry route). Retires the torch PuLID adapter off-Mac (epic 5480, sc-5492).

### Worker route
- **NEW `crates/sceneworks-worker/src/image_jobs/pulid_candle.rs`** — a candle-only `generate_candle_pulid_stream` (mirrors `flux_ipadapter.rs`): resolve the reference + weights (FLUX.1-dev base + `guozinan/PuLID` adapter + the converted EVA02-CLIP + the scrfd/arcface/bisenet face dir, download-on-first-use into one bundle that doubles as the provider's `face_dir`), load `candle_gen_pulid::PulidFlux` once, generate `request.count` images (`idWeight` → `id_weight`), stream via `consume_gen_events` (per-step progress + mid-denoise cancel).
- **`image_jobs.rs`** — candle-gated `use candle_gen_pulid::{PulidFlux, PulidFluxPaths, PulidFluxRequest}` + the `include!` + a dispatch branch (grouped with the reference/identity lanes, before `is_candle_engine`).
- **`jobs_store.rs`** — `pulid_flux_candle_eligible` (delegates to the MLX gate — `character_image` + `referenceAssetId`) + a `pulid_flux_dev` branch in `image_job_is_candle_eligible` + a routing test (`pulid_flux_character_jobs_route_to_candle_off_mac`). The distinct `pulid_flux_dev` model id cleanly disambiguates from the FLUX XLabs IP-Adapter lane (`flux_dev`/`flux_schnell`).

### Lockstep re-pin (de-skews main)
- Re-pin candle-gen `864aa0c` → `b005cf7` (**[candle-gen #84](https://github.com/michaeltrefry/candle-gen/pull/84)**: gen-core `32fdb34` → `154af37`) + add the `candle-gen-pulid` dep. This aligns candle-gen's gen-core to the worker's mlx-gen pin so `--features backend-candle` resolves **one** gen-core rev again — closing the pre-existing main skew tracked as **sc-5905**. Behavior-neutral (the only gen-core delta is the additive `ChatTemplate::Flux2DevMistral` variant).
- **Merge order:** candle-gen #84 first (so `b005cf7` is reachable from candle-gen main), then this PR.

### Verified
- `sceneworks-core` routing test passes.
- `cargo clippy -p sceneworks-worker --features backend-candle -- -D warnings` clean (sm_120, MSVC 14.44) — compiles `pulid_candle.rs` + `candle-gen-pulid` (CUDA) + links single-rev.
- `cargo fmt --check` clean.

(The default PR CI lane does not build `--features backend-candle`, so the candle compile above was run locally on the RTX PRO 6000 box.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)