### PR TITLE
sc-5497: candle kps_extract off-Mac (SCRFD/ArcFace FaceEmbedder)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5225,6 +5225,7 @@ dependencies = [
  "axum",
  "candle-gen",
  "candle-gen-chroma",
+ "candle-gen-face",
  "candle-gen-flux",
  "candle-gen-flux2",
  "candle-gen-instantid",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -5719,6 +5719,54 @@ mod candle_routing_tests {
         ));
     }
 
+    // ---- Candle kps_extract lane (sc-5497, epic 5482) ----
+
+    /// A queued `kps_extract` job carrying `payload`.
+    fn kps_extract_job(payload: Value) -> JobSnapshot {
+        serde_json::from_value(json!({
+            "id": "job_kps",
+            "type": "kps_extract",
+            "status": "queued",
+            "payload": payload,
+            "result": {},
+            "requestedGpu": "auto",
+            "progress": 0,
+            "stage": "queued",
+            "message": "",
+            "attempts": 1,
+            "cancelRequested": false,
+            "createdAt": "2026-06-16T00:00:00Z",
+            "updatedAt": "2026-06-16T00:00:00Z",
+        }))
+        .expect("valid JobSnapshot")
+    }
+
+    /// sc-5497: the candle worker advertises `kps_extract` (the candle SCRFD/ArcFace face stack) and
+    /// claims a kps_extract job — the off-Mac sibling of the native-MLX path. UNLIKE SeedVR2, the Python
+    /// InsightFace path CAN serve kps_extract, so there is NO torch-refusal gate: a co-resident torch
+    /// worker that advertises the capability still claims it (the candle worker just runs it Python-free
+    /// when it polls first; the Python path is retired wholesale in Phase 7, epic 5483). A worker that
+    /// never advertises the capability (e.g. a candle-disabled box) refuses it.
+    #[test]
+    fn candle_worker_claims_kps_extract_no_torch_refusal() {
+        let payload = json!({ "sourceAssetId": "a", "projectId": "p" });
+        let candle = gpu_worker(&["gpu", "kps_extract", "candle"]);
+        assert!(
+            worker_supports_job(&candle, &kps_extract_job(payload.clone())),
+            "candle worker should claim kps_extract"
+        );
+        let torch = gpu_worker(&["gpu", "kps_extract"]);
+        assert!(
+            worker_supports_job(&torch, &kps_extract_job(payload.clone())),
+            "torch worker still claims kps_extract (no refusal — it has the InsightFace path)"
+        );
+        let no_cap = gpu_worker(&["gpu", "image_generate", "candle"]);
+        assert!(
+            !worker_supports_job(&no_cap, &kps_extract_job(payload)),
+            "a worker not advertising kps_extract refuses it"
+        );
+    }
+
     // ---- Candle caption lane (sc-5098) ----
 
     /// A queued `training_caption` job carrying `payload`.

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -223,6 +223,10 @@ backend-candle = [
     # bespoke provider referenced by name (`PulidFlux::load`), NOT inventory-registered, so the worker
     # `generate_candle_pulid_stream` path calls it directly off-Mac — retiring the torch PuLID adapter.
     "dep:candle-gen-pulid",
+    # sc-5497 (epic 5482): the candle SCRFD/ArcFace face stack (sc-5490), reached DIRECTLY from
+    # `kps_jobs.rs` for the standalone kps_extract surface (`candle_gen_face::load` → `detect`) — the
+    # off-Mac sibling of the native-MLX `kps_jobs` path. Retires the Python InsightFace kps_extract path.
+    "dep:candle-gen-face",
     # sc-5928 (epic 4811 / epic 5482): the candle SeedVR2 one-step diffusion upscaler — the Windows/CUDA
     # sibling of `mlx-gen-seedvr2`. Self-registers `seedvr2` / `seedvr2_3b` / `seedvr2_7b` (image upscale
     # + the net-new video upscale) into the shared gen_core inventory; the worker reaches it via
@@ -858,6 +862,14 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
 candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
+# Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
+# `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
+# composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
+# DIRECTLY from `kps_jobs.rs` (`candle_gen_face::load` → `FaceEmbedder::detect`), so it needs to be a
+# direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
+# so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
+# InsightFace `kps_extract` path off-Mac.
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -86,6 +86,17 @@ fn with_candle_capabilities(mut gpu: DiscoveredGpu, settings: &Settings) -> Disc
                     gpu.capabilities.push(capability);
                 }
             }
+            // SCRFD 5-point face-landmark extraction (sc-5497, epic 5482): the candle SCRFD/ArcFace face
+            // stack (`candle-gen-face`, the InstantID/PuLID detector reused directly from kps_jobs.rs)
+            // serves `kps_extract` for the Key Point Library "extract kps from this image" flow — the
+            // off-Mac sibling of the native-MLX path. A job-type capability (not a generation modality),
+            // so it isn't in `registry_capabilities`; advertise it explicitly. Unlike SeedVR2, the Python
+            // InsightFace path CAN serve kps_extract, so there's NO torch-refusal gate — the candle worker
+            // claims it Python-free, with the co-resident torch worker as fallback (the Python kps path is
+            // retired wholesale in Phase 7, epic 5483).
+            if !gpu.capabilities.contains(&WorkerCapability::KpsExtract) {
+                gpu.capabilities.push(WorkerCapability::KpsExtract);
+            }
             // The lane marker the routing gate keys off (mirrors the existing `nvidia` marker).
             gpu.capabilities
                 .push(WorkerCapability::Unknown("candle".to_owned()));

--- a/crates/sceneworks-worker/src/image_jobs/instantid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/instantid.rs
@@ -325,6 +325,43 @@ pub(crate) async fn ensure_scrfd_weights(
     .await
 }
 
+/// Resolve the candle face-stack DIRECTORY (`scrfd_10g.safetensors` + `arcface_iresnet100.safetensors`)
+/// for the off-Mac kps-extraction capability (sc-5497, epic 5482). Unlike the Mac path — which loads
+/// SCRFD alone via [`ensure_scrfd_weights`] — the candle `candle_gen_face::load` loads the SCRFD
+/// detector AND the ArcFace recognizer from one directory by their canonical names, so BOTH files must
+/// be staged. Shares the same env override (`SCENEWORKS_INSTANTID_WEIGHTS`) + app cache +
+/// download-on-first-use with [`ensure_instantid_weights`], so a prior InstantID / PuLID / extraction
+/// run leaves it already cached. Returns the bundle dir (which IS the candle face stack's load dir,
+/// exactly the `face_dir` the candle InstantID path resolves).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+pub(crate) async fn ensure_face_stack_dir(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+) -> WorkerResult<PathBuf> {
+    let client = reqwest::Client::new();
+    let context = DownloadContext {
+        api,
+        client: &client,
+        settings,
+        job_id: &job.id,
+        cancel_message: "KPS extraction canceled while fetching face-stack weights.",
+        fresh_download: false,
+    };
+    let bundle_dir = std::env::var("SCENEWORKS_INSTANTID_WEIGHTS")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| settings.data_dir.join("cache").join("instantid-mlx"));
+    ensure_instantid_file(&context, INSTANTID_MLX_REPO, &bundle_dir, INSTANTID_SCRFD_FILE).await?;
+    ensure_instantid_file(
+        &context,
+        INSTANTID_MLX_REPO,
+        &bundle_dir,
+        INSTANTID_ARCFACE_FILE,
+    )
+    .await?;
+    Ok(bundle_dir)
+}
+
 /// Resolve all InstantID weight inputs, downloading the small converted bundle + the stock
 /// IdentityNet on first use. Returns `(identitynet_dir, ip_adapter, scrfd, arcface)` — all
 /// `Send` paths; the `!Send` MLX load happens on the blocking thread. Resolution order favours

--- a/crates/sceneworks-worker/src/kps_jobs.rs
+++ b/crates/sceneworks-worker/src/kps_jobs.rs
@@ -20,12 +20,25 @@
 
 use std::path::{Path, PathBuf};
 
+// The neutral image type both backends operate on (`mlx_gen` and `candle_gen` both re-export
+// `gen_core::Image`; the single-rev skew gate keeps them the same type).
+use gen_core::Image;
+// Native-MLX SCRFD detector (Mac, sc-4433): the same `scrfd_10g` detector the InstantID face stack runs.
+#[cfg(target_os = "macos")]
 use mlx_gen::weights::Weights;
-use mlx_gen::Image;
+#[cfg(target_os = "macos")]
 use mlx_gen_face::{detector_blob, Scrfd};
+// Candle SCRFD/ArcFace face stack (off-Mac, sc-5497): `FaceEmbedder` brings the `detect` trait method
+// into scope; `candle_gen_face::load` builds it from the staged `face_dir`.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+use gen_core::FaceEmbedder;
 use serde_json::{json, Value};
 
-use crate::image_jobs::{ensure_scrfd_weights, load_reference_image};
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+use crate::image_jobs::ensure_face_stack_dir;
+#[cfg(target_os = "macos")]
+use crate::image_jobs::ensure_scrfd_weights;
+use crate::image_jobs::load_reference_image;
 use crate::{
     heartbeat, normalize_app_managed_cache_path, progress_payload, task_join_error, update_job,
     ApiClient, Settings, WorkerError, WorkerResult,
@@ -33,9 +46,13 @@ use crate::{
 use sceneworks_core::contracts::{JobSnapshot, JobStatus, JsonObject, ProgressStage, WorkerStatus};
 use sceneworks_core::project_store::ProjectStore;
 
-/// SCRFD detection confidence floor (InsightFace / `FaceAnalysis` default).
+/// SCRFD detection confidence floor (InsightFace / `FaceAnalysis` default). Mac only — the candle
+/// `FaceAnalysis::detect` applies the same InsightFace defaults internally, so the off-Mac path never
+/// passes them explicitly.
+#[cfg(target_os = "macos")]
 const DET_THRESH: f32 = 0.5;
-/// Non-max-suppression IoU threshold (InsightFace / `FaceAnalysis` default).
+/// Non-max-suppression IoU threshold (InsightFace / `FaceAnalysis` default). Mac only (see above).
+#[cfg(target_os = "macos")]
 const NMS_THRESH: f32 = 0.4;
 /// Below this detection score the landmarks are returned but flagged `lowConfidence`, so the
 /// caller can warn that the captured angle may be unreliable (extreme profile / poor framing).
@@ -43,6 +60,12 @@ const LOW_CONF_THRESH: f32 = 0.65;
 /// The landmark order, surfaced on the result so a consumer never has to assume it.
 const KPS_ORDER: [&str; 5] = ["left_eye", "right_eye", "nose", "mouth_left", "mouth_right"];
 const DETECTOR_ID: &str = "scrfd_10g";
+/// The detector backend surfaced on the result: native MLX on Mac (sc-4433), candle SCRFD/ArcFace
+/// off-Mac (sc-5497).
+#[cfg(target_os = "macos")]
+const DETECTOR_BACKEND: &str = "mlx";
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+const DETECTOR_BACKEND: &str = "candle";
 
 /// Map a detected pixel coordinate into the square-normalized `[0,1]` preset space, applying
 /// the engine's centered-letterbox geometry analytically (no image resize needed). Pure +
@@ -89,7 +112,7 @@ impl KpsExtraction {
         result.insert("sourceHeight".to_owned(), json!(self.source_height));
         result.insert(
             "detector".to_owned(),
-            json!({ "id": DETECTOR_ID, "backend": "mlx" }),
+            json!({ "id": DETECTOR_ID, "backend": DETECTOR_BACKEND }),
         );
         match self.kps {
             Some(kps) => {
@@ -117,6 +140,7 @@ impl KpsExtraction {
 
 /// Load SCRFD + detect the largest face's landmarks in `image`, normalized to the square
 /// preset space. Runs the `!Send` MLX work; call inside `spawn_blocking`.
+#[cfg(target_os = "macos")]
 fn detect_largest_kps(scrfd_path: &Path, image: &Image) -> WorkerResult<KpsExtraction> {
     let weights = Weights::from_file(scrfd_path)
         .map_err(|error| WorkerError::Engine(format!("SCRFD weights {scrfd_path:?}: {error}")))?;
@@ -151,6 +175,48 @@ fn detect_largest_kps(scrfd_path: &Path, image: &Image) -> WorkerResult<KpsExtra
         bbox: Some([tl[0], tl[1], br[0], br[1]]),
         det_score: det.score,
         low_confidence: det.score < LOW_CONF_THRESH,
+        source_width: w,
+        source_height: h,
+    })
+}
+
+/// Off-Mac sibling of [`detect_largest_kps`] (sc-5497, epic 5482): load the candle SCRFD/ArcFace stack
+/// from `face_dir` and detect the largest face's landmarks, normalized to the same square preset space.
+/// `candle_gen_face::detect` returns every face's 5-point `kps` + `bbox` in original-image pixels (its
+/// inner `FaceAnalysis::detect` applies the InsightFace `det`/`nms` thresholds internally), so this picks
+/// the area-largest detection and normalizes it exactly as the MLX path does — the result is
+/// backend-identical. The candle stack runs f32 on CUDA; call inside `spawn_blocking`.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn detect_largest_kps_candle(face_dir: &Path, image: &Image) -> WorkerResult<KpsExtraction> {
+    let analysis = candle_gen_face::load(face_dir)
+        .map_err(|error| WorkerError::Engine(format!("face stack {face_dir:?}: {error}")))?;
+    let dets = analysis
+        .detect(image)
+        .map_err(|error| WorkerError::Engine(format!("SCRFD detect: {error}")))?;
+
+    let (w, h) = (image.width, image.height);
+    let largest = dets.into_iter().max_by(|a, b| {
+        let area = |d: &gen_core::DetectedFace| {
+            (d.bbox[2] - d.bbox[0]).max(0.0) * (d.bbox[3] - d.bbox[1]).max(0.0)
+        };
+        area(a).total_cmp(&area(b))
+    });
+    let Some(det) = largest else {
+        return Ok(KpsExtraction::none(w, h));
+    };
+
+    let mut kps = [[0.0f32; 2]; 5];
+    for (i, point) in det.kps.iter().enumerate() {
+        kps[i] = normalize_to_square(point[0], point[1], w, h);
+    }
+    let tl = normalize_to_square(det.bbox[0], det.bbox[1], w, h);
+    let br = normalize_to_square(det.bbox[2], det.bbox[3], w, h);
+    Ok(KpsExtraction {
+        detected: true,
+        kps: Some(kps),
+        bbox: Some([tl[0], tl[1], br[0], br[1]]),
+        det_score: det.det_score,
+        low_confidence: det.det_score < LOW_CONF_THRESH,
         source_width: w,
         source_height: h,
     })
@@ -217,8 +283,12 @@ fn load_source_image(settings: &Settings, job: &JobSnapshot) -> WorkerResult<Ima
 }
 
 /// Run a `kps_extract` job: SCRFD landmark extraction from one image → normalized 5-point
-/// preset (or an explicit `detected: false` result on no face).
-#[cfg(target_os = "macos")]
+/// preset (or an explicit `detected: false` result on no face). Native-MLX SCRFD on Mac (sc-4433);
+/// the candle SCRFD/ArcFace stack off-Mac (sc-5497, epic 5482) — the result is backend-identical.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 pub(crate) async fn run_kps_extract_job(
     api: &ApiClient,
     settings: &Settings,
@@ -241,7 +311,13 @@ pub(crate) async fn run_kps_extract_job(
     .await?;
 
     let image = load_source_image(settings, job)?;
-    let scrfd_path = ensure_scrfd_weights(api, settings, job).await?;
+    // `weights` is a single SCRFD weight file on Mac and the SCRFD+ArcFace bundle DIR off-Mac (candle
+    // `load` resolves both files from one dir by name); both are `PathBuf`, both flow into the matching
+    // detector below.
+    #[cfg(target_os = "macos")]
+    let weights = ensure_scrfd_weights(api, settings, job).await?;
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    let weights = ensure_face_stack_dir(api, settings, job).await?;
 
     update_job(
         api,
@@ -258,9 +334,18 @@ pub(crate) async fn run_kps_extract_job(
     )
     .await?;
 
-    let extraction = tokio::task::spawn_blocking(move || detect_largest_kps(&scrfd_path, &image))
-        .await
-        .map_err(|error| task_join_error("kps extraction task", error))??;
+    let extraction = tokio::task::spawn_blocking(move || {
+        #[cfg(target_os = "macos")]
+        {
+            detect_largest_kps(&weights, &image)
+        }
+        #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+        {
+            detect_largest_kps_candle(&weights, &image)
+        }
+    })
+    .await
+    .map_err(|error| task_join_error("kps extraction task", error))??;
 
     let message = if extraction.detected {
         "Face landmarks extracted."
@@ -408,6 +493,68 @@ mod tests {
         );
         println!(
             "  extracted (score {:.3}, low_conf {}): le={le:?} re={re:?} nose={nose:?} ml={ml:?} mr={mr:?}",
+            extraction.det_score, extraction.low_confidence
+        );
+    }
+
+    /// Real-weights smoke (sc-5497, candle): run the actual candle SCRFD/ArcFace path on a real face
+    /// photo and assert the extracted landmarks are well-formed + in valid frontal geometry, the same
+    /// bar the MLX smoke holds — so the off-Mac kps lane is backend-identical. Exercises
+    /// `detect_largest_kps_candle` end to end (`candle_gen_face::load` → `detect` → largest →
+    /// normalize). Needs the staged face bundle dir (`SCENEWORKS_INSTANTID_WEIGHTS`, holding
+    /// `scrfd_10g.safetensors` + `arcface_iresnet100.safetensors`) + a face image
+    /// (`SCENEWORKS_TEST_FACE`) + a CUDA device. On demand: `cargo test -p sceneworks-worker
+    /// --features backend-candle --lib -- --ignored kps_extract_candle --nocapture`.
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    #[test]
+    #[ignore = "needs real SCRFD/ArcFace weights + CUDA device"]
+    fn kps_extract_candle_real_weights_extracts_frontal_landmarks() {
+        let face_dir = std::env::var("SCENEWORKS_INSTANTID_WEIGHTS")
+            .map(PathBuf::from)
+            .expect("set SCENEWORKS_INSTANTID_WEIGHTS to the face bundle dir");
+        assert!(
+            face_dir.join("scrfd_10g.safetensors").exists(),
+            "missing scrfd_10g.safetensors in {face_dir:?}"
+        );
+        assert!(
+            face_dir.join("arcface_iresnet100.safetensors").exists(),
+            "missing arcface_iresnet100.safetensors in {face_dir:?}"
+        );
+        let face_path = std::env::var("SCENEWORKS_TEST_FACE")
+            .expect("set SCENEWORKS_TEST_FACE to a face image");
+        let decoded = image::open(&face_path)
+            .unwrap_or_else(|e| panic!("face {face_path}: {e}"))
+            .to_rgb8();
+        let image = Image {
+            width: decoded.width(),
+            height: decoded.height(),
+            pixels: decoded.into_raw(),
+        };
+
+        let extraction = detect_largest_kps_candle(&face_dir, &image).expect("detect");
+        assert!(extraction.detected, "expected a face in the test image");
+        let kps = extraction.kps.expect("kps on a detected face");
+        let order = KPS_ORDER;
+        for (i, p) in kps.iter().enumerate() {
+            assert!(
+                (0.0..=1.0).contains(&p[0]) && (0.0..=1.0).contains(&p[1]),
+                "{} out of [0,1]: {p:?}",
+                order[i]
+            );
+        }
+        let [le, re, nose, ml, mr] = kps;
+        assert!(le[0] < re[0], "left eye should be left of right eye");
+        assert!(ml[0] < mr[0], "left mouth should be left of right mouth");
+        let eye_y = (le[1] + re[1]) / 2.0;
+        let mouth_y = (ml[1] + mr[1]) / 2.0;
+        assert!(eye_y < nose[1], "eyes above nose ({eye_y} !< {})", nose[1]);
+        assert!(
+            nose[1] < mouth_y,
+            "nose above mouth ({}, {mouth_y})",
+            nose[1]
+        );
+        println!(
+            "  candle extracted (score {:.3}, low_conf {}): le={le:?} re={re:?} nose={nose:?} ml={ml:?} mr={mr:?}",
             extraction.det_score, extraction.low_confidence
         );
     }

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -106,11 +106,15 @@ mod openpose_skeleton;
 // rtmlib path stays the Windows/Linux backend.
 #[cfg(target_os = "macos")]
 mod pose_jobs;
-// SCRFD 5-point face-landmark extraction (epic 4422, sc-4433): native-MLX SCRFD
-// in-process (the InstantID face-stack detector) for the Key Point Library
-// "extract kps from this image" capability. macOS-only; the Python InsightFace
-// path stays the Windows/Linux backend.
-#[cfg(target_os = "macos")]
+// SCRFD 5-point face-landmark extraction (epic 4422, sc-4433): native-MLX SCRFD on Mac, plus the
+// candle SCRFD/ArcFace stack on the Windows/Linux candle lane (sc-5497, epic 5482) — the same
+// InstantID face-stack detector reused in-process for the Key Point Library "extract kps from this
+// image" capability. So the module compiles on Mac AND the candle lane; on a candle-disabled box the
+// Python InsightFace path stays the Windows/Linux backend.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 mod kps_jobs;
 // Image upscaling: Real-ESRGAN (epic 3482, sc-3489) RRDBNet x2/x4 via `ort`/CoreML on Mac, plus the
 // SeedVR2 one-step diffusion upscaler — native MLX on Mac (sc-4815) and the candle CUDA backend on
@@ -146,7 +150,10 @@ mod person_segment_sam3;
 #[cfg(target_os = "macos")]
 mod scail2_masks;
 use downloads::*;
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 use kps_jobs::*;
 #[cfg(target_os = "macos")]
 use pose_jobs::*;
@@ -749,11 +756,15 @@ async fn run_utility_job(
         JobType::PoseDetect => run_pose_detect_job(api, settings, http_client, &job)
             .await
             .map_err(|error| ("Pose detection failed.", error)),
-        // SCRFD 5-point landmark extraction (epic 4422, sc-4433): native-MLX SCRFD
-        // in-process for the Key Point Library. macOS-only; off macOS `KpsExtract` is
-        // never advertised by the Rust worker (the Python InsightFace path handles it),
+        // SCRFD 5-point landmark extraction (epic 4422, sc-4433): native-MLX SCRFD on Mac + the candle
+        // SCRFD/ArcFace stack on the Windows/Linux candle lane (sc-5497, epic 5482), served in-process
+        // for the Key Point Library. Available on Mac AND the candle lane; on a candle-disabled box
+        // `KpsExtract` is never advertised by the Rust worker (the Python InsightFace path handles it),
         // so this falls to the `_` arm there.
-        #[cfg(target_os = "macos")]
+        #[cfg(any(
+            target_os = "macos",
+            all(not(target_os = "macos"), feature = "backend-candle")
+        ))]
         JobType::KpsExtract => run_kps_extract_job(api, settings, &job)
             .await
             .map_err(|error| ("Keypoint extraction failed.", error)),


### PR DESCRIPTION
Wires the `kps_extract` job (Key Point Library "extract kps from this image") to the Phase-3 candle **SCRFD/ArcFace `FaceEmbedder`** (`candle-gen-face`, sc-5490) on the Windows/Linux candle lane — the off-Mac sibling of the native-MLX kps path. Part of **epic 5482** (Candle Phase 5 CV-aux), retiring the Python InsightFace `kps_extract` path off-Mac.

`candle_gen_face::detect` already returns the 5-point `kps` (`[L-eye, R-eye, nose, L-mouth, R-mouth]`) in original-image pixels, so the result is **backend-identical** to the Mac path: same `normalize_to_square` letterbox geometry + `KpsExtraction` output (only the `detector.backend` label flips `mlx` → `candle`).

### Changes
- **Cargo.toml**: `candle-gen-face` becomes a **direct** optional dep (was transitive via `candle-gen-instantid`/`pulid`) + `dep:candle-gen-face` in `backend-candle`. Pinned `c98609f` == every candle-gen dep (gen-core `3714e7b`, single-rev — matches `main`).
- **kps_jobs.rs**: module widened to `cfg(any(macos, all(not(macos), backend-candle)))`; `mlx_gen::Image` → neutral `gen_core::Image`; new `detect_largest_kps_candle` (load → detect → largest-by-area → normalize); `run_kps_extract_job` cfg-splits weight provisioning + the detect call.
- **image_jobs/instantid.rs**: `ensure_face_stack_dir` stages `scrfd_10g` + `arcface_iresnet100` (candle `load` needs both files).
- **lib.rs**: widened mod/use/dispatch cfgs.
- **gpu.rs**: candle worker advertises `WorkerCapability::KpsExtract`. **No torch-refusal gate** — unlike SeedVR2, the Python InsightFace path *can* serve `kps_extract`, so torch stays a co-resident fallback (the Python path is retired wholesale in Phase 7, epic 5483).
- **Tests**: `jobs_store` routing test (`candle_worker_claims_kps_extract_no_torch_refusal`) + a candle real-weights GPU smoke (ignored).

### Validation
- `cargo fmt --all --check` clean
- `sceneworks-core` routing test green
- `clippy -p sceneworks-worker --features backend-candle -D warnings` clean
- **GPU smoke on RTX PRO 6000** (real `antelopev2` SCRFD/ArcFace): face det score **0.856**, geometrically valid frontal landmarks (eyes above nose above mouth, L/R ordered), all normalized to `[0,1]`.

### gen-core / candle-gen rev
Pins candle-gen `c98609f` (= merged candle-gen #87, gen-core `3714e7b`) — already what `main` pins after #730, so this PR adds **only** `candle-gen-face` at that rev; single gen-core rev, no skew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)