### PR TITLE
sc-6229: contain+pad clip boundary/seed frames (stop ffmpeg stretch)

### DIFF
--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -2090,8 +2090,10 @@ async fn resolve_wan_clip_conditioning(
     build_wan_boundary_conditioning(request, left_frame, right_frame)
 }
 
-/// Decode a single boundary frame (first or last) of a source clip into an [`Image`], scaled to the
-/// output `width`×`height` (sc-3357, the Wan boundary-keyframe conditioning input). The last frame
+/// Decode a single boundary frame (first or last) of a source clip into an [`Image`], fit to the
+/// output `width`×`height` by contain+pad (letterbox, `FRAME_PAD_COLOR`) so a clip whose aspect
+/// differs from the output is not distorted — sc-6229, matching the `load_source_video_frames`
+/// recipe (sc-3357, the Wan boundary-keyframe conditioning input). The last frame
 /// uses ffmpeg `-sseof` to seek near the end + `-update 1` so each decoded frame overwrites the lone
 /// output, leaving the final frame; the first frame is a plain `-frames:v 1`. Extracted via the
 /// shared [`run_ffmpeg`] (binary resolution + heartbeat/cancel), then loaded off the async runtime.
@@ -2125,7 +2127,12 @@ async fn extract_clip_boundary_frame(
     args.push("-i".to_owned());
     args.push(clip_path.display().to_string());
     args.push("-vf".to_owned());
-    args.push(format!("scale={width}:{height}"));
+    // Contain+pad (letterbox) to the output dims so a source clip whose aspect differs from the
+    // requested W×H is not stretched (sc-6229); reuses the `FRAME_PAD_COLOR` recipe.
+    args.push(format!(
+        "scale={width}:{height}:force_original_aspect_ratio=decrease,\
+         pad={width}:{height}:(ow-iw)/2:(oh-ih)/2:color={FRAME_PAD_COLOR},format=rgb24"
+    ));
     if position == ClipFramePosition::Last {
         args.push("-update".to_owned());
         args.push("1".to_owned());
@@ -4463,8 +4470,10 @@ fn resolve_clip_media_path(
 /// Decode the first `count` frames of a source clip into [`Image`]s for in-context conditioning.
 /// Mirrors the torch reference `decode_video_by_frame(starting_frame=0, frame_cap=num_frames)` /
 /// `video_preprocess` (ltx_pipelines): **sequential** frames from the start at the clip's native
-/// cadence (no fps resample), scaled to the output `width`×`height` (the engine `build_clips`
-/// LANCZOS-downsizes each frame to stage-1 half-res, so this only bounds memory). `count` is the
+/// cadence (no fps resample), fit to the output `width`×`height` by contain+pad (letterbox,
+/// `FRAME_PAD_COLOR`) so a clip whose aspect differs from the output is not distorted (sc-6229;
+/// the engine `build_clips` LANCZOS-downsizes each frame to stage-1 half-res, so this only bounds
+/// memory). `count` is the
 /// generation's snapped frame count (`8k+1`); a clip shorter than `count` yields fewer frames,
 /// which the engine VAE encode accepts. Extracted via the shared [`run_ffmpeg`] (binary
 /// resolution + heartbeat/cancel), then loaded off the async runtime.
@@ -4496,10 +4505,14 @@ async fn extract_clip_frames(
             "-y".to_owned(),
             "-i".to_owned(),
             clip_path.display().to_string(),
-            // Plain scale (stretch) to the output dims — matches the engine's LANCZOS resize
-            // model (it re-resizes to stage-1 half-res); bounds the extracted frame footprint.
+            // Contain+pad (letterbox) to the output dims so a clip whose aspect differs from the
+            // requested W×H is not stretched (sc-6229); reuses the `FRAME_PAD_COLOR` recipe. The
+            // engine re-resizes to stage-1 half-res, so this only bounds the extracted footprint.
             "-vf".to_owned(),
-            format!("scale={width}:{height}"),
+            format!(
+                "scale={width}:{height}:force_original_aspect_ratio=decrease,\
+                 pad={width}:{height}:(ow-iw)/2:(oh-ih)/2:color={FRAME_PAD_COLOR},format=rgb24"
+            ),
             // First `count` decoded frames, sequential from the start at native cadence.
             "-frames:v".to_owned(),
             count.to_string(),


### PR DESCRIPTION
## What

Fix [sc-6229](https://app.shortcut.com/trefry/story/6229): clip boundary / seed frames are stretched in `extend_clip` / `video_bridge`.

Both ffmpeg frame-extraction sites in `crates/sceneworks-worker/src/video_jobs.rs` built the filter with a bare `scale={width}:{height}` — a non-aspect-preserving **stretch**. When the source clip's aspect differs from the requested output W×H, the extracted frame(s) were distorted, so the continuation/bridge was seeded from a squished frame. Same distortion class as [sc-6139](https://app.shortcut.com/trefry/story/6139), different surface (internal boundary frames vs. the user's starting image).

Replaced the bare scale in both sites with the contain+pad (letterbox) recipe already used by `load_source_video_frames` in this same file:

```
scale=W:H:force_original_aspect_ratio=decrease,
pad=W:H:(ow-iw)/2:(oh-ih)/2:color=FRAME_PAD_COLOR,format=rgb24
```

- `extract_clip_boundary_frame` — the single seed frame for extend_clip / video_bridge continuation.
- `extract_clip_frames` — the resampled in-context clip frames.

Doc comments on both functions updated (they previously described the bare stretch).

## Why pad-by-default (not threaded through `fit_mode`)

The story floated optionally threading `request.fit_mode` so extend/bridge honor the studio's Crop/Pad choice. I went with pad-by-default because the Video Studio UI (`VideoStudio.jsx`) only sends `fitMode` for `image_to_video` / `first_last_frame`; `extend_clip` / `video_bridge` send `undefined`, which the DTO normalizes to the `"crop"` default, and there is **no fit control for these modes**. So "honor the studio's choice" is moot — threading `fit_mode` would expose no user capability, only flip the hardcoded default. Pad also matches the other ffmpeg extractors in this file and is a no-op when the source already matches the output aspect.

## Acceptance criteria

- [x] Extending/bridging a clip whose aspect differs from the output no longer distorts the boundary/seed frames (letterbox, not stretch).
- [x] Both `extract_clip_boundary_frame` and `extract_clip_frames` use a non-distorting filter.
- [x] No regression for clips already at the output aspect (pad is a no-op there).

## Validation

- `cargo fmt -p sceneworks-worker --check`: clean.
- `cargo clippy -p sceneworks-worker --all-targets`: clean, zero warnings/errors.
- **Empirical ffmpeg check** (bundled ffmpeg 7.1, ran the exact new filter, decoded the PNG, sampled pixels):
  - 1280×720 → 512×512: content band rows 112–399 (height 288) with 112px `0x12110f` bars top+bottom — the exact letterbox math for 720→288 centered in 512. **Letterboxed, not stretched.**
  - 512×512 → 512×512 (matching aspect): zero pad-colored pixels anywhere. **True no-op.**

## Reviewer notes

- Verified pad is correct at **every** call site of the two functions, not just extend/bridge: SCAIL-2 `animate_character` driving frames (masks are SAM3-segmented from the extracted frames themselves → auto-aligned under any fit, and segmenting an undistorted person is more accurate), Bernini multi-clip v2v/mv2v/ads2v conditioning, and Wan boundary keyframes (no mask pairing).
- No new Rust unit test: these macOS-gated async extractors are covered by real-ffmpeg / real-weight smokes per the file's convention, and the filter behavior is fully ffmpeg-determined (verified above). Adding ApiClient/Settings/ProjectStore fixture mocking to re-prove ffmpeg would be speculative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
