### PR TITLE
sc-6209: off-Mac ort paths use the GPU (preload CUDA/cuDNN + bundle onnxruntime-gpu)

### DIFF
--- a/apps/desktop/scripts/build-sidecar.mjs
+++ b/apps/desktop/scripts/build-sidecar.mjs
@@ -145,12 +145,36 @@ if (triple.includes("apple-darwin")) {
     );
   }
   console.log(`build-sidecar: staged onnxruntime MIT license + notice`);
+} else if (candle) {
+  // Windows candle build: stage a CUDA-enabled onnxruntime + its CUDA-12 deps so the
+  // candle worker's `ort` paths (DWPose sc-5496, then YOLO / Real-ESRGAN sc-5498/5499,
+  // epic 5482) run on the GPU instead of the onnxruntime CPU EP. The off-Mac analogue of
+  // the macOS CoreML dylib staging above. onnxruntime's DLLs land in `onnxruntime/`;
+  // cuDNN/cuFFT/nvJitLink/nvRTC land in `cuda/` (cudart/cublas/cublasLt/curand come from
+  // the toolkit copy in the cuda block below). setup.rs points ORT_DYLIB_PATH at the
+  // staged onnxruntime.dll + SCENEWORKS_ORT_CUDA_DIR/CUDNN_DIR at the cuda dir.
+  const py = process.env.PYTHON || "python";
+  run(py, [
+    "apps/desktop/scripts/stage-onnxruntime-cuda.py",
+    ortDir,
+    join(desktopDir, "cuda"),
+  ]);
+  // onnxruntime is MIT — ship its license + notice next to the DLLs (as the mac path does).
+  for (const name of ["LICENSE", "NOTICE.txt"]) {
+    copyFileSync(
+      join(desktopDir, "licenses", "onnxruntime", name),
+      join(ortDir, name),
+    );
+  }
+  console.log(
+    `build-sidecar: staged CUDA-enabled onnxruntime into ${ortDir} + CUDA deps into cuda/`,
+  );
 } else {
   writeFileSync(
     join(ortDir, "README.txt"),
-    "onnxruntime CoreML dylib is bundled on macOS only (Rust DWPose detector, sc-3487).\n",
+    "onnxruntime is bundled on macOS (CoreML) and the Windows candle build (CUDA) only; this build uses neither (sc-3487 / sc-5496).\n",
   );
-  console.log(`build-sidecar: ${ortDir} placeholder (non-macOS, no DWPose dylib)`);
+  console.log(`build-sidecar: ${ortDir} placeholder (no DWPose onnxruntime)`);
 }
 
 // The Rust worker shells out to ffmpeg (frame sampling, frame extract, timeline

--- a/apps/desktop/scripts/stage-onnxruntime-cuda.py
+++ b/apps/desktop/scripts/stage-onnxruntime-cuda.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Stage the CUDA-enabled onnxruntime + its CUDA-12 deps for the candle worker's `ort`
+paths (sc-5496, epic 5482) — the Windows analogue of `stage-onnxruntime.py`'s CoreML
+dylib staging on macOS.
+
+The Rust worker links `ort` with `load-dynamic`, so it dlopens onnxruntime at runtime
+from `ORT_DYLIB_PATH` (set by the desktop `setup.rs`). For a packaged, CUDA-Toolkit-free
+machine we must bundle a CUDA-enabled onnxruntime AND the exact CUDA-12 runtime + cuDNN-9
+DLLs its `onnxruntime_providers_cuda.dll` depends on (a `torch` import normally arranges
+these on `PATH`; the Python stack is retired off-Mac). The cleanest version-matched source
+is the PyPI `onnxruntime-gpu` wheel + its `nvidia-*-cu12` dependency wheels: `pip download`
+resolves the precise cuDNN/cuFFT/cuBLAS/cudart set the build was tested against.
+
+We stage onnxruntime's three DLLs into the `onnxruntime` resource dir, and the deps the
+toolkit redist list doesn't cover — cuDNN + cuFFT + nvJitLink + nvRTC — into the `cuda`
+resource dir (which build-sidecar.mjs also fills with the CUDA-12 runtime redist —
+cudart/cublas/cublasLt/curand — from the toolkit, shared with cudarc). `setup.rs` then
+points `ORT_DYLIB_PATH` at the staged onnxruntime.dll and `SCENEWORKS_ORT_CUDA_DIR`/
+`SCENEWORKS_ORT_CUDNN_DIR` at the `cuda` dir; `ort_cuda::preload_cuda_dylibs` preloads
+them and puts the dir on the loader search path so cuDNN's lazily-loaded sub-engine DLLs
+(`cudnn_engines_tensor_ir64_9.dll` et al.) resolve at inference time.
+
+Validated on RTX PRO 6000 against onnxruntime-gpu 1.26.0 + cuDNN-cu12 9.23 (DWPose CUDA EP
+engaged end-to-end). Bump in lockstep with the `ort` crate's ORT API requirement (rc.12 ⇒
+API 24 ⇒ onnxruntime >= 1.24). Invoked by build-sidecar.mjs on the Windows candle build.
+
+USAGE: python stage-onnxruntime-cuda.py <onnxruntime-dir> <cuda-dir>
+"""
+from __future__ import annotations
+
+import glob
+import os
+import subprocess
+import sys
+import tempfile
+import zipfile
+
+# ORT 2.0.0-rc.12 requests ONNX Runtime API 24 (>= onnxruntime 1.24); 1.26.0 is the
+# version validated in the sc-5496 GPU run. Bump in lockstep with the `ort` crate.
+ONNXRUNTIME_GPU_VERSION = "1.26.0"
+
+# onnxruntime's own DLLs (the CUDA execution provider is in providers_cuda; providers_shared
+# is the EP bridge). TensorRT is deliberately omitted — the worker only uses the CUDA EP.
+ORT_DLLS = (
+    "onnxruntime.dll",
+    "onnxruntime_providers_cuda.dll",
+    "onnxruntime_providers_shared.dll",
+)
+
+# The CUDA-12 deps onnxruntime's CUDA provider + cuDNN need that the toolkit redist list
+# (build-sidecar.mjs: cudart/cublas/cublasLt/curand/nvrtc) doesn't guarantee: cuDNN-9 (incl.
+# the lazily-loaded compute-engine sub-DLLs), cuFFT (a hard import of providers_cuda),
+# nvJitLink + nvRTC (cuDNN's runtime-compiled engines JIT through them). cudart/cublas/
+# cublasLt come from the toolkit copy (CUDA-12, shared with cudarc); not re-staged here.
+#
+# IMPORTANT: onnxruntime-gpu does NOT declare the nvidia-*-cu12 wheels as hard dependencies,
+# so `pip download onnxruntime-gpu` alone does NOT pull them — they must be requested
+# explicitly (the cu12 line, matching onnxruntime-gpu's CUDA-12 build). Unpinned ⇒ the
+# latest cu12 release, which is what the sc-5496 GPU run validated (cuDNN 9.23 / cuFFT 11.4).
+CUDA_DEP_PACKAGES = (
+    "nvidia-cudnn-cu12",
+    "nvidia-cufft-cu12",
+    "nvidia-nvjitlink-cu12",
+    "nvidia-cuda-nvrtc-cu12",
+)
+# Wheel filename prefixes (underscored) the packages above resolve to, for harvesting.
+CUDA_DEP_WHEEL_PREFIXES = tuple(p.replace("-", "_") + "-" for p in CUDA_DEP_PACKAGES)
+
+
+def _extract_dlls(wheel: str, names: list[str] | None, dest: str) -> int:
+    """Extract DLLs from a wheel (zip) into dest by basename. names=None → all *.dll."""
+    os.makedirs(dest, exist_ok=True)
+    count = 0
+    with zipfile.ZipFile(wheel) as zf:
+        for entry in zf.namelist():
+            base = os.path.basename(entry)
+            if not base.lower().endswith(".dll"):
+                continue
+            if names is not None and base not in names:
+                continue
+            with zf.open(entry) as src, open(os.path.join(dest, base), "wb") as out:
+                out.write(src.read())
+            count += 1
+    return count
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: stage-onnxruntime-cuda.py <onnxruntime-dir> <cuda-dir>", file=sys.stderr)
+        return 2
+    ort_dir, cuda_dir = sys.argv[1], sys.argv[2]
+
+    with tempfile.TemporaryDirectory() as tmp:
+        # Resolve onnxruntime-gpu + the cu12 deps it needs at runtime (it doesn't declare
+        # them, so they're listed explicitly) — CUDA-12 wheels for this Windows host.
+        subprocess.run(
+            [
+                sys.executable, "-m", "pip", "download",
+                f"onnxruntime-gpu=={ONNXRUNTIME_GPU_VERSION}",
+                *CUDA_DEP_PACKAGES,
+                "--only-binary=:all:", "-d", tmp,
+            ],
+            check=True,
+        )
+
+        def _one(pattern: str) -> str:
+            hits = glob.glob(os.path.join(tmp, pattern))
+            if not hits:
+                print(f"stage-onnxruntime-cuda: no wheel matching {pattern}", file=sys.stderr)
+                raise SystemExit(1)
+            return hits[0]
+
+        n = _extract_dlls(_one("onnxruntime_gpu-*.whl"), list(ORT_DLLS), ort_dir)
+        if n < len(ORT_DLLS):
+            print(f"stage-onnxruntime-cuda: only {n}/{len(ORT_DLLS)} onnxruntime DLLs found", file=sys.stderr)
+            return 1
+        print(f"stage-onnxruntime-cuda: staged {n} onnxruntime DLLs into {ort_dir}")
+
+        # cuDNN-9 (incl. lazily-loaded sub-engines) + cuFFT + nvJitLink + nvRTC into the
+        # shared cuda dir, from the matched nvidia-*-cu12 dep wheels pip resolved.
+        for prefix in CUDA_DEP_WHEEL_PREFIXES:
+            wheel = _one(f"{prefix}*.whl")
+            count = _extract_dlls(wheel, None, cuda_dir)
+            print(f"stage-onnxruntime-cuda: staged {count} DLLs from {os.path.basename(wheel)} into {cuda_dir}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -865,6 +865,23 @@ h=glob.glob(os.path.join(d,'capi','libonnxruntime*.dylib'));sys.stdout.write(h[0
     (!path.is_empty() && Path::new(&path).exists()).then_some(path)
 }
 
+/// Resolve the bundled CUDA-enabled onnxruntime DLL the candle worker's `ort` paths
+/// (DWPose pose_detect sc-5496, + YOLO/Real-ESRGAN next, epic 5482) dlopen at runtime
+/// via `ORT_DYLIB_PATH` (the `load-dynamic` feature). The Windows/CUDA analogue of the
+/// macOS CoreML resolver above: the onnxruntime-gpu DLLs are staged by build-sidecar.mjs
+/// into the `onnxruntime` resource dir on the Windows candle build (with the matching
+/// CUDA-12 runtime + cuDNN-9 in the `cuda` resource dir). Returns None on a plain build —
+/// the placeholder dir ships only a README, so a non-candle desktop leaves `ort` on its
+/// CPU fallback. Windows-only (the candle GPU worker is Windows-gated here).
+#[cfg(target_os = "windows")]
+fn resolve_bundled_onnxruntime(app: &AppHandle) -> Option<String> {
+    let resources = app.path().resource_dir().ok()?;
+    let bundled = resources.join("onnxruntime").join("onnxruntime.dll");
+    bundled
+        .exists()
+        .then(|| bundled.to_string_lossy().to_string())
+}
+
 /// Resolve the bundled CUDA runtime redistributable DLL directory (sc-5560). The
 /// candle (Windows/CUDA) worker links cudarc with dynamic-linking, which
 /// `LoadLibrary`s cudart/cublas/cublasLt/curand/nvrtc by name at runtime; bundling
@@ -1505,10 +1522,26 @@ fn supervise_candle_worker(app: AppHandle, api_port: u16) {
             // without a CUDA Toolkit on the machine (sc-5560).
             if let Some(cuda_dir) = resolve_bundled_cuda_dir(&app) {
                 let existing = std::env::var_os("PATH").unwrap_or_default();
-                let mut paths = vec![cuda_dir];
+                let mut paths = vec![cuda_dir.clone()];
                 paths.extend(std::env::split_paths(&existing));
                 if let Ok(joined) = std::env::join_paths(paths) {
                     command = command.env("PATH", joined);
+                }
+                // The candle worker's `ort` (onnxruntime) paths — DWPose pose_detect
+                // (sc-5496), then YOLO / Real-ESRGAN (sc-5498/5499, epic 5482) — point
+                // `ort` at the bundled CUDA-enabled onnxruntime and tell the worker where
+                // the CUDA-12 runtime + cuDNN-9 DLLs live, so its CUDA execution provider
+                // engages instead of falling back to CPU. The off-Mac analogue of the
+                // macOS CoreML `ORT_DYLIB_PATH` wiring. The `cuda` resource dir holds the
+                // version-matched CUDA-12 runtime + cuDNN-9 (staged by build-sidecar.mjs);
+                // `ort_cuda::preload_cuda_dylibs` preloads them + puts the dir on the
+                // loader search path so cuDNN's lazily-loaded sub-engine DLLs resolve.
+                if let Some(ort_dylib) = resolve_bundled_onnxruntime(&app) {
+                    let cuda = cuda_dir.to_string_lossy().to_string();
+                    command = command
+                        .env("ORT_DYLIB_PATH", ort_dylib)
+                        .env("SCENEWORKS_ORT_CUDA_DIR", &cuda)
+                        .env("SCENEWORKS_ORT_CUDNN_DIR", &cuda);
                 }
             }
             // The worker muxes generated video with ffmpeg; point it at the bundled

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -115,6 +115,14 @@ mod openpose_skeleton;
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 mod pose_jobs;
+// CUDA execution-provider dependency preloading for the off-Mac candle `ort` paths
+// (sc-6209, epic 5482): `ort::ep::cuda::preload_dylibs` dlopens the CUDA-12 runtime +
+// cuDNN-9 DLLs the onnxruntime CUDA EP needs, so it engages the GPU regardless of PATH
+// (the Mac CoreML path needs no equivalent). Shared by pose_jobs (DWPose, sc-5496) +
+// person_jobs (YOLO, sc-5498), and Real-ESRGAN (sc-5499) next — gated to the candle GPU
+// lane only.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+mod ort_cuda;
 // SCRFD 5-point face-landmark extraction (epic 4422, sc-4433): native-MLX SCRFD on Mac, plus the
 // candle SCRFD/ArcFace stack on the Windows/Linux candle lane (sc-5497, epic 5482) — the same
 // InstantID face-stack detector reused in-process for the Key Point Library "extract kps from this

--- a/crates/sceneworks-worker/src/ort_cuda.rs
+++ b/crates/sceneworks-worker/src/ort_cuda.rs
@@ -1,0 +1,161 @@
+//! CUDA execution-provider dependency preloading for the off-Mac `ort` (onnxruntime)
+//! paths (epic 5482). Shared by every candle GPU-worker `ort` surface — DWPose
+//! pose_detect (sc-5496), YOLO person-detect (sc-5498), Real-ESRGAN upscale
+//! (sc-5499) — so the CUDA execution provider's runtime dependencies resolve
+//! regardless of `PATH`.
+//!
+//! The problem: the worker links `ort` with `load-dynamic`, dlopening an
+//! onnxruntime-gpu build (resolved from `ORT_DYLIB_PATH`) at runtime. That build's
+//! `onnxruntime_providers_cuda.dll` in turn needs the CUDA-12 runtime
+//! (cudart/cublas/cublasLt/cufft) + cuDNN-9 DLLs. A `torch` import normally arranges
+//! `PATH` so these resolve; with the Python stack retired off-Mac, nothing does, so
+//! the CUDA EP fails to initialise ("CUDA execution provider is not enabled in this
+//! build") and `Detector::load` honestly falls back to the CPU EP.
+//!
+//! The fix: `ort::ep::cuda::preload_dylibs` dlopens the CUDA + cuDNN DLLs from
+//! explicit directories before the CUDA EP is registered, prioritising them in the
+//! loader's search order (the off-Mac analogue of bundling the CoreML dylib on Mac,
+//! sc-3487). The two directories are resolved independently because they typically
+//! differ: the onnxruntime-gpu wheels are CUDA-12 builds whose cudart/cublas/cufft
+//! live in the CUDA Toolkit `bin`, while cuDNN-9 ships separately (a cuDNN install,
+//! or alongside a torch wheel). The desktop candle bundle stages both into one dir
+//! and points both env vars at it (setup.rs); a server/dev box sets the env vars (or
+//! relies on the toolkit defaults).
+//!
+//! Two mechanisms, because onnxruntime + cuDNN load DLLs in two stages:
+//!  - `preload_dylibs` immediately dlopens onnxruntime's known CUDA/cuDNN deps from the
+//!    resolved dirs, pinning the version-matched copies (CUDA-12) ahead of anything
+//!    else on the loader path.
+//!  - prepending those dirs to `PATH` (Windows) covers what `preload_dylibs` can't: a
+//!    modern cuDNN (9.23) loads its compute-engine sub-libraries LAZILY by name at the
+//!    first conv (`cudnn_engines_tensor_ir64_9.dll` et al.), which aren't in ort's fixed
+//!    dylib list — without the dir on the loader's standard search those lazy loads fail
+//!    mid-inference ("Could not locate cudnn_engines_tensor_ir64_9.dll"). Mirrors the
+//!    PATH-prepend the desktop `setup.rs` already does for cudarc's redist DLLs.
+//!
+//! Best-effort: a preload failure (a missing DLL in the resolved dir) is logged and
+//! execution continues — the CUDA EP may still initialise if `PATH` already satisfies
+//! it, and if it can't, the `.error_on_failure()` registration surfaces the failure so
+//! the detector falls back to CPU and reports `device = "cpu"` honestly.
+
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+/// `SCENEWORKS_ORT_CUDA_DIR` — directory holding the CUDA-12 runtime DLLs the
+/// onnxruntime CUDA EP depends on (cudart64_12 / cublas64_12 / cublasLt64_12 /
+/// cufft64_11 on Windows; the `.so.12` equivalents on Linux).
+const CUDA_DIR_ENV: &str = "SCENEWORKS_ORT_CUDA_DIR";
+/// `SCENEWORKS_ORT_CUDNN_DIR` — directory holding the cuDNN-9 DLLs (cudnn64_9 + the
+/// graph/ops/heuristic/adv/cnn/engines siblings). Defaults to the CUDA dir when unset
+/// (toolkits / bundles that co-locate cuDNN with the CUDA runtime).
+const CUDNN_DIR_ENV: &str = "SCENEWORKS_ORT_CUDNN_DIR";
+
+/// Default CUDA Toolkit directory the runtime DLLs are loaded from when neither the
+/// env override nor `CUDA_PATH` resolves: the Windows toolkit `bin` / the Linux
+/// `lib64`. CUDA 12.9 is the toolchain this candle lane builds + validates against
+/// (the onnxruntime-gpu wheels are CUDA-12 builds).
+#[cfg(target_os = "windows")]
+const DEFAULT_CUDA_DIR: &str = r"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.9\bin";
+#[cfg(all(unix, not(target_os = "macos")))]
+const DEFAULT_CUDA_DIR: &str = "/usr/local/cuda/lib64";
+
+/// An existing directory from `env_key`, if set + non-empty + present.
+fn dir_from_env(env_key: &str) -> Option<PathBuf> {
+    let value = std::env::var(env_key).ok()?;
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let path = PathBuf::from(trimmed);
+    path.is_dir().then_some(path)
+}
+
+/// Resolve the CUDA runtime directory: the explicit `SCENEWORKS_ORT_CUDA_DIR`, then
+/// `CUDA_PATH`/bin (a standard toolkit install), then the platform default.
+fn resolve_cuda_dir() -> Option<PathBuf> {
+    if let Some(dir) = dir_from_env(CUDA_DIR_ENV) {
+        return Some(dir);
+    }
+    if let Some(cuda_path) = std::env::var_os("CUDA_PATH") {
+        let bin = if cfg!(windows) {
+            PathBuf::from(&cuda_path).join("bin")
+        } else {
+            PathBuf::from(&cuda_path).join("lib64")
+        };
+        if bin.is_dir() {
+            return Some(bin);
+        }
+    }
+    let default = PathBuf::from(DEFAULT_CUDA_DIR);
+    default.is_dir().then_some(default)
+}
+
+/// Resolve the cuDNN directory: the explicit `SCENEWORKS_ORT_CUDNN_DIR`, else the
+/// CUDA dir (toolkits / bundles that co-locate cuDNN with the CUDA runtime).
+fn resolve_cudnn_dir(cuda_dir: Option<&PathBuf>) -> Option<PathBuf> {
+    dir_from_env(CUDNN_DIR_ENV).or_else(|| cuda_dir.cloned())
+}
+
+/// Prepend the resolved CUDA + cuDNN dirs (deduped, in order) to the process `PATH` so
+/// the standard Windows loader search finds both the onnxruntime CUDA provider's direct
+/// deps AND cuDNN's lazily-loaded compute-engine sub-DLLs. Windows-only: PATH drives the
+/// DLL search there; on Linux the dynamic linker uses `LD_LIBRARY_PATH` (set by the
+/// launcher) + the `preload_dylibs` RTLD_GLOBAL handles instead.
+#[cfg(target_os = "windows")]
+fn prepend_dll_search_path(dirs: &[&PathBuf]) {
+    let mut prefix: Vec<PathBuf> = Vec::new();
+    for dir in dirs {
+        if !prefix.iter().any(|existing| existing == *dir) {
+            prefix.push((*dir).clone());
+        }
+    }
+    if prefix.is_empty() {
+        return;
+    }
+    let existing = std::env::var_os("PATH").unwrap_or_default();
+    prefix.extend(std::env::split_paths(&existing));
+    if let Ok(joined) = std::env::join_paths(prefix) {
+        std::env::set_var("PATH", joined);
+    }
+}
+
+/// Preload the onnxruntime CUDA EP's CUDA + cuDNN dependency DLLs from the resolved
+/// directories. Runs at most once per process (idempotent across the det + pose
+/// session builds, and across every off-Mac `ort` job path); best-effort.
+pub(crate) fn preload_cuda_dylibs() {
+    static PRELOADED: OnceLock<()> = OnceLock::new();
+    PRELOADED.get_or_init(|| {
+        let cuda_dir = resolve_cuda_dir();
+        let cudnn_dir = resolve_cudnn_dir(cuda_dir.as_ref());
+        if cuda_dir.is_none() && cudnn_dir.is_none() {
+            eprintln!(
+                "[ort-cuda] no CUDA/cuDNN dir resolved (set {CUDA_DIR_ENV}/{CUDNN_DIR_ENV}); \
+                 relying on PATH for the onnxruntime CUDA provider's dependencies"
+            );
+            return;
+        }
+        // Put the resolved dirs on the loader search path first, so cuDNN's lazily-loaded
+        // sub-engine DLLs (not in `preload_dylibs`' fixed list) resolve at inference time.
+        #[cfg(target_os = "windows")]
+        {
+            let dirs: Vec<&PathBuf> = [cuda_dir.as_ref(), cudnn_dir.as_ref()]
+                .into_iter()
+                .flatten()
+                .collect();
+            prepend_dll_search_path(&dirs);
+        }
+        match ort::ep::cuda::preload_dylibs(cuda_dir.as_deref(), cudnn_dir.as_deref()) {
+            Ok(()) => eprintln!(
+                "[ort-cuda] preloaded CUDA EP dependencies (cuda={:?}, cudnn={:?})",
+                cuda_dir, cudnn_dir
+            ),
+            // Non-fatal: the CUDA EP may still initialise from PATH; if it can't, the
+            // `.error_on_failure()` registration falls the detector back to CPU honestly.
+            Err(error) => eprintln!(
+                "[ort-cuda] CUDA EP dependency preload failed (cuda={:?}, cudnn={:?}): {error} \
+                 — the onnxruntime CUDA provider will fall back to PATH/CPU",
+                cuda_dir, cudnn_dir
+            ),
+        }
+    });
+}

--- a/crates/sceneworks-worker/src/person_jobs.rs
+++ b/crates/sceneworks-worker/src/person_jobs.rs
@@ -834,6 +834,12 @@ fn ort_err<R>(e: ort::Error<R>) -> WorkerError {
 fn build_session(path: &Path, accel: bool) -> WorkerResult<Session> {
     let mut b = Session::builder().map_err(ort_err)?;
     if accel {
+        // Preload the CUDA-12 runtime + cuDNN-9 DLLs the onnxruntime CUDA provider needs
+        // before registering the EP — with the Python/torch stack retired off-Mac nothing
+        // else puts them on the loader path, so without this the CUDA EP can't initialise
+        // and YOLO falls back to CPU (sc-6209). Shared helper (once per process, also used
+        // by `pose_jobs`); best-effort, see `ort_cuda`.
+        crate::ort_cuda::preload_cuda_dylibs();
         b = b
             .with_execution_providers([CUDAExecutionProvider::default().build().error_on_failure()])
             .map_err(ort_err)?;

--- a/crates/sceneworks-worker/src/pose_jobs.rs
+++ b/crates/sceneworks-worker/src/pose_jobs.rs
@@ -413,6 +413,12 @@ fn build_session(path: &Path, accel: bool) -> WorkerResult<Session> {
         }
         #[cfg(not(target_os = "macos"))]
         {
+            // Preload the CUDA-12 runtime + cuDNN-9 DLLs the loaded onnxruntime-gpu's
+            // CUDA provider depends on, before registering the EP — with the Python/torch
+            // stack retired off-Mac nothing else puts them on the loader path, so without
+            // this the CUDA EP can't initialise and we fall back to CPU (sc-5496). Shared
+            // helper (once per process); best-effort, see `ort_cuda`.
+            crate::ort_cuda::preload_cuda_dylibs();
             // `error_on_failure` so a CUDA provider that can't initialise (no GPU, or a
             // cuDNN/CUDA mismatch in the loaded onnxruntime) surfaces as an error here —
             // `Detector::load` then falls back to a CPU session and reports `device =


### PR DESCRIPTION
## sc-6209 — off-Mac `ort` paths actually use the GPU

The candle-worker `ort` (onnxruntime) paths — DWPose `pose_detect` (sc-5496) and YOLO `person_detect` (sc-5498) — registered the `CUDAExecutionProvider` but **silently fell back to the onnxruntime CPU EP**:

- Nothing put the CUDA-12 runtime + cuDNN-9 DLLs on the loader path off-Mac (a `torch` import used to; the Python stack is retired).
- ort's `download-binaries` is a **no-op under `load-dynamic`** (verified: empty ort-sys build output) — so no onnxruntime was even provisioned.

### Fix
New shared helper `crates/sceneworks-worker/src/ort_cuda.rs` (`preload_cuda_dylibs`, gated `not(macos)+backend-candle`), called from each CUDA-EP `build_session`:

1. `ort::ep::cuda::preload_dylibs(cuda_dir, cudnn_dir)` — dlopen the version-matched CUDA-12 / cuDNN-9 deps (available because `load-dynamic` pulls in `preload-dylibs`; no extra feature).
2. **Prepend the CUDA + cuDNN dirs to `PATH`** — essential: cuDNN 9.23 loads compute-engine sub-DLLs *lazily by name* at the first conv (`cudnn_engines_tensor_ir64_9.dll`, not in ort's fixed `CUDNN_DYLIBS` list); without the dir on the loader path, session **build** succeeds but `session.run` dies mid-inference.

Wired into `pose_jobs` (DWPose) + `person_jobs` (YOLO). Real-ESRGAN (sc-5499) rides the same helper once it lands. Dirs resolve from `SCENEWORKS_ORT_CUDA_DIR` / `SCENEWORKS_ORT_CUDNN_DIR`, else `CUDA_PATH/bin`, else the CUDA 12.9 toolkit default.

### Source decision + packaging
Source = the PyPI `onnxruntime-gpu` wheel + its `nvidia-*-cu12` dep wheels (the off-Mac analogue of the Mac `stage-onnxruntime.py` CoreML dylib pip-download). Desktop packaging:
- `setup.rs` `supervise_candle_worker` sets `ORT_DYLIB_PATH` + the two dir envs (mirrors the Mac CoreML `ORT_DYLIB_PATH` wiring).
- `build-sidecar.mjs` + new `stage-onnxruntime-cuda.py` stage the onnxruntime-gpu DLLs (`onnxruntime` resource dir) + cuDNN/cuFFT/nvJitLink/nvRTC (`cuda` resource dir, alongside the toolkit cudart/cublas from sc-5560). Note: `pip download onnxruntime-gpu` does **not** pull the `nvidia-*-cu12` wheels (onnxruntime-gpu doesn't declare them) — the script lists them explicitly.

### Validation (RTX PRO 6000, onnxruntime-gpu 1.26.0 + cuDNN-cu12 9.23)
Both off-Mac ort paths GPU-proven end-to-end via their ignored tests with `--features backend-candle`:
- **DWPose** (`pose_detect_candle`) → `DWPose execution device = cuda`, 1 passed (person found, neck between shoulders), process is a CUDA compute-app in `nvidia-smi`.
- **YOLO** (`person_detect_candle`) → `YOLO11 person-detect device = cuda`, 6 detections (top confidence 0.94, normalized box in [0,1]), 1 passed. Weights = `SceneWorks/yolo11m-person-detect-onnx` from HF.
- **Ablation** (proves both mechanisms needed): without the fix → `CUDA EP FAILED … cudnn64_9.dll missing`; with preload-only → `Could not locate cudnn_engines_tensor_ir64_9.dll` mid-inference.
- The staging script's own output was driven through the DWPose test (with the toolkit cudart/cublas added) → `device = cuda`, so the packaging path itself is validated, not just a manual stage.
- `rust:fmt` (`cargo fmt --all -- --check`), worker + desktop `clippy -D warnings`, and `cargo check -p sceneworks-desktop` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
