### PR TITLE
feat(flux2): surface FLUX.2-dev caption upsampling (Enhance prompt) in worker + UI (sc-6135)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_distr 0.5.1",
  "safetensors 0.7.0",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6)",
  "serde_json",
  "thiserror 2.0.18",
 ]
@@ -3284,11 +3284,11 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c52f469d0d32612315a8955e35b76acfd932a74e#c52f469d0d32612315a8955e35b76acfd932a74e"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=c52f469d0d32612315a8955e35b76acfd932a74e)",
  "thiserror 2.0.18",
  "tokenizers 0.21.4",
 ]
@@ -3296,7 +3296,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c52f469d0d32612315a8955e35b76acfd932a74e#c52f469d0d32612315a8955e35b76acfd932a74e"
 dependencies = [
  "image",
  "inventory",
@@ -3310,7 +3310,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c52f469d0d32612315a8955e35b76acfd932a74e#c52f469d0d32612315a8955e35b76acfd932a74e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3322,7 +3322,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c52f469d0d32612315a8955e35b76acfd932a74e#c52f469d0d32612315a8955e35b76acfd932a74e"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3331,7 +3331,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c52f469d0d32612315a8955e35b76acfd932a74e#c52f469d0d32612315a8955e35b76acfd932a74e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3343,7 +3343,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c52f469d0d32612315a8955e35b76acfd932a74e#c52f469d0d32612315a8955e35b76acfd932a74e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3354,7 +3354,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c52f469d0d32612315a8955e35b76acfd932a74e#c52f469d0d32612315a8955e35b76acfd932a74e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3366,7 +3366,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c52f469d0d32612315a8955e35b76acfd932a74e#c52f469d0d32612315a8955e35b76acfd932a74e"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3377,7 +3377,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c52f469d0d32612315a8955e35b76acfd932a74e#c52f469d0d32612315a8955e35b76acfd932a74e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3387,7 +3387,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c52f469d0d32612315a8955e35b76acfd932a74e#c52f469d0d32612315a8955e35b76acfd932a74e"
 dependencies = [
  "image",
  "inventory",
@@ -3399,7 +3399,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c52f469d0d32612315a8955e35b76acfd932a74e#c52f469d0d32612315a8955e35b76acfd932a74e"
 dependencies = [
  "image",
  "inventory",
@@ -3412,7 +3412,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c52f469d0d32612315a8955e35b76acfd932a74e#c52f469d0d32612315a8955e35b76acfd932a74e"
 dependencies = [
  "image",
  "inventory",
@@ -3424,7 +3424,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c52f469d0d32612315a8955e35b76acfd932a74e#c52f469d0d32612315a8955e35b76acfd932a74e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3435,7 +3435,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c52f469d0d32612315a8955e35b76acfd932a74e#c52f469d0d32612315a8955e35b76acfd932a74e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3447,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c52f469d0d32612315a8955e35b76acfd932a74e#c52f469d0d32612315a8955e35b76acfd932a74e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3457,7 +3457,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c52f469d0d32612315a8955e35b76acfd932a74e#c52f469d0d32612315a8955e35b76acfd932a74e"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3466,7 +3466,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c52f469d0d32612315a8955e35b76acfd932a74e#c52f469d0d32612315a8955e35b76acfd932a74e"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3475,7 +3475,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c52f469d0d32612315a8955e35b76acfd932a74e#c52f469d0d32612315a8955e35b76acfd932a74e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3487,7 +3487,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c52f469d0d32612315a8955e35b76acfd932a74e#c52f469d0d32612315a8955e35b76acfd932a74e"
 dependencies = [
  "image",
  "inventory",
@@ -3500,7 +3500,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c52f469d0d32612315a8955e35b76acfd932a74e#c52f469d0d32612315a8955e35b76acfd932a74e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3511,7 +3511,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c52f469d0d32612315a8955e35b76acfd932a74e#c52f469d0d32612315a8955e35b76acfd932a74e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3522,7 +3522,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c52f469d0d32612315a8955e35b76acfd932a74e#c52f469d0d32612315a8955e35b76acfd932a74e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3533,7 +3533,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c52f469d0d32612315a8955e35b76acfd932a74e#c52f469d0d32612315a8955e35b76acfd932a74e"
 dependencies = [
  "image",
  "inventory",
@@ -3547,7 +3547,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7b89d4563b5cdaf6513debc81fbe6c4475ac31e6#7b89d4563b5cdaf6513debc81fbe6c4475ac31e6"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c52f469d0d32612315a8955e35b76acfd932a74e#c52f469d0d32612315a8955e35b76acfd932a74e"
 dependencies = [
  "image",
  "inventory",
@@ -5185,6 +5185,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sceneworks-gen-core"
+version = "0.1.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c52f469d0d32612315a8955e35b76acfd932a74e#c52f469d0d32612315a8955e35b76acfd932a74e"
+dependencies = [
+ "inventory",
+ "safetensors 0.4.5",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokenizers 0.21.4",
+]
+
+[[package]]
 name = "sceneworks-rust-api"
 version = "0.2.0"
 dependencies = [
@@ -5276,7 +5288,7 @@ dependencies = [
  "pmetal-mlx-rs",
  "reqwest 0.12.28",
  "sceneworks-core",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=c52f469d0d32612315a8955e35b76acfd932a74e)",
  "serde",
  "serde_json",
  "sha2",

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -7390,6 +7390,90 @@ describe("SceneWorks app shell", () => {
     );
   });
 
+  it("surfaces the FLUX.2-dev Enhance prompt toggle (ui.promptEnhance) and submits advanced.enhancePrompt", async () => {
+    const createImageJob = vi.fn();
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withImageStudioContext({
+          activeProject: { id: "project-1", name: "Noir" },
+          assets: [],
+          characters: [
+            {
+              id: "char-1",
+              name: "Mira",
+              type: "person",
+              looks: [],
+              approvedReferences: [
+                {
+                  assetId: "ref-1",
+                  approved: true,
+                  asset: {
+                    id: "ref-1",
+                    type: "image",
+                    displayName: "Mira ref",
+                    projectId: "project-1",
+                    file: { path: "assets/images/ref_0001.png", mimeType: "image/png" },
+                  },
+                },
+              ],
+            },
+          ],
+          createImageJob,
+          deleteAsset: () => {},
+          gpuOptions: ["auto"],
+          imageModels: [
+            {
+              id: "flux2_dev",
+              name: "FLUX.2 [dev]",
+              type: "image",
+              family: "flux2-dev",
+              capabilities: ["text_to_image", "character_image"],
+              // The model declares its built-in prompt upsampler — the manifest gates the toggle.
+              ui: { promptEnhance: true },
+            },
+          ],
+          latestAssets: [],
+          launchRequest: { id: "launch-flux2dev", view: "Image", characterId: "char-1", referenceAssetId: "ref-1", mode: "character_image" },
+          loras: [],
+          onPreview: () => {},
+          purgeAsset: () => {},
+          requestedGpu: "auto",
+          selectedAsset: null,
+          setRequestedGpu: () => {},
+          updateAssetStatus: () => {},
+        }),
+      );
+    });
+    await settle();
+
+    // The toggle lives in the (collapsed-by-default) Advanced panel — open it first.
+    await act(async () => {
+      container.querySelector(".advanced-toggle").click();
+    });
+
+    // The manifest-driven "Enhance prompt" toggle renders for flux2_dev (off by default).
+    const enhanceToggle = container.querySelector(".prompt-enhance-toggle input");
+    expect(enhanceToggle).not.toBeNull();
+    expect(enhanceToggle.checked).toBe(false);
+    expect(container.textContent).toContain("Enhance prompt");
+
+    // Turn it on, then generate.
+    await act(async () => {
+      enhanceToggle.click();
+    });
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Generate").click();
+    });
+
+    // The toggle rides advanced.enhancePrompt; the worker threads it into the dev GenerationRequest.
+    expect(createImageJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        advanced: expect.objectContaining({ enhancePrompt: true }),
+      }),
+    );
+  });
+
   it("hides the Reference strength slider for Qwen and submits trueCfgScale alone", async () => {
     const createImageJob = vi.fn();
     root = createRoot(container);

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -370,6 +370,10 @@ export function ImageStudio() {
   // less VRAM. Per-payload (sent in `advanced.flashAttn`); the worker honors it only on candle, and
   // ignores it on every other backend. Default on. Sticky pref (persisted), not model-reset.
   const [flashAttn, setFlashAttn] = useState(saved.flashAttn ?? true);
+  // FLUX.2-dev "Enhance prompt" (sc-6135): the model's built-in Mistral3 caption upsampler rewrites
+  // the prompt before encoding — text-only for txt2img, reference-aware for edit. Per-payload
+  // (`advanced.enhancePrompt`); only flux2_dev acts on it. Sticky pref (persisted), default off.
+  const [enhancePrompt, setEnhancePrompt] = useState(saved.enhancePrompt ?? false);
   const [faceRestore, setFaceRestore] = useState(false);
   // User-created poses (reserved global project) join the built-in library in both
   // the picker and the id→keypoints resolver below, so saved poses can generate.
@@ -556,6 +560,8 @@ export function ImageStudio() {
   const viewAngles = Array.isArray(selectedModel?.ui?.viewAngles) ? selectedModel.ui.viewAngles : null;
   // Whether the model supports the OpenPose pose library (InstantID).
   const poseLibrary = Boolean(selectedModel?.ui?.poseLibrary);
+  // Whether the model exposes its built-in prompt upsampler ("Enhance prompt" toggle) — FLUX.2-dev.
+  const promptEnhance = Boolean(selectedModel?.ui?.promptEnhance);
   // Mac UI gating (sc-3486): disable the per-model feature controls the selected model can't run
   // in the Rust/MLX flow on Mac, so the user never reaches a `mlx_unsupported` error after submit.
   const macEditBlock = macModelFeatureBlock(selectedModel, macCapabilities, "edit");
@@ -955,6 +961,7 @@ export function ImageStudio() {
     steps: stepsOverride,
     guidanceScale: guidanceOverride,
     flashAttn,
+    enhancePrompt,
   });
 
   // Snapshot the current working config into a named recipe preset in the
@@ -1106,6 +1113,9 @@ export function ImageStudio() {
           // when `advanced.flashAttn` is absent, so the default-on case adds nothing to the payload.
           // Only the candle (Windows/CUDA) SDXL backend reads it; every other backend ignores it.
           ...(flashAttn ? {} : { flashAttn: false }),
+          // FLUX.2-dev caption upsampling (sc-6135): emitted only when the model declares the
+          // toggle AND it's on (off-by-default; the worker/engine ignore it for other models).
+          ...(promptEnhance && enhancePrompt ? { enhancePrompt: true } : {}),
           // IP-Adapter / InstantID reference strength only applies when a character
           // reference is attached AND the model uses the IP-Adapter knob; Qwen's
           // edit pipeline ignores this scalar (hideReferenceStrength gates it out).
@@ -1664,6 +1674,19 @@ export function ImageStudio() {
                   />
                   Flash attention
                 </label>
+                {promptEnhance ? (
+                  <label
+                    className="checkline prompt-enhance-toggle"
+                    title="Have FLUX.2-dev's built-in LLM rewrite (upsample) your prompt before generating — text-only for new images, and reference-aware when editing. Distinct from the Refine button; off by default."
+                  >
+                    <input
+                      checked={enhancePrompt}
+                      onChange={(event) => setEnhancePrompt(event.target.checked)}
+                      type="checkbox"
+                    />
+                    Enhance prompt
+                  </label>
+                ) : null}
                 <label className="checkline upscale-toggle">
                   <input
                     checked={upscaleEnabled}

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1315,6 +1315,13 @@
         // Strict ControlNet → expose the pose-lock-strength slider (advanced.controlScale;
         // the dev Fun-Controlnet-Union README recommends 0.65–0.80, worker default 0.75).
         "poseControlScale": true,
+        // FLUX.2-dev's built-in caption upsampler (sc-6030/sc-6135): an opt-in "Enhance prompt"
+        // toggle that has the model's own Mistral3 LLM rewrite the prompt before the diffusion
+        // encode — text-only for txt2img, and image-conditioned on the reference for edit (it reads
+        // the reference image, unlike the generic "Refine my prompt" / prompt_refine button). Sets
+        // advanced.enhancePrompt; the worker threads it into the dev GenerationRequest (off by
+        // default; every other model ignores the field).
+        "promptEnhance": true,
         "promptGuide": {
           "title": "FLUX.2 [dev] Prompt Guide",
           "path": "/prompt-guides/flux2-dev.md",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -137,7 +137,19 @@ sceneworks-core = { path = "../sceneworks-core" }
 # commit 4449260 + the provider commit bcd94ad); pre-merge of #91 this points at the branch SHA — flip to
 # the merged candle-gen main rev once #91 lands. candle-gen #91 is SOURCE-ONLY (gen-core stays 7b89d45,
 # byte-identical), so the backend-candle graph stays single gen-core rev 7b89d45 (no skew).
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+# Rev 7b89d45 -> c52f469 (mlx-gen #484 merge, epic 5914 / sc-6030): bumps EVERY mlx-gen crate +
+# gen-core to c52f469 to consume FLUX.2-dev caption upsampling (the Mistral3 multimodal
+# `upsample_prompt`) — the engine code that acts on the `enhance_prompt` GenerationRequest field for
+# flux2_dev (sc-6135 threads it from the dev Image-Studio "Enhance prompt" toggle). c52f469 is the #484
+# merge commit and is MINIMAL: 7b89d45 is its ancestor, so this adds ONLY sc-6030 (plus the
+# already-merged sc-5920 LoRA, transparent to SceneWorks) over what's shipped — NOT the later sc-6067
+# SeedVR2 main-HEAD work. The gen-core delta 7b89d45 -> c52f469 is DOC-ONLY (the `enhance_prompt` field
+# comments now also name FLUX.2-dev), so the parity contract snapshot is unchanged and mlx-rs is
+# unchanged (44929a0 — MLX core does not rebuild). The DEFAULT skew gate (check.yml) is blind to
+# candle-gen, so it stays single-rev/green at c52f469; candle-gen still pins gen-core 7b89d45 (its
+# workflow_dispatch-only lane is skewed until candle catches up — same deferral as the 3714e7b/7b89d45
+# bumps, tracked sc-5905).
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c52f469d0d32612315a8955e35b76acfd932a74e" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -448,7 +460,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c52f469d0d32612315a8955e35b76acfd932a74e" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -460,59 +472,59 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5
 # internal pin (the Lens engine PRs #407–#414 did not move it; nor did the seedvr2 engine #416/#419/
 # #421 or the softness PR #422, so the 1a97909 bump above leaves mlx-rs at 44929a0).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "44929a001ab8a8837403a71c65cf064224de0cdc" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c52f469d0d32612315a8955e35b76acfd932a74e" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c52f469d0d32612315a8955e35b76acfd932a74e" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c52f469d0d32612315a8955e35b76acfd932a74e" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c52f469d0d32612315a8955e35b76acfd932a74e" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c52f469d0d32612315a8955e35b76acfd932a74e" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c52f469d0d32612315a8955e35b76acfd932a74e" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c52f469d0d32612315a8955e35b76acfd932a74e" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c52f469d0d32612315a8955e35b76acfd932a74e" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c52f469d0d32612315a8955e35b76acfd932a74e" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c52f469d0d32612315a8955e35b76acfd932a74e" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c52f469d0d32612315a8955e35b76acfd932a74e" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c52f469d0d32612315a8955e35b76acfd932a74e" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c52f469d0d32612315a8955e35b76acfd932a74e" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -521,12 +533,12 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c52f469d0d32612315a8955e35b76acfd932a74e" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c52f469d0d32612315a8955e35b76acfd932a74e" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -535,7 +547,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c52f469d0d32612315a8955e35b76acfd932a74e" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -543,7 +555,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c52f469d0d32612315a8955e35b76acfd932a74e" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -554,7 +566,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c52f469d0d32612315a8955e35b76acfd932a74e" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -565,7 +577,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c52f469d0d32612315a8955e35b76acfd932a74e" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -580,7 +592,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4
 # converted in-memory at load (no Python); the precomputed neg-prompt embedding is bundled in-crate. No
 # LoRA/guidance/CFG (one-step). 3B fp16 only here — 7B (sc-5197) + int8 (sc-5198) are engine-side and
 # unwired. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c52f469d0d32612315a8955e35b76acfd932a74e" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -591,7 +603,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b8
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c52f469d0d32612315a8955e35b76acfd932a74e" }
 # Prompt-refine provider (sc-5552, the MLX twin of candle-gen-prompt-refine / sc-5500). An
 # inventory-registered `TextLlm` under id `prompt_refine` (`backend="mlx"`, `mac_only`): a native MLX
 # Llama-3.2-3B-Instruct that rewrites a user's prompt, replacing the Python `prompt_refine.py`
@@ -601,7 +613,7 @@ mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b8
 # textllm registered" trap). Weights = a stock Llama-3.2-3B-Instruct HF snapshot (config.json +
 # tokenizer.json + model-*.safetensors; default `huihui-ai/Llama-3.2-3B-Instruct-abliterated`). Same
 # git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c52f469d0d32612315a8955e35b76acfd932a74e" }
 # SCAIL-2 (zai-org) end-to-end character-animation provider (epic 5439, sc-5448). An inventory-registered
 # `Generator` under id `scail2_14b` (`Modality::Video`): a Wan2.1-14B I2V DiT that animates a reference
 # character with a driving video's motion (`video_mode == "replacement"` flips the cross-identity
@@ -613,7 +625,7 @@ mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev 
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7b89d4563b5cdaf6513debc81fbe6c4475ac31e6" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c52f469d0d32612315a8955e35b76acfd932a74e" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -574,13 +574,52 @@ pub(crate) fn emit_load_event(event: &str, job_id: &str, engine: &str, adapter_c
     );
 }
 
+/// Optional prompt-enhancement settings resolved from a job request's `advanced` block and threaded
+/// into a [`GenerationRequest`] (sc-6135). Mirrors the LTX-2.3 video path (`advanced.enhancePrompt` /
+/// `enhanceTemperature` / `enhanceMaxTokens`). Only FLUX.2-dev / FLUX.2-dev-edit act on it — the
+/// Mistral3 caption upsampler (sc-6030), text-only for txt2img and image-conditioned on the
+/// reference image(s) for edit; every other engine ignores the fields, and the dev Image-Studio
+/// toggle (manifest `ui.promptEnhance`) is the only surface that sets `enhancePrompt`, so this is a
+/// no-op for all other models.
+#[derive(Clone, Default)]
+pub(crate) struct PromptEnhance {
+    enabled: bool,
+    temperature: Option<f32>,
+    max_tokens: Option<u32>,
+}
+
+impl PromptEnhance {
+    /// Resolve from a job request's `advanced` settings (same keys as the LTX-2.3 video path).
+    pub(crate) fn from_advanced(advanced: &JsonObject) -> Self {
+        PromptEnhance {
+            enabled: advanced::bool(advanced, "enhancePrompt"),
+            temperature: advanced
+                .get("enhanceTemperature")
+                .and_then(Value::as_f64)
+                .map(|value| value as f32),
+            max_tokens: advanced
+                .get("enhanceMaxTokens")
+                .and_then(Value::as_u64)
+                .map(|value| value as u32),
+        }
+    }
+
+    /// Write the resolved enhancement settings onto a `GenerationRequest`.
+    fn apply(&self, request: &mut GenerationRequest) {
+        request.enhance_prompt = self.enabled;
+        request.enhance_temperature = self.temperature;
+        request.enhance_max_tokens = self.max_tokens;
+    }
+}
+
 /// Generate one image (RGB8) at the given seed; `on_progress` streams denoise steps.
 /// `guidance` is `None` for distilled variants (the engine rejects it on them).
 ///
 /// `reference` is the optional identity img2img-init (sc-3619): `(image, strength)` adds a
 /// `Reference` conditioning that seeds the denoise from the reference latents — the plain
 /// (no-ControlNet) Z-Image reference-without-pose path, reusing the same engine img2img the
-/// strict-pose tier already drives. `None` → plain txt2img.
+/// strict-pose tier already drives. `None` → plain txt2img. `enhance` carries the optional
+/// caption-upsampling settings (sc-6135; only FLUX.2-dev acts on them).
 #[allow(clippy::too_many_arguments)]
 fn generate_one(
     generator: &dyn Generator,
@@ -596,6 +635,7 @@ fn generate_one(
     sampler: Option<&str>,
     scheduler: Option<&str>,
     scheduler_shift: Option<f32>,
+    enhance: &PromptEnhance,
     cancel: &CancelFlag,
     on_progress: &mut dyn FnMut(Progress),
 ) -> WorkerResult<(u32, u32, Vec<u8>)> {
@@ -606,7 +646,7 @@ fn generate_one(
         }],
         None => Vec::new(),
     };
-    let request = GenerationRequest {
+    let mut request = GenerationRequest {
         prompt: prompt.to_owned(),
         negative_prompt,
         width,
@@ -623,6 +663,7 @@ fn generate_one(
         cancel: cancel.clone(),
         ..Default::default()
     };
+    enhance.apply(&mut request);
     let output = generator
         .generate(&request, on_progress)
         .map_err(|error| WorkerError::Engine(format!("generation failed: {error}")))?;
@@ -995,6 +1036,9 @@ async fn generate_stream(
     let prompt = request.prompt.clone();
     let (width, height) = (request.width, request.height);
     let adapter_count = adapters.len();
+    // sc-6135: caption upsampling (FLUX.2-dev only; every other engine ignores it). Resolved from
+    // the request's advanced `enhancePrompt` toggle, gated to dev by the manifest `ui.promptEnhance`.
+    let enhance = PromptEnhance::from_advanced(&request.advanced);
     let spec = load_spec(weights_dir, quant, adapters, flux_ip_dir);
     let (cancel, rx, blocking) = start_cached_gen_stream(
         job.id.clone(),
@@ -1018,6 +1062,7 @@ async fn generate_stream(
                     sampler.as_deref(),
                     scheduler.as_deref(),
                     scheduler_shift,
+                    &enhance,
                     &cancel,
                     on_progress,
                 )?;
@@ -1189,6 +1234,9 @@ async fn generate_candle_stream(
     let seeds: Vec<i64> = (0..count).map(|index| resolve_seed(request, index)).collect();
     let prompt = request.prompt.clone();
     let (width, height) = (request.width, request.height);
+    // sc-6135: caption upsampling is FLUX.2-dev-only and dev runs on the macOS path, so this is a
+    // no-op here — resolved for uniformity (and so a future candle enhancer would be wired).
+    let enhance = PromptEnhance::from_advanced(&request.advanced);
     // Record the effective CFG knob (guidance for guided families, else true_cfg) + quant bits in the
     // recipe, so a Lens asset's sidecar reflects the Q4/Q8 it ran at (parity with the MLX path).
     let raw_settings = mlx_raw_settings(request, &repo, steps, quant_bits, guidance.or(true_cfg));
@@ -1219,6 +1267,7 @@ async fn generate_candle_stream(
                     None,
                     None,
                     None,
+                    &enhance,
                     &cancel,
                     on_progress,
                 )?;

--- a/crates/sceneworks-worker/src/image_jobs/flux2.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2.rs
@@ -240,10 +240,11 @@ fn flux2_edit_generate_one(
     steps: u32,
     guidance: Option<f32>,
     conditioning: Vec<Conditioning>,
+    enhance: &PromptEnhance,
     cancel: &CancelFlag,
     on_progress: &mut dyn FnMut(Progress),
 ) -> WorkerResult<(u32, u32, Vec<u8>)> {
-    let request = GenerationRequest {
+    let mut request = GenerationRequest {
         prompt: prompt.to_owned(),
         width,
         height,
@@ -255,6 +256,7 @@ fn flux2_edit_generate_one(
         cancel: cancel.clone(),
         ..Default::default()
     };
+    enhance.apply(&mut request);
     let output = generator
         .generate(&request, on_progress)
         .map_err(|error| WorkerError::Engine(format!("edit generation failed: {error}")))?;
@@ -429,6 +431,9 @@ async fn generate_flux2_edit_stream(
     let (width, height) = (request.width, request.height);
     let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
     let adapter_count = adapters.len();
+    // sc-6135: FLUX.2-dev caption upsampling — image-conditioned on the reference for the edit path.
+    // Gated to dev by the engine + the manifest `ui.promptEnhance` toggle; off for klein.
+    let enhance = PromptEnhance::from_advanced(&request.advanced);
     let spec = load_spec(weights_dir, quant, adapters, None);
     let (cancel, rx, blocking) = start_cached_gen_stream(
         job.id.clone(),
@@ -476,6 +481,7 @@ async fn generate_flux2_edit_stream(
                         steps,
                         guidance,
                         conditioning,
+                        &enhance,
                         &cancel,
                         on_progress,
                     )?;

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -996,6 +996,7 @@ fn smoke_generate_one(
         None,
         None,
         None,
+        &PromptEnhance::default(),
         &cancel,
         &mut |p| {
             if let gen_core::Progress::Step { current, .. } = p {
@@ -1169,6 +1170,7 @@ fn lens_turbo_real_weights_bucket_resolution() {
         None,
         None,
         None,
+        &PromptEnhance::default(),
         &cancel,
         &mut |_p| {},
     )
@@ -1416,6 +1418,7 @@ fn kolors_real_weights_img2img_generates_one_image() {
         None,
         None,
         None,
+        &PromptEnhance::default(),
         &cancel,
         &mut |p| {
             if let gen_core::Progress::Step { current, .. } = p {
@@ -1465,6 +1468,7 @@ fn kolors_real_weights_ip_adapter_generates_one_image() {
         None,
         None,
         None,
+        &PromptEnhance::default(),
         &cancel,
         &mut |p| {
             if let gen_core::Progress::Step { current, .. } = p {
@@ -1797,6 +1801,7 @@ fn smoke_generate_one_true_cfg(
         None,
         None,
         None,
+        &PromptEnhance::default(),
         &cancel,
         &mut |p| {
             if let gen_core::Progress::Step { current, .. } = p {
@@ -1987,6 +1992,7 @@ fn sc3031_ab_dump_txt2img() {
         None,
         None,
         None,
+        &PromptEnhance::default(),
         &cancel,
         &mut |_| {},
     )
@@ -2395,6 +2401,34 @@ fn flux2_dev_edit_memory_guard_gates_multiref_on_small_machines() {
     assert!(flux2_dev_edit_memory_guard(2, 1024, 1024, None).is_ok());
 }
 
+// ---- sc-6135: FLUX.2-dev caption-upsampling (enhance_prompt) threading ------------------------
+
+#[cfg(target_os = "macos")]
+#[test]
+fn prompt_enhance_reads_advanced_settings() {
+    // Absent → disabled with no overrides (the default for every model/job).
+    let off = PromptEnhance::from_advanced(
+        &request(json!({
+            "projectId": "p", "model": "flux2_dev", "prompt": "a fox"
+        }))
+        .advanced,
+    );
+    assert!(!off.enabled);
+    assert_eq!(off.temperature, None);
+    assert_eq!(off.max_tokens, None);
+
+    // The dev Image-Studio toggle sets `enhancePrompt`; optional temperature / max-tokens follow
+    // (same keys as the LTX-2.3 video path).
+    let on = PromptEnhance::from_advanced(&request(json!({
+        "projectId": "p", "model": "flux2_dev", "prompt": "a fox",
+        "advanced": { "enhancePrompt": true, "enhanceTemperature": 0.2, "enhanceMaxTokens": 256 }
+    }))
+    .advanced);
+    assert!(on.enabled);
+    assert_eq!(on.temperature, Some(0.2));
+    assert_eq!(on.max_tokens, Some(256));
+}
+
 // ---- sc-6055: FLUX.2-dev strict-pose (flux2_dev_control) -------------------------------------
 
 #[cfg(target_os = "macos")]
@@ -2669,6 +2703,7 @@ fn flux2_edit_real_weights_generates_one_image() {
         4,
         Some(1.0),
         build_edit_conditioning(std::slice::from_ref(&reference)),
+        &PromptEnhance::default(),
         &cancel,
         &mut |p| {
             if let gen_core::Progress::Step { current, .. } = p {
@@ -3362,6 +3397,7 @@ fn flux2_pose_tier_real_weights_generates_one_image() {
         4,
         Some(1.0),
         conditioning,
+        &PromptEnhance::default(),
         &cancel,
         &mut |p| {
             if let gen_core::Progress::Step { current, .. } = p {


### PR DESCRIPTION
## sc-6135 — surface FLUX.2-dev caption upsampling (`enhance_prompt`) in the worker/UI

Sibling of sc-6030 (the mlx-gen engine capability, #484), mirroring the sc-5919→sc-5922 engine→UI pattern. FLUX.2-dev's engine can have its own Mistral3 multimodal LLM **upsample the prompt** before the diffusion encode — text-only for txt2img, **reference-aware** for edit — gated on the existing gen-core `enhance_prompt` field. This makes it reachable in SceneWorks.

### On the redundancy question (the story flagged it as Michael's call)
The T2I path overlaps with the existing model-agnostic **"Refine my prompt"** (`prompt_refine`) button. But this is genuinely distinct: it's the **model's own** upsampler (trained for FLUX.2-dev's preferences), it's invisible/at-generation rather than a visible pre-edit rewrite, and the **edit path reads the reference image** — which neither `prompt_refine` (text-only) nor `joycaption` (captions an image, doesn't rewrite an edit prompt in context) does. The toggle is opt-in (off by default) and labeled to distinguish it from the Refine button. So it completes the model-native surface without replacing the existing affordance.

### Changes
- **Worker** — a `PromptEnhance` resolved from the request's advanced `enhancePrompt` / `enhanceTemperature` / `enhanceMaxTokens` (the LTX-2.3 keys), threaded into the dev **txt2img** (`generate_one`) and **edit** (`flux2_edit_generate_one`) `GenerationRequest`s. Off by default; only FLUX.2-dev acts on it (every other engine ignores the fields). Control/pose path excluded (the engine's upsampler is gated to the dev generator, not the standalone control generator).
- **UI** — an "Enhance prompt" toggle in the Image Studio **Advanced** panel, gated by the manifest `ui.promptEnhance` flag (flux2_dev only) → sets `advanced.enhancePrompt`. Visible in both txt2img and edit modes.
- **Manifest** — `ui.promptEnhance: true` on `flux2_dev`, with a comment distinguishing it from the Refine button.
- **Pin** — bump worker mlx-gen `7b89d45 → c52f469` (the #484 merge) so the engine actually consumes the flag. Minimal (c52f469 has 7b89d45 as ancestor → only sc-6030 + the already-merged sc-5920 LoRA, not the later sc-6067). gen-core delta is **doc-only** (no contract/parity-snapshot change), mlx-rs unchanged (44929a0 → MLX core doesn't rebuild); default skew gate stays single-rev.

### Validation
- `cargo clippy --all-targets -- -D warnings` + `cargo fmt --all --check` clean.
- **316 worker lib tests** (new `prompt_enhance_reads_advanced_settings` pins the advanced→PromptEnhance mapping).
- **rust-api 114 lib tests** — `builtin_manifest_*` parse tests confirm the new `ui.promptEnhance` key parses.
- gen-core skew gate: single rev `c52f469`.
- **Web**: lint **0 errors**; full suite **507 tests / 31 files** pass — new "Enhance prompt toggle" test mounts ImageStudio with `ui.promptEnhance`, opens the Advanced panel, asserts the toggle renders (off by default) and that toggling it flows `advanced.enhancePrompt: true` into the job payload.

No contract-snapshot / constants.js / core change (manifest `ui` flag + worker threading + pin are sufficient — `flux2_dev` is already MLX-eligible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)