### PR TITLE
Ideogram 4: overall/document palette control in the prompt-builder (sc-5996)

### DIFF
--- a/apps/web/src/components/PaletteEditor.jsx
+++ b/apps/web/src/components/PaletteEditor.jsx
@@ -1,0 +1,81 @@
+// Color-palette control for the Ideogram 4 prompt-builder (epic 4725, sc-5996).
+//
+// Authors an ordered list of uppercase #RRGGBB colors via swatch chips + a
+// native color picker. Used for the caption's overall/document palette
+// (style_description.color_palette, ≤16); the per-element palette and the
+// box-tool authoring path live in epic 6087. Colors are normalized and capped
+// here; the ≤max / #RRGGBB validation and order-preserving emission are the
+// sc-5993 contract's job (this just produces a clean array).
+
+import React, { useState } from "react";
+import { isValidHexColor, normalizeHexColor } from "../ideogramCaption.js";
+
+const DEFAULT_DRAFT = "#888888";
+
+export default function PaletteEditor({ value, onChange, max, label }) {
+  const colors = Array.isArray(value) ? value : [];
+  const [draft, setDraft] = useState(DEFAULT_DRAFT);
+
+  const normalizedDraft = normalizeHexColor(draft);
+  const atMax = colors.length >= max;
+  const duplicate = normalizedDraft != null && colors.includes(normalizedDraft);
+  const canAdd = normalizedDraft != null && !atMax && !duplicate;
+
+  function addColor() {
+    if (!canAdd) return;
+    onChange([...colors, normalizedDraft]);
+  }
+  function removeAt(index) {
+    const next = colors.filter((_, i) => i !== index);
+    onChange(next.length ? next : null);
+  }
+
+  return (
+    <div className="palette-editor">
+      <div className="palette-editor-head">
+        <span>{label}</span>
+        <span className="palette-editor-count">
+          {colors.length}/{max}
+        </span>
+      </div>
+      {colors.length ? (
+        <ul className="palette-swatches">
+          {colors.map((color, i) => (
+            <li key={`${color}-${i}`} className="palette-swatch">
+              <span className="palette-swatch-chip" style={{ background: color }} aria-hidden="true" />
+              <span className="palette-swatch-hex">{color}</span>
+              <button type="button" className="palette-swatch-remove" aria-label={`Remove ${color}`} onClick={() => removeAt(i)}>
+                ×
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      <div className="palette-editor-add">
+        <input
+          type="color"
+          aria-label="Pick color"
+          value={isValidHexColor(draft) ? draft.toLowerCase() : DEFAULT_DRAFT}
+          onChange={(e) => setDraft(e.target.value.toUpperCase())}
+          disabled={atMax}
+        />
+        <input
+          type="text"
+          aria-label="Hex color"
+          className="palette-hex-input"
+          placeholder="#RRGGBB"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          disabled={atMax}
+        />
+        <button type="button" className="structured-link" onClick={addColor} disabled={!canAdd}>
+          Add
+        </button>
+      </div>
+      {atMax ? <p className="structured-hint">Maximum {max} colors.</p> : null}
+      {!atMax && normalizedDraft == null && draft.trim() ? (
+        <p className="structured-hint">Enter an uppercase #RRGGBB hex color.</p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/PaletteEditor.test.jsx
+++ b/apps/web/src/components/PaletteEditor.test.jsx
@@ -1,0 +1,99 @@
+import React, { act, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import PaletteEditor from "./PaletteEditor.jsx";
+
+function setValue(el, value) {
+  const proto = el.tagName === "TEXTAREA" ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+  Object.getOwnPropertyDescriptor(proto, "value").set.call(el, value);
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+}
+function click(el) {
+  el.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+}
+
+describe("PaletteEditor", () => {
+  let container;
+  let root;
+  let last;
+
+  function Harness({ initial = null, max = 16 }) {
+    const [value, setVal] = useState(initial);
+    last = value;
+    return (
+      <PaletteEditor
+        value={value}
+        max={max}
+        label="Color palette"
+        onChange={(next) => {
+          last = next;
+          setVal(next);
+        }}
+      />
+    );
+  }
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    last = undefined;
+  });
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  const hexInput = () => container.querySelector('input[aria-label="Hex color"]');
+  const addBtn = () => [...container.querySelectorAll("button")].find((b) => b.textContent.trim() === "Add");
+
+  async function mount(props = {}) {
+    await act(async () => root.render(<Harness {...props} />));
+  }
+
+  it("adds a lowercase hex as a normalized uppercase swatch", async () => {
+    await mount();
+    await act(async () => setValue(hexInput(), "#abcdef"));
+    await act(async () => click(addBtn()));
+    expect(last).toEqual(["#ABCDEF"]);
+    expect([...container.querySelectorAll(".palette-swatch-hex")].map((s) => s.textContent)).toEqual(["#ABCDEF"]);
+  });
+
+  it("preserves insertion order across adds", async () => {
+    await mount();
+    for (const c of ["#111111", "#222222", "#333333"]) {
+      await act(async () => setValue(hexInput(), c));
+      await act(async () => click(addBtn()));
+    }
+    expect(last).toEqual(["#111111", "#222222", "#333333"]);
+  });
+
+  it("disables Add for a duplicate color", async () => {
+    await mount({ initial: ["#FF0000"] });
+    await act(async () => setValue(hexInput(), "#ff0000"));
+    expect(addBtn().disabled).toBe(true);
+  });
+
+  it("disables Add for an invalid hex", async () => {
+    await mount();
+    await act(async () => setValue(hexInput(), "not-a-color"));
+    expect(addBtn().disabled).toBe(true);
+  });
+
+  it("caps at max and disables further input", async () => {
+    await mount({ initial: ["#000000", "#111111"], max: 2 });
+    expect(addBtn().disabled).toBe(true);
+    expect(hexInput().disabled).toBe(true);
+    expect(container.textContent).toContain("Maximum 2 colors");
+  });
+
+  it("removes a swatch, reporting null when the last one is removed", async () => {
+    await mount({ initial: ["#FF0000"] });
+    const remove = container.querySelector('button[aria-label="Remove #FF0000"]');
+    await act(async () => click(remove));
+    expect(last).toBe(null);
+  });
+});

--- a/apps/web/src/components/StructuredPromptBuilder.jsx
+++ b/apps/web/src/components/StructuredPromptBuilder.jsx
@@ -19,11 +19,11 @@ import {
   ELEMENT_PALETTE_MAX,
   makeObjElement,
   makeTextElement,
-  normalizeHexColor,
   orderCaption,
   parseCaption,
   STYLE_PALETTE_MAX,
 } from "../ideogramCaption.js";
+import PaletteEditor from "./PaletteEditor.jsx";
 
 const MODES = [
   ["form", "Builder"],
@@ -45,40 +45,6 @@ function getComposition(caption) {
 function getElements(caption) {
   const els = getComposition(caption).elements;
   return Array.isArray(els) ? els : [];
-}
-
-// A palette field: comma/space-separated #RRGGBB. Keeps its own text buffer so
-// the user can type freely; commits the normalized, valid colors on blur.
-function PaletteField({ value, onChange, max, label }) {
-  const [text, setText] = useState(() => (Array.isArray(value) ? value.join(", ") : ""));
-  // Re-seed from props only when the committed value actually changes (e.g. an
-  // external edit or a JSON-mode apply), not on every keystroke.
-  useEffect(() => {
-    setText(Array.isArray(value) ? value.join(", ") : "");
-  }, [value]);
-
-  function commit() {
-    const tokens = text.split(/[\s,]+/).map((t) => t.trim()).filter(Boolean);
-    const colors = [];
-    for (const token of tokens) {
-      const normalized = normalizeHexColor(token);
-      if (normalized && !colors.includes(normalized)) colors.push(normalized);
-    }
-    onChange(colors.length ? colors.slice(0, max) : null);
-  }
-
-  return (
-    <label className="structured-field structured-palette">
-      <span>{label}</span>
-      <input
-        type="text"
-        placeholder={`#RRGGBB, #RRGGBB … (max ${max})`}
-        value={text}
-        onChange={(e) => setText(e.target.value)}
-        onBlur={commit}
-      />
-    </label>
-  );
 }
 
 // Four integer inputs for a [ymin, xmin, ymax, xmax] box (0–1000). The visual
@@ -342,7 +308,7 @@ export default function StructuredPromptBuilder({
                   <span>Medium</span>
                   <input type="text" placeholder="photograph, oil painting" value={style.medium ?? ""} onChange={(e) => setStyleField("medium", e.target.value)} />
                 </label>
-                <PaletteField
+                <PaletteEditor
                   label={`Color palette (max ${STYLE_PALETTE_MAX})`}
                   value={style.color_palette}
                   max={STYLE_PALETTE_MAX}
@@ -420,7 +386,7 @@ export default function StructuredPromptBuilder({
                     + Bounding box
                   </button>
                 )}
-                <PaletteField
+                <PaletteEditor
                   label={`Palette (max ${ELEMENT_PALETTE_MAX})`}
                   value={el.color_palette}
                   max={ELEMENT_PALETTE_MAX}

--- a/apps/web/src/components/StructuredPromptBuilder.test.jsx
+++ b/apps/web/src/components/StructuredPromptBuilder.test.jsx
@@ -16,11 +16,6 @@ function click(el) {
   el.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 }
 
-function blur(el) {
-  // React 18 delegates onBlur via the bubbling `focusout` event.
-  el.dispatchEvent(new Event("focusout", { bubbles: true }));
-}
-
 describe("StructuredPromptBuilder", () => {
   let container;
   let root;
@@ -96,16 +91,34 @@ describe("StructuredPromptBuilder", () => {
     );
   });
 
-  it("commits a normalized palette on blur (lowercase -> uppercase, dedup)", async () => {
+  it("adds normalized swatches to an element via the palette editor", async () => {
     await mount();
     await act(async () => setValue(byPlaceholder("The scene behind"), "bg"));
     await act(async () => click(buttonByText("+ Object")));
-    const palette = byPlaceholder("#RRGGBB");
-    await act(async () => setValue(palette, "#ff0000, #00ff00 #ff0000"));
-    await act(async () => blur(palette));
+    const hex = container.querySelector('input[aria-label="Hex color"]');
+    await act(async () => setValue(hex, "#ff0000"));
+    await act(async () => click(buttonByText("Add")));
+    await act(async () => setValue(hex, "#00ff00"));
+    await act(async () => click(buttonByText("Add")));
 
     const el = snap.caption.compositional_deconstruction.elements[0];
     expect(el.color_palette).toEqual(["#FF0000", "#00FF00"]);
+  });
+
+  it("round-trips an overall/document palette into the caption JSON (sc-5996)", async () => {
+    await mount();
+    await act(async () => setValue(byPlaceholder("The scene behind"), "a calm studio"));
+    // Enable style so the document-level palette is available (the schema only
+    // allows an overall palette inside a style block with a discriminator).
+    await act(async () => click(container.querySelector('.structured-checkline input[type="checkbox"]')));
+    await act(async () => setValue(byPlaceholder("telephoto"), "studio strobe, eye-level"));
+    const hex = container.querySelector('input[aria-label="Hex color"]');
+    await act(async () => setValue(hex, "#0A2540"));
+    await act(async () => click(buttonByText("Add")));
+
+    expect(snap.validation.ok).toBe(true);
+    expect(snap.caption.style_description.color_palette).toEqual(["#0A2540"]);
+    expect(serializeCaption(snap.caption)).toContain('"color_palette": ["#0A2540"]');
   });
 
   it("shows the live ordered-JSON preview and applies raw-JSON edits", async () => {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1765,6 +1765,93 @@ label {
   color: var(--danger);
 }
 
+/* Palette editor (sc-5996): swatch chips + native color picker. */
+.palette-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.palette-editor-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: color-mix(in oklch, var(--text) 70%, transparent);
+}
+
+.palette-editor-count {
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.palette-swatches {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.palette-swatch {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  padding: 3px 6px 3px 4px;
+  background: var(--bg);
+}
+
+.palette-swatch-chip {
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  border: 1px solid color-mix(in oklch, var(--text) 18%, transparent);
+}
+
+.palette-swatch-hex {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+}
+
+.palette-swatch-remove {
+  border: 0;
+  background: none;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  color: color-mix(in oklch, var(--text) 55%, transparent);
+  padding: 0 2px;
+}
+
+.palette-swatch-remove:hover {
+  color: var(--danger);
+}
+
+.palette-editor-add {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.palette-editor-add input[type="color"] {
+  width: 34px;
+  height: 30px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--bg);
+  cursor: pointer;
+}
+
+.palette-hex-input {
+  width: 104px;
+  font-family: var(--font-mono);
+}
+
 .suggestion-row {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
Delivers the **palette control** for the Ideogram 4 prompt-builder (sc-5996, epic 4725). Replaces the comma-separated palette text field from sc-5994 with a reusable swatch-based `PaletteEditor` — a native color picker + hex entry, a chip list with per-color remove, ordered and deduped.

## Scope
The story was trimmed (2026-06-16): the per-element palette and box-tool authoring moved to epic 6087. What remains is the **overall/document palette** (`style_description.color_palette`, ≤16) in the Image-Studio builder. Validation (≤16, uppercase `#RRGGBB`) and order-preserving emission stay in the sc-5993 contract — the editor just produces a clean array. The same control also tidies the interim per-element palette field for visual consistency (not the 6087 box-tool work).

Schema note carried over from sc-5994: the overall palette **can't be standalone** — a `style_description` requires a `photo`/`art_style` discriminator, so the document palette correctly lives inside the Style section.

## What's here
- **`apps/web/src/components/PaletteEditor.jsx`** (new): swatch chips + `<input type="color">` + hex text input; Add is disabled for duplicates, invalid hex, or at max; remove reports `null` when the last swatch is removed (so the key is dropped).
- `StructuredPromptBuilder` swaps both `PaletteField` usages for `PaletteEditor` and removes the old text field.
- `styles.css`: swatch/chip/picker styling.

## Verification
- **6 new `PaletteEditor` unit tests** (mount the real control): lowercase→uppercase normalize, insertion-order preservation, duplicate-disables-Add, invalid-hex-disables-Add, max cap + disabled inputs, remove→`null` when emptied.
- Updated builder tests: element-palette via the editor + a new **overall-palette round-trips into the caption JSON** test (the sc-5996 acceptance).
- Full web suite green: **498 passed**. ESLint 0 errors. Build clean.
- Same preview caveat as sc-5994: the builder only renders for `ideogram_4` (gated/macOnly), so verification is via the mounted-component tests, which drive the real color/hex inputs and Add/remove.

Stacks on #739 + #742 (both merged). Remaining epic UI: sc-5997 native magic-prompt (plain → JSON caption). sc-5995 (visual bbox canvas) is archived — superseded by epic 6087.

🤖 Generated with [Claude Code](https://claude.com/claude-code)