### PR TITLE
sc-6147: Ideogram 4 structured-prompt recipe round-trip

### DIFF
--- a/apps/web/src/ideogramCaption.test.js
+++ b/apps/web/src/ideogramCaption.test.js
@@ -371,4 +371,20 @@ describe("factories + recipe storage", () => {
     expect(runtimePromptFromRecipe({ caption: FOX })).toBe(FOX_JSON);
     expect(runtimePromptFromRecipe(null)).toBe("");
   });
+
+  it("restore round-trip: a stored caption re-serializes byte-identically (sc-6147)", () => {
+    // What ImageStudio persists in advanced.structuredPrompt, then restores from
+    // rawAdapterSettings.structuredPrompt on "Use this recipe".
+    const recipe = buildStructuredPromptRecipe({ intent: "a red fox in the snow", caption: FOX });
+    // The restore path runs the stored caption back through orderCaption (key order
+    // in the stored object may be insertion-order, not canonical) before re-serializing.
+    const scrambled = {
+      compositional_deconstruction: recipe.caption.compositional_deconstruction,
+      style_description: recipe.caption.style_description,
+      high_level_description: recipe.caption.high_level_description,
+    };
+    expect(validateCaption(scrambled).ok).toBe(true);
+    expect(serializeCaption(orderCaption(scrambled))).toBe(FOX_JSON);
+    expect(serializeCaption(orderCaption(scrambled))).toBe(recipe.runtimePrompt);
+  });
 });

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -8,7 +8,14 @@ import { PromptGuideModal } from "../components/PromptGuideModal.jsx";
 import { PoseLibraryPicker } from "../components/PoseLibraryPicker.jsx";
 import { RefinePromptControl } from "../components/RefinePromptControl.jsx";
 import StructuredPromptBuilder from "../components/StructuredPromptBuilder.jsx";
-import { emptyCaption, parseMagicPromptCaption, serializeCaption, validateCaption } from "../ideogramCaption.js";
+import {
+  buildStructuredPromptRecipe,
+  emptyCaption,
+  orderCaption,
+  parseMagicPromptCaption,
+  serializeCaption,
+  validateCaption,
+} from "../ideogramCaption.js";
 import { usePoseLibrary, useUserPoseLoader } from "../poseLibrary.js";
 
 const PROMPT_SUGGESTION_POOL = [
@@ -793,7 +800,23 @@ export function ImageStudio() {
       }
       setModel(recipe.model);
     }
-    setPrompt(String(recipe.prompt ?? ""));
+    // Structured-prompt round-trip (sc-6147): a structured model's recipe carries
+    // the full caption under rawAdapterSettings.structuredPrompt. Rehydrate the
+    // builder (caption + intent + magic-prompt backend) instead of dropping the
+    // serialized JSON into the plain prompt box. Falls back to the plain `prompt`
+    // path when the blob is absent/invalid (older assets, non-structured models).
+    const structuredRecipe = rawSettings.structuredPrompt;
+    const restoredCaption = structuredRecipe?.caption ?? null;
+    if (restoredCaption && validateCaption(restoredCaption).ok) {
+      setCaption(orderCaption(restoredCaption));
+      setPromptMode("form");
+      setMagicPromptBackend(structuredRecipe.magicPromptBackend ?? null);
+      // The intent (original idea) seeds the plain box; the serialized caption is
+      // authoritative for generation and is rebuilt from `caption` on submit.
+      setPrompt(String(structuredRecipe.intent ?? ""));
+    } else {
+      setPrompt(String(recipe.prompt ?? ""));
+    }
     promptEdited.current = true;
     setNegativePrompt(String(recipe.negativePrompt ?? ""));
     // Recipe replay restores the creative setup, but intentionally leaves Seed
@@ -1086,6 +1109,21 @@ export function ImageStudio() {
           : {}),
         advanced: {
           resolution,
+          // Structured-prompt recipe round-trip (sc-6147): persist the full caption +
+          // original intent + magic-prompt backend alongside the job so "Use this recipe"
+          // can rehydrate the builder rather than replay the serialized JSON as a plain
+          // prompt. Rides in `advanced`, which the worker clones verbatim into the asset's
+          // rawAdapterSettings — no backend change needed. Only for structured models.
+          ...(structuredActive
+            ? {
+                structuredPrompt: buildStructuredPromptRecipe({
+                  intent: prompt,
+                  caption,
+                  magicPromptBackend,
+                  edited: !magicPromptBackend,
+                }),
+              }
+            : {}),
           // Configurable sampler / scheduler (epic 1753). Worker registry
           // falls back to model-native when given "default", so emitting the
           // values unconditionally is safe — invalid values are ignored.

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -13,6 +13,7 @@ vi.mock("../api.js", async (importOriginal) => {
 });
 
 import { AppContext } from "../context/AppContext.js";
+import { buildStructuredPromptRecipe, serializeCaption } from "../ideogramCaption.js";
 import { ImageStudio } from "./ImageStudio.jsx";
 
 const Z_IMAGE = {
@@ -549,5 +550,109 @@ describe("ImageStudio model picker capability gating", () => {
 
     expect(modeButton("Edit").disabled).toBe(true);
     expect(modeButton("Edit").title).toBe("No available Mac model supports this mode.");
+  });
+});
+
+describe("ImageStudio structured-prompt recipe round-trip (sc-6147)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <ImageStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  const IDEOGRAM = {
+    ...Z_IMAGE,
+    id: "ideogram_4",
+    name: "Ideogram 4",
+    family: "ideogram",
+    capabilities: ["text_to_image"],
+    structuredPrompt: true,
+  };
+
+  const CAPTION = {
+    high_level_description: "A red fox in the snow",
+    compositional_deconstruction: {
+      background: "A snowy pine forest",
+      elements: [{ type: "obj", desc: "a red fox sitting upright" }],
+    },
+  };
+
+  const generateButton = () =>
+    [...container.querySelectorAll("button")].find((button) => button.textContent === "Generate");
+
+  it("restores the builder from a recipe, then re-emits the same caption + blob on Generate", async () => {
+    const createImageJob = vi.fn(async () => ({ id: "job-1" }));
+    const structuredPrompt = buildStructuredPromptRecipe({
+      intent: "a red fox in the snow",
+      caption: CAPTION,
+      magicPromptBackend: "prompt_refine",
+    });
+    await render(
+      baseContext({
+        createImageJob,
+        imageModels: [IDEOGRAM],
+        studioLaunch: {
+          id: "launch-1",
+          view: "Image",
+          assetId: "asset-1",
+          // Mirrors a stored Ideogram asset: prompt = serialized caption, with the
+          // full structured-prompt blob under rawAdapterSettings.structuredPrompt.
+          recipe: {
+            model: "ideogram_4",
+            mode: "text_to_image",
+            prompt: serializeCaption(CAPTION),
+            rawAdapterSettings: { structuredPrompt },
+          },
+        },
+      }),
+    );
+
+    // Restore selected the structured model and rehydrated the builder (Generate is
+    // enabled, which requires a valid, non-empty caption in the form — not plain text).
+    expect(field(container, "Model").value).toBe("ideogram_4");
+    expect(generateButton().disabled).toBe(false);
+
+    await click(generateButton());
+
+    const payload = createImageJob.mock.calls[0][0];
+    // Top-level prompt is the canonical serialized caption — byte-identical to source.
+    expect(payload.prompt).toBe(serializeCaption(CAPTION));
+    // The full structured-prompt blob round-trips through advanced (→ rawAdapterSettings).
+    expect(payload.advanced.structuredPrompt.caption).toEqual(CAPTION);
+    expect(payload.advanced.structuredPrompt.intent).toBe("a red fox in the snow");
+    expect(payload.advanced.structuredPrompt.magicPromptBackend).toBe("prompt_refine");
+    expect(payload.advanced.structuredPrompt.runtimePrompt).toBe(serializeCaption(CAPTION));
+  });
+
+  it("does not attach a structured-prompt blob for non-structured models", async () => {
+    const createImageJob = vi.fn(async () => ({ id: "job-1" }));
+    await render(baseContext({ createImageJob, imageModels: [Z_IMAGE] }));
+
+    await click(generateButton());
+
+    const payload = createImageJob.mock.calls[0][0];
+    expect(payload.advanced.structuredPrompt).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Outcome
Generated Ideogram 4 images now carry their **full structured-prompt recipe**, and **"Use this recipe"** rehydrates the prompt-builder — so structured captions round-trip end to end (caption + original intent + magic-prompt backend), serializing byte-identically. Closes [sc-6147](https://app.shortcut.com/trefry/story/6147).

## How it works (web-only — no backend change)
The image job payload's `advanced` object is a free-form `JsonObject` passthrough at every layer: web → API DTO → worker `ImageRequest.advanced` → `mlx_raw_settings` does `request.advanced.clone()` → `"rawAdapterSettings": raw_settings`. Ideogram 4 runs that generic MLX path, so anything in `advanced` lands in the asset `recipe.rawAdapterSettings` with **zero worker code**.

- **Submit** (`ImageStudio.jsx`): structured models attach `advanced.structuredPrompt = buildStructuredPromptRecipe({ intent, caption, magicPromptBackend, edited })` (the sc-5993 contract). `prompt` is the plain-text seed = intent.
- **Restore** (recipe-restore effect): detects `rawAdapterSettings.structuredPrompt`, validates the caption via the sc-5993 verifier, and rehydrates `caption` + `promptMode("form")` + magic-prompt backend, seeding the plain box with the **intent** rather than the serialized JSON. Falls back to the existing plain-`prompt` path when the blob is absent/invalid (older assets) — **non-structured models unchanged**.
- `serializeCaption` re-orders internally via `orderCaption`, so a restored caption re-emits byte-identically regardless of stored key order. Older structured assets (no blob) degrade gracefully to plain text.

## Tests
- Full-mount `ImageStudio.test.jsx` round-trip: restore from a recipe → **Generate** re-emits the same caption + blob byte-identically; and a non-structured model attaches **no** blob.
- Contract-level restore round-trip unit in `ideogramCaption.test.js` (out-of-order stored caption re-serializes to the canonical bytes).
- Web suite **508 green**, ESLint **0 errors**, production build clean.

## Scope notes
My original "touches worker recipe assembly" framing in the story is obsolete — the `advanced` passthrough already carries the blob, so per *minimum code / touch only what you must* the worker is untouched. The browser preview can't exercise the gated Ideogram structured path, so verification is via the full-mount test suite (this codebase's established pattern for web changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)