### PR TITLE
fix(worker): disambiguate "heartbeat timed out" — attribute crashes, honest message, tolerate transport blips (sc-6320)

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -23,7 +23,7 @@ use sceneworks_core::contracts::{
     ClaimRequest, ClaimResponse, ContractNumber, DuplicateJobRequest, ImageUpscaleRequest,
     JobCreateRequest, JobSnapshot, JobStatus, JobType, JsonObject, ProgressRequest, QueueSummary,
     RetryJobRequest, WorkerCapability, WorkerHeartbeatRequest, WorkerRegisterRequest,
-    WorkerSignalDeathRequest, WorkerSnapshot, WorkerStatus,
+    WorkerSnapshot, WorkerStatus, WorkerTerminationRequest,
 };
 use sceneworks_core::hf_home::{huggingface_hub_cache_dir, huggingface_repo_cache_path};
 use sceneworks_core::jobs_store::{
@@ -858,8 +858,8 @@ pub(crate) fn create_app_with_state(
             post(heartbeat_worker),
         )
         .route(
-            "/api/v1/workers/:worker_id/signal-death",
-            post(worker_signal_death),
+            "/api/v1/workers/:worker_id/terminated",
+            post(worker_terminated),
         )
         .fallback(app_fallback)
         .with_state(state.clone())

--- a/apps/rust-api/src/workers.rs
+++ b/apps/rust-api/src/workers.rs
@@ -113,18 +113,20 @@ pub(crate) async fn heartbeat_worker(
     Ok(Json(worker))
 }
 
-/// The supervisor reports a worker child that died by an uncatchable signal
-/// (SIGKILL/OOM, SIGABRT, SIGSEGV, …). We fail that worker's still-active job with
-/// a signal-attributed error instead of waiting for the heartbeat sweep to mark it
-/// the generic `interrupted` — so the user sees a real, actionable failure rather
-/// than a frozen progress bar (sc-4881). Returns the failed job, if any.
-pub(crate) async fn worker_signal_death(
+/// The supervisor reports a worker child that terminated abnormally — killed by an
+/// uncatchable signal (SIGKILL/OOM, SIGABRT, SIGSEGV, …) or exited on its own with
+/// a non-zero status (e.g. a Rust panic, exit code 101). We fail that worker's
+/// still-active job with an attributed error instead of waiting for the heartbeat
+/// sweep to mark it the generic `interrupted` — so the user sees a real, actionable
+/// failure rather than a frozen progress bar (sc-4881 signals; sc-6320 non-signal
+/// exits). Returns the failed job, if any.
+pub(crate) async fn worker_terminated(
     State(state): State<AppState>,
     Path(worker_id): Path<String>,
-    ApiJson(payload): ApiJson<WorkerSignalDeathRequest>,
+    ApiJson(payload): ApiJson<WorkerTerminationRequest>,
 ) -> Result<Json<Option<JobSnapshot>>, ApiError> {
     let failed = store_call(state.clone(), move |store, _timeout| {
-        store.fail_worker_job_killed_by_signal(&worker_id, payload.signal)
+        store.fail_worker_job_terminated(&worker_id, payload.signal, payload.exit_code)
     })
     .await?;
     if let Some(job) = &failed {

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -724,16 +724,23 @@ pub struct WorkerHeartbeatRequest {
     pub extra: ExtraFields,
 }
 
-/// Posted by the supervisor when it reaps a worker child that died by an
-/// uncatchable signal (SIGKILL/OOM, SIGABRT, SIGSEGV, …). The dying worker can't
-/// report its own death, so the supervisor attributes it here and the server
-/// fails the worker's still-active job instead of waiting for the heartbeat sweep
-/// to mark it `interrupted` (sc-4881).
+/// Posted by the supervisor when it reaps a worker child that terminated
+/// abnormally — either killed by an uncatchable signal (SIGKILL/OOM, SIGABRT,
+/// SIGSEGV, …) or exited on its own with a non-zero status (e.g. a Rust panic,
+/// exit code 101). The dying worker can't report its own death, so the supervisor
+/// attributes it here and the server fails the worker's still-active job instead
+/// of waiting for the heartbeat sweep to mark it the generic `interrupted`
+/// (sc-4881 signals; sc-6320 generalized to non-signal exits). Exactly one of
+/// `signal` / `exit_code` is set, matching how the OS reported the child's exit.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct WorkerSignalDeathRequest {
-    /// Terminating signal number reported by the OS (e.g. 9 for SIGKILL).
-    pub signal: i32,
+pub struct WorkerTerminationRequest {
+    /// Terminating signal number reported by the OS (e.g. 9 for SIGKILL) when the
+    /// child died by signal; `None` for a non-zero self-exit.
+    pub signal: Option<i32>,
+    /// Process exit code when the child exited on its own with a non-zero status
+    /// (e.g. 101 for a Rust panic); `None` when it died by signal.
+    pub exit_code: Option<i32>,
     #[serde(flatten)]
     pub extra: ExtraFields,
 }

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -700,8 +700,8 @@ impl JobsStore {
                 update jobs
                    set status = 'interrupted',
                        stage = 'interrupted',
-                       message = 'Job was interrupted after its worker stopped sending heartbeats.',
-                       error = 'Worker heartbeat timed out.',
+                       message = 'Lost contact with the worker.',
+                       error = 'No heartbeat from the worker for {timeout_seconds}s. The worker may have crashed, hung, or lost its connection to the app. If it reconnects you can retry the job; if this keeps happening, check System → Logs.',
                        completed_at = ?1,
                        updated_at = ?1,
                        worker_id = null
@@ -740,20 +740,24 @@ impl JobsStore {
         })
     }
 
-    /// Surface a worker's death-by-uncatchable-signal (SIGKILL/OOM, SIGABRT,
-    /// SIGSEGV, …) as a terminal job FAILURE, instead of letting the heartbeat
-    /// sweep later mark it the generic `interrupted` (which reads to the user like
-    /// a frozen progress bar). The supervisor that reaped the child observes the
-    /// terminating signal — the only layer that can, since the death is
-    /// uncatchable in-process — and calls this with that signal. We fail the
-    /// worker's still-active job with an actionable, signal-attributed error and
-    /// release the worker so the UI doesn't show it pinned to a dead job. Returns
-    /// the failed job if the worker had an active one (else `None` — it died idle
-    /// between jobs). (sc-4881)
-    pub fn fail_worker_job_killed_by_signal(
+    /// Surface a worker's abnormal death — killed by an uncatchable signal
+    /// (SIGKILL/OOM, SIGABRT, SIGSEGV, …) or exited on its own with a non-zero
+    /// status (e.g. a Rust panic, exit code 101) — as a terminal job FAILURE,
+    /// instead of letting the heartbeat sweep later mark it the generic
+    /// `interrupted` (which reads to the user like a frozen progress bar). The
+    /// supervisor that reaped the child observes the termination — the only layer
+    /// that can, since the death is uncatchable in-process — and calls this with
+    /// the signal (when killed) or exit code (when it self-exited non-zero); a
+    /// clean exit-0 is graceful and is never reported here. We fail the worker's
+    /// still-active job with an actionable, attributed error and release the worker
+    /// so the UI doesn't show it pinned to a dead job. Returns the failed job if
+    /// the worker had an active one (else `None` — it died idle between jobs).
+    /// (sc-4881 signals; sc-6320 non-signal exits)
+    pub fn fail_worker_job_terminated(
         &self,
         worker_id: &str,
-        signal: i32,
+        signal: Option<i32>,
+        exit_code: Option<i32>,
     ) -> JobsStoreResult<Option<JobSnapshot>> {
         let _guard = self.lock.lock();
         let mut connection = self.connect()?;
@@ -766,7 +770,7 @@ impl JobsStore {
             // Tailor the OOM/signal hint to the dead job's kind so the guidance is
             // actionable (sc-5567): an image-batch SIGKILL points at count/resolution,
             // not the training-only gradient-checkpointing remediation.
-            let error = signal_failure_error(signal, Some(&job.job_type));
+            let error = termination_failure_error(signal, exit_code, Some(&job.job_type));
             transaction.execute(
                 &format!(
                     "
@@ -1888,25 +1892,51 @@ fn mlx_unavailable_error(job: &JobSnapshot, grace_seconds: u64) -> String {
     )
 }
 
-/// Human, actionable terminal error attributing a worker's death to its
-/// terminating signal (sc-4881). Signal 9 (an uncatchable SIGKILL — almost always an
-/// OS memory-pressure OOM kill) carries a remediation hint tailored to the dead job's
-/// kind (sc-5567): training points at gradient checkpointing (the sc-4874 first-step
-/// OOM), image/video generation at the knobs that actually shrink the working set
-/// (batch count, resolution, frame count). Other uncatchable deaths (SIGABRT GPU/Metal
-/// abort, SIGSEGV) name themselves so the job card and System → Logs show a real cause
-/// instead of a frozen progress bar. `job_type` is the failed job's kind when one was
-/// active (`None` when the worker died idle).
-fn signal_failure_error(signal: i32, job_type: Option<&JobType>) -> String {
-    let hint = match signal {
-        9 => oom_remediation_hint(job_type),
-        6 => ", likely a GPU/Metal command-buffer abort or assertion",
-        11 => " (segmentation fault)",
-        _ => "",
-    };
-    match signal_name(signal) {
-        Some(name) => format!("Worker terminated by signal {signal} ({name}){hint}."),
-        None => format!("Worker terminated by signal {signal}{hint}."),
+/// Human, actionable terminal error attributing a worker's abnormal death to its
+/// terminating signal or non-zero exit code (sc-4881 signals; sc-6320 non-signal
+/// exits). Signal 9 (an uncatchable SIGKILL — almost always an OS memory-pressure
+/// OOM kill) carries a remediation hint tailored to the dead job's kind (sc-5567):
+/// training points at gradient checkpointing (the sc-4874 first-step OOM),
+/// image/video generation at the knobs that actually shrink the working set (batch
+/// count, resolution, frame count). Other uncatchable deaths (SIGABRT GPU/Metal
+/// abort, SIGSEGV) name themselves. A non-signal non-zero exit is a self-terminated
+/// process — exit code 101 is the Rust panic code and self-names; other codes report
+/// the raw code — so the job card and System → Logs show a real cause instead of a
+/// frozen progress bar. A signal takes precedence when both are somehow present.
+/// `job_type` is the failed job's kind when one was active (`None` when the worker
+/// died idle).
+fn termination_failure_error(
+    signal: Option<i32>,
+    exit_code: Option<i32>,
+    job_type: Option<&JobType>,
+) -> String {
+    if let Some(signal) = signal {
+        let hint = match signal {
+            9 => oom_remediation_hint(job_type),
+            6 => ", likely a GPU/Metal command-buffer abort or assertion",
+            11 => " (segmentation fault)",
+            _ => "",
+        };
+        return match signal_name(signal) {
+            Some(name) => format!("Worker terminated by signal {signal} ({name}){hint}."),
+            None => format!("Worker terminated by signal {signal}{hint}."),
+        };
+    }
+    match exit_code {
+        // 101 is the Rust panic exit code — a panic that unwound to a process exit
+        // rather than aborting on a signal. Name it so the cause is unmistakable.
+        Some(101) => "Worker process panicked and exited (code 101). \
+                      Check System → Logs for the panic message."
+            .to_owned(),
+        Some(code) => format!(
+            "Worker process exited unexpectedly (code {code}). Check System → Logs for the cause."
+        ),
+        // Defensive: the supervisor only calls this for an abnormal exit (a signal
+        // or a non-zero code), so neither-present shouldn't reach here — report it
+        // generically rather than fabricate a signal or code.
+        None => {
+            "Worker process terminated unexpectedly. Check System → Logs for the cause.".to_owned()
+        }
     }
 }
 
@@ -4881,16 +4911,17 @@ mod active_statuses_sql_tests {
 }
 
 #[cfg(test)]
-mod signal_failure_error_tests {
+mod termination_failure_error_tests {
     //! sc-4881 signal attribution + sc-5567 job-kind-aware OOM remediation: a signal-9
     //! (SIGKILL/OOM) death must give guidance that fits the dead job — count/resolution
     //! for an image batch, frames for video, gradient checkpointing only for training —
-    //! and non-OOM uncatchable deaths must keep naming their real cause.
-    use super::{signal_failure_error, JobType};
+    //! and non-OOM uncatchable deaths must keep naming their real cause. sc-6320: a
+    //! non-signal non-zero exit (a self-terminated process / panic) names the exit code.
+    use super::{termination_failure_error, JobType};
 
     #[test]
     fn signal_9_image_batch_points_at_count_not_gradient_checkpointing() {
-        let msg = signal_failure_error(9, Some(&JobType::ImageGenerate));
+        let msg = termination_failure_error(Some(9), None, Some(&JobType::ImageGenerate));
         assert!(msg.contains("signal 9 (SIGKILL)"), "{msg}");
         assert!(msg.contains("out-of-memory"), "{msg}");
         assert!(msg.contains("image count or resolution"), "{msg}");
@@ -4901,14 +4932,14 @@ mod signal_failure_error_tests {
 
     #[test]
     fn signal_9_training_keeps_gradient_checkpointing_hint() {
-        let msg = signal_failure_error(9, Some(&JobType::LoraTrain));
+        let msg = termination_failure_error(Some(9), None, Some(&JobType::LoraTrain));
         assert!(msg.contains("Gradient Checkpointing"), "{msg}");
         assert!(msg.contains("training step"), "{msg}");
     }
 
     #[test]
     fn signal_9_video_points_at_frame_count() {
-        let msg = signal_failure_error(9, Some(&JobType::VideoGenerate));
+        let msg = termination_failure_error(Some(9), None, Some(&JobType::VideoGenerate));
         assert!(msg.contains("out-of-memory"), "{msg}");
         assert!(msg.contains("frame count"), "{msg}");
         assert!(!msg.contains("Gradient Checkpointing"), "{msg}");
@@ -4919,7 +4950,7 @@ mod signal_failure_error_tests {
         // No active job (worker died idle) and an unmapped job kind both get the generic
         // OOM hint rather than a misleading training/image/video-specific one.
         for job_type in [None, Some(&JobType::Unknown("future".to_owned()))] {
-            let msg = signal_failure_error(9, job_type);
+            let msg = termination_failure_error(Some(9), None, job_type);
             assert!(msg.contains("out-of-memory"), "{msg}");
             assert!(!msg.contains("Gradient Checkpointing"), "{msg}");
             assert!(!msg.contains("image count"), "{msg}");
@@ -4930,15 +4961,42 @@ mod signal_failure_error_tests {
     #[test]
     fn non_oom_signals_keep_their_own_cause_regardless_of_job_kind() {
         // SIGABRT / SIGSEGV are not OOM, so the job kind must not turn them into one.
-        let abort = signal_failure_error(6, Some(&JobType::ImageGenerate));
+        let abort = termination_failure_error(Some(6), None, Some(&JobType::ImageGenerate));
         assert!(abort.contains("signal 6 (SIGABRT)"), "{abort}");
         assert!(abort.contains("GPU/Metal command-buffer abort"), "{abort}");
         assert!(!abort.contains("out-of-memory"), "{abort}");
 
-        let segv = signal_failure_error(11, Some(&JobType::LoraTrain));
+        let segv = termination_failure_error(Some(11), None, Some(&JobType::LoraTrain));
         assert!(segv.contains("signal 11 (SIGSEGV)"), "{segv}");
         assert!(segv.contains("segmentation fault"), "{segv}");
         assert!(!segv.contains("Gradient Checkpointing"), "{segv}");
+    }
+
+    #[test]
+    fn panic_exit_code_101_self_names_without_claiming_a_signal() {
+        // sc-6320: a Rust panic unwinds to exit 101 (no signal). The attribution must
+        // name the panic + code and must NOT fabricate a signal or an OOM hint.
+        let msg = termination_failure_error(None, Some(101), Some(&JobType::ImageGenerate));
+        assert!(msg.contains("panicked"), "{msg}");
+        assert!(msg.contains("101"), "{msg}");
+        assert!(!msg.contains("signal"), "{msg}");
+        assert!(!msg.contains("out-of-memory"), "{msg}");
+    }
+
+    #[test]
+    fn other_non_zero_exit_reports_the_raw_code() {
+        // A non-zero, non-101 self-exit reports the raw code so the cause is greppable.
+        let msg = termination_failure_error(None, Some(2), None);
+        assert!(msg.contains("exited unexpectedly (code 2)"), "{msg}");
+        assert!(!msg.contains("signal"), "{msg}");
+    }
+
+    #[test]
+    fn signal_takes_precedence_when_both_are_present() {
+        // Defensive: if both somehow arrive, the signal (the harder cause) wins.
+        let msg = termination_failure_error(Some(11), Some(101), None);
+        assert!(msg.contains("signal 11 (SIGSEGV)"), "{msg}");
+        assert!(!msg.contains("101"), "{msg}");
     }
 }
 

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1078,7 +1078,7 @@ fn signal_death_fails_active_job_with_attributed_error() {
     assert_eq!(claimed.id, created.id);
 
     let failed = store
-        .fail_worker_job_killed_by_signal("worker-1", 9)
+        .fail_worker_job_terminated("worker-1", Some(9), None)
         .expect("signal death recorded")
         .expect("the worker's active job is failed");
 
@@ -1111,10 +1111,53 @@ fn signal_death_with_no_active_job_is_a_noop() {
     register_image_worker(&store);
 
     let failed = store
-        .fail_worker_job_killed_by_signal("worker-1", 11)
+        .fail_worker_job_terminated("worker-1", Some(11), None)
         .expect("signal death recorded");
 
     assert!(failed.is_none(), "an idle worker death fails no job");
+}
+
+#[test]
+fn non_signal_exit_fails_active_job_with_exit_code_error() {
+    // sc-6320: a worker child that exited on its own with a non-zero status (e.g. a
+    // Rust panic that unwound to exit 101) is just as dead as a signaled one, but
+    // the supervisor reports an exit code, not a signal. It must still become a real
+    // FAILURE that names the exit code, not a heartbeat-sweep `interrupted` that
+    // reads as a frozen progress bar.
+    let store = store("non-signal-exit-fails-job");
+    register_image_worker(&store);
+    let created = store
+        .create_job(image_job(Map::new()))
+        .expect("job creates");
+    let claimed = store
+        .claim_next_job("worker-1")
+        .expect("claim succeeds")
+        .expect("job claimed");
+    assert_eq!(claimed.id, created.id);
+
+    let failed = store
+        .fail_worker_job_terminated("worker-1", None, Some(101))
+        .expect("termination recorded")
+        .expect("the worker's active job is failed");
+
+    assert_eq!(failed.id, created.id);
+    assert_eq!(failed.status, JobStatus::Failed);
+    assert_eq!(failed.worker_id, None);
+    let error = failed.error.clone().unwrap_or_default();
+    assert!(
+        error.contains("panicked") && error.contains("101"),
+        "a code-101 exit must self-name the panic, got {error:?}"
+    );
+    // A non-signal exit is not a signal — it must not claim to be one.
+    assert!(
+        !error.contains("signal"),
+        "a non-signal exit must not report a signal, got {error:?}"
+    );
+
+    // The worker is released, exactly as on a signal death.
+    let worker = store.get_worker("worker-1").expect("worker loads");
+    assert_eq!(worker.current_job_id, None);
+    assert_eq!(worker.status, WorkerStatus::Offline);
 }
 
 #[test]
@@ -1275,6 +1318,15 @@ fn stale_sweep_marks_worker_offline_and_job_interrupted() {
     assert_eq!(sweep.workers[0].current_job_id, None);
     assert_eq!(sweep.jobs[0].status, JobStatus::Interrupted);
     assert_eq!(sweep.jobs[0].worker_id, None);
+    // sc-6320: the timeout error must be honest (the worker may have crashed, hung,
+    // or lost its connection — not a confirmed death) and name the timeout window.
+    let error = sweep.jobs[0].error.clone().unwrap_or_default();
+    assert!(
+        error.contains("No heartbeat from the worker for 1s")
+            && error.contains("crashed, hung, or lost"),
+        "stale-sweep error must state the ambiguity + timeout, got {error:?}"
+    );
+    assert_eq!(sweep.jobs[0].message, "Lost contact with the worker.");
 }
 
 #[test]
@@ -4551,7 +4603,7 @@ fn progress_cannot_resurrect_terminal_jobs() {
         .expect("same-terminal re-report succeeds");
     assert_eq!(job.status, JobStatus::Interrupted);
     assert_eq!(
-        job.message, "Job was interrupted after its worker stopped sending heartbeats.",
+        job.message, "Lost contact with the worker.",
         "no-op re-report must not rewrite the row"
     );
 

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -646,23 +646,51 @@ async fn register_worker(
     .await
 }
 
+/// Post a worker heartbeat. A transport-level failure (`WorkerError::Http`: the API
+/// is briefly unreachable — a restart, a transient network blip) is logged and
+/// swallowed rather than propagated: a running job must not be torn down for
+/// telemetry we can simply resend. The next heartbeat (≤15s) refreshes the worker's
+/// `last_seen` well inside the API's stale-sweep window (default 90s), so a brief
+/// outage no longer false-positives a live job to `interrupted`; a sustained outage
+/// (> the timeout) still lets the sweep fire — the API stays the authority on
+/// declaring a worker gone. A non-transport error (the API answered and rejected
+/// the heartbeat, e.g. the worker is no longer registered) is a real signal and is
+/// still propagated. (sc-6320)
 async fn heartbeat(
     api: &ApiClient,
     settings: &Settings,
     status: WorkerStatus,
     current_job_id: Option<&str>,
-) -> WorkerResult<WorkerSnapshot> {
-    api.post_json(
-        &format!("/api/v1/workers/{}/heartbeat", settings.worker_id),
-        &WorkerHeartbeatRequest {
-            status,
-            current_job_id: current_job_id.map(str::to_owned),
-            loaded_models: Vec::new(),
-            utilization: gpu_utilization(&settings.gpu_id).await,
-            extra: BTreeMap::new(),
-        },
-    )
-    .await
+) -> WorkerResult<()> {
+    // Capture the label before `status` is moved into the request, for the log line.
+    let status_label = status.as_str().to_owned();
+    let outcome: WorkerResult<WorkerSnapshot> = api
+        .post_json(
+            &format!("/api/v1/workers/{}/heartbeat", settings.worker_id),
+            &WorkerHeartbeatRequest {
+                status,
+                current_job_id: current_job_id.map(str::to_owned),
+                loaded_models: Vec::new(),
+                utilization: gpu_utilization(&settings.gpu_id).await,
+                extra: BTreeMap::new(),
+            },
+        )
+        .await;
+    match outcome {
+        Ok(_) => Ok(()),
+        Err(WorkerError::Http(error)) => {
+            emit_json(json!({
+                "event": "worker_heartbeat_transport_failed",
+                "workerId": settings.worker_id,
+                "jobId": current_job_id,
+                "status": status_label,
+                "error": error.to_string(),
+                "reportedAt": now_rfc3339(),
+            }));
+            Ok(())
+        }
+        Err(other) => Err(other),
+    }
 }
 
 async fn run_utility_job(

--- a/crates/sceneworks-worker/src/supervisor.rs
+++ b/crates/sceneworks-worker/src/supervisor.rs
@@ -27,6 +27,16 @@ fn backoff_resets_after_healthy_uptime(uptime: Duration) -> bool {
     uptime >= HEALTHY_UPTIME_RESET
 }
 
+/// Whether a reaped child died abnormally and should be attributed to the user as a
+/// real job FAILURE (vs. left to the generic heartbeat-sweep `interrupted`). True
+/// for an uncatchable signal death (`signal` set) or a non-zero self-exit
+/// (`exit_code` set and non-zero, e.g. a Rust panic → 101). A clean exit-0 — the
+/// child caught a shutdown signal and exited itself — is graceful and reports
+/// nothing (sc-4881 signals; sc-6320 non-signal exits).
+pub(crate) fn child_died_abnormally(signal: Option<i32>, exit_code: Option<i32>) -> bool {
+    signal.is_some() || exit_code.is_some_and(|code| code != 0)
+}
+
 pub(crate) async fn supervise_auto_workers(settings: Settings) -> WorkerResult<()> {
     let gpus = discover_gpus().await;
     if gpus.is_empty() {
@@ -101,29 +111,35 @@ where
             // backoff below both read the same stored value.
             child.restart_attempt = child.restart_attempt.saturating_add(1);
             let delay = retry_delay(settings.poll_seconds, child.restart_attempt);
-            // A child reaped with a terminating signal died an uncatchable death
-            // (SIGKILL/OOM, SIGABRT, SIGSEGV, …) and never got to report it. Carry
-            // the signal so we can attribute its active job as a real FAILURE
-            // before restarting, rather than letting the heartbeat sweep mark it
-            // the generic `interrupted` (sc-4881).
+            // A child that terminated abnormally never got to report it. A
+            // terminating signal (SIGKILL/OOM, SIGABRT, SIGSEGV, …) is an
+            // uncatchable death; a non-zero exit code is a self-terminated process
+            // (e.g. a Rust panic that unwound to exit 101). Carry both so we can
+            // attribute its active job as a real FAILURE before restarting, rather
+            // than letting the heartbeat sweep mark it the generic `interrupted`
+            // (sc-4881 signals; sc-6320 non-signal exits). `status.code()` is `None`
+            // when the child died by signal and `Some(code)` when it exited itself.
             let signal = terminating_signal(&status);
+            let exit_code = status.code();
             emit_json(json!({
                 "event": "worker_exited",
                 "workerId": worker_id,
                 "gpuId": child.spec.gpu_id,
-                "exitCode": status.code(),
+                "exitCode": exit_code,
                 "signal": signal,
                 "restartInSeconds": delay,
                 "reportedAt": now_rfc3339(),
             }));
-            exited.push((worker_id.clone(), signal));
+            exited.push((worker_id.clone(), signal, exit_code));
         }
     }
-    for (worker_id, signal) in exited {
-        // Surface an uncatchable death to the user before the backoff sleep, so a
-        // job that died on signal fails promptly instead of hanging until restart.
-        if let Some(signal) = signal {
-            report_worker_signal_death(settings, &worker_id, signal).await;
+    for (worker_id, signal, exit_code) in exited {
+        // Surface an abnormal death to the user before the backoff sleep, so a job
+        // that died fails promptly instead of hanging until restart. A clean exit-0
+        // is a graceful stop (e.g. the child caught a shutdown signal and exited
+        // itself) and is never reported (sc-6320).
+        if child_died_abnormally(signal, exit_code) {
+            report_worker_terminated(settings, &worker_id, signal, exit_code).await;
         }
         let Some(mut child) = children.remove(&worker_id) else {
             continue;
@@ -223,20 +239,30 @@ pub(crate) fn terminating_signal(_status: &std::process::ExitStatus) -> Option<i
     None
 }
 
-/// Best-effort: tell the API that a worker child died by `signal` so its active
-/// job is failed (signal-attributed) rather than swept to `interrupted`
-/// (sc-4881). The dying worker can't report this itself, so the supervisor does.
-/// A failure here (API down, job already terminal) must never disrupt the restart
-/// loop — the heartbeat sweep remains the backstop — so it is logged, not raised.
-async fn report_worker_signal_death(settings: &Settings, worker_id: &str, signal: i32) {
+/// Best-effort: tell the API that a worker child terminated abnormally — by
+/// `signal` (uncatchable death) or a non-zero `exit_code` (self-exit / panic) — so
+/// its active job is failed (attributed) rather than swept to the generic
+/// `interrupted` (sc-4881 signals; sc-6320 non-signal exits). The dying worker
+/// can't report this itself, so the supervisor does. A failure here (API down, job
+/// already terminal) must never disrupt the restart loop — the heartbeat sweep
+/// remains the backstop — so it is logged, not raised.
+async fn report_worker_terminated(
+    settings: &Settings,
+    worker_id: &str,
+    signal: Option<i32>,
+    exit_code: Option<i32>,
+) {
     let api = ApiClient::new(settings);
-    let path = format!("/api/v1/workers/{worker_id}/signal-death");
-    let outcome: WorkerResult<Value> = api.post_json(&path, &json!({ "signal": signal })).await;
+    let path = format!("/api/v1/workers/{worker_id}/terminated");
+    let outcome: WorkerResult<Value> = api
+        .post_json(&path, &json!({ "signal": signal, "exitCode": exit_code }))
+        .await;
     if let Err(error) = outcome {
         emit_json(json!({
-            "event": "worker_signal_death_report_failed",
+            "event": "worker_termination_report_failed",
             "workerId": worker_id,
             "signal": signal,
+            "exitCode": exit_code,
             "error": error.to_string(),
             "reportedAt": now_rfc3339(),
         }));

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -42,8 +42,8 @@ use super::model_jobs::{
 #[cfg(unix)]
 use super::supervisor::terminating_signal;
 use super::supervisor::{
-    auto_worker_specs, child_environment, restart_exited_children_with_spawner,
-    utility_worker_specs, SupervisedChild, WorkerSpec,
+    auto_worker_specs, child_died_abnormally, child_environment,
+    restart_exited_children_with_spawner, utility_worker_specs, SupervisedChild, WorkerSpec,
 };
 use super::{
     allow_pattern_matches, bounded_tail, cancel_requested_peek, cleanup_uploaded_import_source,
@@ -882,6 +882,27 @@ async fn terminating_signal_distinguishes_signal_death_from_clean_exit() {
     let mut clean = spawn_exit_child();
     let status = clean.wait().await.expect("clean child reaped");
     assert_eq!(terminating_signal(&status), None);
+}
+
+#[test]
+fn child_died_abnormally_reports_signals_and_non_zero_exits_not_clean_exits() {
+    // sc-6320: the supervisor attributes a real FAILURE for an uncatchable signal
+    // death OR a non-zero self-exit (e.g. a Rust panic → 101), but a clean exit-0
+    // is graceful and must report nothing (else a normal worker shutdown would
+    // spuriously fail its job).
+    assert!(child_died_abnormally(Some(9), None), "SIGKILL is abnormal");
+    assert!(
+        child_died_abnormally(None, Some(101)),
+        "a panic exit (101) is abnormal"
+    );
+    assert!(
+        child_died_abnormally(None, Some(1)),
+        "any non-zero exit is abnormal"
+    );
+    assert!(
+        !child_died_abnormally(None, Some(0)),
+        "a clean exit-0 is graceful, not reported"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Resolves the ambiguity behind **"Worker heartbeat timed out."** ([sc-6320](https://app.shortcut.com/trefry/story/6320), epic 4161; relates to [sc-4881](https://app.shortcut.com/trefry/story/4881) / [sc-4276](https://app.shortcut.com/trefry/story/4276)).

## Why

`"Worker heartbeat timed out."` is a pure time-based backstop on the API side (`jobs_store::mark_stale_workers_interrupted`, default `worker_timeout_seconds = 90`). It fires whenever the API stops *hearing* heartbeats and carries no knowledge of *why* — so it conflated three very different situations and read to the user like a confirmed death + a frozen progress bar:

1. **Worker genuinely died, uncaught** — death-by-signal was already attributed (sc-4881), but a **non-signal abnormal exit** (a Rust panic → exit 101, or `process::exit(N≠0)`) fell through to the generic `interrupted`.
2. **Worker alive but wedged** (deadlock / stuck native call) — only the API timeout catches it.
3. **Transient transport blip** — the worker is fully alive but a single failed heartbeat POST tore down the running job, and/or the 90s sweep marked the in-flight job terminal `interrupted`; the worker's eventual completion is then rejected and the work is silently lost.

## What changed

**Part 1 — attribute non-signal abnormal exits** (generalizes the sc-4881 signal path)
- `contracts.rs`: `WorkerSignalDeathRequest` → `WorkerTerminationRequest { signal: Option<i32>, exit_code: Option<i32> }`
- `jobs_store.rs`: `fail_worker_job_killed_by_signal` → `fail_worker_job_terminated(worker_id, signal, exit_code)`; `signal_failure_error` → `termination_failure_error` (signal branch unchanged + takes precedence; new exit-code branch — 101 self-names the panic, other codes report the raw code)
- `apps/rust-api`: handler `worker_signal_death` → `worker_terminated`, route `/signal-death` → `/terminated`
- `supervisor.rs`: carries `status.code()` alongside the signal; new `child_died_abnormally(signal, exit_code)` reports a signal **or** a non-zero exit. A clean exit-0 stays graceful/unreported, so a normal shutdown never spuriously fails a job.

**Part 2 — honest heartbeat-timeout message** (`mark_stale_workers_interrupted`)
- error: `"Worker heartbeat timed out."` → `"No heartbeat from the worker for {N}s. The worker may have crashed, hung, or lost its connection to the app. If it reconnects you can retry the job; if this keeps happening, check System → Logs."`
- message: `"Job was interrupted after its worker stopped sending heartbeats."` → `"Lost contact with the worker."`

**Part 3 — tolerate transient transport blips** (worker `heartbeat()`)
- A `WorkerError::Http` (transport-level — API restart, network blip) is now logged (`worker_heartbeat_transport_failed`) and swallowed (returns `Ok`) instead of tearing down the running job. The next heartbeat (≤15s) refreshes `last_seen` well inside the 90s sweep window; a sustained outage (> timeout) still lets the sweep fire — the API stays the authority. Genuine API rejections (`WorkerError::Api{}`, e.g. worker no longer registered) still propagate.
- Return type `WorkerResult<WorkerSnapshot>` → `WorkerResult<()>` (the snapshot was discarded at every call site) — one chokepoint, so all ~40 heartbeat call sites benefit without per-site changes.

## Reviewer notes

- The `/signal-death` → `/terminated` rename and the DTO change are an internal worker↔API contract on localhost shipped in **one binary** (the supervisor re-spawns `current_exe()`), so there is no mixed-version wire concern. Verified no TS or contract-snapshot coupling (`rust_api_contract_snapshots/snapshots.json`, `contract_roundtrip.rs`).
- No dependency/pin change → no gen-core skew.
- **Out of scope by design:** case 2 "alive but wedged" — a true hang still legitimately trips the timeout, now with an honest message; a full API→worker liveness probe (Parts 1–3 cover the reported cases without new endpoints/round-trips).

## Tests

- `cargo fmt` clean; `clippy -D warnings` clean (core, rust-api, worker `--all-targets`).
- **sceneworks-core**: 224 lib + 112 integration pass — +4 new (exit-code attribution integration test; panic-101 / raw-code / signal-precedence unit tests; honest-error assertion on the stale-sweep test).
- **sceneworks-worker**: 328 pass / 69 ignored — +1 new `child_died_abnormally` boundary test (incl. exit-0 = not reported).
- Diff: 8 files, +294/−100.

Not yet exercised in the running app — a real smoke (SIGKILL vs panic vs API-restart against a busy worker, observing the three distinct surfaces) is the remaining gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)