### PR TITLE
sc-6225: bump candle-gen pin for SeedVR2 image-path tiling (off-Mac OOM fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5a4d9409001cec1e46721800f875b8aae95bc58#a5a4d9409001cec1e46721800f875b8aae95bc58"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5a4d9409001cec1e46721800f875b8aae95bc58#a5a4d9409001cec1e46721800f875b8aae95bc58"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5a4d9409001cec1e46721800f875b8aae95bc58#a5a4d9409001cec1e46721800f875b8aae95bc58"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5a4d9409001cec1e46721800f875b8aae95bc58#a5a4d9409001cec1e46721800f875b8aae95bc58"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5a4d9409001cec1e46721800f875b8aae95bc58#a5a4d9409001cec1e46721800f875b8aae95bc58"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5a4d9409001cec1e46721800f875b8aae95bc58#a5a4d9409001cec1e46721800f875b8aae95bc58"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -519,7 +519,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5a4d9409001cec1e46721800f875b8aae95bc58#a5a4d9409001cec1e46721800f875b8aae95bc58"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -530,7 +530,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5a4d9409001cec1e46721800f875b8aae95bc58#a5a4d9409001cec1e46721800f875b8aae95bc58"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5a4d9409001cec1e46721800f875b8aae95bc58#a5a4d9409001cec1e46721800f875b8aae95bc58"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -557,7 +557,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5a4d9409001cec1e46721800f875b8aae95bc58#a5a4d9409001cec1e46721800f875b8aae95bc58"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -569,7 +569,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5a4d9409001cec1e46721800f875b8aae95bc58#a5a4d9409001cec1e46721800f875b8aae95bc58"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -580,7 +580,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5a4d9409001cec1e46721800f875b8aae95bc58#a5a4d9409001cec1e46721800f875b8aae95bc58"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -597,7 +597,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5a4d9409001cec1e46721800f875b8aae95bc58#a5a4d9409001cec1e46721800f875b8aae95bc58"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -611,7 +611,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5a4d9409001cec1e46721800f875b8aae95bc58#a5a4d9409001cec1e46721800f875b8aae95bc58"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -629,7 +629,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5a4d9409001cec1e46721800f875b8aae95bc58#a5a4d9409001cec1e46721800f875b8aae95bc58"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -640,7 +640,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5a4d9409001cec1e46721800f875b8aae95bc58#a5a4d9409001cec1e46721800f875b8aae95bc58"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -653,7 +653,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5a4d9409001cec1e46721800f875b8aae95bc58#a5a4d9409001cec1e46721800f875b8aae95bc58"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -664,7 +664,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5a4d9409001cec1e46721800f875b8aae95bc58#a5a4d9409001cec1e46721800f875b8aae95bc58"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -677,7 +677,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=bcd94ad35f514460fa8de279bdfe3f20daed14e4#bcd94ad35f514460fa8de279bdfe3f20daed14e4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a5a4d9409001cec1e46721800f875b8aae95bc58#a5a4d9409001cec1e46721800f875b8aae95bc58"
 dependencies = [
  "candle-core",
  "candle-gen",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -137,6 +137,18 @@ sceneworks-core = { path = "../sceneworks-core" }
 # commit 4449260 + the provider commit bcd94ad); pre-merge of #91 this points at the branch SHA — flip to
 # the merged candle-gen main rev once #91 lands. candle-gen #91 is SOURCE-ONLY (gen-core stays 7b89d45,
 # byte-identical), so the backend-candle graph stays single gen-core rev 7b89d45 (no skew).
+# Rev bcd94ad -> a5a4d94 (candle-gen #93, sc-6225): the off-Mac mirror of the mlx-gen #485 / sc-6067
+# image-path tiling fix below. The candle SeedVR2 image path (`candle-gen-seedvr2 Seedvr2Pipeline::generate`)
+# ran the whole frame in ONE pass with no memory-budget check, so a large image upscale tried a single
+# oversized DiT/VAE allocation and CUDA-OOM'd. This splits `generate` into a budget-injectable
+# `generate_budgeted` that routes `ChunkPlan::OverBudget` through the existing parity-gated
+# `run_frame_tiled` feather-blend tiler (the candle video path already budget-tiled via
+# `generate_video_tiled`). The delta is PURE candle-gen-seedvr2 Rust — gen-core stays 7b89d45
+# (byte-identical), so only seedvr2 recompiles and the backend-candle graph's gen-core rev is unchanged
+# from bcd94ad (same accepted momentary REV-skew vs the mlx-gen 98592bb pin below, sc-5905). a5a4d94 is
+# candle-gen #93's content commit, durable on its branch (an ancestor of the eventual #93 merge); flip to
+# the merged candle-gen main rev once #93 lands. (The worker-thread poison half of sc-6067 is already
+# covered for candle — the catch_unwind crash-recovery in generator_cache.rs is shared, backend-agnostic.)
 # Rev 98592bb (mlx-gen #485 merged, sc-6067): bumps every mlx-gen crate 7b89d45 -> 98592bb to spatially
 # tile the SeedVR2 *image* upscale path. The image path (`Seedvr2Pipeline::generate`) ran the whole frame
 # in ONE pass with no memory-budget check, so a large upscale tried a single DiT/VAE allocation past
@@ -814,38 +826,38 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9859
 # (the delta is the single additive sc-6038 mlx-gen-instantid commit), so behavior-neutral. The candle
 # SDXL edit worker route (`image_jobs/sdxl_edit_candle.rs`) drives candle-gen-sdxl's `SdxlEdit` off-Mac.
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5a4d9409001cec1e46721800f875b8aae95bc58", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5a4d9409001cec1e46721800f875b8aae95bc58", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5a4d9409001cec1e46721800f875b8aae95bc58", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5a4d9409001cec1e46721800f875b8aae95bc58", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5a4d9409001cec1e46721800f875b8aae95bc58", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5a4d9409001cec1e46721800f875b8aae95bc58", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5a4d9409001cec1e46721800f875b8aae95bc58", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5a4d9409001cec1e46721800f875b8aae95bc58", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5a4d9409001cec1e46721800f875b8aae95bc58", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5a4d9409001cec1e46721800f875b8aae95bc58", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -854,19 +866,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5a4d9409001cec1e46721800f875b8aae95bc58", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5a4d9409001cec1e46721800f875b8aae95bc58", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5a4d9409001cec1e46721800f875b8aae95bc58", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -875,12 +887,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5a4d9409001cec1e46721800f875b8aae95bc58", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5a4d9409001cec1e46721800f875b8aae95bc58", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -888,7 +900,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5a4d9409001cec1e46721800f875b8aae95bc58", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -897,7 +909,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5a4d9409001cec1e46721800f875b8aae95bc58", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -905,7 +917,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5a4d9409001cec1e46721800f875b8aae95bc58", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -914,7 +926,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bcd94ad35f514460fa8de279bdfe3f20daed14e4", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a5a4d9409001cec1e46721800f875b8aae95bc58", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -146,8 +146,10 @@ sceneworks-core = { path = "../sceneworks-core" }
 # `generate_video_tiled`). The delta is PURE candle-gen-seedvr2 Rust — gen-core stays 7b89d45
 # (byte-identical), so only seedvr2 recompiles and the backend-candle graph's gen-core rev is unchanged
 # from bcd94ad (same accepted momentary REV-skew vs the mlx-gen 98592bb pin below, sc-5905). a5a4d94 is
-# candle-gen #93's content commit, durable on its branch (an ancestor of the eventual #93 merge); flip to
-# the merged candle-gen main rev once #93 lands. (The worker-thread poison half of sc-6067 is already
+# candle-gen #93's content commit, now a DURABLE ancestor of candle-gen main (merge commit ec01336 of
+# #93, NOT squash) so the pin stays fetchable after the branch delete — it deliberately stays at the
+# minimal seedvr2-only delta a5a4d94 rather than flipping to merged-main HEAD, which has since advanced
+# with the UNRELATED sc-6217 qwen-attn-chunk (#92). (The worker-thread poison half of sc-6067 is already
 # covered for candle — the catch_unwind crash-recovery in generator_cache.rs is shared, backend-agnostic.)
 # Rev 98592bb (mlx-gen #485 merged, sc-6067): bumps every mlx-gen crate 7b89d45 -> 98592bb to spatially
 # tile the SeedVR2 *image* upscale path. The image path (`Seedvr2Pipeline::generate`) ran the whole frame


### PR DESCRIPTION
## Summary
Picks up [candle-gen #93](https://github.com/michaeltrefry/candle-gen/pull/93) (sc-6225) — the off-Mac (Windows/CUDA) mirror of mlx-gen #485 / sc-6067.

The candle SeedVR2 image path `Seedvr2Pipeline::generate` ran the whole frame in **one pass with no memory-budget check**, so a large image upscale attempted a single oversized DiT/VAE allocation → **CUDA OOM**. The video path already budget-tiled (`generate_video_tiled` → `run_frame_tiled`); candle-gen #93 routes the image path through the same feather-blend tiler when over budget. The worker just needs the pin.

## Change
- Lockstep bump of all 19 `candle-gen*` crate revs `bcd94ad` → `a5a4d94` (Cargo.toml + Cargo.lock).
- **Worker source unchanged** — `generate`'s signature is identical; the new behavior is internal (auto-tile when over budget).
- Pure `candle-gen-seedvr2` Rust delta — **gen-core stays 7b89d45** (byte-identical), so only seedvr2 recompiles under `--features backend-candle` and the graph's gen-core rev is unchanged from `bcd94ad` (same accepted momentary REV-skew vs the mlx-gen `98592bb` pin, sc-5905). The default candle-gen-blind PR gate stays single-rev/green.
- `a5a4d94` is candle-gen #93's content commit, durable on its branch (an ancestor of the eventual merge); flip to merged candle-gen main once #93 lands.

## Validation
- GPU build + `seedvr2_image_path_tiles_when_over_budget` (`--features cuda`, RTX PRO 6000, real 3B checkpoint): **in-flight** — will update with the tiled-vs-single-pass cosine.

The worker-thread poison half of sc-6067 is already covered for candle (the `catch_unwind` crash-recovery in `generator_cache.rs` is shared, backend-agnostic worker code), so this is the "completes via tiling instead of CUDA-OOM" half.

Relates to sc-6067 / candle-gen#93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)