### PR TITLE
sc-5487: route candle SDXL img2img / inpaint / outpaint into the candle lane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c98609f551553e2f11a1bd00f8341dc2efb510b5#c98609f551553e2f11a1bd00f8341dc2efb510b5"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -444,7 +444,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_distr 0.5.1",
  "safetensors 0.7.0",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c)",
+ "sceneworks-gen-core",
  "serde_json",
  "thiserror 2.0.18",
 ]
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c98609f551553e2f11a1bd00f8341dc2efb510b5#c98609f551553e2f11a1bd00f8341dc2efb510b5"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c98609f551553e2f11a1bd00f8341dc2efb510b5#c98609f551553e2f11a1bd00f8341dc2efb510b5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c98609f551553e2f11a1bd00f8341dc2efb510b5#c98609f551553e2f11a1bd00f8341dc2efb510b5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c98609f551553e2f11a1bd00f8341dc2efb510b5#c98609f551553e2f11a1bd00f8341dc2efb510b5"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c98609f551553e2f11a1bd00f8341dc2efb510b5#c98609f551553e2f11a1bd00f8341dc2efb510b5"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -519,7 +519,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c98609f551553e2f11a1bd00f8341dc2efb510b5#c98609f551553e2f11a1bd00f8341dc2efb510b5"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -530,7 +530,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c98609f551553e2f11a1bd00f8341dc2efb510b5#c98609f551553e2f11a1bd00f8341dc2efb510b5"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c98609f551553e2f11a1bd00f8341dc2efb510b5#c98609f551553e2f11a1bd00f8341dc2efb510b5"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -557,7 +557,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c98609f551553e2f11a1bd00f8341dc2efb510b5#c98609f551553e2f11a1bd00f8341dc2efb510b5"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -569,7 +569,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c98609f551553e2f11a1bd00f8341dc2efb510b5#c98609f551553e2f11a1bd00f8341dc2efb510b5"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -580,7 +580,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c98609f551553e2f11a1bd00f8341dc2efb510b5#c98609f551553e2f11a1bd00f8341dc2efb510b5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -597,7 +597,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c98609f551553e2f11a1bd00f8341dc2efb510b5#c98609f551553e2f11a1bd00f8341dc2efb510b5"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -611,7 +611,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c98609f551553e2f11a1bd00f8341dc2efb510b5#c98609f551553e2f11a1bd00f8341dc2efb510b5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -629,7 +629,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c98609f551553e2f11a1bd00f8341dc2efb510b5#c98609f551553e2f11a1bd00f8341dc2efb510b5"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -640,7 +640,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c98609f551553e2f11a1bd00f8341dc2efb510b5#c98609f551553e2f11a1bd00f8341dc2efb510b5"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -653,7 +653,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c98609f551553e2f11a1bd00f8341dc2efb510b5#c98609f551553e2f11a1bd00f8341dc2efb510b5"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -664,7 +664,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c98609f551553e2f11a1bd00f8341dc2efb510b5#c98609f551553e2f11a1bd00f8341dc2efb510b5"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -677,7 +677,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c98609f551553e2f11a1bd00f8341dc2efb510b5#c98609f551553e2f11a1bd00f8341dc2efb510b5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -3288,7 +3288,7 @@ source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3714e7b29c1e2016a3453
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=3714e7b29c1e2016a3453295cfdf9fc48a6f9128)",
+ "sceneworks-gen-core",
  "thiserror 2.0.18",
  "tokenizers 0.21.4",
 ]
@@ -5163,18 +5163,6 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
-dependencies = [
- "inventory",
- "safetensors 0.4.5",
- "serde_json",
- "thiserror 2.0.18",
- "tokenizers 0.21.4",
-]
-
-[[package]]
-name = "sceneworks-gen-core"
-version = "0.1.0"
 source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3714e7b29c1e2016a3453295cfdf9fc48a6f9128#3714e7b29c1e2016a3453295cfdf9fc48a6f9128"
 dependencies = [
  "inventory",
@@ -5274,7 +5262,7 @@ dependencies = [
  "pmetal-mlx-rs",
  "reqwest 0.12.28",
  "sceneworks-core",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=3714e7b29c1e2016a3453295cfdf9fc48a6f9128)",
+ "sceneworks-gen-core",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3279,11 +3279,19 @@ fn image_job_is_candle_eligible(job: &JobSnapshot) -> bool {
     if model == "instantid_realvisxl" {
         return instantid_candle_eligible(&job.payload);
     }
+    // SDXL img2img / inpaint / outpaint edit (sc-5487, epic 5480): an sdxl-family `edit_image` job with
+    // a source image is the bespoke candle `SdxlEdit` lane (`generate_candle_sdxl_edit_stream`), NOT
+    // txt2img — the `image_request_candle_eligible` gate below rejects the whole `edit_image` family.
+    // Branch it out first (disjoint from the IP-Adapter lane below, which is reference-only and not
+    // `edit_image`). Mirrors the worker's `sdxl_edit_candle_available` gate.
+    if matches!(model, "sdxl" | "realvisxl") && sdxl_edit_candle_eligible(&job.payload) {
+        return true;
+    }
     // SDXL IP-Adapter-Plus reference conditioning (sc-5488, epic 5480): an sdxl-family model with a
     // reference image is a bespoke candle lane (`generate_candle_sdxl_ipadapter_stream`), NOT txt2img —
     // the `image_request_candle_eligible` gate below rejects `referenceAssetId`. Branch it out first
-    // (pure IP only; img2img/inpaint/edit shapes stay on torch — those are sc-5487). Mirrors the
-    // worker's `sdxl_ipadapter_available` gate.
+    // (pure IP only; img2img/inpaint/edit shapes are the SDXL edit lane above). Mirrors the worker's
+    // `sdxl_ipadapter_available` gate.
     if matches!(model, "sdxl" | "realvisxl") && sdxl_ipadapter_candle_eligible(&job.payload) {
         return true;
     }
@@ -3609,10 +3617,26 @@ fn pulid_flux_candle_eligible(payload: &Map<String, Value>) -> bool {
     pulid_flux_mlx_eligible(payload)
 }
 
+/// SDXL img2img / inpaint / outpaint candle-routing conditions (sc-5487, epic 5480). The candle
+/// `SdxlEdit` provider serves `edit_image` mode with a `sourceAssetId` on the sdxl family: img2img (no
+/// mask), inpaint (+ `maskAssetId`), and outpaint (`fit_mode == "outpaint"`) all route to the one lane.
+/// Disjoint from the IP-Adapter lane (which is `referenceAssetId` and NOT `edit_image`). Mirrors the
+/// worker's `sdxl_edit_candle_available` gate (minus the local weight-resolve check) so the router and
+/// worker agree. Candle-only — macOS keeps the MLX `SdxlSubMode::{Edit,Inpaint,Outpaint}` path.
+fn sdxl_edit_candle_eligible(payload: &Map<String, Value>) -> bool {
+    if payload.get("mode").and_then(Value::as_str) != Some("edit_image") {
+        return false;
+    }
+    payload
+        .get("sourceAssetId")
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.trim().is_empty())
+}
+
 /// SDXL IP-Adapter-Plus candle-routing conditions (sc-5488, epic 5480). The candle `IpAdapterSdxl`
 /// provider serves PURE reference (image-prompt) conditioning on the sdxl family: a `referenceAssetId`
-/// with NO img2img source / inpaint mask and NOT an `edit_image` (those advanced SDXL shapes are
-/// sc-5487, still torch). Mirrors the worker's `sdxl_ipadapter_available` gate (minus the local
+/// with NO img2img source / inpaint mask and NOT an `edit_image` (that advanced SDXL shape is the
+/// sc-5487 `SdxlEdit` lane). Mirrors the worker's `sdxl_ipadapter_available` gate (minus the local
 /// weight-resolve check) so the router and worker agree on the lane boundary. Candle-only — there is no
 /// MLX `IpAdapterSdxl` (the MLX SDXL IP path is the registry `SdxlSubMode::Ip`), so this has no
 /// `*_mlx_eligible` sibling.
@@ -5129,8 +5153,9 @@ mod candle_routing_tests {
                 "advanced": { "poses": [{ "id": "pose_1" }] }
             }))
         ));
-        // …but a plain SDXL edit (img2img) still declines on candle → torch (real edit route, sc-5487).
-        assert!(!worker_supports_job(
+        // sc-5487: a plain SDXL edit (img2img: `edit_image` + a source) is now a candle lane (the
+        // bespoke `SdxlEdit` route), so the candle worker CLAIMS it — it no longer declines → torch.
+        assert!(worker_supports_job(
             &candle,
             &image_generate_job(json!({
                 "model": "sdxl",
@@ -5819,6 +5844,43 @@ mod candle_routing_tests {
         assert!(!sdxl_ipadapter_candle_eligible(&object(json!({
             "model": "sdxl", "referenceAssetId": "a", "maskAssetId": "m"
         }))));
+    }
+
+    #[test]
+    fn sdxl_edit_jobs_route_to_candle() {
+        // SDXL/RealVisXL img2img / inpaint / outpaint edit jobs (sc-5487) route to the bespoke candle
+        // `SdxlEdit` lane via the new branch, NOT the txt2img `image_request_candle_eligible` gate
+        // (which rejects the whole `edit_image` family).
+        for model in ["sdxl", "realvisxl"] {
+            // img2img (source, no mask).
+            let img2img = json!({ "model": model, "mode": "edit_image", "sourceAssetId": "src_1" });
+            assert!(sdxl_edit_candle_eligible(&object(img2img.clone())));
+            assert!(image_job_is_candle_eligible(&image_generate_job(img2img)));
+            // inpaint (source + mask).
+            let inpaint = json!({
+                "model": model, "mode": "edit_image", "sourceAssetId": "src_1", "maskAssetId": "m_1"
+            });
+            assert!(sdxl_edit_candle_eligible(&object(inpaint.clone())));
+            assert!(image_job_is_candle_eligible(&image_generate_job(inpaint)));
+            // outpaint (source + fitMode outpaint).
+            let outpaint = json!({
+                "model": model, "mode": "edit_image", "sourceAssetId": "src_1", "fitMode": "outpaint"
+            });
+            assert!(sdxl_edit_candle_eligible(&object(outpaint.clone())));
+            assert!(image_job_is_candle_eligible(&image_generate_job(outpaint)));
+        }
+        // `edit_image` WITHOUT a source → not this lane (nothing to edit).
+        assert!(!sdxl_edit_candle_eligible(&object(json!({
+            "model": "sdxl", "mode": "edit_image"
+        }))));
+        // A reference (IP-Adapter) job is NOT the edit lane (no source, not `edit_image`) — it's sc-5488.
+        assert!(!sdxl_edit_candle_eligible(&object(json!({
+            "model": "sdxl", "referenceAssetId": "a"
+        }))));
+        // A plain txt2img sdxl job → not the edit lane.
+        assert!(!sdxl_edit_candle_eligible(&object(
+            json!({ "model": "sdxl" })
+        )));
     }
 
     #[test]

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -742,39 +742,47 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3714
 # plain Linux/Windows torch build (no CUDA toolkit) still resolves WITHOUT candle/cudarc/nvcc, exactly as
 # before. Standing Linux-compile validation is the new manual `desktop-candle-linux` CI lane (the Linux
 # sibling of `desktop-candle-windows.yml`); the gen-core single-rev invariant is unchanged (same pins).
+# candle-gen pin re-pinned in lockstep with the worker's mlx-gen pin so `--features backend-candle`
+# resolves ONE `sceneworks-gen-core` rev (the skew gate). Current: candle-gen `c98609f` (candle-gen #87,
+# sc-5487) = candle-gen main (#85 `SdxlEdit` img2img/inpaint/outpaint provider + #86 sc-6038 InstantID
+# user-LoRA) with the gen-core pin re-pinned to `3714e7b` to MATCH this worker's `3714e7b` mlx pin. NB:
+# candle-gen main had been re-pinned to gen-core `aeb471b` by #86 (sc-6038), AHEAD of the worker; #87
+# brings it back to `3714e7b` (the worker's actual pin) — `aeb471b`/`3714e7b` have BYTE-IDENTICAL gen-core
+# (the delta is the single additive sc-6038 mlx-gen-instantid commit), so behavior-neutral. The candle
+# SDXL edit worker route (`image_jobs/sdxl_edit_candle.rs`) drives candle-gen-sdxl's `SdxlEdit` off-Mac.
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c98609f551553e2f11a1bd00f8341dc2efb510b5", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c98609f551553e2f11a1bd00f8341dc2efb510b5", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c98609f551553e2f11a1bd00f8341dc2efb510b5", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c98609f551553e2f11a1bd00f8341dc2efb510b5", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c98609f551553e2f11a1bd00f8341dc2efb510b5", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c98609f551553e2f11a1bd00f8341dc2efb510b5", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c98609f551553e2f11a1bd00f8341dc2efb510b5", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c98609f551553e2f11a1bd00f8341dc2efb510b5", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c98609f551553e2f11a1bd00f8341dc2efb510b5", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c98609f551553e2f11a1bd00f8341dc2efb510b5", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -783,19 +791,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c98609f551553e2f11a1bd00f8341dc2efb510b5", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c98609f551553e2f11a1bd00f8341dc2efb510b5", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c98609f551553e2f11a1bd00f8341dc2efb510b5", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -804,12 +812,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c98609f551553e2f11a1bd00f8341dc2efb510b5", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c98609f551553e2f11a1bd00f8341dc2efb510b5", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -817,7 +825,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005c
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c98609f551553e2f11a1bd00f8341dc2efb510b5", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -826,7 +834,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c98609f551553e2f11a1bd00f8341dc2efb510b5", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -835,7 +843,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c98609f551553e2f11a1bd00f8341dc2efb510b5", features = ["cuda"], optional = true }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -161,7 +161,10 @@ use candle_gen_instantid::{
 // `candle_gen_sdxl` is already force-link anchored above (the registered txt2img `sdxl`); this is the
 // named-type import the bespoke reference route (`image_jobs/sdxl_ipadapter.rs`) drives.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-use candle_gen_sdxl::{IpAdapterSdxl, IpAdapterSdxlPaths, IpAdapterSdxlRequest};
+use candle_gen_sdxl::{
+    IpAdapterSdxl, IpAdapterSdxlPaths, IpAdapterSdxlRequest, SdxlEdit, SdxlEditPaths,
+    SdxlEditRequest,
+};
 // Kolors IP-Adapter-Plus reference provider (sc-5488, epic 5480) — the candle (Windows/CUDA) Kolors
 // sibling of the SDXL IP lane, living in `candle-gen-kolors` (it reuses candle-gen-sdxl's vendored IP
 // UNet + the CLIP ViT-L/14-336 image encoder, with the Kolors ChatGLM3 conditioning + leading-Euler
@@ -489,6 +492,22 @@ pub(crate) async fn run_image_generate_job(
     #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
     let handled = if settings.backend_candle_enabled && instantid_available(&request, settings) {
         generate_instantid_stream(
+            api,
+            settings,
+            job,
+            &plan,
+            &project_path,
+            backend,
+            &mut asset_writes,
+        )
+        .await?;
+        true
+    } else if settings.backend_candle_enabled && sdxl_edit_candle_available(&request, settings) {
+        // SDXL img2img / inpaint / outpaint edit (sc-5487) — checked BEFORE `is_candle_engine` because
+        // `sdxl`/`realvisxl` ARE candle txt2img ids, so without this an `edit_image` job would be caught
+        // by the txt2img branch (which can't honor a source/mask). Disjoint from the IP-Adapter lane
+        // below (that one is reference-only and not `edit_image`).
+        generate_candle_sdxl_edit_stream(
             api,
             settings,
             job,
@@ -1109,6 +1128,11 @@ include!("image_jobs/instantid.rs");
 // candle-exclusive.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 include!("image_jobs/sdxl_ipadapter.rs");
+// SDXL img2img / inpaint / outpaint edit — the Windows/CUDA candle lane ONLY (sc-5487). macOS keeps the
+// MLX SDXL advanced path (sdxl.rs `SdxlSubMode::{Edit,Inpaint,Outpaint}`); the candle `SdxlEdit` is a
+// bespoke provider, so this is candle-exclusive.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+include!("image_jobs/sdxl_edit_candle.rs");
 // Kolors IP-Adapter-Plus reference conditioning — the Windows/CUDA candle lane ONLY (sc-5488). macOS
 // keeps the MLX Kolors IP path (kolors.rs, the registry `Reference` route); the candle `IpAdapterKolors`
 // is a bespoke provider, so this is candle-exclusive.

--- a/crates/sceneworks-worker/src/image_jobs/instantid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/instantid.rs
@@ -631,6 +631,13 @@ async fn generate_instantid_stream(
                 sdxl_base,
                 identitynet: controlnet,
                 ip_adapter,
+                // sc-6038 added a required `adapters` (user LoRA/LoKr) field to the CANDLE
+                // `InstantIdPaths` (candle-gen #86); the macOS mlx `InstantIdPaths` (worker mlx pin
+                // 3714e7b) does not carry it yet, so cfg the field to the candle build to keep BOTH
+                // backends compiling. Empty = no LoRA (the current behavior); populating it from the
+                // request is the candle InstantID-LoRA worker wiring, which is sc-6038's own follow-up.
+                #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+                adapters: Vec::new(),
             };
             let model = InstantId::load(&paths)
                 .map_err(|error| WorkerError::Engine(format!("InstantID load failed: {error}")))?;
@@ -666,18 +673,18 @@ async fn generate_instantid_stream(
                         "InstantID ArcFace weights {arcface_path:?}: {error}"
                     ))
                 })?;
-                model
-                    .with_face(&scrfd, &arcface)
-                    .map_err(|error| WorkerError::Engine(format!("InstantID face stack: {error}")))?
+                model.with_face(&scrfd, &arcface).map_err(|error| {
+                    WorkerError::Engine(format!("InstantID face stack: {error}"))
+                })?
             };
             #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
             let model = {
                 let face_dir = scrfd_path.parent().unwrap_or(scrfd_path.as_path());
                 // `arcface_path` is staged in the same dir; `with_face(dir)` resolves it by name.
                 let _ = &arcface_path;
-                model
-                    .with_face(face_dir)
-                    .map_err(|error| WorkerError::Engine(format!("InstantID face stack: {error}")))?
+                model.with_face(face_dir).map_err(|error| {
+                    WorkerError::Engine(format!("InstantID face stack: {error}"))
+                })?
             };
             // Face-restore needs the reference identity embedding (imposed on the re-rendered crop).
             // Detect it once on the raw reference. The candle `largest_face` takes the neutral

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_edit_candle.rs
@@ -1,0 +1,438 @@
+// Candle (Windows/CUDA) SDXL img2img / inpaint / outpaint edit route (sc-5487, epic 5480) — pixel-
+// conditioned editing on SDXL/RealVisXL off-Mac via `candle_gen_sdxl::SdxlEdit`. The edit sibling of the
+// candle SDXL IP-Adapter lane (sdxl_ipadapter.rs): the same SDXL base resolution + stream plumbing, but
+// a SOURCE (and optional mask) instead of a reference, across the three edit sub-modes.
+//
+// **Candle-only.** macOS keeps the MLX SDXL advanced path (sdxl.rs `SdxlSubMode::{Edit,Inpaint,Outpaint}`);
+// the candle `SdxlEdit` is a bespoke provider, so this whole file is gated to the Windows/CUDA candle
+// build (the `include!` in image_jobs.rs carries the cfg). It is `include!`d into the `image_jobs`
+// module, so it shares that module's imports (ImageRequest/Settings/WorkerResult/`advanced`/
+// `load_reference_image`/`huggingface_snapshot_dir`/`resolve_app_managed_model_dir`/`resolve_seed`/
+// `start_gen_stream`/`drive_gen_items`/`consume_gen_events`/`non_empty`/`gen_core`/… all in scope).
+
+/// img2img strength for a plain SDXL edit (torch `SdxlDiffusersAdapter` default 0.6).
+const SDXL_EDIT_CANDLE_EDIT_STRENGTH: f32 = 0.6;
+/// Strength for masked inpaint / outpaint (torch default 0.85 — the repaint region is mostly regenerated).
+const SDXL_EDIT_CANDLE_INPAINT_STRENGTH: f32 = 0.85;
+/// Denoise steps default (SDXL production).
+const SDXL_EDIT_CANDLE_DEFAULT_STEPS: u32 = 30;
+/// CFG default — base SDXL uses ~7; 5.0 matches the candle SDXL reference-conditioned envelope.
+const SDXL_EDIT_CANDLE_DEFAULT_GUIDANCE: f32 = 5.0;
+/// The adapter/engine id recorded on candle SDXL edit assets + telemetry (distinct from the txt2img
+/// `candle_sdxl` and the `candle_sdxl_ipadapter` lanes).
+const SDXL_EDIT_CANDLE_ENGINE: &str = "candle_sdxl_edit";
+
+/// SDXL model ids the candle edit route accepts (the txt2img-eligible SDXL family).
+fn is_sdxl_edit_candle_model(model: &str) -> bool {
+    matches!(model, "sdxl" | "realvisxl")
+}
+
+/// Default SDXL base repo for a model id when the manifest omits `repo`.
+fn sdxl_edit_candle_default_repo(model: &str) -> &'static str {
+    match model {
+        "realvisxl" => "SG161222/RealVisXL_V5.0",
+        _ => "stabilityai/stable-diffusion-xl-base-1.0",
+    }
+}
+
+/// Which SDXL edit sub-mode a request maps onto — the candle subset of the macOS `sdxl_sub_mode` (the
+/// IP-Adapter case is the separate sdxl_ipadapter lane). `None` = not a candle SDXL edit job.
+#[derive(Clone, Copy)]
+enum SdxlEditCandleMode {
+    /// Plain img2img (source init only).
+    Edit,
+    /// Masked inpaint (source init + mask).
+    Inpaint,
+    /// Outpaint = inpaint with a worker-built border mask (+ optional user-mask union).
+    Outpaint,
+}
+
+/// Classify a candle SDXL edit job: an `edit_image` job with a source. Outpaint wins over a plain mask
+/// when `fit_mode == "outpaint"` (matching the torch path); a mask without outpaint is inpaint; neither
+/// is a plain img2img edit. Mirrors the macOS `sdxl_sub_mode` (minus the `Ip` case).
+fn sdxl_edit_candle_mode(request: &ImageRequest) -> Option<SdxlEditCandleMode> {
+    if request.mode != "edit_image" || !non_empty(&request.source_asset_id) {
+        return None;
+    }
+    if request.fit_mode == "outpaint" {
+        return Some(SdxlEditCandleMode::Outpaint);
+    }
+    if non_empty(&request.mask_asset_id) {
+        return Some(SdxlEditCandleMode::Inpaint);
+    }
+    Some(SdxlEditCandleMode::Edit)
+}
+
+/// Resolve the SDXL base snapshot for the edit route: an explicit `modelPath` dir (advanced or manifest)
+/// wins, else the HF cache snapshot for the manifest `repo` (default by model id). `None` means the base
+/// is not present locally, so the job is not candle-runnable (falls through to torch). Mirrors
+/// `resolve_sdxl_ipadapter_base`.
+fn resolve_sdxl_edit_candle_base(
+    request: &ImageRequest,
+    settings: &Settings,
+) -> WorkerResult<Option<PathBuf>> {
+    if let Some(path) = request
+        .advanced
+        .get("modelPath")
+        .or_else(|| request.model_manifest_entry.get("modelPath"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+    {
+        return resolve_app_managed_model_dir(settings, &path, "SDXL edit modelPath").map(Some);
+    }
+    let repo = request
+        .model_manifest_entry
+        .get("repo")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| sdxl_edit_candle_default_repo(&request.model));
+    Ok(huggingface_snapshot_dir(&settings.data_dir, repo))
+}
+
+/// True when this is a candle-eligible SDXL edit job: an sdxl-family `edit_image` job with a source (an
+/// img2img / inpaint / outpaint shape, NOT a pure reference — that is the sdxl_ipadapter lane) whose base
+/// resolves locally. Mirrors `jobs_store::sdxl_edit_candle_eligible` so the worker and router agree.
+fn sdxl_edit_candle_available(request: &ImageRequest, settings: &Settings) -> bool {
+    is_sdxl_edit_candle_model(&request.model)
+        && sdxl_edit_candle_mode(request).is_some()
+        && matches!(
+            resolve_sdxl_edit_candle_base(request, settings),
+            Ok(Some(_))
+        )
+}
+
+/// Resolve denoise steps: `advanced.steps` (clamped 1..=80) → manifest `steps` → default (30).
+fn sdxl_edit_candle_steps(request: &ImageRequest) -> u32 {
+    let parse = |value: &Value| {
+        value
+            .as_u64()
+            .or_else(|| value.as_str()?.trim().parse().ok())
+    };
+    request
+        .advanced
+        .get("steps")
+        .and_then(parse)
+        .or_else(|| request.model_manifest_entry.get("steps").and_then(parse))
+        .map(|steps| steps.clamp(1, 80) as u32)
+        .unwrap_or(SDXL_EDIT_CANDLE_DEFAULT_STEPS)
+}
+
+/// Resolve guidance: `advanced.guidanceScale` → manifest `guidanceScale` → default (5.0), clamped.
+fn sdxl_edit_candle_guidance(request: &ImageRequest) -> f32 {
+    let manifest_default = request
+        .model_manifest_entry
+        .get("guidanceScale")
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .map(|value| value as f32)
+        .unwrap_or(SDXL_EDIT_CANDLE_DEFAULT_GUIDANCE);
+    advanced::f32_clamped(
+        &request.advanced,
+        "guidanceScale",
+        manifest_default,
+        0.0..=30.0,
+    )
+}
+
+/// Resize an RGB image to exactly `width`×`height` honoring `mode` without distorting it (the candle twin
+/// of the macOS `fit_rgb`): `crop` covers + center-crops, `pad`/`outpaint` contains + letterboxes on a
+/// black canvas (the kept rect aligns with [`gen_core::imageops::contain_box`]), `stretch` is the legacy
+/// non-aspect resize. The candle `SdxlEdit` provider re-resizes to the render size internally, but pre-
+/// fitting here is what honors `fit_mode` (the provider only stretches).
+fn sdxl_edit_fit_rgb(
+    source: &image::RgbImage,
+    width: u32,
+    height: u32,
+    mode: &str,
+) -> image::RgbImage {
+    use image::imageops::FilterType::Lanczos3;
+    let width = width.max(1);
+    let height = height.max(1);
+    let (src_w, src_h) = (source.width(), source.height());
+    match mode {
+        "stretch" => image::imageops::resize(source, width, height, Lanczos3),
+        "crop" => {
+            let ratio = (width as f32 / src_w as f32).max(height as f32 / src_h as f32);
+            // Ceil so the scaled image always fully covers the target before cropping.
+            let new_w = width.max((src_w as f32 * ratio).ceil() as u32);
+            let new_h = height.max((src_h as f32 * ratio).ceil() as u32);
+            let resized = image::imageops::resize(source, new_w, new_h, Lanczos3);
+            let left = (new_w - width) / 2;
+            let top = (new_h - height) / 2;
+            image::imageops::crop_imm(&resized, left, top, width, height).to_image()
+        }
+        // "pad" / "outpaint": contain + center on a black canvas (letterbox).
+        _ => {
+            let (new_w, new_h, left, top) =
+                gen_core::imageops::contain_box(src_w, src_h, width, height);
+            let resized = image::imageops::resize(source, new_w.max(1), new_h.max(1), Lanczos3);
+            let mut canvas = image::RgbImage::from_pixel(width, height, image::Rgb([0, 0, 0]));
+            image::imageops::overlay(&mut canvas, &resized, left as i64, top as i64);
+            canvas
+        }
+    }
+}
+
+/// Fit an engine [`Image`] (RGB8) to `width`×`height` by `mode` via [`sdxl_edit_fit_rgb`].
+fn sdxl_edit_fit_image(source: Image, width: u32, height: u32, mode: &str) -> WorkerResult<Image> {
+    let rgb =
+        image::RgbImage::from_raw(source.width, source.height, source.pixels).ok_or_else(|| {
+            WorkerError::InvalidPayload("SDXL edit image buffer size mismatch".to_owned())
+        })?;
+    let fitted = sdxl_edit_fit_rgb(&rgb, width, height, mode);
+    Ok(Image {
+        width: fitted.width(),
+        height: fitted.height(),
+        pixels: fitted.into_raw(),
+    })
+}
+
+/// Composite `source` contained (long edge fits) + centered on a black `width`×`height` canvas (the
+/// candle twin of the macOS `sdxl_outpaint_canvas`), using the engine's [`gen_core::imageops::contain_box`]
+/// so the padded source lines up pixel-for-pixel with [`gen_core::imageops::outpaint_border_mask`].
+fn sdxl_edit_outpaint_canvas(source: &image::RgbImage, width: u32, height: u32) -> Image {
+    use image::imageops::FilterType::Lanczos3;
+    let (new_w, new_h, left, top) =
+        gen_core::imageops::contain_box(source.width(), source.height(), width, height);
+    let resized = image::imageops::resize(source, new_w.max(1), new_h.max(1), Lanczos3);
+    let mut canvas = image::RgbImage::from_pixel(width, height, image::Rgb([0, 0, 0]));
+    image::imageops::overlay(&mut canvas, &resized, left as i64, top as i64);
+    Image {
+        width,
+        height,
+        pixels: canvas.into_raw(),
+    }
+}
+
+/// Flat telemetry recorded on candle SDXL edit assets (the sub-mode + strength that drove it; parity with
+/// the macOS SDXL advanced recipe keys).
+fn sdxl_edit_candle_raw_settings(
+    request: &ImageRequest,
+    repo: &str,
+    steps: u32,
+    guidance: f32,
+    strength: f32,
+    mode_tag: &str,
+) -> JsonObject {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("repo".to_owned(), Value::String(repo.to_owned()));
+    raw.insert("numInferenceSteps".to_owned(), json!(steps));
+    raw.insert("guidanceScale".to_owned(), json!(guidance));
+    raw.insert("strength".to_owned(), json!(strength));
+    raw.insert("editMode".to_owned(), Value::String(mode_tag.to_owned()));
+    raw.insert(
+        "editEngine".to_owned(),
+        Value::String(SDXL_EDIT_CANDLE_ENGINE.to_owned()),
+    );
+    raw
+}
+
+/// Load the SDXL edit source asset (the `sourceAssetId` is required for every edit sub-mode) as an engine
+/// [`Image`].
+fn load_sdxl_edit_source(
+    request: &ImageRequest,
+    project_path: &Path,
+    settings: &Settings,
+) -> WorkerResult<Image> {
+    let source_id = request
+        .source_asset_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload("SDXL edit requires a source image".to_owned())
+        })?;
+    load_reference_image(
+        &settings.data_dir,
+        &request.project_id,
+        source_id,
+        project_path,
+    )
+}
+
+/// Real candle SDXL edit generation: resolve the source (+ mask) + base on the async side, build the
+/// sub-mode's `(source, mask)` (img2img: a fitted source; inpaint: fitted source + mask; outpaint: the
+/// padded canvas + the border mask, unioned with any user mask), then load `SdxlEdit` once + generate
+/// each image on the blocking thread. `request.count` images, each its own seed. `generate` takes `&self`
+/// (no per-call UNet mutation), so the per-item closure needs no `mut`. Reuses [`consume_gen_events`].
+async fn generate_candle_sdxl_edit_stream(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+    let sdxl_base = resolve_sdxl_edit_candle_base(request, settings)?.ok_or_else(|| {
+        WorkerError::InvalidPayload("SDXL edit base (SDXL/RealVisXL) not found".to_owned())
+    })?;
+    let mode = sdxl_edit_candle_mode(request).ok_or_else(|| {
+        WorkerError::InvalidPayload(
+            "SDXL edit requires edit_image mode + a source image".to_owned(),
+        )
+    })?;
+    let (width, height) = (request.width, request.height);
+    let source = load_sdxl_edit_source(request, project_path, settings)?;
+
+    let is_inpaint = matches!(
+        mode,
+        SdxlEditCandleMode::Inpaint | SdxlEditCandleMode::Outpaint
+    );
+    let strength = advanced::f32_clamped(
+        &request.advanced,
+        "strength",
+        if is_inpaint {
+            SDXL_EDIT_CANDLE_INPAINT_STRENGTH
+        } else {
+            SDXL_EDIT_CANDLE_EDIT_STRENGTH
+        },
+        0.0..=1.0,
+    );
+
+    // Build the sub-mode's (source, optional mask) at the render geometry. The provider re-resizes
+    // internally, so the source/mask only need to be at `width`×`height` with aligned geometry.
+    let (gen_source, gen_mask, mode_tag): (Image, Option<Image>, &str) = match mode {
+        SdxlEditCandleMode::Edit => (
+            sdxl_edit_fit_image(source, width, height, &request.fit_mode)?,
+            None,
+            "edit",
+        ),
+        SdxlEditCandleMode::Inpaint => {
+            let src = sdxl_edit_fit_image(source, width, height, &request.fit_mode)?;
+            let mask_id = request
+                .mask_asset_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|id| !id.is_empty())
+                .ok_or_else(|| {
+                    WorkerError::InvalidPayload("SDXL inpaint requires a mask image".to_owned())
+                })?;
+            let mask = load_reference_image(
+                &settings.data_dir,
+                &request.project_id,
+                mask_id,
+                project_path,
+            )?;
+            let mask = sdxl_edit_fit_image(mask, width, height, &request.fit_mode)?;
+            (src, Some(mask), "inpaint")
+        }
+        SdxlEditCandleMode::Outpaint => {
+            // Pad the source onto the render canvas; the white border is the region to regenerate.
+            let src_rgb = image::RgbImage::from_raw(source.width, source.height, source.pixels)
+                .ok_or_else(|| {
+                    WorkerError::InvalidPayload(
+                        "SDXL outpaint source buffer size mismatch".to_owned(),
+                    )
+                })?;
+            let (src_w, src_h) = (src_rgb.width(), src_rgb.height());
+            let canvas = sdxl_edit_outpaint_canvas(&src_rgb, width, height);
+            // White = regenerate (the padded border), black = keep (the centered source).
+            let mut mask = gen_core::imageops::outpaint_border_mask(src_w, src_h, width, height);
+            if non_empty(&request.mask_asset_id) {
+                // Union any user edit region into the border (white wins) — pad-fit the user mask onto
+                // the same contained geometry first.
+                let mask_id = request.mask_asset_id.as_deref().unwrap().trim();
+                let user_mask = load_reference_image(
+                    &settings.data_dir,
+                    &request.project_id,
+                    mask_id,
+                    project_path,
+                )?;
+                let user_mask = sdxl_edit_fit_image(user_mask, width, height, "pad")?;
+                mask = gen_core::imageops::union_masks(&mask, &user_mask).map_err(|error| {
+                    WorkerError::Engine(format!("SDXL outpaint mask union failed: {error}"))
+                })?;
+            }
+            (canvas, Some(mask), "outpaint")
+        }
+    };
+
+    let steps = sdxl_edit_candle_steps(request);
+    let guidance = sdxl_edit_candle_guidance(request);
+    let repo = request
+        .model_manifest_entry
+        .get("repo")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| sdxl_edit_candle_default_repo(&request.model))
+        .to_owned();
+    let raw_settings =
+        sdxl_edit_candle_raw_settings(request, &repo, steps, guidance, strength, mode_tag);
+
+    // Per-image work items: (seed, prompt) — `request.count` edits of the same source.
+    let work: Vec<(i64, String)> = (0..request.count as usize)
+        .map(|index| (resolve_seed(request, index), request.prompt.clone()))
+        .collect();
+    let total = work.len();
+    let negative = request.negative_prompt.clone();
+
+    let (cancel, rx, blocking) = start_gen_stream(
+        job.id.clone(),
+        "sdxl_edit",
+        0,
+        move || {
+            let model = SdxlEdit::load(&SdxlEditPaths { sdxl_base })
+                .map_err(|error| WorkerError::Engine(format!("SDXL edit load failed: {error}")))?;
+            Ok((model, gen_source, gen_mask))
+        },
+        move |(model, source, mask), tx, cancel| {
+            drive_gen_items(tx, work, move |_index, (seed, prompt), on_progress| {
+                if cancel.is_cancelled() {
+                    return Ok(None);
+                }
+                let req = SdxlEditRequest {
+                    prompt,
+                    negative: negative.clone(),
+                    width,
+                    height,
+                    steps: steps as usize,
+                    guidance,
+                    strength,
+                    seed: seed as u64,
+                    cancel: cancel.clone(),
+                };
+                let result = match &mask {
+                    Some(mask) => model.generate_masked(&req, &source, mask, &mut *on_progress),
+                    None => model.generate(&req, &source, &mut *on_progress),
+                };
+                let out = match result {
+                    Ok(out) => out,
+                    Err(_) if cancel.is_cancelled() => return Ok(None),
+                    Err(error) => {
+                        return Err(WorkerError::Engine(format!(
+                            "SDXL edit generation failed: {error}"
+                        )));
+                    }
+                };
+                Ok(Some((seed, out.width, out.height, out.pixels)))
+            })
+        },
+    );
+
+    consume_gen_events(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        SDXL_EDIT_CANDLE_ENGINE,
+        &raw_settings,
+        total,
+        rx,
+        cancel,
+        blocking,
+        asset_writes,
+    )
+    .await
+}


### PR DESCRIPTION
Wires candle-gen-sdxl's **`SdxlEdit`** provider ([candle-gen #85](https://github.com/michaeltrefry/candle-gen/pull/85)) into the worker as a bespoke off-Mac edit lane — the **first sc-5487 family**. `sdxl`/`realvisxl` + `edit_image` + a `sourceAssetId` now route to candle instead of the torch fallback (img2img / inpaint / outpaint).

## Changes

- **jobs_store.rs** — `sdxl_edit_candle_eligible` (`edit_image` + `sourceAssetId`) + a branch in `image_job_is_candle_eligible` before the IP-Adapter lane (disjoint: the edit lane is source-based, the IP lane reference-based). Routing test covers img2img / inpaint / outpaint for `sdxl` + `realvisxl`.
- **image_jobs/sdxl_edit_candle.rs** (new, candle-gated) — `generate_candle_sdxl_edit_stream` + the sub-mode classifier (Edit/Inpaint/Outpaint via `mode`/`maskAssetId`/`fit_mode`), the fit helpers (`fit_rgb`/`fit_engine_image` — honor `fit_mode`), and the outpaint canvas + `outpaint_border_mask` (+ optional user-mask union) — mirroring the macOS `SdxlAdvanced` handler. Drives `SdxlEdit.generate` / `generate_masked`; reuses the shared stream plumbing.
- **image_jobs.rs** — candle import + `include!` + dispatch branch (before `sdxl_ipadapter`).
- **Cargo.toml** — re-pin candle-gen `b005cf7` → `c98609f` ([candle-gen #87](https://github.com/michaeltrefry/candle-gen/pull/87) = candle-gen main #85 `SdxlEdit` + #86 sc-6038 InstantID-LoRA, with the gen-core pin re-pinned to `3714e7b` to MATCH this worker's mlx pin). Single `sceneworks-gen-core` rev (`3714e7b`) ⇒ skew gate green.
- **instantid.rs** — cfg-gate the candle `InstantIdPaths.adapters` field. #86 added a required `adapters` (user-LoRA) field to the **candle** `InstantIdPaths`; the macOS mlx pin (`3714e7b`) has no such field, so the field is `#[cfg]`'d to the candle build, empty = no LoRA (behavior unchanged). Keeps both backends compiling; the candle InstantID-LoRA worker wiring is sc-6038's follow-up.

## Validation

- Core routing test **PASS** (`sdxl_edit_jobs_route_to_candle`, img2img/inpaint/outpaint).
- `clippy -p sceneworks-worker --features backend-candle -- -D warnings` **clean** (sm_120, MSVC 14.44); `fmt` clean.
- The `SdxlEdit` provider itself is **GPU-validated** (candle-gen #85: img2img strength ablation + inpaint kept-vs-repaint region gate).

**Depends on [candle-gen #87](https://github.com/michaeltrefry/candle-gen/pull/87) — merge that first** (this PR pins its commit `c98609f`).

Remaining sc-5487 families (their candle edit providers still need porting): FLUX.2 klein edit, Qwen-Image-Edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
