### PR TITLE
sc-5487: route candle Qwen-Image-Edit into the worker (closes epic 5480)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -519,7 +519,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -530,7 +530,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -557,7 +557,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -569,7 +569,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -580,7 +580,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -597,7 +597,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -611,7 +611,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -629,7 +629,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -640,7 +640,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -653,7 +653,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -664,7 +664,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -677,7 +677,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=18c1c89ff512a93ea15bb593f826b7171d60417e#18c1c89ff512a93ea15bb593f826b7171d60417e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
 dependencies = [
  "candle-core",
  "candle-gen",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3323,6 +3323,19 @@ fn image_job_is_candle_eligible(job: &JobSnapshot) -> bool {
     {
         return true;
     }
+    // Qwen-Image-Edit reference / dual-latent edit (sc-5487, epic 5480): a non-lightning Qwen-Image-Edit
+    // `edit_image` job with a source image is the bespoke candle `QwenEdit` lane
+    // (`generate_candle_qwen_edit_stream`), NOT txt2img — and `qwen_image_edit*` are not candle txt2img
+    // ids (the gate below only knows `qwen_image`), so they would fall through to torch. Branch it out
+    // first. Off-Mac this was a torch fallback. The `-2511_lightning` distill needs a LoRA the candle
+    // provider lacks, so it is excluded (stays MLX/torch). Mirrors the worker's `qwen_edit_candle_available`.
+    if matches!(
+        model,
+        "qwen_image_edit" | "qwen_image_edit_2509" | "qwen_image_edit_2511"
+    ) && qwen_edit_candle_eligible(&job.payload)
+    {
+        return true;
+    }
     // SDXL IP-Adapter-Plus reference conditioning (sc-5488, epic 5480): an sdxl-family model with a
     // reference image is a bespoke candle lane (`generate_candle_sdxl_ipadapter_stream`), NOT txt2img —
     // the `image_request_candle_eligible` gate below rejects `referenceAssetId`. Branch it out first
@@ -3676,6 +3689,22 @@ fn sdxl_edit_candle_eligible(payload: &Map<String, Value>) -> bool {
 /// worker's `flux2_edit_candle_available` gate (minus the local weight-resolve check) so the router and
 /// worker agree. Candle-only — macOS keeps the MLX `flux2_klein_9b_edit` registry path.
 fn flux2_edit_candle_eligible(payload: &Map<String, Value>) -> bool {
+    if payload.get("mode").and_then(Value::as_str) != Some("edit_image") {
+        return false;
+    }
+    payload
+        .get("sourceAssetId")
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.trim().is_empty())
+}
+
+/// Qwen-Image-Edit candle-routing conditions (sc-5487, epic 5480). The candle `QwenEdit` provider
+/// serves `edit_image` mode with a `sourceAssetId` on the non-lightning Qwen-Image-Edit family —
+/// dual-latent reference editing (no mask / inpaint / outpaint; that masked shape is the SDXL edit
+/// lane's). Same payload predicate as `flux2_edit_candle_eligible`, gated to the qwen-edit family by the
+/// caller. Mirrors the worker's `qwen_edit_candle_available` gate (minus the local weight-resolve check)
+/// so the router and worker agree. Candle-only — macOS keeps the MLX `qwen_image_edit` registry path.
+fn qwen_edit_candle_eligible(payload: &Map<String, Value>) -> bool {
     if payload.get("mode").and_then(Value::as_str) != Some("edit_image") {
         return false;
     }
@@ -5231,6 +5260,38 @@ mod candle_routing_tests {
             "model": "flux2_klein_9b_kv",
             "mode": "edit_image",
             "sourceAssetId": "asset_1"
+        }))));
+        // sc-5487: a Qwen-Image-Edit edit (`edit_image` + a source) is now the candle `QwenEdit` lane
+        // (dual-latent reference editing). Off-Mac this was a torch fallback; the candle worker CLAIMS
+        // it for the non-lightning variants (all map to the single edit engine model).
+        for model in [
+            "qwen_image_edit",
+            "qwen_image_edit_2509",
+            "qwen_image_edit_2511",
+        ] {
+            assert!(
+                worker_supports_job(
+                    &candle,
+                    &image_generate_job(json!({
+                        "model": model,
+                        "mode": "edit_image",
+                        "sourceAssetId": "asset_1"
+                    }))
+                ),
+                "candle worker should claim {model} edit (sc-5487)"
+            );
+        }
+        // The -2511_lightning distill needs the 4-step LoRA the candle provider lacks → NOT claimed by
+        // candle; it stays on the MLX/torch path.
+        assert!(!image_job_is_candle_eligible(&image_generate_job(json!({
+            "model": "qwen_image_edit_2511_lightning",
+            "mode": "edit_image",
+            "sourceAssetId": "asset_1"
+        }))));
+        // A Qwen-Image-Edit job with no source image is not the edit lane → not claimed (would defer).
+        assert!(!image_job_is_candle_eligible(&image_generate_job(json!({
+            "model": "qwen_image_edit",
+            "mode": "edit_image"
         }))));
     }
 

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -131,6 +131,12 @@ sceneworks-core = { path = "../sceneworks-core" }
 # candle-gen main (an ancestor of the #90 merge 7b4d15e). candle-gen #90 is SOURCE-ONLY (gen-core stays
 # 7b89d45, byte-identical), so this is a pure candle rev bump and the backend-candle graph stays single
 # gen-core rev 7b89d45.
+# Rev 18c1c89 -> bcd94ad (candle-gen #91, sc-5487): adds the `candle-gen-qwen-image::QwenEdit`
+# Qwen-Image-Edit provider (Qwen2.5-VL vision encoder + dual-latent edit) that the sc-5487 Qwen worker
+# route (image_jobs/qwen_edit_candle.rs) consumes. bcd94ad is candle-gen #91's branch HEAD (the encoder
+# commit 4449260 + the provider commit bcd94ad); pre-merge of #91 this points at the branch SHA — flip to
+# the merged candle-gen main rev once #91 lands. candle-gen #91 is SOURCE-ONLY (gen-core stays 7b89d45,
+# byte-identical), so the backend-candle graph stays single gen-core rev 7b89d45 (no skew).
 sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -792,38 +798,38 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89
 # (the delta is the single additive sc-6038 mlx-gen-instantid commit), so behavior-neutral. The candle
 # SDXL edit worker route (`image_jobs/sdxl_edit_candle.rs`) drives candle-gen-sdxl's `SdxlEdit` off-Mac.
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -832,19 +838,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -853,12 +859,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -866,7 +872,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -875,7 +881,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -883,7 +889,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -892,7 +898,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "18c1c89ff512a93ea15bb593f826b7171d60417e", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -200,6 +200,12 @@ use candle_gen_flux::{IpAdapterFlux, IpAdapterFluxPaths, IpAdapterFluxRequest};
 // named-type import the bespoke pose route (`image_jobs/qwen_control.rs`) drives.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_qwen_image::{QwenControl, QwenControlPaths, QwenControlRequest};
+// Qwen-Image-Edit provider (sc-5487, epic 5480) — the candle (Windows/CUDA) reference-edit lane (the
+// last family of sc-5487; SDXL + FLUX.2-klein edit already shipped). Candle-only: macOS keeps the MLX
+// `qwen_image_edit` registry path. The named-type import the bespoke edit route
+// (`image_jobs/qwen_edit_candle.rs`) drives.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+use candle_gen_qwen_image::{QwenEdit, QwenEditPaths, QwenEditRequest};
 // Kolors ControlNet (strict pose) provider (sc-5489, epic 5480) — the candle (Windows/CUDA) Kolors
 // sibling of the Qwen strict-pose lane, living in `candle-gen-kolors` (it reuses candle-gen-sdxl's
 // vendored UNet + the SDXL `ControlNet`, with the Kolors ChatGLM3 conditioning + leading-Euler sampler).
@@ -549,6 +555,23 @@ pub(crate) async fn run_image_generate_job(
         // before this an off-Mac klein edit had no real lane (it deferred to a torch worker that lacks
         // the model). Disjoint from the IP-Adapter / SDXL-edit lanes (different model family).
         generate_candle_flux2_edit_stream(
+            api,
+            settings,
+            job,
+            &plan,
+            &project_path,
+            backend,
+            &mut asset_writes,
+        )
+        .await?;
+        true
+    } else if settings.backend_candle_enabled && qwen_edit_candle_available(&request, settings) {
+        // Qwen-Image-Edit reference / dual-latent edit (sc-5487) — checked BEFORE `is_candle_engine`.
+        // `qwen_image_edit` is its OWN model id (not the `qwen_image` candle txt2img id), so it would
+        // not be caught by the txt2img branch; routed here (grouped with the edit lanes) to the bespoke
+        // candle `QwenEdit` stream. Off-Mac this was a torch fallback; candle now serves it. Disjoint
+        // from the Qwen strict-pose control lane below (that one is `qwen_image` + `advanced.poses`).
+        generate_candle_qwen_edit_stream(
             api,
             settings,
             job,
@@ -1179,6 +1202,11 @@ include!("image_jobs/sdxl_edit_candle.rs");
 // provider, so this is candle-exclusive.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 include!("image_jobs/flux2_edit_candle.rs");
+// Qwen-Image-Edit reference / dual-latent edit — the Windows/CUDA candle lane ONLY (sc-5487). macOS keeps
+// the MLX Qwen-Image-Edit path (qwen.rs); the candle `QwenEdit` is a bespoke provider, so this is
+// candle-exclusive.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+include!("image_jobs/qwen_edit_candle.rs");
 // Kolors IP-Adapter-Plus reference conditioning — the Windows/CUDA candle lane ONLY (sc-5488). macOS
 // keeps the MLX Kolors IP path (kolors.rs, the registry `Reference` route); the candle `IpAdapterKolors`
 // is a bespoke provider, so this is candle-exclusive.

--- a/crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs
@@ -1,0 +1,259 @@
+// Candle (Windows/CUDA) Qwen-Image-Edit route (sc-5487, epic 5480) — reference-conditioned image
+// editing on the Qwen-Image-Edit family off-Mac via `candle_gen_qwen_image::QwenEdit`. The reference
+// + edit prompt go through the Qwen2.5-VL vision-language encoder, the reference is VAE-encoded into
+// the transformer's dual-latent sequence, and the MMDiT denoises a reference-respecting edit. Before
+// this an off-Mac `edit_image` job on a Qwen-Image-Edit model fell back to the Python torch worker.
+//
+// **Candle-only.** macOS keeps the MLX `qwen_image_edit` registry path (qwen.rs). The candle `QwenEdit`
+// is a bespoke provider, so this whole file is gated to the Windows/CUDA candle build (the `include!`
+// in image_jobs.rs carries the cfg). It is `include!`d into the `image_jobs` module, so it shares that
+// module's imports (ImageRequest/Settings/WorkerResult/`load_reference_image`/`huggingface_snapshot_dir`/
+// `resolve_app_managed_model_dir`/`resolve_seed`/`start_gen_stream`/`drive_gen_items`/
+// `consume_gen_events`/`non_empty`/`gen_core`/… all in scope).
+//
+// Qwen-Image-Edit is a dual-latent reference concat (NOT strength-img2img + mask): the source is the
+// reference, the prompt is the instruction. So this lane handles `edit_image` + `sourceAssetId` (no
+// sub-modes / inpaint / outpaint — that masked shape is the SDXL edit lane's). The provider
+// condition-resizes the reference internally (~384²), so — unlike the FLUX.2 lane — the source is NOT
+// pre-fit to the render size.
+
+/// Qwen-Image-Edit denoise steps default (the production, non-distilled variants).
+const QWEN_EDIT_CANDLE_DEFAULT_STEPS: u32 = 30;
+/// True-CFG guidance default.
+const QWEN_EDIT_CANDLE_DEFAULT_GUIDANCE: f32 = 4.0;
+/// The adapter/engine id recorded on candle Qwen-Image-Edit assets + telemetry.
+const QWEN_EDIT_CANDLE_ENGINE: &str = "candle_qwen_edit";
+/// Default Qwen-Image-Edit base repo when the manifest omits `repo`.
+const QWEN_EDIT_CANDLE_DEFAULT_REPO: &str = "Qwen/Qwen-Image-Edit";
+
+/// Qwen-Image-Edit model ids the candle edit route accepts. All non-lightning variants map to the
+/// single edit engine model (the architecture is identical; `-2511` only flips `zero_cond_t`, which
+/// `QwenEdit` auto-detects from `transformer/config.json`). The `-2511_lightning` distill needs the
+/// 4-step LoRA — `QwenEdit` has no LoRA support — so it stays on the MLX / torch path.
+fn is_qwen_edit_candle_model(model: &str) -> bool {
+    matches!(
+        model,
+        "qwen_image_edit" | "qwen_image_edit_2509" | "qwen_image_edit_2511"
+    )
+}
+
+/// True when this is a candle-eligible Qwen edit job: a Qwen-Image-Edit `edit_image` job with a source
+/// image. Mirrors `jobs_store::qwen_edit_candle_eligible` so the worker and router agree on the lane.
+fn qwen_edit_candle_mode(request: &ImageRequest) -> bool {
+    request.mode == "edit_image" && non_empty(&request.source_asset_id)
+}
+
+/// The Qwen-Image-Edit base repo for this request: manifest `repo` else the default.
+fn qwen_edit_candle_repo(request: &ImageRequest) -> String {
+    request
+        .model_manifest_entry
+        .get("repo")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(QWEN_EDIT_CANDLE_DEFAULT_REPO)
+        .to_owned()
+}
+
+/// Resolve the Qwen-Image-Edit base snapshot: an explicit `modelPath` dir (advanced or manifest) wins,
+/// else the HF cache snapshot for the manifest `repo`. `None` means the base is not present locally, so
+/// the job is not candle-runnable. Mirrors `resolve_flux2_edit_candle_base`.
+fn resolve_qwen_edit_candle_base(
+    request: &ImageRequest,
+    settings: &Settings,
+) -> WorkerResult<Option<PathBuf>> {
+    if let Some(path) = request
+        .advanced
+        .get("modelPath")
+        .or_else(|| request.model_manifest_entry.get("modelPath"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+    {
+        return resolve_app_managed_model_dir(settings, &path, "Qwen edit modelPath").map(Some);
+    }
+    let repo = qwen_edit_candle_repo(request);
+    Ok(huggingface_snapshot_dir(&settings.data_dir, &repo))
+}
+
+/// True when this is a candle-eligible Qwen edit job (a Qwen-Image-Edit `edit_image` job with a source)
+/// whose base resolves locally. Mirrors `jobs_store::qwen_edit_candle_eligible` (minus the weight-
+/// resolve check).
+fn qwen_edit_candle_available(request: &ImageRequest, settings: &Settings) -> bool {
+    is_qwen_edit_candle_model(&request.model)
+        && qwen_edit_candle_mode(request)
+        && matches!(resolve_qwen_edit_candle_base(request, settings), Ok(Some(_)))
+}
+
+/// Resolve denoise steps: `advanced.steps` (clamped 1..=50) → manifest `steps` → default (30).
+fn qwen_edit_candle_steps(request: &ImageRequest) -> u32 {
+    let parse = |value: &Value| {
+        value
+            .as_u64()
+            .or_else(|| value.as_str()?.trim().parse().ok())
+    };
+    request
+        .advanced
+        .get("steps")
+        .and_then(parse)
+        .or_else(|| request.model_manifest_entry.get("steps").and_then(parse))
+        .map(|steps| steps.clamp(1, 50) as u32)
+        .unwrap_or(QWEN_EDIT_CANDLE_DEFAULT_STEPS)
+}
+
+/// Resolve guidance: `advanced.guidanceScale` → manifest `guidanceScale` → default (4.0), clamped.
+fn qwen_edit_candle_guidance(request: &ImageRequest) -> f32 {
+    let manifest_default = request
+        .model_manifest_entry
+        .get("guidanceScale")
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .map(|value| value as f32)
+        .unwrap_or(QWEN_EDIT_CANDLE_DEFAULT_GUIDANCE);
+    advanced::f32_clamped(
+        &request.advanced,
+        "guidanceScale",
+        manifest_default,
+        0.0..=30.0,
+    )
+}
+
+/// Flat telemetry recorded on candle Qwen-Image-Edit assets.
+fn qwen_edit_candle_raw_settings(
+    request: &ImageRequest,
+    repo: &str,
+    steps: u32,
+    guidance: f32,
+) -> JsonObject {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("repo".to_owned(), Value::String(repo.to_owned()));
+    raw.insert("numInferenceSteps".to_owned(), json!(steps));
+    raw.insert("guidanceScale".to_owned(), json!(guidance));
+    raw.insert("referenceCount".to_owned(), json!(1));
+    raw.insert(
+        "editEngine".to_owned(),
+        Value::String(QWEN_EDIT_CANDLE_ENGINE.to_owned()),
+    );
+    raw
+}
+
+/// Load the Qwen edit source asset (the `sourceAssetId` is required) as an engine [`Image`].
+fn load_qwen_edit_source(
+    request: &ImageRequest,
+    project_path: &Path,
+    settings: &Settings,
+) -> WorkerResult<Image> {
+    let source_id = request
+        .source_asset_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload("Qwen edit requires a source image".to_owned())
+        })?;
+    load_reference_image(
+        &settings.data_dir,
+        &request.project_id,
+        source_id,
+        project_path,
+    )
+}
+
+/// Real candle Qwen-Image-Edit generation: resolve the source + base on the async side, then load
+/// `QwenEdit` once + generate each image on the blocking thread. The provider condition-resizes the
+/// reference internally, so the source is passed as-is (no render-size pre-fit). `request.count` edits
+/// of the same source, each its own seed. `generate` takes `&self`, so the per-item closure needs no
+/// `mut`. Reuses [`consume_gen_events`].
+async fn generate_candle_qwen_edit_stream(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+    let qwen_base = resolve_qwen_edit_candle_base(request, settings)?
+        .ok_or_else(|| WorkerError::InvalidPayload("Qwen-Image-Edit base not found".to_owned()))?;
+    if !qwen_edit_candle_mode(request) {
+        return Err(WorkerError::InvalidPayload(
+            "Qwen edit requires edit_image mode + a source image".to_owned(),
+        ));
+    }
+    let (width, height) = (request.width, request.height);
+    let reference = load_qwen_edit_source(request, project_path, settings)?;
+
+    let steps = qwen_edit_candle_steps(request);
+    let guidance = qwen_edit_candle_guidance(request);
+    let repo = qwen_edit_candle_repo(request);
+    let raw_settings = qwen_edit_candle_raw_settings(request, &repo, steps, guidance);
+
+    // Per-image work items: (seed, prompt) — `request.count` edits of the same source.
+    let work: Vec<(i64, String)> = (0..request.count as usize)
+        .map(|index| (resolve_seed(request, index), request.prompt.clone()))
+        .collect();
+    let total = work.len();
+    let negative = request.negative_prompt.clone();
+
+    let (cancel, rx, blocking) = start_gen_stream(
+        job.id.clone(),
+        "qwen_edit",
+        0,
+        move || {
+            let model = QwenEdit::load(&QwenEditPaths { root: qwen_base })
+                .map_err(|error| WorkerError::Engine(format!("Qwen edit load failed: {error}")))?;
+            Ok((model, reference))
+        },
+        move |(model, reference), tx, cancel| {
+            drive_gen_items(tx, work, move |_index, (seed, prompt), on_progress| {
+                if cancel.is_cancelled() {
+                    return Ok(None);
+                }
+                let req = QwenEditRequest {
+                    prompt,
+                    negative: negative.clone(),
+                    width,
+                    height,
+                    steps: steps as usize,
+                    guidance,
+                    seed: seed as u64,
+                    cancel: cancel.clone(),
+                };
+                let result = model.generate(&req, std::slice::from_ref(&reference), &mut *on_progress);
+                let out = match result {
+                    Ok(out) => out,
+                    Err(_) if cancel.is_cancelled() => return Ok(None),
+                    Err(error) => {
+                        return Err(WorkerError::Engine(format!(
+                            "Qwen edit generation failed: {error}"
+                        )));
+                    }
+                };
+                Ok(Some((seed, out.width, out.height, out.pixels)))
+            })
+        },
+    );
+
+    consume_gen_events(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        QWEN_EDIT_CANDLE_ENGINE,
+        &raw_settings,
+        total,
+        rx,
+        cancel,
+        blocking,
+        asset_writes,
+    )
+    .await
+}


### PR DESCRIPTION
## What

The off-Mac worker route for the candle **Qwen-Image-Edit** provider — the **last family of sc-5487** and the **last story of epic 5480** (candle Phase 3: identity / control / edit). Off-Mac, a Qwen-Image-Edit `edit_image` job previously fell back to the Python torch worker; it now runs on the candle `QwenEdit` lane.

> **Depends on [candle-gen#91](https://github.com/michaeltrefry/candle-gen/pull/91)** (the `QwenEdit` provider). This PR pins candle-gen to #91's branch HEAD (`bcd94ad`); **merge #91 first**, then this. After #91 merges I'll flip the pin to the merged candle-gen `main` rev.

## How

- **`image_jobs/qwen_edit_candle.rs`** — `generate_candle_qwen_edit_stream` + `qwen_edit_candle_available`: load `QwenEdit` once, generate `request.count` edits of the source (each its own seed), reusing `consume_gen_events`. The provider condition-resizes the reference internally, so the source is passed **as-is** (no render-size pre-fit, unlike the FLUX.2 lane). Engine `candle_qwen_edit`; default repo `Qwen/Qwen-Image-Edit`; steps 30 / guidance 4.0.
- **`image_jobs.rs`** — the `QwenEdit` named import (cfg-gated), the dispatch branch **before `is_candle_engine`** (grouped with the SDXL/FLUX.2 edit lanes), and the cfg-gated `include!`.
- **`jobs_store.rs`** — `qwen_edit_candle_eligible` (`edit_image` + `sourceAssetId`) + the `image_job_is_candle_eligible` carve-out for the **non-lightning** variants (`qwen_image_edit` / `_2509` / `_2511` — all map to the single edit engine; `-2511`'s `zero_cond_t` is auto-detected by the provider). The `-2511_lightning` distill needs a LoRA the candle provider lacks, so it stays MLX/torch. Routing-test assertions for both (candle claims the three; lightning + source-less defer).
- **`Cargo.toml`** — bump all candle-gen pins `18c1c89 → bcd94ad` (#91 HEAD with `QwenEdit`; **source-only**, single gen-core `7b89d45`, no skew); `Cargo.lock` refreshed.

## Validation

- `cargo clippy -p sceneworks-worker --features backend-candle -- -D warnings` **clean** on the RTX PRO 6000 box (sm_120, MSVC 14.44) — the worker + `qwen_edit_candle.rs` compile and **link `QwenEdit`** (no CI lane builds `backend-candle`, so this is the local gate).
- **61 `sceneworks-core` jobs_store tests** (incl. the new candle-claims assertions) + **fmt** green.
- The provider itself is **GPU-validated end-to-end** in candle-gen#91 (`edit_validate`): 512² ref → 1024² edits in ~45–49s; prompt A vs B mean pixel diff **64.4** (strong steering); the reference is faithfully reproduced while the prompt restyles the scene; pre + mid-step cancel return `Canceled`.

This closes **sc-5487** (the candle off-Mac img2img/edit family ports) and **epic 5480** (Candle Phase 3 — identity/control/edit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)