### PR TITLE
sc-6303: re-pin mlx-gen to the #490 merge commit + Ideogram edit worker e2e

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3284,11 +3284,11 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e23a8b7ae3b01b433d8fa2fec02d2288cefbc302#e23a8b7ae3b01b433d8fa2fec02d2288cefbc302"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=e23a8b7ae3b01b433d8fa2fec02d2288cefbc302)",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7)",
  "thiserror 2.0.18",
  "tokenizers 0.21.4",
 ]
@@ -3296,7 +3296,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e23a8b7ae3b01b433d8fa2fec02d2288cefbc302#e23a8b7ae3b01b433d8fa2fec02d2288cefbc302"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
 dependencies = [
  "image",
  "inventory",
@@ -3310,7 +3310,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e23a8b7ae3b01b433d8fa2fec02d2288cefbc302#e23a8b7ae3b01b433d8fa2fec02d2288cefbc302"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3322,7 +3322,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e23a8b7ae3b01b433d8fa2fec02d2288cefbc302#e23a8b7ae3b01b433d8fa2fec02d2288cefbc302"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3331,7 +3331,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e23a8b7ae3b01b433d8fa2fec02d2288cefbc302#e23a8b7ae3b01b433d8fa2fec02d2288cefbc302"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3343,7 +3343,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e23a8b7ae3b01b433d8fa2fec02d2288cefbc302#e23a8b7ae3b01b433d8fa2fec02d2288cefbc302"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3354,7 +3354,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e23a8b7ae3b01b433d8fa2fec02d2288cefbc302#e23a8b7ae3b01b433d8fa2fec02d2288cefbc302"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3366,7 +3366,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e23a8b7ae3b01b433d8fa2fec02d2288cefbc302#e23a8b7ae3b01b433d8fa2fec02d2288cefbc302"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3377,7 +3377,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e23a8b7ae3b01b433d8fa2fec02d2288cefbc302#e23a8b7ae3b01b433d8fa2fec02d2288cefbc302"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3387,7 +3387,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e23a8b7ae3b01b433d8fa2fec02d2288cefbc302#e23a8b7ae3b01b433d8fa2fec02d2288cefbc302"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
 dependencies = [
  "image",
  "inventory",
@@ -3399,7 +3399,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e23a8b7ae3b01b433d8fa2fec02d2288cefbc302#e23a8b7ae3b01b433d8fa2fec02d2288cefbc302"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
 dependencies = [
  "image",
  "inventory",
@@ -3412,7 +3412,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e23a8b7ae3b01b433d8fa2fec02d2288cefbc302#e23a8b7ae3b01b433d8fa2fec02d2288cefbc302"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
 dependencies = [
  "image",
  "inventory",
@@ -3424,7 +3424,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e23a8b7ae3b01b433d8fa2fec02d2288cefbc302#e23a8b7ae3b01b433d8fa2fec02d2288cefbc302"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3435,7 +3435,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e23a8b7ae3b01b433d8fa2fec02d2288cefbc302#e23a8b7ae3b01b433d8fa2fec02d2288cefbc302"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3447,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e23a8b7ae3b01b433d8fa2fec02d2288cefbc302#e23a8b7ae3b01b433d8fa2fec02d2288cefbc302"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3457,7 +3457,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e23a8b7ae3b01b433d8fa2fec02d2288cefbc302#e23a8b7ae3b01b433d8fa2fec02d2288cefbc302"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3466,7 +3466,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e23a8b7ae3b01b433d8fa2fec02d2288cefbc302#e23a8b7ae3b01b433d8fa2fec02d2288cefbc302"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3475,7 +3475,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e23a8b7ae3b01b433d8fa2fec02d2288cefbc302#e23a8b7ae3b01b433d8fa2fec02d2288cefbc302"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3487,7 +3487,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e23a8b7ae3b01b433d8fa2fec02d2288cefbc302#e23a8b7ae3b01b433d8fa2fec02d2288cefbc302"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
 dependencies = [
  "image",
  "inventory",
@@ -3500,7 +3500,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e23a8b7ae3b01b433d8fa2fec02d2288cefbc302#e23a8b7ae3b01b433d8fa2fec02d2288cefbc302"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3511,7 +3511,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e23a8b7ae3b01b433d8fa2fec02d2288cefbc302#e23a8b7ae3b01b433d8fa2fec02d2288cefbc302"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3522,7 +3522,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e23a8b7ae3b01b433d8fa2fec02d2288cefbc302#e23a8b7ae3b01b433d8fa2fec02d2288cefbc302"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3533,7 +3533,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e23a8b7ae3b01b433d8fa2fec02d2288cefbc302#e23a8b7ae3b01b433d8fa2fec02d2288cefbc302"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
 dependencies = [
  "image",
  "inventory",
@@ -3547,7 +3547,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e23a8b7ae3b01b433d8fa2fec02d2288cefbc302#e23a8b7ae3b01b433d8fa2fec02d2288cefbc302"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
 dependencies = [
  "image",
  "inventory",
@@ -5175,7 +5175,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=51a6792db3a1c94d23a9ae00e2414665b8c2c9f7#51a6792db3a1c94d23a9ae00e2414665b8c2c9f7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
 dependencies = [
  "inventory",
  "safetensors 0.4.5",
@@ -5187,7 +5187,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e23a8b7ae3b01b433d8fa2fec02d2288cefbc302#e23a8b7ae3b01b433d8fa2fec02d2288cefbc302"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=51a6792db3a1c94d23a9ae00e2414665b8c2c9f7#51a6792db3a1c94d23a9ae00e2414665b8c2c9f7"
 dependencies = [
  "inventory",
  "safetensors 0.4.5",
@@ -5288,7 +5288,7 @@ dependencies = [
  "pmetal-mlx-rs",
  "reqwest 0.12.28",
  "sceneworks-core",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=e23a8b7ae3b01b433d8fa2fec02d2288cefbc302)",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7)",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -202,13 +202,14 @@ sceneworks-core = { path = "../sceneworks-core" }
 # mlx-gen crate + gen-core in lockstep so the default skew gate (check.yml) stays single-rev. candle-gen
 # lane unchanged (sc-5905).
 #
-# Rev 3c65d8d -> e23a8b7 (mlx-gen PR #490, sc-6330): adds the Ideogram 4 img2img + mask inpaint/outpaint
-# EDIT path (companion to the SceneWorks worker wiring sc-6303). PURE mlx-gen-ideogram (EditInit +
-# encode_init_latents + generate_edit_with_progress; descriptor conditioning [Reference, Mask]);
-# gen-core BYTE-IDENTICAL 3c65d8d -> e23a8b7, mlx-rs unchanged (44929a0). T2I render byte-identical when
-# no edit conditioning. Bumps EVERY mlx-gen crate + gen-core in lockstep (skew gate single-rev).
-# NOTE: e23a8b7 is the PR #490 branch tip — re-pin to the squash-merge commit when #490 lands.
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23a8b7ae3b01b433d8fa2fec02d2288cefbc302" }
+# Rev 3c65d8d -> 517ef11 (mlx-gen main, merged PR #490, sc-6330): adds the Ideogram 4 img2img + mask
+# inpaint/outpaint EDIT path (companion to the SceneWorks worker wiring sc-6303). PURE mlx-gen-ideogram
+# (EditInit + encode_init_latents + generate_edit_with_progress; descriptor conditioning [Reference,
+# Mask]); gen-core BYTE-IDENTICAL 3c65d8d -> 517ef11, mlx-rs unchanged (44929a0). T2I render byte-
+# identical when no edit conditioning. Bumps EVERY mlx-gen crate + gen-core in lockstep (skew gate
+# single-rev). (#791 originally pinned the e23a8b7 branch tip; this re-pins to the #490 merge commit on
+# main per convention — 517ef11's ideogram tree == e23a8b7, so the build is byte-identical.)
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -519,7 +520,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23a8b7ae3b01b433d8fa2fec02d2288cefbc302" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -531,59 +532,59 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23a8b7ae3b
 # internal pin (the Lens engine PRs #407–#414 did not move it; nor did the seedvr2 engine #416/#419/
 # #421 or the softness PR #422, so the 1a97909 bump above leaves mlx-rs at 44929a0).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "44929a001ab8a8837403a71c65cf064224de0cdc" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23a8b7ae3b01b433d8fa2fec02d2288cefbc302" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23a8b7ae3b01b433d8fa2fec02d2288cefbc302" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23a8b7ae3b01b433d8fa2fec02d2288cefbc302" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23a8b7ae3b01b433d8fa2fec02d2288cefbc302" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23a8b7ae3b01b433d8fa2fec02d2288cefbc302" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23a8b7ae3b01b433d8fa2fec02d2288cefbc302" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23a8b7ae3b01b433d8fa2fec02d2288cefbc302" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23a8b7ae3b01b433d8fa2fec02d2288cefbc302" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23a8b7ae3b01b433d8fa2fec02d2288cefbc302" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23a8b7ae3b01b433d8fa2fec02d2288cefbc302" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23a8b7ae3b01b433d8fa2fec02d2288cefbc302" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23a8b7ae3b01b433d8fa2fec02d2288cefbc302" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23a8b7ae3b01b433d8fa2fec02d2288cefbc302" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -592,12 +593,12 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23a8b
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23a8b7ae3b01b433d8fa2fec02d2288cefbc302" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23a8b7ae3b01b433d8fa2fec02d2288cefbc302" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -606,7 +607,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23a8b
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23a8b7ae3b01b433d8fa2fec02d2288cefbc302" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -614,7 +615,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23a8b7ae3b01b433d8fa2fec02d2288cefbc302" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -625,7 +626,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23a
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23a8b7ae3b01b433d8fa2fec02d2288cefbc302" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -636,7 +637,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23a8
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23a8b7ae3b01b433d8fa2fec02d2288cefbc302" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -651,7 +652,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23a8b
 # converted in-memory at load (no Python); the precomputed neg-prompt embedding is bundled in-crate. No
 # LoRA/guidance/CFG (one-step). 3B fp16 only here — 7B (sc-5197) + int8 (sc-5198) are engine-side and
 # unwired. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23a8b7ae3b01b433d8fa2fec02d2288cefbc302" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -662,7 +663,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23a8b7ae3b01b433d8fa2fec02d2288cefbc302" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
 # Prompt-refine provider (sc-5552, the MLX twin of candle-gen-prompt-refine / sc-5500). An
 # inventory-registered `TextLlm` under id `prompt_refine` (`backend="mlx"`, `mac_only`): a native MLX
 # Llama-3.2-3B-Instruct that rewrites a user's prompt, replacing the Python `prompt_refine.py`
@@ -672,7 +673,7 @@ mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23
 # textllm registered" trap). Weights = a stock Llama-3.2-3B-Instruct HF snapshot (config.json +
 # tokenizer.json + model-*.safetensors; default `huihui-ai/Llama-3.2-3B-Instruct-abliterated`). Same
 # git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23a8b7ae3b01b433d8fa2fec02d2288cefbc302" }
+mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
 # SCAIL-2 (zai-org) end-to-end character-animation provider (epic 5439, sc-5448). An inventory-registered
 # `Generator` under id `scail2_14b` (`Modality::Video`): a Wan2.1-14B I2V DiT that animates a reference
 # character with a driving video's motion (`video_mode == "replacement"` flips the cross-identity
@@ -684,7 +685,7 @@ mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev 
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23a8b7ae3b01b433d8fa2fec02d2288cefbc302" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -3923,3 +3923,107 @@ fn ideogram_4_real_weights_generates_caption_and_plain_images() {
         eprintln!("ideogram {label}: {w}x{h} RGB8, {steps_seen} steps observed");
     }
 }
+
+/// Real-weight Ideogram 4 **edit** e2e (sc-6303): drives the worker's `generate_one` with a source
+/// `Reference` (img2img/Remix) and a `Reference` + `Mask` (inpaint) through the production engine
+/// load, so the worker's `[Reference, Mask]` conditioning assembly is consumed by the engine's edit
+/// path end-to-end. Mechanics only (low steps); engine-level correctness (keep-vs-repaint) is the
+/// mlx-gen `edit_smoke`. Run:
+/// `cargo test -p sceneworks-worker --lib -- --ignored ideogram_4_real_weights_edit --nocapture`.
+#[cfg(target_os = "macos")]
+#[ignore = "loads the real Ideogram 4 snapshot; run manually on a Mac with SceneWorks/ideogram-4-mlx cached"]
+#[test]
+fn ideogram_4_real_weights_edit_img2img_and_inpaint() {
+    let Some(dir) = ideogram_dir() else {
+        eprintln!(
+            "skipping ideogram_4_real_weights_edit: no SceneWorks/ideogram-4-mlx q4 snapshot found"
+        );
+        return;
+    };
+    let env_u32 = |key: &str, default: u32| {
+        std::env::var(key)
+            .ok()
+            .and_then(|v| v.trim().parse().ok())
+            .unwrap_or(default)
+    };
+    let steps = env_u32("IDEOGRAM4_SMOKE_STEPS", 8);
+    let res = env_u32("IDEOGRAM4_SMOKE_RES", 512);
+
+    let model = mlx_model("ideogram_4").unwrap();
+    let req = request(json!({
+        "projectId": "p", "model": "ideogram_4", "prompt": "p", "advanced": {},
+        "modelManifestEntry": { "mlx": { "quantize": 4 } },
+    }));
+    let (quant, _bits) = resolve_quant(&req);
+    let guidance = resolve_guidance(&req, &model);
+    let generator = load_engine("ideogram_4", dir, quant, Vec::new(), None).unwrap();
+    let cancel = gen_core::CancelFlag::new();
+    let enhance = PromptEnhance::default();
+    const CAPTION_JSON: &str = "{\"high_level_description\": \"A photograph of a red fox sitting in a snowy forest at golden hour.\", \"compositional_deconstruction\": {\"background\": \"A snowy pine forest at golden hour.\", \"elements\": [{\"type\": \"obj\", \"bbox\": [250, 320, 950, 760], \"desc\": \"A red fox sitting upright in the snow, facing the camera.\"}]}}";
+
+    // Synthetic RGB8 source (gradient) + a left-half-white inpaint mask, both res×res.
+    let source = Image {
+        width: res,
+        height: res,
+        pixels: (0..res * res)
+            .flat_map(|i| {
+                [
+                    (255 * (i % res) / res) as u8,
+                    (255 * (i / res) / res) as u8,
+                    128u8,
+                ]
+            })
+            .collect(),
+    };
+    let mask = Image {
+        width: res,
+        height: res,
+        pixels: (0..res * res)
+            .flat_map(|i| {
+                let v = if i % res < res / 2 { 255u8 } else { 0u8 };
+                [v, v, v]
+            })
+            .collect(),
+    };
+
+    let run = |reference: Option<&(Image, f32)>, edit_mask: Option<&Image>, label: &str| {
+        let mut steps_seen = 0u32;
+        let (w, h, pixels) = generate_one(
+            generator.as_ref(),
+            CAPTION_JSON,
+            res,
+            res,
+            42,
+            steps,
+            guidance,
+            None,
+            reference,
+            edit_mask,
+            None,
+            None,
+            None,
+            None,
+            &enhance,
+            &cancel,
+            &mut |p| {
+                if let gen_core::Progress::Step { current, .. } = p {
+                    steps_seen = steps_seen.max(current);
+                }
+            },
+        )
+        .unwrap_or_else(|error| panic!("ideogram edit {label} failed: {error}"));
+        assert_eq!(pixels.len(), (w * h * 3) as usize, "{label}: RGB8 buffer");
+        assert!(w == res && h == res, "{label}: {res}² output");
+        assert!(steps_seen >= 1, "{label}: denoise progress");
+        assert!(
+            pixels.windows(2).any(|x| x[0] != x[1]),
+            "{label}: non-constant image"
+        );
+        eprintln!("ideogram edit {label}: {w}x{h} RGB8, {steps_seen} steps observed");
+    };
+
+    // img2img (Remix): source Reference only.
+    run(Some(&(source.clone(), 0.6)), None, "img2img");
+    // inpaint (Edit): source Reference + Mask (white half repaints, black half keeps).
+    run(Some(&(source, 0.85)), Some(&mask), "inpaint");
+}


### PR DESCRIPTION
Follow-up to the merged [#791](https://github.com/SceneWorks/SceneWorks/pull/791) (Ideogram 4 edit) + [SceneWorks/mlx-gen#490](https://github.com/SceneWorks/mlx-gen/pull/490) (engine).

## Re-pin
#791 pinned the `e23a8b7` **PR-branch tip**; this re-pins to **`517ef11`** — the #490 merge commit on `mlx-gen` main — matching the convention that every pin in `crates/sceneworks-worker/Cargo.toml` is a main merge commit. `517ef11`'s `mlx-gen-ideogram` tree is identical to `e23a8b7` (the merge added nothing else), so the build is **byte-identical**; gen-core + mlx-rs unchanged.

## Worker edit e2e (closes the sc-6303 validation boundary)
Adds `ideogram_4_real_weights_edit_img2img_and_inpaint` (`#[ignore]`, macOS): drives the worker's `generate_one` with a source `Reference` (img2img/Remix) and a `Reference` + `Mask` (inpaint) through the production Q4 engine load, validating that the worker's `[Reference, Mask]` conditioning assembly is consumed by the engine's edit path end-to-end (the layer above the engine's own `edit_smoke`).

**Ran on the `SceneWorks/ideogram-4-mlx` Q4 turnkey** (512²/8-step):
```
ideogram edit img2img: 512x512 RGB8, 4 steps observed
ideogram edit inpaint: 512x512 RGB8, 6 steps observed
test result: ok. 1 passed
```
(4/6 observed steps = `floor(8·0.6)` / `floor(8·0.85)`, the strength-derived `num_run`.)

`cargo clippy --tests -D warnings` + `cargo fmt --check` clean; worker builds + 334 lib tests pass against the re-pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)