### PR TITLE
sc-5487: route candle FLUX.2-klein img2img/reference edit into the candle lane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -519,7 +519,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -530,7 +530,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -557,7 +557,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -569,7 +569,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -580,7 +580,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -597,7 +597,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -611,7 +611,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -629,7 +629,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -640,7 +640,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -653,7 +653,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -664,7 +664,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -677,7 +677,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30a094799ee5f4d75ccbe86547d5d41a809da06f#30a094799ee5f4d75ccbe86547d5d41a809da06f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
 dependencies = [
  "candle-core",
  "candle-gen",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3313,6 +3313,16 @@ fn image_job_is_candle_eligible(job: &JobSnapshot) -> bool {
     if matches!(model, "sdxl" | "realvisxl") && sdxl_edit_candle_eligible(&job.payload) {
         return true;
     }
+    // FLUX.2-klein reference / img2img edit (sc-5487, epic 5480): a klein-family `edit_image` job with a
+    // source image is the bespoke candle `Flux2Edit` lane (`generate_candle_flux2_edit_stream`), NOT
+    // txt2img — the `image_request_candle_eligible` gate below rejects the whole `edit_image` family.
+    // FLUX.2-klein has no torch path, so this is the only off-Mac edit lane for it. Mirrors the worker's
+    // `flux2_edit_candle_available` gate.
+    if matches!(model, "flux2_klein_9b" | "flux2_klein_9b_true_v2")
+        && flux2_edit_candle_eligible(&job.payload)
+    {
+        return true;
+    }
     // SDXL IP-Adapter-Plus reference conditioning (sc-5488, epic 5480): an sdxl-family model with a
     // reference image is a bespoke candle lane (`generate_candle_sdxl_ipadapter_stream`), NOT txt2img —
     // the `image_request_candle_eligible` gate below rejects `referenceAssetId`. Branch it out first
@@ -3650,6 +3660,22 @@ fn pulid_flux_candle_eligible(payload: &Map<String, Value>) -> bool {
 /// worker's `sdxl_edit_candle_available` gate (minus the local weight-resolve check) so the router and
 /// worker agree. Candle-only — macOS keeps the MLX `SdxlSubMode::{Edit,Inpaint,Outpaint}` path.
 fn sdxl_edit_candle_eligible(payload: &Map<String, Value>) -> bool {
+    if payload.get("mode").and_then(Value::as_str) != Some("edit_image") {
+        return false;
+    }
+    payload
+        .get("sourceAssetId")
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.trim().is_empty())
+}
+
+/// FLUX.2-klein edit candle-routing conditions (sc-5487, epic 5480). The candle `Flux2Edit` provider
+/// serves `edit_image` mode with a `sourceAssetId` on the klein family — Kontext-style reference
+/// token-concat editing (no mask / inpaint / outpaint; that masked shape is the SDXL edit lane's). Same
+/// payload predicate as `sdxl_edit_candle_eligible`, gated to the klein family by the caller. Mirrors the
+/// worker's `flux2_edit_candle_available` gate (minus the local weight-resolve check) so the router and
+/// worker agree. Candle-only — macOS keeps the MLX `flux2_klein_9b_edit` registry path.
+fn flux2_edit_candle_eligible(payload: &Map<String, Value>) -> bool {
     if payload.get("mode").and_then(Value::as_str) != Some("edit_image") {
         return false;
     }
@@ -4955,10 +4981,10 @@ mod candle_routing_tests {
                 "qwen_image",
                 json!({ "advanced": { "poses": [{ "id": "pose_1" }] } }),
             ),
-            (
-                "flux2_klein_9b",
-                json!({ "mode": "edit_image", "sourceAssetId": "a" }),
-            ),
+            // NB: `flux2_klein_9b` + `edit_image` is NOT here — sc-5487 wired it to the candle `Flux2Edit`
+            // lane (asserted via `image_job_is_candle_eligible` in `candle_worker_claims_*`), like SDXL
+            // edit. The txt2img gate still rejects it (it rejects all `edit_image`), but it no longer
+            // "falls back to torch" at the router level.
             // sc-5484 / sc-5576: Chroma / Kolors / SenseNova-U1 are pure T2I on candle. Their MLX-only
             // conditioning shapes (Kolors edit / IP-reference / pose-control; SenseNova edit) defer.
             (
@@ -5189,6 +5215,23 @@ mod candle_routing_tests {
                 "sourceAssetId": "asset_1"
             }))
         ));
+        // sc-5487: a FLUX.2-klein edit (`edit_image` + a source) is now the candle `Flux2Edit` lane.
+        // klein has no torch path, so the candle worker CLAIMS it (the only off-Mac lane for it).
+        assert!(worker_supports_job(
+            &candle,
+            &image_generate_job(json!({
+                "model": "flux2_klein_9b",
+                "mode": "edit_image",
+                "sourceAssetId": "asset_1"
+            }))
+        ));
+        // The -kv distill edit has no candle provider yet (needs the reference-K/V cache port) → NOT
+        // claimed by candle; it stays on the MLX/torch path.
+        assert!(!image_job_is_candle_eligible(&image_generate_job(json!({
+            "model": "flux2_klein_9b_kv",
+            "mode": "edit_image",
+            "sourceAssetId": "asset_1"
+        }))));
     }
 
     #[test]

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -125,6 +125,12 @@ sceneworks-core = { path = "../sceneworks-core" }
 # at 44929a0), so the candle pin below moves 344038f -> 30a0947 (candle-gen #89 merged: gen-core-only
 # rev alignment, candle builds nothing new) to keep the `--target all` skew gate at a single gen-core
 # rev. (#737 landed pinning the pre-merge branch SHA e2a262c; flipped to candle main 30a0947 here.)
+# Rev 30a0947 -> 18c1c89 (candle-gen #90, sc-6123): adds the bespoke `candle-gen-flux2::Flux2Edit`
+# reference-edit provider that the sc-5487 FLUX.2 worker route (image_jobs/flux2_edit_candle.rs) consumes.
+# 30a0947 (the #89 merge) predates Flux2Edit; 18c1c89 is candle-gen #90's content commit, now durable on
+# candle-gen main (an ancestor of the #90 merge 7b4d15e). candle-gen #90 is SOURCE-ONLY (gen-core stays
+# 7b89d45, byte-identical), so this is a pure candle rev bump and the backend-candle graph stays single
+# gen-core rev 7b89d45.
 sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -778,38 +784,38 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89
 # (the delta is the single additive sc-6038 mlx-gen-instantid commit), so behavior-neutral. The candle
 # SDXL edit worker route (`image_jobs/sdxl_edit_candle.rs`) drives candle-gen-sdxl's `SdxlEdit` off-Mac.
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -818,19 +824,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -839,12 +845,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -852,7 +858,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a09
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -861,7 +867,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -869,7 +875,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -878,7 +884,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30a094799ee5f4d75ccbe86547d5d41a809da06f", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -168,6 +168,14 @@ use candle_gen_sdxl::{
     IpAdapterSdxl, IpAdapterSdxlPaths, IpAdapterSdxlRequest, SdxlEdit, SdxlEditPaths,
     SdxlEditRequest,
 };
+// FLUX.2-klein reference / img2img edit provider (sc-5487, epic 5480) — the candle (Windows/CUDA) FLUX.2
+// edit lane (the sibling of the SDXL edit lane above), living in `candle-gen-flux2` (Kontext-style
+// reference token-concat over the txt2img FLUX.2 stack + the VAE encoder). Candle-only: macOS keeps the
+// MLX `flux2_klein_9b_edit` registry path. `candle_gen_flux2` is already force-link anchored above (the
+// registered txt2img `flux2_klein_9b`); this is the named-type import the bespoke edit route
+// (`image_jobs/flux2_edit_candle.rs`) drives.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+use candle_gen_flux2::{Flux2Edit, Flux2EditPaths, Flux2EditRequest};
 // Kolors IP-Adapter-Plus reference provider (sc-5488, epic 5480) — the candle (Windows/CUDA) Kolors
 // sibling of the SDXL IP lane, living in `candle-gen-kolors` (it reuses candle-gen-sdxl's vendored IP
 // UNet + the CLIP ViT-L/14-336 image encoder, with the Kolors ChatGLM3 conditioning + leading-Euler
@@ -524,6 +532,23 @@ pub(crate) async fn run_image_generate_job(
         // by the txt2img branch (which can't honor a source/mask). Disjoint from the IP-Adapter lane
         // below (that one is reference-only and not `edit_image`).
         generate_candle_sdxl_edit_stream(
+            api,
+            settings,
+            job,
+            &plan,
+            &project_path,
+            backend,
+            &mut asset_writes,
+        )
+        .await?;
+        true
+    } else if settings.backend_candle_enabled && flux2_edit_candle_available(&request, settings) {
+        // FLUX.2-klein reference / img2img edit (sc-5487) — checked BEFORE `is_candle_engine` because
+        // `flux2_klein_9b` IS a candle txt2img id, so without this an `edit_image` job would be caught by
+        // the txt2img branch (which can't honor a source reference). FLUX.2-klein has no torch path, so
+        // before this an off-Mac klein edit had no real lane (it deferred to a torch worker that lacks
+        // the model). Disjoint from the IP-Adapter / SDXL-edit lanes (different model family).
+        generate_candle_flux2_edit_stream(
             api,
             settings,
             job,
@@ -1149,6 +1174,11 @@ include!("image_jobs/sdxl_ipadapter.rs");
 // bespoke provider, so this is candle-exclusive.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 include!("image_jobs/sdxl_edit_candle.rs");
+// FLUX.2-klein reference / img2img edit — the Windows/CUDA candle lane ONLY (sc-5487). macOS keeps the
+// MLX FLUX.2 edit path (flux2.rs `generate_flux2_edit_stream`); the candle `Flux2Edit` is a bespoke
+// provider, so this is candle-exclusive.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+include!("image_jobs/flux2_edit_candle.rs");
 // Kolors IP-Adapter-Plus reference conditioning — the Windows/CUDA candle lane ONLY (sc-5488). macOS
 // keeps the MLX Kolors IP path (kolors.rs, the registry `Reference` route); the candle `IpAdapterKolors`
 // is a bespoke provider, so this is candle-exclusive.

--- a/crates/sceneworks-worker/src/image_jobs/flux2_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2_edit_candle.rs
@@ -1,0 +1,316 @@
+// Candle (Windows/CUDA) FLUX.2-klein image-edit route (sc-5487, epic 5480) — Kontext-style reference-
+// conditioned editing on FLUX.2-klein off-Mac via `candle_gen_flux2::Flux2Edit`. FLUX.2-klein has no
+// torch path (it is diffusers/MLX-only), so before this an off-Mac `edit_image` job on klein had no
+// real lane; this routes it to candle instead of the torch fallback.
+//
+// **Candle-only.** macOS keeps the MLX FLUX.2 edit path (flux2.rs `generate_flux2_edit_stream`); the
+// candle `Flux2Edit` is a bespoke provider, so this whole file is gated to the Windows/CUDA candle build
+// (the `include!` in image_jobs.rs carries the cfg). It is `include!`d into the `image_jobs` module, so
+// it shares that module's imports (ImageRequest/Settings/WorkerResult/`advanced`/`load_reference_image`/
+// `huggingface_snapshot_dir`/`resolve_app_managed_model_dir`/`resolve_seed`/`start_gen_stream`/
+// `drive_gen_items`/`consume_gen_events`/`non_empty`/`gen_core`/… all in scope).
+//
+// FLUX.2 edit is a single-reference (or multi-reference) token concat, NOT a strength-based img2img +
+// mask: the source is the reference, the prompt is the instruction. So this lane has no sub-modes /
+// inpaint / outpaint (unlike the SDXL edit lane) — it handles `edit_image` + `sourceAssetId`.
+
+/// FLUX.2-klein denoise steps default (distilled klein generates in 4).
+const FLUX2_EDIT_CANDLE_DEFAULT_STEPS: u32 = 4;
+/// Guidance default — distilled klein runs CFG-free at 1.0 (a single forward; >1.0 adds a negative pass).
+const FLUX2_EDIT_CANDLE_DEFAULT_GUIDANCE: f32 = 1.0;
+/// The adapter/engine id recorded on candle FLUX.2 edit assets + telemetry (distinct from the txt2img
+/// `candle_flux2` lane).
+const FLUX2_EDIT_CANDLE_ENGINE: &str = "candle_flux2_edit";
+/// Default FLUX.2-klein base repo when the manifest omits `repo`.
+const FLUX2_EDIT_CANDLE_DEFAULT_REPO: &str = "black-forest-labs/FLUX.2-klein-9B";
+
+/// FLUX.2-klein model ids the candle edit route accepts (the base 9b + true_v2 share the edit variant;
+/// the -kv distill needs the reference-K/V cache port and stays on the MLX/torch path for now, as does
+/// `flux2_dev` — no klein-only candle crate covers them yet).
+fn is_flux2_edit_candle_model(model: &str) -> bool {
+    matches!(model, "flux2_klein_9b" | "flux2_klein_9b_true_v2")
+}
+
+/// True when this is a candle-eligible FLUX.2 edit job: a klein-family `edit_image` job with a source
+/// image. Mirrors `jobs_store::flux2_edit_candle_eligible` so the worker and router agree on the lane
+/// boundary.
+fn flux2_edit_candle_mode(request: &ImageRequest) -> bool {
+    request.mode == "edit_image" && non_empty(&request.source_asset_id)
+}
+
+/// Resolve the FLUX.2-klein base snapshot: an explicit `modelPath` dir (advanced or manifest) wins, else
+/// the HF cache snapshot for the manifest `repo` (default `FLUX2_EDIT_CANDLE_DEFAULT_REPO`). `None` means
+/// the base is not present locally, so the job is not candle-runnable. Mirrors
+/// `resolve_sdxl_edit_candle_base`.
+fn resolve_flux2_edit_candle_base(
+    request: &ImageRequest,
+    settings: &Settings,
+) -> WorkerResult<Option<PathBuf>> {
+    if let Some(path) = request
+        .advanced
+        .get("modelPath")
+        .or_else(|| request.model_manifest_entry.get("modelPath"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+    {
+        return resolve_app_managed_model_dir(settings, &path, "FLUX.2 edit modelPath").map(Some);
+    }
+    let repo = flux2_edit_candle_repo(request);
+    Ok(huggingface_snapshot_dir(&settings.data_dir, &repo))
+}
+
+/// The FLUX.2-klein base repo for this request: manifest `repo` else the klein default.
+fn flux2_edit_candle_repo(request: &ImageRequest) -> String {
+    request
+        .model_manifest_entry
+        .get("repo")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(FLUX2_EDIT_CANDLE_DEFAULT_REPO)
+        .to_owned()
+}
+
+/// True when this is a candle-eligible FLUX.2 edit job (a klein-family `edit_image` job with a source)
+/// whose base resolves locally. Mirrors `jobs_store::flux2_edit_candle_eligible` (minus the weight-
+/// resolve check).
+fn flux2_edit_candle_available(request: &ImageRequest, settings: &Settings) -> bool {
+    is_flux2_edit_candle_model(&request.model)
+        && flux2_edit_candle_mode(request)
+        && matches!(
+            resolve_flux2_edit_candle_base(request, settings),
+            Ok(Some(_))
+        )
+}
+
+/// Resolve denoise steps: `advanced.steps` (clamped 1..=50) → manifest `steps` → default (4).
+fn flux2_edit_candle_steps(request: &ImageRequest) -> u32 {
+    let parse = |value: &Value| {
+        value
+            .as_u64()
+            .or_else(|| value.as_str()?.trim().parse().ok())
+    };
+    request
+        .advanced
+        .get("steps")
+        .and_then(parse)
+        .or_else(|| request.model_manifest_entry.get("steps").and_then(parse))
+        .map(|steps| steps.clamp(1, 50) as u32)
+        .unwrap_or(FLUX2_EDIT_CANDLE_DEFAULT_STEPS)
+}
+
+/// Resolve guidance: `advanced.guidanceScale` → manifest `guidanceScale` → default (1.0), clamped.
+fn flux2_edit_candle_guidance(request: &ImageRequest) -> f32 {
+    let manifest_default = request
+        .model_manifest_entry
+        .get("guidanceScale")
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .map(|value| value as f32)
+        .unwrap_or(FLUX2_EDIT_CANDLE_DEFAULT_GUIDANCE);
+    advanced::f32_clamped(
+        &request.advanced,
+        "guidanceScale",
+        manifest_default,
+        0.0..=30.0,
+    )
+}
+
+/// Resize an RGB image to exactly `width`×`height` honoring `mode` without distorting it (the candle
+/// FLUX.2 twin of the macOS `fit_rgb`): `crop` covers + center-crops, `pad`/`outpaint` contain +
+/// letterbox on black, `stretch` is the legacy non-aspect resize. The Image-Edit source is pre-fitted so
+/// an off-aspect edit doesn't stretch; the provider re-resizes to the render size internally.
+fn flux2_edit_fit_rgb(
+    source: &image::RgbImage,
+    width: u32,
+    height: u32,
+    mode: &str,
+) -> image::RgbImage {
+    use image::imageops::FilterType::Lanczos3;
+    let width = width.max(1);
+    let height = height.max(1);
+    let (src_w, src_h) = (source.width(), source.height());
+    match mode {
+        "stretch" => image::imageops::resize(source, width, height, Lanczos3),
+        "crop" => {
+            let ratio = (width as f32 / src_w as f32).max(height as f32 / src_h as f32);
+            let new_w = width.max((src_w as f32 * ratio).ceil() as u32);
+            let new_h = height.max((src_h as f32 * ratio).ceil() as u32);
+            let resized = image::imageops::resize(source, new_w, new_h, Lanczos3);
+            let left = (new_w - width) / 2;
+            let top = (new_h - height) / 2;
+            image::imageops::crop_imm(&resized, left, top, width, height).to_image()
+        }
+        // "pad" / "outpaint": contain + center on a black canvas (letterbox).
+        _ => {
+            let (new_w, new_h, left, top) =
+                gen_core::imageops::contain_box(src_w, src_h, width, height);
+            let resized = image::imageops::resize(source, new_w.max(1), new_h.max(1), Lanczos3);
+            let mut canvas = image::RgbImage::from_pixel(width, height, image::Rgb([0, 0, 0]));
+            image::imageops::overlay(&mut canvas, &resized, left as i64, top as i64);
+            canvas
+        }
+    }
+}
+
+/// Fit an engine [`Image`] (RGB8) to `width`×`height` by `mode` via [`flux2_edit_fit_rgb`].
+fn flux2_edit_fit_image(source: Image, width: u32, height: u32, mode: &str) -> WorkerResult<Image> {
+    let rgb =
+        image::RgbImage::from_raw(source.width, source.height, source.pixels).ok_or_else(|| {
+            WorkerError::InvalidPayload("FLUX.2 edit image buffer size mismatch".to_owned())
+        })?;
+    let fitted = flux2_edit_fit_rgb(&rgb, width, height, mode);
+    Ok(Image {
+        width: fitted.width(),
+        height: fitted.height(),
+        pixels: fitted.into_raw(),
+    })
+}
+
+/// Flat telemetry recorded on candle FLUX.2 edit assets (parity with the macOS FLUX.2 edit recipe keys).
+fn flux2_edit_candle_raw_settings(
+    request: &ImageRequest,
+    repo: &str,
+    steps: u32,
+    guidance: f32,
+) -> JsonObject {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("repo".to_owned(), Value::String(repo.to_owned()));
+    raw.insert("numInferenceSteps".to_owned(), json!(steps));
+    raw.insert("guidanceScale".to_owned(), json!(guidance));
+    raw.insert("referenceCount".to_owned(), json!(1));
+    raw.insert(
+        "editEngine".to_owned(),
+        Value::String(FLUX2_EDIT_CANDLE_ENGINE.to_owned()),
+    );
+    raw
+}
+
+/// Load the FLUX.2 edit source asset (the `sourceAssetId` is required) as an engine [`Image`].
+fn load_flux2_edit_source(
+    request: &ImageRequest,
+    project_path: &Path,
+    settings: &Settings,
+) -> WorkerResult<Image> {
+    let source_id = request
+        .source_asset_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload("FLUX.2 edit requires a source image".to_owned())
+        })?;
+    load_reference_image(
+        &settings.data_dir,
+        &request.project_id,
+        source_id,
+        project_path,
+    )
+}
+
+/// Real candle FLUX.2-klein edit generation: resolve the source + base on the async side, pre-fit the
+/// source to the render geometry, then load `Flux2Edit` once + generate each image on the blocking
+/// thread. `request.count` edits of the same source, each its own seed. `generate` takes `&self`, so the
+/// per-item closure needs no `mut`. Reuses [`consume_gen_events`].
+async fn generate_candle_flux2_edit_stream(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+    let flux2_base = resolve_flux2_edit_candle_base(request, settings)?.ok_or_else(|| {
+        WorkerError::InvalidPayload("FLUX.2-klein base not found".to_owned())
+    })?;
+    if !flux2_edit_candle_mode(request) {
+        return Err(WorkerError::InvalidPayload(
+            "FLUX.2 edit requires edit_image mode + a source image".to_owned(),
+        ));
+    }
+    let (width, height) = (request.width, request.height);
+    let source = load_flux2_edit_source(request, project_path, settings)?;
+    // Pre-fit the Image-Edit source to W×H (crop / pad / outpaint→pad) so an off-aspect edit doesn't
+    // stretch; `stretch` keeps the legacy non-aspect resize. The provider re-resizes internally.
+    let reference = if request.fit_mode == "stretch" {
+        source
+    } else {
+        flux2_edit_fit_image(source, width, height, &request.fit_mode)?
+    };
+
+    let steps = flux2_edit_candle_steps(request);
+    let guidance = flux2_edit_candle_guidance(request);
+    let repo = flux2_edit_candle_repo(request);
+    let raw_settings = flux2_edit_candle_raw_settings(request, &repo, steps, guidance);
+
+    // Per-image work items: (seed, prompt) — `request.count` edits of the same source.
+    let work: Vec<(i64, String)> = (0..request.count as usize)
+        .map(|index| (resolve_seed(request, index), request.prompt.clone()))
+        .collect();
+    let total = work.len();
+    let negative = request.negative_prompt.clone();
+
+    let (cancel, rx, blocking) = start_gen_stream(
+        job.id.clone(),
+        "flux2_edit",
+        0,
+        move || {
+            let model = Flux2Edit::load(&Flux2EditPaths { root: flux2_base })
+                .map_err(|error| WorkerError::Engine(format!("FLUX.2 edit load failed: {error}")))?;
+            Ok((model, reference))
+        },
+        move |(model, reference), tx, cancel| {
+            drive_gen_items(tx, work, move |_index, (seed, prompt), on_progress| {
+                if cancel.is_cancelled() {
+                    return Ok(None);
+                }
+                let req = Flux2EditRequest {
+                    prompt,
+                    negative: negative.clone(),
+                    width,
+                    height,
+                    steps: steps as usize,
+                    guidance,
+                    seed: seed as u64,
+                    cancel: cancel.clone(),
+                };
+                let result = model.generate(&req, std::slice::from_ref(&reference), &mut *on_progress);
+                let out = match result {
+                    Ok(out) => out,
+                    Err(_) if cancel.is_cancelled() => return Ok(None),
+                    Err(error) => {
+                        return Err(WorkerError::Engine(format!(
+                            "FLUX.2 edit generation failed: {error}"
+                        )));
+                    }
+                };
+                Ok(Some((seed, out.width, out.height, out.pixels)))
+            })
+        },
+    );
+
+    consume_gen_events(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        FLUX2_EDIT_CANDLE_ENGINE,
+        &raw_settings,
+        total,
+        rx,
+        cancel,
+        blocking,
+        asset_writes,
+    )
+    .await
+}


### PR DESCRIPTION
The **FLUX.2 family** of [sc-5487](https://app.shortcut.com/trefry/story/5487) (epic 5480): a `flux2_klein_9b` / `flux2_klein_9b_true_v2` `edit_image` job with a `sourceAssetId` now routes to the bespoke candle `Flux2Edit` provider off-Mac instead of the torch fallback. **FLUX.2-klein has no torch path** (it's diffusers/MLX-only), so before this an off-Mac klein edit had no real lane — this is the first off-Mac FLUX.2 edit lane.

Consumes the provider half **[candle-gen #90](https://github.com/michaeltrefry/candle-gen/pull/90)** ([sc-6123](https://app.shortcut.com/trefry/story/6123), the FLUX.2 sibling of sc-6037's `SdxlEdit`).

## Changes
- **NEW `image_jobs/flux2_edit_candle.rs`** (`generate_candle_flux2_edit_stream` + `flux2_edit_candle_available`): loads the klein base + the source as the reference, pre-fits the Image-Edit source to W×H (crop / pad / outpaint→pad, `stretch` keeps the legacy resize), drives `Flux2Edit.generate` (Kontext-style reference token concat — klein default 4 steps / guidance 1.0), engine id `candle_flux2_edit`. Cfg-gated to the Windows/CUDA candle build (macOS keeps the MLX `flux2_klein_9b_edit` path).
- **`image_jobs.rs`:** dispatch branch BEFORE `is_candle_engine` (`flux2_klein_9b` IS a candle txt2img id, so an `edit_image` job would otherwise be caught by the txt2img branch) + the `Flux2Edit` named-type import + the `include!`.
- **`jobs_store.rs`:** `flux2_edit_candle_eligible` + a klein-family carve-out before the `image_request_candle_eligible` `edit_image`→torch deferral + routing tests (candle claims `flux2_klein_9b` edit; the `-kv` distill edit still defers — no candle provider yet).
- **Cargo re-pin** candle-gen `e2a262c → 18c1c89` (candle-gen #90, **source-only**; single gen-core rev `7b89d45`, no skew). Pre-merge this points at #90's branch commit; flip to the merged candle-gen `main` rev once #90 lands.

## Validation
- **35 core routing tests** pass (incl. `flux2_klein_9b` edit claimed by candle, `-kv` edit deferred).
- `cargo clippy -p sceneworks-worker --features backend-candle -- -D warnings` clean (sm_120, MSVC 14.44); `fmt` clean.
- The provider half (candle-gen #90) is **GPU-validated on the RTX PRO 6000** — 1024² edit coherent (reference identity preserved + instruction applied), pre + mid-denoise cancel → `Canceled`. candle-gen #90 also fixes a real candle CUDA i32-index-overflow in the long-sequence attention.

**Merge order: candle-gen #90 first, then this PR.**

Remaining sc-5487 family: **Qwen-Image-Edit** (needs its candle edit provider ported first — `QwenVaeEncoder` + reference conditioning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)