### PR TITLE
sc-5992: flip worker candle-gen pin to merged candle main (e2a262c → 30a0947)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e2a262c80e90c8bc39a4d646c4b59139b1a72d1e#e2a262c80e90c8bc39a4d646c4b59139b1a72d1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e2a262c80e90c8bc39a4d646c4b59139b1a72d1e#e2a262c80e90c8bc39a4d646c4b59139b1a72d1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e2a262c80e90c8bc39a4d646c4b59139b1a72d1e#e2a262c80e90c8bc39a4d646c4b59139b1a72d1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e2a262c80e90c8bc39a4d646c4b59139b1a72d1e#e2a262c80e90c8bc39a4d646c4b59139b1a72d1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e2a262c80e90c8bc39a4d646c4b59139b1a72d1e#e2a262c80e90c8bc39a4d646c4b59139b1a72d1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e2a262c80e90c8bc39a4d646c4b59139b1a72d1e#e2a262c80e90c8bc39a4d646c4b59139b1a72d1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -519,7 +519,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e2a262c80e90c8bc39a4d646c4b59139b1a72d1e#e2a262c80e90c8bc39a4d646c4b59139b1a72d1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -530,7 +530,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e2a262c80e90c8bc39a4d646c4b59139b1a72d1e#e2a262c80e90c8bc39a4d646c4b59139b1a72d1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e2a262c80e90c8bc39a4d646c4b59139b1a72d1e#e2a262c80e90c8bc39a4d646c4b59139b1a72d1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -557,7 +557,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e2a262c80e90c8bc39a4d646c4b59139b1a72d1e#e2a262c80e90c8bc39a4d646c4b59139b1a72d1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -569,7 +569,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e2a262c80e90c8bc39a4d646c4b59139b1a72d1e#e2a262c80e90c8bc39a4d646c4b59139b1a72d1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -580,7 +580,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e2a262c80e90c8bc39a4d646c4b59139b1a72d1e#e2a262c80e90c8bc39a4d646c4b59139b1a72d1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -597,7 +597,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e2a262c80e90c8bc39a4d646c4b59139b1a72d1e#e2a262c80e90c8bc39a4d646c4b59139b1a72d1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -611,7 +611,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e2a262c80e90c8bc39a4d646c4b59139b1a72d1e#e2a262c80e90c8bc39a4d646c4b59139b1a72d1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -629,7 +629,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e2a262c80e90c8bc39a4d646c4b59139b1a72d1e#e2a262c80e90c8bc39a4d646c4b59139b1a72d1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -640,7 +640,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e2a262c80e90c8bc39a4d646c4b59139b1a72d1e#e2a262c80e90c8bc39a4d646c4b59139b1a72d1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -653,7 +653,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e2a262c80e90c8bc39a4d646c4b59139b1a72d1e#e2a262c80e90c8bc39a4d646c4b59139b1a72d1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -664,7 +664,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e2a262c80e90c8bc39a4d646c4b59139b1a72d1e#e2a262c80e90c8bc39a4d646c4b59139b1a72d1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -677,7 +677,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e2a262c80e90c8bc39a4d646c4b59139b1a72d1e#e2a262c80e90c8bc39a4d646c4b59139b1a72d1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -7396,7 +7396,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -122,8 +122,9 @@ sceneworks-core = { path = "../sceneworks-core" }
 # Rev 7b89d45 (mlx-gen #481, sc-5989/sc-5992): bumps every mlx-gen crate + gen-core 3511476 -> 7b89d45
 # to add the native-MLX `ideogram_4` model (`mlx-gen-ideogram` dep in the macOS block). gen-core is
 # BYTE-IDENTICAL 3511476 -> 7b89d45 (the delta is the additive ideogram quant crate; mlx-rs unchanged
-# at 44929a0), so the candle pin below moves 344038f -> e2a262c (candle-gen #89: gen-core-only rev
-# alignment, candle builds nothing new) to keep the `--target all` skew gate at a single gen-core rev.
+# at 44929a0), so the candle pin below moves 344038f -> 30a0947 (candle-gen #89 merged: gen-core-only
+# rev alignment, candle builds nothing new) to keep the `--target all` skew gate at a single gen-core
+# rev. (#737 landed pinning the pre-merge branch SHA e2a262c; flipped to candle main 30a0947 here.)
 sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -773,38 +774,38 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89
 # (the delta is the single additive sc-6038 mlx-gen-instantid commit), so behavior-neutral. The candle
 # SDXL edit worker route (`image_jobs/sdxl_edit_candle.rs`) drives candle-gen-sdxl's `SdxlEdit` off-Mac.
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e2a262c80e90c8bc39a4d646c4b59139b1a72d1e", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e2a262c80e90c8bc39a4d646c4b59139b1a72d1e", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e2a262c80e90c8bc39a4d646c4b59139b1a72d1e", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e2a262c80e90c8bc39a4d646c4b59139b1a72d1e", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e2a262c80e90c8bc39a4d646c4b59139b1a72d1e", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e2a262c80e90c8bc39a4d646c4b59139b1a72d1e", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e2a262c80e90c8bc39a4d646c4b59139b1a72d1e", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e2a262c80e90c8bc39a4d646c4b59139b1a72d1e", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e2a262c80e90c8bc39a4d646c4b59139b1a72d1e", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e2a262c80e90c8bc39a4d646c4b59139b1a72d1e", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -813,19 +814,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e2a262c80e90c8bc39a4d646c4b59139b1a72d1e", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e2a262c80e90c8bc39a4d646c4b59139b1a72d1e", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e2a262c80e90c8bc39a4d646c4b59139b1a72d1e", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -834,12 +835,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e2a262c80e90c8bc39a4d646c4b59139b1a72d1e", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e2a262c80e90c8bc39a4d646c4b59139b1a72d1e", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -847,7 +848,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e2a26
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e2a262c80e90c8bc39a4d646c4b59139b1a72d1e", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -856,7 +857,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e2a262c80e90c8bc39a4d646c4b59139b1a72d1e", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -865,7 +866,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e2a262c80e90c8bc39a4d646c4b59139b1a72d1e", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Follow-up to #737. candle-gen [#89](https://github.com/michaeltrefry/candle-gen/pull/89) merged, so flip the worker's candle-gen crate pins off the pre-merge branch SHA `e2a262c` onto candle main `30a0947` (so the branch can be retired and main pins a clean rev). gen-core stays `7b89d45`; `check-gen-core-skew.sh` green on default **and** `--features backend-candle`. Pure rev hygiene — gen-core byte-identical, the macOS build doesn't touch candle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)