### PR TITLE
chore(worker): bump mlx-gen pin -> 92d0dc7 (ideogram4 render-parity, #487)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3284,11 +3284,11 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ba0e8d6b96a9c3404c57a44ca5c284736151c329#ba0e8d6b96a9c3404c57a44ca5c284736151c329"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=ba0e8d6b96a9c3404c57a44ca5c284736151c329)",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876)",
  "thiserror 2.0.18",
  "tokenizers 0.21.4",
 ]
@@ -3296,7 +3296,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ba0e8d6b96a9c3404c57a44ca5c284736151c329#ba0e8d6b96a9c3404c57a44ca5c284736151c329"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
 dependencies = [
  "image",
  "inventory",
@@ -3310,7 +3310,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ba0e8d6b96a9c3404c57a44ca5c284736151c329#ba0e8d6b96a9c3404c57a44ca5c284736151c329"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3322,7 +3322,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ba0e8d6b96a9c3404c57a44ca5c284736151c329#ba0e8d6b96a9c3404c57a44ca5c284736151c329"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3331,7 +3331,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ba0e8d6b96a9c3404c57a44ca5c284736151c329#ba0e8d6b96a9c3404c57a44ca5c284736151c329"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3343,7 +3343,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ba0e8d6b96a9c3404c57a44ca5c284736151c329#ba0e8d6b96a9c3404c57a44ca5c284736151c329"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3354,7 +3354,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ba0e8d6b96a9c3404c57a44ca5c284736151c329#ba0e8d6b96a9c3404c57a44ca5c284736151c329"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3366,7 +3366,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ba0e8d6b96a9c3404c57a44ca5c284736151c329#ba0e8d6b96a9c3404c57a44ca5c284736151c329"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3377,7 +3377,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ba0e8d6b96a9c3404c57a44ca5c284736151c329#ba0e8d6b96a9c3404c57a44ca5c284736151c329"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3387,7 +3387,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ba0e8d6b96a9c3404c57a44ca5c284736151c329#ba0e8d6b96a9c3404c57a44ca5c284736151c329"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
 dependencies = [
  "image",
  "inventory",
@@ -3399,7 +3399,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ba0e8d6b96a9c3404c57a44ca5c284736151c329#ba0e8d6b96a9c3404c57a44ca5c284736151c329"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
 dependencies = [
  "image",
  "inventory",
@@ -3412,7 +3412,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ba0e8d6b96a9c3404c57a44ca5c284736151c329#ba0e8d6b96a9c3404c57a44ca5c284736151c329"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
 dependencies = [
  "image",
  "inventory",
@@ -3424,7 +3424,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ba0e8d6b96a9c3404c57a44ca5c284736151c329#ba0e8d6b96a9c3404c57a44ca5c284736151c329"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3435,7 +3435,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ba0e8d6b96a9c3404c57a44ca5c284736151c329#ba0e8d6b96a9c3404c57a44ca5c284736151c329"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3447,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ba0e8d6b96a9c3404c57a44ca5c284736151c329#ba0e8d6b96a9c3404c57a44ca5c284736151c329"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3457,7 +3457,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ba0e8d6b96a9c3404c57a44ca5c284736151c329#ba0e8d6b96a9c3404c57a44ca5c284736151c329"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3466,7 +3466,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ba0e8d6b96a9c3404c57a44ca5c284736151c329#ba0e8d6b96a9c3404c57a44ca5c284736151c329"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3475,7 +3475,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ba0e8d6b96a9c3404c57a44ca5c284736151c329#ba0e8d6b96a9c3404c57a44ca5c284736151c329"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3487,7 +3487,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ba0e8d6b96a9c3404c57a44ca5c284736151c329#ba0e8d6b96a9c3404c57a44ca5c284736151c329"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
 dependencies = [
  "image",
  "inventory",
@@ -3500,7 +3500,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ba0e8d6b96a9c3404c57a44ca5c284736151c329#ba0e8d6b96a9c3404c57a44ca5c284736151c329"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3511,7 +3511,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ba0e8d6b96a9c3404c57a44ca5c284736151c329#ba0e8d6b96a9c3404c57a44ca5c284736151c329"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3522,7 +3522,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ba0e8d6b96a9c3404c57a44ca5c284736151c329#ba0e8d6b96a9c3404c57a44ca5c284736151c329"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3533,7 +3533,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ba0e8d6b96a9c3404c57a44ca5c284736151c329#ba0e8d6b96a9c3404c57a44ca5c284736151c329"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
 dependencies = [
  "image",
  "inventory",
@@ -3547,7 +3547,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ba0e8d6b96a9c3404c57a44ca5c284736151c329#ba0e8d6b96a9c3404c57a44ca5c284736151c329"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
 dependencies = [
  "image",
  "inventory",
@@ -5187,7 +5187,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ba0e8d6b96a9c3404c57a44ca5c284736151c329#ba0e8d6b96a9c3404c57a44ca5c284736151c329"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
 dependencies = [
  "inventory",
  "safetensors 0.4.5",
@@ -5288,7 +5288,7 @@ dependencies = [
  "pmetal-mlx-rs",
  "reqwest 0.12.28",
  "sceneworks-core",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=ba0e8d6b96a9c3404c57a44ca5c284736151c329)",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876)",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -181,7 +181,18 @@ sceneworks-core = { path = "../sceneworks-core" }
 # the change is PURE mlx-gen-flux2 (eval-per-block force-free gated on joint sequence length; shipped
 # T2I/single-ref/pose/LoRA byte-identical). Bumps EVERY mlx-gen crate + gen-core 51a6792 -> c46e8aa
 # in lockstep so the default skew gate (check.yml) stays single-rev. candle-gen lane unchanged (sc-5905).
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0e8d6b96a9c3404c57a44ca5c284736151c329" }
+# Rev ba0e8d6 -> 92d0dc7 (mlx-gen main, merged PR #487, ideogram4 render-parity): fixes FOUR Ideogram 4
+# render bugs vs the diffusers `ideogram4` reference (incoherent/"splattered paint" output) — (1) scheduler
+# mu/std now preset-driven (was const mu=0.5/std=1.0; starved low-noise detail), (2) per-step guidance
+# schedule (7.0 main / 3.0 final-3 "polish" steps, was const 7.0), (3) latent de-norm via the VAE's bn stats
+# (was bogus LATENT_SCALE/LATENT_SHIFT that didn't match), (4) image MRoPE t-axis offset (was 0, collided
+# with the text positions and corrupted text->image cross-attn = the dominant fix). PURE mlx-gen-ideogram +
+# mlx-gen-flux2 Rust (+ a `Flux2Vae::bn_stats()` getter); gen-core BYTE-IDENTICAL ba0e8d6 -> 92d0dc7 (the
+# range is docs-only CODEGRAPH + the engine fix), mlx-rs unchanged (44929a0 — MLX core does not rebuild),
+# and NO weight reconversion (the published q4/q8 turnkey is unchanged — the bugs were all runtime). Bumps
+# EVERY mlx-gen crate + gen-core in lockstep so the default skew gate (check.yml) stays single-rev.
+# candle-gen lane unchanged (sc-5905).
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -492,7 +503,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0e8d6b96a9c3404c57a44ca5c284736151c329" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -504,59 +515,59 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0e8d6b96a
 # internal pin (the Lens engine PRs #407–#414 did not move it; nor did the seedvr2 engine #416/#419/
 # #421 or the softness PR #422, so the 1a97909 bump above leaves mlx-rs at 44929a0).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "44929a001ab8a8837403a71c65cf064224de0cdc" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0e8d6b96a9c3404c57a44ca5c284736151c329" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0e8d6b96a9c3404c57a44ca5c284736151c329" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0e8d6b96a9c3404c57a44ca5c284736151c329" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0e8d6b96a9c3404c57a44ca5c284736151c329" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0e8d6b96a9c3404c57a44ca5c284736151c329" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0e8d6b96a9c3404c57a44ca5c284736151c329" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0e8d6b96a9c3404c57a44ca5c284736151c329" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0e8d6b96a9c3404c57a44ca5c284736151c329" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0e8d6b96a9c3404c57a44ca5c284736151c329" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0e8d6b96a9c3404c57a44ca5c284736151c329" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0e8d6b96a9c3404c57a44ca5c284736151c329" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0e8d6b96a9c3404c57a44ca5c284736151c329" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0e8d6b96a9c3404c57a44ca5c284736151c329" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -565,12 +576,12 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0e8d
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0e8d6b96a9c3404c57a44ca5c284736151c329" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0e8d6b96a9c3404c57a44ca5c284736151c329" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -579,7 +590,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0e8d
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0e8d6b96a9c3404c57a44ca5c284736151c329" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -587,7 +598,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0e8d6b96a9c3404c57a44ca5c284736151c329" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -598,7 +609,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0e
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0e8d6b96a9c3404c57a44ca5c284736151c329" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -609,7 +620,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0e8
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0e8d6b96a9c3404c57a44ca5c284736151c329" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -624,7 +635,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0e8d
 # converted in-memory at load (no Python); the precomputed neg-prompt embedding is bundled in-crate. No
 # LoRA/guidance/CFG (one-step). 3B fp16 only here — 7B (sc-5197) + int8 (sc-5198) are engine-side and
 # unwired. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0e8d6b96a9c3404c57a44ca5c284736151c329" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -635,7 +646,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0e8d6b96a9c3404c57a44ca5c284736151c329" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
 # Prompt-refine provider (sc-5552, the MLX twin of candle-gen-prompt-refine / sc-5500). An
 # inventory-registered `TextLlm` under id `prompt_refine` (`backend="mlx"`, `mac_only`): a native MLX
 # Llama-3.2-3B-Instruct that rewrites a user's prompt, replacing the Python `prompt_refine.py`
@@ -645,7 +656,7 @@ mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0
 # textllm registered" trap). Weights = a stock Llama-3.2-3B-Instruct HF snapshot (config.json +
 # tokenizer.json + model-*.safetensors; default `huihui-ai/Llama-3.2-3B-Instruct-abliterated`). Same
 # git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0e8d6b96a9c3404c57a44ca5c284736151c329" }
+mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
 # SCAIL-2 (zai-org) end-to-end character-animation provider (epic 5439, sc-5448). An inventory-registered
 # `Generator` under id `scail2_14b` (`Modality::Video`): a Wan2.1-14B I2V DiT that animates a reference
 # character with a driving video's motion (`video_mode == "replacement"` flips the cross-identity
@@ -657,7 +668,7 @@ mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev 
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ba0e8d6b96a9c3404c57a44ca5c284736151c329" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory


### PR DESCRIPTION
## Summary

Bumps the worker's `mlx-gen` pin `ba0e8d6` → `92d0dc7` to pick up **[mlx-gen#487](https://github.com/michaeltrefry/mlx-gen/pull/487)**, which fixes four Ideogram 4 render bugs vs the diffusers `ideogram4` reference. Before the fix, native-MLX Ideogram 4 produced incoherent / "splattered paint" output vs ComfyUI on the same structured-JSON-caption prompt.

The four engine bugs (all runtime — **no weight reconversion**, the published q4/q8 turnkey is unchanged):
1. **Scheduler `mu`/`std`** — now preset-driven per step-count (was const `mu=0.5, std=1.0`, which starved the low-noise detail steps → smear).
2. **Per-step guidance** — 7.0 main steps, 3.0 for the final 3 "polish" steps (was a flat 7.0).
3. **Latent de-norm** — uses the VAE's BatchNorm stats `z*bn_std+bn_mean` (was bogus `LATENT_SCALE`/`LATENT_SHIFT`).
4. **Image MRoPE t-axis offset** — `0 → IMAGE_POSITION_OFFSET` (t=0 collided with text positions and corrupted text→image cross-attention; the **dominant** fix for coherence).

## Pin mechanics

Bumps every mlx-gen crate + `sceneworks-gen-core` in lockstep (25 pins). gen-core is **byte-identical** `ba0e8d6 → 92d0dc7` (the range is docs-only CODEGRAPH + the engine fix), so the worker's import surface is unchanged; `mlx-rs` unchanged (`44929a0`, MLX core does not rebuild); `mlx-gen-flux2` only gains an additive `Flux2Vae::bn_stats()`. The default gen-core skew gate stays single-rev at `92d0dc7` (verified locally with `scripts/check-gen-core-skew.sh`). candle-gen lane unchanged (sc-5905).

## Verification

- `scripts/check-gen-core-skew.sh` → single `sceneworks-gen-core` resolution at `92d0dc7`.
- Engine fix validated upstream in mlx-gen#487 (real-weight Q8 render at the reference's 12-step Turbo settings: incoherent → coherent poster matching ComfyUI quality).
- Full build / parity / web left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
