### PR TITLE
fix(models): ideogram_4_turbo cache-health Fix-button + corrected ideogram memory floor (mlx-gen #488)

### DIFF
--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -5432,6 +5432,56 @@ fn huggingface_cache_health_accepts_readable_snapshot_symlinked_model_index() {
     assert!(health.missing_files.is_empty());
 }
 
+#[test]
+fn turbo_cache_health_flags_missing_lora_only_when_listed_explicitly() {
+    // mlx-gen #488: a user who downloaded base Ideogram 4 BEFORE the TurboTime LoRA was published
+    // shares this repo's snapshot — q4/ holds the base files but NOT turbo_lora.safetensors. A coarse
+    // `q4/*` glob is already satisfied by the base files, so the missing LoRA never flags
+    // "incomplete" (no Fix button — the reported symptom). Listing the exact path makes the check
+    // verify that specific file.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let repo_root = temp_dir.path().join("models--SceneWorks--ideogram-4-mlx");
+    let q4 = repo_root.join("snapshots/abc123/q4");
+    std::fs::create_dir_all(&q4).expect("q4 creates");
+    std::fs::create_dir_all(repo_root.join("refs")).expect("refs creates");
+    std::fs::write(repo_root.join("refs/main"), "abc123").expect("ref writes");
+    // A base file under q4/ so the `q4/*` glob is satisfied — but the LoRA is absent.
+    std::fs::write(q4.join("model_index.json"), "{}").expect("base file writes");
+
+    let glob_only = vec!["q4/*".to_owned()];
+    let with_specific = vec!["q4/*".to_owned(), "q4/turbo_lora.safetensors".to_owned()];
+
+    // The coarse glob alone misses it (the bug): q4/model_index.json satisfies `q4/*`.
+    let coarse = super::models::huggingface_cache_health(&repo_root, &glob_only);
+    assert!(
+        coarse.installed && !coarse.incomplete,
+        "coarse `q4/*` glob is satisfied by base files and falsely reports complete"
+    );
+
+    // The explicit path catches the missing LoRA → incomplete → Fix button.
+    let precise = super::models::huggingface_cache_health(&repo_root, &with_specific);
+    assert!(
+        precise.incomplete,
+        "explicit `q4/turbo_lora.safetensors` must flag the missing file"
+    );
+    assert!(
+        precise
+            .missing_files
+            .iter()
+            .any(|file| file == "q4/turbo_lora.safetensors"),
+        "missing_files must name the LoRA, got {:?}",
+        precise.missing_files
+    );
+
+    // Once the LoRA is present, the model is complete again.
+    std::fs::write(q4.join("turbo_lora.safetensors"), "weights").expect("lora writes");
+    let fixed = super::models::huggingface_cache_health(&repo_root, &with_specific);
+    assert!(
+        fixed.installed && !fixed.incomplete && fixed.missing_files.is_empty(),
+        "complete once the LoRA is present"
+    );
+}
+
 #[cfg(windows)]
 fn create_test_symlink_file(
     target: &std::path::Path,

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -931,9 +931,14 @@
         {
           // Same repo as `ideogram_4`; the q4/ subdir now also carries `turbo_lora.safetensors`
           // (~0.85 GB) the engine installs at load. Q8 opt-in via advanced mlxQuantize: 8.
+          // `turbo_lora.safetensors` is listed EXPLICITLY (not just covered by the `q4/*` glob) so
+          // the cache-health check verifies that exact file: a user who downloaded base Ideogram 4
+          // BEFORE the LoRA was published shares this repo's snapshot, and a coarse `q4/*` glob is
+          // already satisfied by the base files — so the missing LoRA would never flag "incomplete"
+          // / show the Fix button. The specific path makes the check exact (apps/rust-api models.rs).
           "provider": "huggingface",
           "repo": "SceneWorks/ideogram-4-mlx",
-          "files": ["q4/*"],
+          "files": ["q4/*", "q4/turbo_lora.safetensors"],
           "platforms": ["macos"],
           "estimatedSizeBytes": 16247340792
         }


### PR DESCRIPTION
Follow-up to #778/#780 — fixes the reported "the Fix button didn't trigger" for the turbo load failure (`bundled TurboTime LoRA not found at .../q4/turbo_lora.safetensors`).

## Root cause
A user who downloaded **base Ideogram 4 before** the TurboTime LoRA was published shares the same repo snapshot. `q4/` has the base files but not `turbo_lora.safetensors`. The Models-page integrity check (`apps/rust-api` `models.rs` → `huggingface_filtered_cache_health`) only verifies each `files` **pattern** matches ≥1 file. Turbo's `files: ["q4/*"]` is already satisfied by the base files (glob `*` doesn't cross `/`, but `q4/model_index.json` etc. satisfy `q4/*`), so the missing LoRA is invisible → `cacheState` stays "installed" → no "incomplete"/Fix affordance.

## Fix
List the exact `q4/turbo_lora.safetensors` in the turbo entry's `files` alongside `q4/*`. A non-glob pattern is checked as an **exact file** (`path_is_readable_file`), so a snapshot missing the LoRA now reports `incomplete` and the Fix button re-downloads it. **No code change** — the health check already handles specific paths; only the catalog spec was too coarse.

## Test
`turbo_cache_health_flags_missing_lora_only_when_listed_explicitly`: a snapshot with base files but no LoRA is falsely "complete" under `q4/*` alone, but correctly flagged `incomplete` (with the LoRA in `missing_files`) once the explicit path is listed — and complete again once the file is present.

Manifest/builtin + cache-health tests pass; fmt + clippy clean.

Note: I already pulled the latest snapshot into the local cache, so turbo works now regardless; this restores the **Fix-button path** for any other pre-existing-base user.

---

## Also in this PR: corrected ideogram memory floor
The base `ideogram_4` note claimed "~28 GB @1024²" with `minMemoryGb: 48`. **Measured** (phys_footprint, Q4, 1024²/8-step): two-DiT base **~60 GiB**, turbo (one DiT) **~52 GiB** — both exceed a 48 GiB Mac, so the default render risks OOM there. Raised both `ideogram_4` and `ideogram_4_turbo` to **`minMemoryGb: 64`** and corrected the notes.

Caveat: the peak includes reclaimable MLX free-buffer cache, so the true post-eviction floor may be lower — 64 is the conservative tier that guarantees 1024² without OOM. (Trade-off: gates 48 GB Macs, which couldn't reliably run the 1024² default anyway.)