### PR TITLE
test(flux2): FLUX.2-dev worker-layer real-weight e2e + footprint validation (sc-5923)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1250,6 +1250,11 @@
       // (sc-2365) — so minMemoryGb 96 (128 GB Macs only). The convert pre-quantizes
       // transformer + text_encoder and symlinks the (identical-to-klein) VAE +
       // tokenizer + model_index.json from the gated source snapshot.
+      // sc-5923 worker-layer footprint (Q4, 1024², /usr/bin/time -l peak): T2I ~74 GB,
+      // single-reference edit ~81 GB — both within 96. Multi-reference (2-image) edit
+      // peaks ~104 GB (> 96, activation-bound on the longer ref sequence); that path is
+      // currently UI-latent for dev (no multi-image picker; pose routes to the
+      // flux2_dev_control engine, sc-6055) and is tracked for an engine/guard fix.
       "mlx": {
         "minMemoryGb": 96,
         "quantize": 4,

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -1192,24 +1192,143 @@ fn flux2_klein_9b_true_v2_real_weights_generates_one_image() {
     smoke_generate_one("flux2_klein_9b_true_v2", dir, Some(1.0), None);
 }
 
-/// Real-weights smoke (sc-5921 / sc-5923 boundary): FLUX.2-dev (embedded guidance, ~28-step).
-/// Loads the install-time pre-quantized Q4 dir under the SceneWorks data dir
-/// (`models/mlx/flux2_dev`, assembled by the `flux2_dev_quant` convert job) via the
-/// `flux2_dev` engine id — proving the worker's `mlx_gen_flux2` force-link reaches the dev
-/// loader and that the packed snapshot loads + generates (the Q8 LoadSpec hint is a no-op on
-/// the already-packed weights). Needs a previously-converted dir + a 128 GB Metal device.
-/// `SCENEWORKS_FLUX2_DEV_DIR` overrides the dir. Run on demand:
+/// The install-time pre-quantized Q4 dev snapshot dir (`models/mlx/flux2_dev`, assembled by the
+/// `flux2_dev_quant` convert job); `SCENEWORKS_FLUX2_DEV_DIR` overrides it.
+#[cfg(target_os = "macos")]
+fn flux2_dev_dir() -> std::path::PathBuf {
+    std::env::var("SCENEWORKS_FLUX2_DEV_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| {
+            dirs_home().join("Library/Application Support/SceneWorks/data/models/mlx/flux2_dev")
+        })
+}
+
+/// Worker-layer dev real-weight e2e (sc-5923): load `engine_id` from the converted Q4 dev dir and
+/// generate one RGB8 image at an env-configurable size/steps (`SCENEWORKS_FLUX2_DEV_SIZE` /
+/// `SCENEWORKS_FLUX2_DEV_STEPS`, default 512 / the dev default 28). For the footprint reconciliation,
+/// set `SCENEWORKS_FLUX2_DEV_SIZE=1024` (the production default) and wrap the test binary in
+/// `/usr/bin/time -l` to read the steady-state "peak memory footprint" vs the manifest `minMemoryGb`
+/// (peak is activation-bound, reached within a couple of steps, so a low `STEPS` measures the same
+/// ceiling faster). `conditioning` adds edit reference(s); empty = T2I. Proves the worker's
+/// `gen_core::load` force-link reaches the dev loader, the packed snapshot loads + generates (the Q4
+/// LoadSpec hint is a no-op on the already-packed weights), and the requested conditioning is
+/// consumed (a real, non-flat RGB8 frame). Returns the decoded image.
+#[cfg(target_os = "macos")]
+fn dev_worker_generate(
+    engine_id: &str,
+    base: std::path::PathBuf,
+    conditioning: Vec<gen_core::Conditioning>,
+) -> Image {
+    let size: u32 = std::env::var("SCENEWORKS_FLUX2_DEV_SIZE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(512);
+    let steps: u32 = std::env::var("SCENEWORKS_FLUX2_DEV_STEPS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(28);
+    let generator =
+        load_engine(engine_id, base, Some(gen_core::Quant::Q4), Vec::new(), None).unwrap();
+    let mut steps_seen = 0u32;
+    let request = GenerationRequest {
+        prompt: "a serene mountain lake at dawn".into(),
+        width: size,
+        height: size,
+        count: 1,
+        seed: Some(42),
+        steps: Some(steps),
+        guidance: Some(4.0),
+        conditioning,
+        ..Default::default()
+    };
+    let out = generator
+        .generate(&request, &mut |p| {
+            if let gen_core::Progress::Step { current, .. } = p {
+                steps_seen = steps_seen.max(current);
+            }
+        })
+        .unwrap();
+    let img = match out {
+        GenerationOutput::Images(mut v) => v.remove(0),
+        other => panic!("expected Images, got {other:?}"),
+    };
+    assert_eq!((img.width, img.height), (size, size), "output dimensions");
+    assert_eq!(
+        img.pixels.len(),
+        (size * size * 3) as usize,
+        "RGB8 pixel count"
+    );
+    assert!(steps_seen >= 1, "expected denoise step progress");
+    assert!(
+        img.pixels.windows(2).any(|w| w[0] != w[1]),
+        "render is flat (degenerate)"
+    );
+    img
+}
+
+/// Real-weights smoke (sc-5921 / sc-5923 boundary): FLUX.2-dev T2I (embedded guidance, ~28-step)
+/// through the worker `flux2_dev` engine path — proves the `mlx_gen_flux2` force-link reaches the dev
+/// loader and the packed snapshot loads + generates. Env-sizable (default 512²; set
+/// `SCENEWORKS_FLUX2_DEV_SIZE=1024` for the production-default footprint run, sc-5923). Needs a
+/// previously-converted Q4 dir + a 128 GB Metal device. Run on demand:
 /// `cargo test -p sceneworks-worker --lib -- --ignored flux2_dev_real_weights`.
 #[cfg(target_os = "macos")]
 #[test]
 #[ignore = "needs a converted FLUX.2-dev Q4 dir + 128 GB Metal device"]
 fn flux2_dev_real_weights_generates_one_image() {
-    let dir = std::env::var("SCENEWORKS_FLUX2_DEV_DIR")
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|_| {
-            dirs_home().join("Library/Application Support/SceneWorks/data/models/mlx/flux2_dev")
-        });
-    smoke_generate_one("flux2_dev", dir, Some(4.0), None);
+    dev_worker_generate("flux2_dev", flux2_dev_dir(), Vec::new());
+}
+
+/// Real-weights smoke (sc-5923): FLUX.2-dev EDIT through the worker `flux2_dev_edit` engine path
+/// (the `flux2_edit_engine_id("flux2_dev")` variant, sc-5919/5922). Loads the SAME converted Q4 dev
+/// snapshot, then renders with a single `Conditioning::Reference` AND with a 2-image
+/// `Conditioning::MultiReference` — the two reference shapes the worker `generate_flux2_edit_stream`
+/// builds (grouped / pose-library `[skeleton, reference]`). Asserts each produces a real, non-flat
+/// RGB8 frame and that the two differ (the references are actually consumed, not dropped). Env-sizable
+/// like the T2I smoke; `SCENEWORKS_FLUX2_DEV_EDIT_REFS=1|2` isolates one pass for a clean per-pass
+/// footprint measurement (sc-5923 — multi-reference adds the most sequence tokens, so it drives the
+/// peak). Needs the converted Q4 dir + a 128 GB Metal device. Run on demand:
+/// `cargo test -p sceneworks-worker --lib -- --ignored flux2_dev_edit_real_weights`.
+#[cfg(target_os = "macos")]
+#[test]
+#[ignore = "needs a converted FLUX.2-dev Q4 dir + 128 GB Metal device"]
+fn flux2_dev_edit_real_weights_generates_one_image() {
+    let dir = flux2_dev_dir();
+    let only: Option<u32> = std::env::var("SCENEWORKS_FLUX2_DEV_EDIT_REFS")
+        .ok()
+        .and_then(|s| s.parse().ok());
+
+    let single = (only != Some(2)).then(|| {
+        dev_worker_generate(
+            "flux2_dev_edit",
+            dir.clone(),
+            vec![gen_core::Conditioning::Reference {
+                image: synthetic_rgb(512, 512, |x, y| {
+                    [((x * 255) / 512) as u8, ((y * 255) / 512) as u8, 96]
+                }),
+                strength: None,
+            }],
+        )
+    });
+    let multi = (only != Some(1)).then(|| {
+        dev_worker_generate(
+            "flux2_dev_edit",
+            dir,
+            vec![gen_core::Conditioning::MultiReference {
+                images: vec![
+                    synthetic_rgb(512, 512, |x, _| [((x * 255) / 512) as u8, 60, 200]),
+                    synthetic_rgb(512, 512, |_, y| [40, ((y * 255) / 512) as u8, 180]),
+                ],
+            }],
+        )
+    });
+    // When both passes ran (the default), the two reference shapes must drive different output.
+    if let (Some(single), Some(multi)) = (single, multi) {
+        assert_ne!(
+            single.pixels, multi.pixels,
+            "single- and multi-reference edits should differ (references consumed)"
+        );
+    }
 }
 
 /// Real-weights smoke: SDXL base (real CFG, guidance 7.0 + a negative prompt,


### PR DESCRIPTION
## Summary
Epic 5914 slice B3 — **the validation boundary** (mirror scail2 sc-5450). Proves the **worker registry path** renders FLUX.2-dev T2I + edit on real weights, and reconciles the manifest `minMemoryGb` against the measured peak footprint. The engine itself is already real-weight validated (sc-2365 T2I, sc-5919 edit); this is the worker-layer e2e proof + the memory reconciliation. **Test-only + a manifest provenance comment — no engine/pin change.**

## Changes
- `dev_worker_generate` helper — loads `engine_id` from the converted Q4 dev dir and generates one RGB8 image, **env-sizable** (`SCENEWORKS_FLUX2_DEV_SIZE`/`_STEPS`) so the same test measures the production-default 1024² footprint under `/usr/bin/time -l`. Asserts the `gen_core::load` force-link reaches the dev loader, the packed snapshot loads + generates, and the conditioning is consumed (non-flat frame).
- `flux2_dev_real_weights_generates_one_image` (T2I) reworked onto the helper (was hardcoded 512²).
- **NEW** `flux2_dev_edit_real_weights_generates_one_image` — loads the `flux2_dev_edit` engine, renders a single `Conditioning::Reference` **and** a 2-image `Conditioning::MultiReference`, asserting each is a real non-flat frame and the two differ (references consumed). `SCENEWORKS_FLUX2_DEV_EDIT_REFS=1|2` isolates a pass for per-pass footprint.
- Manifest: a provenance comment at `minMemoryGb` recording the measurements + the multi-ref caveat.

## Ran on the 128 GB Mac (Q4 packed, `/usr/bin/time -l` peak memory footprint)
| Path (1024²) | Peak | vs `minMemoryGb=96` |
|---|---|---|
| T2I | ~74.0 GB | ✓ fits (matches engine-side sc-2365) |
| edit, single reference | ~80.9 GB | ✓ fits |
| edit, multi-reference (2) | ~103.8 GB | ✗ exceeds |

Functional smokes (512²/8) passed; footprint runs (1024²/4, peak is activation-bound so a low step count captures the same ceiling) gave the table above.

## Reconciliation
`minMemoryGb=96` is **validated for the default reachable surface** (T2I + single-reference edit) — left unchanged. The **multi-reference (2-image) edit at 1024² peaks ~104 GB**, over 96. That path is currently **UI-latent for dev** (no multi-image picker; a dev pose job routes to `flux2_dev_control` after sc-6055, not a `MultiReference` edit), so it isn't reachable from the current UI. Surfaced + tracked as **sc-6124** (engine activation-chunking à la scail2 sc-5681, or a worker-side cap/guard) rather than inflating the global min and gating the common T2I path behind a 128 GB-only requirement.

307 worker lib tests green; `cargo fmt` + `clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)