### PR TITLE
feat(models): add RealVisXL V5.0 Lightning (few-step photoreal SDXL)

### DIFF
--- a/apps/web/public/prompt-guides/realvisxl-lightning.md
+++ b/apps/web/public/prompt-guides/realvisxl-lightning.md
@@ -1,0 +1,88 @@
+# RealVisXL Lightning Prompt Guide
+
+## Best For
+
+Fast photoreal text-to-image — portraits, products, landscapes, and editorial-style scenes in ~5 steps instead of ~30. RealVisXL_V5.0_Lightning is a **standalone distilled** SDXL checkpoint (the SDXL-Lightning few-step distillation is baked into the weights), so it shares RealVisXL's photoreal look at roughly 6× the speed. openrail++, commercial use OK, ungated.
+
+Use this when you want quick photoreal iterations or batches. For edits, masked inpaint, reference identity, or detail-refine, switch to the standard **RealVisXL** — Lightning is text-to-image only.
+
+## How It Differs From Standard RealVisXL
+
+- **~5 steps** (vs ~30). The checkpoint is distilled for a few-step Euler-trailing schedule; pushing steps much higher rarely helps and can over-cook.
+- **CFG off by default (guidance 1.0).** Lightning checkpoints are trained classifier-free-guidance-free. At guidance 1.0 the model runs a single forward per step (fast) and the **negative prompt has no effect**.
+- **Raise guidance toward ~1.5–2.0** only if you specifically want the negative prompt back — that re-enables real CFG at roughly 2× the per-step cost. Keep it low; high CFG on a distilled checkpoint produces harsh, over-contrasted output.
+- **Text-to-image only.** Reference identity, img2img, inpaint, and detail-refine are not available on the few-step path.
+
+## Prompt Shape
+
+Same photoreal-leaning natural language as RealVisXL:
+
+`subject + key details + style/medium + composition + lighting + quality tags`
+
+CLIP encoders weight earlier tokens more heavily, so **lead with the subject and the most important attributes**. Few-step sampling rewards clear, concrete prompts — there are fewer steps to "recover" from a vague or contradictory prompt.
+
+## Build The Prompt
+
+### Subject
+
+Front-load the subject in plain language:
+
+`a candid portrait of a woman in her early 30s holding a ceramic mug`
+
+### Details
+
+Specific material, texture, and atmosphere — where RealVisXL pulls ahead of base SDXL:
+
+- `fine skin texture, visible pores, light freckles`
+- `soft cotton sweater, hand-knit cable pattern`
+- `morning steam rising from the mug`
+
+### Style / Medium
+
+Photographic vocabulary rather than illustrative terms:
+
+- `editorial portrait photography, 50mm`
+- `cinematic film still, 35mm anamorphic`
+- `studio product photography, matte backdrop`
+
+### Lighting
+
+Photoreal output lives or dies on lighting language — be specific:
+
+- `golden hour backlight, warm rim`
+- `soft north-window light, even diffusion`
+- `single key light, deep shadow falloff`
+
+### Quality Tags
+
+Keep these short and photo-realistic — avoid stacking long lists of "8k, masterpiece, best quality" that flatten the result:
+
+`sharp focus, natural skin tones, photorealistic, high detail`
+
+## Negative Prompts
+
+At the default guidance (1.0) the **negative prompt is ignored** — the distilled checkpoint runs CFG-free. If you need to push away a specific failure mode, raise guidance to ~1.5–2.0 to re-enable it, then keep the negative short and targeted:
+
+`blurry, lowres, overprocessed skin, plastic skin, oversaturated, deformed, extra fingers, watermark, text, jpeg artifacts, painting, illustration`
+
+## Tips
+
+- ~5 steps is the sweet spot; try 4–6. Much higher steps waste time and can over-render.
+- Leave guidance at 1.0 for the fastest, most "natural" few-step output. Only raise it (toward 2.0) when you specifically need the negative prompt.
+- Native 1024×1024; the canonical SDXL buckets (1152×896, 896×1152, 1216×832, 832×1216, 1344×768, 768×1344) are trained resolutions — prefer them.
+- Lighting words do more work than style words — invest in specific, physically-plausible lighting.
+- Keep skin/texture tags subtle; over-tagging "ultra-realistic skin" can produce a waxy or over-rendered look — more so at low step counts.
+- Layer sdxl-family LoRAs for specific styles — RealVisXL Lightning accepts the SDXL LoRA ecosystem, though heavy LoRAs may need a step or two more to settle.
+- Want edits, reference likeness, or inpaint? Use the standard **RealVisXL** — the few-step path is text-to-image only.
+
+## Example Prompts
+
+`A candid portrait of a fisherman in his sixties on a wooden dock at dawn, weathered hands holding a coil of rope, fine skin detail, soft golden backlight, shallow depth of field, editorial documentary photography, sharp focus.`
+
+`Studio product shot of a brushed aluminum espresso tamper on warm walnut, soft directional side light, subtle wood grain, minimalist composition, professional product photography, natural color, high detail.`
+
+## Sources
+
+- [RealVisXL_V5.0_Lightning model card](https://huggingface.co/SG161222/RealVisXL_V5.0_Lightning)
+- [SDXL-Lightning (distillation method)](https://huggingface.co/ByteDance/SDXL-Lightning)
+- [SDXL technical report](https://arxiv.org/abs/2307.01952)

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1589,6 +1589,93 @@
       }
     },
     {
+      "id": "realvisxl_lightning",
+      "name": "RealVisXL Lightning (fast photoreal SDXL)",
+      "family": "sdxl",
+      "type": "image",
+      "adapter": "sdxl_diffusers",
+      // Few-step distilled sibling of RealVisXL_V5.0 (sc-6075). A STANDALONE checkpoint
+      // (NOT a LoRA) — the SDXL-Lightning distillation is baked into the weights, so it
+      // renders photoreal images in ~5 steps with CFG off, ~6x faster than the 30-step
+      // base. Same SDXL UNet / dual-CLIP / VAE, so it runs on the shared `sdxl` engine;
+      // the worker pins the engine's `lightning` (Euler-trailing) few-step sampler — no
+      // acceleration LoRA, since the distillation lives in the checkpoint itself. txt2img
+      // ONLY: the few-step accel sampler is engine-incompatible with img2img / reference /
+      // mask conditioning, so edit / inpaint / reference / detail stay on the 30-step base
+      // `realvisxl`. openrail++ (commercial use OK, ungated), same license as the base.
+      "capabilities": ["text_to_image", "style_variations"],
+      // Mac-only for now: the few-step path runs on the Rust mlx-gen `sdxl` engine's
+      // `lightning` (Euler-trailing) sampler. The Windows torch + candle few-step SDXL
+      // schedulers aren't wired yet (epic 2755, sc-2760/sc-2761), so a non-Mac host would
+      // render this distilled checkpoint at the wrong (30-step) schedule. Hide it off-Mac
+      // until that lands rather than ship a degraded result; the base `realvisxl` (30-step)
+      // stays available on every platform.
+      "macOnly": true,
+      "downloads": [
+        {
+          // Distilled checkpoint, distinct weights from RealVisXL_V5.0. openrail++, ungated,
+          // download-on-demand (not Recommended/auto-download). The repo is ~41 GB — it bundles
+          // fp16 AND fp32 diffusers component variants PLUS two redundant root single-file
+          // checkpoints (`*_fp16.safetensors` ~6.6 GB, `*_fp32.safetensors` ~13 GB). The mlx-gen
+          // `sdxl` loader reads only the **fp16 diffusers components** (it prefers
+          // `<comp>/*.fp16.safetensors`), so scope the pull to those + the tiny configs/tokenizers
+          // = ~6.9 GB. An empty `files` would fetch the whole 41 GB repo (allow_pattern_matches
+          // empty == match-all). Globs use `glob::Pattern` (require_literal_separator=false), so
+          // `*/*.fp16.safetensors` requires a subdir (skips the root single-files) and matches the
+          // fp16 stem (skips the fp32 + sharded variants).
+          "provider": "huggingface",
+          "repo": "SG161222/RealVisXL_V5.0_Lightning",
+          "files": [
+            "model_index.json",
+            "scheduler/*",
+            "tokenizer/*",
+            "tokenizer_2/*",
+            "*/config.json",
+            "*/*.fp16.safetensors"
+          ],
+          "estimatedSizeBytes": 6940000000
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/SG161222/RealVisXL_V5.0_Lightning"
+      },
+      "defaults": {
+        // Model-card Lightning defaults: ~5 steps, guidance 1.0 (CFG off — the distilled
+        // checkpoint is trained CFG-free, which also halves per-step UNet work; the negative
+        // prompt is inert until guidance > 1.0). Raise toward 2.0 to re-enable real CFG +
+        // the negative prompt at ~2x cost. Native 1024x1024.
+        "resolution": "1024x1024",
+        "steps": 5,
+        "guidanceScale": 1.0,
+        "count": 4
+      },
+      "limits": {
+        // Native 1024x1024 plus the canonical SDXL aspect-ratio buckets.
+        "resolutions": ["1024x1024", "1152x896", "896x1152", "1216x832", "832x1216", "1344x768", "768x1344"],
+        "count": [1, 2, 4]
+      },
+      "loraCompatibility": {
+        // SDXL UNet, so sdxl-family LoRAs apply on top of the distilled base (per sc-1927
+        // declare the real family rather than an empty list, which would match every LoRA).
+        "families": ["sdxl"],
+        "types": ["style", "enhance", "character"]
+      },
+      "ui": {
+        "label": "RealVisXL Lightning (fast photoreal SDXL)",
+        "description": "Few-step distilled RealVisXL — photoreal SDXL at ~5 steps, roughly 6x faster than the 30-step base. A standalone SDXL-Lightning checkpoint (openrail++, commercial-OK, ungated) tuned for the same photoreal look as RealVisXL_V5.0. Runs CFG-free by default (the negative prompt is inert unless you raise guidance toward 2.0). Text-to-image only; for edits, reference identity, masked inpaint, or detail-refine use the standard RealVisXL. Accepts sdxl-family LoRAs.",
+        "recommendedFor": ["text_to_image", "style_variations"],
+        "promptGuide": {
+          "title": "RealVisXL Lightning Prompt Guide",
+          "path": "/prompt-guides/realvisxl-lightning.md",
+          "sources": [
+            { "label": "RealVisXL_V5.0_Lightning model card", "url": "https://huggingface.co/SG161222/RealVisXL_V5.0_Lightning" },
+            { "label": "SDXL-Lightning (distillation method)", "url": "https://huggingface.co/ByteDance/SDXL-Lightning" },
+            { "label": "SDXL technical report", "url": "https://arxiv.org/abs/2307.01952" }
+          ]
+        }
+      }
+    },
+    {
       "id": "instantid_realvisxl",
       "recommended": true,
       "name": "InstantID (RealVisXL)",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3048,6 +3048,10 @@ const MLX_ROUTED_MODELS: &[&str] = &[
     "flux2_dev",
     "sdxl",
     "realvisxl",
+    // RealVisXL Lightning (sc-6075): standalone few-step distilled SDXL checkpoint on the shared
+    // `sdxl` engine. txt2img only — the engine's `lightning` accel sampler rejects reference/img2img
+    // conditioning (`realvisxl_lightning_mlx_eligible`), so edit/reference shapes fall back to torch.
+    "realvisxl_lightning",
     // InstantID on RealVisXL (sc-3345): single-identity + the 11-view angle set route to the
     // native `mlx-gen-instantid` provider. Pose-library + face-restore InstantID jobs are gated
     // OUT by `instantid_mlx_eligible` and stay on the torch `InstantIDAdapter` (engine sc-3117 /
@@ -3131,6 +3135,7 @@ fn image_request_mlx_eligible(model: &str, payload: &Map<String, Value>) -> bool
             flux2_mlx_eligible(payload)
         }
         "sdxl" | "realvisxl" => sdxl_mlx_eligible(payload),
+        "realvisxl_lightning" => realvisxl_lightning_mlx_eligible(payload),
         "instantid_realvisxl" => instantid_mlx_eligible(payload),
         "pulid_flux_dev" => pulid_flux_mlx_eligible(payload),
         "chroma1_hd" | "chroma1_base" | "chroma1_flash" => chroma_mlx_eligible(payload),
@@ -3200,6 +3205,27 @@ fn understanding_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
 /// `image_detail` is a separate job type with its own routing (see `image_detail_mlx_eligible`).
 fn sdxl_mlx_eligible(_payload: &Map<String, Value>) -> bool {
     true
+}
+
+/// RealVisXL Lightning MLX-routing (sc-6075). The standalone distilled checkpoint runs through the
+/// `sdxl` engine on its few-step `lightning` (Euler-trailing) sampler, which the engine restricts to
+/// **txt2img** (it rejects an img2img/reference init — `mlx-gen-sdxl` "acceleration sampler is
+/// txt2img-only"). So only a plain text-to-image job is MLX-eligible here; any `edit_image`, source,
+/// reference, or mask conditioning falls back to the torch worker (or is hidden by the manifest's
+/// txt2img-only `capabilities`). LoRAs + quant are fine on the SDXL path, so they don't gate.
+fn realvisxl_lightning_mlx_eligible(payload: &Map<String, Value>) -> bool {
+    if payload.get("mode").and_then(Value::as_str) == Some("edit_image") {
+        return false;
+    }
+    let has_nonempty_id = |key: &str| {
+        payload
+            .get(key)
+            .and_then(Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty())
+    };
+    !(has_nonempty_id("sourceAssetId")
+        || has_nonempty_id("referenceAssetId")
+        || has_nonempty_id("maskAssetId"))
 }
 
 /// The models the candle (Windows/CUDA) lane can serve (epic 3672 sc-3678 for SDXL; epic 5095

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -4029,7 +4029,9 @@ fn sdxl_and_realvisxl_route_to_mlx_worker() {
     register_gpu_worker(&store, "worker-torch", "mps", image_caps());
     register_gpu_worker(&store, "worker-mlx", "mlx", image_caps());
 
-    for model in ["sdxl", "realvisxl"] {
+    // `realvisxl_lightning` (sc-6075) is a txt2img-only few-step sibling on the same `sdxl`
+    // engine, so a plain text-to-image job routes to MLX just like the base ids.
+    for model in ["sdxl", "realvisxl", "realvisxl_lightning"] {
         let job = store
             .create_job(image_job_with(
                 json!({ "model": model, "prompt": "a red fox" }),
@@ -4126,6 +4128,55 @@ fn sdxl_and_realvisxl_route_to_mlx_worker() {
         .expect("mlx claims sdxl lycoris job");
     assert_eq!(claimed.id, lycoris.id);
     assert_eq!(claimed.assigned_gpu.as_deref(), Some("mlx"));
+}
+
+#[test]
+fn realvisxl_lightning_reference_falls_back_off_mlx() {
+    // sc-6075: RealVisXL Lightning is txt2img-only — the engine's few-step `lightning` sampler
+    // rejects reference/img2img conditioning. A reference or edit_image job is therefore NOT
+    // MLX-eligible (`realvisxl_lightning_mlx_eligible`), so the torch worker claims it directly
+    // instead of deferring to the mlx worker (the txt2img case is covered above).
+    let store = store("mlx-routing-realvisxl-lightning");
+    register_gpu_worker(&store, "worker-torch", "mps", image_caps());
+    register_gpu_worker(&store, "worker-mlx", "mlx", image_caps());
+
+    for payload in [
+        json!({ "model": "realvisxl_lightning", "prompt": "p", "referenceAssetId": "asset_1" }),
+        json!({ "model": "realvisxl_lightning", "prompt": "p", "mode": "edit_image",
+                "sourceAssetId": "src_1" }),
+    ] {
+        let job = store
+            .create_job(image_job_with(payload, "auto"))
+            .expect("lightning conditioned job creates");
+        let claimed = store
+            .claim_next_job("worker-torch")
+            .expect("torch claim ok")
+            .expect("torch claims the txt2img-only-gated lightning job");
+        assert_eq!(claimed.id, job.id);
+        assert_ne!(
+            claimed.assigned_gpu.as_deref(),
+            Some("mlx"),
+            "txt2img-only lightning conditioning must not route to the mlx worker"
+        );
+        store
+            .update_job_progress(
+                &claimed.id,
+                ProgressUpdate {
+                    status: JobStatus::Completed,
+                    stage: ProgressStage::Completed,
+                    progress: 1.0,
+                    message: "done".to_owned(),
+                    error: None,
+                    result: None,
+                    eta_seconds: None,
+                    peak_gpu_memory_pct: None,
+                    peak_gpu_load_pct: None,
+                    backend: None,
+                    worker_id: Some("worker-torch".to_owned()),
+                },
+            )
+            .expect("complete job");
+    }
 }
 
 #[test]

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -205,6 +205,20 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
         default_guidance: 7.0,
         adapter_label: "mlx_sdxl",
     },
+    // RealVisXL Lightning (sc-6075) — standalone few-step *distilled* sibling of RealVisXL_V5.0.
+    // Same SDXL arch, so it shares the `sdxl` engine via a weights swap; differs only in the
+    // distilled checkpoint + the few-step recipe: ~5 steps at guidance 1.0 (CFG off). The
+    // distillation is baked into the checkpoint (no acceleration LoRA), and the worker pins the
+    // engine's `lightning` Euler-trailing sampler for this id (see `generate_stream`). txt2img only
+    // (the accel sampler is engine-incompatible with reference/img2img conditioning).
+    ModelRow {
+        sceneworks_id: "realvisxl_lightning",
+        engine_id: "sdxl",
+        default_repo: "SG161222/RealVisXL_V5.0_Lightning",
+        default_steps: 5,
+        default_guidance: 1.0,
+        adapter_label: "mlx_sdxl",
+    },
     // Kolors (epic 3090, sc-3875) — Kwai-Kolors SDXL-architecture U-Net + ChatGLM3-6B text
     // encoder + SDXL VAE, EulerDiscrete sampler. Real CFG (negative prompt + guidance 5.0).
     // Python `MODEL_TARGETS` / `KolorsDiffusersAdapter` parity: 25 steps, guidance 5.0. The engine

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -830,6 +830,17 @@ async fn generate_stream(
         .map(str::trim)
         .filter(|value| !value.is_empty() && *value != "default")
         .map(str::to_owned);
+    // RealVisXL Lightning (sc-6075): a standalone few-step *distilled checkpoint* (the
+    // SDXL-Lightning distillation is baked into the weights — no acceleration LoRA). It must run
+    // on the engine's `lightning` (Euler-trailing) few-step schedule, not the 30-step
+    // `euler_ancestral` default, so the schedule matches the checkpoint regardless of the UI
+    // payload — mirrors the qwen `*_lightning` sampler forcing. The engine then applies the
+    // CFG-off, few-step recipe (steps/guidance come from the manifest defaults via the model row).
+    let sampler = if request.model == "realvisxl_lightning" {
+        Some("lightning".to_owned())
+    } else {
+        sampler
+    };
     let scheduler = request
         .advanced
         .get("scheduler")

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -669,6 +669,11 @@ fn model_table_rows_resolve_and_flags_match_descriptor() {
         ("flux2_dev", true, false),
         ("sdxl", true, true),
         ("realvisxl", true, true),
+        // RealVisXL Lightning (sc-6075): shares the `sdxl` engine id, whose descriptor advertises
+        // guidance + negative prompt (true, true). The few-step recipe runs CFG-off (guidance 1.0,
+        // negative inert) via the worker-forced `lightning` sampler, but that's a recipe default,
+        // not a capability the descriptor drops — so the descriptor-derived flags stay (true, true).
+        ("realvisxl_lightning", true, true),
         ("kolors", true, true),
         ("chroma1_hd", false, true),
         ("chroma1_base", false, true),


### PR DESCRIPTION
Adds **`SG161222/RealVisXL_V5.0_Lightning`** as a selectable, **Mac-only** image model ([sc-6075](https://app.shortcut.com/trefry/story/6075), epic [3359](https://app.shortcut.com/trefry/epic/3359)).

## What it is
A **standalone distilled SDXL checkpoint** (NOT a LoRA) — the SDXL-Lightning distillation is baked into the weights, so it renders photoreal images in **~5 steps** (≈6× faster than the 30-step base). It runs on the existing mlx-gen `sdxl` engine via that engine's **`lightning` (Euler-trailing) sampler with no acceleration LoRA**, since the distillation lives in the checkpoint itself. openrail++ (commercial-OK, ungated).

It is **txt2img-only**: the engine rejects an accel sampler combined with img2img/reference conditioning, so edit / inpaint / reference / detail-refine stay on the 30-step base `realvisxl`.

## Changes
- **`config/manifests/builtin.models.jsonc`** — `realvisxl_lightning` entry: steps 5 / guidance 1.0 (CFG off), Q8 default, `macOnly`, and `downloads[].files` scoped to the **fp16 diffusers components (~6.9 GB)** instead of the full **~41 GB** repo (which bundles fp16+fp32 component variants + two redundant root single-file checkpoints; empty `files` would pull all of it).
- **`crates/sceneworks-worker/src/engines.rs`** — `ModelRow` → engine `sdxl`, default_steps 5, default_guidance 1.0.
- **`crates/sceneworks-worker/src/image_jobs/base.rs`** — forces the engine `lightning` sampler for this id (mirrors the qwen `*_lightning` precedent).
- **`crates/sceneworks-core/src/jobs_store.rs`** — MLX routing + `realvisxl_lightning_mlx_eligible` (txt2img-only gate; edit/reference/mask → not MLX). Not added to the candle lane (no candle few-step sampler).
- **`apps/web/public/prompt-guides/realvisxl-lightning.md`** — few-step prompt guide.

## Validation
- **Routing/build:** 111 `jobs_store` tests pass (incl. a new `realvisxl_lightning_reference_falls_back_off_mlx` gate test); worker `cargo check` green; `fmt --check` + `clippy -D warnings` clean; manifest parses.
- **Real-weight render on Apple Silicon ([sc-6076](https://app.shortcut.com/trefry/story/6076)):** excellent photoreal output at 4–6 steps via the `lightning` sampler, no LoRA. The **Q8 production default holds at 5 steps** (no quant degradation); **Q4 viable**. Confirms the engine's existing sampler is sufficient — sc-2769 not required.

## Notes
- **macOnly** until the Windows torch + candle few-step SDXL schedulers land (epic [2755](https://app.shortcut.com/trefry/epic/2755), sc-2760/sc-2761), so a non-Mac host doesn't render the distilled checkpoint at the wrong 30-step schedule.
- This standalone checkpoint is a better "RealVisXL Lightning" than sc-2761's generic-LoRA-on-base plan; whether to retire that sub-plan is a separate decision (sc-2761 untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)