### PR TITLE
feat(image-editor): image_segment job — SAM3 box→mask backend for smart-select (sc-6105)

### DIFF
--- a/apps/web/src/jobTypes.js
+++ b/apps/web/src/jobTypes.js
@@ -13,6 +13,7 @@ export const GPU_REQUIRED_JOB_TYPES = new Set([
   "image_interleave",
   "image_upscale",
   "image_detail",
+  "image_segment",
   "video_generate",
   "video_extend",
   "video_bridge",

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -240,6 +240,12 @@ string_enum! {
         // tile ControlNet run over feathered tiles to add micro-texture; GPU-required
         // like generation. Composes after image_upscale (creative upscale).
         ImageDetail => "image_detail",
+        // Smart-select segmentation of an existing image asset (Image Editor, epic 6087
+        // / sc-6105): a box prompt → a binary inpaint mask asset (white-on-black PNG at
+        // source dims) the editor loads into the sc-2436 mask layer. Native-MLX SAM3 on
+        // the macOS Rust worker (zero-Python, the box-PVS path of the sc-4926 SAM3 stack);
+        // GPU-required like generation, mac-only (no torch SAM3 image path yet).
+        ImageSegment => "image_segment",
         // Standalone upscale of an existing VIDEO asset (Video Studio, epic 4811 /
         // sc-4816) — SceneWorks' first video upscaler. Native-MLX SeedVR2 one-step
         // super-resolution on the macOS Rust worker (zero-Python, epic 3482): decode
@@ -361,6 +367,11 @@ string_enum! {
         // backend is available (runtime.py); the Rust utility worker never emits it.
         // See jobs_store::job_requires_gpu.
         ImageDetail => "image_detail",
+        // Smart-select segmentation (Image Editor, epic 6087 / sc-6105). Advertised
+        // ONLY by the macOS MLX worker (native SAM3, `gpu.rs mlx_gpu`); no torch/candle
+        // worker emits it, so a box-prompt segment job routes to the Mac worker by
+        // construction. See jobs_store::job_requires_gpu / mac_rust_supported.
+        ImageSegment => "image_segment",
         // Standalone VIDEO upscale (Video Studio, epic 4811 / sc-4816). Advertised by
         // the macOS Rust/MLX worker (native SeedVR2, zero-Python); no Python-worker
         // backend (mac-only). GPU-required. See jobs_store::worker_supports_job.

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -1966,6 +1966,7 @@ fn oom_remediation_hint(job_type: Option<&JobType>) -> &'static str {
             | JobType::ImageEdit
             | JobType::ImageUpscale
             | JobType::ImageDetail
+            | JobType::ImageSegment
             | JobType::ImageVqa
             | JobType::ImageInterleave,
         ) => ", likely out-of-memory — reduce the image count or resolution",
@@ -2128,6 +2129,13 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
         // in-process, so the Key Point Library "extract kps from this image" flow is
         // Python-free on Mac.
         JobType::KpsExtract => Ok(()),
+
+        // Smart-select segmentation (epic 6087, sc-6105): native-MLX SAM3 box-prompt
+        // segmentation runs in-process on the macOS Rust worker (the box-PVS path of the
+        // sc-4926 SAM3 stack — `segment_jobs::run_image_segment_job`), so the Image Editor
+        // smart-select tool is Python-free on Mac. Mac-only by construction: the capability
+        // is advertised only by `mlx_gpu`, so no torch/candle worker ever claims it.
+        JobType::ImageSegment => Ok(()),
 
         // Real-ESRGAN image upscaling is ported to the Rust worker (sc-3489) and SeedVR2 (the
         // native-MLX one-step diffusion upscaler, epic 4811 / sc-4815) runs in-process via
@@ -2521,6 +2529,27 @@ pub fn mac_capabilities(platform: &str, mac_gating_active: bool) -> MacCapabilit
         MacFeatureSupport {
             supported: true,
             reason: None,
+        },
+    );
+    features.insert(
+        // Smart-select segmentation (epic 6087, sc-6105): native-MLX SAM3 box-prompt
+        // segmentation runs in-process on the macOS Rust worker, so the Image Editor
+        // smart-select tool works on a Python-free Mac. Mac-only (no torch SAM3 image
+        // path); must agree with the ImageSegment arm of `mac_rust_supported` — what the
+        // UI shows == what routing accepts (sc-4206 / F-CORE-2).
+        "imageSegment".to_owned(),
+        MacFeatureSupport {
+            supported: is_mac,
+            reason: if is_mac {
+                None
+            } else {
+                Some(UnsupportedReason::new(
+                    None,
+                    "image_segment (SAM3 smart-select)",
+                    "smart-select segmentation runs on the native-MLX SAM3 stack (macOS only); there is no torch/candle SAM3 image path yet.",
+                    Some("sc-6105"),
+                ))
+            },
         },
     );
     features.insert(
@@ -4848,6 +4877,7 @@ fn job_requires_gpu(job_type: &JobType) -> bool {
             | JobType::ImageInterleave
             | JobType::ImageUpscale
             | JobType::ImageDetail
+            | JobType::ImageSegment
             | JobType::VideoGenerate
             | JobType::VideoExtend
             | JobType::VideoBridge

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -2614,6 +2614,9 @@ fn mac_capabilities_master_switch_and_infra_features() {
     // Person detect/track is ported (sc-3488 / sc-3633/3634/3709) → supported, no epic.
     assert_eq!(epic("personDetect"), None);
     assert!(mac.features["personDetect"].supported);
+    // Smart-select segmentation is native-MLX SAM3 on Mac (sc-6105) → supported, no epic.
+    assert_eq!(epic("imageSegment"), None);
+    assert!(mac.features["imageSegment"].supported);
     assert_eq!(epic("datasetCaptioning"), None);
     // LyCORIS is ported to MLX (epic 3641) → no longer a capability gap entry at all.
     assert!(!mac.features.contains_key("lycoris"));
@@ -2624,10 +2627,11 @@ fn mac_capabilities_master_switch_and_infra_features() {
     // Video upscale is net-new on Mac (epic 4811 / sc-4816, native-MLX SeedVR2) → supported, no epic.
     assert_eq!(epic("videoUpscale"), None);
     assert!(mac.features["videoUpscale"].supported);
-    // datasetCaptioning + imageUpscale + imageUpscaleSeedvr2 + personDetect + poseFromPhoto +
-    // videoUpscale are the ported (supported) infra features; the rest stay gated until their port
-    // lands. poseFromPhoto joined the supported set in sc-4206 (DWPose ported, sc-3487);
-    // imageUpscaleSeedvr2 in sc-4815, videoUpscale in sc-4816 (both native-MLX SeedVR2, epic 4811).
+    // datasetCaptioning + imageSegment + imageUpscale + imageUpscaleSeedvr2 + personDetect +
+    // poseFromPhoto + videoUpscale are the ported (supported) infra features; the rest stay gated
+    // until their port lands. poseFromPhoto joined the supported set in sc-4206 (DWPose ported,
+    // sc-3487); imageUpscaleSeedvr2 in sc-4815, videoUpscale in sc-4816 (both native-MLX SeedVR2,
+    // epic 4811); imageSegment in sc-6105 (native-MLX SAM3 smart-select).
     assert!(mac
         .features
         .iter()
@@ -2635,6 +2639,7 @@ fn mac_capabilities_master_switch_and_infra_features() {
             !matches!(
                 key.as_str(),
                 "datasetCaptioning"
+                    | "imageSegment"
                     | "imageUpscale"
                     | "imageUpscaleSeedvr2"
                     | "personDetect"

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -565,6 +565,13 @@ pub(crate) fn mlx_gpu(settings: &Settings) -> DiscoveredGpu {
         // works on a Python-free Mac. Only `engine=real-esrgan` (the default) is
         // served here; `aura-sr` stays on the Python worker (routing oracle).
         WorkerCapability::ImageUpscale,
+        // Smart-select segmentation (epic 6087, sc-6105): native-MLX SAM3 box-prompt
+        // segmentation, served in-process by `segment_jobs::run_image_segment_job` (the
+        // box-PVS path of the sc-4926 SAM3 stack). The Image Editor smart-select tool's
+        // backend: a box prompt → a binary inpaint mask asset. Advertised ONLY here (no
+        // torch/candle SAM3 image path), so a segment job routes to the Mac worker by
+        // construction.
+        WorkerCapability::ImageSegment,
         // SeedVR2 video upscaling (epic 4811, sc-4816): native-MLX one-step super-resolution
         // (`mlx-gen-seedvr2`), served in-process by `video_jobs::run_video_upscale_job` —
         // SceneWorks' first video upscaler. Decodes the source clip, runs the temporal-chunked

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -174,6 +174,11 @@ mod person_segment;
 // Windows/Linux backend until a parallel candle backport (cf. epic 3792).
 #[cfg(target_os = "macos")]
 mod person_segment_sam3;
+// Smart-select image segmentation (epic 6087, sc-6105): the `image_segment` job runs SAM3
+// box-prompt segmentation in-process to produce an inpaint mask asset for the Image Editor.
+// macOS-only like its `person_segment_sam3` (SAM3) dependency; no torch/candle image-segment path.
+#[cfg(target_os = "macos")]
+mod segment_jobs;
 // SCAIL-2 color-coded segmentation-mask painting (epic 5439, sc-5448): turns native SAM3
 // per-person masks into the palette-painted RGB masks the SCAIL-2 engine consumes. macOS-only
 // like its SAM3 dependency.
@@ -879,6 +884,16 @@ async fn run_utility_job(
         JobType::ImageUpscale => run_image_upscale_job(api, settings, http_client, &job)
             .await
             .map_err(|error| ("Image upscale failed.", error)),
+        // Smart-select segmentation (epic 6087, sc-6105): native-MLX SAM3 box-prompt segmentation,
+        // served in-process by `segment_jobs::run_image_segment_job` — a box prompt → a binary
+        // inpaint mask asset for the Image Editor. macOS-only (the capability is advertised only by
+        // `mlx_gpu`), so off-Mac this arm is absent and a segment job is never claimed there.
+        #[cfg(target_os = "macos")]
+        JobType::ImageSegment => {
+            segment_jobs::run_image_segment_job(api, settings, http_client, &job)
+                .await
+                .map_err(|error| ("Smart-select segmentation failed.", error))
+        }
         // SeedVR2 video upscaling (epic 4811): one-step super-resolution — native MLX on Mac (sc-4816)
         // / candle CUDA on Windows (sc-5928). SceneWorks' first video upscaler: decodes the source
         // clip, runs the temporal-chunked 5D upscale, re-encodes, and passes the source audio through.

--- a/crates/sceneworks-worker/src/person_segment_sam3.rs
+++ b/crates/sceneworks-worker/src/person_segment_sam3.rs
@@ -28,7 +28,9 @@ use std::sync::{Mutex, OnceLock};
 
 use crate::downloads::{ensure_hf_cached_file, DownloadContext};
 use mlx_gen::weights::Weights;
-use mlx_gen_sam3::{Sam3TextConfig, Sam3Tokenizer, Sam3VideoModel, VideoFrameOutput};
+use mlx_gen_sam3::{
+    Sam3ImageSegmenter, Sam3TextConfig, Sam3Tokenizer, Sam3VideoModel, VideoFrameOutput,
+};
 use mlx_rs::Array;
 
 use crate::{Settings, WorkerError, WorkerResult};
@@ -344,6 +346,138 @@ pub(crate) fn segment_track_blocking(
     Ok(masks)
 }
 
+/// Normalize an `[x1, y1, x2, y2]` pixel box (clamped to the image) to SAM3's `[cx, cy, w, h]`
+/// ∈ [0, 1]. SAM3 squashes the image to a fixed 1008² square (NOT aspect-preserving), so a box's
+/// normalized source coordinates equal its normalized model-input coordinates — no letterbox math.
+fn normalize_box_cxcywh(box_xyxy: [f32; 4], width: u32, height: u32) -> [f32; 4] {
+    let (w, h) = (width.max(1) as f32, height.max(1) as f32);
+    let x1 = box_xyxy[0].min(box_xyxy[2]).clamp(0.0, w);
+    let y1 = box_xyxy[1].min(box_xyxy[3]).clamp(0.0, h);
+    let x2 = box_xyxy[0].max(box_xyxy[2]).clamp(0.0, w);
+    let y2 = box_xyxy[1].max(box_xyxy[3]).clamp(0.0, h);
+    [
+        ((x1 + x2) * 0.5 / w).clamp(0.0, 1.0),
+        ((y1 + y2) * 0.5 / h).clamp(0.0, 1.0),
+        ((x2 - x1) / w).clamp(0.0, 1.0),
+        ((y2 - y1) / h).clamp(0.0, 1.0),
+    ]
+}
+
+/// Smart-select (epic 6087, sc-6105): segment whatever lies under a single box prompt on ONE still
+/// image with the native-MLX SAM3 box-prompted PVS path ([`Sam3ImageSegmenter::segment_with_boxes`],
+/// epic 4910 sc-4923). `box_xyxy` is in source-image pixel coords; `concept` is the optional text
+/// concept paired with the box (empty = rely on the geometric prompt). Returns one binary mask
+/// (row-major `width*height`, `0`/`255`, white = the selected region) at the source dims — the
+/// `maskAssetId` the editor's inpaint flow (sc-2436/2476) consumes. Errors when SAM3 returns no
+/// instance for the box. Loads the segmenter from the shared (cached) SAM3 checkpoint and quantizes
+/// it (Q8 default); run under `spawn_blocking` (MLX is synchronous + holds the autorelease pool).
+pub(crate) fn segment_box_blocking(
+    model_path: PathBuf,
+    tokenizer_path: PathBuf,
+    image: image::RgbImage,
+    box_xyxy: [f32; 4],
+    concept: &str,
+    threshold: f32,
+    mask_threshold: f32,
+) -> WorkerResult<Vec<u8>> {
+    let (width, height) = (image.width(), image.height());
+    if width == 0 || height == 0 {
+        return Err(WorkerError::InvalidPayload(
+            "smart-select source image has zero dimension".into(),
+        ));
+    }
+    let pixels = input_tensor(&image);
+
+    // Cached checkpoint (poison-recovery), shared with the video path — both consume the same
+    // facebook/sam3 weight map (mirrors person_segment / sc-4277 F-MLXW-13).
+    let cell = WEIGHTS.get_or_init(|| Mutex::new(None));
+    let mut guard = cell.lock().unwrap_or_else(|poisoned| {
+        let mut guard = poisoned.into_inner();
+        *guard = None;
+        guard
+    });
+    if guard.is_none() {
+        let weights = Weights::from_file(&model_path)
+            .map_err(|e| WorkerError::Engine(format!("sam3 weights load: {e}")))?;
+        *guard = Some(weights);
+    }
+    let weights = guard.as_ref().expect("weights loaded");
+
+    let mut model = Sam3ImageSegmenter::from_weights(weights)
+        .map_err(|e| WorkerError::Engine(format!("sam3 image model build: {e}")))?;
+    if let Some(bits) = quant_bits() {
+        model
+            .quantize(bits)
+            .map_err(|e| WorkerError::Engine(format!("sam3 quantize q{bits}: {e}")))?;
+    }
+    let tokenizer = Sam3Tokenizer::from_file(&tokenizer_path, &Sam3TextConfig::sam3())
+        .map_err(|e| WorkerError::Engine(format!("sam3 tokenizer load: {e}")))?;
+    let (input_ids, text_mask) = tokenizer
+        .encode(concept)
+        .map_err(|e| WorkerError::Engine(format!("sam3 tokenize: {e}")))?;
+
+    let cxcywh = normalize_box_cxcywh(box_xyxy, width, height);
+    let boxes = Array::from_slice(&cxcywh, &[1, 1, 4]);
+    let box_labels = [1i32]; // a single positive box prompt
+
+    let instances = model
+        .segment_with_boxes(
+            &pixels,
+            &input_ids,
+            &text_mask,
+            &boxes,
+            &box_labels,
+            (width as f32, height as f32),
+            threshold,
+            mask_threshold,
+        )
+        .map_err(|e| WorkerError::Engine(format!("sam3 segment_with_boxes: {e}")))?;
+
+    // Pick the instance whose MASK has the most foreground inside the prompt box. SAM3 PVS returns
+    // the box-echo query (its box ≈ the prompt, but the mask can be degenerate) alongside the
+    // model's own detections (real masks, different boxes); selecting by box-IoU can land on the
+    // empty echo. Mask-in-box intersection is robust for both a tight box (the echo's own real
+    // mask) and a loose box (the best-overlapping real detection). Instance masks are 0/1 at the
+    // 288² grid; the squashed grid maps directly to the normalized frame (uniform 1008² resize).
+    let nx1 = (box_xyxy[0].min(box_xyxy[2]) / width as f32).clamp(0.0, 1.0);
+    let ny1 = (box_xyxy[1].min(box_xyxy[3]) / height as f32).clamp(0.0, 1.0);
+    let nx2 = (box_xyxy[0].max(box_xyxy[2]) / width as f32).clamp(0.0, 1.0);
+    let ny2 = (box_xyxy[1].max(box_xyxy[3]) / height as f32).clamp(0.0, 1.0);
+    let mut best: Option<(u64, usize, Vec<f32>)> = None;
+    for inst in &instances {
+        let grid = inst.mask.shape()[0] as usize;
+        let m: Vec<f32> = inst
+            .mask
+            .as_dtype(mlx_rs::Dtype::Float32)
+            .map_err(|e| WorkerError::Engine(format!("sam3 mask read: {e}")))?
+            .as_slice::<f32>()
+            .to_vec();
+        let mut inside = 0u64;
+        for gy in 0..grid {
+            for gx in 0..grid {
+                if m[gy * grid + gx] > 0.0 {
+                    let cx = (gx as f32 + 0.5) / grid as f32;
+                    let cy = (gy as f32 + 0.5) / grid as f32;
+                    if cx >= nx1 && cx < nx2 && cy >= ny1 && cy < ny2 {
+                        inside += 1;
+                    }
+                }
+            }
+        }
+        if best.as_ref().map_or(true, |(b, _, _)| inside > *b) {
+            best = Some((inside, grid, m));
+        }
+    }
+    let (_, grid, grid_mask) = best.filter(|(inside, _, _)| *inside > 0).ok_or_else(|| {
+        WorkerError::InvalidPayload(
+            "SAM3 found no object in the selection box — try a tighter box or use the brush."
+                .into(),
+        )
+    })?;
+    // Reuse the >0 binarize + resize-to-source path (inverts the 1008² squash back to the frame).
+    Ok(mask_to_frame(&grid_mask, grid, width, height))
+}
+
 /// Every tracked person's per-frame mask + a stable left-to-right paint order — the input to the
 /// SCAIL-2 color-mask painter (sc-5448). Unlike [`segment_track_blocking`] (which selects ONE person
 /// via ByteTrack anchors for replace_person), this keeps EVERY SAM3 object so each person can be
@@ -479,6 +613,26 @@ pub(crate) fn segment_all_persons_in_memory(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn normalize_box_maps_xyxy_pixels_to_unit_cxcywh() {
+        // A 100×200 box at (10,20) on a 200×400 image → center (60,120), size (100,200).
+        let b = normalize_box_cxcywh([10.0, 20.0, 110.0, 220.0], 200, 400);
+        assert!((b[0] - 0.30).abs() < 1e-6, "cx {}", b[0]); // 60/200
+        assert!((b[1] - 0.30).abs() < 1e-6, "cy {}", b[1]); // 120/400
+        assert!((b[2] - 0.50).abs() < 1e-6, "w {}", b[2]); // 100/200
+        assert!((b[3] - 0.50).abs() < 1e-6, "h {}", b[3]); // 200/400
+    }
+
+    #[test]
+    fn normalize_box_orders_corners_and_clamps_to_image() {
+        // Reversed corners + out-of-bounds → ordered + clamped to [0,1].
+        let b = normalize_box_cxcywh([300.0, -50.0, 50.0, 500.0], 200, 400);
+        assert!(b.iter().all(|&v| (0.0..=1.0).contains(&v)), "{b:?}");
+        // x spans [50,200] (clamped from 300) → cx = 125/200 = 0.625, w = 150/200 = 0.75
+        assert!((b[0] - 0.625).abs() < 1e-6, "cx {}", b[0]);
+        assert!((b[2] - 0.75).abs() < 1e-6, "w {}", b[2]);
+    }
 
     #[test]
     fn quant_bits_defaults_to_q8_and_honors_overrides() {
@@ -664,5 +818,86 @@ mod tests {
             );
             eprintln!("frame {i}: fg_frac={frac:.3} containment={containment:.3}");
         }
+    }
+
+    /// Real-weights smoke for the smart-select box path (sc-6105): preprocess →
+    /// `Sam3ImageSegmenter::segment_with_boxes` → pick-best-instance → mask at the source dims,
+    /// against the stock `facebook/sam3` checkpoint. Proves a single box prompt segments the object
+    /// under it (the backend of the sc-3751 canvas tool). `#[ignore]`d (needs the 3.2 GB weights +
+    /// GPU); run with:
+    ///   SCENEWORKS_SAM3_WEIGHTS=<facebook/sam3 snapshot dir> \
+    ///   SCENEWORKS_SAM3_SMOKE_IMAGE=<jpg/png with a clear subject, e.g. zidane.jpg 1280×720> \
+    ///   [SCENEWORKS_SAM3_SMOKE_CONCEPT=<optional text concept>] \
+    ///   cargo test -p sceneworks-worker --release sam3_real_weights_box_segment_smoke -- --ignored --nocapture
+    #[test]
+    #[ignore = "real SAM3 weights + GPU; set SCENEWORKS_SAM3_WEIGHTS + SCENEWORKS_SAM3_SMOKE_IMAGE"]
+    fn sam3_real_weights_box_segment_smoke() {
+        let snap = std::env::var("SCENEWORKS_SAM3_WEIGHTS")
+            .expect("set SCENEWORKS_SAM3_WEIGHTS to a facebook/sam3 snapshot dir");
+        let dir = {
+            let p = PathBuf::from(&snap);
+            if p.is_file() {
+                p.parent().unwrap().to_path_buf()
+            } else {
+                p
+            }
+        };
+        let model = dir.join(MODEL_FILE);
+        let tokenizer = dir.join(TOKENIZER_FILE);
+        let image_path = PathBuf::from(
+            std::env::var("SCENEWORKS_SAM3_SMOKE_IMAGE")
+                .expect("set SCENEWORKS_SAM3_SMOKE_IMAGE to an image with a clear subject"),
+        );
+        let image = crate::image_decode::decode_image_any(&image_path)
+            .expect("decode smoke image")
+            .to_rgb8();
+        let (w, h) = (image.width(), image.height());
+
+        // A box around the prominent foreground subject (zidane.jpg: the central/right player), in
+        // source pixels. The concept defaults to empty (geometric prompt only).
+        let concept = std::env::var("SCENEWORKS_SAM3_SMOKE_CONCEPT").unwrap_or_default();
+        // Default box tightly bounds zidane.jpg's right-hand player; override with
+        // SCENEWORKS_SAM3_SMOKE_BOX="x1,y1,x2,y2" (source pixels) for a different image. A tight box
+        // around ONE object is the realistic smart-select gesture (a loose box spanning multiple
+        // objects is ambiguous by design).
+        let box_xyxy = std::env::var("SCENEWORKS_SAM3_SMOKE_BOX")
+            .ok()
+            .and_then(|s| {
+                let v: Vec<f32> = s.split(',').filter_map(|p| p.trim().parse().ok()).collect();
+                (v.len() == 4).then(|| [v[0], v[1], v[2], v[3]])
+            })
+            .unwrap_or([
+                w as f32 * 0.581,
+                h as f32 * 0.058,
+                w as f32 * 0.894,
+                h as f32 * 0.989,
+            ]);
+        let mask = segment_box_blocking(model, tokenizer, image, box_xyxy, &concept, 0.5, 0.5)
+            .expect("segment_box_blocking");
+
+        assert_eq!(mask.len(), (w * h) as usize, "mask size = source dims");
+        assert!(mask.iter().all(|&v| v == 0 || v == 255), "mask is binary");
+        let fg = mask.iter().filter(|&&v| v > 127).count();
+        let frac = fg as f64 / (w * h) as f64;
+        assert!(
+            (0.02..0.90).contains(&frac),
+            "foreground fraction {frac:.3} implausible (empty or whole-frame)"
+        );
+        // Most emitted foreground sits inside the prompt box.
+        let (x1, y1, x2, y2) = (box_xyxy[0], box_xyxy[1], box_xyxy[2], box_xyxy[3]);
+        let inside = (0..h)
+            .flat_map(|y| (0..w).map(move |x| (x, y)))
+            .filter(|&(x, y)| mask[(y * w + x) as usize] > 127)
+            .filter(|&(x, y)| {
+                let (px, py) = (x as f32 + 0.5, y as f32 + 0.5);
+                px >= x1 && px < x2 && py >= y1 && py < y2
+            })
+            .count();
+        let containment = inside as f64 / fg.max(1) as f64;
+        assert!(
+            containment > 0.5,
+            "mask containment in box {containment:.3} too low (wrong object?)"
+        );
+        eprintln!("box-segment smoke: fg_frac={frac:.3} containment={containment:.3} dims={w}x{h}");
     }
 }

--- a/crates/sceneworks-worker/src/segment_jobs.rs
+++ b/crates/sceneworks-worker/src/segment_jobs.rs
@@ -1,0 +1,371 @@
+//! Smart-select image segmentation on the macOS Rust worker (epic 6087, sc-6105).
+//!
+//! The backend half of the Image Editor's "smart-select" tool (sc-3751): an `image_segment` job
+//! takes a source image asset + a box prompt and returns a binary inpaint mask asset (white-on-black
+//! PNG at the source dims) the editor loads into the existing sc-2436 mask layer / sc-2476 inpaint
+//! seam (`maskAssetId`). It mirrors the standalone `image_upscale` / `image_detail` job shape
+//! (`upscale_jobs`): resolve the `sourceAssetId` against its project, decode, run the engine under
+//! `spawn_blocking`, write one child asset with lineage back to the source.
+//!
+//! Engine: native-MLX **SAM3** box-prompted PVS via `person_segment_sam3::segment_box_blocking`
+//! (the box path of the sc-4926 SAM3 stack — `Sam3ImageSegmenter::segment_with_boxes`, epic 4910
+//! sc-4923). macOS-only, like the SAM3 dependency; the capability is advertised only by the MLX
+//! worker (`gpu.rs mlx_gpu`), so a segment job never routes off-Mac. There is no torch/candle SAM3
+//! image path yet (a Windows/Linux backport is tracked separately).
+
+use std::path::{Path, PathBuf};
+
+use serde_json::{json, Value};
+
+use gen_core::CancelFlag;
+
+use crate::downloads::DownloadContext;
+use crate::person_segment_sam3::{ensure_segmenter_weights, segment_box_blocking};
+use crate::{
+    cancel_requested_peek, fresh_asset_id, heartbeat, mark_job_canceled, now_rfc3339,
+    progress_payload, progress_report_interval, task_join_error, update_job, ApiClient, Settings,
+    WorkerError, WorkerResult,
+};
+use sceneworks_core::contracts::{JobSnapshot, JobStatus, JsonObject, ProgressStage, WorkerStatus};
+use sceneworks_core::project_store::ProjectStore;
+
+/// SAM3 post-process defaults for a single box prompt (the engine parity defaults, geometry_parity
+/// test): keep an instance when `σ(logit)·σ(presence) > THRESHOLD`, binarize its mask at `σ > MASK`.
+const SEGMENT_THRESHOLD: f32 = 0.5;
+const SEGMENT_MASK_THRESHOLD: f32 = 0.5;
+const CANCEL_MESSAGE: &str = "Smart-select canceled by user.";
+
+/// Resolve a `sourceAssetId` to its on-disk media path + the asset's `displayName` via the project
+/// sidecar (mirrors `upscale_jobs::resolve_source` / `image_adapters.find_asset_media_path`).
+fn resolve_source(
+    store: &ProjectStore,
+    project_id: &str,
+    asset_id: &str,
+    project_path: &Path,
+) -> Option<(PathBuf, Option<String>)> {
+    let asset = store.get_asset(project_id, asset_id).ok()?;
+    let rel = asset.get("file")?.get("path")?.as_str()?;
+    let mut path = project_path.to_path_buf();
+    for component in Path::new(rel).components() {
+        if let std::path::Component::Normal(value) = component {
+            path.push(value);
+        } else {
+            return None;
+        }
+    }
+    if !path.exists() {
+        return None;
+    }
+    let display = asset
+        .get("displayName")
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    Some((path, display))
+}
+
+/// Parse `payload.box` (the box prompt in source-image pixel coords). Accepts either the canonical
+/// 4-array `[x1, y1, x2, y2]` or an `{x, y, width, height}` object (the editor's rect shape), so the
+/// frontend can send whichever is convenient.
+fn parse_box(payload: &JsonObject) -> WorkerResult<[f32; 4]> {
+    let value = payload.get("box").ok_or_else(|| {
+        WorkerError::InvalidPayload("Smart-select requires a 'box' prompt.".to_owned())
+    })?;
+    if let Some(arr) = value.as_array() {
+        if arr.len() == 4 {
+            let mut out = [0f32; 4];
+            for (i, slot) in out.iter_mut().enumerate() {
+                *slot = arr[i].as_f64().ok_or_else(|| {
+                    WorkerError::InvalidPayload("Smart-select box must be four numbers.".to_owned())
+                })? as f32;
+            }
+            return Ok(out);
+        }
+    }
+    if let Some(obj) = value.as_object() {
+        let f = |key: &str| obj.get(key).and_then(Value::as_f64).map(|v| v as f32);
+        if let (Some(x), Some(y), Some(w), Some(h)) = (f("x"), f("y"), f("width"), f("height")) {
+            return Ok([x, y, x + w, y + h]);
+        }
+    }
+    Err(WorkerError::InvalidPayload(
+        "Smart-select box must be [x1,y1,x2,y2] or {x,y,width,height}.".to_owned(),
+    ))
+}
+
+/// Heartbeat + cancel poll while the blocking segmentation task runs (mirrors
+/// `upscale_jobs::run_upscale_with_heartbeat`): keeps the worker live during the model load +
+/// inference and propagates a user cancel.
+async fn run_with_heartbeat<R>(
+    api: &ApiClient,
+    settings: &Settings,
+    job_id: &str,
+    cancel: CancelFlag,
+    mut task: tokio::task::JoinHandle<WorkerResult<R>>,
+) -> WorkerResult<R>
+where
+    R: Send + 'static,
+{
+    let mut canceled = false;
+    let mut interval = tokio::time::interval(progress_report_interval(settings));
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        tokio::select! {
+            result = &mut task => {
+                let value = result.map_err(|error| task_join_error("smart-select task", error))??;
+                if canceled {
+                    mark_job_canceled(api, job_id, CANCEL_MESSAGE).await?;
+                    return Err(WorkerError::Canceled(CANCEL_MESSAGE.to_owned()));
+                }
+                return Ok(value);
+            }
+            _ = interval.tick() => {
+                heartbeat(api, settings, WorkerStatus::Busy, Some(job_id)).await?;
+                if !canceled && cancel_requested_peek(api, job_id).await {
+                    cancel.cancel();
+                    canceled = true;
+                }
+            }
+        }
+    }
+}
+
+pub(crate) async fn run_image_segment_job(
+    api: &ApiClient,
+    settings: &Settings,
+    http_client: &reqwest::Client,
+    job: &JobSnapshot,
+) -> WorkerResult<()> {
+    heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+    update_job(
+        api,
+        &job.id,
+        progress_payload(
+            JobStatus::Preparing,
+            ProgressStage::Preparing,
+            0.12,
+            "Loading source image.",
+            None,
+            None,
+            None,
+        ),
+    )
+    .await?;
+
+    let payload = &job.payload;
+    let source_asset_id = payload
+        .get("sourceAssetId")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload("Smart-select requires a source image asset.".to_owned())
+        })?
+        .to_owned();
+    let box_xyxy = parse_box(payload)?;
+    // The optional text concept paired with the box (SAM3 PVS is text⊕box). Empty = rely on the
+    // geometric prompt — the smart-select default, since the user draws a box around any object.
+    let concept = payload
+        .get("concept")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_owned();
+    let threshold = payload
+        .get("threshold")
+        .and_then(Value::as_f64)
+        .map(|v| v.clamp(0.0, 1.0) as f32)
+        .unwrap_or(SEGMENT_THRESHOLD);
+    let mask_threshold = payload
+        .get("maskThreshold")
+        .and_then(Value::as_f64)
+        .map(|v| v.clamp(0.0, 1.0) as f32)
+        .unwrap_or(SEGMENT_MASK_THRESHOLD);
+
+    let project_id = payload
+        .get("projectId")
+        .and_then(Value::as_str)
+        .or(job.project_id.as_deref())
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload("Smart-select requires a projectId.".to_owned())
+        })?
+        .to_owned();
+    let store = ProjectStore::new(settings.data_dir.clone(), "worker");
+    let project = store
+        .get_project(&project_id)
+        .map_err(|e| WorkerError::InvalidPayload(format!("project not found: {e}")))?;
+    let project_path = PathBuf::from(project.path);
+    let (source_path, source_display) =
+        resolve_source(&store, &project_id, &source_asset_id, &project_path).ok_or_else(|| {
+            WorkerError::InvalidPayload(format!(
+                "Source image asset not found or missing: {source_asset_id}."
+            ))
+        })?;
+
+    let source_image = crate::image_decode::decode_image_any(&source_path)
+        .map_err(|e| WorkerError::InvalidPayload(format!("Source image could not be loaded: {e}")))?
+        .to_rgb8();
+    let (src_w, src_h) = (source_image.width(), source_image.height());
+
+    update_job(
+        api,
+        &job.id,
+        progress_payload(
+            JobStatus::Running,
+            ProgressStage::Downloading,
+            0.25,
+            "Loading SAM3 weights.",
+            None,
+            None,
+            None,
+        ),
+    )
+    .await?;
+    let context = DownloadContext {
+        api,
+        client: http_client,
+        settings,
+        job_id: &job.id,
+        cancel_message: "Smart-select canceled while fetching SAM3 weights.",
+        fresh_download: false,
+    };
+    let (model_path, tokenizer_path) = ensure_segmenter_weights(settings, &context).await?;
+
+    update_job(
+        api,
+        &job.id,
+        progress_payload(
+            JobStatus::Running,
+            ProgressStage::Running,
+            0.5,
+            "Segmenting the selection.",
+            None,
+            None,
+            None,
+        ),
+    )
+    .await?;
+    let cancel = CancelFlag::new();
+    let mask = run_with_heartbeat(
+        api,
+        settings,
+        &job.id,
+        cancel.clone(),
+        tokio::task::spawn_blocking(move || {
+            segment_box_blocking(
+                model_path,
+                tokenizer_path,
+                source_image,
+                box_xyxy,
+                &concept,
+                threshold,
+                mask_threshold,
+            )
+        }),
+    )
+    .await?;
+
+    // The mask is a row-major `src_w*src_h` 0/255 grayscale buffer (white = the selected region).
+    let mask_image = image::GrayImage::from_raw(src_w, src_h, mask)
+        .ok_or_else(|| WorkerError::Engine("smart-select mask buffer size mismatch".to_owned()))?;
+
+    // Write exactly one child asset (the mask PNG) with lineage back to the source, mirroring the
+    // upscale/detail asset-write shape so the API materializes it into `result.assets`.
+    let created_at = now_rfc3339();
+    let generation_set_id = format!("genset_{}", uuid::Uuid::new_v4().simple());
+    let asset_id = fresh_asset_id();
+    let date = &created_at[..10];
+    let suffix: String = asset_id.chars().skip(6).take(8).collect();
+    let filename = format!("{date}_mask_{suffix}.png");
+    let media_rel = format!("assets/images/{generation_set_id}/{filename}");
+    let media_path = project_path.join(&media_rel);
+    if let Some(parent) = media_path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let tmp_path = media_path.with_extension("tmp.png");
+    mask_image
+        .save_with_format(&tmp_path, image::ImageFormat::Png)
+        .map_err(|e| WorkerError::Io(std::io::Error::other(e)))?;
+    tokio::fs::rename(&tmp_path, &media_path)
+        .await
+        .inspect_err(|_| {
+            let _ = std::fs::remove_file(&tmp_path);
+        })?;
+
+    let source_name = payload
+        .get("displayName")
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .or(source_display)
+        .unwrap_or_else(|| "Image".to_owned());
+    let fact = json!({
+        "assetId": asset_id,
+        "mediaPath": media_rel,
+        "mimeType": "image/png",
+        "type": "image",
+        "width": src_w,
+        "height": src_h,
+        "normalizedWidth": src_w,
+        "normalizedHeight": src_h,
+        "count": 1,
+        "seed": 0,
+        "displayName": format!("{source_name} (mask)"),
+        "createdAt": created_at.clone(),
+        "mode": "image_segment",
+        "model": "sam3",
+        "adapter": "sam3",
+        "prompt": "",
+        "negativePrompt": "",
+        "loras": [],
+        "stylePreset": "",
+        "sourceAssetId": source_asset_id,
+        "rawAdapterSettings": {
+            "segment": {
+                "engine": "sam3",
+                "box": box_xyxy,
+                "threshold": threshold,
+                "maskThreshold": mask_threshold,
+            }
+        },
+        "parents": [source_asset_id],
+        "extra": {
+            "isMask": true,
+            "maskOfAssetId": source_asset_id,
+        },
+    });
+    let generation_set = json!({
+        "id": generation_set_id,
+        "mode": "image_segment",
+        "model": "sam3",
+        "prompt": "",
+        "negativePrompt": "",
+        "count": 1,
+        "createdAt": created_at,
+    });
+    let mut result = JsonObject::new();
+    result.insert(
+        "generationSetId".to_owned(),
+        Value::String(generation_set_id),
+    );
+    result.insert("expectedCount".to_owned(), json!(1));
+    result.insert("adapter".to_owned(), Value::String("sam3".to_owned()));
+    result.insert("model".to_owned(), Value::String("sam3".to_owned()));
+    result.insert("generationSet".to_owned(), generation_set);
+    result.insert("assetWrites".to_owned(), Value::Array(vec![fact]));
+
+    update_job(
+        api,
+        &job.id,
+        progress_payload(
+            JobStatus::Completed,
+            ProgressStage::Completed,
+            1.0,
+            "Smart-select complete.",
+            None,
+            Some(result),
+            None,
+        ),
+    )
+    .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/sceneworks-worker/src/segment_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/segment_jobs/tests.rs
@@ -1,0 +1,33 @@
+use super::*;
+use serde_json::json;
+
+fn obj(value: Value) -> JsonObject {
+    value.as_object().unwrap().clone()
+}
+
+#[test]
+fn parse_box_accepts_xyxy_array() {
+    let payload = obj(json!({ "box": [10.0, 20.0, 110.0, 220.0] }));
+    assert_eq!(parse_box(&payload).unwrap(), [10.0, 20.0, 110.0, 220.0]);
+}
+
+#[test]
+fn parse_box_accepts_rect_object() {
+    // {x,y,width,height} → [x, y, x+w, y+h] (the editor's rect shape).
+    let payload = obj(json!({ "box": { "x": 10.0, "y": 20.0, "width": 100.0, "height": 200.0 } }));
+    assert_eq!(parse_box(&payload).unwrap(), [10.0, 20.0, 110.0, 220.0]);
+}
+
+#[test]
+fn parse_box_accepts_integer_json_numbers() {
+    let payload = obj(json!({ "box": [10, 20, 110, 220] }));
+    assert_eq!(parse_box(&payload).unwrap(), [10.0, 20.0, 110.0, 220.0]);
+}
+
+#[test]
+fn parse_box_rejects_missing_or_malformed() {
+    assert!(parse_box(&obj(json!({}))).is_err());
+    assert!(parse_box(&obj(json!({ "box": [1.0, 2.0, 3.0] }))).is_err());
+    assert!(parse_box(&obj(json!({ "box": "nope" }))).is_err());
+    assert!(parse_box(&obj(json!({ "box": { "x": 1.0, "y": 2.0 } }))).is_err());
+}

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -623,6 +623,9 @@ fn mlx_gpu_capability_set_matches_expected_full_set() {
         WorkerCapability::PoseDetect,
         WorkerCapability::KpsExtract,
         WorkerCapability::ImageUpscale,
+        // sc-6105: smart-select segmentation (native-MLX SAM3 box-prompt) — Mac-only, advertised
+        // only here so an `image_segment` job routes to the MLX worker by construction.
+        WorkerCapability::ImageSegment,
         WorkerCapability::VideoUpscale,
         WorkerCapability::PersonDetect,
         WorkerCapability::PersonTrack,


### PR DESCRIPTION
Implements **[sc-6105](https://app.shortcut.com/trefry/story/6105)** (epic 6087, Workstream B) — the backend half of smart-select: a new `image_segment` worker job that turns a source image + a box prompt into a binary inpaint mask asset (white-on-black PNG at source dims) for the Image Editor. Native-MLX **SAM3**, macOS-only. Pairs with [sc-3751](https://app.shortcut.com/trefry/story/3751) (the frontend canvas tool).

## Full job-type sync surface (mirrors `image_upscale` / `image_detail`)
- **core** (`sceneworks-core`): `JobType::ImageSegment` + `WorkerCapability::ImageSegment`; `job_requires_gpu`; `mac_rust_supported` (`Ok` on Mac); `mac_capabilities` `imageSegment` feature; OOM hint.
- **worker**: `mlx_gpu` advertises `ImageSegment` — **only** the Mac MLX worker advertises it, so a segment job routes to the Mac worker by construction (no torch/candle gate needed, unlike SeedVR2); `#[cfg(target_os = "macos")]` dispatch arm; new `segment_jobs::run_image_segment_job` (resolve source → decode → run under `spawn_blocking` → write one mask asset with source lineage, the upscale asset-write shape that materializes into `result.assets`).
- **engine** (`person_segment_sam3::segment_box_blocking`): `Sam3ImageSegmenter::segment_with_boxes` on the shared (cached) SAM3 checkpoint, reusing the existing `input_tensor` / `mask_to_frame` / weight-resolution helpers. Box normalized to cxcywh (SAM3's uniform 1008² squash → no letterbox math). Picks the instance whose **mask** has the most foreground inside the prompt box (robust to SAM3's degenerate box-echo query and to a loose box), then resizes the 288² mask to source dims.
- **web**: `image_segment` added to `GPU_REQUIRED_JOB_TYPES`.

## Notes
- **No new API route/DTO**: the generic `POST /api/v1/jobs` already accepts any `JobType` + payload (the detail/upscale path), so the enum variant is sufficient.
- **No contract-snapshot change**: no snapshot captures the JobType/WorkerCapability sets or the global capabilities feature map (verified).
- **Scope = box prompts only.** SAM3's image API is box-only (no point path exists in `mlx-gen-sam3`, and SAM3 PVS is box/exemplar-based unlike SAM2). Point (fg/bg click) support is filed as **[sc-6346](https://app.shortcut.com/trefry/story/6346)** (engine work) — surfaced, not dropped. Off-Mac is unsupported like all SAM paths (epic 3792 lineage).

## Validation
- core **224** + worker **340** unit tests green (incl. new `parse_box` + `normalize_box_cxcywh` tests, and the updated capability-set / mac-feature assertions); `clippy -D warnings` clean.
- web **549** tests + lint + `vite build` clean.
- **Real-GPU E2E smoke** (`#[ignore]` `sam3_real_weights_box_segment_smoke`) on stock `facebook/sam3` @ 128GB Mac (zidane.jpg, concept-free tight box): **fg_frac 0.152, containment 0.993** — a tight, well-contained mask of the boxed object. Finding: SAM3 box-PVS works best with a reasonably tight box (a loose box spanning multiple objects is ambiguous by design); the mask-in-box selector handles SAM3's box-echo query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)