### PR TITLE
sc-5498: YOLO11 person_detect + ByteTrack person_track off-Mac via ort (CUDA/CPU EP)

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -5859,6 +5859,89 @@ mod candle_routing_tests {
         );
     }
 
+    // ---- Candle person detect/track lane (sc-5498) ----
+
+    /// A queued real (non-preview) `person_detect` job carrying `payload`.
+    fn person_detect_job(payload: Value) -> JobSnapshot {
+        serde_json::from_value(json!({
+            "id": "job_person_detect",
+            "type": "person_detect",
+            "status": "queued",
+            "payload": payload,
+            "result": {},
+            "requestedGpu": "auto",
+            "progress": 0,
+            "stage": "queued",
+            "message": "",
+            "attempts": 1,
+            "cancelRequested": false,
+            "createdAt": "2026-06-16T00:00:00Z",
+            "updatedAt": "2026-06-16T00:00:00Z",
+        }))
+        .expect("valid JobSnapshot")
+    }
+
+    /// A queued real (non-preview) `person_track` job carrying `payload`.
+    fn person_track_job(payload: Value) -> JobSnapshot {
+        serde_json::from_value(json!({
+            "id": "job_person_track",
+            "type": "person_track",
+            "status": "queued",
+            "payload": payload,
+            "result": {},
+            "requestedGpu": "auto",
+            "progress": 0,
+            "stage": "queued",
+            "message": "",
+            "attempts": 1,
+            "cancelRequested": false,
+            "createdAt": "2026-06-16T00:00:00Z",
+            "updatedAt": "2026-06-16T00:00:00Z",
+        }))
+        .expect("valid JobSnapshot")
+    }
+
+    /// sc-5498: the candle worker advertises `person_detect` + `person_track` (YOLO11 via the `ort`
+    /// CUDA EP + the pure-Rust ByteTrack) and claims both — the off-Mac sibling of the macOS
+    /// native-MLX path (sc-3633/sc-3634). Like kps_extract / pose_detect (and unlike SeedVR2), the
+    /// Python Ultralytics path CAN serve them, so there is NO torch-refusal gate: a co-resident
+    /// torch worker that advertises the capability still claims it (the candle worker just runs it
+    /// Python-free when it polls first; the Python path is retired wholesale in Phase 7, epic 5483).
+    /// A worker that never advertises the capability refuses the job. (These are the real,
+    /// non-preview jobs; the procedural `preview: true` path keys off the separate
+    /// `person_detect_preview` / `person_track_preview` capabilities.)
+    #[test]
+    fn candle_worker_claims_person_detect_and_track_no_torch_refusal() {
+        let payload = json!({ "projectId": "p", "sourceAssetId": "a" });
+        let candle = gpu_worker(&["gpu", "person_detect", "person_track", "candle"]);
+        assert!(
+            worker_supports_job(&candle, &person_detect_job(payload.clone())),
+            "candle worker should claim person_detect"
+        );
+        assert!(
+            worker_supports_job(&candle, &person_track_job(payload.clone())),
+            "candle worker should claim person_track"
+        );
+        let torch = gpu_worker(&["gpu", "person_detect", "person_track"]);
+        assert!(
+            worker_supports_job(&torch, &person_detect_job(payload.clone())),
+            "torch worker still claims person_detect (no refusal — it has the Ultralytics path)"
+        );
+        assert!(
+            worker_supports_job(&torch, &person_track_job(payload.clone())),
+            "torch worker still claims person_track (no refusal — it has the Ultralytics path)"
+        );
+        let no_cap = gpu_worker(&["gpu", "image_generate", "candle"]);
+        assert!(
+            !worker_supports_job(&no_cap, &person_detect_job(payload.clone())),
+            "a worker not advertising person_detect refuses it"
+        );
+        assert!(
+            !worker_supports_job(&no_cap, &person_track_job(payload)),
+            "a worker not advertising person_track refuses it"
+        );
+    }
+
     // ---- Candle caption lane (sc-5098) ----
 
     /// A queued `training_caption` job carrying `payload`.

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -108,6 +108,25 @@ fn with_candle_capabilities(mut gpu: DiscoveredGpu, settings: &Settings) -> Disc
             if !gpu.capabilities.contains(&WorkerCapability::PoseDetect) {
                 gpu.capabilities.push(WorkerCapability::PoseDetect);
             }
+            // YOLO11 person detection + selected-person ByteTrack tracking (sc-5498, epic 5482):
+            // the off-Mac sibling of the macOS native-MLX path (sc-3633/sc-3634) — `yolo11m.onnx`
+            // via `ort`/CUDA in `person_jobs` + the pure-Rust SORT/ByteTrack in `person_track`,
+            // serving `person_detect` (Replace-Person candidate boxes) + `person_track` (the
+            // reusable selected-person track). Job-type capabilities (not generation modalities),
+            // so they aren't in `registry_capabilities`; advertise them explicitly. Like
+            // kps_extract / pose_detect — and unlike SeedVR2 — the Python Ultralytics path CAN
+            // serve them, so there's NO torch-refusal gate: the candle worker claims them
+            // Python-free, with the co-resident torch worker as a fallback (retired wholesale in
+            // Phase 7, epic 5483). Person *segmentation* (SAM masks) is NOT ported off-Mac yet
+            // (epic 3792, sc-5062), so candle person tracks are box-only (`maskState = "missing"`).
+            for capability in [
+                WorkerCapability::PersonDetect,
+                WorkerCapability::PersonTrack,
+            ] {
+                if !gpu.capabilities.contains(&capability) {
+                    gpu.capabilities.push(capability);
+                }
+            }
             // The lane marker the routing gate keys off (mirrors the existing `nvidia` marker).
             gpu.capabilities
                 .push(WorkerCapability::Unknown("candle".to_owned()));

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -135,12 +135,21 @@ mod kps_jobs;
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 mod upscale_jobs;
-// YOLO11 person detection via onnxruntime/CoreML (epic 3482, sc-3488/sc-3633).
-// macOS-only like pose_jobs: the `ort` engine + CoreML EP only mean anything on
-// Apple Silicon, and the Python Ultralytics path stays the Windows/Linux backend.
-#[cfg(target_os = "macos")]
+// YOLO11 person detection + selected-person ByteTrack tracking (epic 3482, sc-3488/sc-3633;
+// off-Mac candle lane sc-5498, epic 5482). Native-MLX YOLO11m on Mac, `ort`/CUDA on the off-Mac
+// candle GPU-worker lane (the pure-Rust ByteTrack in `person_track` is backend-neutral). So both
+// modules compile on Mac AND the candle lane; on a candle-disabled box the Python Ultralytics
+// path stays the Windows/Linux backend. Person *segmentation* (SAM masks) stays Mac-only
+// (`person_segment*` below) — off-Mac tracks are box-only; a candle SAM backport is epic 3792.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 mod person_jobs;
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 mod person_track;
 // Native-MLX SAM2 person segmentation (epic 3704, sc-3709): the `mlx-gen-sam2`
 // box-prompt segmenter generates per-frame masks in `run_person_track`. macOS-only

--- a/crates/sceneworks-worker/src/media_jobs.rs
+++ b/crates/sceneworks-worker/src/media_jobs.rs
@@ -567,11 +567,15 @@ pub(crate) async fn run_person_detect(
     Ok(result)
 }
 
-/// Run the native MLX YOLO11 person detector on a rendered frame, returning the
-/// normalized detection array (Python `run_person_detect` shape) + the device
-/// the model ran on. macOS-only: MLX (mlx-rs) is the Apple-Silicon backend
-/// (epic 3482, sc-3633); the Python Ultralytics path serves Windows/Linux.
-#[cfg(target_os = "macos")]
+/// Run the YOLO11 person detector on a rendered frame, returning the normalized detection
+/// array (Python `run_person_detect` shape) + the device the model ran on. Available on Mac
+/// (native MLX, epic 3482 / sc-3633) AND the off-Mac candle GPU-worker lane (`ort`/CUDA,
+/// sc-5498); identical body — the platform backend is chosen inside `person_jobs`. On a
+/// candle-disabled box the Python Ultralytics path serves Windows/Linux (the stub below).
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 async fn run_yolo11_person_detect(
     api: &ApiClient,
     settings: &Settings,
@@ -600,7 +604,7 @@ async fn run_yolo11_person_detect(
     Ok((boxes, result.device))
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(all(not(target_os = "macos"), not(feature = "backend-candle")))]
 async fn run_yolo11_person_detect(
     _api: &ApiClient,
     _settings: &Settings,
@@ -619,16 +623,22 @@ async fn run_yolo11_person_detect(
 /// no frame at `duration` (the last decodable frame sits ~`1/fps` before it), and an
 /// `ffmpeg -ss duration` accurate seek then yields no output and fails the whole track.
 /// 0.2 s clears one frame for any clip ≥ 5 fps without meaningfully moving the sample.
-/// macOS-only, like its sole caller `assemble_real_person_track` (the Python Win/Linux
-/// path samples/extracts separately).
-#[cfg(target_os = "macos")]
+/// Available on Mac AND the off-Mac candle lane, like its sole caller
+/// `assemble_real_person_track` (the Python Win/Linux path samples/extracts separately).
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 const FRAME_SEEK_GUARD_SECONDS: f64 = 0.2;
 
 /// Clamp a sample timestamp to a frame-extraction seek that always lands on a real frame:
 /// never past `duration - FRAME_SEEK_GUARD_SECONDS`. Only the final inclusive-end sample is
 /// affected; every interior sample passes through unchanged. The tracker still records the
 /// logical sample time — only the seek used to pull pixels is clamped.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 pub(crate) fn frame_seek_timestamp(timestamp: f64, duration: f64) -> f64 {
     timestamp.min((duration - FRAME_SEEK_GUARD_SECONDS).max(0.0))
 }
@@ -1013,7 +1023,127 @@ fn write_track_mask_pngs(
     written
 }
 
-#[cfg(not(target_os = "macos"))]
+/// Track the selected person through real source content on the off-Mac candle GPU-worker lane
+/// (sc-5498): sample frames at the 2-FPS cadence, run the `ort`/CUDA YOLO11 detector on each,
+/// associate the boxes into track identities with the pure-Rust SORT/ByteTrack tracker
+/// (sc-3634, `person_track`), and resample the chosen identity onto the sample cadence. Person
+/// *segmentation* (SAM masks) is NOT ported off-Mac yet (epic 3792, sc-5062), so candle tracks
+/// are box-only — `maskState = "missing"` and the replacement loader derives box masks from the
+/// frames. Mirrors the macOS path minus the SAM pass; the Python Ultralytics path is the
+/// fallback on a candle-disabled box.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[allow(clippy::too_many_arguments)]
+async fn assemble_real_person_track(
+    api: &ApiClient,
+    settings: &Settings,
+    http_client: &reqwest::Client,
+    job: &JobSnapshot,
+    _project_path: &std::path::Path,
+    source_media_path: &std::path::Path,
+    detection: &Value,
+    _track_id: &str,
+    selected_timestamp: f64,
+    duration: f64,
+    confidence: f64,
+    _segment_enabled: bool,
+) -> WorkerResult<RealPersonTrack> {
+    use crate::person_track as pt;
+
+    let selected_box = pt::NormalizedBox::from_json(detection.get("box").unwrap_or(&Value::Null));
+    let download_context = DownloadContext {
+        api,
+        client: http_client,
+        settings,
+        job_id: &job.id,
+        cancel_message: "Person tracking canceled while fetching detector weights.",
+        fresh_download: false,
+    };
+    let weights = crate::person_jobs::ensure_detector_weights(settings, &download_context).await?;
+    let conf = confidence as f32;
+    let timestamps = pt::sample_timestamps(duration);
+
+    let work_dir = std::env::temp_dir().join(format!("sw-person-track-{}", job.id));
+    tokio::fs::create_dir_all(&work_dir).await?;
+
+    // The detector reports its real execution device per frame (cuda / cpu, per the `ort` EP).
+    let mut device = "cuda";
+    let mut per_frame: Vec<(f64, Vec<(pt::NormalizedBox, f64)>)> =
+        Vec::with_capacity(timestamps.len());
+    for (index, &timestamp) in timestamps.iter().enumerate() {
+        check_cancel(api, &job.id, "Person tracking canceled during sampling.").await?;
+        let frame_path = work_dir.join(format!("frame_{index:04}.png"));
+        let ffmpeg_context = FfmpegContext {
+            api,
+            settings,
+            job_id: &job.id,
+            cancel_message: "Person tracking canceled by user.",
+        };
+        render_frame_png(
+            "ffmpeg",
+            source_media_path,
+            &frame_path,
+            frame_seek_timestamp(timestamp, duration),
+            1280,
+            720,
+            Some(ffmpeg_context),
+        )
+        .await?;
+        let weights_for_frame = weights.clone();
+        let frame_for_task = frame_path.clone();
+        let result = tokio::task::spawn_blocking(move || {
+            crate::person_jobs::detect_people_blocking(weights_for_frame, frame_for_task, conf)
+        })
+        .await
+        .map_err(|error| task_join_error("person track detect task", error))??;
+        device = result.device;
+        let boxes = result
+            .detections
+            .iter()
+            .map(|d| {
+                (
+                    pt::xyxy_to_normalized(
+                        d.x1 as f64,
+                        d.y1 as f64,
+                        d.x2 as f64,
+                        d.y2 as f64,
+                        result.width,
+                        result.height,
+                    ),
+                    d.score as f64,
+                )
+            })
+            .collect::<Vec<_>>();
+        per_frame.push((timestamp, boxes));
+    }
+    let _ = tokio::fs::remove_dir_all(&work_dir).await;
+
+    let observations = pt::observe(per_frame);
+    let assembly = pt::assemble_track(&observations, selected_box, selected_timestamp, &timestamps);
+    if assembly.target_track_id.is_none() || assembly.detected_frames == 0 {
+        return Err(WorkerError::InvalidPayload(
+            "Selected person was not found in the source video. Re-run detection or adjust the selection."
+                .to_owned(),
+        ));
+    }
+
+    Ok(RealPersonTrack {
+        frames: pt::frames_to_json(&assembly.frames),
+        average_confidence: pt::average_confidence(&assembly.frames),
+        // Segmentation (SAM masks) is not ported off-Mac yet (epic 3792, sc-5062), so the track
+        // is box-only; the replacement loader derives box masks from these frames.
+        mask_state: "missing",
+        quality: assembly.quality,
+        tracker_meta: json!({
+            "backend": "candle",
+            "device": device,
+            "model": "yolo11m",
+            "tracker": "sort_bytetrack",
+            "segmenter": "disabled",
+        }),
+    })
+}
+
+#[cfg(all(not(target_os = "macos"), not(feature = "backend-candle")))]
 #[allow(clippy::too_many_arguments)]
 async fn assemble_real_person_track(
     _api: &ApiClient,

--- a/crates/sceneworks-worker/src/person_jobs.rs
+++ b/crates/sceneworks-worker/src/person_jobs.rs
@@ -1,29 +1,42 @@
-//! YOLO11 person detection on the Rust worker (epic 3482, sc-3488 slice 1 / sc-3633).
+//! YOLO11 person detection on the Rust worker (epic 3482, sc-3488 slice 1 / sc-3633;
+//! off-Mac candle lane sc-5498, epic 5482).
 //!
 //! Ports the Python `scene_worker/person_adapters.py` `_UltralyticsDetector`
-//! (Ultralytics `yolo11m.pt`, COCO class 0) to Rust so the Replace-Person
-//! detection step runs on a Python-free Mac.
+//! (Ultralytics `yolo11m.pt`, COCO class 0) to Rust so the Replace-Person detection +
+//! selected-person tracking steps run Python-free. The pure detector math (letterbox /
+//! decode / NMS / box normalization) is backend-neutral and unit-tested without weights;
+//! only the forward pass differs by platform:
 //!
-//! **Backend = native MLX (mlx-rs), not `ort`+CoreML** (Michael's call, 2026-06-08).
-//! The whole Mac stack is MLX (mlx-gen); and the `ort` CoreML EP *hangs indefinitely*
-//! in `commit_from_file` on the Ultralytics YOLO11 ONNX export, so the `ort` path was
-//! abandoned for this model. The YOLO11m forward pass is assembled here directly from
-//! `mlx_gen::nn` primitives (`conv2d`/`silu`/`upsample_nearest`) plus `mlx_rs::ops` for
-//! the CSP splits, depthwise convs, SPPF max-pool, C2PSA attention, and the DFL/anchor
-//! decode head — mirroring how DWPose (`pose_jobs`) lives in the worker rather than a
-//! new mlx-gen crate. Weights are the conv+BN-fused `yolo11m_fused_mlx.safetensors`
-//! (MLX `(out, kH, kW, in)` layout — loaded raw, no further transpose).
+//!  - **macOS = native MLX (mlx-rs)** (Michael's call, 2026-06-08). The whole Mac stack is
+//!    MLX (mlx-gen), and the `ort` CoreML EP *hangs indefinitely* in `commit_from_file` on
+//!    the Ultralytics YOLO11 ONNX export, so the `ort` path was abandoned for this model
+//!    *on CoreML*. The YOLO11m forward is assembled here from `mlx_gen::nn` primitives
+//!    (`conv2d`/`silu`/`upsample_nearest`) plus `mlx_rs::ops` for the CSP splits, depthwise
+//!    convs, SPPF max-pool, C2PSA attention, and the DFL/anchor decode head. Weights are the
+//!    conv+BN-fused `yolo11m_fused_mlx.safetensors` (MLX `(out, kH, kW, in)` layout — loaded
+//!    raw, no further transpose).
+//!  - **off-Mac (Windows/Linux candle GPU-worker lane) = `ort` + CUDA/CPU EP** (sc-5498).
+//!    The CoreML hang is CoreML-specific; onnxruntime's CUDA/CPU EPs run the canonical
+//!    `yolo11m.onnx` export fine. The session is built with the CUDA EP + `error_on_failure`
+//!    and falls back to a CPU session (reporting `device = "cpu"` honestly) — the same EP
+//!    pattern as DWPose (`pose_jobs`, sc-5496). The ONNX output is the SAME `(1,84,8400)`
+//!    channel-major tensor the MLX forward was reverse-engineered to reproduce, so the
+//!    shared `decode`/`nms`/`detections_to_json` consume both backends unchanged.
 //!
-//! macOS-only in practice: it gates with `pose_jobs`, and the Python Ultralytics path
-//! stays the Windows/Linux detector. The pure detector math (letterbox / decode / NMS /
-//! box normalization) is unit-tested without the weights; the forward pass is covered
-//! by an `#[ignore]` parity test against a captured per-block reference oracle.
+//! Available on macOS AND the off-Mac candle lane (it gates with `pose_jobs`/`kps_jobs`);
+//! on a candle-disabled box the Python Ultralytics path stays the Windows/Linux backend
+//! (the candle worker advertises `person_detect`/`person_track` while the Python path stays
+//! a co-resident fallback, retired wholesale in Phase 7, epic 5483). The MLX forward pass is
+//! covered by an `#[ignore]` parity test against a captured per-block reference oracle; the
+//! off-Mac `ort` lane by an `#[ignore]` GPU smoke. Person *segmentation* (SAM masks) is NOT
+//! ported here — off-Mac tracks are box-only (`maskState = "missing"`); a candle SAM backport
+//! is tracked separately (epic 3792, sc-5062).
 //!
 //! Pipeline (matched to the Ultralytics YOLO11 export — verified against the real
 //! `yolo11m.onnx` + `ultralytics.predict`):
-//!  - input `images` (1,640,640,3) f32 NHWC: letterbox to 640 (ratio=min(640/w,640/h),
-//!    pad 114 centered), RGB channel order, divided by 255. cv2 INTER_LINEAR half-pixel
-//!    sampling.
+//!  - input `images` f32 (1,640,640,3 NHWC on MLX / 1,3,640,640 NCHW on ort): letterbox to
+//!    640 (ratio=min(640/w,640/h), pad 114 centered), RGB channel order, divided by 255.
+//!    cv2 INTER_LINEAR half-pixel sampling.
 //!  - the forward produces `(1,84,8400)` channel-major: rows 0..4 = cx,cy,w,h in
 //!    letterbox px; rows 4..84 = 80 sigmoid class scores in [0,1] (no separate
 //!    objectness). Person = class 0 → channel 4.
@@ -39,21 +52,39 @@ use image::RgbImage;
 use serde_json::{json, Value};
 
 // CARVE-OUT(epic 3720): backend-specific; absorbed by Detector in Phase 6.
+// The native-MLX YOLO11m forward is the macOS backend.
+#[cfg(target_os = "macos")]
 use mlx_gen::nn::{conv2d, silu, upsample_nearest};
+#[cfg(target_os = "macos")]
 use mlx_gen::weights::Weights;
+#[cfg(target_os = "macos")]
 use mlx_gen::Result as MlxResult;
+#[cfg(target_os = "macos")]
 use mlx_rs::ops::indexing::TryIndexOp;
+#[cfg(target_os = "macos")]
 use mlx_rs::ops::{
     add, concatenate_axis, maximum, multiply, pad, sigmoid, softmax_axis, split, split_sections,
     subtract, sum_axis,
 };
+#[cfg(target_os = "macos")]
 use mlx_rs::Array;
+
+// The off-Mac (Windows/Linux candle GPU-worker lane) backend is `ort` (onnxruntime) with the
+// CUDA execution provider + a CPU fallback (sc-5498) — the same EP pattern as `pose_jobs`.
+#[cfg(not(target_os = "macos"))]
+use ort::execution_providers::CUDAExecutionProvider;
+#[cfg(not(target_os = "macos"))]
+use ort::session::Session;
+#[cfg(not(target_os = "macos"))]
+use ort::value::Tensor;
 
 use crate::{Settings, WorkerError, WorkerResult};
 
 /// Square detector input edge (the YOLO11 export is fixed 640×640).
 const DET: usize = 640;
-/// Total anchor count across the three detect scales (80²+40²+20²).
+/// Total anchor count across the three detect scales (80²+40²+20²). The MLX head builds its
+/// anchors against this; the off-Mac `ort` path reads the count from the ONNX output shape.
+#[cfg(target_os = "macos")]
 const ANCHORS: i32 = 8400;
 /// COCO "person" class index, matching Python `PERSON_CLASS_INDEX`.
 const PERSON_CLASS: usize = 0;
@@ -61,10 +92,17 @@ const PERSON_CLASS: usize = 0;
 const PAD_VALUE: f32 = 114.0;
 /// Greedy-NMS IoU threshold — Ultralytics `predict` default (`iou=0.7`).
 const NMS_IOU: f32 = 0.7;
-/// The fused MLX-layout detector weights in the app cache / model dir.
+/// The detector weights in the app cache / model dir: the fused MLX safetensors on macOS, the
+/// canonical ONNX export off-Mac (the `ort` lane, sc-5498).
+#[cfg(target_os = "macos")]
 const DET_FILE: &str = "yolo11m_fused_mlx.safetensors";
-/// Hugging Face repo for the fused MLX detector weights.
+/// Hugging Face repo for the detector weights (MLX safetensors on macOS / ONNX off-Mac).
+#[cfg(target_os = "macos")]
 const DET_REPO: &str = "SceneWorks/yolo11m-person-detect-mlx";
+#[cfg(not(target_os = "macos"))]
+const DET_FILE: &str = "yolo11m.onnx";
+#[cfg(not(target_os = "macos"))]
+const DET_REPO: &str = "SceneWorks/yolo11m-person-detect-onnx";
 // ---------------------------------------------------------------------------
 // pure detector math (unit-tested without weights)
 // ---------------------------------------------------------------------------
@@ -152,6 +190,7 @@ fn sample_rgb(img: &RgbImage, x: f32, y: f32, c: usize, border: f32) -> f32 {
 
 /// Build the (1,640,640,3) RGB `/255` letterboxed input in **NHWC** order (the layout
 /// `mlx_gen::nn::conv2d` expects) and return the geometry.
+#[cfg(target_os = "macos")]
 fn preprocess(img: &RgbImage) -> (Vec<f32>, Letterbox) {
     let lb = Letterbox::compute(img.width(), img.height());
     let (w, h) = (img.width() as f32, img.height() as f32);
@@ -319,6 +358,7 @@ pub(crate) fn detections_to_json(dets: &[Detection], frame_w: u32, frame_h: u32)
 /// points the parity oracle (`refs.safetensors`) checks. Block tensors stay NHWC; the
 /// oracle is NCHW, so the test transposes before comparing. The block fields exist only
 /// for the parity test — the production `detect_people` path reads `output` alone.
+#[cfg(target_os = "macos")]
 pub(crate) struct YoloForward {
     #[cfg_attr(not(test), allow(dead_code))]
     pub block4: Array,
@@ -335,6 +375,7 @@ pub(crate) struct YoloForward {
 
 /// Loaded YOLO11m detector: the fused MLX weights plus the precomputed detect anchors
 /// and strides (constant for the fixed 640 input).
+#[cfg(target_os = "macos")]
 struct Yolo {
     weights: Weights,
     anchor_x: Array,
@@ -342,6 +383,7 @@ struct Yolo {
     stride: Array,
 }
 
+#[cfg(target_os = "macos")]
 impl Yolo {
     fn load(path: &Path) -> WorkerResult<Self> {
         let weights = Weights::from_file(path)
@@ -682,9 +724,8 @@ impl Yolo {
     }
 }
 
-static DETECTOR: OnceLock<Mutex<Option<Yolo>>> = OnceLock::new();
-
-/// Person detections for one frame, plus the device the model ran on.
+/// Person detections for one frame, plus the device the model ran on. Backend-neutral —
+/// the macOS MLX path and the off-Mac `ort` path both return this.
 pub(crate) struct DetectResult {
     pub width: u32,
     pub height: u32,
@@ -692,8 +733,13 @@ pub(crate) struct DetectResult {
     pub device: &'static str,
 }
 
-/// Blocking person detection on a single rendered frame. The MLX model is loaded once
-/// and cached process-wide (like Python's lazy model load); invoke via `spawn_blocking`.
+#[cfg(target_os = "macos")]
+static DETECTOR: OnceLock<Mutex<Option<Yolo>>> = OnceLock::new();
+
+/// Blocking person detection on a single rendered frame (macOS native-MLX backend). The
+/// model is loaded once and cached process-wide (like Python's lazy model load); invoke
+/// via `spawn_blocking`.
+#[cfg(target_os = "macos")]
 pub(crate) fn detect_people_blocking(
     weights_path: PathBuf,
     image_path: PathBuf,
@@ -728,12 +774,158 @@ pub(crate) fn detect_people_blocking(
 }
 
 // ---------------------------------------------------------------------------
-// weights resolution + download-on-first-use
+// off-Mac onnxruntime YOLO11 detector (sc-5498) — the Windows/Linux candle-lane sibling
+// of the native-MLX forward above. Runs the canonical `yolo11m.onnx` export through `ort`
+// with the CUDA EP (+ CPU fallback) and feeds its `(1,84,8400)` output into the shared
+// `decode`/`nms` math, exactly as the MLX path does.
 // ---------------------------------------------------------------------------
 
-/// Resolve already-present fused MLX detector weights: explicit env pin
-/// (`SCENEWORKS_PERSON_DETECTOR_WEIGHTS`), then the app cache
-/// `<data_dir>/cache/person-detect/`, then the model dir
+/// Build the (1,3,640,640) RGB `/255` letterboxed input in **NCHW** order (the layout the
+/// `yolo11m.onnx` export expects) and return the geometry. Same letterbox + cv2 half-pixel
+/// sampling as the MLX `preprocess`, only the output channel order differs.
+#[cfg(not(target_os = "macos"))]
+fn preprocess_nchw(img: &RgbImage) -> (Vec<f32>, Letterbox) {
+    let lb = Letterbox::compute(img.width(), img.height());
+    let (w, h) = (img.width() as f32, img.height() as f32);
+    let new_w = (w * lb.ratio).round();
+    let new_h = (h * lb.ratio).round();
+    let sx = w / new_w.max(1.0);
+    let sy = h / new_h.max(1.0);
+    let new_w = new_w as usize;
+    let new_h = new_h as usize;
+    let pad_x = lb.pad_x as usize;
+    let pad_y = lb.pad_y as usize;
+
+    // NCHW: chw[c * DET * DET + y * DET + x].
+    let mut chw = vec![PAD_VALUE / 255.0; 3 * DET * DET];
+    for dy in 0..new_h {
+        let src_y = (dy as f32 + 0.5) * sy - 0.5; // cv2 INTER_LINEAR half-pixel
+        let y = dy + pad_y;
+        for dx in 0..new_w {
+            let src_x = (dx as f32 + 0.5) * sx - 0.5;
+            let x = dx + pad_x;
+            for c in 0..3 {
+                let v = sample_rgb(
+                    img,
+                    src_x.clamp(0.0, w - 1.0),
+                    src_y.clamp(0.0, h - 1.0),
+                    c,
+                    0.0,
+                );
+                chw[c * DET * DET + y * DET + x] = v / 255.0;
+            }
+        }
+    }
+    (chw, lb)
+}
+
+fn ort_err<R>(e: ort::Error<R>) -> WorkerError {
+    WorkerError::Engine(format!("onnxruntime: {e}"))
+}
+
+/// Build a YOLO11 session, optionally registering the CUDA EP before the CPU fallback.
+/// `accel == false` builds a plain CPU session. `error_on_failure` so a CUDA provider that
+/// can't initialise (no GPU, or a cuDNN/CUDA mismatch in the loaded onnxruntime) surfaces as
+/// an error here — `OrtYolo::load` then falls back to a CPU session and reports `device =
+/// "cpu"` honestly, instead of onnxruntime silently CPU-executing while we still claim CUDA
+/// (the same honesty contract as `pose_jobs::build_session`, sc-5496).
+#[cfg(not(target_os = "macos"))]
+fn build_session(path: &Path, accel: bool) -> WorkerResult<Session> {
+    let mut b = Session::builder().map_err(ort_err)?;
+    if accel {
+        b = b
+            .with_execution_providers([CUDAExecutionProvider::default().build().error_on_failure()])
+            .map_err(ort_err)?;
+    }
+    b.commit_from_file(path).map_err(ort_err)
+}
+
+/// Loaded ONNX YOLO11m detector: the `ort` session plus the device it runs on.
+#[cfg(not(target_os = "macos"))]
+struct OrtYolo {
+    session: Session,
+    device: &'static str,
+}
+
+#[cfg(not(target_os = "macos"))]
+impl OrtYolo {
+    /// Load the detector, preferring the CUDA EP and falling back to a CPU session if the
+    /// provider can't initialise (mirrors `pose_jobs::Detector::load`).
+    fn load(path: &Path) -> WorkerResult<Self> {
+        match build_session(path, true) {
+            Ok(session) => Ok(Self {
+                session,
+                device: "cuda",
+            }),
+            Err(_) => Ok(Self {
+                session: build_session(path, false)?,
+                device: "cpu",
+            }),
+        }
+    }
+
+    /// Detect every person in one frame → NMS'd boxes in original px.
+    fn detect_people(&mut self, img: &RgbImage, conf: f32) -> WorkerResult<Vec<Detection>> {
+        let (input, lb) = preprocess_nchw(img);
+        let tensor = Tensor::from_array(([1_i64, 3, DET as i64, DET as i64].to_vec(), input))
+            .map_err(ort_err)?;
+        let outputs = self.session.run(ort::inputs![tensor]).map_err(ort_err)?;
+        // The Ultralytics export has a single output `(1,84,8400)` channel-major — the SAME
+        // tensor the MLX forward was reverse-engineered to reproduce. Read its reported shape
+        // so `decode` indexes it correctly regardless of the exact class count.
+        let (shape, data) = outputs[0].try_extract_tensor::<f32>().map_err(ort_err)?;
+        let shape: Vec<i64> = shape.to_vec();
+        let raw = decode(data, &shape, &lb, conf, img.width(), img.height());
+        Ok(nms(raw, NMS_IOU))
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+static DETECTOR: OnceLock<Mutex<Option<OrtYolo>>> = OnceLock::new();
+
+/// Blocking person detection on a single rendered frame (off-Mac `ort`/CUDA backend). The
+/// session is loaded once and cached process-wide; invoke via `spawn_blocking`.
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn detect_people_blocking(
+    weights_path: PathBuf,
+    image_path: PathBuf,
+    conf: f32,
+) -> WorkerResult<DetectResult> {
+    let img = image::open(&image_path)
+        .map_err(|e| WorkerError::InvalidPayload(format!("person frame open: {e}")))?
+        .to_rgb8();
+    let (width, height) = (img.width(), img.height());
+
+    let cell = DETECTOR.get_or_init(|| Mutex::new(None));
+    // Recover from a poisoned lock instead of panicking every subsequent job (mirrors the
+    // macOS path): drop the possibly-corrupt cached session so the block below reloads.
+    let mut guard = cell.lock().unwrap_or_else(|poisoned| {
+        let mut guard = poisoned.into_inner();
+        *guard = None;
+        guard
+    });
+    if guard.is_none() {
+        *guard = Some(OrtYolo::load(&weights_path)?);
+    }
+    let detector = guard.as_mut().expect("detector loaded");
+    let device = detector.device;
+    let detections = detector.detect_people(&img, conf)?;
+    Ok(DetectResult {
+        width,
+        height,
+        detections,
+        device,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// weights resolution + download-on-first-use (backend-neutral: the macOS MLX safetensors
+// or the off-Mac ONNX export, selected by the cfg-split `DET_FILE`/`DET_REPO`)
+// ---------------------------------------------------------------------------
+
+/// Resolve already-present detector weights (the MLX safetensors on macOS / the ONNX export
+/// off-Mac, per `DET_FILE`): explicit env pin (`SCENEWORKS_PERSON_DETECTOR_WEIGHTS`), then the
+/// app cache `<data_dir>/cache/person-detect/`, then the model dir
 /// `<data_dir>/models/person-detect/`. Returns `None` when nothing is staged (then
 /// `ensure_detector_weights` downloads it).
 pub(crate) fn resolve_detector_weights(settings: &Settings) -> Option<PathBuf> {
@@ -752,8 +944,9 @@ pub(crate) fn resolve_detector_weights(settings: &Settings) -> Option<PathBuf> {
     None
 }
 
-/// Resolve the fused MLX detector weights, downloading them from HuggingFace on first
-/// use (into the app cache) with streaming progress/cancel and size-aware resume.
+/// Resolve the detector weights (MLX safetensors on macOS / ONNX export off-Mac, per
+/// `DET_REPO`/`DET_FILE`), downloading them from HuggingFace on first use (into the app cache)
+/// with streaming progress/cancel and size-aware resume.
 pub(crate) async fn ensure_detector_weights(
     settings: &Settings,
     context: &DownloadContext<'_>,

--- a/crates/sceneworks-worker/src/person_jobs.rs
+++ b/crates/sceneworks-worker/src/person_jobs.rs
@@ -819,6 +819,7 @@ fn preprocess_nchw(img: &RgbImage) -> (Vec<f32>, Letterbox) {
     (chw, lb)
 }
 
+#[cfg(not(target_os = "macos"))]
 fn ort_err<R>(e: ort::Error<R>) -> WorkerError {
     WorkerError::Engine(format!("onnxruntime: {e}"))
 }

--- a/crates/sceneworks-worker/src/person_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/person_jobs/tests.rs
@@ -6,9 +6,12 @@
 
 use super::*;
 // CARVE-OUT(epic 3720): backend-specific; absorbed by Detector in Phase 6.
+#[cfg(target_os = "macos")]
 use mlx_gen::weights::Weights;
+#[cfg(target_os = "macos")]
 use mlx_rs::Array;
 use std::path::PathBuf;
+#[cfg(target_os = "macos")]
 use tokio::io::AsyncWriteExt;
 
 #[test]
@@ -146,6 +149,7 @@ fn detections_to_json_normalizes_orders_and_drops_degenerate() {
 
 /// Cache fixtures staged during development (sc-3633): the exported detector,
 /// the bus.jpg test image, and the `ultralytics.predict` reference detections.
+#[cfg(target_os = "macos")]
 fn cache_fixture(name: &str) -> Option<PathBuf> {
     let home = std::env::var_os("HOME")?;
     let path = PathBuf::from(home)
@@ -156,6 +160,7 @@ fn cache_fixture(name: &str) -> Option<PathBuf> {
 
 /// Flatten an array to a contiguous f32 vec in logical row-major order (forces a copy
 /// of a transposed view), so two arrays of equal shape compare element-by-element.
+#[cfg(target_os = "macos")]
 fn flat(a: &Array) -> Vec<f32> {
     a.reshape(&[-1])
         .expect("flatten")
@@ -164,6 +169,7 @@ fn flat(a: &Array) -> Vec<f32> {
 }
 
 /// Max absolute difference between two equally-shaped arrays.
+#[cfg(target_os = "macos")]
 fn max_abs_diff(got: &Array, want: &Array) -> f32 {
     assert_eq!(got.shape(), want.shape(), "shape mismatch");
     flat(got)
@@ -179,6 +185,7 @@ fn max_abs_diff(got: &Array, want: &Array) -> f32 {
 /// the (separately-verified) letterbox/decode/NMS math. Ignored by default — run with the
 /// fused weights + oracle staged in the app cache:
 ///   cargo test -p sceneworks-worker person_jobs -- --ignored --nocapture
+#[cfg(target_os = "macos")]
 #[test]
 #[ignore = "requires staged yolo11m_fused_mlx.safetensors + refs.safetensors in the app cache"]
 fn yolo11_mlx_forward_matches_reference_oracle() {
@@ -261,6 +268,7 @@ fn yolo11_mlx_forward_matches_reference_oracle() {
 /// extended oracle staged:
 ///   cargo test -p sceneworks-worker person_jobs::tests::yolo11_mlx_per_block_isolation \
 ///     -- --ignored --nocapture --test-threads=1
+#[cfg(target_os = "macos")]
 #[test]
 #[ignore = "requires staged yolo11m_fused_mlx.safetensors + refs_ext.safetensors in the app cache"]
 fn yolo11_mlx_per_block_isolation() {
@@ -448,6 +456,7 @@ fn yolo11_mlx_per_block_isolation() {
 /// reproduce `ultralytics.predict`'s 4 people on the staged photo. Ignored by default —
 /// run with the model + fixtures staged in the app cache:
 ///   cargo test -p sceneworks-worker person_jobs -- --ignored --nocapture
+#[cfg(target_os = "macos")]
 #[test]
 #[ignore = "requires staged yolo11m_fused_mlx.safetensors + people.jpg fixtures in the app cache"]
 fn yolo11_matches_ultralytics_reference_on_photo() {
@@ -513,6 +522,7 @@ fn yolo11_matches_ultralytics_reference_on_photo() {
 /// people. Validates the URL + that the hosted artifact is the right weights.
 /// Ignored by default (network); run with the people.jpg fixture staged:
 ///   cargo test -p sceneworks-worker person_jobs -- --ignored --nocapture
+#[cfg(target_os = "macos")]
 #[test]
 #[ignore = "network: downloads the fused weights from HuggingFace"]
 fn yolo11_downloads_and_detects_from_huggingface() {
@@ -555,4 +565,54 @@ fn yolo11_downloads_and_detects_from_huggingface() {
         4,
         "4 people from downloaded weights"
     );
+}
+
+/// sc-5498 off-Mac GPU smoke (ignored — needs the real `yolo11m.onnx` + CUDA). Validates the
+/// Windows/Linux candle YOLO11 person-detect lane end-to-end: load the detector through the
+/// off-Mac `ort` path, run it on a person photo, and confirm it engages the hardware EP (or CPU
+/// fallback), finds ≥1 person, and decodes a sane normalized box. The numeric parity vs the
+/// Ultralytics reference was established for the model itself (the MLX forward reproduces
+/// `ultralytics.predict`'s boxes from the same `(1,84,8400)` export); this proves the off-Mac
+/// `ort` path produces faithful output through the shared decode/NMS. Stage a yolo11m.onnx +
+/// image via env (the env pin `resolve_detector_weights` honors), then:
+///   cargo test -p sceneworks-worker --features backend-candle --lib -- --ignored person_detect_candle
+#[cfg(not(target_os = "macos"))]
+#[test]
+#[ignore]
+fn person_detect_candle_real_weights_finds_person() {
+    let weights = std::env::var("SCENEWORKS_PERSON_DETECTOR_WEIGHTS")
+        .expect("set SCENEWORKS_PERSON_DETECTOR_WEIGHTS to a yolo11m.onnx export");
+    let img = std::env::var("SCENEWORKS_TEST_PERSON_IMAGE")
+        .expect("set SCENEWORKS_TEST_PERSON_IMAGE to a person photo");
+
+    let result = detect_people_blocking(PathBuf::from(weights), PathBuf::from(img), 0.25)
+        .expect("detect_people_blocking");
+    eprintln!(
+        "YOLO11 person-detect device = {} detections = {}",
+        result.device,
+        result.detections.len()
+    );
+    assert!(
+        !result.detections.is_empty(),
+        "expected at least one detected person"
+    );
+
+    // Boxes normalize into [0,1]; confidence-descending; degenerate boxes dropped.
+    let json = detections_to_json(&result.detections, result.width, result.height);
+    assert!(
+        !json.is_empty(),
+        "expected at least one normalized detection"
+    );
+    let top = &json[0];
+    eprintln!("top detection = {top}");
+    let b = &top["box"];
+    for key in ["x", "y", "width", "height"] {
+        let v = b[key].as_f64().unwrap();
+        assert!(
+            (0.0..=1.0).contains(&v),
+            "normalized box {key} out of [0,1]: {v}"
+        );
+    }
+    assert!(b["width"].as_f64().unwrap() > 0.0 && b["height"].as_f64().unwrap() > 0.0);
+    assert_eq!(top["maskState"], "missing");
 }


### PR DESCRIPTION
Wires Replace-Person **YOLO11 detection + selected-person tracking** onto the off-Mac candle GPU-worker lane (sc-5498, epic 5482 — Candle Phase 5 CV-aux), retiring the Python `ultralytics`/`lap` `person_adapters.py` path off-Mac. Third CV-aux slice after sc-5497 (kps_extract) and sc-5496 (DWPose).

## What
- **person_jobs.rs** — cfg-split. macOS keeps the native-MLX YOLO11m forward; off-Mac adds an `ort` + CUDA/CPU detector (`preprocess_nchw` + `OrtYolo`) that feeds the **shared, already unit-tested** `decode`/`nms`/`detections_to_json`. The canonical `yolo11m.onnx` export emits the SAME `(1,84,8400)` tensor the MLX forward was reverse-engineered to reproduce, so the post-processing is identical across backends. CUDA EP registered with `.error_on_failure()` → honest CPU fallback (device label reports `cpu`, not a fake `cuda`). `DET_FILE`/`DET_REPO` cfg-split (onnx vs mlx safetensors).
- **person_track.rs** — the pure-Rust SORT/ByteTrack tracker is backend-neutral; just compiled on the candle lane (no body change).
- **lib.rs** — widen `mod person_jobs`/`mod person_track` to the candle cfg (the `PersonDetect`/`PersonTrack` dispatch arms were already unconditional).
- **media_jobs.rs** — real `run_yolo11_person_detect` on the candle lane + a candle `assemble_real_person_track` (detect+track, no SAM segmentation → `maskState=missing`, `backend=candle`); stubs narrowed to non-candle off-Mac.
- **gpu.rs** — candle worker advertises `PersonDetect` + `PersonTrack` (no torch-refusal — the Python Ultralytics path can serve them, like kps_extract/pose_detect).

## Not in scope
Person **segmentation** (SAM masks) is not ported off-Mac yet (epic 3792, **sc-5062**), so candle person tracks are **box-only** — the replacement loader derives box masks. This matches how the Python path degrades when SAM2 is unavailable.

## Validation
- Default worker clippy `-D warnings` (stub path; `ort` **absent** from the default tree → the NSIS default sidecar never pulls onnxruntime).
- `backend-candle` clippy `--all-targets -D warnings` — clean; **single gen-core rev `7b89d456`, no skew** (candle-gen `18c1c89f`).
- Core `jobs_store` routing test (candle claims both, torch also claims/no refusal, cap-less refuses); `fmt` clean; **Cargo.lock unchanged** (ort/zip already locked from sc-5496).
- **GPU smoke off-Mac on an RTX PRO 6000** (`ort` CPU EP): real `yolo11m.onnx` → **1 confident person** (conf 0.90, full-body box normalized into [0,1], `maskState=missing`).

> Note (parity with sc-5496): the smoke ran on the `ort` **CPU EP** — the borrowed onnxruntime is a CPU build, and the detector's `error_on_failure` CUDA→CPU fallback reports `cpu` honestly. CUDA acceleration is a runtime onnxruntime-gpu **provisioning** matter (same follow-up as sc-5496), not a code defect; the Python path this retires is itself CPU off-Mac, so this ships at parity + Python-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)