### PR TITLE
sc-6302: register ideogram_4 in core MLX routing/eligibility

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3088,6 +3088,12 @@ const MLX_ROUTED_MODELS: &[&str] = &[
     // The video `bernini` id lives in `VIDEO_MLX_ROUTED_MODELS`, not here. Mirrors
     // `bernini_image_mlx_eligible`.
     "bernini_image",
+    // Ideogram 4 (epic 4725): 9.3B single-stream flow DiT (asymmetric two-DiT CFG) + Qwen3-VL-8B
+    // text encoder on the native `mlx-gen-ideogram` engine (id `ideogram_4`, adapter `mlx_ideogram`),
+    // macOS-only (no torch backend). Text-to-image only as implemented — the predicate keeps
+    // `edit_image`/reference off MLX (edit/remix is net-new engine work, sc-6303). Mirrors
+    // `ideogram_mlx_eligible`.
+    "ideogram_4",
 ];
 
 /// Epic 3018 routing — does this image job belong on the in-process Rust MLX
@@ -3148,6 +3154,7 @@ fn image_request_mlx_eligible(model: &str, payload: &Map<String, Value>) -> bool
         "kolors" => kolors_mlx_eligible(payload),
         "lens" | "lens_turbo" => lens_mlx_eligible(payload),
         "bernini_image" => bernini_image_mlx_eligible(payload),
+        "ideogram_4" => ideogram_mlx_eligible(payload),
         // Every model in MLX_ROUTED_MODELS must have an arm.
         _ => false,
     }
@@ -4084,6 +4091,19 @@ fn bernini_image_mlx_eligible(payload: &Map<String, Value>) -> bool {
             .is_some_and(|id| !id.trim().is_empty());
     }
     true
+}
+
+/// Ideogram 4 (epic 4725) MLX-routing conditions. The native `mlx-gen-ideogram` engine is wired as a
+/// pure text-to-image family today (catalog `capabilities:["text_to_image"]`): the asymmetric two-DiT
+/// flow renderer under a Qwen3-VL-8B encoder has no img2img / edit / reference / pose path in the
+/// worker (no `resolve_ideogram_edit`, unlike z_image/flux2/qwen-edit). So every non-edit
+/// `image_generate` job routes to the in-process Rust worker, and an `edit_image` mode stays OFF MLX
+/// so it is never silently run as plain T2I against a dropped source image (defensive; the UI never
+/// offers edit for Ideogram, lacking the `edit_image` capability). The edit / remix capability is
+/// net-new engine work tracked under sc-6303. Mirrors [`lens_mlx_eligible`]. macOS-only (the catalog
+/// flags `macOnly`); on Windows/Linux no `mlx` worker is registered, so nothing defers.
+fn ideogram_mlx_eligible(payload: &Map<String, Value>) -> bool {
+    payload.get("mode").and_then(Value::as_str) != Some("edit_image")
 }
 
 /// Video models the in-process Rust MLX worker generates today (sc-3034 Wan2.2,
@@ -6365,8 +6385,8 @@ mod candle_routing_tests {
 mod mlx_routing_tests {
     use super::{
         flux2_mlx_eligible, flux_mlx_eligible, image_request_mlx_eligible, instantid_mlx_eligible,
-        qwen_edit_mlx_eligible, qwen_mlx_eligible, sdxl_mlx_eligible, video_mode_is_mlx_eligible,
-        z_image_mlx_eligible, VIDEO_MLX_ROUTED_MODELS,
+        model_mac_support, qwen_edit_mlx_eligible, qwen_mlx_eligible, sdxl_mlx_eligible,
+        video_mode_is_mlx_eligible, z_image_mlx_eligible, VIDEO_MLX_ROUTED_MODELS,
     };
     use serde_json::{json, Map, Value};
 
@@ -6647,6 +6667,32 @@ mod mlx_routing_tests {
             "model": "instantid_realvisxl",
             "mode": "text_to_image"
         }))));
+    }
+
+    #[test]
+    fn ideogram_4_text_to_image_routes_to_mlx_but_edit_stays_off() {
+        // sc-6302: `ideogram_4` is registered in MLX_ROUTED_MODELS with a T2I-only predicate. Plain
+        // text-to-image (the only wired capability) routes to the in-process MLX worker; the
+        // unimplemented edit/remix shape (sc-6303) stays off MLX so it never silently renders as
+        // plain T2I against a dropped source.
+        assert!(image_request_mlx_eligible(
+            "ideogram_4",
+            &object(json!({ "prompt": "a neon city skyline" }))
+        ));
+        assert!(image_request_mlx_eligible("ideogram_4", &Map::new()));
+        assert!(!image_request_mlx_eligible(
+            "ideogram_4",
+            &object(json!({ "mode": "edit_image", "sourceAssetId": "asset_1" }))
+        ));
+
+        // The UI gating oracle (the reported symptom): Ideogram 4 must be macSupport.supported on
+        // Mac so it reaches the Text → Image picker. `edit` is off (the predicate rejects
+        // `edit_image`); `reference`/`pose` mirror the chroma/lens T2I-only quirk (their probes set
+        // no `mode`, so the `!= edit_image` predicate admits them) — harmless because the catalog
+        // `capabilities:["text_to_image"]` gate, not these flags, drives the UI affordances.
+        let support = model_mac_support("ideogram_4", "image");
+        assert!(support.supported, "ideogram_4 must be Mac-supported");
+        assert!(!support.features.edit, "ideogram_4 is T2I-only, no edit");
     }
 
     #[test]


### PR DESCRIPTION
## What

Registers `ideogram_4` in the `sceneworks-core` MLX routing/gating layer. The worker engine (`engines.rs` `ideogram_4` / `mlx_ideogram`) and catalog entry (`builtin.models.jsonc`, `type:"image"`, `capabilities:["text_to_image"]`, `macOnly:true`) were already complete, but core had **zero** `ideogram` references — so the model never reached the Image Studio Text → Image picker, and a submitted job would not route to the MLX worker.

All changes in `crates/sceneworks-core/src/jobs_store.rs` (+48/−2):

1. **`MLX_ROUTED_MODELS`** — add `"ideogram_4"`. Previously `image_model_mac_support("ideogram_4")` took the `!MLX_ROUTED_MODELS.contains` early return → `macSupport.supported:false`, and `apps/web/src/macGating.js` filtered the model out of `macImageModels`. It now reports `supported:true` on Mac. **(the reported symptom)**
2. **`ideogram_mlx_eligible(payload)`** — new predicate, `mode != "edit_image"`, mirroring the existing T2I-only `lens_mlx_eligible` / `chroma_mlx_eligible`. Edit/remix stays off MLX.
3. **Dispatch arm** — `"ideogram_4" => ideogram_mlx_eligible(payload)` in `image_request_mlx_eligible`, so a submitted T2I job routes to the MLX worker instead of hitting the `_ => false` fallthrough (which would strand it on "Waiting for an available worker").
4. **Regression test** — `ideogram_4_text_to_image_routes_to_mlx_but_edit_stays_off`.

## Why

Same class of gap as sc-5549 et al.: worker + catalog wired, core eligibility tables not updated. Closes the picker-visibility + routing bug for Ideogram 4 (T2I).

## Reviewer notes

- **Strictness choice:** mirrors `lens`/`chroma` (`!= edit_image`) rather than adding extra reference/character exclusion branches. Consequence: `model_mac_support("ideogram_4").features` reports `reference:true`/`pose:true` (the probes set no `mode`) — identical to `lens`/`chroma` today, and harmless because the catalog `capabilities:["text_to_image"]` gate (not these flags) drives the UI affordances. `edit` is genuinely off.
- **Out of scope:** image edit / remix (img2img + mask inpaint) is net-new engine work tracked under sc-6303, which this story blocks.
- Ideogram is `macOnly:true`, so it correctly stays out of `CANDLE_ROUTED_MODELS` (Windows/CUDA lane).

## Validation (Mac)

- `cargo test -p sceneworks-core --lib` → **218 passed** (new test + full `mlx_routing_tests` 18/18)
- `cargo clippy -p sceneworks-core --all-targets` → clean
- `cargo fmt --check` → clean
- Engine render path already covered by the existing real-weight worker test `ideogram_4_real_weights_generates_caption_and_plain_images`. Remaining: live Mac desktop-build smoke (picker → submit T2I → render).

Story: https://app.shortcut.com/trefry/story/6302

🤖 Generated with [Claude Code](https://claude.com/claude-code)