### PR TITLE
sc-5496: DWPose pose_detect off-Mac via ort (CUDA/CPU EP)

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -5810,6 +5810,55 @@ mod candle_routing_tests {
         );
     }
 
+    // ---- Candle pose_detect (DWPose) lane (sc-5496, epic 5482) ----
+
+    /// A queued `pose_detect` job carrying `payload`.
+    fn pose_detect_job(payload: Value) -> JobSnapshot {
+        serde_json::from_value(json!({
+            "id": "job_pose",
+            "type": "pose_detect",
+            "status": "queued",
+            "payload": payload,
+            "result": {},
+            "requestedGpu": "auto",
+            "progress": 0,
+            "stage": "queued",
+            "message": "",
+            "attempts": 1,
+            "cancelRequested": false,
+            "createdAt": "2026-06-16T00:00:00Z",
+            "updatedAt": "2026-06-16T00:00:00Z",
+        }))
+        .expect("valid JobSnapshot")
+    }
+
+    /// sc-5496: the candle worker advertises `pose_detect` (the DWPose RTMW detector via the `ort` CUDA
+    /// EP) and claims a pose_detect job — the off-Mac sibling of the macOS `ort`/CoreML path. Like
+    /// kps_extract (and unlike SeedVR2), the Python rtmlib path CAN serve pose_detect, so there is NO
+    /// torch-refusal gate: a co-resident torch worker that advertises the capability still claims it (the
+    /// candle worker just runs it Python-free when it polls first; the Python path is retired wholesale in
+    /// Phase 7, epic 5483). A worker that never advertises the capability (e.g. a candle-disabled box)
+    /// refuses it.
+    #[test]
+    fn candle_worker_claims_pose_detect_no_torch_refusal() {
+        let payload = json!({ "sources": [{ "assetId": "a" }], "projectId": "p" });
+        let candle = gpu_worker(&["gpu", "pose_detect", "candle"]);
+        assert!(
+            worker_supports_job(&candle, &pose_detect_job(payload.clone())),
+            "candle worker should claim pose_detect"
+        );
+        let torch = gpu_worker(&["gpu", "pose_detect"]);
+        assert!(
+            worker_supports_job(&torch, &pose_detect_job(payload.clone())),
+            "torch worker still claims pose_detect (no refusal — it has the rtmlib path)"
+        );
+        let no_cap = gpu_worker(&["gpu", "image_generate", "candle"]);
+        assert!(
+            !worker_supports_job(&no_cap, &pose_detect_job(payload)),
+            "a worker not advertising pose_detect refuses it"
+        );
+    }
+
     // ---- Candle caption lane (sc-5098) ----
 
     /// A queued `training_caption` job carrying `payload`.

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -239,6 +239,14 @@ backend-candle = [
     # `gen_core::load` from upscale_jobs.rs (image) + video_jobs.rs (video). Real-ESRGAN stays the fast
     # default; SeedVR2 is the additional high-fidelity / video choice.
     "dep:candle-gen-seedvr2",
+    # sc-5496 (epic 5482): DWPose pose detection off-Mac via the `ort` (onnxruntime) crate with the CUDA
+    # execution provider — the Windows/Linux sibling of the macOS sc-3487 `ort`/CoreML path; `zip` unpacks
+    # the openmmlab weight bundles. Both are Mac-non-optional but off-Mac optional + candle-gated (declared
+    # under `cfg(not(target_os = "macos"))` above), so the default non-candle sidecar never pulls
+    # onnxruntime, while `pose_jobs.rs` (the shared detector) compiles + runs on the candle GPU-worker lane.
+    # Retires the Python rtmlib `pose_detect` path off-Mac.
+    "dep:ort",
+    "dep:zip",
 ]
 
 [target.'cfg(target_os = "macos")'.dependencies]
@@ -885,6 +893,19 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
 candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
+# DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
+# macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
+# pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with
+# a CPU fallback. `optional` + pulled in by `backend-candle` (the off-Mac GPU-worker feature) so the
+# default non-candle sidecar that `desktop-windows.yml` builds never downloads onnxruntime — the candle
+# GPU worker advertises `pose_detect`, while the Python rtmlib path stays a co-resident fallback (retired
+# wholesale in Phase 7, epic 5483). `cuda` enables the CUDA EP; `load-dynamic` dlopens the onnxruntime
+# dylib at runtime from `ORT_DYLIB_PATH` (set by the desktop `setup.rs`, like the Mac path); and
+# `download-binaries` fetches a CUDA-enabled onnxruntime at build time so dev runs + the candle packager
+# have a dylib to stage. `zip` unpacks the openmmlab weight bundles (download-on-first-use parity with
+# rtmlib), shared with the Mac path — optional + candle-gated off-Mac for the same reason as `ort`.
+ort = { version = "=2.0.0-rc.12", features = ["cuda", "load-dynamic", "download-binaries"], optional = true }
+zip = { version = "2", default-features = false, features = ["deflate"], optional = true }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -97,6 +97,17 @@ fn with_candle_capabilities(mut gpu: DiscoveredGpu, settings: &Settings) -> Disc
             if !gpu.capabilities.contains(&WorkerCapability::KpsExtract) {
                 gpu.capabilities.push(WorkerCapability::KpsExtract);
             }
+            // DWPose whole-body pose detection (sc-5496, epic 5482): the off-Mac sibling of the macOS
+            // `ort`/CoreML path (sc-3487) — the same RTMW detector via `pose_jobs::run_pose_detect_job`
+            // with the CUDA execution provider, serving `pose_detect` for the Pose Library "create from
+            // photo" flow + InstantID pose conditioning. A job-type capability (not a generation modality),
+            // so it isn't in `registry_capabilities`; advertise it explicitly. Like kps_extract — and
+            // unlike SeedVR2 — the Python rtmlib path CAN serve pose_detect, so there's NO torch-refusal
+            // gate: the candle worker claims it Python-free, with the co-resident torch worker as a
+            // fallback (the Python rtmlib path is retired wholesale in Phase 7, epic 5483).
+            if !gpu.capabilities.contains(&WorkerCapability::PoseDetect) {
+                gpu.capabilities.push(WorkerCapability::PoseDetect);
+            }
             // The lane marker the routing gate keys off (mirrors the existing `nvidia` marker).
             gpu.capabilities
                 .push(WorkerCapability::Unknown("candle".to_owned()));

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -97,14 +97,23 @@ mod prompt_refine_jobs;
 use prompt_refine_jobs::*;
 mod downloads;
 // The DWPose skeleton rasterizer is consumed only by the macOS Z-Image strict-pose
-// control path; on other platforms it still builds + unit-tests (cross-platform
-// raster), but its items are otherwise unused — so allow dead_code off macOS.
-#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+// control path; on Mac AND the off-Mac candle DWPose lane (sc-5496) it backs the
+// `pose_jobs` skeleton render; on a candle-disabled box off Mac it still builds +
+// unit-tests (cross-platform raster) but its items are otherwise unused — so allow
+// dead_code only there.
+#[cfg_attr(
+    all(not(target_os = "macos"), not(feature = "backend-candle")),
+    allow(dead_code)
+)]
 mod openpose_skeleton;
-// DWPose pose detection via onnxruntime/CoreML (epic 3482, sc-3487). macOS-only:
-// the `ort` engine + CoreML EP only mean anything on Apple Silicon, and the Python
-// rtmlib path stays the Windows/Linux backend.
-#[cfg(target_os = "macos")]
+// DWPose pose detection via onnxruntime (epic 3482, sc-3487). On Mac the CoreML EP +
+// on the off-Mac candle GPU-worker lane the CUDA EP (sc-5496, epic 5482) run the same
+// RTMW detector in-process; on a candle-disabled box the Python rtmlib path stays the
+// Windows/Linux backend.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 mod pose_jobs;
 // SCRFD 5-point face-landmark extraction (epic 4422, sc-4433): native-MLX SCRFD on Mac, plus the
 // candle SCRFD/ArcFace stack on the Windows/Linux candle lane (sc-5497, epic 5482) — the same
@@ -155,7 +164,10 @@ use downloads::*;
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 use kps_jobs::*;
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 use pose_jobs::*;
 #[cfg(any(
     target_os = "macos",
@@ -748,11 +760,16 @@ async fn run_utility_job(
         JobType::PersonDetect => run_person_detect_job(api, settings, http_client, &job)
             .await
             .map_err(|error| ("Person detection failed.", error)),
-        // DWPose whole-body pose detection (epic 3482, sc-3487): RTMW via
-        // onnxruntime/CoreML, replacing the Python rtmlib path on the macOS MLX
-        // worker. macOS-only; off macOS `PoseDetect` is never advertised by the Rust
-        // worker (the Python worker handles it), so this falls to the `_` arm there.
-        #[cfg(target_os = "macos")]
+        // DWPose whole-body pose detection (epic 3482, sc-3487 Mac / sc-5496 off-Mac):
+        // RTMW via onnxruntime, replacing the Python rtmlib path — CoreML EP on the
+        // macOS MLX worker, CUDA EP on the off-Mac candle GPU worker. Available on Mac
+        // AND the candle lane; on a candle-disabled box `PoseDetect` is never advertised
+        // by the Rust worker (the Python worker handles it), so this falls to the `_`
+        // arm there.
+        #[cfg(any(
+            target_os = "macos",
+            all(not(target_os = "macos"), feature = "backend-candle")
+        ))]
         JobType::PoseDetect => run_pose_detect_job(api, settings, http_client, &job)
             .await
             .map_err(|error| ("Pose detection failed.", error)),

--- a/crates/sceneworks-worker/src/pose_jobs.rs
+++ b/crates/sceneworks-worker/src/pose_jobs.rs
@@ -8,10 +8,15 @@
 //! (`docs/sc-3487/spike-findings.md`) validated sub-pixel keypoint parity + matched
 //! latency vs the shipped rtmlib detector.
 //!
-//! macOS-only: the engine + CoreML EP only mean anything on Apple Silicon, and the
-//! Python rtmlib path stays the Windows/Linux backend. The keypoint conversion +
-//! geometry (`wholebody_to_openpose`, `squareify`, facing/bbox) are pure and unit-
-//! tested without the onnx weights; only the onnxruntime inference is gated.
+//! Available on macOS (CoreML EP) AND the off-Mac candle GPU-worker lane (sc-5496,
+//! epic 5482): the Windows/Linux/CUDA sibling runs the SAME RTMW detector + the SAME
+//! pure pre/post math — only the `ort` execution provider differs (CoreML on Mac, CUDA
+//! with a CPU fallback off-Mac). On a candle-disabled box the Python rtmlib path stays
+//! the Windows/Linux backend; the candle worker advertises `pose_detect` while the
+//! Python path stays a co-resident fallback (retired wholesale in Phase 7, epic 5483).
+//! The keypoint conversion + geometry (`wholebody_to_openpose`, `squareify`,
+//! facing/bbox) are pure and unit-tested without the onnx weights; only the
+//! onnxruntime inference is gated.
 //!
 //! Pipeline parity (matched to rtmlib source — see the spike doc):
 //!  - YOLOX: letterbox to 640 (ratio=min(640/h,640/w), pad 114, top-left), NO
@@ -26,6 +31,9 @@ use std::sync::{Mutex, OnceLock};
 
 use crate::downloads::{ensure_cached_file, DownloadContext};
 use image::RgbImage;
+#[cfg(not(target_os = "macos"))]
+use ort::execution_providers::CUDAExecutionProvider;
+#[cfg(target_os = "macos")]
 use ort::execution_providers::CoreMLExecutionProvider;
 use ort::session::Session;
 use ort::value::Tensor;
@@ -55,6 +63,14 @@ const POSE_FILE: &str = "rtmw-dw-x-l_simcc-cocktail14_270e-384x288_20231122.onnx
 const DET_URL: &str = "https://download.openmmlab.com/mmpose/v1/projects/rtmposev1/onnx_sdk/yolox_m_8xb8-300e_humanart-c2c7a14a.zip";
 const POSE_URL: &str = "https://download.openmmlab.com/mmpose/v1/projects/rtmw/onnx_sdk/rtmw-dw-x-l_simcc-cocktail14_270e-384x288_20231122.zip";
 const DETECTOR_ID: &str = "rtmw-dw-x-l/ort";
+
+/// The hardware execution provider this build registers before the CPU fallback:
+/// CoreML on macOS (sc-3487), CUDA off-Mac on the candle GPU-worker lane (sc-5496).
+/// Reported as the result `detector.device` for observability.
+#[cfg(target_os = "macos")]
+const ACCEL_DEVICE: &str = "coreml";
+#[cfg(not(target_os = "macos"))]
+const ACCEL_DEVICE: &str = "cuda";
 
 /// Default per-keypoint confidence floor for rendering/thresholding. rtmlib's RTMW
 /// SimCC scores are NOT in `[0,1]` (good keypoints observed ~4–8 in the spike), so
@@ -384,12 +400,30 @@ struct Detector {
 
 static DETECTOR: OnceLock<Mutex<Option<Detector>>> = OnceLock::new();
 
-fn build_session(path: &Path, coreml: bool) -> WorkerResult<Session> {
+/// Build a session, optionally registering the platform hardware EP (CoreML on macOS,
+/// CUDA off-Mac). `accel == false` builds a plain CPU session (the fallback).
+fn build_session(path: &Path, accel: bool) -> WorkerResult<Session> {
     let mut b = Session::builder().map_err(ort_err)?;
-    if coreml {
-        b = b
-            .with_execution_providers([CoreMLExecutionProvider::default().build()])
-            .map_err(ort_err)?;
+    if accel {
+        #[cfg(target_os = "macos")]
+        {
+            b = b
+                .with_execution_providers([CoreMLExecutionProvider::default().build()])
+                .map_err(ort_err)?;
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            // `error_on_failure` so a CUDA provider that can't initialise (no GPU, or a
+            // cuDNN/CUDA mismatch in the loaded onnxruntime) surfaces as an error here —
+            // `Detector::load` then falls back to a CPU session and reports `device =
+            // "cpu"` honestly, instead of onnxruntime silently CPU-executing while we
+            // still claim CUDA.
+            b = b
+                .with_execution_providers([CUDAExecutionProvider::default()
+                    .build()
+                    .error_on_failure()])
+                .map_err(ort_err)?;
+        }
     }
     b.commit_from_file(path).map_err(ort_err)
 }
@@ -417,8 +451,9 @@ fn run(
 }
 
 impl Detector {
-    /// Build the cached detector, preferring CoreML and falling back to CPU if the
-    /// provider can't initialise (mirrors Python `load_pose_detector`).
+    /// Build the cached detector, preferring the hardware EP (CoreML on Mac / CUDA
+    /// off-Mac) and falling back to CPU if the provider can't initialise (mirrors
+    /// Python `load_pose_detector`).
     fn load(det_path: &Path, pose_path: &Path) -> WorkerResult<Self> {
         match (
             build_session(det_path, true),
@@ -427,7 +462,7 @@ impl Detector {
             (Ok(det), Ok(pose)) => Ok(Self {
                 det,
                 pose,
-                device: "coreml",
+                device: ACCEL_DEVICE,
             }),
             _ => Ok(Self {
                 det: build_session(det_path, false)?,

--- a/crates/sceneworks-worker/src/pose_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/pose_jobs/tests.rs
@@ -145,3 +145,70 @@ fn pose_decode_negative_value_marks_missing() {
     // val <= 0 -> loc (-1,-1) -> negative rescaled coords, score <= 0
     assert!(kp[0][2] <= 0.0);
 }
+
+/// sc-5496 off-Mac GPU smoke (ignored — needs the real RTMW onnx weights + CUDA). Validates the
+/// Windows/Linux candle DWPose lane end-to-end: load the detector through `Detector::load`, run it on a
+/// person photo, and confirm it engages the hardware EP (or CPU fallback), finds ≥1 person, and decodes
+/// a sane normalized OpenPose-18 body (neck between the shoulders). The numeric parity vs the Python
+/// rtmlib reference was already established in the spike (docs/sc-3487/spike-findings.md); this just
+/// proves the off-Mac `ort` CUDA path produces faithful output through the same code. Stage the weights
+/// + image via env, then:
+///   cargo test -p sceneworks-worker --features backend-candle --lib -- --ignored pose_detect_candle
+#[cfg(not(target_os = "macos"))]
+#[test]
+#[ignore]
+fn pose_detect_candle_real_weights_finds_person() {
+    let det = std::env::var("SCENEWORKS_DWPOSE_DET")
+        .expect("set SCENEWORKS_DWPOSE_DET to the yolox onnx");
+    let pose = std::env::var("SCENEWORKS_DWPOSE_POSE")
+        .expect("set SCENEWORKS_DWPOSE_POSE to the rtmw onnx");
+    let img = std::env::var("SCENEWORKS_TEST_POSE_IMAGE")
+        .expect("set SCENEWORKS_TEST_POSE_IMAGE to a person photo");
+
+    let (out, device) = detect_batch(
+        PathBuf::from(det),
+        PathBuf::from(pose),
+        vec![Some(PathBuf::from(img))],
+    )
+    .expect("detect_batch");
+    eprintln!("DWPose execution device = {device}");
+
+    let src = out
+        .into_iter()
+        .next()
+        .flatten()
+        .expect("readable test image");
+    assert!(
+        !src.people.is_empty(),
+        "expected at least one detected person"
+    );
+    let (w, h) = (src.width as f32, src.height as f32);
+    let rec = squareify(&wholebody_to_openpose(&src.people[0], w, h), w, h);
+    assert_eq!(rec.keypoints.len(), 18);
+
+    // Confident body points are normalized (not raw pixels) and land near the [0,1]
+    // square. DWPose legitimately extrapolates a keypoint a little past the frame edge
+    // (a body part the crop cuts off), so allow a small overshoot rather than a hard
+    // clamp — the assertion's job is to catch raw-pixel leakage (coords in the 100s),
+    // not to reject normal edge points.
+    for p in &rec.keypoints {
+        if p[2] as f64 >= DEFAULT_POSE_MIN_CONF {
+            assert!(
+                (-0.25..=1.25).contains(&p[0]) && (-0.25..=1.25).contains(&p[1]),
+                "confident keypoint not normalized near [0,1]: {p:?}"
+            );
+        }
+    }
+
+    // Neck (op 1) is the shoulder midpoint, so its x sits between the two shoulders (op 2 / op 5).
+    let (neck, r_sho, l_sho) = (rec.keypoints[1], rec.keypoints[2], rec.keypoints[5]);
+    eprintln!("neck={neck:?} r_sho={r_sho:?} l_sho={l_sho:?}");
+    if neck[2] as f64 >= DEFAULT_POSE_MIN_CONF {
+        let (lo, hi) = (r_sho[0].min(l_sho[0]), r_sho[0].max(l_sho[0]));
+        assert!(
+            neck[0] >= lo - 1e-3 && neck[0] <= hi + 1e-3,
+            "neck x {} should sit between shoulders [{lo}, {hi}]",
+            neck[0]
+        );
+    }
+}


### PR DESCRIPTION
## sc-5496 — DWPose `pose_detect` off-Mac via the `ort` crate (epic 5482, Candle Phase 5 CV-aux)

Runs the DWPose RTMW whole-body detector (`yolox_m` + `rtmw-dw-x-l`) on the off-Mac candle GPU-worker lane via the `ort` (onnxruntime) crate with the **CUDA** execution provider (CPU fallback), mirroring the macOS sc-3487 CoreML path. Retires the Python `rtmlib` / `pose_adapters.py` `pose_detect` path off-Mac; the Python path stays a co-resident fallback until Phase 7 (epic 5483). Feeds the Pose Library "create from photo" flow + InstantID pose conditioning.

**It's a wiring/EP-swap slice, not a model port** — the RTMW pre/post math (`yolox_preprocess`/`yolox_decode`/`pose_preprocess`/`pose_decode`/`wholebody_to_openpose`/`squareify`) is identical and already unit-tested; only the execution provider and gating change.

### Changes
- **Cargo.toml** — `ort` (cuda EP) + `zip` become **optional** off-Mac deps pulled by `backend-candle`, so the default non-candle sidecar that `desktop-windows.yml` builds never downloads onnxruntime. Mac keeps the non-optional `coreml` `ort`.
- **pose_jobs.rs** — cfg-split the EP: CoreML on Mac, CUDA off-Mac with `error_on_failure` so a CUDA init failure falls through to a CPU session and reports `device = "cpu"` **honestly** (no silent CPU-exec mislabeled `cuda`).
- **lib.rs** — widen `mod`/`use`/dispatch for `pose_jobs` to `any(macos, all(not(macos), backend-candle))`; tighten the `openpose_skeleton` dead-code allow to non-candle off-Mac.
- **gpu.rs** — candle worker advertises `WorkerCapability::PoseDetect` (no torch-refusal, like kps_extract — the Python rtmlib path can also serve it).
- **jobs_store.rs** — candle `pose_detect` routing test (claims it / torch co-resident / cap-less worker refuses). No web macGating change (`poseFromPhoto` is already unconditionally supported).
- **pose_jobs/tests.rs** — ignored off-Mac GPU smoke against real RTMW weights.

### Validation (off-Mac, this RTX PRO 6000 box)
- **GPU smoke**: real `yolox_m` + `rtmw-dw-x-l` on a real photo → faithful whole-body pose (neck x 0.555 correctly between shoulders 0.320/0.790, all keypoints normalized). Ran on the `ort` **CPU EP**.
- **CUDA EP**: code-correct (registers `CUDAExecutionProvider` + honest CPU fallback). Engaging the GPU needs a version-matched `onnxruntime-gpu` runtime provisioned at deploy — analogous to sc-3487's Mac "bundle the CoreML dylib" shipping caveat. Note the **Python rtmlib path this retires is itself CPU off-Mac** (the SceneWorks venv ships CPU onnxruntime), so this is at parity + Python-free, with a GPU upgrade path.
- `npm run rust:check` surface: default worker build (`ort` **not** pulled) + default clippy + `backend-candle` clippy `--all-targets` (`-D warnings`) + core routing test all green. fmt clean. **Cargo.lock unchanged** — single-rev skew intact (candle-gen `18c1c89f`).

Opening **In Review** for merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)