### PR TITLE
sc-5999: gated-model "Request access" repo link

### DIFF
--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -128,20 +128,36 @@ function loraGroupKey(lora) {
   return lora.family ?? extractFamilies(lora)[0] ?? "";
 }
 
+// The Hugging Face page of a gated model's primary download repo — where the user
+// clicks "Agree and access" to be granted access with their token (sc-5999). Derived
+// from the first HF download repo (or the mlx repo), so it covers every gated model
+// without a per-model manifest field. Falls back to `licenseUrl` when no repo is known.
+function gatedRepoUrl(model) {
+  const host = model.credentialHost || "huggingface.co";
+  const repo =
+    (model.downloads ?? []).find((entry) => entry.provider === "huggingface" && entry.repo)?.repo ??
+    model.mlx?.repo;
+  return repo ? `https://${host}/${repo}` : null;
+}
+
 // Gated models (e.g. FLUX.1 [dev]) need an accepted license + a saved credential
 // before a download can succeed. The catalog flags these with `gated`/
 // `credentialHost`/`licenseUrl` (sc-1898). When the matching credential is already
 // present we soften the notice to a ready state; otherwise we point the user at the
 // Settings credential screen. `present` is undefined while presence is still
 // unknown (e.g. the credential list hasn't loaded) — we still show the link then.
-function GatedModelNotice({ host, licenseUrl, present, onOpenSettings }) {
+// `repoUrl` links the gated repo so the user can request access (sc-5999); shown
+// alongside `licenseUrl` only when the license lives on a different page (e.g.
+// Ideogram 4, whose terms are on the source repo but access is on the SceneWorks repo).
+function GatedModelNotice({ host, repoUrl, licenseUrl, present, onOpenSettings }) {
   const hostLabel = host || "the required service";
+  const showSeparateLicense = licenseUrl && licenseUrl !== repoUrl;
   return (
     <div className={present ? "model-gated-notice ready" : "model-gated-notice"}>
       <p className={present ? "inline-success" : "inline-warning"}>
         {present
-          ? `Credential for ${hostLabel} saved — ready to download.`
-          : `Gated download. Add a ${hostLabel} token, then accept the model's license before downloading.`}
+          ? `Credential for ${hostLabel} saved — request access on the model page, then download.`
+          : `Gated download. Add a ${hostLabel} token, then request access on the model page and accept the license before downloading.`}
       </p>
       <div className="model-gated-actions">
         {present ? null : (
@@ -149,7 +165,12 @@ function GatedModelNotice({ host, licenseUrl, present, onOpenSettings }) {
             Add token in Settings
           </button>
         )}
-        {licenseUrl ? (
+        {repoUrl ? (
+          <a href={repoUrl} target="_blank" rel="noreferrer noopener">
+            Request access on Hugging Face
+          </a>
+        ) : null}
+        {showSeparateLicense ? (
           <a href={licenseUrl} target="_blank" rel="noreferrer noopener">
             Review license
           </a>
@@ -580,6 +601,7 @@ export function ModelManagerScreen() {
         {gated && !installed ? (
           <GatedModelNotice
             host={model.credentialHost}
+            repoUrl={gatedRepoUrl(model) ?? model.licenseUrl ?? null}
             licenseUrl={model.licenseUrl}
             present={credentialPresent}
             onOpenSettings={() => setActiveView("Settings")}

--- a/apps/web/src/screens/ModelManagerScreen.test.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.test.jsx
@@ -25,6 +25,22 @@ const GATED_MODEL = {
   ui: { description: "Gated FLUX model." },
 };
 
+// A gated model re-hosted on the SceneWorks HF org: access is requested at the
+// download repo, but the license terms live on the original source repo (sc-5999).
+const REHOSTED_GATED_MODEL = {
+  id: "ideogram_4",
+  name: "Ideogram 4",
+  type: "image",
+  family: "ideogram",
+  installState: "missing",
+  downloadable: true,
+  gated: true,
+  credentialHost: "huggingface.co",
+  licenseUrl: "https://huggingface.co/ideogram-ai/ideogram-4-fp8",
+  downloads: [{ provider: "huggingface", repo: "SceneWorks/ideogram-4-mlx", files: ["q4/*"] }],
+  ui: { description: "Gated re-hosted model." },
+};
+
 const PLAIN_MODEL = {
   id: "z_image_turbo",
   name: "Z-Image-Turbo",
@@ -116,16 +132,31 @@ describe("ModelManagerScreen gated-model notice", () => {
     await click(settingsButton);
     expect(setActiveView).toHaveBeenCalledWith("Settings");
 
-    const license = container.querySelector(".model-gated-actions a");
-    expect(license?.getAttribute("href")).toBe(
+    // licenseUrl is the gated repo itself (no separate re-host), so a single
+    // request-access link points there — no duplicate "Review license" link.
+    const links = [...container.querySelectorAll(".model-gated-actions a")];
+    expect(links).toHaveLength(1);
+    expect(links[0].textContent).toBe("Request access on Hugging Face");
+    expect(links[0].getAttribute("href")).toBe(
       "https://huggingface.co/black-forest-labs/FLUX.1-dev",
     );
+  });
+
+  it("links the re-hosted repo for access plus the source license when they differ (sc-5999)", async () => {
+    await render([REHOSTED_GATED_MODEL]);
+    const links = [...container.querySelectorAll(".model-gated-actions a")];
+    const access = links.find((anchor) => anchor.textContent === "Request access on Hugging Face");
+    const license = links.find((anchor) => anchor.textContent === "Review license");
+    expect(access?.getAttribute("href")).toBe("https://huggingface.co/SceneWorks/ideogram-4-mlx");
+    expect(license?.getAttribute("href")).toBe("https://huggingface.co/ideogram-ai/ideogram-4-fp8");
   });
 
   it("softens the notice once a matching credential is present", async () => {
     credentials = [{ host: "huggingface.co", label: "Hugging Face", scheme: "bearer", present: true }];
     await render([GATED_MODEL]);
-    expect(container.textContent).toContain("ready to download");
+    // A saved token still requires requesting access on the repo, so the softened
+    // notice nudges that step rather than implying the download is unblocked.
+    expect(container.textContent).toContain("request access on the model page");
     expect(container.textContent).not.toContain("Add token in Settings");
   });
 


### PR DESCRIPTION
## Part of sc-5999 (Ideogram 4 license/gating UI + gated download path)

Adds the one piece of net-new UI sc-5999 needs: a **"Request access on Hugging Face"** link in the gated-download notice, pointing at the gated repo where the user clicks "Agree and access." This is the gap that applies to **all** gated models, surfaced while scoping Ideogram 4.

### Why
The notice only had **"Review license"** (→ `licenseUrl`) + a Settings link — no link to the repo to request access. For models where `licenseUrl` *is* the gated repo (FLUX.1-dev, FLUX.2-*) that was masked. **Ideogram 4 is the exception**: its license terms live on the source repo (`ideogram-ai/ideogram-4-fp8`) but access is requested on the re-hosted **`SceneWorks/ideogram-4-mlx`** repo — so the user had no link to the repo they actually need.

### Change
- `gatedRepoUrl(model)` derives `https://<credentialHost>/<repo>` from the model's primary HF download repo (or `mlx.repo`) — works for every gated model with **no per-model manifest field**; falls back to `licenseUrl` when no repo is known.
- `GatedModelNotice` renders **"Request access on Hugging Face"** → the repo, and shows **"Review license"** only when the license lives on a different page (dedup, so same-page models keep a single link).
- Copy nudges the request-access step (a saved token alone doesn't grant access).

### Tests
- Re-hosted-model shape (Ideogram): asserts both the access link (→ `SceneWorks/ideogram-4-mlx`) and the source license link (→ `ideogram-ai/...`).
- Same-page gated model (FLUX): a single deduped access link → the repo.
- Web suite **513 green**, ESLint **0 errors**, build clean.

### Scope / remaining for sc-5999 (not in this PR)
- **Ops (Michael):** flip `SceneWorks/ideogram-4-mlx` to public + keep gated. Once done, the existing host-keyed download path (`resolve_credential_for_host`, lazy keychain socket sc-5891) authenticates with the user's token — same mechanism FLUX uses, **no backend change**.
- **Verification:** real gated download succeeds with token + granted access / fails clearly without — runs after the repo flip, overlaps sc-6000's real-weight e2e.

Verified via the full-mount component test (renders the real `ModelManagerScreen`, asserts link text + hrefs); the Models screen needs catalog + credential Tauri invokes a bare dev server lacks, so the mount test is the meaningful proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)