### PR TITLE
Ideogram 4: Image Studio structured prompt-builder form (sc-5994)

### DIFF
--- a/apps/web/src/components/StructuredPromptBuilder.jsx
+++ b/apps/web/src/components/StructuredPromptBuilder.jsx
@@ -1,0 +1,462 @@
+// Ideogram 4 structured prompt-builder (epic 4725, sc-5994).
+//
+// Ideogram 4 is prompted with a structured JSON caption, not free text, so this
+// form lets the user author a valid, key-ordered caption without hand-writing
+// schema. It sits on the sc-5993 contract (apps/web/src/ideogramCaption.js):
+// every edit produces a plain caption object that `serializeCaption` emits in
+// the model's exact training order, and the parent validates with the same
+// `validateCaption`.
+//
+// Three modes: Builder (the form), JSON (raw edit, validated live), and Plain
+// (the free-text fallback that seeds magic-prompt, sc-5997). The visual bbox
+// canvas (sc-5995) and rich palette picker (sc-5996) augment this form later;
+// here bbox is four numbers and a palette is comma-separated #RRGGBB.
+
+import React, { useEffect, useRef, useState } from "react";
+import {
+  BBOX_MAX,
+  clampBboxValue,
+  ELEMENT_PALETTE_MAX,
+  makeObjElement,
+  makeTextElement,
+  normalizeHexColor,
+  orderCaption,
+  parseCaption,
+  STYLE_PALETTE_MAX,
+} from "../ideogramCaption.js";
+
+const MODES = [
+  ["form", "Builder"],
+  ["json", "JSON"],
+  ["plain", "Plain text"],
+];
+
+// Pretty-print the caption in canonical order for the read-only preview and the
+// JSON editor. The actual engine payload uses the compact `serializeCaption`
+// form; whitespace differs but content and key order are identical.
+function prettyCaption(caption) {
+  return JSON.stringify(orderCaption(caption), null, 2);
+}
+
+function getComposition(caption) {
+  return caption?.compositional_deconstruction ?? { background: "", elements: [] };
+}
+
+function getElements(caption) {
+  const els = getComposition(caption).elements;
+  return Array.isArray(els) ? els : [];
+}
+
+// A palette field: comma/space-separated #RRGGBB. Keeps its own text buffer so
+// the user can type freely; commits the normalized, valid colors on blur.
+function PaletteField({ value, onChange, max, label }) {
+  const [text, setText] = useState(() => (Array.isArray(value) ? value.join(", ") : ""));
+  // Re-seed from props only when the committed value actually changes (e.g. an
+  // external edit or a JSON-mode apply), not on every keystroke.
+  useEffect(() => {
+    setText(Array.isArray(value) ? value.join(", ") : "");
+  }, [value]);
+
+  function commit() {
+    const tokens = text.split(/[\s,]+/).map((t) => t.trim()).filter(Boolean);
+    const colors = [];
+    for (const token of tokens) {
+      const normalized = normalizeHexColor(token);
+      if (normalized && !colors.includes(normalized)) colors.push(normalized);
+    }
+    onChange(colors.length ? colors.slice(0, max) : null);
+  }
+
+  return (
+    <label className="structured-field structured-palette">
+      <span>{label}</span>
+      <input
+        type="text"
+        placeholder={`#RRGGBB, #RRGGBB … (max ${max})`}
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onBlur={commit}
+      />
+    </label>
+  );
+}
+
+// Four integer inputs for a [ymin, xmin, ymax, xmax] box (0–1000). The visual
+// drag canvas is sc-5995; this is the typed fallback.
+function BboxField({ bbox, onChange, onRemove }) {
+  const labels = ["y min", "x min", "y max", "x max"];
+  function setAt(i, raw) {
+    const next = (Array.isArray(bbox) ? bbox.slice() : [0, 0, BBOX_MAX, BBOX_MAX]);
+    next[i] = clampBboxValue(raw);
+    onChange(next);
+  }
+  return (
+    <div className="structured-bbox">
+      <span className="structured-bbox-label">Bounding box (0–{BBOX_MAX})</span>
+      <div className="structured-bbox-row">
+        {labels.map((lab, i) => (
+          <label key={lab}>
+            <span>{lab}</span>
+            <input
+              type="number"
+              min={0}
+              max={BBOX_MAX}
+              value={Array.isArray(bbox) ? bbox[i] : ""}
+              onChange={(e) => setAt(i, e.target.value)}
+            />
+          </label>
+        ))}
+        <button type="button" className="structured-link" onClick={onRemove}>
+          Remove box
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default function StructuredPromptBuilder({
+  caption,
+  onCaptionChange,
+  validation,
+  mode,
+  onModeChange,
+  plainText,
+  onPlainTextChange,
+}) {
+  const composition = getComposition(caption);
+  const elements = getElements(caption);
+
+  // Stable React keys for the repeatable element rows so child field state stays
+  // aligned with its element across add/remove (elements carry no id of their
+  // own — an id key would be an unknown schema key).
+  const keyCounter = useRef(0);
+  const [elementKeys, setElementKeys] = useState(() => elements.map(() => (keyCounter.current += 1)));
+  useEffect(() => {
+    setElementKeys((prev) => {
+      if (prev.length === elements.length) return prev;
+      const next = prev.slice(0, elements.length);
+      while (next.length < elements.length) next.push((keyCounter.current += 1));
+      return next;
+    });
+  }, [elements.length]);
+
+  // JSON editor buffer — seeded on entering JSON mode, then user-controlled.
+  const [jsonDraft, setJsonDraft] = useState(() => prettyCaption(caption));
+  const [jsonError, setJsonError] = useState(null);
+  useEffect(() => {
+    if (mode === "json") {
+      setJsonDraft(prettyCaption(caption));
+      setJsonError(null);
+    }
+    // Only re-seed when switching into JSON mode, not on every caption keystroke.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode]);
+
+  // ----- immutable caption updates -----
+  function patchCaption(next) {
+    onCaptionChange(next);
+  }
+  function setHighLevel(value) {
+    const next = { ...caption };
+    if (value.trim()) next.high_level_description = value;
+    else delete next.high_level_description;
+    patchCaption(next);
+  }
+  function setBackground(value) {
+    patchCaption({
+      ...caption,
+      compositional_deconstruction: { ...composition, background: value },
+    });
+  }
+  function setElements(nextElements) {
+    patchCaption({
+      ...caption,
+      compositional_deconstruction: { ...composition, elements: nextElements },
+    });
+  }
+  function updateElement(index, updater) {
+    setElements(elements.map((el, i) => (i === index ? updater(el) : el)));
+  }
+  function addElement(type) {
+    const el = type === "text" ? makeTextElement({}) : makeObjElement({});
+    setElementKeys((prev) => [...prev, (keyCounter.current += 1)]);
+    setElements([...elements, el]);
+  }
+  function removeElement(index) {
+    setElementKeys((prev) => prev.filter((_, i) => i !== index));
+    setElements(elements.filter((_, i) => i !== index));
+  }
+  function setElementType(index, type) {
+    updateElement(index, (el) => {
+      if (el.type === type) return el;
+      const base = { type };
+      if ("bbox" in el) base.bbox = el.bbox;
+      if (type === "text") base.text = el.text ?? "";
+      base.desc = el.desc ?? "";
+      if ("color_palette" in el) base.color_palette = el.color_palette;
+      return base;
+    });
+  }
+
+  // ----- style helpers (style_description is optional) -----
+  const style = caption.style_description ?? null;
+  const styleKind = style && "art_style" in style && !("photo" in style) ? "art" : "photo";
+  function setStyleEnabled(on) {
+    if (on) {
+      patchCaption({ ...caption, style_description: { aesthetics: "", lighting: "", photo: "", medium: "" } });
+    } else {
+      const next = { ...caption };
+      delete next.style_description;
+      patchCaption(next);
+    }
+  }
+  function setStyleField(field, value) {
+    patchCaption({ ...caption, style_description: { ...style, [field]: value } });
+  }
+  function setStyleKind(kind) {
+    if (!style) return;
+    const next = { ...style };
+    const current = next.photo ?? next.art_style ?? "";
+    delete next.photo;
+    delete next.art_style;
+    if (kind === "art") next.art_style = current;
+    else next.photo = current;
+    patchCaption({ ...caption, style_description: next });
+  }
+  function setStyleDiscriminatorValue(value) {
+    setStyleField(styleKind === "art" ? "art_style" : "photo", value);
+  }
+
+  // ----- JSON mode -----
+  function onJsonChange(text) {
+    setJsonDraft(text);
+    const { caption: parsed, error } = parseCaption(text);
+    if (error) {
+      setJsonError(error);
+      return;
+    }
+    setJsonError(null);
+    onCaptionChange(parsed);
+  }
+
+  const errors = validation?.errors ?? [];
+  const warnings = validation?.warnings ?? [];
+
+  return (
+    <div className="structured-prompt-builder">
+      <div className="segmented-control structured-mode" role="tablist" aria-label="Prompt mode">
+        {MODES.map(([value, label]) => (
+          <button
+            key={value}
+            type="button"
+            role="tab"
+            aria-selected={mode === value}
+            className={mode === value ? "active" : ""}
+            onClick={() => onModeChange(value)}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {mode === "plain" ? (
+        <div className="structured-plain">
+          <textarea
+            aria-label="Plain prompt"
+            className="prompt-input"
+            placeholder="Describe your idea in plain language…"
+            value={plainText}
+            onChange={(e) => onPlainTextChange(e.target.value)}
+          />
+          <p className="structured-hint">
+            Ideogram 4 was trained on structured captions — plain text produces a coherent but
+            prompt-agnostic image. Use the Builder for accurate adherence, or expand this into a
+            caption with magic-prompt.
+          </p>
+        </div>
+      ) : null}
+
+      {mode === "json" ? (
+        <div className="structured-json">
+          <textarea
+            aria-label="JSON caption"
+            className="prompt-input structured-json-input"
+            spellCheck={false}
+            value={jsonDraft}
+            onChange={(e) => onJsonChange(e.target.value)}
+          />
+          {jsonError ? <p className="structured-error">Invalid JSON: {jsonError}</p> : null}
+        </div>
+      ) : null}
+
+      {mode === "form" ? (
+        <div className="structured-form">
+          <label className="structured-field">
+            <span>High-level description</span>
+            <input
+              type="text"
+              placeholder="One sentence summarizing the whole image"
+              value={caption.high_level_description ?? ""}
+              onChange={(e) => setHighLevel(e.target.value)}
+            />
+          </label>
+
+          <fieldset className="structured-style">
+            <legend>
+              <label className="structured-checkline">
+                <input type="checkbox" checked={Boolean(style)} onChange={(e) => setStyleEnabled(e.target.checked)} />
+                Style
+              </label>
+            </legend>
+            {style ? (
+              <div className="structured-style-fields">
+                <label className="structured-field">
+                  <span>Aesthetics</span>
+                  <input type="text" placeholder="serene, warm, naturalistic" value={style.aesthetics ?? ""} onChange={(e) => setStyleField("aesthetics", e.target.value)} />
+                </label>
+                <label className="structured-field">
+                  <span>Lighting</span>
+                  <input type="text" placeholder="golden hour, soft backlight" value={style.lighting ?? ""} onChange={(e) => setStyleField("lighting", e.target.value)} />
+                </label>
+                <div className="structured-field">
+                  <span>Kind</span>
+                  <div className="segmented-control structured-kind" role="tablist" aria-label="Style kind">
+                    <button type="button" aria-selected={styleKind === "photo"} className={styleKind === "photo" ? "active" : ""} onClick={() => setStyleKind("photo")}>
+                      Photo
+                    </button>
+                    <button type="button" aria-selected={styleKind === "art"} className={styleKind === "art" ? "active" : ""} onClick={() => setStyleKind("art")}>
+                      Art
+                    </button>
+                  </div>
+                </div>
+                <label className="structured-field">
+                  <span>{styleKind === "art" ? "Art style" : "Photo"}</span>
+                  <input
+                    type="text"
+                    placeholder={styleKind === "art" ? "watercolor illustration" : "telephoto, shallow depth of field, eye-level"}
+                    value={(styleKind === "art" ? style.art_style : style.photo) ?? ""}
+                    onChange={(e) => setStyleDiscriminatorValue(e.target.value)}
+                  />
+                </label>
+                <label className="structured-field">
+                  <span>Medium</span>
+                  <input type="text" placeholder="photograph, oil painting" value={style.medium ?? ""} onChange={(e) => setStyleField("medium", e.target.value)} />
+                </label>
+                <PaletteField
+                  label={`Color palette (max ${STYLE_PALETTE_MAX})`}
+                  value={style.color_palette}
+                  max={STYLE_PALETTE_MAX}
+                  onChange={(colors) => {
+                    const next = { ...style };
+                    if (colors) next.color_palette = colors;
+                    else delete next.color_palette;
+                    patchCaption({ ...caption, style_description: next });
+                  }}
+                />
+              </div>
+            ) : null}
+          </fieldset>
+
+          <label className="structured-field">
+            <span>Background</span>
+            <textarea
+              className="structured-textarea"
+              placeholder="The scene behind the elements"
+              value={composition.background ?? ""}
+              onChange={(e) => setBackground(e.target.value)}
+            />
+          </label>
+
+          <div className="structured-elements">
+            <div className="structured-elements-head">
+              <span>Elements</span>
+              <div>
+                <button type="button" className="structured-link" onClick={() => addElement("obj")}>
+                  + Object
+                </button>
+                <button type="button" className="structured-link" onClick={() => addElement("text")}>
+                  + Text
+                </button>
+              </div>
+            </div>
+            {elements.length === 0 ? <p className="structured-hint">Add objects and text blocks to place them on the canvas.</p> : null}
+            {elements.map((el, i) => (
+              <div className="structured-element" key={elementKeys[i] ?? i}>
+                <div className="structured-element-head">
+                  <div className="segmented-control structured-kind" role="tablist" aria-label={`Element ${i + 1} type`}>
+                    <button type="button" aria-selected={el.type !== "text"} className={el.type !== "text" ? "active" : ""} onClick={() => setElementType(i, "obj")}>
+                      Object
+                    </button>
+                    <button type="button" aria-selected={el.type === "text"} className={el.type === "text" ? "active" : ""} onClick={() => setElementType(i, "text")}>
+                      Text
+                    </button>
+                  </div>
+                  <button type="button" className="structured-link" onClick={() => removeElement(i)}>
+                    Remove
+                  </button>
+                </div>
+                {el.type === "text" ? (
+                  <label className="structured-field">
+                    <span>Text to render</span>
+                    <input type="text" placeholder="The exact characters to render" value={el.text ?? ""} onChange={(e) => updateElement(i, (cur) => ({ ...cur, text: e.target.value }))} />
+                  </label>
+                ) : null}
+                <label className="structured-field">
+                  <span>Description</span>
+                  <textarea className="structured-textarea" placeholder="Material, pose, expression, lighting on this element" value={el.desc ?? ""} onChange={(e) => updateElement(i, (cur) => ({ ...cur, desc: e.target.value }))} />
+                </label>
+                {"bbox" in el ? (
+                  <BboxField
+                    bbox={el.bbox}
+                    onChange={(bbox) => updateElement(i, (cur) => ({ ...cur, bbox }))}
+                    onRemove={() => updateElement(i, (cur) => {
+                      const next = { ...cur };
+                      delete next.bbox;
+                      return next;
+                    })}
+                  />
+                ) : (
+                  <button type="button" className="structured-link" onClick={() => updateElement(i, (cur) => ({ ...cur, bbox: [0, 0, BBOX_MAX, BBOX_MAX] }))}>
+                    + Bounding box
+                  </button>
+                )}
+                <PaletteField
+                  label={`Palette (max ${ELEMENT_PALETTE_MAX})`}
+                  value={el.color_palette}
+                  max={ELEMENT_PALETTE_MAX}
+                  onChange={(colors) => updateElement(i, (cur) => {
+                    const next = { ...cur };
+                    if (colors) next.color_palette = colors;
+                    else delete next.color_palette;
+                    return next;
+                  })}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {mode !== "plain" ? (
+        <div className="structured-preview">
+          <div className="structured-preview-head">Generated caption (sent to the model)</div>
+          <pre aria-label="Caption preview">{prettyCaption(caption)}</pre>
+          {errors.length ? (
+            <ul className="structured-issues structured-issues-error">
+              {errors.map((issue, i) => (
+                <li key={`e${i}`}>{issue.message}</li>
+              ))}
+            </ul>
+          ) : null}
+          {warnings.length ? (
+            <ul className="structured-issues structured-issues-warn">
+              {warnings.map((issue, i) => (
+                <li key={`w${i}`}>{issue.message}</li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/StructuredPromptBuilder.test.jsx
+++ b/apps/web/src/components/StructuredPromptBuilder.test.jsx
@@ -1,0 +1,156 @@
+import React, { act, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import StructuredPromptBuilder from "./StructuredPromptBuilder.jsx";
+import { emptyCaption, serializeCaption, validateCaption } from "../ideogramCaption.js";
+
+// Native-setter trick so React's onChange fires for controlled inputs/textareas.
+function setValue(el, value) {
+  const proto = el.tagName === "TEXTAREA" ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+  Object.getOwnPropertyDescriptor(proto, "value").set.call(el, value);
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+function click(el) {
+  el.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+}
+
+function blur(el) {
+  // React 18 delegates onBlur via the bubbling `focusout` event.
+  el.dispatchEvent(new Event("focusout", { bubbles: true }));
+}
+
+describe("StructuredPromptBuilder", () => {
+  let container;
+  let root;
+  let snap;
+
+  // Stateful wrapper so we can drive the controlled component and read back the
+  // caption it builds.
+  function Harness({ initialMode = "form", initialCaption }) {
+    const [caption, setCaption] = useState(initialCaption ?? emptyCaption());
+    const [mode, setMode] = useState(initialMode);
+    const [plain, setPlain] = useState("");
+    const validation = validateCaption(caption, { plainText: plain });
+    snap = { caption, mode, plain, validation };
+    return (
+      <StructuredPromptBuilder
+        caption={caption}
+        onCaptionChange={setCaption}
+        validation={validation}
+        mode={mode}
+        onModeChange={setMode}
+        plainText={plain}
+        onPlainTextChange={setPlain}
+      />
+    );
+  }
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    snap = null;
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  const byPlaceholder = (prefix) => container.querySelector(`[placeholder^="${prefix}"]`);
+  const buttonByText = (text) =>
+    [...container.querySelectorAll("button")].find((b) => b.textContent.trim() === text);
+
+  async function mount(props = {}) {
+    await act(async () => root.render(<Harness {...props} />));
+  }
+
+  it("builds a valid, key-ordered caption from the form fields", async () => {
+    await mount();
+    await act(async () => setValue(byPlaceholder("One sentence"), "A red fox in the snow"));
+    await act(async () => setValue(byPlaceholder("The scene behind"), "A snowy pine forest"));
+    await act(async () => click(buttonByText("+ Object")));
+    await act(async () => setValue(byPlaceholder("Material, pose"), "a red fox sitting upright"));
+
+    expect(snap.validation.ok).toBe(true);
+    expect(serializeCaption(snap.caption)).toBe(
+      '{"high_level_description": "A red fox in the snow", "compositional_deconstruction": {"background": "A snowy pine forest", "elements": [{"type": "obj", "desc": "a red fox sitting upright"}]}}',
+    );
+  });
+
+  it("orders text-element keys (type, bbox, text, desc) when toggled to Text with a box", async () => {
+    await mount();
+    await act(async () => setValue(byPlaceholder("The scene behind"), "bg"));
+    await act(async () => click(buttonByText("+ Text")));
+    await act(async () => setValue(byPlaceholder("The exact characters"), "HELLO"));
+    await act(async () => setValue(byPlaceholder("Material, pose"), "bold serif headline"));
+    await act(async () => click(buttonByText("+ Bounding box")));
+
+    expect(snap.validation.ok).toBe(true);
+    expect(serializeCaption(snap.caption)).toBe(
+      '{"compositional_deconstruction": {"background": "bg", "elements": [{"type": "text", "bbox": [0, 0, 1000, 1000], "text": "HELLO", "desc": "bold serif headline"}]}}',
+    );
+  });
+
+  it("commits a normalized palette on blur (lowercase -> uppercase, dedup)", async () => {
+    await mount();
+    await act(async () => setValue(byPlaceholder("The scene behind"), "bg"));
+    await act(async () => click(buttonByText("+ Object")));
+    const palette = byPlaceholder("#RRGGBB");
+    await act(async () => setValue(palette, "#ff0000, #00ff00 #ff0000"));
+    await act(async () => blur(palette));
+
+    const el = snap.caption.compositional_deconstruction.elements[0];
+    expect(el.color_palette).toEqual(["#FF0000", "#00FF00"]);
+  });
+
+  it("shows the live ordered-JSON preview and applies raw-JSON edits", async () => {
+    await mount({ initialMode: "json" });
+    const editor = container.querySelector('textarea[aria-label="JSON caption"]');
+    expect(editor).toBeTruthy();
+
+    const edited = '{"compositional_deconstruction": {"background": "new bg", "elements": []}}';
+    await act(async () => setValue(editor, edited));
+    expect(snap.caption.compositional_deconstruction.background).toBe("new bg");
+
+    // Invalid JSON surfaces an error and preserves the last valid caption.
+    await act(async () => setValue(editor, "{not json"));
+    expect(container.querySelector(".structured-error")).toBeTruthy();
+    expect(snap.caption.compositional_deconstruction.background).toBe("new bg");
+  });
+
+  it("renders the plain-text fallback and forwards edits", async () => {
+    await mount({ initialMode: "plain" });
+    const plain = container.querySelector('textarea[aria-label="Plain prompt"]');
+    expect(plain).toBeTruthy();
+    await act(async () => setValue(plain, "a fox in the snow"));
+    expect(snap.plain).toBe("a fox in the snow");
+    // No JSON preview in plain mode.
+    expect(container.querySelector('[aria-label="Caption preview"]')).toBeFalsy();
+  });
+
+  it("switches modes via the segmented control", async () => {
+    await mount();
+    const jsonTab = [...container.querySelectorAll(".structured-mode button")].find(
+      (b) => b.textContent.trim() === "JSON",
+    );
+    await act(async () => click(jsonTab));
+    expect(snap.mode).toBe("json");
+  });
+
+  it("reports blocking validation errors in the preview (out-of-range bbox)", async () => {
+    const bad = {
+      compositional_deconstruction: {
+        background: "bg",
+        elements: [{ type: "obj", bbox: [0, 0, 5000, 10], desc: "d" }],
+      },
+    };
+    await mount({ initialCaption: bad });
+    expect(snap.validation.ok).toBe(false);
+    expect(container.querySelector(".structured-issues-error")).toBeTruthy();
+  });
+});

--- a/apps/web/src/ideogramCaption.js
+++ b/apps/web/src/ideogramCaption.js
@@ -73,9 +73,10 @@ export const ELEMENT_PALETTE_MAX = 5;
 
 // A structurally-valid empty caption: `compositional_deconstruction` is the
 // only required section, with a (string) background and an elements list.
+// high_level_description / style_description are optional and omitted until the
+// user fills them, so an untouched skeleton never serializes empty keys.
 export function emptyCaption() {
   return {
-    high_level_description: "",
     compositional_deconstruction: { background: "", elements: [] },
   };
 }

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -7,6 +7,8 @@ import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
 import { PromptGuideModal } from "../components/PromptGuideModal.jsx";
 import { PoseLibraryPicker } from "../components/PoseLibraryPicker.jsx";
 import { RefinePromptControl } from "../components/RefinePromptControl.jsx";
+import StructuredPromptBuilder from "../components/StructuredPromptBuilder.jsx";
+import { emptyCaption, serializeCaption, validateCaption } from "../ideogramCaption.js";
 import { usePoseLibrary, useUserPoseLoader } from "../poseLibrary.js";
 
 const PROMPT_SUGGESTION_POOL = [
@@ -297,6 +299,13 @@ export function ImageStudio() {
   // prompt never clobbers their own wording. A restored prompt counts as edited so
   // re-entering character mode doesn't overwrite it.
   const promptEdited = useRef(saved.prompt != null);
+  // Structured JSON-caption prompt (Ideogram 4, epic 4725). `caption` is the
+  // typed model from ideogramCaption.js; `promptMode` selects the builder form,
+  // raw-JSON edit, or the plain-text fallback. Only used when the selected model
+  // declares `structuredPrompt`; the plain `prompt` state doubles as the
+  // plain-text / magic-prompt seed.
+  const [caption, setCaption] = useState(() => saved.structuredCaption ?? emptyCaption());
+  const [promptMode, setPromptMode] = useState(saved.promptMode ?? "form");
   const setPromptFromUser = (value) => {
     promptEdited.current = true;
     setPrompt(value);
@@ -553,6 +562,28 @@ export function ImageStudio() {
   // the IP-Adapter reference-strength slider (sc-2017).
   const variationStrength = selectedModel?.ui?.variationStrength;
   const hideReferenceStrength = Boolean(selectedModel?.ui?.hideReferenceStrength);
+  // Structured JSON-caption surface (Ideogram 4, epic 4725). When the model
+  // declares `structuredPrompt`, the prompt hero swaps the plain textarea for the
+  // builder and the engine receives the canonically-ordered JSON caption string.
+  const structuredPromptModel = Boolean(selectedModel?.structuredPrompt);
+  const captionValidation = useMemo(
+    () => (structuredPromptModel ? validateCaption(caption, { plainText: prompt }) : null),
+    [structuredPromptModel, caption, prompt],
+  );
+  // Structured mode is active when a structured model is selected and the user
+  // isn't in the plain-text fallback tab.
+  const structuredActive = structuredPromptModel && promptMode !== "plain";
+  // A non-empty caption: at least a high-level description, a background, or one
+  // element carrying content — guards Generate against the empty-but-valid skeleton.
+  const captionHasContent = useMemo(() => {
+    if (!structuredActive) return false;
+    const cd = caption?.compositional_deconstruction ?? {};
+    if (String(caption?.high_level_description ?? "").trim()) return true;
+    if (String(cd.background ?? "").trim()) return true;
+    return (Array.isArray(cd.elements) ? cd.elements : []).some(
+      (el) => (el?.desc && String(el.desc).trim()) || (el?.type === "text" && el?.text && String(el.text).trim()),
+    );
+  }, [structuredActive, caption]);
   // Reset the reference tuning to the selected model's declared defaults whenever the
   // model changes, so InstantID starts at its tuned 0.8/0.8 and Kolors at 0.6, and the
   // view angle never carries over to a model that doesn't support it. Skip the mount
@@ -857,6 +888,8 @@ export function ImageStudio() {
   useStudioSettingsWriter("image", activeProject?.id ?? null, {
     mode,
     prompt,
+    structuredCaption: caption,
+    promptMode,
     count,
     advancedOpen,
     model,
@@ -979,9 +1012,12 @@ export function ImageStudio() {
         mode === "character_image" && referenceAssetId && poseLibrary && selectedPoseIds.length
           ? selectedPoseIds.map((id) => poseById[id]).filter(Boolean).map((pose) => ({ id: pose.id, keypoints: pose.keypoints }))
           : [];
+      // Structured models send the canonically-ordered JSON caption as the
+      // prompt; plain-text mode (and every other model) sends the literal prompt.
+      const promptToSend = structuredActive ? serializeCaption(caption) : prompt;
       const job = await createImageJob({
         mode,
-        prompt,
+        prompt: promptToSend,
         negativePrompt,
         model,
         count: posePayload.length ? 1 : count,
@@ -1066,7 +1102,9 @@ export function ImageStudio() {
   const generateDisabled =
     submitting ||
     !activeProject ||
-    !prompt.trim() ||
+    // Structured models gate on a valid, non-empty caption; everyone else on a
+    // non-empty prompt. (Plain-text fallback falls through to the prompt check.)
+    (structuredActive ? !captionValidation?.ok || !captionHasContent : !prompt.trim()) ||
     (mode === "character_image" && !characterId) ||
     Boolean(macActiveModeBlock) ||
     !presetValidationResult.ok ||
@@ -1122,46 +1160,64 @@ export function ImageStudio() {
             </div>
           </div>
 
-          <div className="prompt-input-row">
-            <textarea
-              aria-label="Prompt"
-              className="prompt-input"
-              onChange={(event) => setPromptFromUser(event.target.value)}
-              onKeyDown={onPromptKeyDown}
-              placeholder="Describe your shot — subject, lighting, mood, lens…"
-              value={prompt}
-            />
+          <div className={`prompt-input-row${structuredPromptModel ? " structured" : ""}`}>
+            {structuredPromptModel ? (
+              <StructuredPromptBuilder
+                caption={caption}
+                onCaptionChange={setCaption}
+                validation={captionValidation}
+                mode={promptMode}
+                onModeChange={setPromptMode}
+                plainText={prompt}
+                onPlainTextChange={setPromptFromUser}
+              />
+            ) : (
+              <textarea
+                aria-label="Prompt"
+                className="prompt-input"
+                onChange={(event) => setPromptFromUser(event.target.value)}
+                onKeyDown={onPromptKeyDown}
+                placeholder="Describe your shot — subject, lighting, mood, lens…"
+                value={prompt}
+              />
+            )}
             <button className="prompt-cta" disabled={generateDisabled} type="submit">
               <Icon.Sparkle size={14} />
               {submitting ? "Queueing…" : "Generate"}
             </button>
           </div>
 
-          <RefinePromptControl
-            guidePath={promptGuide.path}
-            modelId={model}
-            onApply={setPromptFromUser}
-            prompt={prompt}
-            refinePrompt={refinePrompt}
-            refineModel={refineModel}
-            onDownloadRefineModel={refineModel ? () => createModelDownloadJob(refineModel) : undefined}
-            workflow="image"
-          />
+          {/* Plain-text refine + scene suggestions only make sense for free-text
+              prompts; structured models get the builder + (later) magic-prompt. */}
+          {structuredPromptModel ? null : (
+            <>
+              <RefinePromptControl
+                guidePath={promptGuide.path}
+                modelId={model}
+                onApply={setPromptFromUser}
+                prompt={prompt}
+                refinePrompt={refinePrompt}
+                refineModel={refineModel}
+                onDownloadRefineModel={refineModel ? () => createModelDownloadJob(refineModel) : undefined}
+                workflow="image"
+              />
 
-          <div className="suggestion-row">
-            <span className="suggestion-row-label">Try:</span>
-            {suggestions.map((suggestion) => (
-              <button
-                className="suggestion"
-                key={suggestion}
-                onClick={() => setPromptFromUser(suggestion)}
-                type="button"
-              >
-                <Icon.Sparkle size={11} />
-                {suggestion}
-              </button>
-            ))}
-          </div>
+              <div className="suggestion-row">
+                <span className="suggestion-row-label">Try:</span>
+                {suggestions.map((suggestion) => (
+                  <button
+                    className="suggestion"
+                    key={suggestion}
+                    onClick={() => setPromptFromUser(suggestion)}
+                    type="button"
+                  >
+                    <Icon.Sparkle size={11} />
+                    {suggestion}
+                  </button>
+                ))}
+              </div>
+            </>
+          )}
         </div>
 
         {mode === "edit_image" || mode === "character_image" ? (

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1542,6 +1542,229 @@ label {
   box-shadow: none;
 }
 
+/* Ideogram 4 structured JSON-caption builder (epic 4725, sc-5994). The
+   structured row stacks the full-width builder above a full-width Generate CTA. */
+.prompt-input-row.structured {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.structured-prompt-builder {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  padding: 14px 16px;
+  box-shadow: var(--shadow-sm);
+}
+
+.structured-mode {
+  align-self: flex-start;
+}
+
+.structured-form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.structured-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12.5px;
+  font-weight: 600;
+}
+
+.structured-field > span,
+.structured-bbox-label {
+  color: color-mix(in oklch, var(--text) 70%, transparent);
+}
+
+.structured-field input[type="text"],
+.structured-field input[type="number"],
+.structured-textarea,
+.structured-json-input,
+.structured-plain .prompt-input {
+  font-weight: 400;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  padding: 8px 10px;
+  font-size: 13.5px;
+  color: var(--text);
+}
+
+.structured-textarea {
+  min-height: 56px;
+  resize: vertical;
+  font-family: inherit;
+  line-height: 1.45;
+}
+
+.structured-field input:focus,
+.structured-textarea:focus,
+.structured-json-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: var(--shadow-glow);
+}
+
+.structured-style {
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  padding: 8px 12px 12px;
+  margin: 0;
+}
+
+.structured-style legend {
+  padding: 0 4px;
+}
+
+.structured-checkline {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12.5px;
+  font-weight: 600;
+}
+
+.structured-style-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.structured-kind {
+  align-self: flex-start;
+}
+
+.structured-elements {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.structured-elements-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 12.5px;
+  font-weight: 600;
+}
+
+.structured-element {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  padding: 10px 12px;
+}
+
+.structured-element-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.structured-bbox-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: flex-end;
+}
+
+.structured-bbox-row label {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.structured-bbox-row input {
+  width: 72px;
+}
+
+.structured-link {
+  background: none;
+  border: 0;
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 2px 6px;
+}
+
+.structured-link:hover {
+  text-decoration: underline;
+}
+
+.structured-hint {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 400;
+  color: color-mix(in oklch, var(--text) 60%, transparent);
+}
+
+.structured-json-input {
+  min-height: 180px;
+  font-family: var(--font-mono);
+  line-height: 1.5;
+  white-space: pre;
+}
+
+.structured-preview {
+  border-top: 1px solid var(--border);
+  padding-top: 10px;
+}
+
+.structured-preview-head {
+  font-size: 11.5px;
+  font-weight: 600;
+  color: color-mix(in oklch, var(--text) 60%, transparent);
+  margin-bottom: 6px;
+}
+
+.structured-preview pre {
+  margin: 0;
+  max-height: 220px;
+  overflow: auto;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  padding: 10px 12px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.structured-issues {
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  font-size: 12px;
+}
+
+.structured-issues-error {
+  color: var(--danger);
+}
+
+.structured-issues-warn {
+  color: var(--warm);
+}
+
+.structured-error {
+  margin: 6px 0 0;
+  font-size: 12px;
+  color: var(--danger);
+}
+
 .suggestion-row {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
Adds the structured JSON-caption **builder UI** to Image Studio (sc-5994, epic 4725), sitting on the sc-5993 contract. Users author valid Ideogram 4 captions without hand-writing schema; every edit produces a caption object that `serializeCaption` emits in the model's exact training key order, and the same `validateCaption` gates Generate.

## What's here
**`apps/web/src/components/StructuredPromptBuilder.jsx`** (new) — three modes via a segmented control:
- **Builder** (form): `high_level_description`; optional `style_description` (aesthetics, lighting, **photo↔art toggle**, medium, optional palette — correct key order for each); `background`; **repeatable obj/text elements** with `desc`, literal `text` for text elements, optional bbox (four 0–1000 ints), optional per-element palette.
- **JSON**: raw edit, parsed + validated live against the contract; invalid JSON surfaces an error and preserves the last valid caption.
- **Plain text**: the free-text fallback (the magic-prompt seed, sc-5997).
- Live **read-only ordered-JSON preview** + blocking errors / advisory warnings from `validateCaption`.
- Stable element keys keep child field state aligned across add/remove (elements carry no schema id); palette fields keep a local buffer and commit normalized `#RRGGBB` on blur.

**`apps/web/src/screens/ImageStudio.jsx`** — gated on `selectedModel.structuredPrompt`: swaps the plain textarea for the builder, hides the plain-text refine + scene suggestions, persists the caption + prompt mode, and submits `serializeCaption(caption)` as the prompt in structured mode. Generate is gated on a valid, non-empty caption. Plain-text mode and every other model are unchanged.

**`ideogramCaption.js`** — `emptyCaption()` no longer seeds an empty `high_level_description`, so an untouched skeleton never serializes empty optional keys.

**`styles.css`** — builder layout (stacked structured row, fields, preview, issues).

## Verification
- **7 new component tests mount the real builder** and drive it through the DOM: form → caption → byte-exact key-ordered serialization, text-element key order with a bbox, palette normalize-on-blur, JSON apply + invalid-JSON guard, plain fallback, mode switching, and error surfacing. Acceptance met (form produces a valid, key-ordered caption accepted by the validator; tests mount the real component).
- Full web suite green: **491 passed**. ESLint: 0 errors. Production build clean.
- Not driven in a live preview: the builder only renders for `ideogram_4` (gated/macOnly/not-downloaded), which isn't reachably selectable in a bare dev server — the mounted-component tests exercise the real DOM instead.

Stacks on #739 (sc-5993 contract, merged). Next: bbox visual canvas (sc-5995), rich palette picker (sc-5996), native magic-prompt (sc-5997).

🤖 Generated with [Claude Code](https://claude.com/claude-code)