### PR TITLE
sc-6139: Video Studio Crop/Pad fit-mode for the starting image (Image → Video / First → Last)

### DIFF
--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -511,6 +511,13 @@ pub(crate) struct VideoJobRequest {
     pub(crate) replacement_mode: String,
     #[serde(default)]
     pub(crate) source_asset_id: Option<String>,
+    // How the starting image is fitted to the output W×H for the image-conditioned
+    // modes (image_to_video / first_last_frame), mirroring Image Studio Edit (sc-6139):
+    // "crop" (cover, default) or "pad" (letterbox) — never distort. Threaded to the
+    // worker as-is; the worker normalizes unknown values back to crop. Outpaint is
+    // inpaint-only and not offered for video.
+    #[serde(default = "default_fit_mode")]
+    pub(crate) fit_mode: String,
     #[serde(default)]
     pub(crate) last_frame_asset_id: Option<String>,
     #[serde(default)]

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { pickClosestResolution } from "../resolutionMatch.js";
 import { AssetPickerField } from "../components/AssetPicker.jsx";
+import { FitModeControl, effectiveFitMode } from "../components/FitModeControl.jsx";
 import { AssetCard } from "../components/assetPanels.jsx";
 import { AssetMedia, assetCanRenderAsVideo } from "../components/assetMedia.jsx";
 import { Icon } from "../components/Icons.jsx";
@@ -263,6 +264,10 @@ export function VideoStudio() {
     saved.bridgeRightVideoConditioningStrength ?? "",
   );
   const [sourceAssetId, setSourceAssetId] = useState(["image", "frame"].includes(selectedAsset?.type) ? selectedAsset.id : "");
+  // How the starting image is fitted to the output resolution for the image-conditioned
+  // modes (sc-6139), mirroring Image Studio Edit. Crop/Pad only — video has no inpaint
+  // mask, so Outpaint is hidden (`inpaintCapable={false}`). Default crop = fill, not stretch.
+  const [fitMode, setFitMode] = useState(saved.fitMode ?? "crop");
   const [lastFrameAssetId, setLastFrameAssetId] = useState("");
   const [sourceClipAssetId, setSourceClipAssetId] = useState(selectedAsset?.type === "video" ? selectedAsset.id : "");
   const [bridgeRightClipAssetId, setBridgeRightClipAssetId] = useState("");
@@ -637,6 +642,7 @@ export function VideoStudio() {
     videoRescaleScale: ltxVideoRescale,
     videoConditioningStrength,
     bridgeRightVideoConditioningStrength,
+    fitMode,
   });
 
   useEffect(() => {
@@ -775,6 +781,12 @@ export function VideoStudio() {
         characterId: characterId || null,
         characterLookId: characterLookId || null,
         sourceAssetId: ["image_to_video", "first_last_frame"].includes(mode) ? sourceAssetId || null : null,
+        // Crop/Pad fit for the starting image (sc-6139) — only the image-conditioned
+        // modes carry it; `effectiveFitMode(_, false)` coerces any stale outpaint back to
+        // crop (video has no inpaint mask). Other modes omit it (DTO defaults to crop).
+        fitMode: ["image_to_video", "first_last_frame"].includes(mode)
+          ? effectiveFitMode(fitMode, false)
+          : undefined,
         lastFrameAssetId: mode === "first_last_frame" ? lastFrameAssetId || null : null,
         sourceClipAssetId: [
           "extend_clip",
@@ -1004,6 +1016,14 @@ export function VideoStudio() {
                 label="Last frame"
                 onChange={setLastFrameAssetId}
                 value={lastFrameAssetId}
+              />
+            ) : null}
+
+            {mode === "image_to_video" || mode === "first_last_frame" ? (
+              <FitModeControl
+                value={effectiveFitMode(fitMode, false)}
+                onChange={setFitMode}
+                inpaintCapable={false}
               />
             ) : null}
 

--- a/apps/web/src/screens/VideoStudio.test.jsx
+++ b/apps/web/src/screens/VideoStudio.test.jsx
@@ -248,6 +248,83 @@ describe("VideoStudio video_bridge", () => {
   });
 });
 
+describe("VideoStudio fit mode (sc-6139)", () => {
+  let container;
+  let root;
+
+  const source = { id: "img_src", type: "image", projectId: "project_1", displayName: "Source" };
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <VideoStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  const modeButton = (label) => buttonWithText(container.querySelector(".mode-control"), label);
+  const fitField = () => container.querySelector(".fit-mode-field");
+  const fitButton = (label) => fitField() && buttonWithText(fitField(), label);
+
+  it("offers Crop/Pad only (no Outpaint) in the image-conditioned modes", async () => {
+    const context = baseContext({ assets: [source], selectedAsset: source });
+    await render(context);
+
+    // Default Text → Video has no starting image, so no fit control.
+    expect(fitField()).toBeFalsy();
+
+    await click(modeButton("Image → Video"));
+    expect([...fitField().querySelectorAll("button")].map((b) => b.textContent.trim())).toEqual([
+      "Crop",
+      "Pad",
+    ]);
+
+    await click(modeButton("First → Last"));
+    expect(fitField()).toBeTruthy();
+    expect(fitButton("Outpaint")).toBeFalsy();
+  });
+
+  it("threads the chosen fitMode into the image_to_video payload (default crop)", async () => {
+    const context = baseContext({ assets: [source], selectedAsset: source });
+    await render(context);
+    await click(modeButton("Image → Video"));
+
+    // Default selection is crop.
+    await click(buttonWithText(container, "Render clip"));
+    expect(context.createVideoJob.mock.calls[0][0].fitMode).toBe("crop");
+
+    // Choosing Pad threads through on the next submit.
+    await click(fitButton("Pad"));
+    await click(buttonWithText(container, "Render clip"));
+    expect(context.createVideoJob.mock.calls[1][0].fitMode).toBe("pad");
+  });
+
+  it("omits fitMode for non-image-conditioned modes", async () => {
+    const context = baseContext({ assets: [source], selectedAsset: source });
+    await render(context);
+    // Text → Video is the default mode; it carries no starting image to fit.
+    await click(buttonWithText(container, "Render clip"));
+    expect(context.createVideoJob.mock.calls[0][0].fitMode).toBeUndefined();
+  });
+});
+
 describe("VideoStudio Bernini task modes", () => {
   let container;
   let root;

--- a/crates/sceneworks-core/src/image_request.rs
+++ b/crates/sceneworks-core/src/image_request.rs
@@ -15,8 +15,10 @@ use crate::contracts::JsonObject;
 const DEFAULT_MODEL: &str = "z_image_turbo";
 const DEFAULT_MODE: &str = "text_to_image";
 const DEFAULT_STYLE_PRESET: &str = "cinematic";
-const DEFAULT_FIT_MODE: &str = "crop";
-const FIT_MODES: [&str; 4] = ["crop", "pad", "outpaint", "stretch"];
+/// Default fit mode (epic 2551): never distort, cover the frame. Shared with the
+/// video request (sc-6139) so image- and video-conditioned sources normalize identically.
+pub(crate) const DEFAULT_FIT_MODE: &str = "crop";
+pub(crate) const FIT_MODES: [&str; 4] = ["crop", "pad", "outpaint", "stretch"];
 
 /// A typed image-generation request, parsed from a job payload.
 #[derive(Debug, Clone, PartialEq)]
@@ -176,7 +178,7 @@ fn object_or_empty(payload: &JsonObject, key: &str) -> JsonObject {
         .unwrap_or_default()
 }
 
-fn normalize_fit_mode(value: Option<&str>) -> String {
+pub(crate) fn normalize_fit_mode(value: Option<&str>) -> String {
     let normalized = value
         .unwrap_or(DEFAULT_FIT_MODE)
         .trim()

--- a/crates/sceneworks-core/src/video_request.rs
+++ b/crates/sceneworks-core/src/video_request.rs
@@ -51,6 +51,12 @@ pub struct VideoRequest {
     pub character_look_id: Option<String>,
     /// Image→video conditioning source (consumed by the MLX I2V path).
     pub source_asset_id: Option<String>,
+    /// How the starting image is fitted to the output `width`×`height` before
+    /// conditioning — one of crop/pad/outpaint/stretch, default crop (sc-6139).
+    /// Mirrors `ImageRequest::fit_mode`; the I2V / first-last resolve paths pass it
+    /// to the same `fit_engine_image` helper the image-edit lane uses so a square
+    /// source no longer silently stretches into an off-aspect output.
+    pub fit_mode: String,
     // --- Advanced-mode fields: parsed + carried, but Python-routed (sc-3036). ---
     pub person_track_id: Option<String>,
     pub replacement_mode: String,
@@ -100,6 +106,9 @@ impl VideoRequest {
             character_id: optional_id(payload, "characterId"),
             character_look_id: optional_id(payload, "characterLookId"),
             source_asset_id: optional_id(payload, "sourceAssetId"),
+            fit_mode: crate::image_request::normalize_fit_mode(
+                payload.get("fitMode").and_then(Value::as_str),
+            ),
             person_track_id: optional_id(payload, "personTrackId"),
             replacement_mode: string_or(payload, "replacementMode", DEFAULT_REPLACEMENT_MODE),
             last_frame_asset_id: optional_id(payload, "lastFrameAssetId"),
@@ -301,6 +310,28 @@ mod tests {
         assert!(request.loras.is_empty());
         assert!(request.advanced.is_empty());
         assert!(request.source_asset_id.is_none());
+        // sc-6139: starting-image fit defaults to crop (never stretch), like images.
+        assert_eq!(request.fit_mode, "crop");
+    }
+
+    #[test]
+    fn normalizes_fit_mode_like_images() {
+        let pad = VideoRequest::from_payload(&payload(json!({
+            "projectId": "p", "mode": "image_to_video", "fitMode": "pad"
+        })));
+        assert_eq!(pad.fit_mode, "pad");
+
+        // Case-insensitive, same normalizer as ImageRequest.
+        let stretch = VideoRequest::from_payload(&payload(json!({
+            "projectId": "p", "fitMode": "Stretch"
+        })));
+        assert_eq!(stretch.fit_mode, "stretch");
+
+        // Unknown / blank coerce back to the crop default.
+        let bogus = VideoRequest::from_payload(&payload(json!({
+            "projectId": "p", "fitMode": "nonsense"
+        })));
+        assert_eq!(bogus.fit_mode, "crop");
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/image_jobs/flux2.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2.rs
@@ -88,7 +88,14 @@ fn fit_rgb(source: &image::RgbImage, width: u32, height: u32, mode: &str) -> ima
 }
 
 /// Fit an engine [`Image`] (RGB8) to `width`×`height` by `mode` via [`fit_rgb`].
-fn fit_engine_image(source: Image, width: u32, height: u32, mode: &str) -> WorkerResult<Image> {
+/// `pub(crate)` so the video I2V resolve paths (`video_jobs.rs`, sc-6139) can pre-fit a
+/// starting image to the output dims with the same crop/pad geometry as the image-edit lane.
+pub(crate) fn fit_engine_image(
+    source: Image,
+    width: u32,
+    height: u32,
+    mode: &str,
+) -> WorkerResult<Image> {
     let rgb =
         image::RgbImage::from_raw(source.width, source.height, source.pixels).ok_or_else(|| {
             WorkerError::InvalidPayload("edit source buffer size mismatch".to_owned())

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -1942,6 +1942,15 @@ fn resolve_wan_conditioning(
                 asset_id,
                 project_path,
             )?;
+            // Pre-fit to the output W×H by the chosen crop/pad mode (sc-6139) — see
+            // `resolve_ltx_conditioning`; without it the provider VAE-encodes a stretched
+            // first frame into its channel-concat `y`.
+            let image = crate::image_jobs::fit_engine_image(
+                image,
+                request.width,
+                request.height,
+                &request.fit_mode,
+            )?;
             Ok(vec![Conditioning::Reference {
                 image,
                 strength: None,
@@ -2912,6 +2921,15 @@ fn resolve_candle_video_conditioning(
         &request.project_id,
         asset_id,
         project_path,
+    )?;
+    // Pre-fit the source to the output W×H by the chosen crop/pad mode (sc-6139), the
+    // same as the macOS LTX/Wan paths, so the Windows/CUDA candle I2V engine conditions
+    // on an undistorted frame instead of an internal stretch.
+    let image = crate::image_jobs::fit_engine_image(
+        image,
+        request.width,
+        request.height,
+        &request.fit_mode,
     )?;
     Ok(vec![Conditioning::Reference {
         image,
@@ -4198,6 +4216,16 @@ fn resolve_ltx_conditioning(
                 asset_id,
                 project_path,
             )?;
+            // Pre-fit the starting image to the output W×H by the chosen crop/pad mode
+            // (sc-6139) — without this the engine resizes it internally = stretch. Reuses
+            // the image-edit lane's helper; a pre-fit-to-exact-dims reference is a no-op
+            // for any further internal resize.
+            let image = crate::image_jobs::fit_engine_image(
+                image,
+                request.width,
+                request.height,
+                &request.fit_mode,
+            )?;
             Ok(vec![Conditioning::Reference {
                 image,
                 strength: None,
@@ -4243,6 +4271,21 @@ fn resolve_keyframe_conditioning(
         &request.project_id,
         last_id,
         project_path,
+    )?;
+    // Fit both keyframes to the output W×H by the chosen crop/pad mode (sc-6139) so a
+    // square first/last frame letterboxes (pad) or fills+trims (crop) into an off-aspect
+    // clip instead of the engine stretching each internally.
+    let first = crate::image_jobs::fit_engine_image(
+        first,
+        request.width,
+        request.height,
+        &request.fit_mode,
+    )?;
+    let last = crate::image_jobs::fit_engine_image(
+        last,
+        request.width,
+        request.height,
+        &request.fit_mode,
     )?;
     Ok(vec![
         Conditioning::Keyframe {

--- a/tests/fixtures/rust_api_contract_snapshots/snapshots.json
+++ b/tests/fixtures/rust_api_contract_snapshots/snapshots.json
@@ -2602,6 +2602,7 @@
       "characterId": "character_fixture",
       "characterLookId": null,
       "duration": 6,
+      "fitMode": "crop",
       "fps": 25,
       "height": 512,
       "lastFrameAssetId": null,


### PR DESCRIPTION
Closes [sc-6139](https://app.shortcut.com/trefry/story/6139). Found during MLX-port QA on Mac: Video Studio had no Crop/Pad control, so a starting image for Image → Video (or First → Last) was silently **stretched** into the chosen output resolution. This adds the same never-distort fit choice Image Studio Edit already has, reusing the same UI component and worker helper.

## Changes
**UI** — [`VideoStudio.jsx`](apps/web/src/screens/VideoStudio.jsx)
- `<FitModeControl inpaintCapable={false}>` (Crop/Pad only — Outpaint is inpaint-only and video has no inpaint mask) on `image_to_video` + `first_last_frame`.
- New `fitMode` state seeded from `saved.fitMode ?? "crop"`, persisted via the settings writer, and threaded into the submit payload as `effectiveFitMode(fitMode, false)` for those two modes only (other modes omit it → DTO default crop).

**Contract**
- `VideoRequest.fit_mode` ([`video_request.rs`](crates/sceneworks-core/src/video_request.rs)) normalized via the **shared** `image_request::normalize_fit_mode` (promoted `normalize_fit_mode`/`FIT_MODES`/`DEFAULT_FIT_MODE` to `pub(crate)` — no duplication), default `crop`.
- `VideoJobRequest.fit_mode` DTO ([`dto.rs`](apps/rust-api/src/dto.rs)) with `#[serde(default = "default_fit_mode")]`, reusing the existing image-side default.
- Parity contract snapshot regenerated (`replace person job response` gains `"fitMode": "crop"`).

**Worker** — [`video_jobs.rs`](crates/sceneworks-worker/src/video_jobs.rs)
- Pre-fit the starting image to the output W×H via the image-edit lane's `fit_engine_image` (promoted to `pub(crate)` in [`flux2.rs`](crates/sceneworks-worker/src/image_jobs/flux2.rs); `fit_rgb`/`contain_box` stay private) in **all four** I2V resolve paths: `resolve_ltx_conditioning`, `resolve_wan_conditioning`, `resolve_keyframe_conditioning` (**both** first + last keyframes), and the candle `resolve_candle_video_conditioning`. No new fit logic.

Default = crop, so existing behavior becomes "fill the frame" instead of stretch — a quality improvement even before the user touches the control.

## Verification
- `sceneworks-core` / `sceneworks-worker` / `sceneworks-rust-api`: `cargo check` ✓, `clippy --all-targets -D warnings` ✓, `fmt --check` ✓
- Unit: core 11 (inc. new `normalizes_fit_mode_like_images`) + worker 19 (fit/conditioning/keyframe) ✓
- Web: 25 tests (VideoStudio + FitModeControl, inc. 3 new) ✓, eslint 0 errors ✓
- **Parity: full `test_rust_api_contract_snapshots.py` suite 12/12** against a live Rust API run — the new `fitMode` key placement/value is byte-for-byte confirmed, not assumed.
- Real-weight visual smoke (square source → Crop fill vs Pad letterbox on LTX-2.3 / Wan I2V) — running separately on the Mac GPU; results to follow on the story.

## Notes
- Windows/candle path is cfg-gated off on Mac, so it compiles only on the build-windows runner; the candle edit mirrors the macOS one exactly using all-target symbols (`fit_engine_image` already compiles on candle via `sdxl.rs`).
- **Deferred (per the story's scope guard):** `extract_clip_boundary_frame` (extend_clip/video_bridge) still ffmpeg-`scale`-stretches — a different distortion class (clip boundary frame, not the user's starting image) and non-trivial to fold in. Follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)