### PR TITLE
docs(models): clarify ideogram memory note (active floor ~20-24 GiB, not phys_footprint)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -877,9 +877,13 @@
         "types": ["style", "enhance"]
       },
       // Pre-quantized turnkey (q4/ default, q8/ opt-in via advanced mlxQuantize: 8); the worker
-      // resolve_ideogram_model_dir picks the subdir. Q4 measured peak ~28 GB @1024² (64 GB @2048²);
-      // packed, so NO bf16 load transient. minMemoryGb covers the 1024² default + headroom; the
-      // 2048²/6:1 ceiling wants ~96 GB (advanced high-res on smaller Macs is capped UI-side).
+      // resolve_ideogram_model_dir picks the subdir; packed, so NO bf16 load transient. MEASURED Q4
+      // @1024²/8-step: peak ACTIVE memory (the true RAM floor) ~20 GiB for the two-DiT path. Do NOT
+      // confuse this with the ~52–60 GiB phys_footprint peak — that is mostly MLX's RECLAIMABLE
+      // free-buffer cache (evicted under memory pressure), not a hard requirement. minMemoryGb 48
+      // comfortably covers the ~20 GiB active floor plus the cache MLX keeps for speed; raising it
+      // toward the phys_footprint would needlessly gate Macs that run this fine. 2048²/6:1 needs
+      // more — advanced high-res is capped UI-side on smaller Macs.
       "mlx": {
         "minMemoryGb": 48,
         // The turnkey's default subdir is the packed q4/ weights, so the resolved quant must be Q4 —
@@ -963,8 +967,10 @@
         "schedulers": ["default"]
       },
       // Same packed turnkey + quant resolution as the base (resolve_ideogram_model_dir picks the
-      // q4/q8 subdir, which carries the bundled LoRA). Measured Q4 peak ~52 GB @1024²/8-step (one
-      // DiT); minMemoryGb mirrors the base entry (turbo is strictly lighter than the 2-DiT base).
+      // q4/q8 subdir, which carries the bundled LoRA). MEASURED Q4 @1024²/8-step: peak ACTIVE ~24 GiB
+      // (one DiT + the bf16 LoRA residuals) — the true RAM floor; the ~52 GiB phys_footprint is mostly
+      // reclaimable MLX cache, NOT a hard requirement (see the base entry). minMemoryGb 48 covers the
+      // active floor comfortably.
       "mlx": {
         "minMemoryGb": 48,
         "quantize": 4,


### PR DESCRIPTION
The "new PR" for the ideogram memory-floor question — but the answer flipped after a proper measurement, so this is a **note-only** clarification, **no value change**.

## What changed my mind
Earlier I measured the **phys_footprint** peak (~60 GiB base / ~52 GiB turbo @1024²/8-step) and concluded `minMemoryGb: 48` was understated → proposed 64. That was wrong. Measuring **peak ACTIVE** memory (`mlx_rs::memory::get_peak_memory`, which excludes MLX's reclaimable buffer cache):

| | peak **active** (true floor) | phys_footprint | reclaimable cache |
|---|---|---|---|
| base (2 DiTs) | **~20 GiB** | ~60 GiB | ~40 GiB |
| turbo (1 DiT) | **~24 GiB** | ~52 GiB | ~41 GiB |

The 52–60 GiB is mostly MLX's free-buffer cache, which evicts under memory pressure — **not** a hard requirement. So `minMemoryGb: 48` is correct (comfortably covers the ~20–24 GiB active floor plus the cache MLX keeps for speed); raising it toward the phys_footprint would needlessly gate Macs that run this fine.

(My 64 raise was bundled into #788 but its commit never made the merge — main already has the correct 48. This just fixes the misleading notes so the mistake isn't repeated.)

## This PR
- `ideogram_4` / `ideogram_4_turbo` notes: state the measured **active** floor (~20 / ~24 GiB) and warn against confusing it with the phys_footprint. `minMemoryGb` stays **48**.

Manifest parse + builtin tests pass.