### PR TITLE
fix(flux2): guard FLUX.2-dev multi-reference edit against silent OOM (sc-6124)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1251,10 +1251,17 @@
       // transformer + text_encoder and symlinks the (identical-to-klein) VAE +
       // tokenizer + model_index.json from the gated source snapshot.
       // sc-5923 worker-layer footprint (Q4, 1024², /usr/bin/time -l peak): T2I ~74 GB,
-      // single-reference edit ~81 GB — both within 96. Multi-reference (2-image) edit
-      // peaks ~104 GB (> 96, activation-bound on the longer ref sequence); that path is
-      // currently UI-latent for dev (no multi-image picker; pose routes to the
-      // flux2_dev_control engine, sc-6055) and is tracked for an engine/guard fix.
+      // single-reference edit ~81 GB — both within 96, so minMemoryGb stays 96. A
+      // multi-reference (2-image) edit peaks ~104 GB (> 96, activation-bound on the longer
+      // ref sequence): it runs on a 128 GB Mac but would OOM a 96–104 GB one. That path is
+      // currently UI-latent (no multi-image picker; the worker assembles at most one user
+      // reference, and dev poses route to the flux2_dev_control engine, sc-6055). sc-6124
+      // reconciles this WITHOUT inflating the global floor (which would gate the common 74 GB
+      // T2I path behind 128 GB-only): the worker `flux2_dev_edit_memory_guard` rejects a
+      // multi-reference dev edit whose estimated peak + headroom exceeds the machine's unified
+      // memory (so no silent OOM), leaving 96 honest for the reachable surface. Making the
+      // multi-reference edit a first-class sub-96 GB mode (engine activation-chunking) is the
+      // tracked follow-up, gated on a future multi-image edit picker.
       "mlx": {
         "minMemoryGb": 96,
         "quantize": 4,

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -257,6 +257,15 @@ async fn sysctl_memsize_mb() -> Option<u64> {
     }
 }
 
+/// Total unified memory in GB (`sysctl hw.memsize`), for per-job memory-budget guards such as the
+/// FLUX.2-dev multi-reference edit footprint check (sc-6124). `None` if the probe fails (the guard
+/// then no-ops rather than blocking a possibly-fine job). macOS-only — its sole caller, the FLUX.2
+/// edit path (`image_jobs/flux2.rs`), is itself `#[cfg(target_os = "macos")]`.
+#[cfg(target_os = "macos")]
+pub(crate) async fn total_unified_memory_gb() -> Option<f64> {
+    sysctl_memsize_mb().await.map(|mb| mb as f64 / 1024.0)
+}
+
 /// Numeric `PerformanceStatistics` from the `IOAccelerator` IOKit node, via
 /// `ioreg -r -c IOAccelerator -d 1` (the integrated GPU's live stats, no elevated
 /// privileges). Empty when ioreg is unavailable.

--- a/crates/sceneworks-worker/src/image_jobs/flux2.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2.rs
@@ -171,6 +171,63 @@ fn build_edit_conditioning(references: &[Image]) -> Vec<Conditioning> {
     }
 }
 
+/// Estimated peak unified-memory footprint (GB) of a FLUX.2-dev edit at `width`×`height` with
+/// `reference_count` reference images — the input to the sc-6124 multi-reference memory guard. The
+/// dev edit is activation-bound: the DiT attends over the target latent plus every reference latent,
+/// each ≈⌈W/16⌉·⌈H/16⌉ tokens (VAE ×8, patch ×2), so the peak scales with the total sequence length.
+/// Anchored on the sc-5923 worker-layer measurements (Q4 packed, `/usr/bin/time -l` peak on a 128 GB
+/// Mac): single-reference 1024² ~81 GB, two-reference 1024² ~104 GB — a linear-in-tokens fit over
+/// those two edit points (`BASE + PER_TOKEN·(1 + refs)·tokens_per_image`). Only used on the
+/// multi-reference branch (`reference_count >= 2`); txt2img and single-reference are covered directly
+/// by the declared `minMemoryGb`, and the cheaper txt2img per-token slope is intentionally out of
+/// scope here (the fit is calibrated to the heavier edit sequence the guard actually gates).
+fn flux2_dev_edit_peak_gb(reference_count: usize, width: u32, height: u32) -> f64 {
+    const BASE_GB: f64 = 35.0;
+    const PER_TOKEN_GB: f64 = 0.005_615; // (104 − 81) GB / (12288 − 8192) tokens, sc-5923.
+    let tokens_per_image = (f64::from(width) / 16.0).ceil() * (f64::from(height) / 16.0).ceil();
+    let total_tokens = (1.0 + reference_count as f64) * tokens_per_image;
+    BASE_GB + PER_TOKEN_GB * total_tokens
+}
+
+/// Prevent a silent OOM on a FLUX.2-dev **multi-reference** edit (sc-6124). The default reachable
+/// surface (txt2img + single-reference edit) fits the declared `minMemoryGb` (96), but a
+/// multi-reference edit adds each reference's latent tokens to the DiT sequence and is
+/// activation-bound — two references at 1024² peak ~104 GB (sc-5923), above the floor. It runs on a
+/// 128 GB Mac but would be SIGKILL'd mid-render on a 96–104 GB machine. When the estimated peak plus
+/// a fixed runtime/OS headroom exceeds the machine's unified memory, reject with an actionable
+/// message instead. `reference_count < 2` and a failed RAM probe (`available_gb == None`)
+/// short-circuit to `Ok`, so the guard is inert for every path reachable today (the worker assembles
+/// at most one user reference; this fires only once a multi-image edit picker feeds two or more) and
+/// never blocks a machine that can actually fit the edit.
+fn flux2_dev_edit_memory_guard(
+    reference_count: usize,
+    width: u32,
+    height: u32,
+    available_gb: Option<f64>,
+) -> WorkerResult<()> {
+    if reference_count < 2 {
+        return Ok(());
+    }
+    let Some(available_gb) = available_gb else {
+        return Ok(());
+    };
+    // The measured 2-reference/1024² config (~104 GB) completed on a 128 GB Mac, so require the
+    // estimated peak plus a fixed headroom for the OS + MLX Metal transient allocations.
+    const HEADROOM_GB: f64 = 16.0;
+    let needed_gb = flux2_dev_edit_peak_gb(reference_count, width, height);
+    if available_gb + f64::EPSILON < needed_gb + HEADROOM_GB {
+        return Err(WorkerError::InvalidPayload(format!(
+            "FLUX.2-dev multi-reference edit at {width}×{height} with {reference_count} reference \
+             images needs ~{needed} GB of unified memory (with headroom) but this machine has \
+             ~{available} GB. Lower the output resolution, use a single reference image, or run on \
+             a Mac with more memory.",
+            needed = needed_gb.round() as i64,
+            available = available_gb.round() as i64,
+        )));
+    }
+    Ok(())
+}
+
 /// Generate one FLUX.2 edit image conditioned on `conditioning` (the reference set).
 /// Distilled klein: guidance 1.0, no negative prompt.
 #[allow(clippy::too_many_arguments)]
@@ -292,6 +349,20 @@ async fn generate_flux2_edit_stream(
                 fit_engine_image(reference, request.width, request.height, &request.fit_mode)
             })
             .collect::<WorkerResult<Vec<_>>>()?;
+    }
+
+    // sc-6124: guard the activation-bound FLUX.2-dev *multi-reference* edit against a silent OOM on
+    // machines below its real requirement. The reachable surface (txt2img + single-reference edit)
+    // fits the declared `minMemoryGb` (96); a second reference adds ~4096 latent tokens to the DiT
+    // stream and pushes the 1024² peak to ~104 GB (sc-5923), over the floor. Single-reference and
+    // txt2img short-circuit, so this is inert until a multi-image edit picker feeds ≥2 references.
+    if engine_id == "flux2_dev_edit" {
+        flux2_dev_edit_memory_guard(
+            references.len(),
+            request.width,
+            request.height,
+            crate::gpu::total_unified_memory_gb().await,
+        )?;
     }
 
     // sc-3030 per-iteration grouping: a Character-Studio angle set (11 shared-seed,

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -2354,6 +2354,47 @@ fn flux2_edit_engine_id_maps_variants() {
     assert_eq!(flux2_edit_engine_id("sdxl"), None);
 }
 
+// ---- sc-6124: FLUX.2-dev multi-reference edit memory guard -----------------------------------
+
+#[cfg(target_os = "macos")]
+#[test]
+fn flux2_dev_edit_peak_gb_tracks_sc5923_measurements() {
+    // sc-5923 worker-layer peaks (Q4, 1024², /usr/bin/time -l): single-ref ~81, 2-ref ~104 GB.
+    let single = flux2_dev_edit_peak_gb(1, 1024, 1024);
+    let double = flux2_dev_edit_peak_gb(2, 1024, 1024);
+    assert!(
+        (single - 81.0).abs() < 2.0,
+        "single-reference estimate {single} GB ≉ measured ~81"
+    );
+    assert!(
+        (double - 104.0).abs() < 2.0,
+        "two-reference estimate {double} GB ≉ measured ~104"
+    );
+    // Monotonic in both reference count and resolution.
+    assert!(double > single);
+    assert!(flux2_dev_edit_peak_gb(2, 768, 768) < double);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn flux2_dev_edit_memory_guard_gates_multiref_on_small_machines() {
+    // Single reference / txt2img always pass — covered by the declared minMemoryGb — even on a
+    // small machine, and regardless of the RAM probe.
+    assert!(flux2_dev_edit_memory_guard(1, 1024, 1024, Some(64.0)).is_ok());
+    assert!(flux2_dev_edit_memory_guard(0, 1024, 1024, Some(64.0)).is_ok());
+    // Two references at 1024² (~104 GB peak): fits a 128 GB Mac, rejected on a 96 GB one.
+    assert!(flux2_dev_edit_memory_guard(2, 1024, 1024, Some(128.0)).is_ok());
+    let err = flux2_dev_edit_memory_guard(2, 1024, 1024, Some(96.0)).unwrap_err();
+    assert!(
+        matches!(&err, WorkerError::InvalidPayload(msg) if msg.contains("multi-reference")),
+        "expected an actionable multi-reference rejection, got {err:?}"
+    );
+    // Dropping to 768² brings the two-reference edit (~74 GB) back under a 96 GB budget.
+    assert!(flux2_dev_edit_memory_guard(2, 768, 768, Some(96.0)).is_ok());
+    // A failed RAM probe is lenient (don't block a possibly-fine job).
+    assert!(flux2_dev_edit_memory_guard(2, 1024, 1024, None).is_ok());
+}
+
 // ---- sc-6055: FLUX.2-dev strict-pose (flux2_dev_control) -------------------------------------
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
## sc-6124 — FLUX.2-dev multi-reference edit at 1024² exceeds minMemoryGb (activation-bound)

**Found in sc-5923.** Worker-layer footprint (Q4, 1024², `/usr/bin/time -l` peak, 128 GB Mac):

| config | peak | vs `minMemoryGb=96` |
|---|---|---|
| T2I | ~74 GB | ✅ |
| edit, single `Reference` | ~81 GB | ✅ |
| edit, `MultiReference` (2 images) | ~104 GB | ❌ (runs on 128 GB, OOMs 96–104 GB) |

### Decision: Option 2 (memory-aware worker guard), not engine chunking

Investigation surfaced that the dev multi-reference edit is **doubly-latent** — unreachable from the UI (no multi-image picker) *and* from the worker: `flux2_edit_reference_ids` assembles at most **one** user reference, and dev pose jobs route to `flux2_dev_control` (sc-6055) before the edit path. So nothing currently produces a 2-reference dev edit; the sc-5923 footprint was measured by building the conditioning directly in a test.

Given that, rearchitecting the shipped/validated DiT forward (T2I/single-ref/pose/LoRA all ride it) for an unreachable path would be disproportionate. This implements the acceptance criteria's guard path instead, and keeps `minMemoryGb` honest without inflating it (which would gate the common 74 GB T2I path behind 128 GB-only).

### Changes (worker-only, mac-relevant)
- **`gpu::total_unified_memory_gb()`** — `sysctl hw.memsize` accessor (`None` off-Mac).
- **`flux2_dev_edit_peak_gb()`** — activation-footprint estimate anchored on the sc-5923 measurements (single-ref 1024² ≈ 81, two-ref 1024² ≈ 104; linear in DiT sequence length).
- **`flux2_dev_edit_memory_guard()`** — rejects a dev *multi-reference* edit whose estimated peak + 16 GB headroom exceeds the machine's unified memory, with an actionable message ("lower the resolution, use a single reference, or run on a Mac with more memory"). Single-reference / txt2img / failed-probe **short-circuit**, so a 128 GB Mac and every reachable path are untouched; the guard fires only once a multi-image picker feeds ≥2 references.
- **Manifest** — the `flux2_dev` sc-5923 footprint comment is reconciled to the enforced guard (`minMemoryGb` stays 96).

### Not done here (tracked)
Engine activation-chunking to make the multi-reference edit a first-class **sub-96 GB** mode (the [[sc-5681]] SCAIL-2 lever) remains the follow-up, gated on a future multi-image edit picker.

### Validation
- `cargo clippy -p sceneworks-worker --all-targets -- -D warnings` clean; `cargo fmt` clean.
- 309 worker lib tests pass (2 new): `flux2_dev_edit_peak_gb_tracks_sc5923_measurements`, `flux2_dev_edit_memory_guard_gates_multiref_on_small_machines` (gates 2-ref/1024² on 96 GB, passes on 128 GB, passes 2-ref/768² on 96 GB, lenient on probe failure).
- No engine/pin/contract-snapshot/JS change (manifest edit is comment-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)