### PR TITLE
fix(instantid): apply user-selected SDXL LoRAs to InstantID generation (sc-6038)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7daadce922365726c8255fd32e667b006ae82b9e#7daadce922365726c8255fd32e667b006ae82b9e"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7daadce922365726c8255fd32e667b006ae82b9e#7daadce922365726c8255fd32e667b006ae82b9e"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7daadce922365726c8255fd32e667b006ae82b9e#7daadce922365726c8255fd32e667b006ae82b9e"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7daadce922365726c8255fd32e667b006ae82b9e#7daadce922365726c8255fd32e667b006ae82b9e"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7daadce922365726c8255fd32e667b006ae82b9e#7daadce922365726c8255fd32e667b006ae82b9e"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7daadce922365726c8255fd32e667b006ae82b9e#7daadce922365726c8255fd32e667b006ae82b9e"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -519,7 +519,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7daadce922365726c8255fd32e667b006ae82b9e#7daadce922365726c8255fd32e667b006ae82b9e"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -530,7 +530,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7daadce922365726c8255fd32e667b006ae82b9e#7daadce922365726c8255fd32e667b006ae82b9e"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7daadce922365726c8255fd32e667b006ae82b9e#7daadce922365726c8255fd32e667b006ae82b9e"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -557,7 +557,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7daadce922365726c8255fd32e667b006ae82b9e#7daadce922365726c8255fd32e667b006ae82b9e"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -569,7 +569,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7daadce922365726c8255fd32e667b006ae82b9e#7daadce922365726c8255fd32e667b006ae82b9e"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -580,7 +580,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7daadce922365726c8255fd32e667b006ae82b9e#7daadce922365726c8255fd32e667b006ae82b9e"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -597,7 +597,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7daadce922365726c8255fd32e667b006ae82b9e#7daadce922365726c8255fd32e667b006ae82b9e"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -611,7 +611,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7daadce922365726c8255fd32e667b006ae82b9e#7daadce922365726c8255fd32e667b006ae82b9e"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -629,7 +629,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7daadce922365726c8255fd32e667b006ae82b9e#7daadce922365726c8255fd32e667b006ae82b9e"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -640,7 +640,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7daadce922365726c8255fd32e667b006ae82b9e#7daadce922365726c8255fd32e667b006ae82b9e"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -653,7 +653,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7daadce922365726c8255fd32e667b006ae82b9e#7daadce922365726c8255fd32e667b006ae82b9e"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -664,7 +664,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7daadce922365726c8255fd32e667b006ae82b9e#7daadce922365726c8255fd32e667b006ae82b9e"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -677,7 +677,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b005cf72b57af42a27fc2c7965b0df9ea0ca73d1#b005cf72b57af42a27fc2c7965b0df9ea0ca73d1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7daadce922365726c8255fd32e667b006ae82b9e#7daadce922365726c8255fd32e667b006ae82b9e"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -3284,7 +3284,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=aeb471bdb79efa8c23573e7ae43d34d30acac3b4#aeb471bdb79efa8c23573e7ae43d34d30acac3b4"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3296,7 +3296,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=aeb471bdb79efa8c23573e7ae43d34d30acac3b4#aeb471bdb79efa8c23573e7ae43d34d30acac3b4"
 dependencies = [
  "image",
  "inventory",
@@ -3310,7 +3310,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=aeb471bdb79efa8c23573e7ae43d34d30acac3b4#aeb471bdb79efa8c23573e7ae43d34d30acac3b4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3322,7 +3322,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=aeb471bdb79efa8c23573e7ae43d34d30acac3b4#aeb471bdb79efa8c23573e7ae43d34d30acac3b4"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3331,7 +3331,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=aeb471bdb79efa8c23573e7ae43d34d30acac3b4#aeb471bdb79efa8c23573e7ae43d34d30acac3b4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3343,7 +3343,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=aeb471bdb79efa8c23573e7ae43d34d30acac3b4#aeb471bdb79efa8c23573e7ae43d34d30acac3b4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3354,7 +3354,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=aeb471bdb79efa8c23573e7ae43d34d30acac3b4#aeb471bdb79efa8c23573e7ae43d34d30acac3b4"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3365,7 +3365,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=aeb471bdb79efa8c23573e7ae43d34d30acac3b4#aeb471bdb79efa8c23573e7ae43d34d30acac3b4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3375,7 +3375,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=aeb471bdb79efa8c23573e7ae43d34d30acac3b4#aeb471bdb79efa8c23573e7ae43d34d30acac3b4"
 dependencies = [
  "image",
  "inventory",
@@ -3387,7 +3387,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=aeb471bdb79efa8c23573e7ae43d34d30acac3b4#aeb471bdb79efa8c23573e7ae43d34d30acac3b4"
 dependencies = [
  "image",
  "inventory",
@@ -3400,7 +3400,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=aeb471bdb79efa8c23573e7ae43d34d30acac3b4#aeb471bdb79efa8c23573e7ae43d34d30acac3b4"
 dependencies = [
  "image",
  "inventory",
@@ -3412,7 +3412,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=aeb471bdb79efa8c23573e7ae43d34d30acac3b4#aeb471bdb79efa8c23573e7ae43d34d30acac3b4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3423,7 +3423,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=aeb471bdb79efa8c23573e7ae43d34d30acac3b4#aeb471bdb79efa8c23573e7ae43d34d30acac3b4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3435,7 +3435,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=aeb471bdb79efa8c23573e7ae43d34d30acac3b4#aeb471bdb79efa8c23573e7ae43d34d30acac3b4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3445,7 +3445,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=aeb471bdb79efa8c23573e7ae43d34d30acac3b4#aeb471bdb79efa8c23573e7ae43d34d30acac3b4"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3454,7 +3454,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=aeb471bdb79efa8c23573e7ae43d34d30acac3b4#aeb471bdb79efa8c23573e7ae43d34d30acac3b4"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3463,7 +3463,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=aeb471bdb79efa8c23573e7ae43d34d30acac3b4#aeb471bdb79efa8c23573e7ae43d34d30acac3b4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3475,7 +3475,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=aeb471bdb79efa8c23573e7ae43d34d30acac3b4#aeb471bdb79efa8c23573e7ae43d34d30acac3b4"
 dependencies = [
  "image",
  "inventory",
@@ -3488,7 +3488,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=aeb471bdb79efa8c23573e7ae43d34d30acac3b4#aeb471bdb79efa8c23573e7ae43d34d30acac3b4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3499,7 +3499,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=aeb471bdb79efa8c23573e7ae43d34d30acac3b4#aeb471bdb79efa8c23573e7ae43d34d30acac3b4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3510,7 +3510,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=aeb471bdb79efa8c23573e7ae43d34d30acac3b4#aeb471bdb79efa8c23573e7ae43d34d30acac3b4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3521,7 +3521,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=aeb471bdb79efa8c23573e7ae43d34d30acac3b4#aeb471bdb79efa8c23573e7ae43d34d30acac3b4"
 dependencies = [
  "image",
  "inventory",
@@ -3535,7 +3535,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=aeb471bdb79efa8c23573e7ae43d34d30acac3b4#aeb471bdb79efa8c23573e7ae43d34d30acac3b4"
 dependencies = [
  "image",
  "inventory",
@@ -5163,7 +5163,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=154af374f4f925b88552af664bacc8388f2f3c2c#154af374f4f925b88552af664bacc8388f2f3c2c"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=aeb471bdb79efa8c23573e7ae43d34d30acac3b4#aeb471bdb79efa8c23573e7ae43d34d30acac3b4"
 dependencies = [
  "inventory",
  "safetensors 0.4.5",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -564,8 +564,13 @@
         "schedulers": ["shift"]
       },
       "loraCompatibility": {
-        // An 8-step distill LoRA exists upstream but is not wired yet.
-        "families": [],
+        // SenseNova-U1 is an 8B MoT autoregressive image model with no diffusion-LoRA merge path,
+        // so no user LoRAs apply. Declare the model's own family rather than [] (sc-6038): an empty
+        // list matches EVERY LoRA in the picker (loraMatchesModel returns true when the model has no
+        // families) while the worker drops them all (sensenova.rs loads Vec::new()) — a silent
+        // ignore. No LoRA declares `sensenova-u1`, so the picker correctly offers none. (An 8-step
+        // distill LoRA exists upstream but is not wired.)
+        "families": ["sensenova-u1"],
         "types": []
       },
       "ui": {
@@ -634,8 +639,11 @@
         "schedulers": ["shift"]
       },
       "loraCompatibility": {
-        // The distill LoRA is baked into this variant; user LoRAs are not wired.
-        "families": [],
+        // No user-LoRA path (MoT autoregressive; the distill LoRA is baked into this variant).
+        // Declare the model's own family rather than [] (sc-6038): an empty list matches every LoRA
+        // in the picker but the worker drops them — no LoRA declares `sensenova-u1`, so none are
+        // offered.
+        "families": ["sensenova-u1"],
         "types": []
       },
       "ui": {

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -114,8 +114,11 @@ sceneworks-core = { path = "../sceneworks-core" }
 # below is re-pinned in LOCKSTEP to candle-gen 7daadce (#86) — which itself re-pins gen-core 154af37 ->
 # aeb471b — so `--features backend-candle --target all` resolves the single rev aeb471b again (closing the
 # sc-5905 skew). candle-gen 7daadce = the candle InstantID LoRA seam (`load_instantid_unet_with_adapters`)
-# + that gen-core re-pin. NB: both engine pins point at the PR branch commits pre-merge; flip to the merge
-# commits once mlx-gen #477 / candle-gen #86 land.
+# + that gen-core re-pin. Both #477 and #86 are MERGED (merge commits, 2026-06-16), so aeb471b + 7daadce
+# are now ancestors of their repos' `main` (permanently fetchable). KEEP these exact revs — do NOT flip to
+# the merge-commit HEADs: candle-gen's internal gen-core is pinned at aeb471b, so moving mlx-gen to the
+# newer main HEAD would resolve TWO gen-core revs under `--features backend-candle` again. Pinning the
+# precise pre-merge tips also keeps the delta minimal (154af37 + exactly the sc-6038 change, no main drift).
 sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "aeb471bdb79efa8c23573e7ae43d34d30acac3b4" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -106,7 +106,17 @@ sceneworks-core = { path = "../sceneworks-core" }
 # but that lane is workflow_dispatch-only (not a PR gate) and build-windows builds WITHOUT backend-candle,
 # so this PR is unaffected; candle catches up in its own repo (same deferral as the 32fdb34 bump above,
 # tracked: sc-5905).
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
+# Rev aeb471b (mlx-gen #477, sc-6038): bumps EVERY mlx-gen crate 154af37 -> aeb471b in lockstep to add
+# the InstantID user-LoRA seam — `mlx_gen_instantid::InstantIdPaths.adapters` merges SDXL LoRAs onto the
+# RealVisXL UNet via `apply_sdxl_adapters_with` (InstantID generation was silently dropping selected
+# LoRAs). gen-core is BYTE-IDENTICAL 154af37 -> aeb471b (the change is pure mlx-gen-instantid Rust), so
+# this is a rev-only alignment; mlx-rs unchanged (44929a0), MLX core does not rebuild. The candle-gen pin
+# below is re-pinned in LOCKSTEP to candle-gen 7daadce (#86) — which itself re-pins gen-core 154af37 ->
+# aeb471b — so `--features backend-candle --target all` resolves the single rev aeb471b again (closing the
+# sc-5905 skew). candle-gen 7daadce = the candle InstantID LoRA seam (`load_instantid_unet_with_adapters`)
+# + that gen-core re-pin. NB: both engine pins point at the PR branch commits pre-merge; flip to the merge
+# commits once mlx-gen #477 / candle-gen #86 land.
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "aeb471bdb79efa8c23573e7ae43d34d30acac3b4" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -405,7 +415,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "aeb471bdb79efa8c23573e7ae43d34d30acac3b4" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -417,55 +427,55 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f
 # internal pin (the Lens engine PRs #407–#414 did not move it; nor did the seedvr2 engine #416/#419/
 # #421 or the softness PR #422, so the 1a97909 bump above leaves mlx-rs at 44929a0).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "44929a001ab8a8837403a71c65cf064224de0cdc" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "aeb471bdb79efa8c23573e7ae43d34d30acac3b4" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "aeb471bdb79efa8c23573e7ae43d34d30acac3b4" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "aeb471bdb79efa8c23573e7ae43d34d30acac3b4" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "aeb471bdb79efa8c23573e7ae43d34d30acac3b4" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "aeb471bdb79efa8c23573e7ae43d34d30acac3b4" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "aeb471bdb79efa8c23573e7ae43d34d30acac3b4" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "aeb471bdb79efa8c23573e7ae43d34d30acac3b4" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "aeb471bdb79efa8c23573e7ae43d34d30acac3b4" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "aeb471bdb79efa8c23573e7ae43d34d30acac3b4" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "aeb471bdb79efa8c23573e7ae43d34d30acac3b4" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "aeb471bdb79efa8c23573e7ae43d34d30acac3b4" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "aeb471bdb79efa8c23573e7ae43d34d30acac3b4" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -474,12 +484,12 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af3
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "aeb471bdb79efa8c23573e7ae43d34d30acac3b4" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "aeb471bdb79efa8c23573e7ae43d34d30acac3b4" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -488,7 +498,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af3
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "aeb471bdb79efa8c23573e7ae43d34d30acac3b4" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -496,7 +506,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "aeb471bdb79efa8c23573e7ae43d34d30acac3b4" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -507,7 +517,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154a
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "aeb471bdb79efa8c23573e7ae43d34d30acac3b4" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -518,7 +528,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "aeb471bdb79efa8c23573e7ae43d34d30acac3b4" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -533,7 +543,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af3
 # converted in-memory at load (no Python); the precomputed neg-prompt embedding is bundled in-crate. No
 # LoRA/guidance/CFG (one-step). 3B fp16 only here — 7B (sc-5197) + int8 (sc-5198) are engine-side and
 # unwired. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "aeb471bdb79efa8c23573e7ae43d34d30acac3b4" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -544,7 +554,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "aeb471bdb79efa8c23573e7ae43d34d30acac3b4" }
 # Prompt-refine provider (sc-5552, the MLX twin of candle-gen-prompt-refine / sc-5500). An
 # inventory-registered `TextLlm` under id `prompt_refine` (`backend="mlx"`, `mac_only`): a native MLX
 # Llama-3.2-3B-Instruct that rewrites a user's prompt, replacing the Python `prompt_refine.py`
@@ -554,7 +564,7 @@ mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154
 # textllm registered" trap). Weights = a stock Llama-3.2-3B-Instruct HF snapshot (config.json +
 # tokenizer.json + model-*.safetensors; default `huihui-ai/Llama-3.2-3B-Instruct-abliterated`). Same
 # git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
+mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "aeb471bdb79efa8c23573e7ae43d34d30acac3b4" }
 # SCAIL-2 (zai-org) end-to-end character-animation provider (epic 5439, sc-5448). An inventory-registered
 # `Generator` under id `scail2_14b` (`Modality::Video`): a Wan2.1-14B I2V DiT that animates a reference
 # character with a driving video's motion (`video_mode == "replacement"` flips the cross-identity
@@ -566,7 +576,7 @@ mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev 
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154af374f4f925b88552af664bacc8388f2f3c2c" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "aeb471bdb79efa8c23573e7ae43d34d30acac3b4" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -743,38 +753,38 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "154a
 # before. Standing Linux-compile validation is the new manual `desktop-candle-linux` CI lane (the Linux
 # sibling of `desktop-candle-windows.yml`); the gen-core single-rev invariant is unchanged (same pins).
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7daadce922365726c8255fd32e667b006ae82b9e", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7daadce922365726c8255fd32e667b006ae82b9e", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7daadce922365726c8255fd32e667b006ae82b9e", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7daadce922365726c8255fd32e667b006ae82b9e", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7daadce922365726c8255fd32e667b006ae82b9e", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7daadce922365726c8255fd32e667b006ae82b9e", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7daadce922365726c8255fd32e667b006ae82b9e", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7daadce922365726c8255fd32e667b006ae82b9e", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7daadce922365726c8255fd32e667b006ae82b9e", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7daadce922365726c8255fd32e667b006ae82b9e", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -783,19 +793,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7daadce922365726c8255fd32e667b006ae82b9e", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7daadce922365726c8255fd32e667b006ae82b9e", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7daadce922365726c8255fd32e667b006ae82b9e", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -804,12 +814,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7daadce922365726c8255fd32e667b006ae82b9e", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7daadce922365726c8255fd32e667b006ae82b9e", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -817,7 +827,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005c
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7daadce922365726c8255fd32e667b006ae82b9e", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -826,7 +836,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 154af37, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7daadce922365726c8255fd32e667b006ae82b9e", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -835,7 +845,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 154af37; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b005cf72b57af42a27fc2c7965b0df9ea0ca73d1", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7daadce922365726c8255fd32e667b006ae82b9e", features = ["cuda"], optional = true }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/image_jobs/instantid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/instantid.rs
@@ -488,6 +488,14 @@ async fn generate_instantid_stream(
     let (controlnet, ip_adapter, scrfd_path, arcface_path) =
         ensure_instantid_weights(api, settings, job).await?;
 
+    // User style/character LoRAs (sc-6038). InstantID is a stock SDXL (RealVisXL) UNet, so SDXL
+    // adapters apply on top of IdentityNet + the identity IP-Adapter — and the manifest advertises
+    // `families:[sdxl]`, so the picker offers them. Resolved + path-confined exactly like every other
+    // SDXL-family path (base.rs/sdxl.rs); merged onto the UNet by the engine `InstantIdPaths.adapters`
+    // seam. Shared across all three modes (identity / angle set / pose) since they share the one load.
+    let adapters = resolve_adapters(request, settings)?;
+    let adapter_count = adapters.len();
+
     let steps = instantid_steps(request);
     let guidance = instantid_guidance(request);
     let (quant_bits, recipe_bits) = instantid_quant(request);
@@ -558,6 +566,11 @@ async fn generate_instantid_stream(
     if face_restore {
         raw_settings.insert("faceRestore".to_owned(), Value::Bool(true));
     }
+    // Record how many user LoRAs were merged onto the SDXL UNet (sc-6038) so the asset sidecar shows
+    // the adapters were applied (they previously rode the request but were silently dropped).
+    if adapter_count > 0 {
+        raw_settings.insert("appliedLoraCount".to_owned(), json!(adapter_count));
+    }
     // Record which collection + ordered presets produced the set, so each asset (by index) maps
     // back to the preset that rendered it (sc-4450).
     if let Some((collection_id, presets)) = &angle_collection {
@@ -625,12 +638,13 @@ async fn generate_instantid_stream(
     let (cancel, rx, blocking) = start_gen_stream(
         job.id.clone(),
         "instantid",
-        0,
+        adapter_count,
         move || {
             let paths = InstantIdPaths {
                 sdxl_base,
                 identitynet: controlnet,
                 ip_adapter,
+                adapters,
             };
             let model = InstantId::load(&paths)
                 .map_err(|error| WorkerError::Engine(format!("InstantID load failed: {error}")))?;

--- a/crates/sceneworks-worker/src/image_jobs/sensenova.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sensenova.rs
@@ -243,6 +243,11 @@ async fn generate_sensenova_edit_stream(
         raw_settings.insert("angleSet".to_owned(), Value::Bool(true));
     }
 
+    // No user adapters by design (sc-6038): SenseNova-U1 is an 8B MoT autoregressive model with no
+    // diffusion-LoRA merge path, and its manifest declares `loraCompatibility.families:
+    // ["sensenova-u1"]` (its own family — no LoRA declares it), so the picker offers none. The empty
+    // adapter list is intentional, not a dropped wiring (contrast `instantid.rs`, which DOES apply
+    // user SDXL LoRAs).
     let spec = load_spec(weights_dir, quant, Vec::new(), None);
     let (cancel, rx, blocking) = start_cached_gen_stream(
         job.id.clone(),

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -1537,6 +1537,7 @@ fn instantid_angle_kps_real_weights_fills_frame_and_holds_identity() {
         sdxl_base,
         identitynet: WeightsSource::Dir(identitynet),
         ip_adapter,
+        adapters: Vec::new(),
     };
     let model = InstantId::load(&paths).expect("InstantID load");
     let scrfd = Weights::from_file(&scrfd_path).expect("SCRFD weights");
@@ -2395,6 +2396,64 @@ fn flux2_grouping_poses_over_angles_over_plain() {
         "advanced": { "angleSet": true }
     }));
     assert!(matches!(flux2_grouping(&edit), Flux2Grouping::Plain));
+}
+
+/// Minimal valid safetensors (8-byte LE header length + JSON header). No `networkType`, so
+/// `classify_adapter` reports `Lora`; the resolver only reads the header, so empty tensors are fine.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn write_min_lora(path: &std::path::Path) {
+    let header = json!({ "__metadata__": { "format": "pt" } });
+    let header_bytes = serde_json::to_vec(&header).unwrap();
+    let mut buffer = (header_bytes.len() as u64).to_le_bytes().to_vec();
+    buffer.extend_from_slice(&header_bytes);
+    std::fs::write(path, buffer).unwrap();
+}
+
+/// sc-6038: InstantID is a stock SDXL (RealVisXL) UNet, so a user-selected SDXL LoRA must resolve
+/// into a non-empty adapter set — the worker now feeds these into `InstantIdPaths.adapters` (they
+/// were previously dropped: `instantid.rs` never called `resolve_adapters`). Guards the worker half
+/// of the fix; the engine merge is covered by mlx-gen #477 / candle-gen #86 + the real-weight smoke.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+#[test]
+fn instantid_resolves_user_loras_into_adapters() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut settings = Settings::from_env();
+    settings.data_dir = dir.path().to_path_buf();
+
+    // A real (tiny, valid) safetensors LoRA under the app-managed data dir — both the path
+    // containment guard and the header classification in `resolve_adapters` run against it.
+    let lora_file = dir.path().join("style.safetensors");
+    write_min_lora(&lora_file);
+
+    let req = request(json!({
+        "projectId": "p", "model": "instantid_realvisxl", "mode": "character_image",
+        "prompt": "portrait", "referenceAssetId": "ref-1",
+        "loras": [{ "path": lora_file.to_string_lossy(), "weight": 0.65 }],
+        "modelManifestEntry": { "family": "instantid" }
+    }));
+
+    let adapters = resolve_adapters(&req, &settings).expect("resolve adapters");
+    assert_eq!(
+        adapters.len(),
+        1,
+        "the selected SDXL LoRA must resolve to one InstantID adapter (not silently dropped)"
+    );
+    assert_eq!(
+        adapters[0].scale, 0.65,
+        "the per-LoRA weight carries through"
+    );
+    assert!(matches!(adapters[0].kind, AdapterKind::Lora));
+    assert_eq!(
+        adapters[0].path.file_name().and_then(|n| n.to_str()),
+        Some("style.safetensors"),
+        "the confined LoRA path resolves to the on-disk file"
+    );
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
Fixes [sc-6038](https://app.shortcut.com/trefry/story/6038). InstantID generation (single identity, the 11-view Character Studio angle set, and pose mode) **silently ignored user-selected LoRAs**: the UI sent `loras` and the manifest advertised `families:[sdxl]`, but `image_jobs/instantid.rs` never resolved or applied them. InstantID is a stock SDXL (RealVisXL) UNet, so SDXL LoRAs validly apply alongside IdentityNet + the identity IP-Adapter.

Root cause was deeper than the story's "fix direction" assumed: the InstantID **engine** had no adapter seam at all. This is a 3-repo change.

## Engine (prereq PRs)
- mlx-gen [#477](https://github.com/michaeltrefry/mlx-gen/pull/477): `InstantIdPaths.adapters` → `apply_sdxl_adapters_with` merges SDXL LoRAs onto the dense fp16 UNet before the IP-Adapter install + the worker's quantize (mirrors `mlx_gen_sdxl::model::load`).
- candle-gen [#86](https://github.com/michaeltrefry/candle-gen/pull/86): the Windows/CUDA sibling (`load_instantid_unet_with_adapters` via `merge_adapters`) + a gen-core re-pin so the backend-candle skew lane stays single-rev.

## Worker (this PR)
- `image_jobs/instantid.rs`: `resolve_adapters(request, settings)` → `InstantIdPaths.adapters`; records `appliedLoraCount` + the real adapter count on load events. Shared by all three modes.
- Pin bumps: mlx-gen `154af37→aeb471b`, candle-gen `b005cf7→7daadce`, lockstep (gen-core byte-identical across the bump). **Engine pins are PR branch commits pre-merge — flip to the merge commits once #477/#86 land.**
- SenseNova manifest: `sensenova_u1_8b{,_fast}` declared `loraCompatibility.families: []`, which matches **every** LoRA in the picker while `sensenova.rs` drops them all — the same silent-ignore class. SenseNova-U1 is an 8B MoT autoregressive model (no diffusion-LoRA path), so declare its own family `["sensenova-u1"]`; no LoRA declares it, so the picker offers none.
- New worker test: non-empty `request.loras` ⇒ non-empty InstantID adapter set.

## Validation
- **Real-weight smoke** (RealVisXL + InstantID + a diffusers-block SDXL LoRA): same seed/prompt renders **98.3% different pixels** with vs without the LoRA (mlx-gen `instantid_user_lora_changes_output`).
- 303 worker lib tests + gen-core skew gate + clippy `-D warnings` + fmt all green.

## Adjacent finding (not in scope)
The shared SDXL merger rejects original-SD `lora_unet_input_blocks_*` naming (common in A1111/civitai SDXL LoRAs) — now a **loud error** rather than a silent drop, but those LoRAs still won't apply to any SDXL-family model. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)