### PR TITLE
Ideogram 4: structured JSON-caption contract (sc-5993)

### DIFF
--- a/apps/web/public/prompt-guides/ideogram-4.md
+++ b/apps/web/public/prompt-guides/ideogram-4.md
@@ -26,13 +26,19 @@ A caption has up to three top-level sections:
 
 ### Style
 
-`style_description` keys, in order:
+`style_description` carries exactly one of **`photo`** (e.g. "telephoto, shallow depth of field, eye-level") or **`art_style`** (e.g. "watercolor illustration"), and the two use a slightly different key order:
+
+- **Photo captions:** `aesthetics`, `lighting`, `photo`, `medium`, `color_palette`
+- **Non-photo captions:** `aesthetics`, `lighting`, `medium`, `art_style`, `color_palette`
+
+Where:
 
 - `aesthetics` — mood/feel (e.g. "serene, warm, naturalistic")
 - `lighting` — (e.g. "golden hour, soft backlight, long shadows")
-- exactly one of **`photo`** (e.g. "telephoto, shallow depth of field, eye-level") **or `art_style`** (e.g. "watercolor illustration")
 - `medium` — (e.g. "photograph", "oil painting")
 - `color_palette` (optional) — up to 16 uppercase `#RRGGBB` colors
+
+SceneWorks emits these in the correct order for you; the distinction matters only if you paste raw JSON.
 
 ### Composition & layout
 

--- a/apps/web/src/ideogramCaption.js
+++ b/apps/web/src/ideogramCaption.js
@@ -1,0 +1,603 @@
+// Ideogram 4 structured JSON-caption contract (epic 4725, sc-5993).
+//
+// Ideogram 4 was trained EXCLUSIVELY on structured JSON captions; plain text is
+// out-of-distribution and produces prompt-agnostic images. This module is the
+// SceneWorks-side implementation of that caption format (the realization of
+// spike sc-4727): a typed representation, a serializer that emits keys in the
+// EXACT order the model was trained on, a validator that mirrors Ideogram's
+// `CaptionVerifier` (src/ideogram4/caption_verifier.py), and the recipe shape
+// the studio stores so a generation can be replayed.
+//
+// The serializer reproduces `json.dumps(caption, ensure_ascii=False)` with
+// Python's default separators (", " and ": ") byte-for-byte — that is the
+// string the native MLX engine tokenizes, and the format the validated
+// reference render was produced with. JS `JSON.stringify(obj)` drops those
+// separator spaces, so we emit by hand.
+//
+// The builder UI (sc-5994), bbox canvas (sc-5995), palette picker (sc-5996) and
+// magic-prompt expander (sc-5997) all sit on top of this contract.
+
+// ----- schema constants (mirror CaptionVerifier) ---------------------------
+
+export const TOP_LEVEL_KEYS = Object.freeze([
+  "high_level_description",
+  "style_description",
+  "compositional_deconstruction",
+]);
+
+// Note the discriminator's position differs: `photo` sits at index 2, but
+// `art_style` sits at index 3 (after `medium`). They are NOT interchangeable in
+// place — this is the verifier's actual rule.
+export const STYLE_KEY_ORDER_PHOTO = Object.freeze([
+  "aesthetics",
+  "lighting",
+  "photo",
+  "medium",
+  "color_palette",
+]);
+export const STYLE_KEY_ORDER_NON_PHOTO = Object.freeze([
+  "aesthetics",
+  "lighting",
+  "medium",
+  "art_style",
+  "color_palette",
+]);
+export const STYLE_KNOWN_KEYS = Object.freeze([
+  "aesthetics",
+  "lighting",
+  "photo",
+  "art_style",
+  "medium",
+  "color_palette",
+]);
+
+export const COMPOSITION_KEY_ORDER = Object.freeze(["background", "elements"]);
+
+export const ELEMENT_KEY_ORDER_OBJ = Object.freeze(["type", "bbox", "desc", "color_palette"]);
+export const ELEMENT_KEY_ORDER_TEXT = Object.freeze([
+  "type",
+  "bbox",
+  "text",
+  "desc",
+  "color_palette",
+]);
+export const ELEMENT_KNOWN_KEYS = Object.freeze(["type", "bbox", "text", "desc", "color_palette"]);
+export const ELEMENT_TYPES = Object.freeze(["obj", "text"]);
+
+export const BBOX_MIN = 0;
+export const BBOX_MAX = 1000;
+export const STYLE_PALETTE_MAX = 16;
+export const ELEMENT_PALETTE_MAX = 5;
+
+// ----- typed-model factories -----------------------------------------------
+
+// A structurally-valid empty caption: `compositional_deconstruction` is the
+// only required section, with a (string) background and an elements list.
+export function emptyCaption() {
+  return {
+    high_level_description: "",
+    compositional_deconstruction: { background: "", elements: [] },
+  };
+}
+
+export function makeObjElement({ bbox = null, desc = "", color_palette = null } = {}) {
+  const elem = { type: "obj" };
+  if (bbox != null) elem.bbox = bbox;
+  elem.desc = desc;
+  if (color_palette != null) elem.color_palette = color_palette;
+  return elem;
+}
+
+export function makeTextElement({ bbox = null, text = "", desc = "", color_palette = null } = {}) {
+  const elem = { type: "text" };
+  if (bbox != null) elem.bbox = bbox;
+  elem.text = text;
+  elem.desc = desc;
+  if (color_palette != null) elem.color_palette = color_palette;
+  return elem;
+}
+
+// ----- bbox + palette helpers ----------------------------------------------
+
+export function isValidBbox(bbox) {
+  if (!Array.isArray(bbox) || bbox.length !== 4) return false;
+  if (!bbox.every((v) => Number.isInteger(v))) return false;
+  if (!bbox.every((v) => v >= BBOX_MIN && v <= BBOX_MAX)) return false;
+  const [ymin, xmin, ymax, xmax] = bbox;
+  return ymin <= ymax && xmin <= xmax;
+}
+
+// Coerce a single bbox coordinate into an in-range integer.
+export function clampBboxValue(value) {
+  const n = Math.round(Number(value));
+  if (!Number.isFinite(n)) return BBOX_MIN;
+  return Math.min(BBOX_MAX, Math.max(BBOX_MIN, n));
+}
+
+const HEX_COLOR_RE = /^#[0-9A-F]{6}$/;
+
+export function isValidHexColor(color) {
+  return typeof color === "string" && HEX_COLOR_RE.test(color);
+}
+
+// Uppercase + validate a hex color, accepting lowercase input. Returns null when
+// it is not a #RRGGBB string (the model only accepts uppercase 6-digit hex).
+export function normalizeHexColor(color) {
+  if (typeof color !== "string") return null;
+  const upper = color.trim().toUpperCase();
+  return HEX_COLOR_RE.test(upper) ? upper : null;
+}
+
+// ----- canonical serialization ---------------------------------------------
+
+// Python-`json.dumps(value, ensure_ascii=False)` default formatting: compact,
+// ", " between items, ": " after keys, literal (non-escaped) UTF-8. JSON
+// `JSON.stringify` already escapes strings the ensure_ascii=False way (it keeps
+// literal non-ASCII and escapes control chars / `"` / `\`); we only need to
+// supply the separator spaces and preserve object key insertion order.
+function emit(value) {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "[" + value.map(emit).join(", ") + "]";
+  if (typeof value === "object") {
+    const parts = Object.keys(value).map((k) => JSON.stringify(k) + ": " + emit(value[k]));
+    return "{" + parts.join(", ") + "}";
+  }
+  return JSON.stringify(value);
+}
+
+function styleOrderFor(style) {
+  const hasPhoto = "photo" in style;
+  const hasArt = "art_style" in style;
+  // When the discriminator is ambiguous (both/neither) serialization still has
+  // to produce something; validation reports the real problem separately.
+  if (hasPhoto && !hasArt) return STYLE_KEY_ORDER_PHOTO;
+  if (hasArt && !hasPhoto) return STYLE_KEY_ORDER_NON_PHOTO;
+  if (hasPhoto) return STYLE_KEY_ORDER_PHOTO;
+  return STYLE_KEY_ORDER_NON_PHOTO;
+}
+
+function elementOrderFor(element) {
+  return element?.type === "text" ? ELEMENT_KEY_ORDER_TEXT : ELEMENT_KEY_ORDER_OBJ;
+}
+
+// Build a deep copy with keys in the model's canonical order, dropping any keys
+// not in the schema so the engine payload is always order-clean. This is what
+// guarantees we never emit schema-valid-but-order-drifted JSON.
+export function orderCaption(caption) {
+  const out = {};
+  if (!caption || typeof caption !== "object") return out;
+  for (const key of TOP_LEVEL_KEYS) {
+    if (!(key in caption)) continue;
+    if (key === "style_description") {
+      out.style_description = orderObjectKeys(caption.style_description, styleOrderFor(caption.style_description));
+    } else if (key === "compositional_deconstruction") {
+      out.compositional_deconstruction = orderComposition(caption.compositional_deconstruction);
+    } else {
+      out[key] = caption[key];
+    }
+  }
+  return out;
+}
+
+function orderComposition(cd) {
+  if (!cd || typeof cd !== "object") return cd;
+  const out = {};
+  if ("background" in cd) out.background = cd.background;
+  if ("elements" in cd) {
+    out.elements = Array.isArray(cd.elements)
+      ? cd.elements.map((el) => orderObjectKeys(el, elementOrderFor(el)))
+      : cd.elements;
+  }
+  return out;
+}
+
+function orderObjectKeys(obj, order) {
+  if (!obj || typeof obj !== "object") return obj;
+  const out = {};
+  for (const key of order) {
+    if (key in obj) out[key] = obj[key];
+  }
+  return out;
+}
+
+// The exact string the engine tokenizes. Always canonical order, ensure_ascii=False.
+export function serializeCaption(caption) {
+  return emit(orderCaption(caption));
+}
+
+export function parseCaption(text) {
+  try {
+    return { caption: JSON.parse(text), error: null };
+  } catch (e) {
+    return { caption: null, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+// ----- verifier (faithful mirror of CaptionVerifier) -----------------------
+//
+// Returns structured issues `{ code, path, severity, message }`. `severity` is
+// the model-side default used by `validateCaption`; "error" blocks generation,
+// "warning" is advisory. Mirrors which checks fire and where, not the exact
+// Python message strings.
+
+function pushUnknownKeys(obj, known, path, issues) {
+  const unknown = Object.keys(obj).filter((k) => !known.includes(k));
+  if (unknown.length) {
+    issues.push({
+      code: "unknown_keys",
+      path,
+      severity: "error",
+      message: `${path}: unknown keys [${unknown.join(", ")}] (not in schema)`,
+    });
+  }
+}
+
+function pushKeyOrder(obj, expectedOrder, path, issues) {
+  const present = Object.keys(obj).filter((k) => expectedOrder.includes(k));
+  const sameOrder =
+    present.length === expectedOrder.length && present.every((k, i) => k === expectedOrder[i]);
+  if (!sameOrder) {
+    issues.push({
+      code: "key_order",
+      path,
+      severity: "warning",
+      message: `${path}: key order is [${present.join(", ")}], expected [${expectedOrder.join(", ")}]`,
+    });
+  }
+  const extra = Object.keys(obj).filter((k) => !expectedOrder.includes(k));
+  if (extra.length) {
+    issues.push({
+      code: "key_context",
+      path,
+      severity: "error",
+      message: `${path}: keys [${extra.join(", ")}] are not allowed in this context`,
+    });
+  }
+}
+
+function typeName(value) {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
+}
+
+function verifyColorPalette(palette, path, max, issues) {
+  if (!Array.isArray(palette)) {
+    issues.push({ code: "bad_palette", path, severity: "error", message: `${path}: expected a list` });
+    return;
+  }
+  if (palette.length > max) {
+    issues.push({
+      code: "bad_palette",
+      path,
+      severity: "error",
+      message: `${path}: too many colors (${palette.length}), expected at most ${max}`,
+    });
+    return;
+  }
+  palette.forEach((color, i) => {
+    if (!isValidHexColor(color)) {
+      issues.push({
+        code: "bad_palette",
+        path: `${path}[${i}]`,
+        severity: "error",
+        message: `${path}[${i}]: '${color}' is not a valid #RRGGBB hex color`,
+      });
+    }
+  });
+}
+
+function verifyBbox(bbox, path, issues) {
+  if (!Array.isArray(bbox) || bbox.length !== 4) {
+    issues.push({ code: "bad_bbox", path, severity: "error", message: `${path}: expected [ymin, xmin, ymax, xmax]` });
+    return;
+  }
+  if (!bbox.every((v) => Number.isInteger(v))) {
+    issues.push({ code: "bad_bbox", path, severity: "error", message: `${path}: all values must be integers` });
+    return;
+  }
+  const [ymin, xmin, ymax, xmax] = bbox;
+  if (!bbox.every((v) => v >= BBOX_MIN && v <= BBOX_MAX)) {
+    issues.push({
+      code: "bad_bbox",
+      path,
+      severity: "error",
+      message: `${path}: values must be in [${BBOX_MIN}, ${BBOX_MAX}], got [${bbox.join(", ")}]`,
+    });
+  }
+  if (ymin > ymax) {
+    issues.push({ code: "bad_bbox", path, severity: "error", message: `${path}: ymin (${ymin}) > ymax (${ymax})` });
+  }
+  if (xmin > xmax) {
+    issues.push({ code: "bad_bbox", path, severity: "error", message: `${path}: xmin (${xmin}) > xmax (${xmax})` });
+  }
+}
+
+function styleOrderPresentOnly(style) {
+  // The verifier's expected order includes color_palette only when present.
+  const base = styleOrderFor(style);
+  return base.filter((k) => k !== "color_palette" || "color_palette" in style);
+}
+
+function elementOrderPresentOnly(element) {
+  // bbox + color_palette appear in the expected order only when present.
+  return elementOrderFor(element).filter((k) => {
+    if (k === "bbox") return "bbox" in element;
+    if (k === "color_palette") return "color_palette" in element;
+    return true;
+  });
+}
+
+function verifyStyle(style, issues) {
+  if (style === null || typeof style !== "object" || Array.isArray(style)) {
+    issues.push({ code: "bad_type", path: "style_description", severity: "error", message: "style_description: expected an object" });
+    return;
+  }
+  pushUnknownKeys(style, STYLE_KNOWN_KEYS, "style_description", issues);
+  const hasPhoto = "photo" in style;
+  const hasArt = "art_style" in style;
+  if (hasPhoto && hasArt) {
+    issues.push({
+      code: "style_discriminator",
+      path: "style_description",
+      severity: "error",
+      message: "style_description: contains both 'photo' and 'art_style'; expected exactly one",
+    });
+    return;
+  }
+  if (!hasPhoto && !hasArt) {
+    issues.push({
+      code: "style_discriminator",
+      path: "style_description",
+      severity: "error",
+      message: "style_description: expected one of 'photo' (photo captions) or 'art_style' (non-photo captions)",
+    });
+    return;
+  }
+  pushKeyOrder(style, styleOrderPresentOnly(style), "style_description", issues);
+  if ("color_palette" in style) {
+    verifyColorPalette(style.color_palette, "style_description.color_palette", STYLE_PALETTE_MAX, issues);
+  }
+}
+
+function verifyElement(element, i, issues) {
+  const path = `elements[${i}]`;
+  if (element === null || typeof element !== "object" || Array.isArray(element)) {
+    issues.push({ code: "bad_type", path, severity: "error", message: `${path}: expected an object` });
+    return;
+  }
+  pushUnknownKeys(element, ELEMENT_KNOWN_KEYS, path, issues);
+  if (!("type" in element)) {
+    issues.push({ code: "missing_section", path, severity: "error", message: `${path}: 'type' must exist` });
+    return;
+  }
+  if (!ELEMENT_TYPES.includes(element.type)) {
+    issues.push({
+      code: "bad_type",
+      path,
+      severity: "error",
+      message: `${path}: 'type' must be one of [${ELEMENT_TYPES.join(", ")}]`,
+    });
+    return;
+  }
+  pushKeyOrder(element, elementOrderPresentOnly(element), path, issues);
+  if ("bbox" in element) verifyBbox(element.bbox, `${path}.bbox`, issues);
+  if ("color_palette" in element) {
+    verifyColorPalette(element.color_palette, `${path}.color_palette`, ELEMENT_PALETTE_MAX, issues);
+  }
+}
+
+function verifyComposition(cd, issues) {
+  if (cd === null || typeof cd !== "object" || Array.isArray(cd)) {
+    issues.push({ code: "bad_type", path: "compositional_deconstruction", severity: "error", message: "compositional_deconstruction: expected an object" });
+    return;
+  }
+  if (!("background" in cd)) {
+    issues.push({ code: "missing_section", path: "compositional_deconstruction.background", severity: "error", message: "compositional_deconstruction: 'background' must exist" });
+    return;
+  }
+  if (typeof cd.background !== "string") {
+    issues.push({
+      code: "bad_type",
+      path: "compositional_deconstruction.background",
+      severity: "error",
+      message: `compositional_deconstruction.background: expected a string, got ${typeName(cd.background)}`,
+    });
+    return;
+  }
+  if (!("elements" in cd)) {
+    issues.push({ code: "missing_section", path: "compositional_deconstruction.elements", severity: "error", message: "compositional_deconstruction: 'elements' must exist" });
+    return;
+  }
+  pushKeyOrder(cd, COMPOSITION_KEY_ORDER, "compositional_deconstruction", issues);
+  if (!Array.isArray(cd.elements)) {
+    issues.push({ code: "bad_type", path: "compositional_deconstruction.elements", severity: "error", message: "compositional_deconstruction.elements: expected a list" });
+    return;
+  }
+  cd.elements.forEach((el, i) => verifyElement(el, i, issues));
+}
+
+// Faithful CaptionVerifier.verify(caption) — structured issues.
+export function verifyCaption(caption) {
+  const issues = [];
+  if (caption === null || typeof caption !== "object" || Array.isArray(caption)) {
+    issues.push({ code: "bad_type", path: "root", severity: "error", message: `root: expected a JSON object, got ${typeName(caption)}` });
+    return issues;
+  }
+  pushUnknownKeys(caption, TOP_LEVEL_KEYS, "root", issues);
+  if ("high_level_description" in caption && typeof caption.high_level_description !== "string") {
+    issues.push({
+      code: "bad_type",
+      path: "high_level_description",
+      severity: "error",
+      message: `high_level_description: expected a string, got ${typeName(caption.high_level_description)}`,
+    });
+  }
+  if ("style_description" in caption) verifyStyle(caption.style_description, issues);
+  if ("compositional_deconstruction" in caption) {
+    verifyComposition(caption.compositional_deconstruction, issues);
+  } else {
+    issues.push({ code: "missing_section", path: "compositional_deconstruction", severity: "error", message: "root: 'compositional_deconstruction' must exist" });
+  }
+  return issues;
+}
+
+// Detect `\uXXXX` escapes for non-ASCII with no literal non-ASCII — usually a
+// sign the JSON was written with ensure_ascii=True (advisory, mirrors verifier).
+const NON_ASCII_ESCAPE_RE = /\\u(?:00[89a-fA-F][0-9a-fA-F]|0[1-9a-fA-F][0-9a-fA-F]{2}|[1-9a-fA-F][0-9a-fA-F]{3})/g;
+
+export function verifyRaw(rawText) {
+  const issues = [];
+  const escapes = rawText.match(NON_ASCII_ESCAPE_RE);
+  const hasLiteralNonAscii = [...rawText].some((c) => c.charCodeAt(0) > 0x7f);
+  if (escapes && !hasLiteralNonAscii) {
+    issues.push({
+      code: "ensure_ascii",
+      path: "raw",
+      severity: "warning",
+      message:
+        "raw text: found non-ASCII unicode escapes and no literal non-ASCII characters; " +
+        "usually means the JSON was saved with ensure_ascii=True. Prefer literal UTF-8.",
+    });
+  }
+  const { caption, error } = parseCaption(rawText);
+  if (error) {
+    issues.push({ code: "invalid_json", path: "root", severity: "error", message: `invalid JSON: ${error}` });
+    return issues;
+  }
+  return issues.concat(verifyCaption(caption));
+}
+
+// ----- SceneWorks validation policy ----------------------------------------
+//
+// Wraps the faithful verifier with SceneWorks UX policy and the extra,
+// non-verifier checks the story calls for (recommended sections, empty
+// elements, conflicting plain-text + JSON). Accepts either a parsed caption
+// object or a raw JSON string.
+//
+// Key-order issues are surfaced as warnings, not errors: `serializeCaption`
+// canonicalizes order before the string ever reaches the engine, so drift is
+// auto-corrected — we report it so the user knows we reordered, but it does not
+// block. Everything else from the verifier blocks.
+export function validateCaption(input, { plainText = "" } = {}) {
+  const errors = [];
+  const warnings = [];
+
+  let caption = input;
+  let issues;
+  if (typeof input === "string") {
+    issues = verifyRaw(input);
+    const parsed = parseCaption(input);
+    caption = parsed.caption;
+  } else {
+    issues = verifyCaption(input);
+  }
+
+  for (const issue of issues) {
+    (issue.severity === "warning" ? warnings : errors).push(issue);
+  }
+
+  // SceneWorks advisories (non-blocking) — only meaningful once the caption parsed.
+  if (caption && typeof caption === "object" && !Array.isArray(caption)) {
+    if (!("high_level_description" in caption) || !caption.high_level_description) {
+      warnings.push({
+        code: "missing_recommended",
+        path: "high_level_description",
+        severity: "warning",
+        message: "Recommended: add a one-sentence high_level_description for better adherence.",
+      });
+    }
+    if (!("style_description" in caption)) {
+      warnings.push({
+        code: "missing_recommended",
+        path: "style_description",
+        severity: "warning",
+        message: "Recommended: add a style_description to control the look.",
+      });
+    }
+    const elements = caption?.compositional_deconstruction?.elements;
+    if (Array.isArray(elements)) {
+      if (elements.length === 0) {
+        warnings.push({
+          code: "empty_elements",
+          path: "compositional_deconstruction.elements",
+          severity: "warning",
+          message: "No elements placed — the layout is unguided. Add object/text elements with bounding boxes.",
+        });
+      }
+      elements.forEach((el, i) => {
+        if (el && typeof el === "object") {
+          const hasContent = (el.desc && String(el.desc).trim()) || (el.type === "text" && el.text && String(el.text).trim());
+          if (!hasContent) {
+            warnings.push({
+              code: "empty_element",
+              path: `elements[${i}]`,
+              severity: "warning",
+              message: `elements[${i}]: has no description${el.type === "text" ? "/text" : ""}.`,
+            });
+          }
+        }
+      });
+    }
+  }
+
+  // Conflicting plain-text + JSON: the JSON caption is authoritative; a leftover
+  // plain-text prompt that is not just the high_level_description would be
+  // silently ignored, so surface it.
+  if (caption && typeof plainText === "string" && plainText.trim()) {
+    const hld = caption.high_level_description ? String(caption.high_level_description).trim() : "";
+    if (plainText.trim() !== hld) {
+      warnings.push({
+        code: "conflicting_inputs",
+        path: "prompt",
+        severity: "warning",
+        message: "A plain-text prompt is present alongside the JSON caption. The JSON caption is used for generation; the plain text is kept only as the original intent.",
+      });
+    }
+  }
+
+  const ok = errors.length === 0;
+  return {
+    ok,
+    errors,
+    warnings,
+    issues: errors.concat(warnings),
+    caption: caption ?? null,
+    serialized: ok && caption ? serializeCaption(caption) : null,
+  };
+}
+
+// ----- recipe / raw-settings storage ---------------------------------------
+//
+// Stored under the image recipe so a structured-prompt generation can be
+// replayed and re-edited. Captures: the original plain-text intent (the
+// magic-prompt seed), the edited JSON caption (which carries bboxes + palette
+// choices inside its elements/style), the magic-prompt backend that drafted it,
+// whether the user hand-edited it, and the exact runtime payload string sent to
+// the engine.
+
+export const STRUCTURED_PROMPT_RECIPE_VERSION = 1;
+
+export function buildStructuredPromptRecipe({
+  intent = "",
+  caption,
+  magicPromptBackend = null,
+  edited = false,
+} = {}) {
+  return {
+    version: STRUCTURED_PROMPT_RECIPE_VERSION,
+    intent: String(intent ?? ""),
+    caption: caption ?? null,
+    magicPromptBackend: magicPromptBackend ?? null,
+    edited: Boolean(edited),
+    runtimePrompt: caption ? serializeCaption(caption) : "",
+  };
+}
+
+// The exact `prompt` string to send in the job payload. Prefers the stored
+// runtime payload, falling back to re-serializing the caption.
+export function runtimePromptFromRecipe(recipe) {
+  if (!recipe) return "";
+  if (typeof recipe.runtimePrompt === "string" && recipe.runtimePrompt) return recipe.runtimePrompt;
+  return recipe.caption ? serializeCaption(recipe.caption) : "";
+}

--- a/apps/web/src/ideogramCaption.test.js
+++ b/apps/web/src/ideogramCaption.test.js
@@ -1,0 +1,347 @@
+import { describe, expect, it } from "vitest";
+import {
+  BBOX_MAX,
+  buildStructuredPromptRecipe,
+  clampBboxValue,
+  emptyCaption,
+  isValidBbox,
+  isValidHexColor,
+  makeObjElement,
+  makeTextElement,
+  normalizeHexColor,
+  orderCaption,
+  parseCaption,
+  runtimePromptFromRecipe,
+  serializeCaption,
+  STYLE_KEY_ORDER_NON_PHOTO,
+  validateCaption,
+  verifyCaption,
+  verifyRaw,
+} from "./ideogramCaption.js";
+
+// The validated reference render's caption, byte-identical to the engine's
+// `mlx-gen-ideogram/tests/common/mod.rs` CAPTION_JSON — which is itself
+// `json.dumps(CAPTION, ensure_ascii=False)`. Our serializer must reproduce this
+// exactly, since this is the string the model tokenizes.
+const FOX_JSON =
+  '{"high_level_description": "A photograph of a red fox sitting in a snowy forest at golden hour.", "style_description": {"aesthetics": "serene, warm, naturalistic", "lighting": "golden hour, soft warm backlight, long shadows", "photo": "telephoto, shallow depth of field, sharp focus, eye-level", "medium": "photograph"}, "compositional_deconstruction": {"background": "A snowy forest of tall pine trees, soft golden sunlight filtering through the branches, snow on the ground.", "elements": [{"type": "obj", "bbox": [250, 320, 950, 760], "desc": "A red fox with vivid orange fur, white chest and a thick bushy tail, sitting upright in the snow and facing the camera."}]}}';
+
+const FOX = {
+  high_level_description: "A photograph of a red fox sitting in a snowy forest at golden hour.",
+  style_description: {
+    aesthetics: "serene, warm, naturalistic",
+    lighting: "golden hour, soft warm backlight, long shadows",
+    photo: "telephoto, shallow depth of field, sharp focus, eye-level",
+    medium: "photograph",
+  },
+  compositional_deconstruction: {
+    background:
+      "A snowy forest of tall pine trees, soft golden sunlight filtering through the branches, snow on the ground.",
+    elements: [
+      {
+        type: "obj",
+        bbox: [250, 320, 950, 760],
+        desc: "A red fox with vivid orange fur, white chest and a thick bushy tail, sitting upright in the snow and facing the camera.",
+      },
+    ],
+  },
+};
+
+describe("serializeCaption — training format", () => {
+  it("reproduces the engine CAPTION_JSON byte-for-byte", () => {
+    expect(serializeCaption(FOX)).toBe(FOX_JSON);
+  });
+
+  it("round-trips: serialize -> parse -> serialize is stable", () => {
+    const once = serializeCaption(FOX);
+    const { caption } = parseCaption(once);
+    expect(serializeCaption(caption)).toBe(once);
+  });
+
+  it("uses Python default separators (', ' and ': '), not JSON.stringify defaults", () => {
+    const s = serializeCaption({ compositional_deconstruction: { background: "x", elements: [] } });
+    expect(s).toBe('{"compositional_deconstruction": {"background": "x", "elements": []}}');
+  });
+
+  it("keeps non-ASCII literal (ensure_ascii=False)", () => {
+    const s = serializeCaption({ compositional_deconstruction: { background: "café au lait", elements: [] } });
+    expect(s).toContain("café");
+    expect(s).not.toContain("\\u");
+  });
+});
+
+describe("orderCaption — key-order preservation", () => {
+  it("canonicalizes scrambled top-level + nested keys to training order", () => {
+    const scrambled = {
+      compositional_deconstruction: {
+        elements: [{ desc: "d", bbox: [0, 0, 10, 10], type: "obj" }],
+        background: "bg",
+      },
+      style_description: {
+        medium: "photograph",
+        photo: "eye-level",
+        lighting: "soft",
+        aesthetics: "warm",
+      },
+      high_level_description: "hi",
+    };
+    expect(serializeCaption(scrambled)).toBe(
+      '{"high_level_description": "hi", "style_description": {"aesthetics": "warm", "lighting": "soft", "photo": "eye-level", "medium": "photograph"}, "compositional_deconstruction": {"background": "bg", "elements": [{"type": "obj", "bbox": [0, 0, 10, 10], "desc": "d"}]}}',
+    );
+  });
+
+  it("orders non-photo style as aesthetics, lighting, medium, art_style, color_palette", () => {
+    const ordered = orderCaption({
+      style_description: {
+        art_style: "watercolor",
+        color_palette: ["#FFFFFF"],
+        medium: "painting",
+        lighting: "soft",
+        aesthetics: "dreamy",
+      },
+      compositional_deconstruction: { background: "b", elements: [] },
+    });
+    expect(Object.keys(ordered.style_description)).toEqual([...STYLE_KEY_ORDER_NON_PHOTO]);
+  });
+
+  it("orders text-element keys as type, bbox, text, desc, color_palette", () => {
+    const ordered = orderCaption({
+      compositional_deconstruction: {
+        background: "b",
+        elements: [{ color_palette: ["#000000"], desc: "d", text: "HELLO", bbox: [1, 2, 3, 4], type: "text" }],
+      },
+    });
+    expect(Object.keys(ordered.compositional_deconstruction.elements[0])).toEqual([
+      "type",
+      "bbox",
+      "text",
+      "desc",
+      "color_palette",
+    ]);
+  });
+
+  it("drops unknown keys from the serialized payload", () => {
+    const s = serializeCaption({
+      bogus: "nope",
+      compositional_deconstruction: { background: "b", elements: [], extra: 1 },
+    });
+    expect(s).toBe('{"compositional_deconstruction": {"background": "b", "elements": []}}');
+  });
+});
+
+describe("bbox + palette helpers", () => {
+  it("validates bbox shape, integer-ness, range and ordering", () => {
+    expect(isValidBbox([0, 0, 1000, 1000])).toBe(true);
+    expect(isValidBbox([250, 320, 950, 760])).toBe(true);
+    expect(isValidBbox([0, 0, 10])).toBe(false); // wrong length
+    expect(isValidBbox([0, 0, 10.5, 10])).toBe(false); // non-integer
+    expect(isValidBbox([0, 0, 1001, 10])).toBe(false); // out of range
+    expect(isValidBbox([900, 0, 100, 10])).toBe(false); // ymin > ymax
+  });
+
+  it("clamps bbox coordinates into range", () => {
+    expect(clampBboxValue(-50)).toBe(0);
+    expect(clampBboxValue(5000)).toBe(BBOX_MAX);
+    expect(clampBboxValue(250.7)).toBe(251);
+  });
+
+  it("validates and normalizes hex colors (uppercase only)", () => {
+    expect(isValidHexColor("#FF00AA")).toBe(true);
+    expect(isValidHexColor("#ff00aa")).toBe(false); // lowercase not accepted by the model
+    expect(isValidHexColor("FF00AA")).toBe(false);
+    expect(isValidHexColor("#FFF")).toBe(false);
+    expect(normalizeHexColor("#ff00aa")).toBe("#FF00AA");
+    expect(normalizeHexColor(" #abcdef ")).toBe("#ABCDEF");
+    expect(normalizeHexColor("teal")).toBe(null);
+  });
+});
+
+describe("validateCaption — failure modes", () => {
+  function codes(result) {
+    return result.errors.map((e) => e.code);
+  }
+
+  it("accepts the canonical fox caption", () => {
+    const result = validateCaption(FOX);
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.serialized).toBe(FOX_JSON);
+  });
+
+  it("fails on malformed JSON", () => {
+    const result = validateCaption("{not valid json");
+    expect(result.ok).toBe(false);
+    expect(codes(result)).toContain("invalid_json");
+  });
+
+  it("fails when compositional_deconstruction is missing", () => {
+    const result = validateCaption({ high_level_description: "hi" });
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.code === "missing_section")).toBe(true);
+  });
+
+  it("fails on missing background", () => {
+    const result = validateCaption({ compositional_deconstruction: { elements: [] } });
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.path === "compositional_deconstruction.background")).toBe(true);
+  });
+
+  it("fails on out-of-range bbox", () => {
+    const result = validateCaption({
+      compositional_deconstruction: {
+        background: "b",
+        elements: [{ type: "obj", bbox: [0, 0, 2000, 10], desc: "d" }],
+      },
+    });
+    expect(result.ok).toBe(false);
+    expect(codes(result)).toContain("bad_bbox");
+  });
+
+  it("fails on inverted bbox (ymin > ymax)", () => {
+    const result = validateCaption({
+      compositional_deconstruction: {
+        background: "b",
+        elements: [{ type: "obj", bbox: [900, 0, 100, 10], desc: "d" }],
+      },
+    });
+    expect(result.ok).toBe(false);
+    expect(codes(result)).toContain("bad_bbox");
+  });
+
+  it("fails on lowercase / over-limit palettes", () => {
+    const lower = validateCaption({
+      compositional_deconstruction: {
+        background: "b",
+        elements: [{ type: "obj", bbox: [0, 0, 10, 10], desc: "d", color_palette: ["#ff0000"] }],
+      },
+    });
+    expect(lower.ok).toBe(false);
+    expect(codes(lower)).toContain("bad_palette");
+
+    const tooMany = validateCaption({
+      compositional_deconstruction: {
+        background: "b",
+        elements: [
+          { type: "obj", bbox: [0, 0, 10, 10], desc: "d", color_palette: ["#000000", "#111111", "#222222", "#333333", "#444444", "#555555"] },
+        ],
+      },
+    });
+    expect(tooMany.ok).toBe(false);
+    expect(codes(tooMany)).toContain("bad_palette");
+  });
+
+  it("fails on invalid element type and unknown keys", () => {
+    const badType = validateCaption({
+      compositional_deconstruction: { background: "b", elements: [{ type: "widget", desc: "d" }] },
+    });
+    expect(badType.ok).toBe(false);
+    expect(codes(badType)).toContain("bad_type");
+
+    const unknown = validateCaption({
+      surprise: 1,
+      compositional_deconstruction: { background: "b", elements: [] },
+    });
+    expect(unknown.ok).toBe(false);
+    expect(codes(unknown)).toContain("unknown_keys");
+  });
+
+  it("fails when style has both or neither discriminator", () => {
+    const both = validateCaption({
+      style_description: { aesthetics: "a", lighting: "l", photo: "p", art_style: "x", medium: "m" },
+      compositional_deconstruction: { background: "b", elements: [] },
+    });
+    expect(both.ok).toBe(false);
+    expect(codes(both)).toContain("style_discriminator");
+
+    const neither = validateCaption({
+      style_description: { aesthetics: "a", lighting: "l", medium: "m" },
+      compositional_deconstruction: { background: "b", elements: [] },
+    });
+    expect(neither.ok).toBe(false);
+    expect(codes(neither)).toContain("style_discriminator");
+  });
+
+  it("treats key-order drift in pasted JSON as a non-blocking warning (auto-corrected on serialize)", () => {
+    // bbox after desc — drifted from canonical type,bbox,desc.
+    const drifted =
+      '{"compositional_deconstruction": {"elements": [{"type": "obj", "desc": "d", "bbox": [0, 0, 10, 10]}], "background": "b"}}';
+    const result = validateCaption(drifted);
+    expect(result.ok).toBe(true);
+    expect(result.warnings.some((w) => w.code === "key_order")).toBe(true);
+    // The emitted engine payload is canonical regardless of the input order.
+    expect(result.serialized).toBe(
+      '{"compositional_deconstruction": {"background": "b", "elements": [{"type": "obj", "bbox": [0, 0, 10, 10], "desc": "d"}]}}',
+    );
+  });
+
+  it("warns on conflicting plain-text + JSON inputs without blocking", () => {
+    const result = validateCaption(FOX, { plainText: "a totally different idea" });
+    expect(result.ok).toBe(true);
+    expect(result.warnings.some((w) => w.code === "conflicting_inputs")).toBe(true);
+  });
+
+  it("does not warn when plain text equals the high_level_description", () => {
+    const result = validateCaption(FOX, { plainText: FOX.high_level_description });
+    expect(result.warnings.some((w) => w.code === "conflicting_inputs")).toBe(false);
+  });
+
+  it("warns on empty elements and missing recommended sections", () => {
+    const result = validateCaption({ compositional_deconstruction: { background: "b", elements: [] } });
+    expect(result.ok).toBe(true);
+    expect(result.warnings.some((w) => w.code === "empty_elements")).toBe(true);
+    expect(result.warnings.some((w) => w.code === "missing_recommended")).toBe(true);
+  });
+});
+
+describe("verifier mirror", () => {
+  it("verifyCaption returns no issues for the canonical fox", () => {
+    expect(verifyCaption(FOX)).toEqual([]);
+  });
+
+  it("verifyRaw flags ensure_ascii escapes as a warning", () => {
+    const raw = '{"compositional_deconstruction": {"background": "caf\\u00e9", "elements": []}}';
+    const issues = verifyRaw(raw);
+    expect(issues.some((i) => i.code === "ensure_ascii" && i.severity === "warning")).toBe(true);
+  });
+
+  it("verifyRaw flags both an obj with wrong-context key and missing-type", () => {
+    const objWithText = verifyCaption({
+      compositional_deconstruction: { background: "b", elements: [{ type: "obj", bbox: [0, 0, 1, 1], text: "X", desc: "d" }] },
+    });
+    expect(objWithText.some((i) => i.code === "key_context")).toBe(true);
+  });
+});
+
+describe("factories + recipe storage", () => {
+  it("emptyCaption is a valid skeleton", () => {
+    const result = validateCaption(emptyCaption());
+    expect(result.ok).toBe(true);
+  });
+
+  it("element factories order optional keys correctly", () => {
+    const obj = makeObjElement({ bbox: [0, 0, 10, 10], desc: "d" });
+    expect(Object.keys(obj)).toEqual(["type", "bbox", "desc"]);
+    const text = makeTextElement({ text: "HI", desc: "d" });
+    expect(Object.keys(text)).toEqual(["type", "text", "desc"]);
+  });
+
+  it("builds a structured-prompt recipe carrying intent, caption and runtime payload", () => {
+    const recipe = buildStructuredPromptRecipe({
+      intent: "a red fox in the snow",
+      caption: FOX,
+      magicPromptBackend: "prompt_refine",
+      edited: true,
+    });
+    expect(recipe.version).toBe(1);
+    expect(recipe.intent).toBe("a red fox in the snow");
+    expect(recipe.magicPromptBackend).toBe("prompt_refine");
+    expect(recipe.edited).toBe(true);
+    expect(recipe.runtimePrompt).toBe(FOX_JSON);
+    expect(runtimePromptFromRecipe(recipe)).toBe(FOX_JSON);
+  });
+
+  it("runtimePromptFromRecipe falls back to re-serializing the caption", () => {
+    expect(runtimePromptFromRecipe({ caption: FOX })).toBe(FOX_JSON);
+    expect(runtimePromptFromRecipe(null)).toBe("");
+  });
+});


### PR DESCRIPTION
Implements the SceneWorks-side structured-prompt **contract** for Ideogram 4 (sc-5993, epic 4725) — the realization of spike sc-4727. Ideogram 4 was trained exclusively on structured JSON captions, so this is the data foundation the builder UI (sc-5994), bbox canvas (sc-5995), palette picker (sc-5996) and magic-prompt expander (sc-5997) will sit on. No UI yet — this is the typed model + serializer + validator + recipe shape.

## What's here
`apps/web/src/ideogramCaption.js`:
- **Typed-model factories** (`emptyCaption`, `makeObjElement`, `makeTextElement`) + bbox / `#RRGGBB` palette helpers.
- **`serializeCaption`** — emits keys in the model's exact training order and reproduces `json.dumps(caption, ensure_ascii=False)` **byte-for-byte** (Python default `", "` / `": "` separators, literal UTF-8). `JSON.stringify` drops those separator spaces, so we emit by hand. Unknown keys are dropped so the engine payload is always order-clean. A test asserts it is byte-identical to the engine's proven-good `CAPTION_JSON` (the validated red-fox render).
- **`verifyCaption` / `verifyRaw`** — a faithful mirror of Ideogram's `CaptionVerifier` (`src/ideogram4/caption_verifier.py`, fetched from upstream). `compositional_deconstruction` is the only required section; photo vs non-photo style key orders genuinely differ.
- **`validateCaption`** — SceneWorks UX policy on top: structural problems block; **key-order drift is a non-blocking warning** because `serializeCaption` auto-canonicalizes before the string reaches the engine; plus recommended-section / empty-element / conflicting plain-text+JSON advisories.
- **`buildStructuredPromptRecipe` / `runtimePromptFromRecipe`** — recipe/raw-settings storage shape (original intent, edited caption, magic-prompt backend, runtime payload).

Also **fixes a key-order bug in the prompt guide**: non-photo style is `aesthetics, lighting, medium, art_style, color_palette` (art_style sits *after* medium, not in the photo discriminator's slot).

## Verification
- 31 new tests in `ideogramCaption.test.js`, incl. byte-identical serialization vs the engine `CAPTION_JSON`, key-order preservation from scrambled input, and every validation failure mode.
- Full web suite green: **484 passed**. ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)