### PR TITLE
sc-5160: enable candle SeedVR2 upscaler on Linux/NVIDIA (rides the Windows port)

### DIFF
--- a/.github/workflows/server-candle-linux.yml
+++ b/.github/workflows/server-candle-linux.yml
@@ -1,0 +1,86 @@
+name: Server Candle (Linux/NVIDIA)
+
+# Compile-checks + builds the candle (Linux/NVIDIA) server with `--features
+# backend-candle` (epic 4811 / epic 5482, sc-5160). Candle is CPU+CUDA cross-
+# platform, so the Linux server "rides the Windows candle port": the same provider
+# crates desktop-candle-windows.yml builds on Windows/CUDA also build here on
+# Linux/NVIDIA — including the SeedVR2 upscaler (image_upscale + video_upscale),
+# the sc-5160 deliverable. This is the standing Linux-compile validation for the
+# candle-gated worker/server code (the default Linux `parity` job and the Docker
+# image build both build WITHOUT backend-candle, so the candle paths — the
+# crates/sceneworks-worker caption/image/video/upscale/engines/gpu modules under
+# `#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]` — are
+# otherwise only ever validated by hand on the dev box, and there is no Linux GPU
+# box in the dev loop).
+#
+# Manual `workflow_dispatch` only, like the Windows lane (sc-3676/sc-5562): a candle
+# build (nvcc compiles every provider's CUDA kernels) is heavy and there is no
+# standing self-hosted GPU runner. Compilation does NOT need a GPU (nvcc + the host
+# gcc suffice); only running the binary would. Trigger it from the Actions tab
+# before merging candle changes that should hold on Linux as well as Windows.
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: server-candle-linux-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-candle:
+    runs-on: ubuntu-22.04
+    env:
+      # compute_80 PTX the driver JITs forward to sm_120 — one binary covers
+      # Ampere->Blackwell (mirrors the Windows lane / build-sidecar.mjs default).
+      CUDA_COMPUTE_CAP: "80"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      # Install the CUDA 12.9 Toolkit (nvcc + cudart/cublas/curand/nvrtc dev libs)
+      # the candle `cuda` feature links against. Sets CUDA_PATH for the build.
+      # `--toolkit` skips the (GPU-less runner) driver install — we only compile.
+      - name: Install CUDA Toolkit 12.9
+        uses: Jimver/cuda-toolkit@v0.2.21
+        with:
+          cuda: "12.9.1"
+          method: "network"
+          linux-local-args: '["--toolkit"]'
+      # The candle-gen single-rev invariant the default skew gate is blind to: with
+      # `--features backend-candle` the optional candle-gen providers are pulled, so
+      # a candle-gen pin that resolves a different gen-core rev would split the
+      # inventory registry => runtime "engine not found" (sc-4482). `--target all`
+      # also resolves the macOS-only mlx-gen transitive gen-core.
+      - name: Guard against gen-core version skew (candle)
+        run: |
+          bash scripts/check-gen-core-skew.sh --self-test
+          bash scripts/check-gen-core-skew.sh sceneworks-worker --features backend-candle
+          bash scripts/check-gen-core-skew.sh sceneworks-rust-api --features embed-web,backend-candle
+      # Lint the candle-gated code so it can't silently rot between hand-builds. The
+      # worker carries all the `#[cfg(feature = "backend-candle")]` paths; checking
+      # it alone (no embed-web) avoids a web build for the rot guard. This is the
+      # core "does the candle worker code compile on Linux" gate.
+      - name: Clippy candle-gated code
+        run: cargo clippy -p sceneworks-worker --features backend-candle -- -D warnings
+      - name: Install web dependencies
+        run: npm ci --prefix apps/web
+      # `embed-web` bakes apps/web/dist into the binary (rust-embed), so build the
+      # web bundle first — mirrors build-sidecar.mjs on the Windows lane.
+      - name: Build web assets
+        run: npm run build --prefix apps/web
+      # The faithful "build the candle Linux server" step: the rust-api binary with
+      # the embedded web bundle + the candle backend — nvcc compiles every provider's
+      # CUDA kernels and the full link exercises the real Linux/NVIDIA candle wiring.
+      - name: Build candle server (rust-api, embed-web + backend-candle)
+        run: cargo build -p sceneworks-rust-api --release --features embed-web,backend-candle
+      - name: Upload candle server artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sceneworks-api-candle-linux
+          path: target/release/sceneworks-rust-api
+          if-no-files-found: error

--- a/apps/web/src/macGating.js
+++ b/apps/web/src/macGating.js
@@ -113,10 +113,11 @@ export function macFeatureBlock(caps, key) {
 //   * `aura-sr` — a torch-only GigaGAN DROPPED on Mac (sc-3668). Hidden only under active Mac
 //     gating; available on Windows/Linux. Real-ESRGAN is the cross-platform default.
 //   * `seedvr2` — the one-step diffusion upscaler (epic 4811 / sc-4815), the INVERSE of AuraSR:
-//     backed by native MLX on Mac and the Candle CUDA port on Windows (sc-5928); Linux candle
-//     enablement is sc-5160. Gated off the platform-intrinsic `imageUpscaleSeedvr2` capability (true
-//     on macOS + Windows, in any mode), so it is hidden pre-load and on Linux and shown on Mac +
-//     Windows — independent of the gating switch.
+//     backed by native MLX on Mac and the Candle CUDA/NVIDIA port on Windows (sc-5928) + Linux
+//     (sc-5160 — candle is CPU+CUDA cross-platform, so Linux rides the Windows port). Gated off the
+//     platform-intrinsic `imageUpscaleSeedvr2` capability (true on macOS + Windows + Linux, in any
+//     mode), so it is hidden only pre-load (no caps yet) and shown on every GPU platform —
+//     independent of the gating switch.
 export function macUpscaleEngineBlocked(caps, engine) {
   if (engine === "seedvr2") {
     return caps?.features?.imageUpscaleSeedvr2?.supported !== true;

--- a/apps/web/src/macGating.test.js
+++ b/apps/web/src/macGating.test.js
@@ -82,12 +82,12 @@ describe("macGating helpers", () => {
     expect(macUpscaleEngineBlocked(DEFAULT_MAC_CAPABILITIES, "aura-sr")).toBe(false);
   });
 
-  it("offers SeedVR2 wherever the capability confirms a backend — Mac + Windows (epic 4811 / sc-5928)", () => {
+  it("offers SeedVR2 wherever the capability confirms a backend — Mac + Windows + Linux (epic 4811 / sc-5928 / sc-5160)", () => {
     // Supported on Mac (the capability is true) → shown.
     expect(macUpscaleEngineBlocked(gating, "seedvr2")).toBe(false);
     // Pre-load (no features) → hidden until the capability endpoint responds. INVERSE of AuraSR.
     expect(macUpscaleEngineBlocked(DEFAULT_MAC_CAPABILITIES, "seedvr2")).toBe(true);
-    // Windows now has the candle CUDA backend (sc-5928): the capability is true → shown.
+    // Windows has the candle CUDA backend (sc-5928): the capability is true → shown.
     const windows = {
       ...DEFAULT_MAC_CAPABILITIES,
       platform: "windows",
@@ -95,18 +95,14 @@ describe("macGating helpers", () => {
     };
     expect(macUpscaleEngineBlocked(windows, "seedvr2")).toBe(false);
     expect(macUpscaleEngineBlocked(windows, "real-esrgan")).toBe(false);
-    // Linux candle enablement is sc-5160 → capability false → still hidden there.
+    // Linux now has the same candle CUDA/NVIDIA backend (sc-5160 — candle is cross-platform, so Linux
+    // rides the Windows port): the capability is true → shown there too.
     const linux = {
       ...DEFAULT_MAC_CAPABILITIES,
       platform: "linux",
-      features: {
-        imageUpscaleSeedvr2: {
-          supported: false,
-          reason: { feature: "image_upscale (SeedVR2)", detail: "Linux candle pending.", suggestedEpic: "sc-5160" },
-        },
-      },
+      features: { imageUpscaleSeedvr2: { supported: true } },
     };
-    expect(macUpscaleEngineBlocked(linux, "seedvr2")).toBe(true);
+    expect(macUpscaleEngineBlocked(linux, "seedvr2")).toBe(false);
   });
 
   it("blocks a training kernel without a native Rust trainer", () => {

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -2402,9 +2402,10 @@ pub fn mac_capabilities(platform: &str, mac_gating_active: bool) -> MacCapabilit
     // accept the legacy `"darwin"` alias defensively. Drives the platform-intrinsic engine flags
     // (e.g. `imageUpscaleSeedvr2`, which is Mac-only) rather than the gating-rollout flag.
     let is_mac = matches!(platform, "macos" | "darwin");
-    // SeedVR2 has a backend on Mac (native MLX) and Windows (the candle CUDA port, sc-5928); Linux
-    // candle enablement is sc-5160. Drives the platform-intrinsic `imageUpscaleSeedvr2` flag.
-    let seedvr2_supported = is_mac || matches!(platform, "windows");
+    // SeedVR2 has a backend on Mac (native MLX) and on Windows + Linux (the candle CUDA/NVIDIA port:
+    // Windows sc-5928, Linux sc-5160 — candle is CPU+CUDA cross-platform so Linux rides the Windows
+    // port). Drives the platform-intrinsic `imageUpscaleSeedvr2` flag.
+    let seedvr2_supported = is_mac || matches!(platform, "windows" | "linux");
     let mut features = BTreeMap::new();
     // Third-party LyCORIS (LoHa / non-peft LoKr) now applies on every MLX provider (epic 3641:
     // core loader sc-3642/3643 + SDXL/Wan/LTX sc-3671), so it is no longer a Mac feature gap — the
@@ -2439,24 +2440,25 @@ pub fn mac_capabilities(platform: &str, mac_gating_active: bool) -> MacCapabilit
     );
     features.insert(
         // SeedVR2 (`engine=seedvr2`) is the one-step diffusion super-resolution upscaler — native MLX
-        // on Mac (epic 4811 / sc-4815, in-process `mlx-gen-seedvr2`) and the candle CUDA port on
-        // Windows (sc-5928 / epic 5482, `candle-gen-seedvr2`). Both back the same `engine=seedvr2`
-        // image upscale + the net-new `video_upscale`. This flag is platform-intrinsic (a backend
-        // exists, regardless of the gating rollout flag) so the web upscale picker offers SeedVR2 on
-        // Mac AND Windows and hides it only where there is no backend yet. Linux candle enablement is
-        // sc-5160 — until then SeedVR2 stays hidden on Linux (contrast AuraSR, which the UI hides only
-        // under active gating). Must agree with the routing oracle (mlx OR candle claims seedvr2; a
-        // plain torch worker refuses it).
+        // on Mac (epic 4811 / sc-4815, in-process `mlx-gen-seedvr2`) and the candle CUDA/NVIDIA port on
+        // Windows (sc-5928) + Linux (sc-5160) (epic 5482, `candle-gen-seedvr2`). Both back the same
+        // `engine=seedvr2` image upscale + the net-new `video_upscale`. This flag is platform-intrinsic
+        // (a backend exists, regardless of the gating rollout flag) so the web upscale picker offers
+        // SeedVR2 on every platform that has a backend (Mac, Windows, Linux) and hides it only where
+        // there is none (contrast AuraSR, which the UI hides only under active gating). Must agree with
+        // the routing oracle (mlx OR candle claims seedvr2; a plain torch worker refuses it).
         "imageUpscaleSeedvr2".to_owned(),
         MacFeatureSupport {
             supported: seedvr2_supported,
             reason: if seedvr2_supported {
                 None
             } else {
+                // Unreachable on the three platforms that build a SeedVR2 backend (mac/windows/linux);
+                // kept for any future platform that has neither MLX nor the candle CUDA/NVIDIA port.
                 Some(UnsupportedReason::new(
                     None,
                     "image_upscale (SeedVR2)",
-                    "SeedVR2 runs on Mac (native MLX) and Windows (the candle CUDA backend); Linux candle enablement is in progress.",
+                    "SeedVR2 runs on Mac (native MLX) and Windows/Linux (the candle CUDA/NVIDIA backend); this platform has no SeedVR2 backend.",
                     Some("sc-5160"),
                 ))
             },

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -2589,19 +2589,13 @@ fn mac_capabilities_master_switch_and_infra_features() {
             )
         })
         .all(|(_, f)| !f.supported));
-    // SeedVR2 has a backend on Mac (native MLX) + Windows (candle CUDA, sc-5928); Linux candle
-    // enablement is sc-5160. On the inert Linux host the capability is unsupported and names sc-5160,
-    // so the web picker hides it there.
-    assert!(!inert.features["imageUpscaleSeedvr2"].supported);
-    assert_eq!(
-        inert.features["imageUpscaleSeedvr2"]
-            .reason
-            .as_ref()
-            .and_then(|r| r.suggested_epic.as_deref()),
-        Some("sc-5160")
-    );
-    // Windows now carries the candle SeedVR2 backend (sc-5928): the capability is platform-true there
-    // too (not just Mac), so the web picker offers `engine=seedvr2` on Windows.
+    // SeedVR2 now has a backend on every GPU platform: native MLX on Mac, and the candle CUDA/NVIDIA
+    // port on Windows (sc-5928) + Linux (sc-5160 — candle is CPU+CUDA cross-platform, so Linux rides
+    // the Windows port). On the (inert-gated) Linux host the capability is platform-true with no
+    // reason, so the web picker offers `engine=seedvr2` there too.
+    assert!(inert.features["imageUpscaleSeedvr2"].supported);
+    assert!(inert.features["imageUpscaleSeedvr2"].reason.is_none());
+    // Windows carries the same candle SeedVR2 backend (sc-5928): platform-true there too (not just Mac).
     let windows = mac_capabilities("windows", false);
     assert!(windows.features["imageUpscaleSeedvr2"].supported);
     assert!(windows.features["imageUpscaleSeedvr2"].reason.is_none());

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -143,8 +143,10 @@ inventory = "0.3"
 # (sc-3022, next) to prove the cross-crate registry path end to end.
 
 [features]
-# Off by default. Opt-in build flag for the candle (Windows/CUDA) generative backend (epic 3672,
-# sc-3675): pulls the optional `candle-gen-sdxl` provider (built with its `cuda` feature). Kept OUT
+# Off by default. Opt-in build flag for the candle (Windows/CUDA + Linux/NVIDIA, sc-5160) generative
+# backend (epic 3672, sc-3675): pulls the optional `candle-gen-sdxl` provider (built with its `cuda`
+# feature). The candle providers are declared under `cfg(not(target_os = "macos"))` below, so this
+# feature lights them up on both Windows and Linux (Mac uses the mlx providers). Kept OUT
 # of the default set so the Desktop (Windows) installer build (desktop-windows.yml, windows-latest,
 # no CUDA toolkit) and every non-CUDA build resolve WITHOUT candle / cudarc / nvcc. The dedicated
 # candle Windows CI lane (sc-3676) builds with `--features backend-candle`. Linking the crate does
@@ -729,7 +731,18 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154a
 # `advanced.poses` lane routes onto (image_jobs/zimage_control.rs). #79 is SOURCE-ONLY off `f459ab9` (its
 # parent), so 864aa0c still resolves gen-core `32fdb34` == this worker's mlx-gen pin (single gen-core rev,
 # no skew). With this all three candle strict-pose families (qwen / kolors / z_image) are wired.
-[target.'cfg(target_os = "windows")'.dependencies]
+#
+# sc-5160 (epic 4811 / epic 5482) widens this dependency table's target gate from `target_os = "windows"`
+# to `not(target_os = "macos")` so the candle backend builds on Linux/NVIDIA as well as Windows/CUDA —
+# candle is CPU+CUDA cross-platform, so Linux "rides the Windows port" (the SeedVR2 upscaler is the
+# validated deliverable; the rest of the candle suite compiles for Linux too). This mirrors the macOS mlx
+# table above (`cfg(target_os = "macos")`) — candle is simply the non-Apple GPU backend — and matches the
+# `#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]` convention the worker's candle-gated
+# code already uses (sensenova_jobs.rs, sc-5501). The deps stay `optional` behind `backend-candle`, so the
+# plain Linux/Windows torch build (no CUDA toolkit) still resolves WITHOUT candle/cudarc/nvcc, exactly as
+# before. Standing Linux-compile validation is the new manual `desktop-candle-linux` CI lane (the Linux
+# sibling of `desktop-candle-windows.yml`); the gen-core single-rev invariant is unchanged (same pins).
+[target.'cfg(not(target_os = "macos"))'.dependencies]
 candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
@@ -814,8 +827,8 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 154af37, matching mlx-gen).
 candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
-# Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928, epic 4811 / epic 5482) — the
-# Windows/CUDA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
+# Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
+# / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
 # quant + the 7B variant from sc-5927) into the shared gen_core inventory. The worker reaches it via
 # `gen_core::load("seedvr2")` / `"seedvr2_3b"` from `upscale_jobs::run_seedvr2_upscale` (image) and

--- a/crates/sceneworks-worker/src/caption_jobs.rs
+++ b/crates/sceneworks-worker/src/caption_jobs.rs
@@ -12,12 +12,12 @@ use super::*;
 
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 const JOY_CAPTION_MODEL: &str = "fancyfeast/llama-joycaption-beta-one-hf-llava";
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 const CANCEL_MESSAGE: &str = "Training captioning canceled by user.";
 
@@ -26,7 +26,7 @@ const CANCEL_MESSAGE: &str = "Training captioning canceled by user.";
 // the registry).
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 use gen_core::{
     CancelFlag, CaptionOptions, CaptionRequest, CaptionSampling, Image, LoadSpec, Progress,
@@ -37,12 +37,12 @@ use mlx_gen_joycaption as _;
 // Candle JoyCaption captioner force-link anchor (sc-5098): keeps its `inventory::submit!` captioner
 // registration (`fancyfeast/llama-joycaption-beta-one-hf-llava`, backend `candle`) from being dropped
 // by the MSVC release linker. Mirrors the mlx anchor above.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_joycaption as _;
 
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 #[derive(Clone, Debug)]
 struct CaptionItem {
@@ -53,7 +53,7 @@ struct CaptionItem {
 
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 #[derive(Clone, Debug)]
 struct CaptionJobOptions {
@@ -63,7 +63,7 @@ struct CaptionJobOptions {
 
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 #[derive(Debug)]
 enum CaptionEvent {
@@ -82,7 +82,7 @@ enum CaptionEvent {
 
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 pub(crate) async fn run_training_caption_job(
     api: &ApiClient,
@@ -330,7 +330,7 @@ pub(crate) async fn run_training_caption_job(
 
 #[cfg(not(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 )))]
 pub(crate) async fn run_training_caption_job(
     _api: &ApiClient,
@@ -346,7 +346,7 @@ pub(crate) async fn run_training_caption_job(
 
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn caption_progress(
     status: JobStatus,
@@ -375,7 +375,7 @@ fn caption_progress(
 
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn caption_result(
     model_name_or_path: &str,
@@ -408,7 +408,7 @@ fn caption_result(
 
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn caption_items(settings: &Settings, payload: &JsonObject) -> WorkerResult<Vec<CaptionItem>> {
     let dataset_root = payload
@@ -482,7 +482,7 @@ fn caption_items(settings: &Settings, payload: &JsonObject) -> WorkerResult<Vec<
 
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn caption_job_options(payload: &JsonObject) -> CaptionJobOptions {
     let options = payload
@@ -529,7 +529,7 @@ fn caption_job_options(payload: &JsonObject) -> CaptionJobOptions {
 
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn option_string(options: &JsonObject, key: &str, default: &str) -> String {
     options
@@ -541,7 +541,7 @@ fn option_string(options: &JsonObject, key: &str, default: &str) -> String {
 
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn resolve_caption_weights_dir(
     settings: &Settings,
@@ -552,7 +552,7 @@ fn resolve_caption_weights_dir(
 
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn load_caption_image(path: &Path) -> WorkerResult<Image> {
     let decoded = image::open(path)
@@ -569,7 +569,7 @@ fn load_caption_image(path: &Path) -> WorkerResult<Image> {
 
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn caption_step_progress(index: usize, current: u32, total: u32, item_count: usize) -> f64 {
     let item_count = item_count.max(1) as f64;
@@ -589,7 +589,7 @@ fn caption_step_progress(index: usize, current: u32, total: u32, item_count: usi
 /// case (just the missing trigger words).
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn apply_trigger_words(caption: &str, trigger_words: &[String]) -> String {
     let cleaned = caption.split_whitespace().collect::<Vec<_>>().join(" ");
@@ -611,7 +611,7 @@ fn apply_trigger_words(caption: &str, trigger_words: &[String]) -> String {
     test,
     any(
         target_os = "macos",
-        all(target_os = "windows", feature = "backend-candle")
+        all(not(target_os = "macos"), feature = "backend-candle")
     )
 ))]
 mod tests {

--- a/crates/sceneworks-worker/src/downloads.rs
+++ b/crates/sceneworks-worker/src/downloads.rs
@@ -11,7 +11,7 @@ use std::net::SocketAddr;
 // DownloadProgress, DownloadContext, HuggingFaceSnapshot — already build on every platform.)
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 pub(crate) async fn ensure_cached_file(
     context: &DownloadContext<'_>,
@@ -51,7 +51,7 @@ pub(crate) async fn ensure_cached_file(
 
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 async fn remote_content_length(client: &reqwest::Client, url: &str) -> WorkerResult<Option<u64>> {
     // `url` is built from trusted operator/runtime configuration
@@ -73,7 +73,7 @@ async fn remote_content_length(client: &reqwest::Client, url: &str) -> WorkerRes
 /// installed through the full model-download flow.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 pub(crate) async fn ensure_hf_cached_file(
     context: &DownloadContext<'_>,

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -371,7 +371,7 @@ pub(crate) const TRAINER_IDS: &[&str] = &[
 /// only decides which provider crate registered the descriptor, not how it is resolved.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 pub(crate) struct ResolvedModel {
     pub row: &'static ModelRow,
@@ -380,7 +380,7 @@ pub(crate) struct ResolvedModel {
 
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 impl ResolvedModel {
     pub fn engine_id(&self) -> &'static str {
@@ -399,7 +399,7 @@ impl ResolvedModel {
     // `image_jobs::candle_adapter_label` instead, so this accessor is MLX-path-only — silence the
     // dead-code lint on the candle-only build where the macOS dispatch is cfg'd out.
     #[cfg_attr(
-        all(target_os = "windows", feature = "backend-candle"),
+        all(not(target_os = "macos"), feature = "backend-candle"),
         allow(dead_code)
     )]
     pub fn adapter_label(&self) -> &'static str {
@@ -418,14 +418,14 @@ impl ResolvedModel {
     /// candle SDXL / sc-5096 families advertise none (dense only); Lens advertises Q4/Q8 (sc-5126).
     /// Candle-lane-only: the MLX path always resolves quant unconditionally, so this gate is unused
     /// on macOS.
-    #[cfg(all(target_os = "windows", feature = "backend-candle"))]
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
     pub fn supports_quant(&self) -> bool {
         !self.descriptor.capabilities.supported_quants.is_empty()
     }
     /// Whether the engine accepts LoRA/LoKr adapters (descriptor-derived). Lens is the first candle
     /// family to advertise either (sc-5126); the others advertise neither. Candle-lane-only for the
     /// same reason as [`Self::supports_quant`].
-    #[cfg(all(target_os = "windows", feature = "backend-candle"))]
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
     pub fn supports_adapters(&self) -> bool {
         self.descriptor.capabilities.supports_lora || self.descriptor.capabilities.supports_lokr
     }
@@ -444,7 +444,7 @@ impl ResolvedModel {
 /// resolves the MLX engine on macOS — the candle `generate_candle_stream` calls it directly.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 pub(crate) fn mlx_model(sceneworks_id: &str) -> Option<ResolvedModel> {
     let row = MODEL_TABLE

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -43,11 +43,11 @@ pub(crate) async fn discover_gpu(settings: &Settings) -> DiscoveredGpu {
 /// All-targets signature so `discover_gpu` is uniform; a no-op everywhere except the Windows candle
 /// build with `backend_candle_enabled`, so production routing is unchanged until the lane is on.
 #[cfg_attr(
-    not(all(target_os = "windows", feature = "backend-candle")),
+    not(all(not(target_os = "macos"), feature = "backend-candle")),
     allow(unused_mut, unused_variables)
 )]
 fn with_candle_capabilities(mut gpu: DiscoveredGpu, settings: &Settings) -> DiscoveredGpu {
-    #[cfg(all(target_os = "windows", feature = "backend-candle"))]
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
     if settings.backend_candle_enabled && gpu.capabilities.contains(&WorkerCapability::Gpu) {
         let derived = crate::engines::registry_capabilities(settings);
         if !derived.is_empty() {

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -28,7 +28,7 @@ use sceneworks_core::image_request::ImageRequest;
 // lane (sc-3675), so broadened from macOS-only. `gen_core` is a direct worker dep on every platform.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 use gen_core::{
     AdapterKind, AdapterSpec, CancelFlag, Conditioning, GenerationOutput, GenerationRequest,
@@ -84,45 +84,45 @@ use mlx_gen_bernini as _;
 // dispatch, `cfg(target_os)` just decides which backend registers. Gated on the optional
 // `backend-candle` build feature too (the dep is pulled only by the CUDA build); whether candle is
 // actually USED at runtime is the separate `backend_candle_enabled` setting, not this link anchor.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_sdxl as _;
 // The four candle image families wired in sc-5096 (epic 5095). Same force-link anchor pattern as the
 // SDXL crate above + the mlx providers: each self-registers its engine id (`z_image_turbo` /
 // `flux1_schnell` + `flux1_dev` / `flux2_klein_9b` / `qwen_image`) into the shared gen_core inventory
 // registry, and the `as _;` keeps the MSVC release linker from GC-ing the `inventory::submit!`.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_flux as _;
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_flux2 as _;
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_qwen_image as _;
 // Candle Chroma (sc-5484, epic 3692): chroma1_hd / chroma1_base / chroma1_flash self-register into the
 // shared gen_core inventory; the `as _;` keeps the MSVC release linker from GC-ing the registrations.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_chroma as _;
 // Candle Kolors (sc-5576, epic 3692): the `kolors` T2I id self-registers into the shared gen_core
 // inventory; `as _;` keeps the MSVC release linker from GC-ing the registration.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_kolors as _;
 // Candle SenseNova-U1 (sc-5576, epic 3692): `sensenova_u1_8b` + `sensenova_u1_8b_fast` self-register
 // into the shared gen_core inventory; force-linked so the registrations survive linker GC.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_sensenova as _;
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_z_image as _;
 // Lens / Lens-Turbo (epic 5107 engine / sc-5126 cutover) — the candle Windows/CUDA sibling of the
 // `mlx_gen_lens` anchor above, and the 8th candle image family (effectively). Self-registers `lens`
 // (20-step/CFG-5) + `lens_turbo` (4-step/g-1.0) into the shared gen_core inventory registry; the
 // FIRST candle family to advertise Q4/Q8 quant + LoRA/LoKr. Force-linked so the MSVC release linker
 // keeps the `inventory::submit!` (the dead-strip trap that bit Kolors on MLX).
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_lens as _;
 // Candle SeedVR2 upscaler (sc-5928, epic 4811 / epic 5482) — the Windows/CUDA sibling of the Mac
 // `mlx_gen_seedvr2` anchor above. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 // `seedvr2_7b` into the shared gen_core inventory; the image upscale path reaches it via
 // `gen_core::load("seedvr2")` from `upscale_jobs::run_seedvr2_upscale`. Force-linked so the MSVC
 // release linker keeps the `inventory::submit!` registrations.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_seedvr2 as _;
 // CARVE-OUT(epic 3720): backend-specific; absorbed by FaceEmbedder in Phase 3.
 // InstantID (sc-3345) is a bespoke provider, not an inventory-registered `Generator`, so it is
@@ -150,7 +150,7 @@ use mlx_gen_instantid::{
 // conditioning types they carry (`WeightsSource`, `Image`, `CancelFlag`, `Progress`) are the SHARED
 // `gen_core` contract — the single-rev skew gate (sc-4482) is what makes the worker's `gen_core::Image`
 // the exact type `InstantId::generate` consumes.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_instantid::{
     BodyPoint, InstantId, InstantIdPaths, InstantIdRequest, FACE_RESTORE_PROMPT,
 };
@@ -160,7 +160,7 @@ use candle_gen_instantid::{
 // the MLX SDXL IP path (the registry `SdxlSubMode::Ip`), so these named types resolve only off-Mac.
 // `candle_gen_sdxl` is already force-link anchored above (the registered txt2img `sdxl`); this is the
 // named-type import the bespoke reference route (`image_jobs/sdxl_ipadapter.rs`) drives.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_sdxl::{IpAdapterSdxl, IpAdapterSdxlPaths, IpAdapterSdxlRequest};
 // Kolors IP-Adapter-Plus reference provider (sc-5488, epic 5480) — the candle (Windows/CUDA) Kolors
 // sibling of the SDXL IP lane, living in `candle-gen-kolors` (it reuses candle-gen-sdxl's vendored IP
@@ -169,7 +169,7 @@ use candle_gen_sdxl::{IpAdapterSdxl, IpAdapterSdxlPaths, IpAdapterSdxlRequest};
 // named types resolve only off-Mac. `candle_gen_kolors` is already force-link anchored above (the
 // registered txt2img `kolors`); this is the named-type import the bespoke reference route
 // (`image_jobs/kolors_ipadapter.rs`) drives.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_kolors::{IpAdapterKolors, IpAdapterKolorsPaths, IpAdapterKolorsRequest};
 // FLUX XLabs IP-Adapter reference provider (sc-5872, epic 5480) — the candle (Windows/CUDA) FLUX sibling
 // of the SDXL/Kolors IP lanes, living in `candle-gen-flux` (the forked FLUX DiT with the per-double-block
@@ -177,14 +177,14 @@ use candle_gen_kolors::{IpAdapterKolors, IpAdapterKolorsPaths, IpAdapterKolorsRe
 // (epic 3621, the registry `Reference` route). `candle_gen_flux` is already force-link anchored above (the
 // registered txt2img `flux1_*`); this is the named-type import the bespoke reference route
 // (`image_jobs/flux_ipadapter.rs`) drives.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_flux::{IpAdapterFlux, IpAdapterFluxPaths, IpAdapterFluxRequest};
 // Qwen-Image ControlNet (strict pose) provider (sc-5489, epic 5480) — the candle (Windows/CUDA)
 // strict-pose lane (the first candle ControlNet family beyond the InstantID SDXL path). Candle-only:
 // macOS keeps the MLX `qwen_image_control` registry generator. `candle_gen_qwen_image` is already a
 // force-link anchor (`use candle_gen_qwen_image as _;`) from the Qwen txt2img wiring; this is the
 // named-type import the bespoke pose route (`image_jobs/qwen_control.rs`) drives.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_qwen_image::{QwenControl, QwenControlPaths, QwenControlRequest};
 // Kolors ControlNet (strict pose) provider (sc-5489, epic 5480) — the candle (Windows/CUDA) Kolors
 // sibling of the Qwen strict-pose lane, living in `candle-gen-kolors` (it reuses candle-gen-sdxl's
@@ -192,7 +192,7 @@ use candle_gen_qwen_image::{QwenControl, QwenControlPaths, QwenControlRequest};
 // Candle-only: macOS keeps the MLX Kolors ControlNet path. `candle_gen_kolors` is already force-link
 // anchored above (the registered txt2img `kolors`); this is the named-type import the bespoke pose route
 // (`image_jobs/kolors_control.rs`) drives.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_kolors::{KolorsControl, KolorsControlPaths, KolorsControlRequest};
 // Z-Image Fun-ControlNet (strict pose) provider (sc-5489, epic 5480) — the candle (Windows/CUDA)
 // Z-Image sibling of the Qwen/Kolors strict-pose lanes, living in `candle-gen-z-image` (the VACE-style
@@ -200,7 +200,7 @@ use candle_gen_kolors::{KolorsControl, KolorsControlPaths, KolorsControlRequest}
 // registry generator. `candle_gen_z_image` is already force-link anchored above (the registered txt2img
 // `z_image_turbo`); this is the named-type import the bespoke pose route (`image_jobs/zimage_control.rs`)
 // drives.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_z_image::{ZImageControl, ZImageControlPaths, ZImageControlRequest};
 // PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the candle (Windows/CUDA) sibling of the
 // macOS `pulid_flux` registry generator, living in `candle-gen-pulid` (the EVA02-CLIP tower + IDFormer
@@ -209,7 +209,7 @@ use candle_gen_z_image::{ZImageControl, ZImageControlPaths, ZImageControlRequest
 // Candle-only: macOS keeps the inventory-registered `pulid_flux` MLX generator; the candle `PulidFlux`
 // is a bespoke provider referenced BY NAME (like `InstantId`), so no `as _;` anchor is needed — this is
 // the named-type import the bespoke route (`image_jobs/pulid_candle.rs`) drives.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_pulid::{PulidFlux, PulidFluxPaths, PulidFluxRequest};
 
 /// The stub adapter id recorded on generated assets (matches the contract fixture
@@ -218,13 +218,13 @@ const STUB_ADAPTER: &str = "procedural_preview";
 /// The adapter id recorded on assets produced by the candle (Windows/CUDA) SDXL lane (sc-3678).
 /// Used both per-asset (`generate_candle_stream`) and at the generation-set level (`adapter_id`)
 /// so the sidecar + result agree on which backend produced the image.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 const CANDLE_ADAPTER: &str = "candle_sdxl";
 // Shared by the MLX path and the candle Lens lane (sc-5126) — both cap a job's user LoRAs at 3
 // (`resolve_adapters`), so the const is available on the Windows candle build too.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 const MAX_JOB_LORAS: usize = 3;
 
@@ -236,7 +236,7 @@ const MAX_JOB_LORAS: usize = 3;
 // through the same `mlx_model` lookup the MLX path uses.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 use crate::engines::{mlx_model, ResolvedModel};
 /// Dispatch handler for `JobType::ImageGenerate`: generate, save, and stream image
@@ -271,7 +271,7 @@ pub(crate) async fn run_image_generate_job(
     // collection's length, or the pose count), not `request.count` — bake the real total into the plan
     // so the generation set + streamed `expectedCount` match (sc-5491, mirroring the macOS route's
     // `image_count`). Any other candle job stays `request.count`.
-    #[cfg(all(target_os = "windows", feature = "backend-candle"))]
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
     let plan = {
         let count = if settings.backend_candle_enabled && instantid_available(&request, settings) {
             instantid_image_count(&request, settings)
@@ -282,7 +282,7 @@ pub(crate) async fn run_image_generate_job(
     };
     #[cfg(all(
         not(target_os = "macos"),
-        not(all(target_os = "windows", feature = "backend-candle"))
+        not(all(not(target_os = "macos"), feature = "backend-candle"))
     ))]
     let plan = ImagePlan::with_count(&request, request.count);
 
@@ -486,7 +486,7 @@ pub(crate) async fn run_image_generate_job(
     // gets its own bespoke path (`generate_instantid_stream`, the off-Mac sibling of the macOS
     // `ImageRoute::InstantId` arm) — checked first since `instantid_realvisxl` is not an inventory
     // `is_candle_engine` id.
-    #[cfg(all(target_os = "windows", feature = "backend-candle"))]
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
     let handled = if settings.backend_candle_enabled && instantid_available(&request, settings) {
         generate_instantid_stream(
             api,
@@ -646,7 +646,7 @@ pub(crate) async fn run_image_generate_job(
     };
     #[cfg(not(any(
         target_os = "macos",
-        all(target_os = "windows", feature = "backend-candle")
+        all(not(target_os = "macos"), feature = "backend-candle")
     )))]
     let handled = false;
 
@@ -899,7 +899,7 @@ fn adapter_id(request: &ImageRequest) -> &'static str {
     // instead of falling through to the procedural-stub label. Routing (`worker_supports_job`) only
     // lets candle-eligible txt2img jobs reach this worker, so `is_candle_engine` here implies the
     // candle path ran.
-    #[cfg(all(target_os = "windows", feature = "backend-candle"))]
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
     if is_candle_engine(&request.model) {
         return candle_adapter_label(&request.model);
     }
@@ -1000,7 +1000,7 @@ pub(crate) fn backend_label(gpu_id: &str) -> &str {
 // non-macOS / non-candle builds.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 async fn begin_image_cancel(
     api: &ApiClient,
@@ -1064,14 +1064,14 @@ fn lerp(a: u8, t: f32) -> u8 {
 // AND on the Windows candle build.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 // MLX/candle generator stream helpers.
 include!("image_jobs/stream.rs");
 
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 // base image routing (MLX) + neutral txt2img generation harness + the candle execution path.
 include!("image_jobs/base.rs");
@@ -1101,40 +1101,40 @@ include!("image_jobs/kolors.rs");
 // signature), cfg-split inside; the per-item generate/restore loop is backend-neutral over `gen_core`.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 include!("image_jobs/instantid.rs");
 // SDXL IP-Adapter-Plus reference conditioning — the Windows/CUDA candle lane ONLY (sc-5488). macOS keeps
 // the MLX SDXL IP path (sdxl.rs `SdxlSubMode::Ip`); there is no MLX `IpAdapterSdxl`, so this is
 // candle-exclusive.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 include!("image_jobs/sdxl_ipadapter.rs");
 // Kolors IP-Adapter-Plus reference conditioning — the Windows/CUDA candle lane ONLY (sc-5488). macOS
 // keeps the MLX Kolors IP path (kolors.rs, the registry `Reference` route); the candle `IpAdapterKolors`
 // is a bespoke provider, so this is candle-exclusive.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 include!("image_jobs/kolors_ipadapter.rs");
 // FLUX XLabs IP-Adapter reference conditioning — the Windows/CUDA candle lane ONLY (sc-5872). macOS keeps
 // the MLX FLUX XLabs IP path (epic 3621, the registry `Reference` route); the candle `IpAdapterFlux` is a
 // bespoke provider, so this is candle-exclusive.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 include!("image_jobs/flux_ipadapter.rs");
 // Qwen-Image ControlNet (strict pose) — the Windows/CUDA candle lane ONLY (sc-5489). macOS keeps the
 // MLX `qwen_image_control` registry generator; the candle `QwenControl` is a bespoke provider.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 include!("image_jobs/qwen_control.rs");
 // Kolors ControlNet (strict pose) — the Windows/CUDA candle lane ONLY (sc-5489). macOS keeps the MLX
 // Kolors ControlNet path; the candle `KolorsControl` is a bespoke provider.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 include!("image_jobs/kolors_control.rs");
 // Z-Image Fun-ControlNet (strict pose) — the Windows/CUDA candle lane ONLY (sc-5489). macOS keeps the
 // MLX `z_image_turbo_control` registry generator; the candle `ZImageControl` is a bespoke provider.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 include!("image_jobs/zimage_control.rs");
 // PuLID-FLUX face identity — the Windows/CUDA candle lane ONLY (sc-5492). macOS keeps the
 // inventory-registered `pulid_flux` MLX generator (image_jobs/pulid.rs); the candle `PulidFlux` is a
 // bespoke provider, so this file is candle-gated and distinct from the macOS route.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 include!("image_jobs/pulid_candle.rs");
 #[cfg(target_os = "macos")]
 // PuLID-FLUX native routing.

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -91,7 +91,7 @@ fn grouped_edit_image_count(request: &ImageRequest) -> u32 {
 /// family default. Shared by the MLX path and the candle lane (sc-5096).
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn model_repo(request: &ImageRequest, model: &ResolvedModel) -> String {
     request
@@ -135,7 +135,7 @@ pub(crate) fn resolve_weights_dir(
 
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn quant_int(value: &Value) -> Option<i64> {
     if value.is_boolean() {
@@ -156,7 +156,7 @@ fn quant_int(value: &Value) -> Option<i64> {
 /// the sc-3675/sc-5096 candle families advertise no quant and never reach this resolver (stay dense).
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn resolve_quant(request: &ImageRequest) -> (Option<Quant>, Option<i64>) {
     let raw = request
@@ -182,7 +182,7 @@ fn resolve_quant(request: &ImageRequest) -> (Option<Quant>, Option<i64>) {
 /// Shared by the MLX path and the candle lane (sc-5096).
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn resolve_steps(request: &ImageRequest, model: &ResolvedModel) -> u32 {
     request
@@ -205,7 +205,7 @@ fn resolve_steps(request: &ImageRequest, model: &ResolvedModel) -> u32 {
 /// gets `None` and a guided one (flux dev, flux2, qwen, sdxl) gets the scale.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn resolve_guidance(request: &ImageRequest, model: &ResolvedModel) -> Option<f32> {
     if !model.supports_guidance() {
@@ -232,7 +232,7 @@ fn resolve_guidance(request: &ImageRequest, model: &ResolvedModel) -> Option<f32
 /// family the worker forwards `advanced.guidanceScale` as `true_cfg`, not `guidance`.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn uses_true_cfg(model: &ResolvedModel) -> bool {
     !model.supports_guidance() && model.supports_negative_prompt()
@@ -244,7 +244,7 @@ fn uses_true_cfg(model: &ResolvedModel) -> bool {
 /// Shared by the MLX path and the candle lane (sc-5096).
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn resolve_true_cfg(request: &ImageRequest, model: &ResolvedModel) -> Option<f32> {
     if !uses_true_cfg(model) {
@@ -270,7 +270,7 @@ fn resolve_true_cfg(request: &ImageRequest, model: &ResolvedModel) -> Option<f32
 /// is the candle descriptor, so distilled candle families (z-image, flux schnell) get `None`.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn resolve_negative_prompt(request: &ImageRequest, model: &ResolvedModel) -> Option<String> {
     if !model.supports_negative_prompt() {
@@ -288,7 +288,7 @@ fn resolve_negative_prompt(request: &ImageRequest, model: &ResolvedModel) -> Opt
 /// Shared by the MLX path and the candle Lens lane (sc-5126).
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 pub(crate) fn lora_path(lora: &Value) -> Option<PathBuf> {
     for key in ["installedPath", "sourcePath", "path"] {
@@ -323,7 +323,7 @@ pub(crate) fn lora_path(lora: &Value) -> Option<PathBuf> {
 /// it surfaces the mismatch loudly), so the same `networkType: lokr` classification feeds both lanes.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 pub(crate) fn classify_adapter(file: &Path) -> WorkerResult<AdapterKind> {
     let header = read_safetensors_header(file)
@@ -343,7 +343,7 @@ pub(crate) fn classify_adapter(file: &Path) -> WorkerResult<AdapterKind> {
 /// Shared by the MLX path and the candle Lens lane (sc-5126).
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn resolve_adapters(request: &ImageRequest, settings: &Settings) -> WorkerResult<Vec<AdapterSpec>> {
     if request.loras.len() > MAX_JOB_LORAS {
@@ -618,7 +618,7 @@ fn step_fraction(index: usize, current: u32, total: u32, count: u32) -> f64 {
 /// rather than in a macOS-only include.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 pub(crate) fn load_reference_image(
     data_dir: &Path,
@@ -669,7 +669,7 @@ pub(crate) fn load_reference_image(
 /// so the candle InstantID lane (sc-5491) can use it off-Mac.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn non_empty(value: &Option<String>) -> bool {
     value.as_deref().is_some_and(|id| !id.trim().is_empty())
@@ -678,7 +678,7 @@ fn non_empty(value: &Option<String>) -> bool {
 /// The object-shaped `advanced.poses` entries (the strict-pose tier; empty otherwise).
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn pose_entries(request: &ImageRequest) -> Vec<&Value> {
     request
@@ -694,7 +694,7 @@ fn pose_entries(request: &ImageRequest) -> Vec<&Value> {
 // the Z-Image whole-body strict-pose path's (macOS), so allow them dead off-Mac.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 struct PoseInput {
@@ -705,7 +705,7 @@ struct PoseInput {
 
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn parse_poses(request: &ImageRequest) -> Vec<PoseInput> {
     use crate::openpose_skeleton::{normalize_face, normalize_hands, normalize_keypoints};
@@ -726,7 +726,7 @@ fn parse_poses(request: &ImageRequest) -> Vec<PoseInput> {
 /// `character_studio_angles.ANGLE_PROMPT_AUGMENTS`). Unknown angle → empty.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn angle_prompt_augment(angle: &str) -> &'static str {
     match angle {
@@ -768,7 +768,7 @@ fn angle_prompt_augment(angle: &str) -> &'static str {
 /// leave a trailing space, e.g. `"a . "` → `"a "`).
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn strip_base_prompt(base: &str) -> &str {
     base.trim().trim_end_matches([',', '.', ';'])
@@ -778,7 +778,7 @@ fn strip_base_prompt(base: &str) -> &str {
 /// `augment_prompt_for_angle`). Empty base + unknown angle → empty string.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn augment_prompt_for_angle(base: &str, angle: &str) -> String {
     let augment = angle_prompt_augment(angle);
@@ -1004,7 +1004,7 @@ async fn generate_stream(
 /// this gate is intentionally the base-id set only. Lens is pure T2I (no conditioning), so it joins
 /// the lane with no new dispatch shape — only quant + adapters, which `generate_candle_stream`
 /// resolves from the descriptor.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 fn is_candle_engine(model: &str) -> bool {
     matches!(
         model,
@@ -1030,7 +1030,7 @@ fn is_candle_engine(model: &str) -> bool {
 /// sibling of the `MODEL_TABLE` `mlx_<family>` labels. Used both per-asset (`generate_candle_stream`)
 /// and at the generation-set level (`adapter_id`) so the sidecar + result agree on the backend.
 /// (sc-5099 extends this same labeling to the video + caption engines.)
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 fn candle_adapter_label(model: &str) -> &'static str {
     match model {
         "z_image_turbo" => "candle_z_image",
@@ -1060,7 +1060,7 @@ fn candle_adapter_label(model: &str) -> &'static str {
 /// adapter-free exactly as before. No reference/img2img/control — those shapes fall back to the Python
 /// worker upstream (`image_request_candle_eligible`). Reached only when `backend_candle_enabled`
 /// (default off → production routing unchanged until parity).
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 async fn generate_candle_stream(
     api: &ApiClient,
     settings: &Settings,
@@ -1400,7 +1400,7 @@ async fn consume_gen_events(
 
 // Candle image lane labeling + engine-gate unit tests (sc-5099). Windows/candle-gated (the functions
 // only exist on that build); pure string maps, no GPU.
-#[cfg(all(test, target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(test, not(target_os = "macos"), feature = "backend-candle"))]
 mod candle_label_tests {
     use super::*;
 

--- a/crates/sceneworks-worker/src/image_jobs/instantid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/instantid.rs
@@ -33,7 +33,7 @@ const INSTANTID_FACE_RESTORE_SIDE: u32 = 1024;
 /// lanes in the asset sidecar + the `instantIdEngine` raw-settings key.
 #[cfg(target_os = "macos")]
 const INSTANTID_ENGINE: &str = "mlx_instantid";
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 const INSTANTID_ENGINE: &str = "candle_instantid";
 
 /// How an InstantID character job batches its iterations (torch-parity precedence: a pose set
@@ -495,7 +495,7 @@ async fn generate_instantid_stream(
     // knob entirely on this lane: don't apply it (the `quantize` step in the load closure is macOS-
     // only) and don't record it as applied (`recipe_bits` -> None). `let _` consumes the otherwise-
     // unused `quant_bits`.
-    #[cfg(all(target_os = "windows", feature = "backend-candle"))]
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
     let recipe_bits: Option<i64> = {
         let _ = (quant_bits, recipe_bits);
         None
@@ -670,7 +670,7 @@ async fn generate_instantid_stream(
                     .with_face(&scrfd, &arcface)
                     .map_err(|error| WorkerError::Engine(format!("InstantID face stack: {error}")))?
             };
-            #[cfg(all(target_os = "windows", feature = "backend-candle"))]
+            #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
             let model = {
                 let face_dir = scrfd_path.parent().unwrap_or(scrfd_path.as_path());
                 // `arcface_path` is staged in the same dir; `with_face(dir)` resolves it by name.
@@ -696,7 +696,7 @@ async fn generate_instantid_stream(
                         ))
                     })?
                     .embedding;
-                #[cfg(all(target_os = "windows", feature = "backend-candle"))]
+                #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
                 let embedding = model
                     .largest_face(&reference)
                     .map_err(|error| {

--- a/crates/sceneworks-worker/src/image_jobs/stream.rs
+++ b/crates/sceneworks-worker/src/image_jobs/stream.rs
@@ -94,7 +94,7 @@ fn release_gen_cache_between_items() {}
 // `spawn_blocking`, so it never needs to be `Send`.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn start_gen_stream<G, L, D>(
     job_id: String,

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -40,7 +40,7 @@ use uuid::Uuid;
 // Windows/Linux build it stays excluded, so its accessors are never uncalled-dead there.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 mod advanced;
@@ -119,7 +119,7 @@ mod kps_jobs;
 // Windows/Linux backend), while the SeedVR2 path is backend-neutral (`gen_core::load("seedvr2")`).
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 mod upscale_jobs;
 // YOLO11 person detection via onnxruntime/CoreML (epic 3482, sc-3488/sc-3633).
@@ -152,7 +152,7 @@ use kps_jobs::*;
 use pose_jobs::*;
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 use upscale_jobs::*;
 
@@ -765,7 +765,7 @@ async fn run_utility_job(
         // refuses `engine=seedvr2` on torch and `engine=real-esrgan`/`aura-sr` on the candle worker.
         #[cfg(any(
             target_os = "macos",
-            all(target_os = "windows", feature = "backend-candle")
+            all(not(target_os = "macos"), feature = "backend-candle")
         ))]
         JobType::ImageUpscale => run_image_upscale_job(api, settings, http_client, &job)
             .await
@@ -777,7 +777,7 @@ async fn run_utility_job(
         // (no torch path), so it falls to the `_` arm and the routing oracle reports it unsupported.
         #[cfg(any(
             target_os = "macos",
-            all(target_os = "windows", feature = "backend-candle")
+            all(not(target_os = "macos"), feature = "backend-candle")
         ))]
         JobType::VideoUpscale => run_video_upscale_job(api, settings, &job)
             .await

--- a/crates/sceneworks-worker/src/prompt_refine_jobs.rs
+++ b/crates/sceneworks-worker/src/prompt_refine_jobs.rs
@@ -22,7 +22,7 @@ use super::*;
 // registration (id `prompt_refine`) from being dropped by the release linker. sc-5552 adds the native
 // MLX twin (`mlx_gen_prompt_refine`, backend `mlx`) alongside sc-5525's candle anchor; mirrors the
 // dual JoyCaption anchors in caption_jobs.rs.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_prompt_refine as _;
 #[cfg(target_os = "macos")]
 use mlx_gen_prompt_refine as _;
@@ -32,26 +32,26 @@ use mlx_gen_prompt_refine as _;
 // twin on macOS and the candle provider on the Windows candle build.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 const PROMPT_REFINE_ENGINE_ID: &str = "prompt_refine";
 // Default refinement checkpoint — the small abliterated Llama-3.2-3B instruction model, parity with
 // the Python `DEFAULT_REFINE_MODEL`. Overridable per-job via `payload.model`.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 const DEFAULT_REFINE_MODEL: &str = "huihui-ai/Llama-3.2-3B-Instruct-abliterated";
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 const CANCEL_MESSAGE: &str = "Prompt refinement canceled by user.";
 // Architecture-pill label for the streamed progress (mirrors the candle image/video paths): the MLX
 // twin on macOS, candle on the Windows candle build.
 #[cfg(target_os = "macos")]
 const REFINE_BACKEND: &str = "mlx";
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 const REFINE_BACKEND: &str = "candle";
 
 // ----------------------------------------------------------------------------------------------
@@ -66,7 +66,7 @@ const REFINE_BACKEND: &str = "candle";
 #[cfg(any(
     test,
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn base_rules(medium: &str) -> String {
     [
@@ -105,7 +105,7 @@ fn base_rules(medium: &str) -> String {
 #[cfg(any(
     test,
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn build_refine_system_prompt(guide: Option<&str>, workflow: Option<&str>) -> String {
     let medium = if workflow
@@ -131,7 +131,7 @@ fn build_refine_system_prompt(guide: Option<&str>, workflow: Option<&str>) -> St
 #[cfg(any(
     test,
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn clean_refine_output(text: &str) -> String {
     let mut text = strip_think_blocks(text.trim()).trim().to_owned();
@@ -166,7 +166,7 @@ fn clean_refine_output(text: &str) -> String {
 #[cfg(any(
     test,
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn strip_think_blocks(input: &str) -> String {
     const OPEN: &str = "<think>";
@@ -199,7 +199,7 @@ fn strip_think_blocks(input: &str) -> String {
 #[cfg(any(
     test,
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn first_ci(haystack: &str, needle: &str) -> Option<usize> {
     let (h, n) = (haystack.as_bytes(), needle.as_bytes());
@@ -213,7 +213,7 @@ fn first_ci(haystack: &str, needle: &str) -> Option<usize> {
 #[cfg(any(
     test,
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn last_ci(haystack: &str, needle: &str) -> Option<usize> {
     let (h, n) = (haystack.as_bytes(), needle.as_bytes());
@@ -233,7 +233,7 @@ fn last_ci(haystack: &str, needle: &str) -> Option<usize> {
 
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 pub(crate) async fn run_prompt_refine_job(
     api: &ApiClient,
@@ -418,7 +418,7 @@ pub(crate) async fn run_prompt_refine_job(
 /// `prompt_refine`. Kept so the `run_utility_job` dispatch compiles on all targets.
 #[cfg(not(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 )))]
 pub(crate) async fn run_prompt_refine_job(
     _api: &ApiClient,
@@ -434,7 +434,7 @@ pub(crate) async fn run_prompt_refine_job(
 
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn refine_progress(
     status: JobStatus,
@@ -464,7 +464,7 @@ fn refine_progress(
 /// The `prompt_refine` result payload, parity with the Python `run_prompt_refine_job`.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn refine_result(original_prompt: &str, refined_prompt: &str) -> JsonObject {
     let mut result = JsonObject::new();

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -2633,7 +2633,7 @@ async fn cancel_peek_tolerates_transient_get_errors() {
 // acknowledgement status is `running`, not the terminal `canceled`.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 async fn spawn_progress_capture_stub() -> (String, std::sync::Arc<std::sync::Mutex<Vec<Value>>>) {
     use std::sync::{Arc, Mutex};
@@ -2671,7 +2671,7 @@ async fn spawn_progress_capture_stub() -> (String, std::sync::Arc<std::sync::Mut
 /// until the GPU is genuinely free.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 #[tokio::test]
 async fn begin_video_cancel_trips_flag_and_stays_non_terminal() {

--- a/crates/sceneworks-worker/src/upscale_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs/tests.rs
@@ -6,7 +6,7 @@ use super::*;
 // real-weight smoke (Mac MLX + the Windows/CUDA candle lane).
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 use image::{Rgb, RgbImage};
 use serde_json::json;
@@ -224,7 +224,7 @@ fn manifest_seedvr2_resource_extracts_overrides_and_defaults() {
 /// so the smoke below can run on real weights without a download. `None` ⇒ skip.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn cached_seedvr2_checkpoint() -> Option<std::path::PathBuf> {
     if let Ok(pinned) = std::env::var("SCENEWORKS_SEEDVR2_CHECKPOINT") {
@@ -250,7 +250,7 @@ fn cached_seedvr2_checkpoint() -> Option<std::path::PathBuf> {
 /// `cargo test -p sceneworks-worker --features backend-candle -- --ignored seedvr2_upscale_real_weight_smoke`.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 #[tokio::test]
 #[ignore = "real-weight: needs the cached numz/SeedVR2_comfyUI checkpoint (~7 GB) + the seedvr2 backend (MLX on Mac / candle on Windows)"]

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -41,7 +41,7 @@ use crate::image_jobs::{classify_adapter, load_reference_image, lora_path};
 // video engine, not which contract types this module names.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 use gen_core::{
     AdapterSpec, CancelFlag, Conditioning, GenerationOutput, GenerationRequest, Generator,
@@ -54,7 +54,7 @@ use gen_core::{AdapterKind, MoeExpert};
 // lane (sc-5494), so they are available on both the macos and windows+backend-candle builds.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 use gen_core::{Image, ReplacementMode};
 #[cfg(target_os = "macos")]
@@ -78,33 +78,33 @@ use mlx_gen_scail2 as _;
 // Candle (Windows/CUDA) video providers (sc-5097; sc-5493 adds svd) — force-link anchors so their
 // `inventory::submit!` registrations (`wan2_2_ti2v_5b` / `ltx_2_3_distilled` / `svd_xt`) survive the
 // MSVC release linker, mirroring the image providers in image_jobs.rs.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_ltx as _;
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_svd as _;
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_wan as _;
 // Candle SeedVR2 video upscaler (sc-5928, epic 4811 / epic 5482) — the Windows/CUDA sibling of the
 // Mac `mlx_gen_seedvr2` anchor above. Self-registers `seedvr2_3b` (+ `seedvr2` / `seedvr2_7b`) into
 // the shared gen_core inventory; the `video_upscale` path reaches it via `gen_core::load` from
 // `run_video_upscale_job`. Force-linked so the MSVC release linker keeps the `inventory::submit!`.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_seedvr2 as _;
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 use sceneworks_core::character_store::CharacterStore;
 // Frame-count stride coercion (Wan needs frames ≡ 1 mod 4; LTX snaps to 8k+1) — used by the MLX path
 // and the candle entry (sc-5097).
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 use sceneworks_core::video_request::{ltx_frame_count, wan_frame_count};
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 use std::time::{Duration, Instant};
 
@@ -409,7 +409,7 @@ pub(crate) async fn run_video_generate_job(
     // candle lane doesn't serve stubs exactly as before. Gated on `backend_candle_enabled` (default
     // off → routing unchanged until parity). Conditioning shapes never reach here — the router's
     // `video_job_is_candle_eligible` confines the candle worker to txt2video.
-    #[cfg(all(target_os = "windows", feature = "backend-candle"))]
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
     let (decoded, adapter, raw_settings, replacement_status) = if settings.backend_candle_enabled
         && request.mode == "replace_person"
     {
@@ -459,7 +459,7 @@ pub(crate) async fn run_video_generate_job(
     };
     #[cfg(not(any(
         target_os = "macos",
-        all(target_os = "windows", feature = "backend-candle")
+        all(not(target_os = "macos"), feature = "backend-candle")
     )))]
     let (decoded, adapter, raw_settings, replacement_status) = (
         generate_stub_video(&request, seed),
@@ -1046,35 +1046,35 @@ fn video_progress(
 // constants/helpers are backend-neutral (gen_core + ffmpeg + the shared streaming driver).
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 const SEEDVR2_REPO: &str = "numz/SeedVR2_comfyUI";
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 const SEEDVR2_VAE_FILE: &str = "ema_vae_fp16.safetensors";
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 const SEEDVR2_DIT_3B_FILE: &str = "seedvr2_ema_3b_fp16.safetensors";
 /// The engine registry id wired for video upscale (3B; 7B = sc-5197 / sc-5927).
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 const SEEDVR2_ENGINE_ID: &str = "seedvr2_3b";
 /// Adapter id recorded on the result asset for provenance (mirrors the other `mlx_*` video adapters;
 /// SeedVR2 itself takes no LoRA — this is metadata only).
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 const SEEDVR2_ADAPTER: &str = "mlx_seedvr2";
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 const SEEDVR2_CANCEL_MESSAGE: &str = "Video upscale canceled by user.";
 
@@ -1082,7 +1082,7 @@ const SEEDVR2_CANCEL_MESSAGE: &str = "Video upscale canceled by user.";
 /// requirement), rounding to nearest and clamping to the engine's `[16, 4096]` size range.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn snap_seedvr2_dim(value: u32) -> u32 {
     let rounded = value.saturating_add(8) / 16 * 16;
@@ -1093,7 +1093,7 @@ fn snap_seedvr2_dim(value: u32) -> u32 {
 /// components — same guard as `upscale_jobs::resolve_source`).
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn safe_join(project_path: &Path, rel: &str) -> Option<PathBuf> {
     let mut path = project_path.to_path_buf();
@@ -1111,7 +1111,7 @@ fn safe_join(project_path: &Path, rel: &str) -> Option<PathBuf> {
 /// the dir to hand the engine as `WeightsSource::Dir`.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 async fn ensure_seedvr2_weights(
     api: &ApiClient,
@@ -1148,7 +1148,7 @@ async fn ensure_seedvr2_weights(
 /// temp dir, then loads them in order. `-fps_mode passthrough` keeps the exact source frame count.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 async fn decode_seedvr2_source_frames(
     api: &ApiClient,
@@ -1215,7 +1215,7 @@ async fn decode_seedvr2_source_frames(
 /// and stream a single upscaled video asset.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 pub(crate) async fn run_video_upscale_job(
     api: &ApiClient,
@@ -1957,7 +1957,7 @@ fn resolve_wan_conditioning(
 /// Which boundary frame of a source clip to extract for Wan-native clip conditioning (sc-3357).
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum ClipFramePosition {
@@ -2182,7 +2182,7 @@ const WAN5B_INTERIM_STEPS: u32 = 20;
 /// Shared by the MLX path and the candle video lane (sc-5097).
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn advanced_opt_u32(request: &VideoRequest, key: &str) -> Option<u32> {
     request.advanced.get(key).and_then(|value| {
@@ -2197,7 +2197,7 @@ fn advanced_opt_u32(request: &VideoRequest, key: &str) -> Option<u32> {
 /// Shared by the MLX path and the candle video lane (sc-5097).
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn advanced_opt_f32(request: &VideoRequest, key: &str) -> Option<f32> {
     request.advanced.get(key).and_then(|value| {
@@ -2273,7 +2273,7 @@ fn scail2_adapters_have_lightning(adapters: &[AdapterSpec]) -> bool {
 /// prompt-enhance) default off for Wan; the Wan-only `moe_expert` rides on `adapters`.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 struct VideoGenInput {
     engine_id: &'static str,
@@ -2314,7 +2314,7 @@ struct VideoGenInput {
 
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 impl Default for VideoGenInput {
     fn default() -> Self {
@@ -2351,7 +2351,7 @@ impl Default for VideoGenInput {
 
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn video_load_spec(input: &VideoGenInput) -> LoadSpec {
     LoadSpec {
@@ -2371,7 +2371,7 @@ fn video_load_spec(input: &VideoGenInput) -> LoadSpec {
 /// The engine fills the audio track (LTX) or leaves it `None` (Wan).
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn run_loaded_video_generation(
     generator: &dyn Generator,
@@ -2465,7 +2465,7 @@ fn run_video_generation(
 /// unusually large/slow model or disk.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 const VIDEO_STALL_TIMEOUT: Duration = Duration::from_secs(600);
 
@@ -2476,7 +2476,7 @@ const VIDEO_STALL_TIMEOUT: Duration = Duration::from_secs(600);
 /// itself re-hanging on the join.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 const VIDEO_STALL_GRACE: Duration = Duration::from_secs(60);
 
@@ -2484,7 +2484,7 @@ const VIDEO_STALL_GRACE: Duration = Duration::from_secs(60);
 /// integer number of seconds) when set, else [`VIDEO_STALL_TIMEOUT`].
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn video_stall_timeout() -> Duration {
     parse_stall_timeout(std::env::var("SCENEWORKS_VIDEO_STALL_SECS").ok())
@@ -2494,7 +2494,7 @@ fn video_stall_timeout() -> Duration {
 /// falling back to [`VIDEO_STALL_TIMEOUT`] when unset, blank, non-numeric, or zero.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn parse_stall_timeout(raw: Option<String>) -> Duration {
     raw.and_then(|raw| raw.trim().parse::<u64>().ok())
@@ -2513,7 +2513,7 @@ fn parse_stall_timeout(raw: Option<String>) -> Duration {
 /// worker. Mirrors the image path's `begin_image_cancel` (sc-5515).
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 pub(crate) async fn begin_video_cancel(
     api: &ApiClient,
@@ -2543,7 +2543,7 @@ pub(crate) async fn begin_video_cancel(
 /// ([`video_stall_timeout`]) fails a wedged job loudly rather than letting it look alive forever.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 async fn generate_video(
     api: &ApiClient,
@@ -2730,41 +2730,41 @@ async fn generate_video(
 
 /// Per-asset adapter ids for the candle video engines (`candle_<family>`), the candle siblings of
 /// the MLX `mlx_wan` / `mlx_ltx` labels (sc-5097).
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 const CANDLE_WAN_ADAPTER: &str = "candle_wan";
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 const CANDLE_LTX_ADAPTER: &str = "candle_ltx";
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 const CANDLE_SVD_ADAPTER: &str = "candle_svd";
 
 /// Default HuggingFace repos the candle video providers load (overridable via the manifest `repo`).
 /// The candle wan providers read a Wan2.2 diffusers snapshot — the TI2V-5B, or the T2V-A14B /
 /// I2V-A14B 14B MoE (sc-5175); ltx reads the LTX-2.3 checkpoint plus a separate Gemma-3-12B encoder
 /// snapshot (`LTX_GEMMA_DIR`).
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 const CANDLE_WAN_5B_REPO: &str = "Wan-AI/Wan2.2-TI2V-5B-Diffusers";
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 const CANDLE_WAN_T2V_14B_REPO: &str = "Wan-AI/Wan2.2-T2V-A14B-Diffusers";
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 const CANDLE_WAN_I2V_14B_REPO: &str = "Wan-AI/Wan2.2-I2V-A14B-Diffusers";
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 const CANDLE_LTX_REPO: &str = "Lightricks/LTX-2.3";
 // The `ltx_2_3_eros` weights repo (sc-5495): a full dense LTX-2.3 fine-tune (the candle provider
 // loads its `10Eros_v1_bf16.safetensors` like the base; same architecture, same Gemma encoder).
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 const CANDLE_LTX_EROS_REPO: &str = "TenStrip/LTX2.3-10Eros";
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 const CANDLE_LTX_GEMMA_REPO: &str = "google/gemma-3-12b-it";
 
 /// Per-asset adapter id for the candle Wan-VACE controllable-video lane (sc-5494) — the candle sibling
 /// of the MLX `mlx_wan_vace` label.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 const CANDLE_WAN_VACE_ADAPTER: &str = "candle_wan_vace";
 
 /// The diffusers Wan2.1-VACE-14B snapshot the candle `wan_vace` provider reads (`transformer/` +
 /// `text_encoder/` + `vae/` + `tokenizer/`). Overridable via `SCENEWORKS_CANDLE_WAN_VACE_DIR`. The 14B
 /// repo matches the provider's `WanVaceConfig::vace_14b` dims (dim 5120, 40 layers).
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 const CANDLE_WAN_VACE_REPO: &str = "Wan-AI/Wan2.1-VACE-14B-diffusers";
 
 /// SceneWorks video model id → candle registry engine id, or `None` for an id the candle video lane
@@ -2773,7 +2773,7 @@ const CANDLE_WAN_VACE_REPO: &str = "Wan-AI/Wan2.1-VACE-14B-diffusers";
 /// (sc-5174 / sc-5175): `wan_2_2_t2v_14b` (text→video) and `wan_2_2_i2v_14b` (image→video), plus `svd`
 /// (image→video, sc-5493 / epic 5481). `ltx_2_3_eros` (sc-5495) maps to the same `ltx_2_3_distilled`
 /// engine as the base — it's a full dense LTX-2.3 fine-tune — differing only in the weights repo.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 fn candle_video_engine_id(model: &str) -> Option<&'static str> {
     match model {
         "wan_2_2" => Some("wan2_2_ti2v_5b"),
@@ -2789,12 +2789,12 @@ fn candle_video_engine_id(model: &str) -> Option<&'static str> {
 }
 
 /// Whether `model` is served by the candle video lane (sc-5097).
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 fn is_candle_video_engine(model: &str) -> bool {
     candle_video_engine_id(model).is_some()
 }
 
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 fn candle_video_adapter_label(engine_id: &str) -> &'static str {
     match engine_id {
         "ltx_2_3_distilled" => CANDLE_LTX_ADAPTER,
@@ -2805,7 +2805,7 @@ fn candle_video_adapter_label(engine_id: &str) -> &'static str {
 
 /// The candle default weights repo for a video engine id (the per-variant Wan2.2 diffusers snapshot,
 /// or the LTX-2.3 checkpoint). Used when the manifest entry omits `repo`.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 fn candle_video_default_repo(engine_id: &str) -> &'static str {
     match engine_id {
         "ltx_2_3_distilled" => CANDLE_LTX_REPO,
@@ -2820,7 +2820,7 @@ fn candle_video_default_repo(engine_id: &str) -> &'static str {
 /// The candle weights repo for a video engine: the manifest `repo` wins, else `ltx_2_3_eros` selects
 /// its own fine-tune repo (it shares the `ltx_2_3_distilled` engine id with the base), else the candle
 /// default repo for the engine.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 fn candle_video_repo(request: &VideoRequest, engine_id: &str) -> String {
     request
         .model_manifest_entry
@@ -2840,7 +2840,7 @@ fn candle_video_repo(request: &VideoRequest, engine_id: &str) -> String {
 
 /// Resolve the candle weights snapshot dir for `repo`. Errors loudly (no procedural-stub fallback)
 /// when the snapshot is absent, so a missing model surfaces a re-download error.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 fn candle_video_snapshot_dir(settings: &Settings, repo: &str) -> WorkerResult<PathBuf> {
     huggingface_snapshot_dir(&settings.data_dir, repo).ok_or_else(|| {
         WorkerError::InvalidPayload(format!(
@@ -2854,7 +2854,7 @@ fn candle_video_snapshot_dir(settings: &Settings, repo: &str) -> WorkerResult<Pa
 /// Gemma snapshot isn't in the HF cache we leave `LTX_GEMMA_DIR` unset so the provider tries its
 /// `<root>/text_encoder` fallback and emits its own clear "set LTX_GEMMA_DIR …" error. The worker runs
 /// video jobs sequentially, so the process-global env set is race-free.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 fn ensure_ltx_gemma_dir(settings: &Settings) {
     if std::env::var_os("LTX_GEMMA_DIR").is_some() {
         return; // honor an explicit operator override.
@@ -2866,7 +2866,7 @@ fn ensure_ltx_gemma_dir(settings: &Settings) {
 
 /// Raw-settings recorded on a candle video asset (mirrors `wan_raw_settings`, trimmed to the
 /// txt2video surface): the request `advanced` knobs plus the real-inference markers.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 fn candle_video_raw_settings(request: &VideoRequest, repo: &str) -> Value {
     let mut raw = request.advanced.clone();
     raw.insert("realModelInference".to_owned(), Value::Bool(true));
@@ -2885,7 +2885,7 @@ fn candle_video_raw_settings(request: &VideoRequest, repo: &str) -> Value {
 /// Every other candle video engine (5B, T2V-14B, ltx) is txt2video-only, so this returns an empty set.
 /// The router's `video_request_candle_eligible` already guarantees the i2v shape carries a source and
 /// the txt2video ids do not, but the source is required here too so a mis-routed job fails clearly.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 fn resolve_candle_video_conditioning(
     settings: &Settings,
     request: &VideoRequest,
@@ -2923,7 +2923,7 @@ fn resolve_candle_video_conditioning(
 /// Resolves the engine + weights, provisions the LTX Gemma encoder, resolves any i2v source-image
 /// conditioning, builds a `VideoGenInput`, and runs it through the shared [`generate_video`] streaming
 /// driver. Returns the decoded clip + the candle adapter label.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 async fn generate_candle_video(
     api: &ApiClient,
     settings: &Settings,
@@ -3028,7 +3028,7 @@ async fn generate_candle_video(
 /// Resolve the candle Wan-VACE diffusers snapshot dir (sc-5494): `SCENEWORKS_CANDLE_WAN_VACE_DIR`
 /// override (when it holds a `transformer/config.json`), else the HF [`CANDLE_WAN_VACE_REPO`] snapshot.
 /// Errors loudly when absent (no stub fallback — a missing VACE checkpoint surfaces a re-download error).
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 fn resolve_candle_wan_vace_model_dir(settings: &Settings) -> WorkerResult<PathBuf> {
     if let Ok(dir) = std::env::var("SCENEWORKS_CANDLE_WAN_VACE_DIR") {
         let path = PathBuf::from(dir.trim());
@@ -3045,7 +3045,7 @@ fn resolve_candle_wan_vace_model_dir(settings: &Settings) -> WorkerResult<PathBu
 /// `wan_vace` engine. Person detect/track/segment stays upstream (the masks are pre-saved); the
 /// conditioning builders are shared with the MLX path. No quant / LoRA (the candle VACE provider rejects
 /// them). Returns the decoded clip + the honest `replacementStatus`.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 async fn generate_candle_wan_vace(
     api: &ApiClient,
     settings: &Settings,
@@ -3125,7 +3125,7 @@ async fn generate_candle_wan_vace(
 /// [`generate_wan_vace_extend_bridge`]. Loads the real source-clip anchor frames (the left clip's tail
 /// for extend; both clips' boundaries for bridge), builds the source-at-kept-positions + generated-span
 /// ControlClip, and runs the `wan_vace` engine. No reference images, no quant / LoRA.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 async fn generate_candle_wan_vace_extend_bridge(
     api: &ApiClient,
     settings: &Settings,
@@ -4383,7 +4383,7 @@ fn build_video_clip_conditioning(
 /// Rust equivalent of the torch `source_asset_media_path`).
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn resolve_clip_media_path(
     settings: &Settings,
@@ -4684,7 +4684,7 @@ const SVD_ADAPTER: &str = "svd_video";
 /// Shared by the MLX (macOS) lane and the candle (Windows/CUDA) lane (sc-5493).
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 const SVD_REPO: &str = "stabilityai/stable-video-diffusion-img2vid-xt";
 
@@ -4745,7 +4745,7 @@ fn resolve_svd_model_dir(settings: &Settings) -> WorkerResult<PathBuf> {
 /// the builtin default; the resolved value is clamped).
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn svd_i32(
     request: &VideoRequest,
@@ -4769,7 +4769,7 @@ fn svd_i32(
 /// (no clamp). Mirrors the torch `float(advanced.get(adv_key, target.get(manifest_key, default)))`.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn svd_f32(request: &VideoRequest, adv_key: &str, manifest_key: &str, default: f32) -> f32 {
     request
@@ -4786,7 +4786,7 @@ fn svd_f32(request: &VideoRequest, adv_key: &str, manifest_key: &str, default: f
 /// Mirrors the torch `_num_inference_steps` for the `svd_video` adapter.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn svd_steps(request: &VideoRequest) -> u32 {
     let builtin = match request.quality.as_str() {
@@ -4845,7 +4845,7 @@ fn resolve_svd_conditioning(
 /// the MLX (macOS) and candle (Windows/CUDA, sc-5493) lanes.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn svd_raw_settings(request: &VideoRequest) -> Value {
     let mut raw = request.advanced.clone();
@@ -4965,7 +4965,7 @@ const WAN_VACE_ADAPTER: &str = "mlx_wan_vace";
 /// identity-resize preprocess.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 const FRAME_PAD_COLOR: &str = "0x12110f";
 
@@ -4973,7 +4973,7 @@ const FRAME_PAD_COLOR: &str = "0x12110f";
 /// markers; the engine id is `wan_vace`, not the user-picked replace-capable model).
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn wan_vace_raw_settings(request: &VideoRequest) -> Value {
     let mut raw = request.advanced.clone();
@@ -4994,7 +4994,7 @@ fn wan_vace_raw_settings(request: &VideoRequest) -> Value {
 /// SceneWorks `replacementMode` string → engine [`ReplacementMode`] (default FaceOnly).
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn replacement_mode_from(value: &str) -> ReplacementMode {
     match value {
@@ -5077,7 +5077,7 @@ fn resolve_wan_vace_model_dir(settings: &Settings) -> WorkerResult<PathBuf> {
 /// frames are the (un-neutralized) Wan-VACE control video; the engine masks them.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 async fn load_source_video_frames(
     api: &ApiClient,
@@ -5150,7 +5150,7 @@ async fn load_source_video_frames(
 /// decode the selected frames to engine [`Image`]s. Blocking IO/decoding runs off the runtime.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 async fn select_extracted_frames(work_dir: PathBuf, count: usize) -> WorkerResult<Vec<Image>> {
     tokio::task::spawn_blocking(move || -> WorkerResult<Vec<Image>> {
@@ -5180,7 +5180,7 @@ async fn select_extracted_frames(work_dir: PathBuf, count: usize) -> WorkerResul
 /// `_validate_inputs` parity). The engine cover-fits each to the output size.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn resolve_character_references(
     settings: &Settings,
@@ -5246,7 +5246,7 @@ fn resolve_character_references(
 /// Convert an `image::RgbImage` (the rasterized mask) to an engine [`Image`].
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn rgb_image_to_engine(image: image::RgbImage) -> Image {
     Image {
@@ -5261,7 +5261,7 @@ fn rgb_image_to_engine(image: image::RgbImage) -> Image {
 /// [`Conditioning::Reference`] per character reference image.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn build_vace_conditioning(
     frames: Vec<Image>,
@@ -5299,7 +5299,7 @@ fn build_vace_conditioning(
 /// `replacement_status`); the API folds it into the video sidecar's normalizedSettings.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn replacement_status_value(
     track: &Value,
@@ -5455,7 +5455,7 @@ async fn generate_wan_vace(
 /// freely from the kept frames + prompt, never biased toward a frozen filler image.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn neutral_control_frame(width: u32, height: u32) -> Image {
     Image {
@@ -5469,7 +5469,7 @@ fn neutral_control_frame(width: u32, height: u32) -> Image {
 /// 0.5), matching the `image::RgbImage` form `person_track_masks` produces for replace_person.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn solid_mask(width: u32, height: u32, value: u8) -> image::RgbImage {
     image::RgbImage::from_pixel(width, height, image::Rgb([value, value, value]))
@@ -5481,7 +5481,7 @@ fn solid_mask(width: u32, height: u32, value: u8) -> image::RgbImage {
 /// is clamped so at least 5 frames (one z16 chunk) are left to generate.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn extend_anchor_frames(request: &VideoRequest, frame_count: usize) -> usize {
     let per_side = if request.mode == "video_bridge" { 2 } else { 1 };
@@ -5507,7 +5507,7 @@ fn extend_anchor_frames(request: &VideoRequest, frame_count: usize) -> usize {
 /// clip's actual motion velocity at the boundary. Decodes only the kept subset (`decode_png_image`).
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 #[allow(clippy::too_many_arguments)]
 async fn load_clip_anchor_frames(
@@ -5563,7 +5563,7 @@ async fn load_clip_anchor_frames(
 /// [`Image`]s, preserving temporal order. Fewer available than `count` ⇒ all of them (short clip).
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 async fn select_anchor_frames(
     work_dir: PathBuf,
@@ -5595,7 +5595,7 @@ async fn select_anchor_frames(
 /// Decode one RGB PNG into an engine [`Image`] (shared by the resample + anchor frame selectors).
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn decode_png_image(path: &Path) -> WorkerResult<Image> {
     let decoded = image::open(path)
@@ -5619,7 +5619,7 @@ fn decode_png_image(path: &Path) -> WorkerResult<Image> {
 /// shared [`Conditioning::ControlClip`] contract), so they take the neutral defaults.
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn build_extend_bridge_vace_conditioning(
     request: &VideoRequest,
@@ -5694,7 +5694,7 @@ fn build_extend_bridge_vace_conditioning(
 /// no `replacementMode` (these modes are not person-replacement).
 #[cfg(any(
     target_os = "macos",
-    all(target_os = "windows", feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn wan_vace_extend_raw_settings(request: &VideoRequest) -> Value {
     let mut raw = request.advanced.clone();
@@ -8315,7 +8315,7 @@ mod tests {
 }
 
 // Candle video lane labeling + engine-mapping unit tests (sc-5099). Windows/candle-gated; pure maps.
-#[cfg(all(test, target_os = "windows", feature = "backend-candle"))]
+#[cfg(all(test, not(target_os = "macos"), feature = "backend-candle"))]
 mod candle_video_label_tests {
     use super::*;
 


### PR DESCRIPTION
## sc-5160 — SeedVR2 Linux/NVIDIA enablement via candle (epic 5482)

Tertiary slice of the SeedVR2 candle set: enable the candle SeedVR2 image + video upscaler on **Linux/NVIDIA**. Candle is CPU+CUDA cross-platform, so Linux **rides the Windows candle port** (engine sc-5157 + video sc-5926 + 7B/quant sc-5927 + worker wiring sc-5928). This retires the R6 "Real-ESRGAN-only on Linux" interim. SeedVR2 is the validated deliverable; the rest of the candle suite compiles for Linux too (it's the same cross-platform code).

### What changed
- **`crates/sceneworks-worker/Cargo.toml`** — moved the candle-gen provider deps from `[target.'cfg(target_os = "windows")'.dependencies]` to `cfg(not(target_os = "macos"))`, mirroring the macOS mlx table (candle = the non-Apple GPU backend). This also **fixes a latent skew**: `sensenova_jobs.rs` already gated its candle path on `not(target_os = "macos")` while `candle-gen-sensenova` was windows-only, so a Linux candle build could not have compiled.
- **`crates/sceneworks-worker/src` (13 files, 204 gates)** — uniform widen `all(target_os = "windows", feature = "backend-candle")` → `all(not(target_os = "macos"), feature = "backend-candle")` (matches the existing `sensenova_jobs.rs` convention). On Windows this is the **identical code set** (windows ⊂ non-mac); it additionally lights the candle lane up on Linux.
- **`sceneworks-core` jobs_store** — `imageUpscaleSeedvr2` is platform-true on Linux too (`seedvr2_supported = mac || windows || linux`). Routing/eligibility is already capability-based (`engine==seedvr2` + `worker_is_candle`), so a Linux candle worker routes seedvr2 exactly like Windows — **no routing change**.
- **`apps/web` macGating** — SeedVR2 now offered on Linux (capability-driven; comment + test updated).
- **`.github/workflows/server-candle-linux.yml`** — new manual (`workflow_dispatch`) Linux/NVIDIA candle compile lane: ubuntu + CUDA 12.9 toolkit + gen-core skew guard + `clippy -p sceneworks-worker --features backend-candle -D warnings` + `cargo build -p sceneworks-rust-api --release --features embed-web,backend-candle`. The Linux sibling of `desktop-candle-windows.yml` — the standing Linux-compile guard for the candle-gated code.

### Validation (Windows dev box)
- `cargo fmt --all --check` clean
- gen-core skew guard single-rev (`154af374`) for both `sceneworks-worker` and `sceneworks-rust-api` — **pins unchanged**, no skew introduced by the dep-table widen
- `cargo test -p sceneworks-core` (jobs_store: unit + 110 integration, incl. the flipped Linux `imageUpscaleSeedvr2` assertion)
- `cargo clippy -p sceneworks-worker --features backend-candle -- -D warnings` — **exit 0, zero warnings** (the widened gates compile clean on the candle lane; on Windows the compiled set is identical to the merged sc-5928 build)
- full `npm run rust:check` (fmt + clippy + test + build, default lane, all crates) green
- web vitest **449 passing** (28 files)

### Follow-up (hardware lane)
The candle runtime/CUDA path is OS-neutral (the only OS-specific worker code is the Mac `ort`/CoreML path, which stays `cfg(macos)`), and SeedVR2 is **GPU-validated on Blackwell (Windows/CUDA)** in sc-5157/5926/5927/5928. The Linux/NVIDIA still + short-clip GPU E2E is the remaining hardware-lane step (there is no Linux GPU box in the dev loop; this Windows box has no native WSL2 Linux distro). The new `server-candle-linux.yml` CI lane is the standing Linux-compile guard until that run lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)