### PR TITLE
sc-6137: verify content digests on LoRA/model download

### DIFF
--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -593,6 +593,11 @@ pub(crate) struct ModelImportRequest {
     pub(crate) files: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) family: Option<String>,
+    /// Optional caller-supplied SHA-256 of the imported file. When present, the worker
+    /// verifies the downloaded file against it and fails on a mismatch (sc-6137). HF
+    /// repo imports are verified automatically from HF's own per-file digests.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) expected_sha256: Option<String>,
     #[serde(default, skip_deserializing, skip_serializing_if = "bool_is_false")]
     pub(crate) uploaded_source_path: bool,
 }
@@ -618,6 +623,11 @@ pub(crate) struct LoraImportRequest {
     /// the manifest entry so the loader's base-model gating can match it (sc-1955).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) base_model: Option<String>,
+    /// Optional caller-supplied SHA-256 of the imported file. When present, the worker
+    /// verifies the downloaded file against it and fails on a mismatch (sc-6137). HF
+    /// repo imports are verified automatically from HF's own per-file digests.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) expected_sha256: Option<String>,
     #[serde(default = "default_lora_scope")]
     pub(crate) scope: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/apps/rust-api/src/loras.rs
+++ b/apps/rust-api/src/loras.rs
@@ -595,6 +595,7 @@ pub(crate) async fn lora_import_request_from_multipart(
         files: Vec::new(),
         family: None,
         base_model: None,
+        expected_sha256: None,
         scope: default_lora_scope(),
         project_id: None,
         uploaded_source_path: false,

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -605,6 +605,7 @@ pub(crate) async fn model_import_request_from_multipart(
         source_path: None,
         files: Vec::new(),
         family: None,
+        expected_sha256: None,
         uploaded_source_path: false,
     };
     let mut staged_path = None;

--- a/crates/sceneworks-worker/src/downloads.rs
+++ b/crates/sceneworks-worker/src/downloads.rs
@@ -45,7 +45,16 @@ pub(crate) async fn ensure_cached_file(
         expected_size,
         progress_report_interval(context.settings),
     );
-    download_file(context, url, target, expected_size, label, &mut progress).await?;
+    download_file(
+        context,
+        url,
+        target,
+        expected_size,
+        None,
+        label,
+        &mut progress,
+    )
+    .await?;
     Ok(target.to_path_buf())
 }
 
@@ -114,6 +123,10 @@ pub(crate) struct SnapshotFile {
     pub(crate) path: String,
     pub(crate) size: Option<u64>,
     pub(crate) download_url: String,
+    /// SHA-256 of the file content from Hugging Face's `lfs.oid` (tree API
+    /// `expand=1`). Present for LFS-tracked files (the weights); `None` for small
+    /// non-LFS files (configs/tokenizers), whose integrity rides on the size check.
+    pub(crate) sha256: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -193,7 +206,30 @@ pub(crate) fn snapshot_file_from_entry(
             quote_path(revision),
             quote_path(path)
         ),
+        sha256: entry
+            .get("lfs")
+            .and_then(|lfs| lfs.get("oid"))
+            .and_then(Value::as_str)
+            .and_then(normalize_sha256),
     })
+}
+
+/// Normalize a candidate SHA-256 digest (from `lfs.oid` or an HF ETag): strip an
+/// optional `sha256:` prefix and surrounding whitespace, lowercase it, and accept it
+/// only if it is exactly 64 hex characters. Returns `None` for anything else (e.g. a
+/// git blob SHA-1 ETag, a fallback blob name) so callers verify only real content
+/// digests.
+pub(crate) fn normalize_sha256(value: &str) -> Option<String> {
+    let digest = value
+        .trim()
+        .trim_start_matches("sha256:")
+        .trim()
+        .to_ascii_lowercase();
+    if digest.len() == 64 && digest.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        Some(digest)
+    } else {
+        None
+    }
 }
 
 pub(crate) struct DownloadContext<'a> {
@@ -207,10 +243,79 @@ pub(crate) struct DownloadContext<'a> {
 
 const AUTO_RESUME_ATTEMPTS: usize = 1;
 
+/// Download a single file to `dest` (resumable via HTTP Range), rejecting a truncated
+/// response (size mismatch) and, when `expected_sha256` is provided, a corrupt one
+/// (content-digest mismatch). On a digest mismatch the file is removed so a corrupt
+/// artifact is never left behind (sc-6137). `label` names the file in the error.
+async fn download_file(
+    context: &DownloadContext<'_>,
+    url: &str,
+    dest: &Path,
+    expected_size: Option<u64>,
+    expected_sha256: Option<&str>,
+    label: &str,
+    progress: &mut DownloadProgress<'_>,
+) -> WorkerResult<()> {
+    download_file_inner(context, url, dest, expected_size, label, progress).await?;
+    if let Some(expected) = expected_sha256 {
+        verify_file_sha256(dest, expected, label).await?;
+    }
+    Ok(())
+}
+
+/// Verify `path`'s SHA-256 equals `expected`; on mismatch, remove the file and return
+/// an actionable error. A malformed/absent `expected` (not 64 hex) is treated as "no
+/// digest available" and skipped — only a real content digest is enforced.
+pub(crate) async fn verify_file_sha256(
+    path: &Path,
+    expected: &str,
+    label: &str,
+) -> WorkerResult<()> {
+    let Some(expected) = normalize_sha256(expected) else {
+        return Ok(());
+    };
+    let actual = sha256_file(path).await?;
+    if actual != expected {
+        let _ = tokio::fs::remove_file(path).await;
+        return Err(WorkerError::InvalidPayload(format!(
+            "{label} failed its integrity check (sha256 {actual}, but the source declares {expected}); \
+             the download was corrupted. Re-download the file."
+        )));
+    }
+    Ok(())
+}
+
+/// Stream `path` through SHA-256 on the blocking pool (weights are multi-GB; hashing
+/// on the async runtime would stall heartbeats/cancel checks).
+async fn sha256_file(path: &Path) -> WorkerResult<String> {
+    let path = path.to_path_buf();
+    tokio::task::spawn_blocking(move || -> std::io::Result<String> {
+        use std::io::Read;
+        let mut file = std::fs::File::open(&path)?;
+        let mut hasher = Sha256::new();
+        let mut buffer = vec![0_u8; 1024 * 1024];
+        loop {
+            let read = file.read(&mut buffer)?;
+            if read == 0 {
+                break;
+            }
+            hasher.update(&buffer[..read]);
+        }
+        Ok(format!("{:x}", hasher.finalize()))
+    })
+    .await
+    .map_err(|error| {
+        WorkerError::Io(std::io::Error::other(format!(
+            "sha256 task failed: {error}"
+        )))
+    })?
+    .map_err(WorkerError::Io)
+}
+
 /// Download a single file to `dest` (resumable via HTTP Range), reporting transfer
 /// progress and rejecting a truncated response. `label` names the file in the
 /// size-mismatch error.
-async fn download_file(
+async fn download_file_inner(
     context: &DownloadContext<'_>,
     url: &str,
     dest: &Path,
@@ -386,6 +491,7 @@ pub(crate) async fn download_snapshot(
             &file.download_url,
             &target_path,
             file.size,
+            file.sha256.as_deref(),
             &file.path,
             progress,
         )
@@ -438,6 +544,9 @@ pub(crate) async fn download_snapshot_into_cache(
             &file.download_url,
             &blobs_dir.join(&etag),
             file.size,
+            // The blob is named by its etag (= the LFS sha256), and the tree API
+            // reports the same digest as `lfs.oid`; verify the content against it.
+            file.sha256.as_deref(),
             &file.path,
             progress,
         )

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -1406,6 +1406,19 @@ pub(crate) async fn run_lora_import_job(
         .await;
     }
 
+    // sc-6137: verify a caller-supplied content digest. HF repo files are already
+    // per-file verified during download; this covers source-URL/uploaded imports where
+    // a SHA-256 is supplied out-of-band. `verify_file_sha256` removes the file on
+    // mismatch, so a corrupt artifact is never left behind.
+    if let Some(expected_sha256) = optional_payload_string(&job.payload, "expectedSha256") {
+        if let Some(file) = first_safetensors_path(&target_dir) {
+            if let Err(error) = verify_file_sha256(&file, expected_sha256, "Imported LoRA").await {
+                return fail_job(api, &job.id, "LoRA import failed.", Some(error.to_string()))
+                    .await;
+            }
+        }
+    }
+
     let detected_family = match detect_family_in_target_dir(&target_dir) {
         Ok(detected) => detected,
         Err(error) => {
@@ -1712,6 +1725,23 @@ pub(crate) async fn run_model_import_job(
             Some("Provide repo, sourceUrl, or sourcePath for model import".to_owned()),
         )
         .await;
+    }
+
+    // sc-6137: verify a caller-supplied content digest for source-URL/uploaded model
+    // imports (HF repo files are per-file verified during download). On mismatch the
+    // file is removed and the job fails with an actionable message.
+    if let Some(expected_sha256) = optional_payload_string(&job.payload, "expectedSha256") {
+        if let Some(file) = first_safetensors_path(&target_dir) {
+            if let Err(error) = verify_file_sha256(&file, expected_sha256, "Imported model").await {
+                return fail_job(
+                    api,
+                    &job.id,
+                    "Model import failed.",
+                    Some(error.to_string()),
+                )
+                .await;
+            }
+        }
     }
 
     let detected_family = match detect_model_family(&target_dir) {

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -17,8 +17,8 @@ use tempfile::tempdir;
 use super::api_client::ApiClient;
 use super::downloads::{
     build_source_url_client, credential_for_host, download_lora_source_url,
-    download_progress_payload, download_snapshot_into_cache, DownloadContext, DownloadProgress,
-    HuggingFaceSnapshot, SnapshotFile,
+    download_progress_payload, download_snapshot_into_cache, normalize_sha256, DownloadContext,
+    DownloadProgress, HuggingFaceSnapshot, SnapshotFile,
 };
 #[cfg(target_os = "macos")]
 use super::gpu::mlx_gpu;
@@ -1134,6 +1134,7 @@ async fn download_snapshot_rejects_truncated_file() {
             path: "shard.safetensors".to_owned(),
             size: Some(64),
             download_url: format!("{base_url}/owner/model/resolve/main/shard.safetensors"),
+            sha256: None,
         }],
     };
     let mut progress = DownloadProgress::new(
@@ -1172,6 +1173,133 @@ async fn download_snapshot_rejects_truncated_file() {
     assert!(!repo_dir.join("snapshots").exists());
 }
 
+#[test]
+fn normalize_sha256_accepts_only_real_digests() {
+    let hex = "a".repeat(64);
+    // Bare 64-hex, a `sha256:` prefix, and uppercase all normalize to lowercase hex.
+    assert_eq!(normalize_sha256(&hex).as_deref(), Some(hex.as_str()));
+    assert_eq!(
+        normalize_sha256(&format!("  sha256:{hex}  ")).as_deref(),
+        Some(hex.as_str())
+    );
+    assert_eq!(
+        normalize_sha256(&"A".repeat(64)).as_deref(),
+        Some(hex.as_str())
+    );
+    // A git blob SHA-1 (40 hex), a non-hex string, and empty are not content digests.
+    assert_eq!(normalize_sha256(&"a".repeat(40)), None);
+    assert_eq!(normalize_sha256(&"z".repeat(64)), None);
+    assert_eq!(normalize_sha256(""), None);
+}
+
+#[tokio::test]
+async fn download_snapshot_rejects_digest_mismatch() {
+    let temp = tempdir().expect("tempdir creates");
+    let base_url = spawn_binary_stub(b"weights!!".to_vec()).await;
+    let mut settings = test_settings("http://127.0.0.1".to_owned(), None);
+    settings.api_url = base_url.clone();
+    let api = ApiClient::new(&settings);
+    let client = reqwest::Client::new();
+    let repo_dir = temp.path().join("models--owner--model");
+
+    // The transfer is complete (size matches) but the source-declared sha256 does
+    // not — a corrupted download that must be rejected and discarded (sc-6137).
+    let snapshot = HuggingFaceSnapshot {
+        files: vec![SnapshotFile {
+            path: "model.safetensors".to_owned(),
+            size: Some(9),
+            download_url: format!("{base_url}/owner/model/resolve/main/model.safetensors"),
+            sha256: Some("0".repeat(64)),
+        }],
+    };
+    let mut progress = DownloadProgress::new(
+        "owner/model",
+        0,
+        snapshot.total_bytes(),
+        Duration::from_secs(3600),
+    );
+
+    let error = download_snapshot_into_cache(
+        &DownloadContext {
+            api: &api,
+            client: &client,
+            settings: &settings,
+            job_id: "job-1",
+            cancel_message: "canceled",
+            fresh_download: false,
+        },
+        &repo_dir,
+        "main",
+        &snapshot,
+        &mut progress,
+    )
+    .await
+    .expect_err("a digest mismatch is rejected");
+
+    assert!(error
+        .to_string()
+        .to_ascii_lowercase()
+        .contains("integrity check"));
+    // The corrupt blob is removed and the snapshot is never materialized.
+    assert!(!repo_dir
+        .join("blobs")
+        .join("etag-model.safetensors")
+        .exists());
+    assert!(!repo_dir.join("snapshots").exists());
+}
+
+#[tokio::test]
+async fn download_snapshot_accepts_matching_digest() {
+    use sha2::{Digest, Sha256};
+    let temp = tempdir().expect("tempdir creates");
+    let base_url = spawn_binary_stub(b"weights!!".to_vec()).await;
+    let mut settings = test_settings("http://127.0.0.1".to_owned(), None);
+    settings.api_url = base_url.clone();
+    let api = ApiClient::new(&settings);
+    let client = reqwest::Client::new();
+    let repo_dir = temp.path().join("models--owner--model");
+
+    let digest = format!("{:x}", Sha256::digest(b"weights!!"));
+    let snapshot = HuggingFaceSnapshot {
+        files: vec![SnapshotFile {
+            path: "model.safetensors".to_owned(),
+            size: Some(9),
+            download_url: format!("{base_url}/owner/model/resolve/main/model.safetensors"),
+            sha256: Some(digest),
+        }],
+    };
+    let mut progress = DownloadProgress::new(
+        "owner/model",
+        0,
+        snapshot.total_bytes(),
+        Duration::from_secs(3600),
+    );
+
+    download_snapshot_into_cache(
+        &DownloadContext {
+            api: &api,
+            client: &client,
+            settings: &settings,
+            job_id: "job-1",
+            cancel_message: "canceled",
+            fresh_download: false,
+        },
+        &repo_dir,
+        "main",
+        &snapshot,
+        &mut progress,
+    )
+    .await
+    .expect("a matching digest is accepted");
+
+    assert_eq!(
+        tokio::fs::read(repo_dir.join("blobs").join("etag-model.safetensors"))
+            .await
+            .unwrap(),
+        b"weights!!"
+    );
+}
+
 #[tokio::test]
 async fn download_snapshot_resumes_existing_partial_blob() {
     let temp = tempdir().expect("tempdir creates");
@@ -1192,6 +1320,7 @@ async fn download_snapshot_resumes_existing_partial_blob() {
             path: "model.safetensors".to_owned(),
             size: Some(9),
             download_url: format!("{base_url}/owner/model/resolve/main/model.safetensors"),
+            sha256: None,
         }],
     };
     let mut progress = DownloadProgress::new(
@@ -1241,6 +1370,7 @@ async fn download_snapshot_fresh_retry_discards_partial_blob() {
             path: "model.safetensors".to_owned(),
             size: Some(9),
             download_url: format!("{base_url}/owner/model/resolve/main/model.safetensors"),
+            sha256: None,
         }],
     };
     let mut progress = DownloadProgress::new(
@@ -1425,6 +1555,7 @@ async fn download_snapshot_writes_hugging_face_cache_layout() {
             path: "model.safetensors".to_owned(),
             size: Some(9),
             download_url: format!("{base_url}/owner/model/resolve/main/model.safetensors"),
+            sha256: None,
         }],
     };
     let mut progress = DownloadProgress::new(


### PR DESCRIPTION
Follow-up to sc-6072 (which added completeness/size validation). Completeness catches truncation; this adds **content-digest verification** to catch silent corruption — "when a source provides a digest, verify it."

[Story](https://app.shortcut.com/trefry/story/6137)

## HF downloads — automatic (the source provides the digest)
- `downloads.rs::SnapshotFile` gained `sha256`, parsed from the tree API's `lfs.oid` (`expand=1`) via a new `normalize_sha256` (strips a `sha256:` prefix/whitespace, lowercases, accepts only 64-hex — so git-blob SHA-1 etags and fallback blob names are ignored).
- `download_file` verifies the written file's SHA-256 after the size check; on mismatch it removes the file and returns an actionable `… failed its integrity check … Re-download` error. Wired through `download_snapshot` (LoRA HF import) and `download_snapshot_into_cache` (model download).
- Hashing runs on `spawn_blocking` (weights are multi-GB — keeps heartbeats/cancel responsive). Non-LFS small files (no `lfs.oid`) ride the existing size check; runtime-weight fetches (`ensure_cached_file`) pass `None` (out of the LoRA/model-download scope).

## Source-URL / uploaded imports — opt-in (caller-supplied)
- `LoraImportRequest` + `ModelImportRequest` accept an optional `expectedSha256` (`skip_serializing_if=None` + `default`, so existing payloads/contracts are byte-identical — no regression). It forwards into the job payload.
- `run_lora_import_job` / `run_model_import_job` verify the imported file against it via the shared `verify_file_sha256` (removes the file + fails the job on mismatch).

## Decision
Verification is **default-on for HF** (the digest is free from HF metadata) and **opt-in for source-URL** (caller supplies it). No setting added.

## Deliberately out of scope
Auto-fetching the SHA-256 from the civitai model API (the story's "if worthwhile" optional): fragile third-party integration (URL→version-id parsing, extra API/auth/SSRF surface), and the common HF path is fully covered. It can ride the new `expectedSha256` plumbing later.

## Validation
- worker 319 + rust-api 114 tests green; `cargo fmt --check` + `cargo clippy --all-targets -D warnings` clean.
- New tests: `download_snapshot_rejects_digest_mismatch` (corrupt content with a valid-but-wrong digest → error, blob removed, snapshot not materialized), `download_snapshot_accepts_matching_digest`, `normalize_sha256_accepts_only_real_digests`. Existing truncation/resume/layout tests updated for the new field and still green.
- No request/response contract regression (new field omitted when absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)