### PR TITLE
sc-6042: rework Character Studio asset flow — scoped reference picker + Import dialog

### DIFF
--- a/apps/web/src/components/AssetPicker.jsx
+++ b/apps/web/src/components/AssetPicker.jsx
@@ -16,6 +16,15 @@ const sourceImageTabs = [
   ["character", "Character"],
 ];
 
+// sc-6042: Character Assets "Import" dialog tabs. Images/Videos pick from the
+// Project library; Upload brings files in from the local computer. All three add
+// the chosen media to the character's asset library.
+const characterImportTabs = [
+  ["images", "Images"],
+  ["videos", "Videos"],
+  ["upload", "Upload"],
+];
+
 function compactDate(value) {
   if (!value) {
     return "No date";
@@ -130,6 +139,15 @@ function activeProjectImageAsset(asset, projectId) {
   return (
     projectMatches(asset, projectId) &&
     (assetCanRenderAsImage(asset) || asset?.type === "frame") &&
+    !asset?.status?.trashed &&
+    !asset?.status?.rejected
+  );
+}
+
+function activeProjectVideoAsset(asset, projectId) {
+  return (
+    projectMatches(asset, projectId) &&
+    assetCanRenderAsVideo(asset) &&
     !asset?.status?.trashed &&
     !asset?.status?.rejected
   );
@@ -445,6 +463,11 @@ export function AssetPickerField({
   changeLabel = "Change",
   multiple = false,
   onChange,
+  // showCategories=false drops the All/Images/Video/Uploads/Renders segmented
+  // control and renders just a scoped multi-select grid (sc-6042). Used by the
+  // character reference picker, which is already scoped to one character's
+  // assets, so the category tabs were redundant/empty noise there.
+  showCategories = true,
   value = "",
   values = [],
 }) {
@@ -473,6 +496,7 @@ export function AssetPickerField({
           multiple={multiple}
           onCancel={() => setOpen(false)}
           onConfirm={confirm}
+          showCategories={showCategories}
           title={label}
         />
       ) : null}
@@ -480,7 +504,15 @@ export function AssetPickerField({
   );
 }
 
-export function AssetPickerModal({ assets, initialSelectedIds, multiple = false, onCancel, onConfirm, title = "Select assets" }) {
+export function AssetPickerModal({
+  assets,
+  initialSelectedIds,
+  multiple = false,
+  onCancel,
+  onConfirm,
+  showCategories = true,
+  title = "Select assets",
+}) {
   const [category, setCategory] = useState("all");
   const [query, setQuery] = useState("");
   const [selectedIds, setSelectedIds] = useState(() => normalizeSelection(initialSelectedIds, assets, multiple));
@@ -495,10 +527,13 @@ export function AssetPickerModal({ assets, initialSelectedIds, multiple = false,
 
   const searchIndex = useMemo(() => assetSearchIndex(assets), [assets]);
 
+  // With the category control hidden the grid is unfiltered (the caller already
+  // scoped `assets`), so pin the active category to "all".
+  const activeCategory = showCategories ? category : "all";
   const visibleAssets = useMemo(() => {
     const needle = query.trim().toLowerCase();
-    return assets.filter((asset) => categoryMatches(asset, category) && (!needle || searchIndex.get(asset.id)?.includes(needle)));
-  }, [assets, category, query, searchIndex]);
+    return assets.filter((asset) => categoryMatches(asset, activeCategory) && (!needle || searchIndex.get(asset.id)?.includes(needle)));
+  }, [assets, activeCategory, query, searchIndex]);
 
   function toggleAsset(asset) {
     setSelectedIds((ids) => {
@@ -522,13 +557,15 @@ export function AssetPickerModal({ assets, initialSelectedIds, multiple = false,
         </header>
 
         <div className="asset-picker-toolbar">
-          <div className="segmented-control compact-segment" role="tablist" aria-label="Asset category">
-            {categoryOptions.map(([key, label]) => (
-              <button className={category === key ? "active" : ""} key={key} onClick={() => setCategory(key)} type="button">
-                {label} <span>{categoryCounts[key]}</span>
-              </button>
-            ))}
-          </div>
+          {showCategories ? (
+            <div className="segmented-control compact-segment" role="tablist" aria-label="Asset category">
+              {categoryOptions.map(([key, label]) => (
+                <button className={category === key ? "active" : ""} key={key} onClick={() => setCategory(key)} type="button">
+                  {label} <span>{categoryCounts[key]}</span>
+                </button>
+              ))}
+            </div>
+          ) : null}
           <input
             aria-label="Search assets"
             onChange={(event) => setQuery(event.target.value)}
@@ -579,6 +616,237 @@ export function AssetPickerModal({ assets, initialSelectedIds, multiple = false,
             </button>
           </div>
         </footer>
+    </Modal>
+  );
+}
+
+// sc-6042: Import media into a character's asset library. Three tabs, all
+// multi-select: Images and Videos pull from the Project asset library (of the
+// matching type, excluding media already in this character's library); Upload
+// brings file(s) in from the local computer. Project selections are attached via
+// onImport(assetIds); uploads are imported into the project first (importAsset)
+// then handed to the same onImport so both paths converge on one "attach" step.
+export function CharacterImportDialog({
+  assets = [],
+  projectId,
+  characterId,
+  character,
+  characterName,
+  importAsset,
+  onImport,
+  onClose,
+}) {
+  const [tab, setTab] = useState("images");
+  const [query, setQuery] = useState("");
+  const [selectedIds, setSelectedIds] = useState([]);
+  const [dragActive, setDragActive] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  const imageCandidates = useMemo(
+    () =>
+      assets.filter(
+        (asset) => activeProjectImageAsset(asset, projectId) && !assetMatchesCharacter(asset, characterId, character),
+      ),
+    [assets, projectId, characterId, character],
+  );
+  const videoCandidates = useMemo(
+    () =>
+      assets.filter(
+        (asset) => activeProjectVideoAsset(asset, projectId) && !assetMatchesCharacter(asset, characterId, character),
+      ),
+    [assets, projectId, characterId, character],
+  );
+
+  const tabAssets = tab === "videos" ? videoCandidates : imageCandidates;
+  const searchIndex = useMemo(() => assetSearchIndex(tabAssets), [tabAssets]);
+  const visibleAssets = useMemo(() => filterPickerAssets(tabAssets, query, searchIndex), [tabAssets, query, searchIndex]);
+
+  function toggleAsset(id) {
+    setSelectedIds((ids) => (ids.includes(id) ? ids.filter((value) => value !== id) : [...ids, id]));
+  }
+
+  function switchTab(next) {
+    setTab(next);
+    setQuery("");
+    setSelectedIds([]);
+    setError("");
+  }
+
+  async function attach(assetIds) {
+    await onImport(assetIds);
+    onClose();
+  }
+
+  async function commitSelection() {
+    if (!selectedIds.length || busy) {
+      return;
+    }
+    setBusy(true);
+    setError("");
+    try {
+      await attach(selectedIds);
+    } catch (err) {
+      setError(err?.message ?? "Could not import the selection.");
+      setBusy(false);
+    }
+  }
+
+  async function handleUploadFiles(fileList) {
+    const files = Array.from(fileList ?? []);
+    if (!files.length || busy) {
+      return;
+    }
+    if (!importAsset) {
+      setError("File upload is unavailable in this context.");
+      return;
+    }
+    setBusy(true);
+    setError("");
+    try {
+      const importedIds = [];
+      for (const file of files) {
+        const imported = await importAsset(file, { throwOnError: true });
+        if (imported?.id) {
+          importedIds.push(imported.id);
+        }
+      }
+      if (importedIds.length) {
+        await attach(importedIds);
+      } else {
+        setError("Upload failed — try another file.");
+        setBusy(false);
+      }
+    } catch (err) {
+      setError(err?.message ?? "Upload failed — try another file.");
+      setBusy(false);
+    }
+  }
+
+  function handleDrop(event) {
+    event.preventDefault();
+    setDragActive(false);
+    handleUploadFiles(event.dataTransfer?.files);
+  }
+
+  function renderGrid(emptyLabel) {
+    return (
+      <div aria-multiselectable className="asset-picker-grid" role="listbox">
+        {visibleAssets.map((asset) => {
+          const selected = selectedIds.includes(asset.id);
+          const status = statusLabel(asset);
+          return (
+            <button
+              aria-selected={selected}
+              className={selected ? "asset-picker-card selected" : "asset-picker-card"}
+              key={asset.id}
+              onClick={() => toggleAsset(asset.id)}
+              role="option"
+              type="button"
+            >
+              <AssetThumbnail asset={asset} />
+              <span className="asset-picker-card-copy">
+                <strong>{titleFor(asset)}</strong>
+                <small>
+                  {typeLabel(asset)} | {sourceLabel(asset)}
+                </small>
+                <small title={asset.id}>
+                  {compactDate(asset.createdAt ?? asset.updatedAt)} | ID {assetIdentity(asset)}
+                  {status ? ` | ${status}` : ""}
+                </small>
+              </span>
+            </button>
+          );
+        })}
+        {visibleAssets.length ? null : <div className="empty-panel compact-panel">{emptyLabel}</div>}
+      </div>
+    );
+  }
+
+  return (
+    <Modal className="asset-picker-modal character-import-modal" labelledBy="character-import-title" onClose={onClose}>
+      <header className="asset-picker-modal-head">
+        <div>
+          <p className="eyebrow">Character assets</p>
+          <h2 id="character-import-title">Import to {characterName || "character"}</h2>
+        </div>
+        <button className="modal-close" onClick={onClose} type="button">
+          Close
+        </button>
+      </header>
+
+      <div className="asset-picker-toolbar">
+        <div className="segmented-control compact-segment" role="tablist" aria-label="Import source">
+          {characterImportTabs.map(([key, label]) => (
+            <button
+              aria-selected={tab === key}
+              className={tab === key ? "active" : ""}
+              key={key}
+              onClick={() => switchTab(key)}
+              role="tab"
+              type="button"
+            >
+              {label}
+              {key === "images" ? <span>{imageCandidates.length}</span> : null}
+              {key === "videos" ? <span>{videoCandidates.length}</span> : null}
+            </button>
+          ))}
+        </div>
+        {tab === "upload" ? null : (
+          <input
+            aria-label="Search project assets"
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search project assets"
+            value={query}
+          />
+        )}
+      </div>
+
+      {tab === "images" ? renderGrid("No project images to import") : null}
+      {tab === "videos" ? renderGrid("No project videos to import") : null}
+
+      {tab === "upload" ? (
+        <div
+          className={dragActive ? "dataset-add-dropzone active" : "dataset-add-dropzone"}
+          onDragLeave={() => setDragActive(false)}
+          onDragOver={(event) => {
+            event.preventDefault();
+            setDragActive(true);
+          }}
+          onDrop={handleDrop}
+        >
+          <p>{busy ? "Importing…" : "Drop images or videos here, or"}</p>
+          <label className="file-upload-button">
+            <input
+              accept="image/*,video/*"
+              disabled={busy}
+              multiple
+              onChange={(event) => {
+                handleUploadFiles(event.target.files);
+                event.target.value = "";
+              }}
+              type="file"
+            />
+            {busy ? "Importing" : "Browse files"}
+          </label>
+        </div>
+      ) : null}
+
+      {error ? <p className="inline-warning">{error}</p> : null}
+
+      {tab === "upload" ? null : (
+        <footer className="asset-picker-footer">
+          <span>{selectedIds.length ? `${selectedIds.length} selected` : "No selection"}</span>
+          <div className="detail-actions">
+            <button onClick={onClose} type="button">
+              Cancel
+            </button>
+            <button className="primary-action" disabled={!selectedIds.length || busy} onClick={commitSelection} type="button">
+              {busy ? "Importing…" : `Import ${selectedIds.length || ""}`.trim()}
+            </button>
+          </div>
+        </footer>
+      )}
     </Modal>
   );
 }

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -2,7 +2,7 @@ import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App, ErrorBoundary, eventUrl } from "./main.jsx";
-import { AssetPickerField } from "./components/AssetPicker.jsx";
+import { AssetPickerField, CharacterImportDialog } from "./components/AssetPicker.jsx";
 import { assetUrl } from "./components/assetMedia.jsx";
 import { AssetDetail, FullscreenPreview } from "./components/assetPanels.jsx";
 import { liveElapsedSeconds } from "./formatting.js";
@@ -2176,6 +2176,109 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("Beta");
   });
 
+  it("drops the category tabs when showCategories is false (sc-6042 reference picker)", async () => {
+    const onChange = vi.fn();
+    const assets = [
+      { id: "image-alpha", type: "image", displayName: "Alpha" },
+      { id: "clip-gamma", type: "video", displayName: "Gamma", file: { mimeType: "video/mp4" } },
+    ];
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <AssetPickerField assets={assets} label="Reference assets" multiple onChange={onChange} showCategories={false} values={[]} />,
+      );
+    });
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Select").click();
+    });
+
+    // No "Asset category" segmented control, but the scoped grid still renders.
+    expect(container.querySelector('[aria-label="Asset category"]')).toBeNull();
+    expect(container.textContent).not.toContain("Renders");
+    expect(container.querySelectorAll(".asset-picker-card")).toHaveLength(2);
+  });
+
+  const characterImportAssets = () => [
+    { id: "p-img1", type: "image", projectId: "project-1", displayName: "Project Image 1" },
+    { id: "p-img2", type: "image", projectId: "project-1", displayName: "Project Image 2" },
+    { id: "p-vid1", type: "video", projectId: "project-1", displayName: "Project Video 1", file: { mimeType: "video/mp4" } },
+    // Already in the character library → excluded from the Images tab.
+    { id: "c-img", type: "image", projectId: "project-1", displayName: "Already linked", recipe: { normalizedSettings: { characterId: "char-1" } } },
+    // Different project → excluded everywhere.
+    { id: "x-img", type: "image", projectId: "project-2", displayName: "Other project" },
+  ];
+
+  function renderCharacterImport(overrides = {}) {
+    const props = {
+      assets: characterImportAssets(),
+      character: { id: "char-1", name: "Mira", references: [] },
+      characterId: "char-1",
+      characterName: "Mira",
+      importAsset: vi.fn(async () => ({ id: "uploaded-1", type: "image", projectId: "project-1", displayName: "Fresh" })),
+      onClose: vi.fn(),
+      onImport: vi.fn(async () => {}),
+      projectId: "project-1",
+      ...overrides,
+    };
+    root = createRoot(container);
+    return { props };
+  }
+
+  it("imports the selected project images into the character library (sc-6042)", async () => {
+    const { props } = renderCharacterImport();
+    await act(async () => {
+      root.render(<CharacterImportDialog {...props} />);
+    });
+
+    // Three tabs, all multi-select; Images excludes already-linked + other-project.
+    expect([...container.querySelectorAll('[role="tab"]')].map((tab) => tab.textContent.replace(/\d+/g, ""))).toEqual([
+      "Images",
+      "Videos",
+      "Upload",
+    ]);
+    const cards = [...container.querySelectorAll(".asset-picker-card")];
+    expect(cards).toHaveLength(2);
+    await act(async () => {
+      cards[0].click();
+      cards[1].click();
+    });
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent.startsWith("Import")).click();
+    });
+    expect(props.onImport).toHaveBeenCalledWith(["p-img1", "p-img2"]);
+    expect(props.onClose).toHaveBeenCalled();
+  });
+
+  it("lists project videos and uploads local files into the character library (sc-6042)", async () => {
+    const { props } = renderCharacterImport();
+    await act(async () => {
+      root.render(<CharacterImportDialog {...props} />);
+    });
+
+    // Videos tab lists only project videos.
+    await act(async () => {
+      [...container.querySelectorAll('[role="tab"]')].find((tab) => tab.textContent.startsWith("Videos")).click();
+    });
+    expect(container.querySelectorAll(".asset-picker-card")).toHaveLength(1);
+    expect(container.querySelector('[title="p-vid1"]')).not.toBeNull();
+
+    // Upload tab accepts local image + video files, then imports + attaches them.
+    await act(async () => {
+      [...container.querySelectorAll('[role="tab"]')].find((tab) => tab.textContent === "Upload").click();
+    });
+    const fileInput = container.querySelector('input[type="file"]');
+    expect(fileInput.getAttribute("accept")).toBe("image/*,video/*");
+    expect(fileInput.multiple).toBe(true);
+    const file = new File(["x"], "ref.png", { type: "image/png" });
+    await act(async () => {
+      Object.defineProperty(fileInput, "files", { value: [file], configurable: true });
+      fileInput.dispatchEvent(new window.Event("change", { bubbles: true }));
+    });
+    expect(props.importAsset).toHaveBeenCalledTimes(1);
+    expect(props.onImport).toHaveBeenCalledWith(["uploaded-1"]);
+  });
+
   it("keeps unsaved character reference selections when a multi-add partially fails", async () => {
     const addCharacterReference = vi.fn(async (_characterId, reference) => {
       if (reference.assetId === "image-beta") {
@@ -2183,9 +2286,11 @@ describe("SceneWorks app shell", () => {
       }
       return {};
     });
+    // sc-6042: the reference picker is scoped to this character's assets, so the
+    // candidates must already belong to char-1 (here: generated for it).
     const assets = [
-      { id: "image-alpha", type: "image", displayName: "Alpha" },
-      { id: "image-beta", type: "image", displayName: "Beta" },
+      { id: "image-alpha", type: "image", displayName: "Alpha", recipe: { normalizedSettings: { characterId: "char-1" } } },
+      { id: "image-beta", type: "image", displayName: "Beta", recipe: { normalizedSettings: { characterId: "char-1" } } },
     ];
 
     root = createRoot(container);
@@ -3050,6 +3155,32 @@ describe("SceneWorks app shell", () => {
       previewButtons[0].click();
     });
     expect(onPreview).toHaveBeenCalled();
+  });
+
+  it("opens the Import dialog from the Character Assets page (sc-6042)", async () => {
+    const selectedCharacter = { id: "char-1", name: "Mira", references: [] };
+    const assets = [{ id: "p-img1", type: "image", projectId: "project-1", displayName: "Project Image 1" }];
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <CharacterAssets
+          addCharacterReference={vi.fn(async () => ({}))}
+          assets={assets}
+          importAsset={vi.fn()}
+          onPreview={vi.fn()}
+          projectId="project-1"
+          selectedCharacter={selectedCharacter}
+        />,
+      );
+    });
+
+    const importButton = [...container.querySelectorAll("button")].find((button) => button.textContent === "Import");
+    expect(importButton).toBeTruthy();
+    await act(async () => {
+      importButton.click();
+    });
+    expect(container.textContent).toContain("Import to Mira");
+    expect(container.querySelector('[title="p-img1"]')).not.toBeNull();
   });
 
   it("lists a character's associated datasets and opens one (sc-2022)", async () => {

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -180,12 +180,19 @@ export function CharacterStudio() {
     () => datasetsForProject.filter((dataset) => dataset.characterId === selectedCharacter?.id),
     [datasetsForProject, selectedCharacter?.id],
   );
-  const characterImageAssetIds = useMemo(
+  // This character's image/frame assets (generated for it, generated referencing
+  // it, or attached as references). sc-6042: this is the pool the Reference picker
+  // selects from — the character's own assets, not the whole project library.
+  const characterReferenceCandidates = useMemo(
     () =>
       selectedCharacter
-        ? imageAssets.filter((asset) => assetMatchesCharacter(asset, selectedCharacter.id, selectedCharacter)).map((asset) => asset.id)
+        ? imageAssets.filter((asset) => assetMatchesCharacter(asset, selectedCharacter.id, selectedCharacter))
         : [],
     [imageAssets, selectedCharacter?.id],
+  );
+  const characterImageAssetIds = useMemo(
+    () => characterReferenceCandidates.map((asset) => asset.id),
+    [characterReferenceCandidates],
   );
   // Thumbnail for the compact selector (sc-2025): a character's first approved
   // reference image, falling back to any reference. Null → placeholder tile.
@@ -523,7 +530,7 @@ export function CharacterStudio() {
               </div>
 
               <CharacterReferences
-                imageAssets={imageAssets}
+                referenceCandidates={characterReferenceCandidates}
                 onGenerateFromReference={(assetId) => onSendImage(selectedCharacter, testLookId || null, assetId)}
                 onPreview={onPreview}
                 referenceMessage={referenceMessage}
@@ -572,9 +579,12 @@ export function CharacterStudio() {
               role="tabpanel"
             >
               <CharacterAssets
+                addCharacterReference={addCharacterReference}
                 assets={assets}
                 deleteAsset={deleteAsset}
+                importAsset={importAsset}
                 onPreview={onPreview}
+                projectId={activeProject?.id}
                 purgeAsset={purgeAsset}
                 selectedCharacter={selectedCharacter}
                 updateAssetStatus={updateAssetStatus}

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { AssetPickerField } from "../components/AssetPicker.jsx";
+import { AssetPickerField, CharacterImportDialog } from "../components/AssetPicker.jsx";
 import { AssetCard, emptyTrash } from "../components/assetPanels.jsx";
 import { AssetMedia } from "../components/assetMedia.jsx";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
@@ -83,7 +83,7 @@ function summarizeCompatibility(item) {
 }
 
 export function CharacterReferences({
-  imageAssets,
+  referenceCandidates,
   onGenerateFromReference,
   onPreview,
   referenceMessage,
@@ -105,13 +105,17 @@ export function CharacterReferences({
         <h2>Approved set</h2>
       </div>
       <form className="inline-create asset-reference-create" onSubmit={submitReference}>
+        {/* sc-6042: scoped to this character's assets (no category tabs). Import
+            project/uploaded media into the character on the Assets tab to grow
+            this set. */}
         <AssetPickerField
-          assets={imageAssets}
+          assets={referenceCandidates}
           buttonLabel="Add image or frame"
           emptyLabel="No references selected"
           label="Reference assets"
           multiple
           onChange={setReferenceAssetIds}
+          showCategories={false}
           values={referenceAssetIds}
         />
         <button disabled={!referenceAssetIds.length} type="submit">
@@ -792,13 +796,30 @@ export function CharacterAngleSet({ angleModel, angleModels, ...props }) {
 export function CharacterAssets({
   selectedCharacter,
   assets = [],
+  projectId,
+  importAsset,
+  addCharacterReference,
   onPreview,
   deleteAsset,
   purgeAsset,
   updateAssetStatus,
 }) {
   const [viewMode, setViewMode] = React.useState("active");
+  const [importOpen, setImportOpen] = React.useState(false);
   const characterId = selectedCharacter?.id;
+  // sc-6042: attach project-selected or freshly-uploaded assets to this character.
+  // addCharacterReference is the canonical asset↔character link (it writes both the
+  // character's references[] and the asset's metadata.characterReferences), so the
+  // imports immediately surface in this gallery and the reference picker. Added
+  // unapproved so they're library members, not auto-promoted identity references.
+  async function importAssetIds(assetIds) {
+    if (!characterId || !addCharacterReference) {
+      return;
+    }
+    for (const assetId of assetIds) {
+      await addCharacterReference(characterId, { assetId, approved: false, role: "import" });
+    }
+  }
   if (!selectedCharacter) {
     return null;
   }
@@ -844,6 +865,16 @@ export function CharacterAssets({
             Trashcan ({trashedAssets.length})
           </button>
         </div>
+        {/* sc-6042: bring Project assets or local files into this character's
+            library so they become selectable in the Reference picker. */}
+        <button
+          className="secondary-action character-import-button"
+          disabled={!characterId}
+          onClick={() => setImportOpen(true)}
+          type="button"
+        >
+          Import
+        </button>
         {showingTrash ? (
           <button
             className="danger-action empty-trash-button"
@@ -855,6 +886,18 @@ export function CharacterAssets({
           </button>
         ) : null}
       </div>
+      {importOpen ? (
+        <CharacterImportDialog
+          assets={assets}
+          character={selectedCharacter}
+          characterId={characterId}
+          characterName={selectedCharacter.name}
+          importAsset={importAsset}
+          onClose={() => setImportOpen(false)}
+          onImport={importAssetIds}
+          projectId={projectId}
+        />
+      ) : null}
       {visibleAssets.length ? (
         <div className="reference-thumb-row">
           {visibleAssets.map((asset) => (

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1760,6 +1760,11 @@ label {
   font-size: 12px;
 }
 
+/* sc-6042: Import button trails the Media/Trashcan toggle, pushed to the row end. */
+.character-import-button {
+  margin-left: auto;
+}
+
 /* Pose library picker (multi-select OpenPose gallery) */
 .pose-library {
   display: flex;


### PR DESCRIPTION
Reworks the Character Studio reference-asset flow into a clear two-level model — **Project assets → (Import) → Character Assets → (Reference picker) → generation** — and fixes the confused/empty category tabs reported in [sc-6042](https://app.shortcut.com/trefry/story/6042). Frontend-only; **no backend change** (the existing `addCharacterReference` already writes the canonical asset↔character link).

## A — Reference picker selects only from Character Assets
The "Approved set" picker on the Character tab was fed the whole project image library with `All / Images / Video / Uploads / Renders` tabs that, for an all-render character dataset, either matched the identical set or were always empty.

- Added a `showCategories` prop to `AssetPickerModal`/`AssetPickerField` (`AssetPicker.jsx`). When `false`, the category segmented control is dropped and the grid is unfiltered (the caller scopes the assets). The same picker used by the Video / Document / ReplacePerson / Upscale studios is **unchanged** (defaults to `true`).
- `CharacterReferences` now gets the character-scoped image set + `showCategories={false}`. `CharacterStudio` derives `characterReferenceCandidates` (`imageAssets` filtered by `assetMatchesCharacter`) and reuses it for the existing `characterImageAssetIds` (no duplicate filter).

## B — Character Assets page → Import button + dialog
The page had no way to import media into a character.

- New `CharacterImportDialog` (`AssetPicker.jsx`) with **Images / Videos / Upload** tabs, all multi-select. Images/Videos list **Project** assets of the matching type (via `activeProjectImageAsset` / new `activeProjectVideoAsset`), excluding media already in the character's library; Upload accepts multiple local image+video files (`accept="image/*,video/*"`, matching the server which only accepts those).
- `CharacterAssets` gained an **Import** button in the Media/Trashcan controls row. Project picks and uploads both converge on `addCharacterReference(assetId, approved:false, role:"import")`, which writes the asset's `metadata.characterReferences` link — so imports immediately surface in the gallery **and** the now-scoped reference picker. Uploads import into the project first (so the link target exists), then attach.

## Behavior change for reviewers
The reference picker no longer lets you select **arbitrary** project images directly — that path moved to **Import** on the Assets tab (the intended flow above). A brand-new character's reference picker is empty until you Import or generate. This matches the story's target design.

## Verification
- `eslint src` — clean
- `vitest run` — **453 pass** (4 new: `showCategories` drops tabs; import project images; list videos + upload; Import button opens dialog). Updated one existing fixture that encoded the old "pick any project image as a reference" behavior.
- `vite build` — succeeds (only the pre-existing chunk-size warning)

Live Character Studio verification needs the full rust-api backend + a seeded project (not stood up in this worktree); the new web tests mount the **real** `CharacterStudio` / `CharacterImportDialog` / `CharacterAssets` components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)