### PR TITLE
sc-6067: contain MLX generation panics + tile SeedVR2 image upscale

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_distr 0.5.1",
  "safetensors 0.7.0",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6)",
  "serde_json",
  "thiserror 2.0.18",
 ]
@@ -3284,11 +3284,11 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=98592bb0de7e76a99e9d944d19dd11f241e76d29#98592bb0de7e76a99e9d944d19dd11f241e76d29"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=98592bb0de7e76a99e9d944d19dd11f241e76d29)",
  "thiserror 2.0.18",
  "tokenizers 0.21.4",
 ]
@@ -3296,7 +3296,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=98592bb0de7e76a99e9d944d19dd11f241e76d29#98592bb0de7e76a99e9d944d19dd11f241e76d29"
 dependencies = [
  "image",
  "inventory",
@@ -3310,7 +3310,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=98592bb0de7e76a99e9d944d19dd11f241e76d29#98592bb0de7e76a99e9d944d19dd11f241e76d29"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3322,7 +3322,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=98592bb0de7e76a99e9d944d19dd11f241e76d29#98592bb0de7e76a99e9d944d19dd11f241e76d29"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3331,7 +3331,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=98592bb0de7e76a99e9d944d19dd11f241e76d29#98592bb0de7e76a99e9d944d19dd11f241e76d29"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3343,7 +3343,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=98592bb0de7e76a99e9d944d19dd11f241e76d29#98592bb0de7e76a99e9d944d19dd11f241e76d29"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3354,7 +3354,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=98592bb0de7e76a99e9d944d19dd11f241e76d29#98592bb0de7e76a99e9d944d19dd11f241e76d29"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3366,7 +3366,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=98592bb0de7e76a99e9d944d19dd11f241e76d29#98592bb0de7e76a99e9d944d19dd11f241e76d29"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3377,7 +3377,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=98592bb0de7e76a99e9d944d19dd11f241e76d29#98592bb0de7e76a99e9d944d19dd11f241e76d29"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3387,7 +3387,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=98592bb0de7e76a99e9d944d19dd11f241e76d29#98592bb0de7e76a99e9d944d19dd11f241e76d29"
 dependencies = [
  "image",
  "inventory",
@@ -3399,7 +3399,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=98592bb0de7e76a99e9d944d19dd11f241e76d29#98592bb0de7e76a99e9d944d19dd11f241e76d29"
 dependencies = [
  "image",
  "inventory",
@@ -3412,7 +3412,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=98592bb0de7e76a99e9d944d19dd11f241e76d29#98592bb0de7e76a99e9d944d19dd11f241e76d29"
 dependencies = [
  "image",
  "inventory",
@@ -3424,7 +3424,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=98592bb0de7e76a99e9d944d19dd11f241e76d29#98592bb0de7e76a99e9d944d19dd11f241e76d29"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3435,7 +3435,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=98592bb0de7e76a99e9d944d19dd11f241e76d29#98592bb0de7e76a99e9d944d19dd11f241e76d29"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3447,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=98592bb0de7e76a99e9d944d19dd11f241e76d29#98592bb0de7e76a99e9d944d19dd11f241e76d29"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3457,7 +3457,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=98592bb0de7e76a99e9d944d19dd11f241e76d29#98592bb0de7e76a99e9d944d19dd11f241e76d29"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3466,7 +3466,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=98592bb0de7e76a99e9d944d19dd11f241e76d29#98592bb0de7e76a99e9d944d19dd11f241e76d29"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3475,7 +3475,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=98592bb0de7e76a99e9d944d19dd11f241e76d29#98592bb0de7e76a99e9d944d19dd11f241e76d29"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3487,7 +3487,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=98592bb0de7e76a99e9d944d19dd11f241e76d29#98592bb0de7e76a99e9d944d19dd11f241e76d29"
 dependencies = [
  "image",
  "inventory",
@@ -3500,7 +3500,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=98592bb0de7e76a99e9d944d19dd11f241e76d29#98592bb0de7e76a99e9d944d19dd11f241e76d29"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3511,7 +3511,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=98592bb0de7e76a99e9d944d19dd11f241e76d29#98592bb0de7e76a99e9d944d19dd11f241e76d29"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3522,7 +3522,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=98592bb0de7e76a99e9d944d19dd11f241e76d29#98592bb0de7e76a99e9d944d19dd11f241e76d29"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3533,7 +3533,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=98592bb0de7e76a99e9d944d19dd11f241e76d29#98592bb0de7e76a99e9d944d19dd11f241e76d29"
 dependencies = [
  "image",
  "inventory",
@@ -3547,7 +3547,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=98592bb0de7e76a99e9d944d19dd11f241e76d29#98592bb0de7e76a99e9d944d19dd11f241e76d29"
 dependencies = [
  "image",
  "inventory",
@@ -5185,6 +5185,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sceneworks-gen-core"
+version = "0.1.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=98592bb0de7e76a99e9d944d19dd11f241e76d29#98592bb0de7e76a99e9d944d19dd11f241e76d29"
+dependencies = [
+ "inventory",
+ "safetensors 0.4.5",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokenizers 0.21.4",
+]
+
+[[package]]
 name = "sceneworks-rust-api"
 version = "0.2.0"
 dependencies = [
@@ -5276,7 +5288,7 @@ dependencies = [
  "pmetal-mlx-rs",
  "reqwest 0.12.28",
  "sceneworks-core",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=98592bb0de7e76a99e9d944d19dd11f241e76d29)",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -131,7 +131,26 @@ sceneworks-core = { path = "../sceneworks-core" }
 # candle-gen main (an ancestor of the #90 merge 7b4d15e). candle-gen #90 is SOURCE-ONLY (gen-core stays
 # 7b89d45, byte-identical), so this is a pure candle rev bump and the backend-candle graph stays single
 # gen-core rev 7b89d45.
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+# Rev 98592bb (mlx-gen branch claude/sc-6067-seedvr2-image-tiling, sc-6067): bumps every mlx-gen crate
+# 7b89d45 -> 98592bb to spatially tile the SeedVR2 *image* upscale path. The image path
+# (`Seedvr2Pipeline::generate`) ran the whole frame in ONE pass with no memory-budget check, so a large
+# upscale tried a single DiT/VAE allocation past Metal's max buffer size (~80.6 GiB) and the mlx-rs
+# `.unwrap()` panicked the worker's shared generator-cache thread (the catch_unwind crash-recovery in
+# generator_cache.rs is the companion worker fix). The video path already budget-tiled (sc-5201); this
+# routes the image path through the same `run_frame_tiled` feather-blend tiler when over budget. The
+# delta is PURE mlx-gen-seedvr2 Rust — gen-core is BYTE-IDENTICAL 7b89d45 -> 98592bb, mlx-rs unchanged
+# (44929a0), so the direct `mlx-rs` pin below is unchanged, MLX core does not rebuild (only seedvr2
+# recompiles), and the DEFAULT skew gate (PR gate, candle-gen-blind) stays single-rev/green. candle-gen
+# still pins gen-core 7b89d45 (byte-identical), so the workflow_dispatch-only `--features backend-candle`
+# lane is momentarily skewed on REV; build-windows builds without backend-candle so this PR is unaffected
+# and candle catches up in its own repo (same deferral as the prior single-crate bumps, tracked sc-5905).
+# Merged as mlx-gen #485 (merge commit 51a6792); 98592bb is its content commit AND a durable ancestor of
+# main (merge, not squash), so it stays fetchable after the branch is deleted. The pin deliberately stays
+# at 98592bb (the MINIMAL seedvr2-only delta over 7b89d45) rather than flipping to merged-main HEAD: main
+# has since advanced with the UNRELATED sc-6030 FLUX.2-dev caption-upsample work (#484 — mlx-gen-flux2 +
+# a gen-core generator.rs change) that this fix must not drag in. A later mlx-gen bump that wants sc-6030
+# (or anything past 7b89d45) re-pins all crates forward in lockstep then, on its own validation.
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "98592bb0de7e76a99e9d944d19dd11f241e76d29" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -434,7 +453,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "98592bb0de7e76a99e9d944d19dd11f241e76d29" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -446,59 +465,59 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5
 # internal pin (the Lens engine PRs #407–#414 did not move it; nor did the seedvr2 engine #416/#419/
 # #421 or the softness PR #422, so the 1a97909 bump above leaves mlx-rs at 44929a0).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "44929a001ab8a8837403a71c65cf064224de0cdc" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "98592bb0de7e76a99e9d944d19dd11f241e76d29" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "98592bb0de7e76a99e9d944d19dd11f241e76d29" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "98592bb0de7e76a99e9d944d19dd11f241e76d29" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "98592bb0de7e76a99e9d944d19dd11f241e76d29" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "98592bb0de7e76a99e9d944d19dd11f241e76d29" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "98592bb0de7e76a99e9d944d19dd11f241e76d29" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "98592bb0de7e76a99e9d944d19dd11f241e76d29" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "98592bb0de7e76a99e9d944d19dd11f241e76d29" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "98592bb0de7e76a99e9d944d19dd11f241e76d29" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "98592bb0de7e76a99e9d944d19dd11f241e76d29" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "98592bb0de7e76a99e9d944d19dd11f241e76d29" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "98592bb0de7e76a99e9d944d19dd11f241e76d29" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "98592bb0de7e76a99e9d944d19dd11f241e76d29" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -507,12 +526,12 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "98592bb0de7e76a99e9d944d19dd11f241e76d29" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "98592bb0de7e76a99e9d944d19dd11f241e76d29" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -521,7 +540,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "98592bb0de7e76a99e9d944d19dd11f241e76d29" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -529,7 +548,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "98592bb0de7e76a99e9d944d19dd11f241e76d29" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -540,7 +559,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "98592bb0de7e76a99e9d944d19dd11f241e76d29" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -551,7 +570,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "98592bb0de7e76a99e9d944d19dd11f241e76d29" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -566,7 +585,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4
 # converted in-memory at load (no Python); the precomputed neg-prompt embedding is bundled in-crate. No
 # LoRA/guidance/CFG (one-step). 3B fp16 only here — 7B (sc-5197) + int8 (sc-5198) are engine-side and
 # unwired. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "98592bb0de7e76a99e9d944d19dd11f241e76d29" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -577,7 +596,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b8
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "98592bb0de7e76a99e9d944d19dd11f241e76d29" }
 # Prompt-refine provider (sc-5552, the MLX twin of candle-gen-prompt-refine / sc-5500). An
 # inventory-registered `TextLlm` under id `prompt_refine` (`backend="mlx"`, `mac_only`): a native MLX
 # Llama-3.2-3B-Instruct that rewrites a user's prompt, replacing the Python `prompt_refine.py`
@@ -587,7 +606,7 @@ mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b8
 # textllm registered" trap). Weights = a stock Llama-3.2-3B-Instruct HF snapshot (config.json +
 # tokenizer.json + model-*.safetensors; default `huihui-ai/Llama-3.2-3B-Instruct-abliterated`). Same
 # git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "98592bb0de7e76a99e9d944d19dd11f241e76d29" }
 # SCAIL-2 (zai-org) end-to-end character-animation provider (epic 5439, sc-5448). An inventory-registered
 # `Generator` under id `scail2_14b` (`Modality::Video`): a Wan2.1-14B I2V DiT that animates a reference
 # character with a driving video's motion (`video_mode == "replacement"` flips the cross-identity
@@ -599,7 +618,7 @@ mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev 
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "98592bb0de7e76a99e9d944d19dd11f241e76d29" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory

--- a/crates/sceneworks-worker/src/generator_cache.rs
+++ b/crates/sceneworks-worker/src/generator_cache.rs
@@ -97,6 +97,13 @@ impl GeneratorCache {
         Self { entry: None }
     }
 
+    /// Drop the resident generator so the next job reloads from scratch. Called after a contained
+    /// panic (sc-6067): MLX/Metal state after a mid-op abort is suspect, so the cached generator
+    /// must not be reused.
+    fn evict(&mut self) {
+        self.entry = None;
+    }
+
     fn with_generator<R>(
         &mut self,
         key: GeneratorCacheKey,
@@ -131,12 +138,34 @@ fn generator_worker() -> &'static mpsc::Sender<GeneratorJob> {
             .spawn(move || {
                 let mut cache = GeneratorCache::new();
                 while let Ok(job) = rx.recv() {
-                    job(&mut cache);
+                    // Backstop: contain any panic that escapes a job's own guard so this single
+                    // shared cache thread can never die and poison every later generation (sc-6067).
+                    // A job normally catches its own panic, replies with a clean error, and evicts;
+                    // this catches anything it misses. On a contained panic the cache is reset
+                    // because post-abort MLX/Metal state is suspect.
+                    if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| job(&mut cache)))
+                        .is_err()
+                    {
+                        cache.evict();
+                    }
                 }
             })
             .expect("start MLX generator cache worker");
         tx
     })
+}
+
+/// Best-effort human-readable text from a caught panic payload — the `&str`/`String` a `panic!`
+/// produces. mlx-rs `.unwrap()`/`.expect()` panics carry their formatted message as a `String`
+/// (e.g. the `[metal::malloc] Attempting to allocate …` Metal OOM), so this surfaces the real cause.
+fn panic_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = payload.downcast_ref::<&str>() {
+        (*s).to_owned()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "unknown panic payload".to_owned()
+    }
 }
 
 pub(crate) async fn with_cached_generator<R>(
@@ -152,7 +181,23 @@ where
     let load_error_context = load_error_context.into();
     let (reply_tx, reply_rx) = oneshot::channel::<WorkerResult<R>>();
     let job = Box::new(move |cache: &mut GeneratorCache| {
-        let result = cache.with_generator(key, spec, load_error_context, run);
+        // Contain a panic from inside the engine (e.g. mlx-rs `.unwrap()`-ing a Metal allocation
+        // failure) so it fails THIS job with a clean error instead of unwinding out of the shared
+        // cache thread and stopping every subsequent generation (sc-6067). The cached generator is
+        // evicted on panic — post-abort MLX/Metal state is suspect, so the next job reloads fresh.
+        let result = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            cache.with_generator(key, spec, load_error_context, run)
+        })) {
+            Ok(result) => result,
+            Err(panic) => {
+                cache.evict();
+                Err(WorkerError::Engine(format!(
+                    "MLX generation panicked and was contained (the engine likely ran out of \
+                     memory; the cached generator was reset): {}",
+                    panic_message(panic.as_ref())
+                )))
+            }
+        };
         let _ = reply_tx.send(result);
     });
     generator_worker()
@@ -361,6 +406,57 @@ mod tests {
         assert!(
             matches!(result, Err(WorkerError::Canceled(_))),
             "expected the cancel flag to map to WorkerError::Canceled, got {result:?}"
+        );
+    }
+
+    // sc-6067: a panic inside a job closure (e.g. mlx-rs `.unwrap()`-ing a Metal OOM) must be
+    // CONTAINED — it fails only that job with a clean error AND the single shared cache thread keeps
+    // serving. Without the `catch_unwind` guard the worker thread unwinds and dies, and every later
+    // generation fails with "MLX generator cache worker stopped" until a process restart. (The panic
+    // backtrace this test triggers is printed by the default panic hook — that is expected.)
+    #[tokio::test]
+    async fn panicking_job_is_contained_and_worker_keeps_serving() {
+        let weights = tempfile::tempdir().expect("weights tempdir");
+        let spec = LoadSpec::new(WeightsSource::Dir(weights.path().to_path_buf()));
+
+        // A run closure that panics mid-generation → comes back as a clean Engine error, not a hang.
+        let panicked = with_cached_generator(
+            "sc3724_stub",
+            spec.clone(),
+            "stub load",
+            move |_generator| -> WorkerResult<()> {
+                panic!("simulated mlx-rs Metal allocation panic");
+            },
+        )
+        .await;
+        let Err(WorkerError::Engine(msg)) = &panicked else {
+            panic!("a job-closure panic must map to a clean Engine error, got {panicked:?}");
+        };
+        assert!(
+            msg.contains("was contained"),
+            "contained-panic message: {msg}"
+        );
+        assert!(
+            msg.contains("simulated mlx-rs Metal allocation panic"),
+            "the original panic text must surface for diagnostics: {msg}"
+        );
+
+        // The shared cache thread must still be alive and serving: a subsequent job succeeds.
+        let after = with_cached_generator("sc3724_stub", spec, "stub load", move |generator| {
+            let req = gen_core::GenerationRequest {
+                width: 2,
+                height: 2,
+                ..Default::default()
+            };
+            generator
+                .generate(&req, &mut |_progress| {})
+                .map(|_| ())
+                .map_err(|error| WorkerError::Engine(error.to_string()))
+        })
+        .await;
+        assert!(
+            after.is_ok(),
+            "worker must keep serving after a contained panic, got {after:?}"
         );
     }
 }


### PR DESCRIPTION
Fixes a SeedVR2 image-upscale OOM that **permanently killed** the shared MLX generator-cache thread (a 128 GiB Metal alloc → an mlx-rs `.unwrap()` panic unwinding out of the single cache-worker loop, after which every later generation — image AND video — failed "MLX generator cache worker stopped" until restart). sc-6067.

## 1. Crash-recovery (the severe part) — `generator_cache.rs`
Each job now runs inside `std::panic::catch_unwind`. A caught panic:
- fails **only that job** with a clean `WorkerError` carrying the panic / Metal-OOM text (a `panic_message` helper downcasts the payload), and
- **evicts** the suspect cached generator (post-abort MLX/Metal state is untrustworthy) so the next job reloads fresh, while
- the single shared cache thread **keeps serving**.

A loop-level backstop catches anything a job's own guard misses. Independent of the upscale fix → this contains a panic from **any** engine.

## 2. SeedVR2 image tiling — pin bump only
mlx-gen pin `7b89d45` → `98592bb` ([mlx-gen#485](https://github.com/michaeltrefry/mlx-gen/pull/485), merged). The engine's image path now budget-checks and spatial-tiles over-budget targets through its existing feather-blend tiler (the video path already did this, sc-5201), so a large upscale never attempts a single allocation past Metal's max buffer size. The engine `generate` signature is unchanged, so there's **no worker call-site change** — only the pin.

`98592bb` is a durable merge-ancestor of mlx-gen `main` (deliberately kept minimal rather than flipped to merged-main HEAD, which has since advanced with the unrelated sc-6030 flux2 work — see the Cargo.toml comment). gen-core byte-identical vs `7b89d45`, mlx-rs unchanged (44929a0); 25 mlx-gen crates bumped in lockstep, default skew gate single-rev/green.

## Pre-flight guard (story item #2)
No new code: tiling makes peak fit by construction; ≤4096 tiles & completes, 4096–8192 rejected by the engine `max_size` validate, >8192 by the worker's existing `validate_upscale_target_dimensions`; the catch_unwind net covers any residual.

## Tests
- `generator_cache::panicking_job_is_contained_and_worker_keeps_serving` — panic → clean error, thread survives, subsequent job succeeds. (all 5 generator_cache tests green)
- Engine tiling validated in mlx-gen#485 on the real 3B checkpoint: tiled vs single-pass **cosine 0.999951**.
- Worker `cargo check` + `clippy --lib --tests -D warnings` + `fmt` + gen-core skew gate all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)