### PR TITLE
sc-5499: Real-ESRGAN image_upscale off-Mac via ort (CUDA/CPU EP); drop AuraSR

### DIFF
--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -2823,11 +2823,12 @@ async fn models_catalog_carries_mac_support_and_capabilities_endpoint() {
     // Real-ESRGAN upscaling is ported to the Rust worker (sc-3489) → tool supported, no reason.
     assert_eq!(caps["features"]["imageUpscale"]["supported"], true);
     assert_eq!(caps["features"]["imageUpscale"]["reason"], Value::Null);
-    // The AuraSR engine is dropped on Mac (sc-3668) → its per-engine feature is unsupported.
+    // The AuraSR engine is dropped on Mac (sc-3668) AND off-Mac as an offered engine (sc-5499) → its
+    // per-engine feature is unsupported on every platform and names the drop.
     assert_eq!(caps["features"]["imageUpscaleAuraSr"]["supported"], false);
     assert_eq!(
         caps["features"]["imageUpscaleAuraSr"]["reason"]["suggestedEpic"],
-        "sc-3668"
+        "sc-5499"
     );
     // DWPose pose detection is ported to the Rust worker (sc-3487) → supported (sc-4206).
     assert_eq!(caps["features"]["poseFromPhoto"]["supported"], true);

--- a/apps/web/src/macGating.js
+++ b/apps/web/src/macGating.js
@@ -110,8 +110,13 @@ export function macFeatureBlock(caps, key) {
 
 // Whether a specific image_upscale engine should be hidden from the picker on this platform.
 // Two engines are platform-restricted (ids match the worker):
-//   * `aura-sr` — a torch-only GigaGAN DROPPED on Mac (sc-3668). Hidden only under active Mac
-//     gating; available on Windows/Linux. Real-ESRGAN is the cross-platform default.
+//   * `aura-sr` — a torch-only GigaGAN DROPPED on Mac (sc-3668) and now dropped as an offered engine
+//     on EVERY platform (sc-5499): it has no native (MLX/candle) path and the Python torch backend
+//     that served it off-Mac is retired in Phase 7 (epic 5483), so the picker hides it everywhere
+//     (users don't build on a path about to disappear). Gated off the platform-intrinsic
+//     `imageUpscaleAuraSr` capability (`supported: false` on every platform), so — like SeedVR2 — the
+//     check is gating-independent (hidden even pre-load, when caps haven't arrived). Real-ESRGAN is
+//     the cross-platform default upscaler.
 //   * `seedvr2` — the one-step diffusion upscaler (epic 4811 / sc-4815), the INVERSE of AuraSR:
 //     backed by native MLX on Mac and the Candle CUDA/NVIDIA port on Windows (sc-5928) + Linux
 //     (sc-5160 — candle is CPU+CUDA cross-platform, so Linux rides the Windows port). Gated off the
@@ -123,7 +128,7 @@ export function macUpscaleEngineBlocked(caps, engine) {
     return caps?.features?.imageUpscaleSeedvr2?.supported !== true;
   }
   if (engine === "aura-sr") {
-    return Boolean(macFeatureBlock(caps, "imageUpscaleAuraSr"));
+    return caps?.features?.imageUpscaleAuraSr?.supported !== true;
   }
   return false;
 }

--- a/apps/web/src/macGating.test.js
+++ b/apps/web/src/macGating.test.js
@@ -75,11 +75,21 @@ describe("macGating helpers", () => {
     expect(macFeatureBlock(gating, "lycoris")).toBeNull();
   });
 
-  it("drops the AuraSR upscale engine on a gated Mac, keeps Real-ESRGAN (sc-3668)", () => {
+  it("drops the AuraSR upscale engine on every platform (sc-3668 / sc-5499), keeps Real-ESRGAN", () => {
+    // Dropped under active Mac gating...
     expect(macUpscaleEngineBlocked(gating, "aura-sr")).toBe(true);
     expect(macUpscaleEngineBlocked(gating, "real-esrgan")).toBe(false);
-    // Inert on Windows/Linux / observe mode — the engine picker is untouched.
-    expect(macUpscaleEngineBlocked(DEFAULT_MAC_CAPABILITIES, "aura-sr")).toBe(false);
+    // ...and now off-Mac too (sc-5499): the capability is false on every platform, so the check is
+    // gating-independent — hidden on Windows/Linux and pre-load (the INVERSE of the old behavior).
+    expect(macUpscaleEngineBlocked(DEFAULT_MAC_CAPABILITIES, "aura-sr")).toBe(true);
+    const windows = {
+      ...DEFAULT_MAC_CAPABILITIES,
+      platform: "windows",
+      features: { imageUpscaleAuraSr: { supported: false }, imageUpscaleSeedvr2: { supported: true } },
+    };
+    expect(macUpscaleEngineBlocked(windows, "aura-sr")).toBe(true);
+    // Real-ESRGAN stays the cross-platform default upscaler.
+    expect(macUpscaleEngineBlocked(windows, "real-esrgan")).toBe(false);
   });
 
   it("offers SeedVR2 wherever the capability confirms a backend — Mac + Windows + Linux (epic 4811 / sc-5928 / sc-5160)", () => {

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -6974,23 +6974,12 @@ describe("SceneWorks app shell", () => {
       }),
     );
 
-    await changeField(field(container, "Engine"), "aura-sr");
-    expect(field(container, "Scale").value).toBe("4");
-    expect([...field(container, "Scale").querySelectorAll("option")].map((option) => option.value)).toEqual(["4"]);
-
-    await act(async () => {
-      [...container.querySelectorAll("button")].find((button) => button.textContent === "Generate").click();
-    });
-
-    expect(createImageJob).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        upscale: {
-          enabled: true,
-          factor: 4,
-          engine: "aura-sr",
-        },
-      }),
-    );
+    // AuraSR is dropped as an offered engine (sc-3668 / sc-5499) and SeedVR2 needs its platform
+    // capability flag, so under the default capabilities the picker offers only Real-ESRGAN — there
+    // is no `aura-sr` option to select.
+    expect([...field(container, "Engine").querySelectorAll("option")].map((option) => option.value)).toEqual([
+      "real-esrgan",
+    ]);
   });
 
   it("submits a Kolors character job with the approved reference and IP-Adapter scale", async () => {

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -194,10 +194,12 @@ function konvaColorFilter(imageData) {
   applyColorAdjustments(imageData.data, this.getAttr("colorAdjust"));
 }
 
-// Upscale engines + their valid factors (sc-2433). Mirrors the engines the worker
-// supports (image_adapters.create_image_upscaler): Real-ESRGAN 2x/4x, AuraSR 4x,
-// SeedVR2 2x/4x (the native-MLX one-step diffusion upscaler, Mac-only, epic 4811 / sc-4815).
-// `seedvr2` exposes a detail/softness control; the others do not (`softness: true`).
+// Upscale engines + their valid factors (sc-2433). Real-ESRGAN 2x/4x is the cross-platform default
+// (`ort`: CoreML on Mac / CUDA off-Mac, sc-3489 / sc-5499); SeedVR2 2x/4x is the one-step diffusion
+// upscaler (native MLX on Mac / candle off-Mac, epic 4811 / sc-5928 / sc-5160) and exposes a
+// detail/softness control (`softness: true`). `aura-sr` is kept here only so a stale saved selection
+// gracefully falls back — it is hidden on every platform (dropped, sc-3668 / sc-5499) via
+// `macUpscaleEngineBlocked`.
 const UPSCALE_ENGINES = [
   { key: "real-esrgan", label: "Real-ESRGAN", factors: [2, 4] },
   { key: "seedvr2", label: "SeedVR2", factors: [2, 4], softness: true },
@@ -381,12 +383,12 @@ export function ImageEditor() {
   const [upscaleFactor, setUpscaleFactor] = useState(2);
   // SeedVR2 detail/softness knob (0..1, sc-4815) — only meaningful for the seedvr2 engine.
   const [upscaleSoftness, setUpscaleSoftness] = useState(0);
-  // Engines offered in the picker; AuraSR is dropped on a gated Mac (sc-3668).
+  // Engines offered in the picker; AuraSR is dropped on every platform (sc-3668 / sc-5499).
   const availableUpscaleEngines = UPSCALE_ENGINES.filter(
     (entry) => !macUpscaleEngineBlocked(macCapabilities, entry.key),
   );
-  // If the selected engine got gated out (e.g. AuraSR on a Mac), fall back to the default
-  // real-esrgan engine (the guaranteed-available Mac upscaler) so the tool stays usable.
+  // If the selected engine got gated out (e.g. a stale saved AuraSR selection), fall back to the
+  // default real-esrgan engine (the guaranteed-available cross-platform upscaler) so the tool stays usable.
   useEffect(() => {
     if (macUpscaleEngineBlocked(macCapabilities, upscaleEngine)) {
       setUpscaleEngine("real-esrgan");

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -132,9 +132,11 @@ function preferredResolution(model, options) {
 
 const UPSCALE_ENGINES = [
   { id: "real-esrgan", label: "Real-ESRGAN", factors: [2, 4] },
-  // SeedVR2: native-MLX one-step diffusion upscaler (Mac-only, epic 4811 / sc-4815) with a
-  // detail/softness control; gated to Mac via macUpscaleEngineBlocked + imageUpscaleSeedvr2.
+  // SeedVR2: one-step diffusion upscaler (native MLX on Mac / candle off-Mac, epic 4811 / sc-5928 /
+  // sc-5160) with a detail/softness control; shown on every GPU platform via imageUpscaleSeedvr2.
   { id: "seedvr2", label: "SeedVR2", factors: [2, 4], softness: true },
+  // AuraSR is kept only for graceful fallback of a stale saved selection — hidden on every platform
+  // (dropped, sc-3668 / sc-5499) via macUpscaleEngineBlocked.
   { id: "aura-sr", label: "AuraSR", factors: [4] },
 ];
 
@@ -410,12 +412,12 @@ export function ImageStudio() {
     }
   }
 
-  // Engines offered in the picker; AuraSR is dropped on a gated Mac (sc-3668).
+  // Engines offered in the picker; AuraSR is dropped on every platform (sc-3668 / sc-5499).
   const availableUpscaleEngines = UPSCALE_ENGINES.filter(
     (engine) => !macUpscaleEngineBlocked(macCapabilities, engine.id),
   );
-  // If a restored/saved engine is gated out (e.g. AuraSR on a Mac), fall back to the default
-  // real-esrgan engine so the user never submits an aura-sr job that the Mac would refuse.
+  // If a restored/saved engine is gated out (e.g. a stale saved AuraSR selection), fall back to the
+  // default real-esrgan engine so the user never submits an aura-sr job the native workers refuse.
   useEffect(() => {
     if (!macUpscaleEngineBlocked(macCapabilities, upscaleEngine)) return;
     setUpscaleEngine("real-esrgan");

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -2104,8 +2104,9 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
         // `mlx-gen-seedvr2`, so the upscale tool runs Python-free. The AuraSR engine (`aura-sr`,
         // a 617M-param torch-only GigaGAN) was DROPPED on Mac after the sc-3668 port-or-drop
         // spike (no viable Rust path; only a marginal, ~35-50x-slower quality difference vs
-        // Real-ESRGAN x4). The Mac UI hides the AuraSR engine option, so this Err is now a
-        // defensive submit-time guard; AuraSR stays available on Windows/Linux.
+        // Real-ESRGAN x4) and is now dropped as an offered engine off-Mac too (sc-5499 — the
+        // Python torch backend that served it is retired in Phase 7). The UI hides the AuraSR
+        // engine option on every platform, so this Err is a defensive submit-time guard.
         JobType::ImageUpscale => {
             if upscale_job_is_mlx_eligible(job) {
                 Ok(())
@@ -2113,8 +2114,8 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
                 Err(UnsupportedReason::new(
                     model,
                     "image_upscale (AuraSR)",
-                    "the Rust upscaler runs Real-ESRGAN; the AuraSR engine is dropped on Mac (available on Windows/Linux).",
-                    Some("sc-3668"),
+                    "the Rust upscaler runs Real-ESRGAN (+ SeedVR2); the AuraSR engine is dropped as an offered engine (sc-3668 / sc-5499).",
+                    Some("sc-5499"),
                 ))
             }
         }
@@ -2421,20 +2422,24 @@ pub fn mac_capabilities(platform: &str, mac_gating_active: bool) -> MacCapabilit
         },
     );
     features.insert(
-        // The AuraSR upscale engine (`engine=aura-sr`) is dropped on Mac (sc-3668,
-        // port-or-drop spike): it is a 617M-param torch-only GigaGAN with no viable Rust
-        // path and only a marginal, ~35-50x-slower quality difference vs the already-ported
-        // Real-ESRGAN x4. The Mac UI hides this engine option so a user never reaches the
-        // `mlx_unsupported` error; it stays available on Windows/Linux. This must agree with
-        // the AuraSR arm of `mac_rust_supported` (what the UI hides == what routing refuses).
+        // The AuraSR upscale engine (`engine=aura-sr`) is dropped on Mac (sc-3668, port-or-drop
+        // spike): it is a 617M-param torch-only GigaGAN with no viable Rust path and only a marginal,
+        // ~35-50x-slower quality difference vs the already-ported Real-ESRGAN x4. As of sc-5499 it is
+        // also dropped as an OFFERED engine off-Mac — there is no native (MLX/candle) path and the
+        // Python torch backend that served it on Windows/Linux is retired in Phase 7 (epic 5483), so
+        // exposing it would point users at a path about to disappear. `supported: false` on every
+        // platform (platform-intrinsic, like `imageUpscaleSeedvr2`), so the UI hides the engine
+        // everywhere. Must agree with the AuraSR arm of `mac_rust_supported` (UI-hidden == routing
+        // refuses): the native MLX/candle workers refuse it; only the (transitional) torch worker runs
+        // an explicitly-submitted aura-sr job until Phase 7.
         "imageUpscaleAuraSr".to_owned(),
         MacFeatureSupport {
             supported: false,
             reason: Some(UnsupportedReason::new(
                 None,
                 "image_upscale (AuraSR)",
-                "AuraSR is a torch-only GAN upscaler, dropped on Mac; Real-ESRGAN x4 is the Mac upscaler (it stays available on Windows/Linux).",
-                Some("sc-3668"),
+                "AuraSR is a torch-only GAN upscaler, dropped as an offered engine on all platforms (sc-3668 / sc-5499); Real-ESRGAN is the cross-platform upscaler (SeedVR2 the high-fidelity option).",
+                Some("sc-5499"),
             )),
         },
     );
@@ -4318,12 +4323,16 @@ fn upscale_job_requests_seedvr2(job: &JobSnapshot) -> bool {
             .is_some_and(|engine| engine.trim().eq_ignore_ascii_case("seedvr2"))
 }
 
-/// Whether an `image_upscale` job is candle-eligible (sc-5928, epic 4811 / epic 5482): the candle
-/// SeedVR2 provider (`candle-gen-seedvr2`) serves `engine=seedvr2` off-Mac. Unlike the mlx gate, the
-/// default (`real-esrgan`) engine is NOT candle-eligible — only an explicit SeedVR2 request routes to
-/// the candle worker; Real-ESRGAN / AuraSR have no candle path and stay on the Python torch worker.
+/// Whether an `image_upscale` job is candle-eligible (sc-5928 SeedVR2 + sc-5499 Real-ESRGAN, epic
+/// 4811 / epic 5482): the candle worker serves **Real-ESRGAN** (`ort`/CUDA, the off-Mac sibling of
+/// the Mac CoreML path — sc-5499) AND **SeedVR2** (`candle-gen-seedvr2`, sc-5928) off-Mac. This now
+/// mirrors `upscale_job_is_mlx_eligible` exactly (the default `real-esrgan` engine + `seedvr2`);
+/// `aura-sr` was dropped as an offered engine (sc-3668 Mac / sc-5499 off-Mac) so it has no candle
+/// path — a candle worker refuses it (it runs only on the Python torch worker until Phase 7). Note
+/// Real-ESRGAN keeps its torch path as a co-resident fallback (the torch worker is NOT refused it,
+/// unlike SeedVR2), so a Real-ESRGAN job may run on whichever worker claims it first.
 fn upscale_job_is_candle_eligible(job: &JobSnapshot) -> bool {
-    upscale_job_requests_seedvr2(job)
+    upscale_job_is_mlx_eligible(job)
 }
 
 /// Whether a `video_upscale` job is candle-eligible (sc-5928, epic 4811 / epic 5482): the candle
@@ -4513,10 +4522,10 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
         {
             return false;
         }
-        // Image upscale (sc-5928, epic 4811 / epic 5482): the candle worker serves SeedVR2 image
-        // upscaling (`candle-gen-seedvr2`, the Windows/CUDA sibling of mlx-gen-seedvr2). Real-ESRGAN
-        // (the default engine) / AuraSR have no candle path, so a non-SeedVR2 engine is refused and
-        // stays on the Python torch worker.
+        // Image upscale (sc-5928 SeedVR2 + sc-5499 Real-ESRGAN, epic 4811 / epic 5482): the candle
+        // worker serves Real-ESRGAN (`ort`/CUDA, sc-5499) AND SeedVR2 (`candle-gen-seedvr2`, the
+        // Windows/CUDA sibling of mlx-gen-seedvr2). Only `aura-sr` has no candle path — it is refused
+        // and runs on the Python torch worker until Phase 7.
         if matches!(job.job_type, JobType::ImageUpscale) && !upscale_job_is_candle_eligible(job) {
             return false;
         }
@@ -5704,23 +5713,30 @@ mod candle_routing_tests {
         .expect("valid JobSnapshot")
     }
 
-    /// sc-5928: the candle worker claims `engine=seedvr2` image upscale (the candle-gen-seedvr2
-    /// provider) but refuses Real-ESRGAN (the default), which stays on the Python torch worker.
+    /// sc-5499 + sc-5928: the candle worker claims both off-Mac image upscalers — Real-ESRGAN
+    /// (`ort`/CUDA, sc-5499, incl. the default engine) and SeedVR2 (`candle-gen-seedvr2`, sc-5928).
+    /// Only `aura-sr` (an offered engine dropped on every platform, sc-3668 / sc-5499) has no candle
+    /// path → refused (it runs only on the Python torch worker until Phase 7).
     #[test]
-    fn candle_worker_claims_seedvr2_image_upscale_refuses_real_esrgan() {
+    fn candle_worker_claims_real_esrgan_and_seedvr2_image_upscale_refuses_aura_sr() {
         let candle = gpu_worker(&["gpu", "image_upscale", "candle"]);
         assert!(worker_supports_job(
             &candle,
             &image_upscale_job(json!({ "sourceAssetId": "a", "engine": "seedvr2" }))
         ));
-        // Real-ESRGAN (the default engine) has no candle path → refused → stays on the torch worker.
-        assert!(!worker_supports_job(
+        // Real-ESRGAN (incl. the default engine) now has a candle path (the off-Mac ort/CUDA upscaler).
+        assert!(worker_supports_job(
             &candle,
             &image_upscale_job(json!({ "sourceAssetId": "a", "engine": "real-esrgan" }))
         ));
-        assert!(!worker_supports_job(
+        assert!(worker_supports_job(
             &candle,
             &image_upscale_job(json!({ "sourceAssetId": "a" })) // default = real-esrgan
+        ));
+        // AuraSR is dropped as an offered engine → no candle path → refused.
+        assert!(!worker_supports_job(
+            &candle,
+            &image_upscale_job(json!({ "sourceAssetId": "a", "engine": "aura-sr" }))
         ));
     }
 

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -2168,8 +2168,9 @@ fn mac_rust_supported_names_infra_job_types() {
     let kps = job_of(&store, JobType::KpsExtract, json!({}));
     assert!(mac_rust_supported(&kps).is_ok());
     // Real-ESRGAN upscaling is ported to the Rust worker (sc-3489): the default engine
-    // (real-esrgan) is supported; the AuraSR engine is dropped on Mac (sc-3668). SeedVR2 is the
-    // native-MLX one-step diffusion upscaler (epic 4811 / sc-4815) and is also supported.
+    // (real-esrgan) is supported; the AuraSR engine is dropped on Mac (sc-3668) and off-Mac as an
+    // offered engine (sc-5499). SeedVR2 is the one-step diffusion upscaler (epic 4811 / sc-4815) and
+    // is also supported.
     let upscale = job_of(&store, JobType::ImageUpscale, json!({}));
     assert!(mac_rust_supported(&upscale).is_ok());
     let seedvr2 = job_of(
@@ -2185,7 +2186,7 @@ fn mac_rust_supported_names_infra_job_types() {
     );
     let aura_reason = mac_rust_supported(&aura).unwrap_err();
     assert!(aura_reason.feature.contains("AuraSR"));
-    assert_eq!(aura_reason.suggested_epic.as_deref(), Some("sc-3668"));
+    assert_eq!(aura_reason.suggested_epic.as_deref(), Some("sc-5499"));
     // JoyCaption dataset captioning is ported to the Rust/MLX worker (sc-3556).
     let caption = job_of(
         &store,
@@ -2547,10 +2548,11 @@ fn mac_capabilities_master_switch_and_infra_features() {
     // Real-ESRGAN upscaling is ported (sc-3489) → the tool is supported, no reason/epic.
     assert_eq!(epic("imageUpscale"), None);
     assert!(mac.features["imageUpscale"].supported);
-    // The AuraSR engine is dropped on Mac (sc-3668) → its per-engine feature is unsupported
-    // and names the spike; this must agree with the AuraSR arm of `mac_rust_supported`.
+    // The AuraSR engine is dropped on Mac (sc-3668) AND off-Mac as an offered engine (sc-5499) → its
+    // per-engine feature is unsupported on every platform and names the drop; this must agree with the
+    // AuraSR arm of `mac_rust_supported`.
     assert!(!mac.features["imageUpscaleAuraSr"].supported);
-    assert_eq!(epic("imageUpscaleAuraSr"), Some("sc-3668".to_owned()));
+    assert_eq!(epic("imageUpscaleAuraSr"), Some("sc-5499".to_owned()));
     // SeedVR2 is the native-MLX upscaler (epic 4811 / sc-4815) → supported on Mac, no reason/epic.
     assert!(mac.features["imageUpscaleSeedvr2"].supported);
     assert_eq!(epic("imageUpscaleSeedvr2"), None);
@@ -2599,6 +2601,10 @@ fn mac_capabilities_master_switch_and_infra_features() {
     let windows = mac_capabilities("windows", false);
     assert!(windows.features["imageUpscaleSeedvr2"].supported);
     assert!(windows.features["imageUpscaleSeedvr2"].reason.is_none());
+    // AuraSR is dropped as an offered engine off-Mac too (sc-5499): unsupported on Windows (and Linux),
+    // not just under active Mac gating — so the web picker hides it on every platform.
+    assert!(!windows.features["imageUpscaleAuraSr"].supported);
+    assert!(!inert.features["imageUpscaleAuraSr"].supported);
     // Training kernels with a native Rust trainer stay enabled; LoKr-on-Wan does not.
     assert!(mac
         .training

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -70,14 +70,15 @@ fn with_candle_capabilities(mut gpu: DiscoveredGpu, settings: &Settings) -> Disc
                     gpu.capabilities.push(capability);
                 }
             }
-            // SeedVR2 image + video upscaling (sc-5928, epic 4811 / epic 5482): the candle SeedVR2
-            // provider (`candle-gen-seedvr2`, force-linked under backend-candle) serves `image_upscale`
-            // AND the net-new `video_upscale` via `gen_core::load("seedvr2")` — the Windows/CUDA sibling
-            // of the Mac mlx-gen-seedvr2 path. These are job-type capabilities (not a generation
+            // Image + video upscaling (sc-5928 SeedVR2 + sc-5499 Real-ESRGAN, epic 4811 / epic 5482):
+            // off-Mac the candle worker serves `image_upscale` for BOTH Real-ESRGAN (`ort`/CUDA in
+            // `upscale_jobs`, the off-Mac sibling of the Mac CoreML path — sc-5499) and SeedVR2
+            // (`candle-gen-seedvr2`, force-linked under backend-candle, via `gen_core::load("seedvr2")`),
+            // AND the net-new SeedVR2 `video_upscale`. These are job-type capabilities (not a generation
             // modality), so they aren't in `registry_capabilities`; advertise them explicitly. The
-            // routing gate confines the candle worker to the SeedVR2 engine ids
-            // (`upscale_job_is_candle_eligible` / `video_upscale_job_is_candle_eligible`); Real-ESRGAN /
-            // AuraSR have no candle path and stay on the Python torch worker.
+            // routing gate (`upscale_job_is_candle_eligible` / `video_upscale_job_is_candle_eligible`)
+            // admits Real-ESRGAN + SeedVR2; only `aura-sr` has no candle path (dropped as an offered
+            // engine, sc-3668 / sc-5499) and runs on the Python torch worker until Phase 7.
             for capability in [
                 WorkerCapability::ImageUpscale,
                 WorkerCapability::VideoUpscale,

--- a/crates/sceneworks-worker/src/upscale_jobs.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs.rs
@@ -1,40 +1,45 @@
-//! Real-ESRGAN image upscaling on the Rust worker (epic 3482, sc-3489).
+//! Real-ESRGAN image upscaling on the Rust worker (epic 3482, sc-3489; off-Mac sc-5499).
 //!
 //! Ports the Python `scene_worker/upscalers.py` + `image_adapters.run_image_upscale`
 //! `image_upscale` job to Rust so the Image Editor upscale tool (epic 2427) keeps
-//! working on a Python-free Mac. The upscaler is Real-ESRGAN (RRDBNet x2/x4) run via
-//! `ort` (onnxruntime) with the CoreML execution provider — the same `ort` stack +
-//! bundled `libonnxruntime.dylib` sc-3487 ships for DWPose. The path-selection spike
-//! (`docs/sc-3489/spike-findings.md`) validated pixel parity vs the shipped torch
-//! upscaler (CoreML PSNR ~72–74 dB, visually identical) at ~9× the CPU-EP speed.
+//! working Python-free. The upscaler is Real-ESRGAN (RRDBNet x2/x4) run via `ort`
+//! (onnxruntime): the **CoreML** execution provider on macOS (sc-3489, the same `ort`
+//! stack + bundled `libonnxruntime.dylib` sc-3487 ships for DWPose) and the **CUDA**
+//! execution provider off-Mac on the candle GPU-worker lane (sc-5499, the Windows/Linux
+//! sibling — the same `ort`/CUDA pattern sc-5496 brought off-Mac for DWPose). Both fall
+//! back to a plain CPU session if the hardware EP can't initialise (reported honestly as
+//! `device = "cpu"`). The path-selection spike (`docs/sc-3489/spike-findings.md`)
+//! validated pixel parity vs the shipped torch upscaler (CoreML PSNR ~72–74 dB, visually
+//! identical) at ~9× the CPU-EP speed; the ONNX graph is identical off-Mac.
 //!
-//! macOS-only: the CoreML EP only means anything on Apple Silicon, and the Python
-//! torch Real-ESRGAN / AuraSR path stays the Windows/Linux backend. The tiling math
-//! (`tile_slices`, crop/place) is pure and unit-tested without the onnx weights; only
-//! the onnxruntime inference is gated.
+//! Backend split: the Real-ESRGAN `ort` path compiles on macOS (the MLX worker) and on
+//! the candle lane (`backend-candle`, off-Mac) — the same gate as the module. The tiling
+//! math (`tile_slices`, crop/place) is pure and unit-tested without the onnx weights;
+//! only the execution provider (`build_session`) is cfg-split. Off-Mac, Real-ESRGAN is
+//! served by the candle worker; the Python torch Real-ESRGAN path stays a co-resident
+//! fallback until Phase 7 (epic 5483) retires it.
 //!
-//! Engine scope: `engine=real-esrgan` (the default, the `ort`/CoreML path above) and
-//! `engine=seedvr2` (epic 4811 / sc-4815 — the native-MLX one-step diffusion super-resolution
-//! upscaler) are served here. SeedVR2 runs in-process via the `mlx-gen-seedvr2` registry generator,
-//! driven through the shared `with_cached_generator` seam (single-resident engine cache — it evicts
-//! any cached image-gen engine, bounding peak memory, which matters because the SeedVR2 image path
-//! has no spatial tiling yet). It takes a target resolution (factor → `round_to_16(src × factor)`)
-//! and an optional `--softness` pre-blur; `mac_only` (the Windows/Linux SeedVR2 backend is the
-//! separate Candle port, sc-5157). `aura-sr` (a 617M-param torch-only GigaGAN) was dropped on Mac
-//! after the sc-3668 port-or-drop spike — it is refused by the routing oracle
-//! (`upscale_job_is_mlx_eligible`) and hidden in the Mac UI, so it only runs on the Python worker on
-//! Windows/Linux.
+//! Engine scope: `engine=real-esrgan` (the default, the `ort` path above) and
+//! `engine=seedvr2` (epic 4811 / sc-4815 — the one-step diffusion super-resolution upscaler) are
+//! served here. SeedVR2 runs in-process via the registry generator (native MLX on Mac /
+//! `candle-gen-seedvr2` off-Mac, sc-5157), driven through the shared `with_cached_generator` seam
+//! (single-resident engine cache — it evicts any cached image-gen engine, bounding peak memory,
+//! which matters because the SeedVR2 image path has no spatial tiling yet). It takes a target
+//! resolution (factor → `round_to_16(src × factor)`) and an optional `--softness` pre-blur.
+//! `aura-sr` (a 617M-param torch-only GigaGAN) was dropped on Mac after the sc-3668 port-or-drop
+//! spike and is now dropped as an offered engine off-Mac too (sc-5499): it is refused by the routing
+//! oracle (`upscale_job_is_mlx_eligible` / `upscale_job_is_candle_eligible`) and hidden in the UI,
+//! so it only runs if explicitly submitted to the Python torch worker (retired in Phase 7).
 //!
 //! Tiling parity (matched to `upscalers.py:_run_tiled`):
 //!  - tile grid `tile_slices(w,h,512)`; per-tile crop padded by `tile_pad=16`
 //!    (clamped to image bounds); inner (unpadded) region copied back at factor scale.
 //!  - input RGB f32 CHW in `[0,1]`; output clamp `[0,1]` → round → u8.
 
-// `HashMap`/`Mutex`/`OnceLock` back the Real-ESRGAN per-factor session cache (Mac-only `ort` path).
-#[cfg(target_os = "macos")]
+// `HashMap`/`Mutex`/`OnceLock` back the Real-ESRGAN per-factor session cache (the `ort` path,
+// macOS + the off-Mac candle lane).
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-#[cfg(target_os = "macos")]
 use std::sync::{Mutex, OnceLock};
 
 use crate::downloads::{ensure_hf_cached_file, DownloadContext};
@@ -44,13 +49,14 @@ use gen_core::{
     WeightsSource,
 };
 use image::RgbImage;
-// Real-ESRGAN runs via `ort` + the CoreML execution provider — Mac-only (the candle Windows lane
-// serves SeedVR2, not Real-ESRGAN; Real-ESRGAN/AuraSR stay on the Python torch worker off-Mac).
+// Real-ESRGAN runs via `ort`: the CoreML EP on macOS (sc-3489) and the CUDA EP off-Mac on the
+// candle GPU-worker lane (sc-5499, the same pattern sc-5496 brought off-Mac for DWPose). `Session` /
+// `Tensor` are shared; only the execution provider is cfg-split in `build_session`.
+#[cfg(not(target_os = "macos"))]
+use ort::execution_providers::CUDAExecutionProvider;
 #[cfg(target_os = "macos")]
 use ort::execution_providers::CoreMLExecutionProvider;
-#[cfg(target_os = "macos")]
 use ort::session::Session;
-#[cfg(target_os = "macos")]
 use ort::value::Tensor;
 use serde_json::{json, Value};
 
@@ -62,11 +68,16 @@ use crate::{
 use sceneworks_core::contracts::{JobSnapshot, JobStatus, JsonObject, ProgressStage, WorkerStatus};
 use sceneworks_core::project_store::ProjectStore;
 
-// Real-ESRGAN tiling (Mac-only `ort`/CoreML path).
-#[cfg(target_os = "macos")]
+// Real-ESRGAN tiling (the `ort` path, macOS + the off-Mac candle lane).
 const TILE_SIZE: usize = 512;
-#[cfg(target_os = "macos")]
 const TILE_PAD: usize = 16;
+/// The hardware execution provider this build registers before the CPU fallback for the
+/// Real-ESRGAN `ort` session: CoreML on macOS (sc-3489), CUDA off-Mac on the candle GPU-worker
+/// lane (sc-5499). Stored as `Upscaler.device` for observability.
+#[cfg(target_os = "macos")]
+const ACCEL_DEVICE: &str = "coreml";
+#[cfg(not(target_os = "macos"))]
+const ACCEL_DEVICE: &str = "cuda";
 const MAX_UPSCALE_TARGET_DIMENSION: u32 = 8192;
 const MAX_UPSCALE_TARGET_PIXELS: u64 =
     MAX_UPSCALE_TARGET_DIMENSION as u64 * MAX_UPSCALE_TARGET_DIMENSION as u64;
@@ -74,21 +85,19 @@ const CANCEL_MESSAGE: &str = "Image upscale canceled by user.";
 
 /// SceneWorks-owned HuggingFace repo hosting the pre-exported ONNX (reproducible from
 /// `scripts/spikes/sc3489_export_reference.py`). Public; downloaded on first use,
-/// parity with sc-3487's rtmlib weights. Overridable via the manifest `onnx` resource
-/// or the env pin `SCENEWORKS_REALESRGAN_X{2,4}_ONNX`.
-#[cfg(target_os = "macos")]
+/// parity with sc-3487's rtmlib weights. The same export feeds the off-Mac CUDA EP
+/// (sc-5499). Overridable via the manifest `onnx` resource or the env pin
+/// `SCENEWORKS_REALESRGAN_X{2,4}_ONNX`.
 const ONNX_REPO: &str = "SceneWorks/real-esrgan-onnx";
 
-#[cfg(target_os = "macos")]
 fn onnx_file(factor: u8) -> String {
     format!("real_esrgan_x{factor}.onnx")
 }
 
 // ---------------------------------------------------------------------------
-// pure tiling math (ported from upscalers.py; unit-tested without weights) — Real-ESRGAN, Mac-only
+// pure tiling math (ported from upscalers.py; unit-tested without weights) — Real-ESRGAN
 // ---------------------------------------------------------------------------
 
-#[cfg(target_os = "macos")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct Tile {
     x0: usize,
@@ -98,7 +107,6 @@ struct Tile {
 }
 
 /// `upscalers.py:tile_slices` — single tile if the image fits, else a row-major grid.
-#[cfg(target_os = "macos")]
 fn tile_slices(w: usize, h: usize, tile: usize) -> Vec<Tile> {
     if tile == 0 || tile >= w.max(h) {
         return vec![Tile {
@@ -127,7 +135,6 @@ fn tile_slices(w: usize, h: usize, tile: usize) -> Vec<Tile> {
 }
 
 /// CHW f32 `[0,1]` for the crop region `[x0,x1) × [y0,y1)` of an RGB image.
-#[cfg(target_os = "macos")]
 fn crop_to_chw(
     img: &RgbImage,
     x0: usize,
@@ -164,45 +171,58 @@ fn validate_upscale_target_dimensions(width: u32, height: u32) -> WorkerResult<(
 }
 
 // ---------------------------------------------------------------------------
-// onnxruntime upscaler (cached per-factor process-wide, like pose_jobs::DETECTOR) — Real-ESRGAN,
-// Mac-only (`ort`/CoreML). The candle Windows lane serves SeedVR2 (below), not Real-ESRGAN.
+// onnxruntime upscaler (cached per-factor process-wide, like pose_jobs::DETECTOR) — Real-ESRGAN
+// via `ort`: CoreML on macOS, CUDA off-Mac on the candle GPU-worker lane (both fall back to CPU).
 // ---------------------------------------------------------------------------
 
-#[cfg(target_os = "macos")]
 struct Upscaler {
     session: Session,
     #[allow(dead_code)]
     device: &'static str,
 }
 
-#[cfg(target_os = "macos")]
 static UPSCALERS: OnceLock<Mutex<HashMap<u8, Upscaler>>> = OnceLock::new();
 
-#[cfg(target_os = "macos")]
 fn ort_err<R>(e: ort::Error<R>) -> WorkerError {
     WorkerError::Engine(format!("onnxruntime: {e}"))
 }
 
-#[cfg(target_os = "macos")]
-fn build_session(path: &Path, coreml: bool) -> WorkerResult<Session> {
+/// Build a session, optionally registering the platform hardware EP (CoreML on macOS,
+/// CUDA off-Mac on the candle lane). `accel == false` builds a plain CPU session (the fallback).
+fn build_session(path: &Path, accel: bool) -> WorkerResult<Session> {
     let mut b = Session::builder().map_err(ort_err)?;
-    if coreml {
-        b = b
-            .with_execution_providers([CoreMLExecutionProvider::default().build()])
-            .map_err(ort_err)?;
+    if accel {
+        #[cfg(target_os = "macos")]
+        {
+            b = b
+                .with_execution_providers([CoreMLExecutionProvider::default().build()])
+                .map_err(ort_err)?;
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            // `error_on_failure` so a CUDA provider that can't initialise (no GPU, or a
+            // cuDNN/CUDA mismatch in the loaded onnxruntime) surfaces as an error here —
+            // `Upscaler::load` then falls back to a CPU session and reports `device = "cpu"`
+            // honestly, instead of onnxruntime silently CPU-executing while we claim CUDA
+            // (mirrors `pose_jobs::build_session`, sc-5496).
+            b = b
+                .with_execution_providers([CUDAExecutionProvider::default()
+                    .build()
+                    .error_on_failure()])
+                .map_err(ort_err)?;
+        }
     }
     b.commit_from_file(path).map_err(ort_err)
 }
 
-#[cfg(target_os = "macos")]
 impl Upscaler {
-    /// Load the session, preferring CoreML and falling back to CPU if the provider
-    /// can't initialise (mirrors `pose_jobs::Detector::load`).
+    /// Load the session, preferring the hardware EP (CoreML on Mac / CUDA off-Mac) and
+    /// falling back to CPU if the provider can't initialise (mirrors `pose_jobs::Detector::load`).
     fn load(path: &Path) -> WorkerResult<Self> {
         match build_session(path, true) {
             Ok(session) => Ok(Self {
                 session,
-                device: "coreml",
+                device: ACCEL_DEVICE,
             }),
             Err(_) => Ok(Self {
                 session: build_session(path, false)?,
@@ -270,10 +290,9 @@ impl Upscaler {
     }
 }
 
-/// Blocking upscale: load+cache the factor's session (amortising the CoreML graph
+/// Blocking upscale: load+cache the factor's session (amortising the CoreML/CUDA graph
 /// compile across a batch), run it. All `ort` objects live inside this closure and
 /// never cross an await (mirrors `pose_jobs::detect_batch`).
-#[cfg(target_os = "macos")]
 fn upscale_blocking(
     onnx_path: PathBuf,
     factor: u8,
@@ -306,7 +325,6 @@ fn upscale_blocking(
 /// (`SCENEWORKS_REALESRGAN_X{factor}_ONNX`, then `SCENEWORKS_REALESRGAN_ONNX`), then the
 /// app cache `<data_dir>/cache/upscale/`, then a manifest `onnx` resource if the job
 /// carried one, else download from the default HF repo.
-#[cfg(target_os = "macos")]
 async fn ensure_onnx(
     api: &ApiClient,
     settings: &Settings,
@@ -360,7 +378,6 @@ async fn ensure_onnx(
 
 /// Pull a `{repo,file}` ONNX resource out of a job's `modelManifestEntry` if present:
 /// `resources.imageUpscalers.real-esrgan.x{factor}.onnx`.
-#[cfg(target_os = "macos")]
 fn manifest_onnx_resource(manifest_entry: &Value, factor: u8) -> Option<(String, String)> {
     let onnx = manifest_entry
         .get("resources")?
@@ -675,15 +692,16 @@ pub(crate) async fn run_image_upscale_job(
         .filter(|s| !s.is_empty())
         .unwrap_or("real-esrgan")
         .to_lowercase();
-    // Canonical engine id. The mlx worker serves Real-ESRGAN (`ort`/CoreML) and SeedVR2 (native
-    // MLX); aura-sr was dropped on Mac (sc-3668). The routing oracle (`upscale_job_is_mlx_eligible`)
-    // already refuses anything else for the mlx worker, so this match is a defensive guard.
+    // Canonical engine id. The Rust upscaler serves Real-ESRGAN (`ort`: CoreML on Mac / CUDA off-Mac,
+    // sc-3489 / sc-5499) and SeedVR2 (native MLX / candle). `aura-sr` was dropped on Mac (sc-3668) and
+    // as an offered engine off-Mac (sc-5499). The routing oracle (`upscale_job_is_mlx_eligible` /
+    // `upscale_job_is_candle_eligible`) already refuses anything else, so this match is a defensive guard.
     let engine_id = match engine.as_str() {
         "real-esrgan" | "realesrgan" | "real_esrgan" => "real-esrgan",
         "seedvr2" => "seedvr2",
         other => {
             return Err(WorkerError::InvalidPayload(format!(
-                "Rust upscaler supports engine=real-esrgan or engine=seedvr2 (got {other}); aura-sr is dropped on Mac, available on Windows/Linux (sc-3668)."
+                "Rust upscaler supports engine=real-esrgan or engine=seedvr2 (got {other}); aura-sr is dropped (sc-3668 / sc-5499) and runs only on the Python torch worker until Phase 7."
             )));
         }
     };
@@ -769,62 +787,53 @@ pub(crate) async fn run_image_upscale_job(
         )
         .await?
     } else {
-        // Real-ESRGAN runs via `ort`/CoreML — Mac-only. Off-Mac the candle worker serves only
-        // `engine=seedvr2` (the routing oracle refuses Real-ESRGAN here, sending it to the Python
-        // torch worker), so this branch is unreachable on the candle lane; keep it a clear error so
-        // the function compiles and a misroute fails loudly rather than silently.
-        #[cfg(target_os = "macos")]
-        {
-            update_job(
-                api,
-                &job.id,
-                progress_payload(
-                    JobStatus::Running,
-                    ProgressStage::Downloading,
-                    0.25,
-                    "Loading Real-ESRGAN weights.",
-                    None,
-                    None,
-                    None,
-                ),
-            )
-            .await?;
-            let onnx_path =
-                ensure_onnx(api, settings, http_client, job, factor, &manifest_entry).await?;
+        // Real-ESRGAN via `ort` — the CoreML EP on macOS (sc-3489), the CUDA EP off-Mac on the
+        // candle GPU-worker lane (sc-5499), both with a CPU fallback. The routing oracle
+        // (`upscale_job_is_candle_eligible` / `upscale_job_is_mlx_eligible`) admits Real-ESRGAN on
+        // both lanes; `engine=aura-sr` is refused before reaching here (defensive `engine_id` guard
+        // above), staying on the Python torch worker until Phase 7.
+        update_job(
+            api,
+            &job.id,
+            progress_payload(
+                JobStatus::Running,
+                ProgressStage::Downloading,
+                0.25,
+                "Loading Real-ESRGAN weights.",
+                None,
+                None,
+                None,
+            ),
+        )
+        .await?;
+        let onnx_path =
+            ensure_onnx(api, settings, http_client, job, factor, &manifest_entry).await?;
 
-            update_job(
-                api,
-                &job.id,
-                progress_payload(
-                    JobStatus::Running,
-                    ProgressStage::Running,
-                    0.45,
-                    &format!("Upscaling {factor}x with Real-ESRGAN."),
-                    None,
-                    None,
-                    None,
-                ),
-            )
-            .await?;
-            let cancel = CancelFlag::new();
-            run_upscale_with_heartbeat(
-                api,
-                settings,
-                &job.id,
-                cancel.clone(),
-                tokio::task::spawn_blocking(move || {
-                    upscale_blocking(onnx_path, factor, source_image, cancel)
-                }),
-            )
-            .await?
-        }
-        #[cfg(not(target_os = "macos"))]
-        {
-            return Err(WorkerError::InvalidPayload(format!(
-                "engine={engine_id} is not served by the candle worker (it serves engine=seedvr2); \
-                 Real-ESRGAN / AuraSR run on the Python torch worker off-Mac"
-            )));
-        }
+        update_job(
+            api,
+            &job.id,
+            progress_payload(
+                JobStatus::Running,
+                ProgressStage::Running,
+                0.45,
+                &format!("Upscaling {factor}x with Real-ESRGAN."),
+                None,
+                None,
+                None,
+            ),
+        )
+        .await?;
+        let cancel = CancelFlag::new();
+        run_upscale_with_heartbeat(
+            api,
+            settings,
+            &job.id,
+            cancel.clone(),
+            tokio::task::spawn_blocking(move || {
+                upscale_blocking(onnx_path, factor, source_image, cancel)
+            }),
+        )
+        .await?
     };
     let (out_w, out_h) = (upscaled.width(), upscaled.height());
 

--- a/crates/sceneworks-worker/src/upscale_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs/tests.rs
@@ -1,9 +1,10 @@
 //! Pure-math unit tests for the Real-ESRGAN tiling port (sc-3489). No onnx weights
-//! needed — these lock the tiling/crop/manifest logic against `upscalers.py`.
+//! needed — these lock the tiling/crop/manifest logic against `upscalers.py`. They run on
+//! macOS and on the off-Mac candle lane (sc-5499), since the tiling path is now shared.
 
 use super::*;
-// `Rgb`/`RgbImage` back the Real-ESRGAN tiling/crop tests (Mac-only ort path) AND the SeedVR2
-// real-weight smoke (Mac MLX + the Windows/CUDA candle lane).
+// `Rgb`/`RgbImage` back the Real-ESRGAN tiling/crop tests + the off-Mac ort smoke (the `ort` path,
+// macOS + the candle lane) AND the SeedVR2 real-weight smoke (Mac MLX + the candle lane).
 #[cfg(any(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
@@ -11,7 +12,10 @@ use super::*;
 use image::{Rgb, RgbImage};
 use serde_json::json;
 
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 #[test]
 fn tile_slices_single_when_image_fits() {
     // tile >= max(w,h) → one tile covering the whole image (upscalers.py).
@@ -29,7 +33,10 @@ fn tile_slices_single_when_image_fits() {
     assert_eq!(tile_slices(512, 512, 512).len(), 1);
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 #[test]
 fn tile_slices_grid_row_major_clamped() {
     // 768x768 @ tile 512 → 2x2 grid, edge tiles clamped to bounds.
@@ -76,13 +83,19 @@ fn tile_slices_grid_row_major_clamped() {
     assert_eq!(covered, 768 * 768);
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 #[test]
 fn tile_slices_zero_tile_is_single() {
     assert_eq!(tile_slices(100, 50, 0).len(), 1);
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 #[test]
 fn crop_to_chw_layout_and_normalization() {
     let mut img = RgbImage::new(3, 2);
@@ -107,7 +120,10 @@ fn crop_to_chw_layout_and_normalization() {
     assert!((data[g_plane - 1] - 1.0).abs() < 1e-6); // R(2,1)=255 last in R plane
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 #[test]
 fn crop_to_chw_subregion() {
     let mut img = RgbImage::new(4, 4);
@@ -125,14 +141,20 @@ fn crop_to_chw_subregion() {
     assert!((data[g + 3] - 20.0 / 255.0).abs() < 1e-6);
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 #[test]
 fn onnx_filename_per_factor() {
     assert_eq!(onnx_file(2), "real_esrgan_x2.onnx");
     assert_eq!(onnx_file(4), "real_esrgan_x4.onnx");
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 #[test]
 fn manifest_onnx_resource_extracts_repo_file() {
     let entry = json!({
@@ -278,5 +300,72 @@ async fn seedvr2_upscale_real_weight_smoke() {
         faithful.as_raw(),
         softened.as_raw(),
         "softness must change the output (the request field is wired to the engine)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Real-ESRGAN off-Mac (sc-5499): a gated real-weight smoke on the candle lane's `ort`/CUDA path
+// ---------------------------------------------------------------------------
+
+/// Real-weight smoke for the off-Mac Real-ESRGAN `ort` path (sc-5499): drives the exact worker seam
+/// `upscale_blocking` → `Upscaler::load` (CUDA EP, CPU fallback) → tiled `Upscaler::upscale` on a real
+/// exported `real_esrgan_x{2,4}.onnx`, asserting the output is exactly `factor×` the input and is a
+/// real super-resolution (not an all-zero / identity buffer). Gated on the ONNX being present (skips in
+/// CI, which has no weights), like the SeedVR2 smoke. Point `SCENEWORKS_REALESRGAN_X{factor}_ONNX` at a
+/// local export (optionally `SCENEWORKS_TEST_UPSCALE_IMAGE` at a source image; else a synthetic gradient
+/// is used) and run with `cargo test -p sceneworks-worker --features backend-candle --lib -- --ignored
+/// real_esrgan_candle_real_weights_upscales`. `ORT_DYLIB_PATH` must point at an onnxruntime build.
+#[cfg(not(target_os = "macos"))]
+#[test]
+#[ignore = "real-weight: needs an exported real_esrgan ONNX (SCENEWORKS_REALESRGAN_X{factor}_ONNX) + an onnxruntime (ORT_DYLIB_PATH)"]
+fn real_esrgan_candle_real_weights_upscales() {
+    let factor: u8 = match std::env::var("SCENEWORKS_TEST_UPSCALE_FACTOR")
+        .ok()
+        .as_deref()
+    {
+        Some("4") => 4,
+        _ => 2,
+    };
+    let Some(onnx) = ["SCENEWORKS_REALESRGAN_X".to_owned() + &factor.to_string() + "_ONNX"]
+        .into_iter()
+        .chain(["SCENEWORKS_REALESRGAN_ONNX".to_owned()])
+        .find_map(|key| std::env::var(&key).ok().map(std::path::PathBuf::from))
+        .filter(|p| p.exists())
+    else {
+        eprintln!("SKIP: no Real-ESRGAN ONNX (set SCENEWORKS_REALESRGAN_X{factor}_ONNX)");
+        return;
+    };
+
+    // A real photo if provided, else a deterministic gradient (Real-ESRGAN is a deterministic conv,
+    // so a synthetic input still exercises the full graph + tiling end-to-end).
+    let src = match std::env::var("SCENEWORKS_TEST_UPSCALE_IMAGE").ok() {
+        Some(path) => image::open(&path)
+            .unwrap_or_else(|e| panic!("load SCENEWORKS_TEST_UPSCALE_IMAGE {path}: {e}"))
+            .to_rgb8(),
+        None => {
+            let mut img = RgbImage::new(64, 48);
+            for (x, y, pixel) in img.enumerate_pixels_mut() {
+                *pixel = Rgb([(x * 3) as u8, (y * 5) as u8, ((x + y) * 2 % 256) as u8]);
+            }
+            img
+        }
+    };
+    let (sw, sh) = (src.width(), src.height());
+
+    let out = upscale_blocking(onnx, factor, src, CancelFlag::new()).expect("Real-ESRGAN upscale");
+    assert_eq!(
+        (out.width(), out.height()),
+        (sw * u32::from(factor), sh * u32::from(factor)),
+        "output must be exactly factor× the source"
+    );
+    // not an all-zero buffer (the graph actually ran + wrote pixels).
+    assert!(
+        out.as_raw().iter().any(|&b| b != 0),
+        "upscaled image must not be all-black"
+    );
+    eprintln!(
+        "Real-ESRGAN x{factor}: {sw}x{sh} -> {}x{}",
+        out.width(),
+        out.height()
     );
 }


### PR DESCRIPTION
## sc-5499 — Real-ESRGAN as a gen-core Transform off-Mac; drop AuraSR (epic 5482, last upscaler slice)

Brings the **Real-ESRGAN** `image_upscale` engine to the off-Mac candle GPU-worker lane via `ort` (the Windows/Linux sibling of the Mac CoreML path), and **drops AuraSR** as an offered engine on every platform. The last CV-aux/upscaler slice of epic 5482.

### Real-ESRGAN off-Mac (`ort`/CUDA)
- Widened the Mac-only Real-ESRGAN `ort` path in `upscale_jobs.rs` to the candle lane: **CUDA EP** with `.error_on_failure()` + honest **CPU fallback** (`device="cpu"`), CoreML kept on Mac — mirrors the sc-5496 DWPose EP-swap. The tiling math + ONNX graph are unchanged and now shared (the pure-math unit tests run on both lanes).
- The Real-ESRGAN branch of `run_image_upscale_job` now runs on both lanes (the old `not(macos)` "unreachable" error stub is gone).
- **Wiring + EP slice, not a model port** — zero new deps (`ort` already dual-optional from sc-5496).

### Routing
- `upscale_job_is_candle_eligible` now mirrors `upscale_job_is_mlx_eligible` (Real-ESRGAN default + SeedVR2). The candle worker claims both; **AuraSR has no candle path → refused**.
- Real-ESRGAN keeps its **torch co-resident fallback** (the torch worker is *not* refused it, unlike SeedVR2) until Phase 7 (epic 5483).

### Drop AuraSR
- `macUpscaleEngineBlocked("aura-sr")` is now **gating-independent** (mirrors the platform-intrinsic `imageUpscaleAuraSr` capability, `false` everywhere) → the picker hides AuraSR on Mac + Windows + Linux (it was previously hidden only under active Mac gating). Capability reason + UI comments updated. Kept in `UPSCALE_ENGINES` only for graceful fallback of a stale saved selection.

### Validation
- **GPU smoke** (RTX PRO 6000, `ort` CPU EP): real exported `real_esrgan_x2.onnx`, **512→1024** through the exact worker seam (`upscale_blocking` → `Upscaler::load` → tiled `Upscaler::upscale`). Ran on the CPU EP (the borrowed onnxruntime is a CPU build; the CUDA→CPU fallback reports device honestly) — same provisioning situation as sc-5496/5498, at parity with the retired Python CPU off-Mac path and Python-free.
- `backend-candle` clippy `--all-targets -D warnings` clean; default worker clippy clean; `ort` absent from the default tree.
- core tests 201 + integration 111 + routing 9 + 7 + 30; web vitest 39 + 178.
- **Cargo.lock unchanged** — single gen-core rev `7b89d456` (no skew), candle-gen `18c1c89f`.

> CUDA hardware accel is a runtime onnxruntime-provisioning concern (ship a version-matched onnxruntime-gpu / set `ORT_DYLIB_PATH`), not a code defect — analogous to sc-3487's Mac CoreML-dylib shipping caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)