### PR TITLE
Ideogram 4: native magic-prompt (plain text → editable JSON caption) (sc-5997)

### DIFF
--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -18,6 +18,12 @@ pub(crate) struct PromptRefineRequest {
     /// worker can build a guide-aware system prompt without filesystem access to
     /// the web assets.
     pub(crate) guide: Option<String>,
+    /// `"refine"` (default) or `"magic_prompt"` — the latter expands a plain idea
+    /// into a structured Ideogram 4 JSON caption (epic 4725, sc-5997).
+    pub(crate) task: Option<String>,
+    /// Target image aspect ratio as `"W:H"` (magic-prompt only); drives bbox/layout
+    /// decisions in the caption. Defaults to `"1:1"` worker-side when absent.
+    pub(crate) aspect_ratio: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/apps/rust-api/src/prompts.rs
+++ b/apps/rust-api/src/prompts.rs
@@ -39,6 +39,21 @@ pub(crate) async fn create_prompt_refine_job(
             job_payload.insert("guide".to_owned(), Value::String(guide.to_owned()));
         }
     }
+    // Magic-prompt expansion (sc-5997): the worker swaps in Ideogram's caption system
+    // prompt and the aspect ratio steers its layout/bbox decisions.
+    if let Some(task) = payload.task.as_deref() {
+        if !task.trim().is_empty() {
+            job_payload.insert("task".to_owned(), Value::String(task.trim().to_owned()));
+        }
+    }
+    if let Some(aspect_ratio) = payload.aspect_ratio.as_deref() {
+        if !aspect_ratio.trim().is_empty() {
+            job_payload.insert(
+                "aspectRatio".to_owned(),
+                Value::String(aspect_ratio.trim().to_owned()),
+            );
+        }
+    }
 
     let job = create_generation_job(
         state,

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1384,6 +1384,41 @@ export function App() {
     [token],
   );
 
+  // Magic-prompt expansion (epic 4725, sc-5997): same `prompts/refine` endpoint + native
+  // utility model, but `task: "magic_prompt"` swaps in Ideogram's caption system prompt and
+  // returns a JSON caption string (the caller parses + validates it). Reuses the refine job's
+  // poll-to-completion contract; captions can take longer, so the deadline is generous.
+  const magicPrompt = useCallback(
+    async ({ prompt, modelId, aspectRatio, guide, signal }) => {
+      const created = await apiFetch("/api/v1/prompts/refine", token, {
+        method: "POST",
+        signal,
+        body: JSON.stringify({ prompt, modelId, task: "magic_prompt", aspectRatio, guide }),
+      });
+      const jobId = created?.id;
+      if (!jobId) {
+        throw new Error("Could not start magic-prompt.");
+      }
+      const deadline = Date.now() + 180000;
+      while (Date.now() < deadline) {
+        await abortableDelay(1000, signal);
+        const job = await apiFetch(`/api/v1/jobs/${jobId}`, token, { signal });
+        if (job.status === "completed") {
+          const caption = job.result?.refinedPrompt;
+          if (!caption) {
+            throw new Error("Magic-prompt returned an empty caption.");
+          }
+          return caption;
+        }
+        if (job.status === "failed" || job.status === "canceled" || job.status === "interrupted") {
+          throw new Error(job.message || job.error || "Magic-prompt failed.");
+        }
+      }
+      throw new Error("Magic-prompt timed out. Is the refinement runtime running?");
+    },
+    [token],
+  );
+
   const createVqaJob = useCallback(
     async (asset, question, maxNewTokens) => {
       if (!activeProject) {
@@ -1747,6 +1782,7 @@ export function App() {
     createVideoUpscaleJob,
     createImageJob,
     refinePrompt,
+    magicPrompt,
     latestVideoAssets,
     recentImageAssets,
     recentVideoAssets,
@@ -1836,7 +1872,7 @@ export function App() {
     updateAssetStatus, updateAssetTags, latestImageAssets,
     jobs, jobAction, createVqaJob, createInterleaveJob, createPlaceholderJob, filteredJobs,
     jobPrompt, setJobPrompt, projectFilter, setProjectFilter, projects, visibleWorkers, workersById,
-    createVideoJob, createVideoUpscaleJob, createImageJob, refinePrompt, latestVideoAssets, recentImageAssets,
+    createVideoJob, createVideoUpscaleJob, createImageJob, refinePrompt, magicPrompt, latestVideoAssets, recentImageAssets,
     recentVideoAssets, videoLocalJobs, imageLocalJobs, documentLocalJobs, studioLaunch,
     rememberLocalGenerationJob, personTracks, personReadiness, createPersonDetectionJob,
     createPersonTrackJob, saveTrackCorrections, imageModels, videoModels, models, macCapabilities,

--- a/apps/web/src/components/StructuredPromptBuilder.jsx
+++ b/apps/web/src/components/StructuredPromptBuilder.jsx
@@ -88,9 +88,46 @@ export default function StructuredPromptBuilder({
   onModeChange,
   plainText,
   onPlainTextChange,
+  onMagicExpand,
+  magicModelMissing = false,
+  onDownloadMagicModel,
 }) {
   const composition = getComposition(caption);
   const elements = getElements(caption);
+
+  // Magic-prompt expansion (sc-5997): plain idea -> populated, editable caption.
+  const [magicBusy, setMagicBusy] = useState(false);
+  const [magicError, setMagicError] = useState("");
+  const [magicDownloadRequested, setMagicDownloadRequested] = useState(false);
+  const magicModelNeeded =
+    magicModelMissing || /not cached|not installed|snapshot is not/i.test(magicError);
+
+  async function handleMagicExpand() {
+    if (typeof onMagicExpand !== "function" || !plainText.trim() || magicBusy) return;
+    setMagicBusy(true);
+    setMagicError("");
+    try {
+      const next = await onMagicExpand(plainText.trim());
+      if (next) {
+        onCaptionChange(next);
+        onModeChange("form"); // drop the user into the editable builder
+      }
+    } catch (e) {
+      setMagicError(e?.message || "Magic-prompt failed.");
+    } finally {
+      setMagicBusy(false);
+    }
+  }
+
+  async function handleDownloadMagicModel() {
+    if (typeof onDownloadMagicModel !== "function") return;
+    try {
+      const job = await onDownloadMagicModel();
+      if (job) setMagicDownloadRequested(true);
+    } catch (e) {
+      setMagicError(e?.message || "Could not start the model download.");
+    }
+  }
 
   // Stable React keys for the repeatable element rows so child field state stays
   // aligned with its element across add/remove (elements carry no id of their
@@ -236,9 +273,45 @@ export default function StructuredPromptBuilder({
           />
           <p className="structured-hint">
             Ideogram 4 was trained on structured captions — plain text produces a coherent but
-            prompt-agnostic image. Use the Builder for accurate adherence, or expand this into a
+            prompt-agnostic image. Use the Builder for accurate adherence, or expand this idea into a
             caption with magic-prompt.
           </p>
+          {typeof onMagicExpand === "function" ? (
+            <div className="structured-magic">
+              <button
+                type="button"
+                className="secondary-action"
+                disabled={!plainText.trim() || magicBusy}
+                onClick={handleMagicExpand}
+              >
+                {magicBusy ? "Expanding…" : "✨ Expand to caption"}
+              </button>
+              {magicError && magicModelNeeded ? (
+                <div className="structured-magic-missing" role="alert">
+                  {magicDownloadRequested ? (
+                    <p className="structured-hint">
+                      Downloading the prompt-refiner model… track it on the Models screen, then try again.
+                    </p>
+                  ) : (
+                    <>
+                      <p className="structured-error">The prompt-refiner model isn’t installed yet.</p>
+                      {typeof onDownloadMagicModel === "function" ? (
+                        <button type="button" className="secondary-action" onClick={handleDownloadMagicModel}>
+                          Download prompt-refiner model
+                        </button>
+                      ) : (
+                        <p className="structured-hint">Open the Models screen to download it.</p>
+                      )}
+                    </>
+                  )}
+                </div>
+              ) : magicError ? (
+                <p className="structured-error" role="alert">
+                  {magicError}
+                </p>
+              ) : null}
+            </div>
+          ) : null}
         </div>
       ) : null}
 

--- a/apps/web/src/components/StructuredPromptBuilder.test.jsx
+++ b/apps/web/src/components/StructuredPromptBuilder.test.jsx
@@ -23,10 +23,10 @@ describe("StructuredPromptBuilder", () => {
 
   // Stateful wrapper so we can drive the controlled component and read back the
   // caption it builds.
-  function Harness({ initialMode = "form", initialCaption }) {
+  function Harness({ initialMode = "form", initialCaption, initialPlain = "", onMagicExpand, magicModelMissing = false, onDownloadMagicModel }) {
     const [caption, setCaption] = useState(initialCaption ?? emptyCaption());
     const [mode, setMode] = useState(initialMode);
-    const [plain, setPlain] = useState("");
+    const [plain, setPlain] = useState(initialPlain);
     const validation = validateCaption(caption, { plainText: plain });
     snap = { caption, mode, plain, validation };
     return (
@@ -38,8 +38,19 @@ describe("StructuredPromptBuilder", () => {
         onModeChange={setMode}
         plainText={plain}
         onPlainTextChange={setPlain}
+        onMagicExpand={onMagicExpand}
+        magicModelMissing={magicModelMissing}
+        onDownloadMagicModel={onDownloadMagicModel}
       />
     );
+  }
+
+  // Click + let an async handler's promise chain + state updates settle.
+  async function clickAndSettle(el) {
+    await act(async () => {
+      click(el);
+      await new Promise((r) => setTimeout(r, 0));
+    });
   }
 
   beforeEach(() => {
@@ -153,6 +164,56 @@ describe("StructuredPromptBuilder", () => {
     );
     await act(async () => click(jsonTab));
     expect(snap.mode).toBe("json");
+  });
+
+  it("expands a plain idea into the editable builder via magic-prompt (sc-5997)", async () => {
+    const expanded = {
+      high_level_description: "a red fox",
+      compositional_deconstruction: { background: "snow", elements: [{ type: "obj", desc: "a red fox" }] },
+    };
+    const onMagicExpand = vi.fn(async () => expanded);
+    await mount({ initialMode: "plain", initialPlain: "a red fox in the snow", onMagicExpand });
+    await clickAndSettle(buttonByText("✨ Expand to caption"));
+
+    expect(onMagicExpand).toHaveBeenCalledWith("a red fox in the snow");
+    expect(snap.mode).toBe("form"); // dropped into the builder
+    expect(snap.caption).toEqual(expanded);
+  });
+
+  it("surfaces a magic-prompt error and stays on plain text", async () => {
+    const onMagicExpand = vi.fn(async () => {
+      throw new Error("expansion blew up");
+    });
+    await mount({ initialMode: "plain", initialPlain: "an idea", onMagicExpand });
+    await clickAndSettle(buttonByText("✨ Expand to caption"));
+
+    expect(container.querySelector(".structured-error")?.textContent).toContain("expansion blew up");
+    expect(snap.mode).toBe("plain");
+  });
+
+  it("offers a model download when the magic model is missing", async () => {
+    const onMagicExpand = vi.fn(async () => {
+      throw new Error("snapshot is not cached");
+    });
+    const onDownloadMagicModel = vi.fn(async () => ({ id: "job1" }));
+    await mount({
+      initialMode: "plain",
+      initialPlain: "an idea",
+      onMagicExpand,
+      magicModelMissing: true,
+      onDownloadMagicModel,
+    });
+    await clickAndSettle(buttonByText("✨ Expand to caption"));
+
+    const download = buttonByText("Download prompt-refiner model");
+    expect(download).toBeTruthy();
+    await clickAndSettle(download);
+    expect(onDownloadMagicModel).toHaveBeenCalled();
+  });
+
+  it("hides the magic-prompt button when no expander is provided", async () => {
+    await mount({ initialMode: "plain", initialPlain: "an idea" });
+    expect(buttonByText("✨ Expand to caption")).toBeFalsy();
   });
 
   it("reports blocking validation errors in the preview (out-of-range bbox)", async () => {

--- a/apps/web/src/ideogramCaption.js
+++ b/apps/web/src/ideogramCaption.js
@@ -214,6 +214,35 @@ export function parseCaption(text) {
   }
 }
 
+// Turn a magic-prompt model reply (sc-5997) into a schema-clean caption: parse it,
+// drop the non-schema top-level `aspect_ratio` key the prompt emits, and (by default,
+// matching the reference) strip per-element bboxes — the model's box guesses are
+// unreliable and the user places boxes themselves. The result is validated by the
+// caller; serializeCaption drops any remaining unknown keys.
+export function parseMagicPromptCaption(rawText, { stripBboxes = true } = {}) {
+  const { caption, error } = parseCaption(rawText);
+  if (error) return { caption: null, error };
+  if (!caption || typeof caption !== "object" || Array.isArray(caption)) {
+    return { caption: null, error: "Magic-prompt did not return a JSON object." };
+  }
+  const out = { ...caption };
+  delete out.aspect_ratio;
+  const cd = out.compositional_deconstruction;
+  if (stripBboxes && cd && typeof cd === "object" && Array.isArray(cd.elements)) {
+    out.compositional_deconstruction = {
+      ...cd,
+      elements: cd.elements.map((el) => {
+        if (el && typeof el === "object" && "bbox" in el) {
+          const { bbox: _bbox, ...rest } = el;
+          return rest;
+        }
+        return el;
+      }),
+    };
+  }
+  return { caption: out, error: null };
+}
+
 // ----- verifier (faithful mirror of CaptionVerifier) -----------------------
 //
 // Returns structured issues `{ code, path, severity, message }`. `severity` is

--- a/apps/web/src/ideogramCaption.test.js
+++ b/apps/web/src/ideogramCaption.test.js
@@ -11,6 +11,7 @@ import {
   normalizeHexColor,
   orderCaption,
   parseCaption,
+  parseMagicPromptCaption,
   runtimePromptFromRecipe,
   serializeCaption,
   STYLE_KEY_ORDER_NON_PHOTO,
@@ -290,6 +291,32 @@ describe("validateCaption — failure modes", () => {
     expect(result.ok).toBe(true);
     expect(result.warnings.some((w) => w.code === "empty_elements")).toBe(true);
     expect(result.warnings.some((w) => w.code === "missing_recommended")).toBe(true);
+  });
+});
+
+describe("parseMagicPromptCaption", () => {
+  // What the v1 magic-prompt emits: a top-level aspect_ratio + bboxes on elements.
+  const MAGIC_OUTPUT =
+    '{"aspect_ratio": "16:9", "high_level_description": "A red fox in the snow", "compositional_deconstruction": {"background": "a snowy forest", "elements": [{"type": "obj", "bbox": [250, 320, 950, 760], "desc": "a red fox"}]}}';
+
+  it("strips the non-schema aspect_ratio key and validates clean", () => {
+    const { caption, error } = parseMagicPromptCaption(MAGIC_OUTPUT);
+    expect(error).toBe(null);
+    expect("aspect_ratio" in caption).toBe(false);
+    expect(validateCaption(caption).ok).toBe(true);
+  });
+
+  it("strips element bboxes by default but keeps them when asked", () => {
+    const stripped = parseMagicPromptCaption(MAGIC_OUTPUT).caption;
+    expect("bbox" in stripped.compositional_deconstruction.elements[0]).toBe(false);
+
+    const kept = parseMagicPromptCaption(MAGIC_OUTPUT, { stripBboxes: false }).caption;
+    expect(kept.compositional_deconstruction.elements[0].bbox).toEqual([250, 320, 950, 760]);
+  });
+
+  it("errors on non-JSON and on non-object JSON", () => {
+    expect(parseMagicPromptCaption("not json").error).toBeTruthy();
+    expect(parseMagicPromptCaption("[1, 2]").error).toBeTruthy();
   });
 });
 

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -8,7 +8,7 @@ import { PromptGuideModal } from "../components/PromptGuideModal.jsx";
 import { PoseLibraryPicker } from "../components/PoseLibraryPicker.jsx";
 import { RefinePromptControl } from "../components/RefinePromptControl.jsx";
 import StructuredPromptBuilder from "../components/StructuredPromptBuilder.jsx";
-import { emptyCaption, serializeCaption, validateCaption } from "../ideogramCaption.js";
+import { emptyCaption, parseMagicPromptCaption, serializeCaption, validateCaption } from "../ideogramCaption.js";
 import { usePoseLibrary, useUserPoseLoader } from "../poseLibrary.js";
 
 const PROMPT_SUGGESTION_POOL = [
@@ -170,6 +170,16 @@ function normalizeImageMode(mode) {
   return IMAGE_MODES.includes(mode) ? mode : "text_to_image";
 }
 
+// Greatest common divisor, for reducing a W×H resolution to an aspect ratio (sc-5997).
+function gcd(a, b) {
+  let x = Math.abs(Math.round(a));
+  let y = Math.abs(Math.round(b));
+  while (y) {
+    [x, y] = [y, x % y];
+  }
+  return x;
+}
+
 function recipeMode(recipe) {
   return normalizeImageMode(recipe?.mode);
 }
@@ -242,6 +252,7 @@ export function ImageStudio() {
     createImageJob,
     createPreset,
     refinePrompt,
+    magicPrompt,
     createModelDownloadJob,
     deleteAsset,
     purgeAsset,
@@ -306,6 +317,9 @@ export function ImageStudio() {
   // plain-text / magic-prompt seed.
   const [caption, setCaption] = useState(() => saved.structuredCaption ?? emptyCaption());
   const [promptMode, setPromptMode] = useState(saved.promptMode ?? "form");
+  // The magic-prompt backend (utility model id) that drafted the current caption, recorded in the
+  // structured-prompt recipe (sc-5997). Null until the user runs magic-prompt.
+  const [magicPromptBackend, setMagicPromptBackend] = useState(saved.magicPromptBackend ?? null);
   const setPromptFromUser = (value) => {
     promptEdited.current = true;
     setPrompt(value);
@@ -824,6 +838,29 @@ export function ImageStudio() {
   }, [launchRequest?.id]);
   const [width, height] = resolution.split("x").map((value) => Number(value));
 
+  // Magic-prompt expansion (sc-5997): expand the plain-text idea into an editable caption via the
+  // native utility model (same backend as Refine), recording which model drafted it. Returns the
+  // cleaned caption (aspect_ratio + bboxes stripped); the builder applies it and switches to the
+  // form. Only wired when a structured model is selected.
+  const magicModelMissing = refineModel?.installState === "missing";
+  const onMagicExpand = useCallback(
+    async (idea) => {
+      if (typeof magicPrompt !== "function") {
+        throw new Error("Magic-prompt is unavailable.");
+      }
+      const divisor = gcd(width, height) || 1;
+      const aspectRatio = Number.isFinite(width) && Number.isFinite(height) ? `${width / divisor}:${height / divisor}` : "1:1";
+      const raw = await magicPrompt({ prompt: idea, modelId: model, aspectRatio });
+      const { caption: expanded, error } = parseMagicPromptCaption(raw);
+      if (error || !expanded) {
+        throw new Error(error || "Magic-prompt returned an unusable caption.");
+      }
+      setMagicPromptBackend(PROMPT_REFINE_MODEL_ID);
+      return expanded;
+    },
+    [magicPrompt, model, width, height],
+  );
+
   // When restoring a snapshot, the saved count/resolution/negativePrompt already
   // reflect the user's last state — skip the one preset-default pass that fires as the
   // restored preset resolves so it doesn't overwrite them. "None" applies no defaults,
@@ -890,6 +927,7 @@ export function ImageStudio() {
     prompt,
     structuredCaption: caption,
     promptMode,
+    magicPromptBackend,
     count,
     advancedOpen,
     model,
@@ -1170,6 +1208,9 @@ export function ImageStudio() {
                 onModeChange={setPromptMode}
                 plainText={prompt}
                 onPlainTextChange={setPromptFromUser}
+                onMagicExpand={magicPrompt ? onMagicExpand : undefined}
+                magicModelMissing={magicModelMissing}
+                onDownloadMagicModel={refineModel ? () => createModelDownloadJob(refineModel) : undefined}
               />
             ) : (
               <textarea

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1852,6 +1852,15 @@ label {
   font-family: var(--font-mono);
 }
 
+/* Magic-prompt control in the structured builder's plain-text tab (sc-5997). */
+.structured-magic,
+.structured-magic-missing {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: flex-start;
+}
+
 .suggestion-row {
   display: flex;
   flex-wrap: wrap;

--- a/crates/sceneworks-worker/src/ideogram_magic_prompt_v1.txt
+++ b/crates/sceneworks-worker/src/ideogram_magic_prompt_v1.txt
@@ -1,0 +1,296 @@
+[META]
+frozen: false
+description: Slim single-shot magic prompt — splatter planning + v15 output discipline, deduped for faster inference. Thinking off.
+thinking_mode: disabled
+
+[SYSTEM]
+You convert a natural-language user idea into a structured JSON caption an image renderer can consume. You receive the user idea plus a target aspect ratio, and you emit one JSON object.
+
+## OUTPUT CONTRACT — exactly three top-level keys, in this order:
+
+```json
+{"aspect_ratio":"W:H","high_level_description":"...","compositional_deconstruction":{"background":"...","elements":[ ... ]}}
+```
+
+- Emit a SINGLE-LINE MINIFIED JSON object — no markdown fences, no commentary, no other top-level keys.
+- Preserve non-ASCII characters as-is (CJK, Cyrillic, Devanagari, Arabic, accented Latin). Never escape with `\uNNNN`, transliterate, or replace `café` with `cafe`.
+- Use SINGLE quotes for embedded text references in prose fields (`'Joe's Diner'`, not `\"Joe's Diner\"`). The `text` field of text elements is the exception — that field holds the user's verbatim characters, may use any characters, and follows QUOTED SPAN FIDELITY below.
+
+### `aspect_ratio` (first field, always required)
+
+A string in `W:H` form with positive integers (`1:1`, `16:9`, `9:16`, `4:5`, `3:1`, `2:3`, etc.).
+- If the user message gives a concrete `W:H`, echo it verbatim.
+- If the user message says `auto`, pick a concrete ratio that matches the medium and composition (panoramic subjects → wide ratios like `16:9` or `3:1`; portrait subjects → tall like `9:16` or `4:5`; designed artifacts → format conventions like `2:3` book cover, `3:4` poster; ambiguous → `1:1`). NEVER emit the literal string `auto`.
+- The aspect ratio you commit to drives every bbox decision. Pick it first.
+
+### `high_level_description` — observational summary (50-word hard cap)
+
+- ONE long sentence preferred, never more than two.
+- Reads like a short natural-language prompt, not an analysis. Starts immediately with the subject — no "this image shows", "depicts", "captures".
+- Identifies subject(s), medium, and overall composition. Names recognized pop-culture entities by full name (`Nike Air Jordan 1`, `Eiffel Tower`, `Mario (Nintendo character)`).
+- Don't enumerate granular features (every color, every grid dimension, every typography choice). That detail belongs in element descs or `background`.
+- `various`, `multiple`, general categories ARE appropriate here. Specificity rule (below) applies to element descs and `background`, NOT this field.
+- For transparent backgrounds, include the literal phrase `on a transparent background`.
+
+GOOD: `A full-action shot of a male soccer player in a red kit and black Adidas cleats kicking a soccer ball on a green turf field, with a blurred crowd in the stadium background.`
+BAD (over-specifies): `A male soccer player captured mid-kick on a bright green grass pitch, right leg fully extended through the follow-through at the precise moment his black-and-white studded boot makes contact with a white-and-black size-5 ball...`
+
+## ELEMENTS — what they are, what they're not
+
+Each element is one of:
+```
+{"type":"obj","bbox":[y1,x1,y2,x2],"desc":"..."}
+{"type":"text","bbox":[y1,x1,y2,x2],"text":"LINE ONE\nLINE TWO","desc":"..."}
+```
+
+`bbox` is optional per-element (see BBOX section below).
+
+### SINGLE SUBJECT = SINGLE ELEMENT
+
+A coherent subject — one animal, person, vehicle, building, plant, instrument, machine — is exactly ONE `obj` element. Anatomical and structural parts are descriptive attributes inside that element's `desc`, NOT separate elements.
+
+FORBIDDEN: a bee split into 8 elements (thorax/abdomen/wings/eyes/legs/...); a car split into 6 (body/wheels/windshield/...); a person split into 7 (head/torso/each limb/...); a building split into 5 (foundation/walls/windows/roof/door); a flower split into 3 (petals/stem/leaves).
+
+When MULTIPLE distinct subjects appear (a person AND a dog; two bees; three runners), use MULTIPLE elements — one per subject.
+
+**Test:** part-of-one-thing → goes in that thing's desc. Separate thing → its own element.
+
+**Transparent enclosure + featured contents = ONE element.** Display cases, snow globes, terrariums, aquariums, specimen jars, bell jars, vitrines containing a featured subject: name the enclosure + contents as a single unified desc.
+
+**Configured parts + revealed interior = ONE element.** A car with an open door, a machine with raised hood, a building with drawn curtains: the open state and any revealed interior are attributes of the single subject's desc, not separate elements.
+
+### Element desc — what to write (30–60 words, 60-word HARD CAP)
+
+Identity first, then major attributes briefly, then one distinguishing detail if relevant. Each desc is a standalone catalog entry — open with the subject's identity, not a referring phrase like "the X" that assumes the reader has seen the scene.
+
+GOOD (introduces from scratch):
+- `Woman walking on the platform, medium size. Shoulder-length dark wavy hair, medium skin tone, light blue button-down shirt and grey trousers. Small bag slung over the right shoulder.`
+- `Circular concrete tunnel entrance with glowing blue ring lights along the interior. Train tracks lead directly into the dark opening.`
+
+**Major attributes — always name:**
+- People: skin tone, hair (color + style), each visible garment with color, expression/gaze, pose, distinguishing feature (mole, glasses, jewelry, held prop).
+- Objects: shape, material, color, distinctive parts (handle, label, logo, marking).
+- Scenes/structures: type, primary material, color, distinctive structural elements.
+
+**Skip (eat word budget for marginal benefit):**
+- Surface-finish micro-prose (`finely granular matte texture with subtle sheen along the elytral ridges`). Pick one short descriptor (matte/glossy/metallic/textured) or omit.
+- Pose mechanics per-limb. Pick ONE summary action phrase plus the major attributes.
+- Camera/shadow/lighting micro-detail per element. Belongs in `background`.
+- Fabric weave, skin texture nuances, micro-anatomy.
+
+### Element desc — what NOT to include
+
+**No shadows.** Cast shadows, drop shadows, ground shadows, contact shadows, ambient occlusion — describe in `background` only when scene-wide, otherwise omit (the renderer infers them). Forbidden: `casts a thin hard shadow to the lower right`, `with a soft drop shadow beneath`.
+
+**No camera or render language.** Depth of field, focus, sharpness, bokeh, exposure, motion blur, lens flare, chromatic aberration, film grain — render properties belong in `high_level_description` or `background` as natural prose ONLY when the user prompt explicitly named them. NEVER inside an obj desc.
+  - EXCEPTION — viewpoint/angle (`from a low-angle perspective`, `bird's-eye view`, `eye-level`) IS allowed in obj descs when the prompt calls for it. Place once, usually in the focal subject's desc or background.
+
+**No describing impressions instead of physical reality.** Avoid `luminous`, `radiant`, `vibrant`, `lush`, `dynamic`, `glowing` (metaphorically), `gorgeous`, `stunning`, `breathtaking`, `mesmerizing`. Use observable properties: `cheekbone catches a small highlight`, not `luminous complexion`.
+
+**No scene-context repetition per-element.** Lighting direction, ambient surface, mounting context, weather → describe ONCE in `background`. Each element's desc focuses on what's UNIQUE to that element.
+
+### Anchor placements to named references
+
+Specify body parts, surfaces, spatial landmarks.
+- CORRECT: `applied to the forehead near the hairline above the left eyebrow`.
+- INCORRECT: `pressed against the skin`.
+- CORRECT: `resting on the lower-right corner of the table directly in front of the laptop`.
+- INCORRECT: `sitting on the surface`.
+
+## BACKGROUND — what goes here, what doesn't (CRITICAL)
+
+`background` describes the scene SHELL: walls and finishes, floor/ground and surface state, ceiling and architectural fixtures, windows as architecture, atmospheric context (sky, clouds, fog, dust, mist), scene-wide ambient lighting, distant out-of-focus context (horizon, blurred crowds, distant scenery).
+
+### No double-counting
+
+Anything described in `background` CANNOT also appear as an obj element. Each scene component lives in EXACTLY ONE field. Decide once and commit. Before emitting an obj element, scan `background` — if the component is named there, omit the obj element.
+
+### ALWAYS-BACKGROUND — these live in `background` only, never as obj elements:
+
+- sky, clouds, atmospheric color
+- horizon
+- distant mountains, hills, tree lines
+- atmospheric weather (fog, haze, mist, smoke)
+- distant cityscape or stadium architecture
+- distant blurred or simplified crowds
+- the floor / ground / turf / paving surface the scene sits on
+- ambient walls or studio backdrop behind focal subjects
+
+You cannot split these by region. `sky upper-left portion`, `sky behind the fortress`, `sky upper two-thirds` are the SAME component — describe in `background` once. Same for crowd, ground, horizon.
+
+If you want technique-level detail on an atmospheric component (watercolor wet-on-wet sky blooms, fog with directional density variation), put that detail in `background`. The `background` field is allowed to be long.
+
+### Ground/floor/pavement is ALWAYS background — zero tolerance
+
+The surface the scene sits on — floor, ground, turf, grass, dirt, sand, asphalt, pavement, road, sidewalk, deck, water surface, snow, tile floor, hardwood, marble — lives in `background` only. This holds REGARDLESS of how the input formats it: if the prompt lists `Wet rain-slicked pavement below` as a foreground bullet, RE-CLASSIFY it into background.
+
+**Surface character that belongs in background, not as a separate obj:** wet / rain-slicked / mud-streaked / dusty / cracked / polished / weathered surface state; reflective neon pools, fragmented color reflections, puddles, wet patches, mud patches, ice patches, frost, snow on the floor, water pooled on the ground, oil slicks, footprints, tire tracks; surface material (asphalt, cobblestone, hardwood, tile, marble, packed dirt); texture words for the floor (glassy, mirror-like, matte, polished, rough).
+
+**Puddles, reflections, wet patches are part of the ground surface** — never separate obj elements, regardless of whether they reflect the hero's silhouette or carry visible content.
+
+**Failure mode this prevents:** when a standing hero is the focal element and the floor is also emitted as an obj at the bottom of the frame, the renderer treats the floor obj as a 2D frame band rather than a perspectival receding plane, and clips the hero's legs into it — figure rendered half-in-the-ground with feet/calves buried.
+
+**Discrete objects ON the floor are still elements:** broken glass shards, crushed cans, scattered debris, leaves, rocks, dropped tools, brick fragments, foreground litter remain obj elements. The rule applies to the SURFACE itself and any state of that surface (wet, frozen, muddy, puddled), never to solid objects resting on it.
+
+### Background is the shell only — no individually-placeable things
+
+Furniture, vehicles, equipment, people, animals, decor (artwork, signs, plants in pots, stacks of books), free-standing lamps → obj elements, never `background`.
+
+### Shell-affixed prominent objects → DUAL MENTION
+
+Some objects are simultaneously part of the shell AND focal elements that define the room's identity: a chalkboard covering the back wall of a classroom, a fireplace built into a living-room wall, a large mounted TV, a stage proscenium, a built-in altar, a built-in bookshelf, a large fixed reception desk, a fixed sign/banner.
+
+For these, MANDATORY all three steps:
+1. **MENTION in `background`** as part of the shell — anchors the object to the wall.
+2. **EMIT as an obj element** with the qualifier `"the primary background element"` (or similar) at the start of its desc. The obj carries the detail (material, content, frame, mounting).
+3. **PLACE FIRST in the elements list** so painter's-algorithm draws it behind foreground items.
+
+Skipping step 1 (the most common failure) makes the renderer float the object in mid-room or render it in front of foreground subjects.
+
+This is an EXCEPTION to the shell rule's "no individually placeable things". Applies ONLY to objects that genuinely define the room's architectural identity. Free-standing items (chairs, table lamps, plants in pots, framed pictures on a wall) get the normal treatment: elements only, no background mention.
+
+### Recession/arrangement is not architecture
+
+Do not smuggle furniture or people into `background` by describing them as a receding arrangement. Forbidden background phrasings: `rows of desks recede toward the back`, `a grid of desks fills the room`, `students seated at the desks`, `chairs arranged in front of the podium`, `the room is filled with people`, `cars parked along the street`, `customers seated at the tables`. The arrangement IS the foreground content — emit elements.
+
+### No medium/post-processing effects in background
+
+`background` describes WHAT is in the scene, not HOW it was made. Forbidden in `background` — even when the prompt names the effect (route those to HLD instead):
+- Film grain, Kodak/Portra/Tri-X grain, ISO noise
+- Lens flare, chromatic aberration, vignetting, bokeh quality
+- Color cast / film-stock shift (warm shift, cool shift)
+- Paper texture, paper grain, canvas texture
+- Brushstroke texture, palette-knife texture
+- Halftone dots, screen-print texture, risograph texture
+
+**Test:** read `background` aloud. If you can picture the EMPTY room from the description — no furniture, no people, no equipment, no wall decor — you're in the shell. If anything disappears when you remove the room's contents, the background has leaked.
+
+## BBOX STRATEGY
+
+INCLUDE bboxes on elements where precise positioning matters — portrait subjects, products on a surface, logos, signs on a wall, distinct individually-placeable objects.
+
+OMIT bboxes on elements that represent dense or hard-to-enumerate visuals — crowds, fields of wildflowers, scattered particles, starry skies. Per-element judgment.
+
+### Coordinate system
+
+Coordinates are normalized to the target image shape: `x` runs left→right along full width (0 = left edge, 1000 = right), `y` runs top→bottom along full height (0 = top, 1000 = bottom). Top-left origin. Format `[y1, x1, y2, x2]` with `y1 < y2`, `x1 < x2`.
+
+### Shape warning (common failure)
+
+Bbox values are normalized to 0–1000 in BOTH axes. A square `[0, 0, 500, 500]` is square only on a square frame; on 16:9 it becomes a wide rectangle, on 9:16 a tall rectangle. Most bbox failures (extra subjects, duplicates, mis-scaled objects) come from this mismatch.
+
+For round objects or square on-screen regions, scale spans so `(x2-x1)/(y2-y1) ≈ W/H`. For single-subject prompts on wide frames, prefer narrower x-spans. For multi-subject prompts, give each a tight bbox so no one bbox dominates and invites a duplicate.
+
+## SPECIFICITY — commit to one value
+
+This JSON feeds a diffusion model. Leave nothing for the model to invent or choose.
+
+**Banned hedge phrasings** (in elements and background): `things like`, `such as`, `e.g.`, `for example`, `or similar`, `various`, `could include`, `might be`, `some kind of`, `style of`. Replace with concrete nouns, counts, colors, materials, poses.
+
+**Banned alternative listings for one property:** `pale institutional off-white or pale green`, `oak or walnut`, `cream or ivory`, `late afternoon or early evening`, `italic serif or italic sans-serif`, `bold or semibold`. Pick ONE and commit. `or` is reserved for the loader's exclusive-choice idiom (`'YES' or 'NO'`), not captioner hedging.
+
+**Typography specifically:** name ONE typeface category (serif OR sans-serif OR display OR script OR monospace), ONE weight (bold/regular/light/medium), ONE style (italic OR upright). Never two joined by `or`.
+
+**Banned "implied/suggested" hedges:** `a desk corner implied`, `a chair suggested beneath the figure`, `a building hinted at`, `a shadow that reads as a person`. If it's in the scene, paint it concretely. If it isn't, leave it out. Forbidden words: `implied, suggested, hinted, barely visible, possibly, perhaps, maybe, might be, could be, reads as, almost`.
+
+**Exhaustive content preservation.** When the user provides enumerable content — schedules, itineraries, lists, menu items, steps, names, times — every item must appear in the output. Use as many text elements as needed; never sacrifice completeness for layout.
+
+**Named prompt elements MUST appear.** Every explicitly-named visual unit in the user prompt MUST appear as its own element:
+- Input `text:` sections — every entry becomes its own text element, verbatim. Zero tolerance: 3 entries in input → ≥3 text elements in output. Empty `text: []` is the only case where text elements may be omitted on that basis.
+- Quoted strings (single or double quotes) — each is its own text element.
+- Speech bubbles / dialogue callouts / thought bubbles / captions — each gets a text element for the quoted string AND an obj element for the bubble/balloon/container.
+- Named decorative elements (`small medical cross icon top-left`, `airplane arc trajectory`, `flame-lick flourish at the tail`) — each gets its own obj.
+- Named badges / chips / CTAs / strips — each gets its own obj (and text if it carries a quoted string).
+- Named accents / graphic devices (`hairline rule`, `dot grid`, `accent line`, `divider`) — each gets its own obj UNLESS it's a scene-wide overlay belonging in `background`.
+
+**Test before emitting:** count named visual units in the user prompt; element list must contain at least that many.
+
+**No placeholder enumeration.** When the imagined image contains a sequentially-numbered, alphabetically-labeled, or otherwise individually-identified set (stones numbered 1–50, parking spaces A1–A20, place cards `1st`–`12th`, a periodic table of 118 elements, a calendar grid of 31 dates, a 22-name team roster), EACH item is its own element. No `etc.`, no `and so on`, no `6 through 49`, no single obj grouping all into one cluster. List ALL of them.
+
+The "dense unenumerable group" exception (crowd of thousands, field of wildflowers, starry sky) does NOT apply to enumerable sets — if items are sequentially identified, they're enumerable BY DEFINITION.
+
+**Don't invent visual concepts the user didn't ask for.** Forbidden without explicit user request: `glitch art`, `wireframe overlay`, `mesh that fragments the body`, `digital artifacts`, `dissolved`, `decompose`. If the prompt asks for a cinematic photo of a journalist, render a cinematic photo of a journalist — not a glitch-art composite.
+
+## PLANNING — turn the user idea into elements
+
+### 1. Pick a medium
+
+`photograph | illustration | 3D render | graphic design` — applies as natural-language framing inside HLD/background, NOT as a structured slot.
+
+Decision: **DESIGNED artifact vs CAPTURED / DRAWN / RENDERED moment.**
+- **graphic design** — poster, book cover, album cover, magazine cover, flyer, banner, social post, sticker, logo, wordmark, packaging, app icon, UI mockup, infographic, menu, greeting card, ticket, signage. If a human designer would sit at a desk to make it.
+- **photograph** — portrait, landscape, lifestyle, street, sport, wildlife, food, product, fashion editorial (when described as a photograph). Default for ambiguous everyday scenes.
+- **illustration** — cartoon, anime, manga, comic, watercolor, oil painting, ink, vector, pixel art, children's book illustration, named studios (Ghibli, KyoAni, Pixar 2D).
+- **3D render** — CGI, octane/unreal/blender, hyperrealistic product render, arch viz, isometric low-poly, voxel, named 3D studios.
+
+Silent / ambiguous → photograph (default). The subject's reality status does NOT override this default — wizards, dragons, aliens, robots in a photograph are valid; the brief must explicitly ASK for illustration / painting / render to get one.
+
+Imperative verbs at the start ("Illustrate a…", "Paint a…", "Draw a…", "Render a…") are NOT medium signals — they mean "depict / show". Default to photograph unless an explicit medium-noun or style name appears.
+
+### 2. Style commitment
+
+Inside HLD/background prose, name the style ONCE (`Studio Ghibli animation`, `Pixar 3D animation`, `35mm film photograph`, `iPhone photo`, `editorial digital painting`, `flat vector illustration`). Keep it short — recognizable style names are enough; the renderer knows them. Don't append technique detail (`with hand-painted gouache backgrounds`) on top of well-known names.
+
+**"Professional picture/photo/portrait" of a person means PROFESSIONAL CONTEXT, not professional camera equipment.** Read as corporate headshot, LinkedIn profile, business bio — neutral business attire, soft even daylight, neutral backdrop, friendly approachable expression. NOT dramatic studio rim-lighting, creamy DSLR bokeh, dark moody backdrop.
+
+### 3. Photoreal defaults — AVOID "warm"
+
+For photographic prompts (no specified medium beyond `photo`/`photorealistic`/`selfie`/real-world scene):
+- Default to iPhone aesthetic — phone snapshot, ambient natural light, neutral white balance, accurate (not flattering) skin tones, ordinary framing. AVOID DSLR-magazine markers (creamy bokeh, telephoto compression, dramatic rim lighting, cinematic grade) — those signal AI-generation.
+- Default lighting framing: `natural daylight`, `overcast daylight`, `diffused daylight`, `cool-neutral white balance`. The word **"warm"** (in any phrase: `warm light`, `warm window light`, `warm tone`, `warm grading`) is BANNED as a grading adjective — it triggers the amber/golden AI look that ruins photorealism. When a scene physically has a warm-coloured light source (candle, sodium streetlamp, sunset), describe the SOURCE concretely (`candle flame`, `sodium streetlamp`) and the colour of the LIGHT POOL (`amber pool from the candle`) — but the global grade stays neutral.
+- Default composition: prefer non-centered framing (off-center, rule-of-thirds, asymmetrical, leading lines) for portraits, products, single-subject scenes. Use centered framing ONLY when the prompt explicitly calls for it (`centered`, `symmetrical`, `mandala`, `kaleidoscope`) or when the genre is inherently symmetric.
+- No motion blur in candid/realistic/iPhone-aesthetic photos. Motion blur is a craft signature (long-exposure pans, light streaks); using it in a candid signals AI. Real phone snapshots freeze the moment.
+- Saturation: don't stack `vibrant + bright + intense + saturated + electric + neon` for a neutral subject. Mention saturation ONCE (in HLD or background) only when the prompt explicitly asks.
+
+### 4. Populate underspecified scenes
+
+When the brief is sparse, don't render only what's explicitly named. Real scenes are populated. Add believable secondary subjects, micro-props that imply the subject's life, environmental texture, small narrative moments. Each invented element should belong in the world the brief implies — a paddy-field food stall plausibly has a chicken, a sauce bowl, a hand-painted price sign, a lantern.
+
+**Populate by depth layer.** Foreground (often-skipped), midground, background — each gets its own content. A foreground crop (an out-of-focus leaf at the bottom corner, the rim of a bowl, a fly mid-air close to camera) separates a real photograph from a postcard.
+
+**Commit to a specific cultural / regional identity.** "Southeast Asian village" is a hedge that produces generic AI visuals. "Vietnamese pho stall by the rice paddies outside Hoi An" is a real place. Specific commitment shapes architecture, signage script, food, dress, props.
+
+**Built environments need text everywhere.** Real shops, stalls, restaurants, vehicles, signage carry text on practically every surface. Generate text generously: shop name sign, sub-signs (`OPEN` / `TODAY'S SPECIAL`), menu board with handwritten items, price labels, jar/bottle labels, name tags, posters, fortune slips, vehicle/equipment labels, sponsor logos. `text: []` is almost always wrong for built environments — if your scene has a shop/stall/restaurant/workshop/market/vehicle, populate text. Specific content, never `various labels` or `menu items`.
+
+**Override:** when the brief explicitly says `minimal`, `sparse`, `empty`, `lonely`, `isolated`, `quiet`, `still`, `negative space`, `alone`, `single subject`, `in the middle of nowhere`, respect the restraint and skip populate.
+
+**Fantastical / sci-fi / fantasy / futuristic briefs get a populate bonus.** Stack sky drama (galaxies, ringed planets, multiple moons, nebulae), opposing focal points (volcano right / waterfall left), mid-distance scale anchors (crystal columns, futuristic cityscape, megastructures), light/energy effects throughout, exotic architecture/geology, deeply saturated palettes.
+
+## TEXT HANDLING
+
+For each text element:
+- `text` — literal characters appearing in the image, verbatim. Preserve diacritics, capitalization, punctuation. Never transliterate or strip.
+- `bbox` — optional, same coordinate system as obj elements.
+- `desc` — free-form prose covering size, location, font style, color, orientation, visual effects.
+
+**Sources of text to include:**
+1. **User-quoted text** (single OR double quotes) — verbatim, exact characters.
+2. **Format-required text** — headlines, taglines, author names, dates, venues, CTA copy, brand names, publisher marks, edition numbers (when format implies them).
+3. **In-scene contextual text** — signage, labels, license plates, badges, jersey numbers, t-shirt prints, awnings, neon signs, name tags.
+4. **Numeric content** — race numbers, jersey numbers, dates, prices, scores, time displays, address numbers. Numbers ARE text.
+5. **Prominent product brand text** — if an element names a prominent product (bottle, cosmetic, package, beverage) and the user didn't supply a real brand, invent a complete brand identity and list every label as text elements.
+
+**Rules:**
+- Exhaustive: if a viewer could read it, it goes in the list.
+- Each text element appears ONCE in the list. Do NOT also describe its characters in `description` — refer by role/position instead.
+- Use `\n` for line breaks WITHIN a single text element (multi-line sign, stacked headline). Use SEPARATE list items for visually distinct text blocks.
+- For stylized hero typography where each letter is a distinct visual unit, stack with `\n` at natural word breaks — long single-line stylized titles produce typos and dropped letters. e.g., `"ENTRE\nVERSOS E\nCONTOS"` not `"ENTRE VERSOS E CONTOS"`.
+- **Language scoping:** `scene`/`elements`/`description`/position descriptors are always in ENGLISH regardless of the user's brief language. Only the literal `text` field characters follow the user's brief language. Portuguese brief → English prose + Portuguese `text:` content.
+
+## POP CULTURE, BRANDS, NAMED REFERENCES
+
+When the user idea names or clearly implies a brand, trademark, product (sneaker/car/device), public figure, athlete, musician, actor, fictional character, film, show, game, franchise, team — the output MUST carry an explicit named reference in the relevant element `desc`, not a generic stand-in describing the look.
+
+Don't replace `Nike Dunk Low Panda` with `black and white retro sneakers`, `Spider-Man` with `a red-and-blue masked superhero`, `The Beatles` with `four men in matching suits` — unless the user asked for an anonymous lookalike. Name the specific thing the user pointed at.
+
+## TRANSPARENT BACKGROUND
+
+If the user's idea calls for transparent background, transparent canvas, alpha channel, cutout/isolated subject, sticker-style with no backdrop, or similar, the `background` field MUST be exactly this string, verbatim and nothing else: `transparent background`
+
+Do not paraphrase (no `clear backdrop`, `empty alpha`, `no background`, `PNG transparency`).
+
+In `high_level_description`, include the literal phrase `on a transparent background`.
+
+[USER]
+TARGET IMAGE ASPECT RATIO: {{aspect_ratio}} (width:height).
+User idea: {{original_prompt}}

--- a/crates/sceneworks-worker/src/prompt_refine_jobs.rs
+++ b/crates/sceneworks-worker/src/prompt_refine_jobs.rs
@@ -226,6 +226,103 @@ fn last_ci(haystack: &str, needle: &str) -> Option<usize> {
 }
 
 // ----------------------------------------------------------------------------------------------
+// Magic-prompt expansion (epic 4725, sc-5997) — plain idea → structured JSON caption. Drives the
+// SAME `prompt_refine` TextLlm (Llama-3.2-3B) with Ideogram's open-source magic-prompt system prompt
+// (`task: "magic_prompt"`) instead of the rewrite rules. The hosted Ideogram / OpenRouter Sonnet/Opus
+// configs in the reference are replaced by the local model (native-first, offline). The caller (web)
+// strips the non-schema `aspect_ratio` key + bboxes and validates the result against the sc-5993
+// caption contract, so this side stays generic: build messages, run, extract the JSON object.
+// ----------------------------------------------------------------------------------------------
+
+/// Ideogram 4's magic-prompt system-prompt file, embedded verbatim. Source (Apache-2.0):
+/// github.com/ideogram-oss/ideogram4 `src/ideogram4/magic_prompt_system_prompts/v1.txt`. Parsed for
+/// its `[SYSTEM]` + `[USER]` sections at runtime (the `[META]` block is ignored).
+#[cfg(any(
+    test,
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+const MAGIC_PROMPT_V1: &str = include_str!("ideogram_magic_prompt_v1.txt");
+
+/// Body of a `[NAME]` section in the magic-prompt file (port of the reference `_load_sections`):
+/// section markers are a bracketed single word alone on a line. Returns the trimmed body, or empty.
+#[cfg(any(
+    test,
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn magic_section(name: &str) -> String {
+    let mut capturing = false;
+    let mut body: Vec<&str> = Vec::new();
+    for line in MAGIC_PROMPT_V1.lines() {
+        let trimmed = line.trim();
+        let is_marker = trimmed.len() >= 2
+            && trimmed.starts_with('[')
+            && trimmed.ends_with(']')
+            && !trimmed.contains(' ');
+        if is_marker {
+            if capturing {
+                break;
+            }
+            capturing = trimmed[1..trimmed.len() - 1].eq_ignore_ascii_case(name);
+            continue;
+        }
+        if capturing {
+            body.push(line);
+        }
+    }
+    body.join("\n").trim().to_owned()
+}
+
+/// The `(system, user)` chat messages for a magic-prompt expansion: the `[SYSTEM]` block, and the
+/// `[USER]` template with `{{aspect_ratio}}` / `{{original_prompt}}` substituted (port of the
+/// reference `build_messages`). `aspect_ratio` is `"W:H"`.
+#[cfg(any(
+    test,
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn build_magic_prompt_messages(prompt: &str, aspect_ratio: &str) -> (String, String) {
+    let system = magic_section("SYSTEM");
+    let mut user = magic_section("USER");
+    if user.is_empty() {
+        user = "TARGET IMAGE ASPECT RATIO: {{aspect_ratio}} (width:height).".to_owned();
+    }
+    user = user.replace("{{aspect_ratio}}", aspect_ratio);
+    user = if user.contains("{{original_prompt}}") {
+        user.replace("{{original_prompt}}", prompt)
+    } else {
+        format!("{user}\n\n{prompt}")
+    };
+    (system, user)
+}
+
+/// Reduce a magic-prompt reply to its JSON object: strip `<think>` blocks and a wrapping code fence
+/// (reusing the refine cleanup), then take the outermost `{ … }` span so leading/trailing prose from
+/// a small model is dropped. The caller parses + validates; here we only isolate the object.
+#[cfg(any(
+    test,
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn clean_json_output(text: &str) -> String {
+    let mut text = strip_think_blocks(text.trim()).trim().to_owned();
+    if let Some(pos) = last_ci(&text, "</think>") {
+        text = text[pos + "</think>".len()..].trim().to_owned();
+    }
+    if text.starts_with("```") && text.ends_with("```") {
+        let lines: Vec<&str> = text.lines().collect();
+        if lines.len() >= 2 {
+            text = lines[1..lines.len() - 1].join("\n").trim().to_owned();
+        }
+    }
+    match (text.find('{'), text.rfind('}')) {
+        (Some(start), Some(end)) if end > start => text[start..=end].to_owned(),
+        _ => text,
+    }
+}
+
+// ----------------------------------------------------------------------------------------------
 // Job handler — native MLX on macOS (sc-5552) and candle on the Windows candle build (sc-5525). The
 // body is backend-agnostic: `gen_core::load_textllm("prompt_refine", …)` resolves whichever provider
 // is force-linked above. The Python torch `PromptRefiner` remains the fallback on other platforms.
@@ -271,14 +368,46 @@ pub(crate) async fn run_prompt_refine_job(
         .filter(|value| !value.is_empty())
         .unwrap_or(DEFAULT_REFINE_MODEL)
         .to_owned();
+    // Magic-prompt expansion (sc-5997) drives the same model with Ideogram's caption system prompt
+    // instead of the rewrite rules; captions run longer than a one-line prompt, so allow more tokens
+    // and sample cooler for steadier JSON.
+    let is_magic = payload
+        .get("task")
+        .and_then(Value::as_str)
+        .map(|task| task.trim().eq_ignore_ascii_case("magic_prompt"))
+        .unwrap_or(false);
     let max_new_tokens = payload
         .get("maxNewTokens")
         .and_then(Value::as_u64)
         .and_then(|value| u32::try_from(value).ok())
         .filter(|value| *value > 0)
-        .unwrap_or(512);
+        .unwrap_or(if is_magic { 2048 } else { 512 });
+    let temperature = if is_magic { 0.4 } else { 0.7 };
+    let work_message = if is_magic {
+        "Expanding to a caption…"
+    } else {
+        "Refining prompt…"
+    };
+    let done_message = if is_magic {
+        "Caption ready."
+    } else {
+        "Prompt refined."
+    };
 
-    let system = build_refine_system_prompt(guide.as_deref(), workflow.as_deref());
+    let (system, user_message) = if is_magic {
+        let aspect_ratio = payload
+            .get("aspectRatio")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("1:1");
+        build_magic_prompt_messages(&original_prompt, aspect_ratio)
+    } else {
+        (
+            build_refine_system_prompt(guide.as_deref(), workflow.as_deref()),
+            original_prompt.clone(),
+        )
+    };
     let weights_dir = resolve_app_managed_model_dir(settings, &model, "prompt-refine model path")?;
     // Attribute the run to the active backend (MLX on macOS, candle off-Mac) on the streamed progress
     // + UI architecture pill (mirrors the image/video paths), not the gpu-id device label.
@@ -304,7 +433,7 @@ pub(crate) async fn run_prompt_refine_job(
     let (tx, mut rx) = tokio::sync::mpsc::channel::<(u32, u32)>(64);
     let blocking_cancel = cancel.clone();
     let job_id = job.id.clone();
-    let prompt = original_prompt.clone();
+    let prompt = user_message;
     let engine_label = model.clone();
     let blocking = tokio::task::spawn_blocking(move || -> WorkerResult<String> {
         emit_event(
@@ -327,7 +456,7 @@ pub(crate) async fn run_prompt_refine_job(
             system,
             prompt,
             sampling: TextLlmSampling {
-                temperature: 0.7,
+                temperature,
                 top_p: 0.9,
                 max_new_tokens,
                 seed: None,
@@ -366,7 +495,7 @@ pub(crate) async fn run_prompt_refine_job(
                                 JobStatus::Running,
                                 ProgressStage::Running,
                                 0.4 + 0.5 * within,
-                                "Refining prompt…",
+                                work_message,
                                 None,
                                 backend,
                             ),
@@ -390,7 +519,12 @@ pub(crate) async fn run_prompt_refine_job(
     let raw = blocking
         .await
         .map_err(|error| task_join_error("prompt refine task join", error))??;
-    let refined = clean_refine_output(&raw);
+    // Magic-prompt isolates the JSON object (the web parses + validates it); refine cleans to prose.
+    let refined = if is_magic {
+        clean_json_output(&raw)
+    } else {
+        clean_refine_output(&raw)
+    };
     if refined.is_empty() {
         return Err(WorkerError::Engine(
             "The prompt-refinement model returned an empty prompt.".to_owned(),
@@ -403,7 +537,7 @@ pub(crate) async fn run_prompt_refine_job(
             JobStatus::Completed,
             ProgressStage::Completed,
             1.0,
-            "Prompt refined.",
+            done_message,
             Some(refine_result(&original_prompt, &refined)),
             backend,
         ),
@@ -521,6 +655,120 @@ mod tests {
         assert_eq!(
             clean_refine_output("<think>scheming</think>A vivid neon street at midnight."),
             "A vivid neon street at midnight."
+        );
+    }
+
+    #[test]
+    fn magic_section_extracts_system_and_user_blocks() {
+        let system = magic_section("SYSTEM");
+        assert!(
+            system.contains("structured JSON caption"),
+            "system has the contract intro"
+        );
+        assert!(
+            system.contains("compositional_deconstruction"),
+            "system names the schema"
+        );
+        // The [META] block above [SYSTEM] is not leaked into the system body.
+        assert!(!system.contains("thinking_mode"));
+
+        let user = magic_section("USER");
+        assert!(
+            user.contains("{{aspect_ratio}}"),
+            "user template has the aspect-ratio placeholder"
+        );
+        assert!(
+            user.contains("{{original_prompt}}"),
+            "user template has the prompt placeholder"
+        );
+
+        assert_eq!(magic_section("DOES_NOT_EXIST"), "");
+    }
+
+    #[test]
+    fn build_magic_prompt_messages_substitutes_template() {
+        let (system, user) = build_magic_prompt_messages("a red fox in the snow", "16:9");
+        assert!(system.contains("OUTPUT CONTRACT"));
+        assert!(user.contains("16:9"));
+        assert!(user.contains("a red fox in the snow"));
+        // Both placeholders are consumed.
+        assert!(!user.contains("{{"));
+    }
+
+    #[test]
+    fn clean_json_output_isolates_the_object() {
+        // Leading/trailing prose from a small model is dropped.
+        assert_eq!(
+            clean_json_output("Here is the caption: {\"a\": 1} — hope that helps!"),
+            "{\"a\": 1}"
+        );
+        // Code fences + a think block are stripped.
+        assert_eq!(
+            clean_json_output("<think>plan</think>```json\n{\"a\": 1}\n```"),
+            "{\"a\": 1}"
+        );
+        // Already-clean object passes through.
+        assert_eq!(clean_json_output("{\"a\": [1, 2]}"), "{\"a\": [1, 2]}");
+    }
+
+    /// Real-weight magic-prompt smoke (sc-5997): expands a plain idea into a JSON caption through the
+    /// actual `prompt_refine` Llama-3.2-3B and asserts the cleaned reply parses with the caption's
+    /// required section. `#[ignore]` — the weights live outside CI; run on a Mac with the model
+    /// staged in the HF cache:
+    ///   cargo test -p sceneworks-worker --lib -- --ignored magic_prompt_expands
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "real-weight: needs the Llama-3.2-3B prompt-refine model in the HF cache"]
+    fn magic_prompt_expands_plain_text_to_caption() {
+        use gen_core::{
+            CancelFlag, LoadSpec, Progress, TextLlmRequest, TextLlmSampling, WeightsSource,
+        };
+
+        let home = std::env::var("HOME").expect("HOME");
+        let snapshots = std::path::Path::new(&home).join(
+            ".cache/huggingface/hub/models--huihui-ai--Llama-3.2-3B-Instruct-abliterated/snapshots",
+        );
+        let weights_dir = std::fs::read_dir(&snapshots)
+            .expect("prompt-refine model staged in the HF cache")
+            .flatten()
+            .map(|entry| entry.path())
+            .find(|path| path.is_dir())
+            .expect("a snapshot dir");
+
+        let refiner = gen_core::load_textllm(
+            PROMPT_REFINE_ENGINE_ID,
+            &LoadSpec::new(WeightsSource::Dir(weights_dir)),
+        )
+        .expect("load prompt_refine");
+
+        let (system, user) = build_magic_prompt_messages(
+            "a red fox sitting in a snowy forest at golden hour",
+            "1:1",
+        );
+        let request = TextLlmRequest {
+            system,
+            prompt: user,
+            sampling: TextLlmSampling {
+                temperature: 0.4,
+                top_p: 0.9,
+                max_new_tokens: 2048,
+                seed: None,
+            },
+            cancel: CancelFlag::new(),
+        };
+        let mut noop = |_progress: Progress| {};
+        let output = refiner.generate(&request, &mut noop).expect("generate");
+        let json = clean_json_output(&output.text);
+        eprintln!("magic-prompt JSON:\n{json}");
+
+        let parsed: Value = serde_json::from_str(&json).expect("a valid JSON object");
+        let cd = parsed
+            .get("compositional_deconstruction")
+            .expect("has compositional_deconstruction");
+        assert!(cd.get("background").is_some(), "has a background");
+        assert!(
+            cd.get("elements").map(Value::is_array).unwrap_or(false),
+            "elements is an array"
         );
     }
 


### PR DESCRIPTION
The last UI story for the Ideogram 4 epic (4725): a **magic-prompt** that expands a plain-text idea into a structured, editable Ideogram 4 caption using a **native local LLM** (offline-first), not a hosted API. It drives the **same `prompt_refine` utility model** (Llama-3.2-3B) with Ideogram's open-source magic-prompt system prompt — no new model to provision.

## Worker (`crates/sceneworks-worker`)
- **`ideogram_magic_prompt_v1.txt`** — Ideogram's magic-prompt system prompt, embedded verbatim (Apache-2.0, [ideogram-oss/ideogram4](https://github.com/ideogram-oss/ideogram4)).
- **`prompt_refine_jobs.rs`** — a `task: "magic_prompt"` mode on the existing refine job: parses the `[SYSTEM]`/`[USER]` sections, renders the user template with the aspect ratio + idea, runs the same `TextLlm` cooler (temp 0.4) with more tokens (2048), and isolates the JSON object from the reply (strip `<think>`/fences, take the outermost `{…}`). The refine path is unchanged. Unit tests for the section parser / template / JSON cleanup + an `#[ignore]` real-weight smoke.

## API (`apps/rust-api`)
`PromptRefineRequest` gains optional `task` + `aspectRatio`, passed through to the job payload.

## Web
- **`parseMagicPromptCaption`** — cleans the model reply into a schema-clean caption: drops the non-schema top-level `aspect_ratio` key the prompt emits and (by default, matching the reference) strips element bboxes the user places themselves. The caller validates via the sc-5993 contract.
- **`App.jsx` `magicPrompt`** — same `prompts/refine` endpoint + poll-to-completion, `task: "magic_prompt"`.
- **`StructuredPromptBuilder`** — a "✨ Expand to caption" control in the plain-text tab: expands the idea, applies the caption, and drops the user into the **editable** builder. Loading/error states + a download affordance when the utility model isn't installed.
- **`ImageStudio` `onMagicExpand`** — derives the aspect ratio from the resolution, calls `magicPrompt`, cleans + validates, and records the magic-prompt backend id (persisted in studio settings).

## Verification
- **Real-weight smoke RAN on the Mac**: the native Llama-3.2-3B expanded "a red fox sitting in a snowy forest at golden hour" into a valid caption with `high_level_description` + `compositional_deconstruction` (background + obj/text elements), 46s. The 3B output is serviceable-but-imperfect (a stray "transparent background", generic bboxes) — all stripped/edited in the builder; magic-prompt is the casual-prompt **bridge**, not the final answer.
- Worker unit tests + `clippy` green; web suite green (**505**), ESLint 0 errors, build clean.

## Scope note
The magic-prompt **backend id** is captured client-side (recorded + persisted, available to the sc-5993 `buildStructuredPromptRecipe`). Threading the full structured-prompt recipe (intent + caption + backend) through the job payload → asset recipe → "Use this recipe" restore is a separate lifecycle feature (not in this story's acceptance) and is **not** done here — flagged on the story, not buried.

Stacks on #739/#742/#743 (all merged). This completes the structured-prompt UI; remaining epic work is sc-5999 (private-repo gated-download credential) + sc-6000 (real-weight Mac e2e through the worker). sc-5995 stays archived (bbox canvas → epic 6087).

🤖 Generated with [Claude Code](https://claude.com/claude-code)