### PR TITLE
feat(image): wire ideogram_4_turbo opt-in fast model (mlx-gen #488)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3284,11 +3284,11 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3c65d8d26322ae240d062d0c1cb42b19d5c97209#3c65d8d26322ae240d062d0c1cb42b19d5c97209"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876)",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=3c65d8d26322ae240d062d0c1cb42b19d5c97209)",
  "thiserror 2.0.18",
  "tokenizers 0.21.4",
 ]
@@ -3296,7 +3296,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3c65d8d26322ae240d062d0c1cb42b19d5c97209#3c65d8d26322ae240d062d0c1cb42b19d5c97209"
 dependencies = [
  "image",
  "inventory",
@@ -3310,7 +3310,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3c65d8d26322ae240d062d0c1cb42b19d5c97209#3c65d8d26322ae240d062d0c1cb42b19d5c97209"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3322,7 +3322,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3c65d8d26322ae240d062d0c1cb42b19d5c97209#3c65d8d26322ae240d062d0c1cb42b19d5c97209"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3331,7 +3331,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3c65d8d26322ae240d062d0c1cb42b19d5c97209#3c65d8d26322ae240d062d0c1cb42b19d5c97209"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3343,7 +3343,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3c65d8d26322ae240d062d0c1cb42b19d5c97209#3c65d8d26322ae240d062d0c1cb42b19d5c97209"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3354,7 +3354,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3c65d8d26322ae240d062d0c1cb42b19d5c97209#3c65d8d26322ae240d062d0c1cb42b19d5c97209"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3366,7 +3366,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3c65d8d26322ae240d062d0c1cb42b19d5c97209#3c65d8d26322ae240d062d0c1cb42b19d5c97209"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3377,7 +3377,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3c65d8d26322ae240d062d0c1cb42b19d5c97209#3c65d8d26322ae240d062d0c1cb42b19d5c97209"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3387,7 +3387,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3c65d8d26322ae240d062d0c1cb42b19d5c97209#3c65d8d26322ae240d062d0c1cb42b19d5c97209"
 dependencies = [
  "image",
  "inventory",
@@ -3399,7 +3399,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3c65d8d26322ae240d062d0c1cb42b19d5c97209#3c65d8d26322ae240d062d0c1cb42b19d5c97209"
 dependencies = [
  "image",
  "inventory",
@@ -3412,7 +3412,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3c65d8d26322ae240d062d0c1cb42b19d5c97209#3c65d8d26322ae240d062d0c1cb42b19d5c97209"
 dependencies = [
  "image",
  "inventory",
@@ -3424,7 +3424,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3c65d8d26322ae240d062d0c1cb42b19d5c97209#3c65d8d26322ae240d062d0c1cb42b19d5c97209"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3435,7 +3435,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3c65d8d26322ae240d062d0c1cb42b19d5c97209#3c65d8d26322ae240d062d0c1cb42b19d5c97209"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3447,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3c65d8d26322ae240d062d0c1cb42b19d5c97209#3c65d8d26322ae240d062d0c1cb42b19d5c97209"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3457,7 +3457,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3c65d8d26322ae240d062d0c1cb42b19d5c97209#3c65d8d26322ae240d062d0c1cb42b19d5c97209"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3466,7 +3466,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3c65d8d26322ae240d062d0c1cb42b19d5c97209#3c65d8d26322ae240d062d0c1cb42b19d5c97209"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3475,7 +3475,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3c65d8d26322ae240d062d0c1cb42b19d5c97209#3c65d8d26322ae240d062d0c1cb42b19d5c97209"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3487,7 +3487,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3c65d8d26322ae240d062d0c1cb42b19d5c97209#3c65d8d26322ae240d062d0c1cb42b19d5c97209"
 dependencies = [
  "image",
  "inventory",
@@ -3500,7 +3500,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3c65d8d26322ae240d062d0c1cb42b19d5c97209#3c65d8d26322ae240d062d0c1cb42b19d5c97209"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3511,7 +3511,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3c65d8d26322ae240d062d0c1cb42b19d5c97209#3c65d8d26322ae240d062d0c1cb42b19d5c97209"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3522,7 +3522,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3c65d8d26322ae240d062d0c1cb42b19d5c97209#3c65d8d26322ae240d062d0c1cb42b19d5c97209"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3533,7 +3533,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3c65d8d26322ae240d062d0c1cb42b19d5c97209#3c65d8d26322ae240d062d0c1cb42b19d5c97209"
 dependencies = [
  "image",
  "inventory",
@@ -3547,7 +3547,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3c65d8d26322ae240d062d0c1cb42b19d5c97209#3c65d8d26322ae240d062d0c1cb42b19d5c97209"
 dependencies = [
  "image",
  "inventory",
@@ -5175,7 +5175,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=51a6792db3a1c94d23a9ae00e2414665b8c2c9f7#51a6792db3a1c94d23a9ae00e2414665b8c2c9f7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3c65d8d26322ae240d062d0c1cb42b19d5c97209#3c65d8d26322ae240d062d0c1cb42b19d5c97209"
 dependencies = [
  "inventory",
  "safetensors 0.4.5",
@@ -5187,7 +5187,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876#92d0dc77a5080c199c41c3bb96a889601cb89876"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=51a6792db3a1c94d23a9ae00e2414665b8c2c9f7#51a6792db3a1c94d23a9ae00e2414665b8c2c9f7"
 dependencies = [
  "inventory",
  "safetensors 0.4.5",
@@ -5288,7 +5288,7 @@ dependencies = [
  "pmetal-mlx-rs",
  "reqwest 0.12.28",
  "sceneworks-core",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=92d0dc77a5080c199c41c3bb96a889601cb89876)",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=3c65d8d26322ae240d062d0c1cb42b19d5c97209)",
  "serde",
  "serde_json",
  "sha2",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -910,6 +910,79 @@
       }
     },
     {
+      "id": "ideogram_4_turbo",
+      "name": "Ideogram 4 Turbo",
+      "family": "ideogram",
+      "type": "image",
+      // Ideogram 4 Turbo (mlx-gen #488) — the few-step, CFG-free, single-DiT variant: the same
+      // gated turnkey base (q4/q8 subdirs) plus the bundled ostris TurboTime LoRA the engine
+      // installs onto the conditional DiT at load. ~8 steps and one DiT forward per step (no
+      // unconditional branch / guidance), so a render is ~2x faster and ~12 GB lighter than the
+      // 48-step asymmetric-CFG base (measured: 52 GB vs 64 GB peak @1024²/8-step Q4). Opt-in "fast
+      // mode" — NOT `recommended` until structured-caption adherence + the safety-placeholder path
+      // are re-validated under no-CFG. Dispatched through engines::MODEL_TABLE id `ideogram_4_turbo`.
+      "adapter": "mlx_ideogram",
+      "capabilities": ["text_to_image"],
+      "macOnly": true,
+      // Same structured JSON-caption prompt surface as the base model (turbo distills the base, so
+      // the caption contract is identical).
+      "structuredPrompt": true,
+      "downloads": [
+        {
+          // Same repo as `ideogram_4`; the q4/ subdir now also carries `turbo_lora.safetensors`
+          // (~0.85 GB) the engine installs at load. Q8 opt-in via advanced mlxQuantize: 8.
+          "provider": "huggingface",
+          "repo": "SceneWorks/ideogram-4-mlx",
+          "files": ["q4/*"],
+          "platforms": ["macos"],
+          "estimatedSizeBytes": 16247340792
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/SceneWorks/ideogram-4-mlx"
+      },
+      "defaults": {
+        // Few-step turbo default (8); CFG-free, so guidanceScale is inert (the engine descriptor
+        // advertises supports_guidance=false → the worker never forwards a guidance value).
+        "resolution": "1024x1024",
+        "steps": 8,
+        "guidanceScale": 0,
+        "count": 1,
+        "sampler": "default",
+        "scheduler": "default"
+      },
+      "limits": {
+        "resolutions": ["1024x1024", "768x1024", "1024x768", "1280x720", "720x1280"],
+        "count": [1, 2, 4],
+        "samplers": ["default"],
+        "schedulers": ["default"]
+      },
+      // Same packed turnkey + quant resolution as the base (resolve_ideogram_model_dir picks the
+      // q4/q8 subdir, which carries the bundled LoRA). Measured Q4 peak ~52 GB @1024²/8-step (one
+      // DiT); minMemoryGb mirrors the base entry (turbo is strictly lighter than the 2-DiT base).
+      "mlx": {
+        "minMemoryGb": 48,
+        "quantize": 4,
+        "repo": "SceneWorks/ideogram-4-mlx"
+      },
+      "gated": true,
+      "credentialHost": "huggingface.co",
+      "licenseUrl": "https://huggingface.co/ideogram-ai/ideogram-4-fp8",
+      "ui": {
+        "label": "Ideogram 4 Turbo",
+        "description": "Ideogram 4 Turbo — the few-step (~8) fast variant of Ideogram 4: same 9.3B flow-matching model and structured JSON-caption prompting, distilled to a CFG-free single-DiT path (the ostris TurboTime LoRA) for ~2x faster renders. MLX-only (Apple Silicon). Shares the gated Ideogram 4 turnkey — accept the license at huggingface.co/ideogram-ai/ideogram-4-fp8 and add a Hugging Face token under Settings → Service credentials before downloading.",
+        "recommendedFor": ["text_to_image"],
+        "promptGuide": {
+          "title": "Ideogram 4 Prompt Guide",
+          "path": "/prompt-guides/ideogram-4.md",
+          "sources": [
+            { "label": "Ideogram 4 model card", "url": "https://huggingface.co/ideogram-ai/ideogram-4-fp8" },
+            { "label": "ostris TurboTime LoRA", "url": "https://huggingface.co/ostris/ideogram_4_turbotime_lora" }
+          ]
+        }
+      }
+    },
+    {
       "id": "flux2_klein_9b",
       "name": "FLUX.2 [klein] 9B",
       "family": "flux2-klein",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -192,7 +192,16 @@ sceneworks-core = { path = "../sceneworks-core" }
 # and NO weight reconversion (the published q4/q8 turnkey is unchanged — the bugs were all runtime). Bumps
 # EVERY mlx-gen crate + gen-core in lockstep so the default skew gate (check.yml) stays single-rev.
 # candle-gen lane unchanged (sc-5905).
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
+# Rev 92d0dc7 -> 3c65d8d (mlx-gen main, merged PR #489, Ideogram 4 Turbo / mlx-gen #488): adds the
+# few-step CFG-free `ideogram_4_turbo` engine — the conditional DiT + the ostris TurboTime LoRA
+# installed at load (single forward/step, guidance off), ~2x faster + ~12 GB lighter than the 48-step
+# 2-DiT base (measured 52 GB vs 64 GB peak @1024²/8-step Q4). PURE mlx-gen-ideogram + a new
+# `tools/convert_ideogram4_turbo_lora.py`; gen-core BYTE-IDENTICAL 92d0dc7 -> 3c65d8d, mlx-rs unchanged
+# (44929a0 — MLX core does not rebuild), and the base `ideogram_4` engine is untouched. The published
+# turnkey gained a bundled `turbo_lora.safetensors` in q4/ + q8/ (no base reconversion). Bumps EVERY
+# mlx-gen crate + gen-core in lockstep so the default skew gate (check.yml) stays single-rev. candle-gen
+# lane unchanged (sc-5905).
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3c65d8d26322ae240d062d0c1cb42b19d5c97209" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -503,7 +512,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3c65d8d26322ae240d062d0c1cb42b19d5c97209" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -515,59 +524,59 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a50
 # internal pin (the Lens engine PRs #407–#414 did not move it; nor did the seedvr2 engine #416/#419/
 # #421 or the softness PR #422, so the 1a97909 bump above leaves mlx-rs at 44929a0).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "44929a001ab8a8837403a71c65cf064224de0cdc" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3c65d8d26322ae240d062d0c1cb42b19d5c97209" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3c65d8d26322ae240d062d0c1cb42b19d5c97209" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3c65d8d26322ae240d062d0c1cb42b19d5c97209" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3c65d8d26322ae240d062d0c1cb42b19d5c97209" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3c65d8d26322ae240d062d0c1cb42b19d5c97209" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3c65d8d26322ae240d062d0c1cb42b19d5c97209" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3c65d8d26322ae240d062d0c1cb42b19d5c97209" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3c65d8d26322ae240d062d0c1cb42b19d5c97209" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3c65d8d26322ae240d062d0c1cb42b19d5c97209" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3c65d8d26322ae240d062d0c1cb42b19d5c97209" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3c65d8d26322ae240d062d0c1cb42b19d5c97209" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3c65d8d26322ae240d062d0c1cb42b19d5c97209" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3c65d8d26322ae240d062d0c1cb42b19d5c97209" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -576,12 +585,12 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3c65d8d26322ae240d062d0c1cb42b19d5c97209" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3c65d8d26322ae240d062d0c1cb42b19d5c97209" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -590,7 +599,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3c65d8d26322ae240d062d0c1cb42b19d5c97209" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -598,7 +607,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3c65d8d26322ae240d062d0c1cb42b19d5c97209" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -609,7 +618,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3c65d8d26322ae240d062d0c1cb42b19d5c97209" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -620,7 +629,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0d
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3c65d8d26322ae240d062d0c1cb42b19d5c97209" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -635,7 +644,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc
 # converted in-memory at load (no Python); the precomputed neg-prompt embedding is bundled in-crate. No
 # LoRA/guidance/CFG (one-step). 3B fp16 only here — 7B (sc-5197) + int8 (sc-5198) are engine-side and
 # unwired. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3c65d8d26322ae240d062d0c1cb42b19d5c97209" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -646,7 +655,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3c65d8d26322ae240d062d0c1cb42b19d5c97209" }
 # Prompt-refine provider (sc-5552, the MLX twin of candle-gen-prompt-refine / sc-5500). An
 # inventory-registered `TextLlm` under id `prompt_refine` (`backend="mlx"`, `mac_only`): a native MLX
 # Llama-3.2-3B-Instruct that rewrites a user's prompt, replacing the Python `prompt_refine.py`
@@ -656,7 +665,7 @@ mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d
 # textllm registered" trap). Weights = a stock Llama-3.2-3B-Instruct HF snapshot (config.json +
 # tokenizer.json + model-*.safetensors; default `huihui-ai/Llama-3.2-3B-Instruct-abliterated`). Same
 # git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
+mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3c65d8d26322ae240d062d0c1cb42b19d5c97209" }
 # SCAIL-2 (zai-org) end-to-end character-animation provider (epic 5439, sc-5448). An inventory-registered
 # `Generator` under id `scail2_14b` (`Modality::Video`): a Wan2.1-14B I2V DiT that animates a reference
 # character with a driving video's motion (`video_mode == "replacement"` flips the cross-identity
@@ -668,7 +677,7 @@ mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev 
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "92d0dc77a5080c199c41c3bb96a889601cb89876" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3c65d8d26322ae240d062d0c1cb42b19d5c97209" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -54,6 +54,18 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
         default_guidance: 7.0,
         adapter_label: "mlx_ideogram",
     },
+    // Ideogram 4 Turbo (mlx-gen #488) — the CFG-free, single-DiT few-step variant: the same
+    // turnkey base (q4/q8 subdirs) plus the bundled ostris TurboTime LoRA the engine installs at
+    // load. 8 steps; guidance is INERT (the `ideogram_4_turbo` descriptor advertises
+    // supports_guidance=false, so `resolve_guidance` returns None and never forwards a value).
+    ModelRow {
+        sceneworks_id: "ideogram_4_turbo",
+        engine_id: "ideogram_4_turbo",
+        default_repo: "SceneWorks/ideogram-4-mlx",
+        default_steps: 8,
+        default_guidance: 0.0,
+        adapter_label: "mlx_ideogram",
+    },
     // Z-Image-Edit (epic 3529) — img2img/edit. No dedicated Edit checkpoint exists yet, so
     // (like the Python `MODEL_TARGETS` row) it runs the **Turbo weights** through the engine's
     // img2img path (`Conditioning::Reference` — VAE-encode the source + denoise from

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -210,8 +210,10 @@ pub(crate) fn resolve_weights_dir(
     let snapshot = huggingface_snapshot_dir(&settings.data_dir, &model_repo(request, &model));
     // Ideogram 4 ships a turnkey with packed `q4/` (default) + `q8/` self-contained subdirs; point
     // the engine at the chosen quant's subdir rather than the repo root (epic 4725 / sc-5992),
-    // mirroring the LTX bundle pattern. The packed weights auto-detect their quant on load.
-    if request.model == "ideogram_4" {
+    // mirroring the LTX bundle pattern. The packed weights auto-detect their quant on load. The
+    // turbo variant (mlx-gen #488) shares the same turnkey — each subdir also carries the bundled
+    // `turbo_lora.safetensors` the `ideogram_4_turbo` engine installs at load.
+    if request.model == "ideogram_4" || request.model == "ideogram_4_turbo" {
         return Ok(snapshot.map(|root| ideogram_model_subdir(&root, request)));
     }
     Ok(snapshot)

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -650,6 +650,10 @@ fn model_table_rows_resolve_and_flags_match_descriptor() {
         // Ideogram 4 (epic 4725): asymmetric-CFG guidance (supports_guidance=true) with no user
         // negative prompt (the "negative" is a fixed unconditional DiT, not a prompt).
         ("ideogram_4", true, false),
+        // Ideogram 4 Turbo (mlx-gen #488): CFG-free single-DiT — the descriptor drops guidance
+        // (supports_guidance=false), no negative prompt. Requires the mlx-gen pin to include the
+        // `ideogram_4_turbo` engine (PR #489) for this row to resolve through the registry.
+        ("ideogram_4_turbo", false, false),
         ("z_image_edit", false, false),
         ("flux_schnell", false, false),
         ("flux_dev", true, false),


### PR DESCRIPTION
Surfaces the new **Ideogram 4 Turbo** engine (SceneWorks/mlx-gen#488, engine PR SceneWorks/mlx-gen#489 — CFG-free single-DiT, ~8-step) as an **opt-in fast image model**. Closes SceneWorks/SceneWorks#777.

## Changes
- **Catalog** (`builtin.models.jsonc`): new `ideogram_4_turbo` entry — same gated turnkey (`SceneWorks/ideogram-4-mlx`; the q4/q8 subdirs now carry the bundled `turbo_lora.safetensors`), 8 steps, guidance off, `structuredPrompt: true`, **not `recommended`** (opt-in).
- **Worker** (`engines.rs`): `MODEL_TABLE` row → engine `ideogram_4_turbo`, `default_steps: 8`. Guidance is inert — the engine descriptor advertises `supports_guidance: false`, so `resolve_guidance` returns `None` and never forwards a value (same path as `z_image_turbo`).
- **Worker** (`image_jobs/base.rs`): `ideogram_model_subdir` now resolves the q4/q8 subdir for `ideogram_4_turbo` too.
- **Pin bump** (`Cargo.toml`/`Cargo.lock`): mlx-gen `92d0dc7 → 3c65d8d` to pick up the turbo engine. **Pure `mlx-gen-ideogram`** — gen-core byte-identical, mlx-rs unchanged; skew gate green.
- **UI: no code** — `ImageStudio.jsx` gates the structured-caption builder on the catalog `structuredPrompt` flag, so turbo inherits the full Ideogram prompt surface.

## Validation
- Worker: **327 tests pass** (incl. `model_table_rows_resolve_and_flags_match_descriptor`, which now resolves `ideogram_4_turbo` through the gen_core registry with CFG-free flags `(false, false)`); fmt + clippy clean; gen-core skew gate green.
- Engine (mlx-gen#489): real-weight validated — clean photorealistic fox @1024² in **8 / 4 / 2 steps**; **52 GB peak vs the 2-DiT base's 64 GB**, ~2.2× faster.

## Follow-ups
- Full worker-job e2e (fresh repo download → resolve q4 subdir → `load_turbo` with hosted LoRA → save asset).
- Re-validate structured-caption adherence + the safety-placeholder path under no-CFG before considering flipping `recommended`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)