### PR TITLE
sc-5928: wire candle SeedVR2 upscaler into the worker off-Mac (image + video)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,6 +627,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "candle-gen-seedvr2"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+dependencies = [
+ "candle-gen",
+ "inventory",
+ "rand 0.9.4",
+ "rand_distr 0.5.1",
+]
+
+[[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
 source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
@@ -5213,6 +5224,7 @@ dependencies = [
  "candle-gen-pulid",
  "candle-gen-qwen-image",
  "candle-gen-sdxl",
+ "candle-gen-seedvr2",
  "candle-gen-sensenova",
  "candle-gen-svd",
  "candle-gen-wan",
@@ -7371,7 +7383,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/apps/web/src/macGating.js
+++ b/apps/web/src/macGating.js
@@ -112,10 +112,11 @@ export function macFeatureBlock(caps, key) {
 // Two engines are platform-restricted (ids match the worker):
 //   * `aura-sr` — a torch-only GigaGAN DROPPED on Mac (sc-3668). Hidden only under active Mac
 //     gating; available on Windows/Linux. Real-ESRGAN is the cross-platform default.
-//   * `seedvr2` — the native-MLX one-step diffusion upscaler (epic 4811 / sc-4815), the INVERSE:
-//     Mac-ONLY (the Windows/Linux backend is the separate Candle port, sc-5157). Gated off the
-//     platform-intrinsic `imageUpscaleSeedvr2` capability (true only on macOS, in any mode), so it
-//     is hidden pre-load and on Windows/Linux and shown on Mac — independent of the gating switch.
+//   * `seedvr2` — the one-step diffusion upscaler (epic 4811 / sc-4815), the INVERSE of AuraSR:
+//     backed by native MLX on Mac and the Candle CUDA port on Windows (sc-5928); Linux candle
+//     enablement is sc-5160. Gated off the platform-intrinsic `imageUpscaleSeedvr2` capability (true
+//     on macOS + Windows, in any mode), so it is hidden pre-load and on Linux and shown on Mac +
+//     Windows — independent of the gating switch.
 export function macUpscaleEngineBlocked(caps, engine) {
   if (engine === "seedvr2") {
     return caps?.features?.imageUpscaleSeedvr2?.supported !== true;

--- a/apps/web/src/macGating.test.js
+++ b/apps/web/src/macGating.test.js
@@ -82,24 +82,31 @@ describe("macGating helpers", () => {
     expect(macUpscaleEngineBlocked(DEFAULT_MAC_CAPABILITIES, "aura-sr")).toBe(false);
   });
 
-  it("offers SeedVR2 only where the capability confirms support — Mac-only (epic 4811 / sc-4815)", () => {
+  it("offers SeedVR2 wherever the capability confirms a backend — Mac + Windows (epic 4811 / sc-5928)", () => {
     // Supported on Mac (the capability is true) → shown.
     expect(macUpscaleEngineBlocked(gating, "seedvr2")).toBe(false);
-    // Pre-load (no features) and on Windows/Linux (capability absent/false) → hidden, even though
-    // gating is inert there. This is the INVERSE of AuraSR's gating.
+    // Pre-load (no features) → hidden until the capability endpoint responds. INVERSE of AuraSR.
     expect(macUpscaleEngineBlocked(DEFAULT_MAC_CAPABILITIES, "seedvr2")).toBe(true);
+    // Windows now has the candle CUDA backend (sc-5928): the capability is true → shown.
     const windows = {
       ...DEFAULT_MAC_CAPABILITIES,
       platform: "windows",
+      features: { imageUpscaleSeedvr2: { supported: true } },
+    };
+    expect(macUpscaleEngineBlocked(windows, "seedvr2")).toBe(false);
+    expect(macUpscaleEngineBlocked(windows, "real-esrgan")).toBe(false);
+    // Linux candle enablement is sc-5160 → capability false → still hidden there.
+    const linux = {
+      ...DEFAULT_MAC_CAPABILITIES,
+      platform: "linux",
       features: {
         imageUpscaleSeedvr2: {
           supported: false,
-          reason: { feature: "image_upscale (SeedVR2)", detail: "Mac-only.", suggestedEpic: "sc-5157" },
+          reason: { feature: "image_upscale (SeedVR2)", detail: "Linux candle pending.", suggestedEpic: "sc-5160" },
         },
       },
     };
-    expect(macUpscaleEngineBlocked(windows, "seedvr2")).toBe(true);
-    expect(macUpscaleEngineBlocked(windows, "real-esrgan")).toBe(false);
+    expect(macUpscaleEngineBlocked(linux, "seedvr2")).toBe(true);
   });
 
   it("blocks a training kernel without a native Rust trainer", () => {

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -2402,6 +2402,9 @@ pub fn mac_capabilities(platform: &str, mac_gating_active: bool) -> MacCapabilit
     // accept the legacy `"darwin"` alias defensively. Drives the platform-intrinsic engine flags
     // (e.g. `imageUpscaleSeedvr2`, which is Mac-only) rather than the gating-rollout flag.
     let is_mac = matches!(platform, "macos" | "darwin");
+    // SeedVR2 has a backend on Mac (native MLX) and Windows (the candle CUDA port, sc-5928); Linux
+    // candle enablement is sc-5160. Drives the platform-intrinsic `imageUpscaleSeedvr2` flag.
+    let seedvr2_supported = is_mac || matches!(platform, "windows");
     let mut features = BTreeMap::new();
     // Third-party LyCORIS (LoHa / non-peft LoKr) now applies on every MLX provider (epic 3641:
     // core loader sc-3642/3643 + SDXL/Wan/LTX sc-3671), so it is no longer a Mac feature gap — the
@@ -2435,24 +2438,26 @@ pub fn mac_capabilities(platform: &str, mac_gating_active: bool) -> MacCapabilit
         },
     );
     features.insert(
-        // SeedVR2 (`engine=seedvr2`) is the native-MLX one-step diffusion upscaler (epic 4811 /
-        // sc-4815) — the INVERSE of AuraSR: it is supported on Mac (in-process `mlx-gen-seedvr2`)
-        // and NOT yet available on Windows/Linux, where the backend is a separate Candle port
-        // (sc-5157). This flag is platform-intrinsic (true only on Mac, regardless of the gating
-        // rollout flag) so the web upscale picker can offer SeedVR2 on Mac and hide it elsewhere —
-        // contrast the other entries here, which describe Mac torch-only gaps the UI hides only
-        // under active gating.
+        // SeedVR2 (`engine=seedvr2`) is the one-step diffusion super-resolution upscaler — native MLX
+        // on Mac (epic 4811 / sc-4815, in-process `mlx-gen-seedvr2`) and the candle CUDA port on
+        // Windows (sc-5928 / epic 5482, `candle-gen-seedvr2`). Both back the same `engine=seedvr2`
+        // image upscale + the net-new `video_upscale`. This flag is platform-intrinsic (a backend
+        // exists, regardless of the gating rollout flag) so the web upscale picker offers SeedVR2 on
+        // Mac AND Windows and hides it only where there is no backend yet. Linux candle enablement is
+        // sc-5160 — until then SeedVR2 stays hidden on Linux (contrast AuraSR, which the UI hides only
+        // under active gating). Must agree with the routing oracle (mlx OR candle claims seedvr2; a
+        // plain torch worker refuses it).
         "imageUpscaleSeedvr2".to_owned(),
         MacFeatureSupport {
-            supported: is_mac,
-            reason: if is_mac {
+            supported: seedvr2_supported,
+            reason: if seedvr2_supported {
                 None
             } else {
                 Some(UnsupportedReason::new(
                     None,
                     "image_upscale (SeedVR2)",
-                    "SeedVR2 is a Mac-only native-MLX upscaler; Windows/Linux support is a separate Candle backend port.",
-                    Some("sc-5157"),
+                    "SeedVR2 runs on Mac (native MLX) and Windows (the candle CUDA backend); Linux candle enablement is in progress.",
+                    Some("sc-5160"),
                 ))
             },
         },
@@ -4222,6 +4227,35 @@ fn video_upscale_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
     matches!(engine.as_str(), "" | "seedvr2" | "seedvr2_3b")
 }
 
+/// Whether an `image_upscale` job explicitly requests the SeedVR2 engine (`engine=seedvr2`, the id the
+/// web sends and the worker accepts). SeedVR2 has no torch backend — it runs on MLX (Mac) or candle
+/// (Windows/Linux) — so this also drives the torch worker's refusal (the inverse of the AuraSR gate).
+/// The image default engine is Real-ESRGAN, so an absent engine is NOT SeedVR2.
+fn upscale_job_requests_seedvr2(job: &JobSnapshot) -> bool {
+    matches!(job.job_type, JobType::ImageUpscale)
+        && job
+            .payload
+            .get("engine")
+            .and_then(Value::as_str)
+            .is_some_and(|engine| engine.trim().eq_ignore_ascii_case("seedvr2"))
+}
+
+/// Whether an `image_upscale` job is candle-eligible (sc-5928, epic 4811 / epic 5482): the candle
+/// SeedVR2 provider (`candle-gen-seedvr2`) serves `engine=seedvr2` off-Mac. Unlike the mlx gate, the
+/// default (`real-esrgan`) engine is NOT candle-eligible — only an explicit SeedVR2 request routes to
+/// the candle worker; Real-ESRGAN / AuraSR have no candle path and stay on the Python torch worker.
+fn upscale_job_is_candle_eligible(job: &JobSnapshot) -> bool {
+    upscale_job_requests_seedvr2(job)
+}
+
+/// Whether a `video_upscale` job is candle-eligible (sc-5928, epic 4811 / epic 5482): the candle
+/// SeedVR2 provider is the off-Mac video upscaler. Mirrors `video_upscale_job_is_mlx_eligible`
+/// exactly (same engine set the worker's `run_video_upscale_job` accepts) — the engine defaults to
+/// `seedvr2` when the payload omits it.
+fn video_upscale_job_is_candle_eligible(job: &JobSnapshot) -> bool {
+    video_upscale_job_is_mlx_eligible(job)
+}
+
 /// Training kernels with NO non-Rust fallback — only the in-process Rust mlx worker
 /// can run them. `ltx_mlx_lora` was Apple-Silicon-only MLX-Python; epic 3039 (sc-3049)
 /// retired that Python trainer, leaving the native Rust LTX trainer as the sole path,
@@ -4401,6 +4435,32 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
         {
             return false;
         }
+        // Image upscale (sc-5928, epic 4811 / epic 5482): the candle worker serves SeedVR2 image
+        // upscaling (`candle-gen-seedvr2`, the Windows/CUDA sibling of mlx-gen-seedvr2). Real-ESRGAN
+        // (the default engine) / AuraSR have no candle path, so a non-SeedVR2 engine is refused and
+        // stays on the Python torch worker.
+        if matches!(job.job_type, JobType::ImageUpscale) && !upscale_job_is_candle_eligible(job) {
+            return false;
+        }
+        // Video upscale (sc-5928): the candle worker serves the net-new SeedVR2 video upscaler. A
+        // non-SeedVR2 engine is refused (no other video-upscale backend exists off-Mac).
+        if matches!(job.job_type, JobType::VideoUpscale)
+            && !video_upscale_job_is_candle_eligible(job)
+        {
+            return false;
+        }
+    }
+    // SeedVR2 upscaling has NO torch backend — it runs on the native MLX worker (Mac) or the candle
+    // worker (Windows/Linux). A plain torch GPU/CPU worker (neither `mlx` nor candle) must refuse a
+    // SeedVR2 `image_upscale` job so it stays queued for the mlx/candle worker instead of being
+    // claimed and failing with "no generator registered". This is the inverse of the AuraSR gate
+    // (torch-only → mlx/candle refuse it). `video_upscale` is candle/mlx-only by capability (a torch
+    // worker never advertises it), so it needs no torch guard here.
+    if !worker.gpu_id.eq_ignore_ascii_case("mlx")
+        && !worker_is_candle(worker)
+        && upscale_job_requests_seedvr2(job)
+    {
+        return false;
     }
     let advertises = |capability: &str| {
         worker
@@ -5524,6 +5584,86 @@ mod candle_routing_tests {
             json!({ "sourceAssetId": "a", "engine": "aura-sr" })
         ))
         .is_err());
+    }
+
+    // ---- Candle SeedVR2 upscale lane (sc-5928) ----
+
+    /// A queued `image_upscale` job carrying `payload`.
+    fn image_upscale_job(payload: Value) -> JobSnapshot {
+        serde_json::from_value(json!({
+            "id": "job_iu",
+            "type": "image_upscale",
+            "status": "queued",
+            "payload": payload,
+            "result": {},
+            "requestedGpu": "auto",
+            "progress": 0,
+            "stage": "queued",
+            "message": "",
+            "attempts": 1,
+            "cancelRequested": false,
+            "createdAt": "2026-06-16T00:00:00Z",
+            "updatedAt": "2026-06-16T00:00:00Z",
+        }))
+        .expect("valid JobSnapshot")
+    }
+
+    /// sc-5928: the candle worker claims `engine=seedvr2` image upscale (the candle-gen-seedvr2
+    /// provider) but refuses Real-ESRGAN (the default), which stays on the Python torch worker.
+    #[test]
+    fn candle_worker_claims_seedvr2_image_upscale_refuses_real_esrgan() {
+        let candle = gpu_worker(&["gpu", "image_upscale", "candle"]);
+        assert!(worker_supports_job(
+            &candle,
+            &image_upscale_job(json!({ "sourceAssetId": "a", "engine": "seedvr2" }))
+        ));
+        // Real-ESRGAN (the default engine) has no candle path → refused → stays on the torch worker.
+        assert!(!worker_supports_job(
+            &candle,
+            &image_upscale_job(json!({ "sourceAssetId": "a", "engine": "real-esrgan" }))
+        ));
+        assert!(!worker_supports_job(
+            &candle,
+            &image_upscale_job(json!({ "sourceAssetId": "a" })) // default = real-esrgan
+        ));
+    }
+
+    /// sc-5928: the candle worker claims the net-new SeedVR2 `video_upscale` (default/seedvr2 ids) and
+    /// refuses other engines, exactly like the mlx worker (the engine set is shared).
+    #[test]
+    fn candle_worker_claims_seedvr2_video_upscale_and_refuses_other_engines() {
+        let candle = gpu_worker(&["gpu", "video_upscale", "candle"]);
+        for engine in [json!("seedvr2"), json!("seedvr2_3b"), Value::Null] {
+            let payload = if engine.is_null() {
+                json!({ "sourceAssetId": "a" })
+            } else {
+                json!({ "sourceAssetId": "a", "engine": engine })
+            };
+            assert!(
+                worker_supports_job(&candle, &video_upscale_job(payload.clone())),
+                "candle should claim video_upscale for {payload}"
+            );
+        }
+        assert!(!worker_supports_job(
+            &candle,
+            &video_upscale_job(json!({ "sourceAssetId": "a", "engine": "aura-sr" }))
+        ));
+    }
+
+    /// sc-5928: SeedVR2 has no torch backend, so a plain torch GPU worker (neither `mlx` nor candle)
+    /// REFUSES a `seedvr2` image upscale — it stays queued for the mlx/candle worker instead of being
+    /// claimed and failing. Real-ESRGAN (the torch engine) is still claimed. The inverse of AuraSR.
+    #[test]
+    fn torch_worker_refuses_seedvr2_image_upscale_but_claims_real_esrgan() {
+        let torch = gpu_worker(&["gpu", "image_upscale"]); // no candle marker, gpu_id != "mlx"
+        assert!(!worker_supports_job(
+            &torch,
+            &image_upscale_job(json!({ "sourceAssetId": "a", "engine": "seedvr2" }))
+        ));
+        assert!(worker_supports_job(
+            &torch,
+            &image_upscale_job(json!({ "sourceAssetId": "a", "engine": "real-esrgan" }))
+        ));
     }
 
     // ---- Candle caption lane (sc-5098) ----

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -2589,16 +2589,22 @@ fn mac_capabilities_master_switch_and_infra_features() {
             )
         })
         .all(|(_, f)| !f.supported));
-    // SeedVR2 is Mac-only (epic 4811 R6): on a non-Mac host the capability is unsupported and
-    // names the Windows/Linux Candle backend port (sc-5157), so the web picker hides it there.
+    // SeedVR2 has a backend on Mac (native MLX) + Windows (candle CUDA, sc-5928); Linux candle
+    // enablement is sc-5160. On the inert Linux host the capability is unsupported and names sc-5160,
+    // so the web picker hides it there.
     assert!(!inert.features["imageUpscaleSeedvr2"].supported);
     assert_eq!(
         inert.features["imageUpscaleSeedvr2"]
             .reason
             .as_ref()
             .and_then(|r| r.suggested_epic.as_deref()),
-        Some("sc-5157")
+        Some("sc-5160")
     );
+    // Windows now carries the candle SeedVR2 backend (sc-5928): the capability is platform-true there
+    // too (not just Mac), so the web picker offers `engine=seedvr2` on Windows.
+    let windows = mac_capabilities("windows", false);
+    assert!(windows.features["imageUpscaleSeedvr2"].supported);
+    assert!(windows.features["imageUpscaleSeedvr2"].reason.is_none());
     // Training kernels with a native Rust trainer stay enabled; LoKr-on-Wan does not.
     assert!(mac
         .training

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -202,6 +202,12 @@ backend-candle = [
     # bespoke provider referenced by name (`PulidFlux::load`), NOT inventory-registered, so the worker
     # `generate_candle_pulid_stream` path calls it directly off-Mac — retiring the torch PuLID adapter.
     "dep:candle-gen-pulid",
+    # sc-5928 (epic 4811 / epic 5482): the candle SeedVR2 one-step diffusion upscaler — the Windows/CUDA
+    # sibling of `mlx-gen-seedvr2`. Self-registers `seedvr2` / `seedvr2_3b` / `seedvr2_7b` (image upscale
+    # + the net-new video upscale) into the shared gen_core inventory; the worker reaches it via
+    # `gen_core::load` from upscale_jobs.rs (image) + video_jobs.rs (video). Real-ESRGAN stays the fast
+    # default; SeedVR2 is the additional high-fidelity / video choice.
+    "dep:candle-gen-seedvr2",
 ]
 
 [target.'cfg(target_os = "macos")'.dependencies]
@@ -808,6 +814,15 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 154af37, matching mlx-gen).
 candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+# Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928, epic 4811 / epic 5482) — the
+# Windows/CUDA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
+# `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
+# quant + the 7B variant from sc-5927) into the shared gen_core inventory. The worker reaches it via
+# `gen_core::load("seedvr2")` / `"seedvr2_3b"` from `upscale_jobs::run_seedvr2_upscale` (image) and
+# `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
+# (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
+# single gen-core pin == the mlx-gen pin 154af37; carries sc-5157/5926/5927 from candle-gen #80/81/82).
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -70,6 +70,22 @@ fn with_candle_capabilities(mut gpu: DiscoveredGpu, settings: &Settings) -> Disc
                     gpu.capabilities.push(capability);
                 }
             }
+            // SeedVR2 image + video upscaling (sc-5928, epic 4811 / epic 5482): the candle SeedVR2
+            // provider (`candle-gen-seedvr2`, force-linked under backend-candle) serves `image_upscale`
+            // AND the net-new `video_upscale` via `gen_core::load("seedvr2")` — the Windows/CUDA sibling
+            // of the Mac mlx-gen-seedvr2 path. These are job-type capabilities (not a generation
+            // modality), so they aren't in `registry_capabilities`; advertise them explicitly. The
+            // routing gate confines the candle worker to the SeedVR2 engine ids
+            // (`upscale_job_is_candle_eligible` / `video_upscale_job_is_candle_eligible`); Real-ESRGAN /
+            // AuraSR have no candle path and stay on the Python torch worker.
+            for capability in [
+                WorkerCapability::ImageUpscale,
+                WorkerCapability::VideoUpscale,
+            ] {
+                if !gpu.capabilities.contains(&capability) {
+                    gpu.capabilities.push(capability);
+                }
+            }
             // The lane marker the routing gate keys off (mirrors the existing `nvidia` marker).
             gpu.capabilities
                 .push(WorkerCapability::Unknown("candle".to_owned()));

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -117,6 +117,13 @@ use candle_gen_z_image as _;
 // keeps the `inventory::submit!` (the dead-strip trap that bit Kolors on MLX).
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
 use candle_gen_lens as _;
+// Candle SeedVR2 upscaler (sc-5928, epic 4811 / epic 5482) — the Windows/CUDA sibling of the Mac
+// `mlx_gen_seedvr2` anchor above. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
+// `seedvr2_7b` into the shared gen_core inventory; the image upscale path reaches it via
+// `gen_core::load("seedvr2")` from `upscale_jobs::run_seedvr2_upscale`. Force-linked so the MSVC
+// release linker keeps the `inventory::submit!` registrations.
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+use candle_gen_seedvr2 as _;
 // CARVE-OUT(epic 3720): backend-specific; absorbed by FaceEmbedder in Phase 3.
 // InstantID (sc-3345) is a bespoke provider, not an inventory-registered `Generator`, so it is
 // referenced by name (`InstantId::load`) rather than anchored with `as _;` — and the native face

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -112,10 +112,15 @@ mod pose_jobs;
 // path stays the Windows/Linux backend.
 #[cfg(target_os = "macos")]
 mod kps_jobs;
-// Real-ESRGAN image upscaling (epic 3482, sc-3489): RRDBNet x2/x4 via `ort`/CoreML,
-// reusing the same bundled onnxruntime sc-3487 ships. macOS-only; the Python torch
-// Real-ESRGAN / AuraSR path stays the Windows/Linux backend.
-#[cfg(target_os = "macos")]
+// Image upscaling: Real-ESRGAN (epic 3482, sc-3489) RRDBNet x2/x4 via `ort`/CoreML on Mac, plus the
+// SeedVR2 one-step diffusion upscaler — native MLX on Mac (sc-4815) and the candle CUDA backend on
+// Windows (sc-5928). So the module compiles on Mac AND the Windows/CUDA candle lane; the ort/CoreML
+// Real-ESRGAN path inside stays Mac-gated (the Python torch Real-ESRGAN / AuraSR path is the
+// Windows/Linux backend), while the SeedVR2 path is backend-neutral (`gen_core::load("seedvr2")`).
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 mod upscale_jobs;
 // YOLO11 person detection via onnxruntime/CoreML (epic 3482, sc-3488/sc-3633).
 // macOS-only like pose_jobs: the `ort` engine + CoreML EP only mean anything on
@@ -145,7 +150,10 @@ use downloads::*;
 use kps_jobs::*;
 #[cfg(target_os = "macos")]
 use pose_jobs::*;
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 use upscale_jobs::*;
 
 const INSTALL_MARKER: &str = ".sceneworks-download-complete.json";
@@ -749,22 +757,28 @@ async fn run_utility_job(
         JobType::KpsExtract => run_kps_extract_job(api, settings, &job)
             .await
             .map_err(|error| ("Keypoint extraction failed.", error)),
-        // Real-ESRGAN image upscaling (epic 3482, sc-3489): RRDBNet x2/x4 via
-        // onnxruntime/CoreML, served in-process by `upscale_jobs::run_image_upscale_job`.
-        // Replaces the Python torch Real-ESRGAN path so the Image Editor upscale tool
-        // works on a Python-free Mac. macOS-only; off macOS `ImageUpscale` is never
-        // advertised by the Rust worker, so this falls to the `_` arm (Python path).
-        // The routing oracle keeps `engine=aura-sr` on the Python worker.
-        #[cfg(target_os = "macos")]
+        // Image upscaling, served in-process by `upscale_jobs::run_image_upscale_job`: Real-ESRGAN
+        // RRDBNet x2/x4 via onnxruntime/CoreML (epic 3482, sc-3489, Mac) + SeedVR2 one-step diffusion
+        // (native MLX on Mac sc-4815 / candle CUDA on Windows sc-5928). Available on Mac AND the
+        // Windows/CUDA candle lane; on a plain Windows/Linux box `ImageUpscale` is never advertised by
+        // the Rust worker, so it falls to the `_` arm (Python Real-ESRGAN/AuraSR). The routing oracle
+        // refuses `engine=seedvr2` on torch and `engine=real-esrgan`/`aura-sr` on the candle worker.
+        #[cfg(any(
+            target_os = "macos",
+            all(target_os = "windows", feature = "backend-candle")
+        ))]
         JobType::ImageUpscale => run_image_upscale_job(api, settings, http_client, &job)
             .await
             .map_err(|error| ("Image upscale failed.", error)),
-        // SeedVR2 video upscaling (epic 4811, sc-4816): native-MLX one-step super-resolution
-        // (`mlx-gen-seedvr2`) — SceneWorks' first video upscaler. Decodes the source clip,
-        // runs the temporal-chunked 5D upscale, re-encodes, and passes the source audio
-        // through. macOS-only; off macOS `VideoUpscale` is never advertised by any worker (no
-        // torch path), so this falls to the `_` arm and the routing oracle reports it unsupported.
-        #[cfg(target_os = "macos")]
+        // SeedVR2 video upscaling (epic 4811): one-step super-resolution — native MLX on Mac (sc-4816)
+        // / candle CUDA on Windows (sc-5928). SceneWorks' first video upscaler: decodes the source
+        // clip, runs the temporal-chunked 5D upscale, re-encodes, and passes the source audio through.
+        // Available on Mac + the Windows/CUDA candle lane; elsewhere `VideoUpscale` is never advertised
+        // (no torch path), so it falls to the `_` arm and the routing oracle reports it unsupported.
+        #[cfg(any(
+            target_os = "macos",
+            all(target_os = "windows", feature = "backend-candle")
+        ))]
         JobType::VideoUpscale => run_video_upscale_job(api, settings, &job)
             .await
             .map_err(|error| ("Video upscale failed.", error)),

--- a/crates/sceneworks-worker/src/upscale_jobs.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs.rs
@@ -30,8 +30,11 @@
 //!    (clamped to image bounds); inner (unpadded) region copied back at factor scale.
 //!  - input RGB f32 CHW in `[0,1]`; output clamp `[0,1]` → round → u8.
 
+// `HashMap`/`Mutex`/`OnceLock` back the Real-ESRGAN per-factor session cache (Mac-only `ort` path).
+#[cfg(target_os = "macos")]
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+#[cfg(target_os = "macos")]
 use std::sync::{Mutex, OnceLock};
 
 use crate::downloads::{ensure_hf_cached_file, DownloadContext};
@@ -41,8 +44,13 @@ use gen_core::{
     WeightsSource,
 };
 use image::RgbImage;
+// Real-ESRGAN runs via `ort` + the CoreML execution provider — Mac-only (the candle Windows lane
+// serves SeedVR2, not Real-ESRGAN; Real-ESRGAN/AuraSR stay on the Python torch worker off-Mac).
+#[cfg(target_os = "macos")]
 use ort::execution_providers::CoreMLExecutionProvider;
+#[cfg(target_os = "macos")]
 use ort::session::Session;
+#[cfg(target_os = "macos")]
 use ort::value::Tensor;
 use serde_json::{json, Value};
 
@@ -54,7 +62,10 @@ use crate::{
 use sceneworks_core::contracts::{JobSnapshot, JobStatus, JsonObject, ProgressStage, WorkerStatus};
 use sceneworks_core::project_store::ProjectStore;
 
+// Real-ESRGAN tiling (Mac-only `ort`/CoreML path).
+#[cfg(target_os = "macos")]
 const TILE_SIZE: usize = 512;
+#[cfg(target_os = "macos")]
 const TILE_PAD: usize = 16;
 const MAX_UPSCALE_TARGET_DIMENSION: u32 = 8192;
 const MAX_UPSCALE_TARGET_PIXELS: u64 =
@@ -65,16 +76,19 @@ const CANCEL_MESSAGE: &str = "Image upscale canceled by user.";
 /// `scripts/spikes/sc3489_export_reference.py`). Public; downloaded on first use,
 /// parity with sc-3487's rtmlib weights. Overridable via the manifest `onnx` resource
 /// or the env pin `SCENEWORKS_REALESRGAN_X{2,4}_ONNX`.
+#[cfg(target_os = "macos")]
 const ONNX_REPO: &str = "SceneWorks/real-esrgan-onnx";
 
+#[cfg(target_os = "macos")]
 fn onnx_file(factor: u8) -> String {
     format!("real_esrgan_x{factor}.onnx")
 }
 
 // ---------------------------------------------------------------------------
-// pure tiling math (ported from upscalers.py; unit-tested without weights)
+// pure tiling math (ported from upscalers.py; unit-tested without weights) — Real-ESRGAN, Mac-only
 // ---------------------------------------------------------------------------
 
+#[cfg(target_os = "macos")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct Tile {
     x0: usize,
@@ -84,6 +98,7 @@ struct Tile {
 }
 
 /// `upscalers.py:tile_slices` — single tile if the image fits, else a row-major grid.
+#[cfg(target_os = "macos")]
 fn tile_slices(w: usize, h: usize, tile: usize) -> Vec<Tile> {
     if tile == 0 || tile >= w.max(h) {
         return vec![Tile {
@@ -112,6 +127,7 @@ fn tile_slices(w: usize, h: usize, tile: usize) -> Vec<Tile> {
 }
 
 /// CHW f32 `[0,1]` for the crop region `[x0,x1) × [y0,y1)` of an RGB image.
+#[cfg(target_os = "macos")]
 fn crop_to_chw(
     img: &RgbImage,
     x0: usize,
@@ -148,21 +164,26 @@ fn validate_upscale_target_dimensions(width: u32, height: u32) -> WorkerResult<(
 }
 
 // ---------------------------------------------------------------------------
-// onnxruntime upscaler (cached per-factor process-wide, like pose_jobs::DETECTOR)
+// onnxruntime upscaler (cached per-factor process-wide, like pose_jobs::DETECTOR) — Real-ESRGAN,
+// Mac-only (`ort`/CoreML). The candle Windows lane serves SeedVR2 (below), not Real-ESRGAN.
 // ---------------------------------------------------------------------------
 
+#[cfg(target_os = "macos")]
 struct Upscaler {
     session: Session,
     #[allow(dead_code)]
     device: &'static str,
 }
 
+#[cfg(target_os = "macos")]
 static UPSCALERS: OnceLock<Mutex<HashMap<u8, Upscaler>>> = OnceLock::new();
 
+#[cfg(target_os = "macos")]
 fn ort_err<R>(e: ort::Error<R>) -> WorkerError {
     WorkerError::Engine(format!("onnxruntime: {e}"))
 }
 
+#[cfg(target_os = "macos")]
 fn build_session(path: &Path, coreml: bool) -> WorkerResult<Session> {
     let mut b = Session::builder().map_err(ort_err)?;
     if coreml {
@@ -173,6 +194,7 @@ fn build_session(path: &Path, coreml: bool) -> WorkerResult<Session> {
     b.commit_from_file(path).map_err(ort_err)
 }
 
+#[cfg(target_os = "macos")]
 impl Upscaler {
     /// Load the session, preferring CoreML and falling back to CPU if the provider
     /// can't initialise (mirrors `pose_jobs::Detector::load`).
@@ -251,6 +273,7 @@ impl Upscaler {
 /// Blocking upscale: load+cache the factor's session (amortising the CoreML graph
 /// compile across a batch), run it. All `ort` objects live inside this closure and
 /// never cross an await (mirrors `pose_jobs::detect_batch`).
+#[cfg(target_os = "macos")]
 fn upscale_blocking(
     onnx_path: PathBuf,
     factor: u8,
@@ -283,6 +306,7 @@ fn upscale_blocking(
 /// (`SCENEWORKS_REALESRGAN_X{factor}_ONNX`, then `SCENEWORKS_REALESRGAN_ONNX`), then the
 /// app cache `<data_dir>/cache/upscale/`, then a manifest `onnx` resource if the job
 /// carried one, else download from the default HF repo.
+#[cfg(target_os = "macos")]
 async fn ensure_onnx(
     api: &ApiClient,
     settings: &Settings,
@@ -336,6 +360,7 @@ async fn ensure_onnx(
 
 /// Pull a `{repo,file}` ONNX resource out of a job's `modelManifestEntry` if present:
 /// `resources.imageUpscalers.real-esrgan.x{factor}.onnx`.
+#[cfg(target_os = "macos")]
 fn manifest_onnx_resource(manifest_entry: &Value, factor: u8) -> Option<(String, String)> {
     let onnx = manifest_entry
         .get("resources")?
@@ -744,48 +769,62 @@ pub(crate) async fn run_image_upscale_job(
         )
         .await?
     } else {
-        update_job(
-            api,
-            &job.id,
-            progress_payload(
-                JobStatus::Running,
-                ProgressStage::Downloading,
-                0.25,
-                "Loading Real-ESRGAN weights.",
-                None,
-                None,
-                None,
-            ),
-        )
-        .await?;
-        let onnx_path =
-            ensure_onnx(api, settings, http_client, job, factor, &manifest_entry).await?;
+        // Real-ESRGAN runs via `ort`/CoreML — Mac-only. Off-Mac the candle worker serves only
+        // `engine=seedvr2` (the routing oracle refuses Real-ESRGAN here, sending it to the Python
+        // torch worker), so this branch is unreachable on the candle lane; keep it a clear error so
+        // the function compiles and a misroute fails loudly rather than silently.
+        #[cfg(target_os = "macos")]
+        {
+            update_job(
+                api,
+                &job.id,
+                progress_payload(
+                    JobStatus::Running,
+                    ProgressStage::Downloading,
+                    0.25,
+                    "Loading Real-ESRGAN weights.",
+                    None,
+                    None,
+                    None,
+                ),
+            )
+            .await?;
+            let onnx_path =
+                ensure_onnx(api, settings, http_client, job, factor, &manifest_entry).await?;
 
-        update_job(
-            api,
-            &job.id,
-            progress_payload(
-                JobStatus::Running,
-                ProgressStage::Running,
-                0.45,
-                &format!("Upscaling {factor}x with Real-ESRGAN."),
-                None,
-                None,
-                None,
-            ),
-        )
-        .await?;
-        let cancel = CancelFlag::new();
-        run_upscale_with_heartbeat(
-            api,
-            settings,
-            &job.id,
-            cancel.clone(),
-            tokio::task::spawn_blocking(move || {
-                upscale_blocking(onnx_path, factor, source_image, cancel)
-            }),
-        )
-        .await?
+            update_job(
+                api,
+                &job.id,
+                progress_payload(
+                    JobStatus::Running,
+                    ProgressStage::Running,
+                    0.45,
+                    &format!("Upscaling {factor}x with Real-ESRGAN."),
+                    None,
+                    None,
+                    None,
+                ),
+            )
+            .await?;
+            let cancel = CancelFlag::new();
+            run_upscale_with_heartbeat(
+                api,
+                settings,
+                &job.id,
+                cancel.clone(),
+                tokio::task::spawn_blocking(move || {
+                    upscale_blocking(onnx_path, factor, source_image, cancel)
+                }),
+            )
+            .await?
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            return Err(WorkerError::InvalidPayload(format!(
+                "engine={engine_id} is not served by the candle worker (it serves engine=seedvr2); \
+                 Real-ESRGAN / AuraSR run on the Python torch worker off-Mac"
+            )));
+        }
     };
     let (out_w, out_h) = (upscaled.width(), upscaled.height());
 

--- a/crates/sceneworks-worker/src/upscale_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs/tests.rs
@@ -2,9 +2,16 @@
 //! needed — these lock the tiling/crop/manifest logic against `upscalers.py`.
 
 use super::*;
+// `Rgb`/`RgbImage` back the Real-ESRGAN tiling/crop tests (Mac-only ort path) AND the SeedVR2
+// real-weight smoke (Mac MLX + the Windows/CUDA candle lane).
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 use image::{Rgb, RgbImage};
 use serde_json::json;
 
+#[cfg(target_os = "macos")]
 #[test]
 fn tile_slices_single_when_image_fits() {
     // tile >= max(w,h) → one tile covering the whole image (upscalers.py).
@@ -22,6 +29,7 @@ fn tile_slices_single_when_image_fits() {
     assert_eq!(tile_slices(512, 512, 512).len(), 1);
 }
 
+#[cfg(target_os = "macos")]
 #[test]
 fn tile_slices_grid_row_major_clamped() {
     // 768x768 @ tile 512 → 2x2 grid, edge tiles clamped to bounds.
@@ -68,11 +76,13 @@ fn tile_slices_grid_row_major_clamped() {
     assert_eq!(covered, 768 * 768);
 }
 
+#[cfg(target_os = "macos")]
 #[test]
 fn tile_slices_zero_tile_is_single() {
     assert_eq!(tile_slices(100, 50, 0).len(), 1);
 }
 
+#[cfg(target_os = "macos")]
 #[test]
 fn crop_to_chw_layout_and_normalization() {
     let mut img = RgbImage::new(3, 2);
@@ -97,6 +107,7 @@ fn crop_to_chw_layout_and_normalization() {
     assert!((data[g_plane - 1] - 1.0).abs() < 1e-6); // R(2,1)=255 last in R plane
 }
 
+#[cfg(target_os = "macos")]
 #[test]
 fn crop_to_chw_subregion() {
     let mut img = RgbImage::new(4, 4);
@@ -114,12 +125,14 @@ fn crop_to_chw_subregion() {
     assert!((data[g + 3] - 20.0 / 255.0).abs() < 1e-6);
 }
 
+#[cfg(target_os = "macos")]
 #[test]
 fn onnx_filename_per_factor() {
     assert_eq!(onnx_file(2), "real_esrgan_x2.onnx");
     assert_eq!(onnx_file(4), "real_esrgan_x4.onnx");
 }
 
+#[cfg(target_os = "macos")]
 #[test]
 fn manifest_onnx_resource_extracts_repo_file() {
     let entry = json!({
@@ -209,7 +222,10 @@ fn manifest_seedvr2_resource_extracts_overrides_and_defaults() {
 
 /// Resolve the locally-cached `numz/SeedVR2_comfyUI` checkpoint dir (env override or the HF cache),
 /// so the smoke below can run on real weights without a download. `None` ⇒ skip.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn cached_seedvr2_checkpoint() -> Option<std::path::PathBuf> {
     if let Ok(pinned) = std::env::var("SCENEWORKS_SEEDVR2_CHECKPOINT") {
         let dir = std::path::PathBuf::from(pinned);
@@ -223,15 +239,21 @@ fn cached_seedvr2_checkpoint() -> Option<std::path::PathBuf> {
     (snap.join(SEEDVR2_DIT_FILE).exists() && snap.join(SEEDVR2_VAE_FILE).exists()).then_some(snap)
 }
 
-/// Real-weight smoke for the SceneWorks SeedVR2 integration (sc-4815): drives the exact worker
-/// dispatch path — `with_cached_generator("seedvr2", …)` → registry → `generate` — on the cached
-/// 3B checkpoint, asserting (a) the factor→`round_to_16` target dims and (b) that the new `softness`
-/// request field actually reaches the engine (a softened run differs from a faithful one). Gated on
-/// the checkpoint being present (skips in CI, which has no weights), mirroring the family worker E2E
-/// smokes. Run with `cargo test -p sceneworks-worker -- --ignored seedvr2_upscale_real_weight_smoke`.
-#[cfg(target_os = "macos")]
+/// Real-weight smoke for the SceneWorks SeedVR2 integration (sc-4815 Mac / sc-5928 candle): drives the
+/// exact worker dispatch path — `with_cached_generator("seedvr2", …)` → registry → `generate` — on the
+/// cached 3B checkpoint, asserting (a) the factor→`round_to_16` target dims and (b) that the `softness`
+/// request field actually reaches the engine (a softened run differs from a faithful one). On Mac this
+/// resolves to the MLX provider; on the Windows/CUDA candle build it resolves to `candle-gen-seedvr2`
+/// (the sc-5928 worker-path validation that the force-link + routing reach the candle engine end-to-
+/// end). Gated on the checkpoint being present (skips in CI, which has no weights), mirroring the
+/// family worker E2E smokes. Set `SCENEWORKS_SEEDVR2_CHECKPOINT` to the ckpt dir and run with
+/// `cargo test -p sceneworks-worker --features backend-candle -- --ignored seedvr2_upscale_real_weight_smoke`.
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 #[tokio::test]
-#[ignore = "real-weight: needs the cached numz/SeedVR2_comfyUI checkpoint (~7 GB); Mac/MLX only"]
+#[ignore = "real-weight: needs the cached numz/SeedVR2_comfyUI checkpoint (~7 GB) + the seedvr2 backend (MLX on Mac / candle on Windows)"]
 async fn seedvr2_upscale_real_weight_smoke() {
     let Some(dir) = cached_seedvr2_checkpoint() else {
         eprintln!("SKIP: SeedVR2 checkpoint not cached (numz/SeedVR2_comfyUI)");

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -84,6 +84,12 @@ use candle_gen_ltx as _;
 use candle_gen_svd as _;
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
 use candle_gen_wan as _;
+// Candle SeedVR2 video upscaler (sc-5928, epic 4811 / epic 5482) — the Windows/CUDA sibling of the
+// Mac `mlx_gen_seedvr2` anchor above. Self-registers `seedvr2_3b` (+ `seedvr2` / `seedvr2_7b`) into
+// the shared gen_core inventory; the `video_upscale` path reaches it via `gen_core::load` from
+// `run_video_upscale_job`. Force-linked so the MSVC release linker keeps the `inventory::submit!`.
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+use candle_gen_seedvr2 as _;
 #[cfg(any(
     target_os = "macos",
     all(target_os = "windows", feature = "backend-candle")
@@ -1036,24 +1042,48 @@ fn video_progress(
 
 /// HF repo hosting the raw SeedVR2 checkpoint (`numz/SeedVR2_comfyUI`); the engine converts it
 /// in-memory at load (no Python). Override the staged dir with `SCENEWORKS_SEEDVR2_DIR`.
-#[cfg(target_os = "macos")]
+// SeedVR2 video upscale runs on Mac (native MLX) AND the Windows/CUDA candle lane (sc-5928); these
+// constants/helpers are backend-neutral (gen_core + ffmpeg + the shared streaming driver).
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 const SEEDVR2_REPO: &str = "numz/SeedVR2_comfyUI";
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 const SEEDVR2_VAE_FILE: &str = "ema_vae_fp16.safetensors";
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 const SEEDVR2_DIT_3B_FILE: &str = "seedvr2_ema_3b_fp16.safetensors";
-/// The engine registry id wired for video upscale (3B; 7B = sc-5197).
-#[cfg(target_os = "macos")]
+/// The engine registry id wired for video upscale (3B; 7B = sc-5197 / sc-5927).
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 const SEEDVR2_ENGINE_ID: &str = "seedvr2_3b";
-/// Adapter id recorded on the result asset (mirrors the other `mlx_*` video adapters).
-#[cfg(target_os = "macos")]
+/// Adapter id recorded on the result asset for provenance (mirrors the other `mlx_*` video adapters;
+/// SeedVR2 itself takes no LoRA — this is metadata only).
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 const SEEDVR2_ADAPTER: &str = "mlx_seedvr2";
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 const SEEDVR2_CANCEL_MESSAGE: &str = "Video upscale canceled by user.";
 
 /// Snap a dimension to the SeedVR2 VAE/patch stride (a multiple of 16, the engine's hard
 /// requirement), rounding to nearest and clamping to the engine's `[16, 4096]` size range.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn snap_seedvr2_dim(value: u32) -> u32 {
     let rounded = value.saturating_add(8) / 16 * 16;
     rounded.clamp(16, 4096)
@@ -1061,7 +1091,10 @@ fn snap_seedvr2_dim(value: u32) -> u32 {
 
 /// Resolve a project-relative asset path safely under `project_path` (reject `..` / absolute
 /// components — same guard as `upscale_jobs::resolve_source`).
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn safe_join(project_path: &Path, rel: &str) -> Option<PathBuf> {
     let mut path = project_path.to_path_buf();
     for component in Path::new(rel).components() {
@@ -1076,7 +1109,10 @@ fn safe_join(project_path: &Path, rel: &str) -> Option<PathBuf> {
 /// Provision the SeedVR2 checkpoint dir: an env-pinned dir (pre-staged for local validation) wins,
 /// else the app cache (download the VAE + 3B DiT from `numz/SeedVR2_comfyUI` on first use). Returns
 /// the dir to hand the engine as `WeightsSource::Dir`.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 async fn ensure_seedvr2_weights(
     api: &ApiClient,
     settings: &Settings,
@@ -1110,7 +1146,10 @@ async fn ensure_seedvr2_weights(
 /// Decode every frame of `source` to an engine [`Image`] sequence (native resolution — the engine
 /// bicubic-upscales internally to the target). Uses the bundled ffmpeg (`run_ffmpeg`) into PNGs in a
 /// temp dir, then loads them in order. `-fps_mode passthrough` keeps the exact source frame count.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 async fn decode_seedvr2_source_frames(
     api: &ApiClient,
     settings: &Settings,
@@ -1171,9 +1210,13 @@ async fn decode_seedvr2_source_frames(
     Ok(frames)
 }
 
-/// Dispatch handler for `JobType::VideoUpscale`: decode the source clip, run the native-MLX SeedVR2
-/// upscaler, re-encode, pass the source audio through, and stream a single upscaled video asset.
-#[cfg(target_os = "macos")]
+/// Dispatch handler for `JobType::VideoUpscale`: decode the source clip, run the SeedVR2 upscaler
+/// (native MLX on Mac / candle CUDA on Windows, sc-5928), re-encode, pass the source audio through,
+/// and stream a single upscaled video asset.
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 pub(crate) async fn run_video_upscale_job(
     api: &ApiClient,
     settings: &Settings,


### PR DESCRIPTION
## sc-5928 — SeedVR2 worker wiring off-Mac (image + video)

Exposes the candle **SeedVR2** engine (sc-5157 image / sc-5926 video / sc-5927 7B+quant) through the worker on **Windows/CUDA** — `image_upscale engine=seedvr2` + the net-new `video_upscale`. The job types, contract, provisioning, and Image/Video Studio+Editor UI shipped with the Mac work (sc-4815/4816); this flips the gating and wires the candle lane. **Real-ESRGAN stays the fast default** — SeedVR2 is the additional high-fidelity / video choice.

### Linking + skew
- Re-pin candle-gen `a610664` → `1f67b59` (main) + add the `candle-gen-seedvr2` dep to the `backend-candle` feature (Windows target, `cuda`). `1f67b59` still pins gen-core `32fdb34` == the worker's mlx-gen pin, so the `--features backend-candle` graph stays **single-rev** (no skew). Force-linked in `image_jobs.rs` + `video_jobs.rs`.

### Worker dispatch (Windows/candle lane)
- `upscale_jobs` now compiles on Mac **and** the Windows/candle lane. The Real-ESRGAN `ort`/CoreML path stays Mac-gated (the candle worker serves only SeedVR2; the else-branch errors off-Mac). `run_image_upscale_job` / `run_video_upscale_job` + the SeedVR2 helpers extended to the candle cfg; the SeedVR2 path is backend-neutral (`gen_core::load("seedvr2")`).

### Routing / capabilities
- The candle worker advertises `image_upscale` + `video_upscale` and claims **only** `engine=seedvr2` (`upscale_job_is_candle_eligible` / `video_upscale_job_is_candle_eligible`); Real-ESRGAN / AuraSR have no candle path and stay on the Python torch worker. A plain torch worker now **refuses** a seedvr2 upscale (the inverse of the AuraSR gate) so it stays queued for the candle/mlx worker.
- Gating: the `imageUpscaleSeedvr2` capability is platform-true on Mac **and** Windows now (Linux candle = sc-5160); `macGating.js` + tests updated so the web upscale picker offers SeedVR2 on Windows.

### Validation
- **`npm run rust:check`**: core jobs_store tests (incl. new candle/torch upscale-routing + the Windows capability test), worker **default + `--features backend-candle`** clippy `-D warnings` clean; web vitest **433**. (One pre-existing Windows-only failure in `training::resolve_item_path_rejects_paths_outside_dataset_root` — hard-codes Unix `/dataset` paths; unrelated to this PR, passes on the Linux/Mac CI.)
- **Worker-path GPU smoke** on RTX PRO 6000 (candle, bf16): `run_seedvr2_upscale` resolves to `candle-gen-seedvr2` (1f67b59) and produces a real upscale through the worker's exact dispatch seam — the force-link survives the MSVC linker (no "no generator registered") and `softness` reaches the engine.
- The SeedVR2 **engine** itself is GPU-validated in sc-5157 (image) / sc-5926 (video, temporal chunk + overlap + HD tiling) / sc-5927 (7B + int8/int4). The video worker path reuses the same `generate_video` streaming driver as the epic-5095 candle video-gen lane (already deployed-E2E-validated). Full deployed-worker video E2E (API progress/cancel streaming) is the hardware-lane step.

Unblocks **sc-5160** (Linux/NVIDIA enablement).
