### PR TITLE
sc-6220: route qwen_image_edit_2511_lightning to the candle QwenEdit lane off-Mac

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c683c43d76b5940c03764dbfb18aa4ed069d8aa1#c683c43d76b5940c03764dbfb18aa4ed069d8aa1"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -444,7 +444,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_distr 0.5.1",
  "safetensors 0.7.0",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=51a6792db3a1c94d23a9ae00e2414665b8c2c9f7)",
+ "sceneworks-gen-core",
  "serde_json",
  "thiserror 2.0.18",
 ]
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c683c43d76b5940c03764dbfb18aa4ed069d8aa1#c683c43d76b5940c03764dbfb18aa4ed069d8aa1"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c683c43d76b5940c03764dbfb18aa4ed069d8aa1#c683c43d76b5940c03764dbfb18aa4ed069d8aa1"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c683c43d76b5940c03764dbfb18aa4ed069d8aa1#c683c43d76b5940c03764dbfb18aa4ed069d8aa1"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c683c43d76b5940c03764dbfb18aa4ed069d8aa1#c683c43d76b5940c03764dbfb18aa4ed069d8aa1"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c683c43d76b5940c03764dbfb18aa4ed069d8aa1#c683c43d76b5940c03764dbfb18aa4ed069d8aa1"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -519,7 +519,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c683c43d76b5940c03764dbfb18aa4ed069d8aa1#c683c43d76b5940c03764dbfb18aa4ed069d8aa1"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -530,7 +530,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c683c43d76b5940c03764dbfb18aa4ed069d8aa1#c683c43d76b5940c03764dbfb18aa4ed069d8aa1"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c683c43d76b5940c03764dbfb18aa4ed069d8aa1#c683c43d76b5940c03764dbfb18aa4ed069d8aa1"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -557,7 +557,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c683c43d76b5940c03764dbfb18aa4ed069d8aa1#c683c43d76b5940c03764dbfb18aa4ed069d8aa1"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -569,7 +569,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c683c43d76b5940c03764dbfb18aa4ed069d8aa1#c683c43d76b5940c03764dbfb18aa4ed069d8aa1"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -580,7 +580,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c683c43d76b5940c03764dbfb18aa4ed069d8aa1#c683c43d76b5940c03764dbfb18aa4ed069d8aa1"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -597,13 +597,14 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c683c43d76b5940c03764dbfb18aa4ed069d8aa1#c683c43d76b5940c03764dbfb18aa4ed069d8aa1"
 dependencies = [
  "candle-gen",
  "candle-transformers",
  "inventory",
  "rand 0.9.4",
  "rand_distr 0.5.1",
+ "safetensors 0.7.0",
  "serde_json",
  "tokenizers 0.22.2",
 ]
@@ -611,7 +612,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c683c43d76b5940c03764dbfb18aa4ed069d8aa1#c683c43d76b5940c03764dbfb18aa4ed069d8aa1"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -629,7 +630,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c683c43d76b5940c03764dbfb18aa4ed069d8aa1#c683c43d76b5940c03764dbfb18aa4ed069d8aa1"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -640,7 +641,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c683c43d76b5940c03764dbfb18aa4ed069d8aa1#c683c43d76b5940c03764dbfb18aa4ed069d8aa1"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -653,7 +654,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c683c43d76b5940c03764dbfb18aa4ed069d8aa1#c683c43d76b5940c03764dbfb18aa4ed069d8aa1"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -664,7 +665,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c683c43d76b5940c03764dbfb18aa4ed069d8aa1#c683c43d76b5940c03764dbfb18aa4ed069d8aa1"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -677,7 +678,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c683c43d76b5940c03764dbfb18aa4ed069d8aa1#c683c43d76b5940c03764dbfb18aa4ed069d8aa1"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -3288,7 +3289,7 @@ source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e23a8b7ae3b01b433d8fa
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=e23a8b7ae3b01b433d8fa2fec02d2288cefbc302)",
+ "sceneworks-gen-core",
  "thiserror 2.0.18",
  "tokenizers 0.21.4",
 ]
@@ -5175,18 +5176,6 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=51a6792db3a1c94d23a9ae00e2414665b8c2c9f7#51a6792db3a1c94d23a9ae00e2414665b8c2c9f7"
-dependencies = [
- "inventory",
- "safetensors 0.4.5",
- "serde_json",
- "thiserror 2.0.18",
- "tokenizers 0.21.4",
-]
-
-[[package]]
-name = "sceneworks-gen-core"
-version = "0.1.0"
 source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e23a8b7ae3b01b433d8fa2fec02d2288cefbc302#e23a8b7ae3b01b433d8fa2fec02d2288cefbc302"
 dependencies = [
  "inventory",
@@ -5288,7 +5277,7 @@ dependencies = [
  "pmetal-mlx-rs",
  "reqwest 0.12.28",
  "sceneworks-core",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=e23a8b7ae3b01b433d8fa2fec02d2288cefbc302)",
+ "sceneworks-gen-core",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3374,11 +3374,15 @@ fn image_job_is_candle_eligible(job: &JobSnapshot) -> bool {
     // `edit_image` job with a source image is the bespoke candle `QwenEdit` lane
     // (`generate_candle_qwen_edit_stream`), NOT txt2img — and `qwen_image_edit*` are not candle txt2img
     // ids (the gate below only knows `qwen_image`), so they would fall through to torch. Branch it out
-    // first. Off-Mac this was a torch fallback. The `-2511_lightning` distill needs a LoRA the candle
-    // provider lacks, so it is excluded (stays MLX/torch). Mirrors the worker's `qwen_edit_candle_available`.
+    // first. Off-Mac this was a torch fallback. The `-2511_lightning` distill is the same `-2511` base
+    // with the lightx2v 4-step LoRA folded into the MMDiT at load (sc-6220), so it routes to candle too.
+    // Mirrors the worker's `qwen_edit_candle_available`.
     if matches!(
         model,
-        "qwen_image_edit" | "qwen_image_edit_2509" | "qwen_image_edit_2511"
+        "qwen_image_edit"
+            | "qwen_image_edit_2509"
+            | "qwen_image_edit_2511"
+            | "qwen_image_edit_2511_lightning"
     ) && qwen_edit_candle_eligible(&job.payload)
     {
         return true;
@@ -5356,11 +5360,13 @@ mod candle_routing_tests {
         }))));
         // sc-5487: a Qwen-Image-Edit edit (`edit_image` + a source) is now the candle `QwenEdit` lane
         // (dual-latent reference editing). Off-Mac this was a torch fallback; the candle worker CLAIMS
-        // it for the non-lightning variants (all map to the single edit engine model).
+        // it. The `-2511_lightning` distill (sc-6220) is the same `-2511` base with the lightx2v 4-step
+        // LoRA folded into the MMDiT at load, so it is candle-claimed too.
         for model in [
             "qwen_image_edit",
             "qwen_image_edit_2509",
             "qwen_image_edit_2511",
+            "qwen_image_edit_2511_lightning",
         ] {
             assert!(
                 worker_supports_job(
@@ -5371,16 +5377,9 @@ mod candle_routing_tests {
                         "sourceAssetId": "asset_1"
                     }))
                 ),
-                "candle worker should claim {model} edit (sc-5487)"
+                "candle worker should claim {model} edit (sc-5487 / sc-6220)"
             );
         }
-        // The -2511_lightning distill needs the 4-step LoRA the candle provider lacks → NOT claimed by
-        // candle; it stays on the MLX/torch path.
-        assert!(!image_job_is_candle_eligible(&image_generate_job(json!({
-            "model": "qwen_image_edit_2511_lightning",
-            "mode": "edit_image",
-            "sourceAssetId": "asset_1"
-        }))));
         // A Qwen-Image-Edit job with no source image is not the edit lane → not claimed (would defer).
         assert!(!image_job_is_candle_eligible(&image_generate_job(json!({
             "model": "qwen_image_edit",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -145,6 +145,14 @@ sceneworks-core = { path = "../sceneworks-core" }
 # gen-core rev 51a6792 (= the mlx pin), closing the sc-5905/sc-6067 candle-lane skew. No worker logic
 # change — width/height pass through. GPU-validated (RTX PRO 6000): 1536² edit coherent (no corrupted
 # tail) + 1024² regression unchanged.
+# Rev c4641cb -> c683c43 (candle-gen #103, sc-6220): added the Qwen-Image-Edit LoRA/LoKr merge + the
+# Qwen-Image-Edit-2511-Lightning few-step distill to `candle-gen-qwen-image::QwenEdit` (the route below
+# now stacks the lightx2v 4-step LoRA + runs the CFG-off lightning schedule). a13904d is the provider
+# content commit; c683c43 then re-pins candle-gen's gen-core 51a6792 -> e23a8b7 (BYTE-IDENTICAL gen-core,
+# empty tree diff) to track THIS worker's mlx pin, which advanced to e23a8b7 AFTER #92/#95. The
+# `--features backend-candle` graph again resolves a SINGLE gen-core rev e23a8b7 (= the mlx pin).
+# GPU-validated (RTX PRO 6000): 4-step lightning edit coherent (std 58/68, prompt diff 74) + empty-adapter
+# production regression byte-identical to the prior run.
 # Rev 98592bb (mlx-gen #485 merged, sc-6067): bumps every mlx-gen crate 7b89d45 -> 98592bb to spatially
 # tile the SeedVR2 *image* upscale path. The image path (`Seedvr2Pipeline::generate`) ran the whole frame
 # in ONE pass with no memory-budget check, so a large upscale tried a single DiT/VAE allocation past
@@ -861,46 +869,44 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e23a
 # before. Standing Linux-compile validation is the new manual `desktop-candle-linux` CI lane (the Linux
 # sibling of `desktop-candle-windows.yml`); the gen-core single-rev invariant is unchanged (same pins).
 # candle-gen pin re-pinned in lockstep with the worker's mlx-gen pin so `--features backend-candle`
-# resolves ONE `sceneworks-gen-core` rev (the skew gate). Current: candle-gen `c98609f` (candle-gen #87,
-# sc-5487) = candle-gen main (#85 `SdxlEdit` img2img/inpaint/outpaint provider + #86 sc-6038 InstantID
-# user-LoRA) with the gen-core pin re-pinned to `3714e7b` to MATCH this worker's `3714e7b` mlx pin. NB:
-# candle-gen main had been re-pinned to gen-core `aeb471b` by #86 (sc-6038), AHEAD of the worker; #87
-# brings it back to `3714e7b` (the worker's actual pin) — `aeb471b`/`3714e7b` have BYTE-IDENTICAL gen-core
-# (the delta is the single additive sc-6038 mlx-gen-instantid commit), so behavior-neutral. The candle
-# SDXL edit worker route (`image_jobs/sdxl_edit_candle.rs`) drives candle-gen-sdxl's `SdxlEdit` off-Mac.
+# resolves ONE `sceneworks-gen-core` rev (the skew gate). Current: candle-gen `c683c43` (candle-gen #103,
+# sc-6220) = candle-gen main + the Qwen-Image-Edit LoRA/LoKr merge + 2511-Lightning few-step distill,
+# with its gen-core pin re-pinned `51a6792` -> `e23a8b7` to MATCH this worker's `e23a8b7` mlx pin (the
+# gen-core tree is byte-identical, so behavior-neutral). The candle Qwen-Image-Edit worker route
+# (`image_jobs/qwen_edit_candle.rs`) drives candle-gen-qwen-image's `QwenEdit` off-Mac.
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c683c43d76b5940c03764dbfb18aa4ed069d8aa1", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c683c43d76b5940c03764dbfb18aa4ed069d8aa1", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c683c43d76b5940c03764dbfb18aa4ed069d8aa1", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c683c43d76b5940c03764dbfb18aa4ed069d8aa1", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c683c43d76b5940c03764dbfb18aa4ed069d8aa1", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c683c43d76b5940c03764dbfb18aa4ed069d8aa1", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c683c43d76b5940c03764dbfb18aa4ed069d8aa1", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c683c43d76b5940c03764dbfb18aa4ed069d8aa1", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c683c43d76b5940c03764dbfb18aa4ed069d8aa1", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c683c43d76b5940c03764dbfb18aa4ed069d8aa1", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -909,19 +915,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c683c43d76b5940c03764dbfb18aa4ed069d8aa1", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c683c43d76b5940c03764dbfb18aa4ed069d8aa1", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c683c43d76b5940c03764dbfb18aa4ed069d8aa1", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -930,12 +936,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c683c43d76b5940c03764dbfb18aa4ed069d8aa1", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c683c43d76b5940c03764dbfb18aa4ed069d8aa1", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -943,7 +949,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c683c43d76b5940c03764dbfb18aa4ed069d8aa1", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -952,7 +958,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c683c43d76b5940c03764dbfb18aa4ed069d8aa1", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -960,7 +966,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c683c43d76b5940c03764dbfb18aa4ed069d8aa1", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -969,7 +975,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c683c43d76b5940c03764dbfb18aa4ed069d8aa1", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs
@@ -19,22 +19,40 @@
 
 /// Qwen-Image-Edit denoise steps default (the production, non-distilled variants).
 const QWEN_EDIT_CANDLE_DEFAULT_STEPS: u32 = 30;
+/// Qwen-Image-Edit-2511-Lightning few-step distill: 4-step default, matching the 4-step distill LoRA (sc-6220).
+const QWEN_EDIT_CANDLE_LIGHTNING_STEPS: u32 = 4;
 /// True-CFG guidance default.
 const QWEN_EDIT_CANDLE_DEFAULT_GUIDANCE: f32 = 4.0;
 /// The adapter/engine id recorded on candle Qwen-Image-Edit assets + telemetry.
 const QWEN_EDIT_CANDLE_ENGINE: &str = "candle_qwen_edit";
 /// Default Qwen-Image-Edit base repo when the manifest omits `repo`.
 const QWEN_EDIT_CANDLE_DEFAULT_REPO: &str = "Qwen/Qwen-Image-Edit";
+/// The Qwen-Image-Edit-2511 base repo — the Lightning distill is `-2511` + the lightx2v LoRA (sc-6220).
+const QWEN_EDIT_CANDLE_2511_REPO: &str = "Qwen/Qwen-Image-Edit-2511";
+/// The lightx2v Qwen-Image-Edit-2511-Lightning distill LoRA (4-step bf16), fetched lazily into the HF
+/// cache on first use — mirrors the MLX `qwen_edit_lightning` (sc-3398) repo/file.
+const QWEN_EDIT_CANDLE_LIGHTNING_LORA_REPO: &str = "lightx2v/Qwen-Image-Edit-2511-Lightning";
+const QWEN_EDIT_CANDLE_LIGHTNING_LORA_FILE: &str =
+    "Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors";
 
-/// Qwen-Image-Edit model ids the candle edit route accepts. All non-lightning variants map to the
-/// single edit engine model (the architecture is identical; `-2511` only flips `zero_cond_t`, which
-/// `QwenEdit` auto-detects from `transformer/config.json`). The `-2511_lightning` distill needs the
-/// 4-step LoRA — `QwenEdit` has no LoRA support — so it stays on the MLX / torch path.
+/// Qwen-Image-Edit model ids the candle edit route accepts. The base variants map to the single edit
+/// engine (the architecture is identical; `-2511` only flips `zero_cond_t`, which `QwenEdit` auto-detects
+/// from `transformer/config.json`). The `-2511_lightning` distill is the same `-2511` base with the
+/// lightx2v 4-step LoRA folded into the MMDiT at load + the CFG-off static-shift lightning schedule (sc-6220).
 fn is_qwen_edit_candle_model(model: &str) -> bool {
     matches!(
         model,
-        "qwen_image_edit" | "qwen_image_edit_2509" | "qwen_image_edit_2511"
+        "qwen_image_edit"
+            | "qwen_image_edit_2509"
+            | "qwen_image_edit_2511"
+            | "qwen_image_edit_2511_lightning"
     )
+}
+
+/// The Qwen-Image-Edit-2511-Lightning few-step distill variant (sc-6220): `QwenEdit` folds the lightx2v
+/// LoRA into the MMDiT at load and runs the CFG-off lightning schedule (4 steps).
+fn is_qwen_edit_lightning(model: &str) -> bool {
+    model == "qwen_image_edit_2511_lightning"
 }
 
 /// True when this is a candle-eligible Qwen edit job: a Qwen-Image-Edit `edit_image` job with a source
@@ -43,15 +61,21 @@ fn qwen_edit_candle_mode(request: &ImageRequest) -> bool {
     request.mode == "edit_image" && non_empty(&request.source_asset_id)
 }
 
-/// The Qwen-Image-Edit base repo for this request: manifest `repo` else the default.
+/// The Qwen-Image-Edit base repo for this request: manifest `repo` else the family default — the
+/// Lightning distill's base is `-2511` (sc-6220); the other variants default to the `Qwen-Image-Edit` alias.
 fn qwen_edit_candle_repo(request: &ImageRequest) -> String {
+    let default = if is_qwen_edit_lightning(&request.model) {
+        QWEN_EDIT_CANDLE_2511_REPO
+    } else {
+        QWEN_EDIT_CANDLE_DEFAULT_REPO
+    };
     request
         .model_manifest_entry
         .get("repo")
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .unwrap_or(QWEN_EDIT_CANDLE_DEFAULT_REPO)
+        .unwrap_or(default)
         .to_owned()
 }
 
@@ -83,11 +107,20 @@ fn resolve_qwen_edit_candle_base(
 fn qwen_edit_candle_available(request: &ImageRequest, settings: &Settings) -> bool {
     is_qwen_edit_candle_model(&request.model)
         && qwen_edit_candle_mode(request)
-        && matches!(resolve_qwen_edit_candle_base(request, settings), Ok(Some(_)))
+        && matches!(
+            resolve_qwen_edit_candle_base(request, settings),
+            Ok(Some(_))
+        )
 }
 
-/// Resolve denoise steps: `advanced.steps` (clamped 1..=50) → manifest `steps` → default (30).
+/// Resolve denoise steps: `advanced.steps` (clamped 1..=50) → manifest `steps` → family default
+/// (Lightning → 4, else 30).
 fn qwen_edit_candle_steps(request: &ImageRequest) -> u32 {
+    let default = if is_qwen_edit_lightning(&request.model) {
+        QWEN_EDIT_CANDLE_LIGHTNING_STEPS
+    } else {
+        QWEN_EDIT_CANDLE_DEFAULT_STEPS
+    };
     let parse = |value: &Value| {
         value
             .as_u64()
@@ -99,7 +132,7 @@ fn qwen_edit_candle_steps(request: &ImageRequest) -> u32 {
         .and_then(parse)
         .or_else(|| request.model_manifest_entry.get("steps").and_then(parse))
         .map(|steps| steps.clamp(1, 50) as u32)
-        .unwrap_or(QWEN_EDIT_CANDLE_DEFAULT_STEPS)
+        .unwrap_or(default)
 }
 
 /// Resolve guidance: `advanced.guidanceScale` → manifest `guidanceScale` → default (4.0), clamped.
@@ -164,6 +197,85 @@ fn load_qwen_edit_source(
     )
 }
 
+/// Ensure the lightx2v distill LoRA (`file` from HuggingFace `repo`) is materialized in the shared HF
+/// hub cache, returning its absolute path (sc-6220). Fast-paths when already cached; else fetches just
+/// that one file into the standard `models--<org>--<name>` layout (deduping with the Python loader +
+/// other tools, sc-1904). The candle off-Mac twin of the MLX `qwen.rs::ensure_distill_lora_cached`
+/// (sc-3398) — fully qualified because this file is `include!`d into the candle `image_jobs` build,
+/// which does not import the MLX download helpers.
+async fn ensure_qwen_lightning_lora_cached(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    repo: &str,
+    file: &str,
+) -> WorkerResult<PathBuf> {
+    // Fast path: already materialized in the hub cache (the common case after first use).
+    if let Some(snapshot_dir) =
+        crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, repo)
+    {
+        let candidate = snapshot_dir.join(file);
+        if candidate.is_file() {
+            return Ok(candidate);
+        }
+    }
+    let repo_dir = sceneworks_core::hf_home::huggingface_repo_cache_path(&settings.data_dir, repo)
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload(format!(
+                "Unable to resolve Hugging Face cache path for {repo}."
+            ))
+        })?;
+    let revision = "main";
+    let client = reqwest::Client::new();
+    let snapshot = crate::downloads::HuggingFaceSnapshot::resolve(
+        &client,
+        settings,
+        repo,
+        revision,
+        &[file.to_owned()],
+    )
+    .await?;
+    if snapshot.files.is_empty() {
+        return Err(WorkerError::InvalidPayload(format!(
+            "Distill LoRA {file} not found in Hugging Face repo {repo}."
+        )));
+    }
+    let mut progress = crate::downloads::DownloadProgress::new(
+        repo,
+        crate::directory_size(&repo_dir.join("blobs")).await,
+        snapshot.total_bytes(),
+        crate::progress_report_interval(settings),
+    );
+    crate::downloads::download_snapshot_into_cache(
+        &crate::downloads::DownloadContext {
+            api,
+            client: &client,
+            settings,
+            job_id: &job.id,
+            cancel_message: "Generation canceled while fetching the Lightning distill LoRA.",
+            fresh_download: false,
+        },
+        &repo_dir,
+        revision,
+        &snapshot,
+        &mut progress,
+    )
+    .await?;
+    let snapshot_dir = crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, repo)
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload(format!(
+                "Hugging Face snapshot for {repo} missing after download."
+            ))
+        })?;
+    let path = snapshot_dir.join(file);
+    if !path.is_file() {
+        return Err(WorkerError::InvalidPayload(format!(
+            "Distill LoRA {file} missing from the {repo} snapshot after download."
+        )));
+    }
+    Ok(path)
+}
+
 /// Real candle Qwen-Image-Edit generation: resolve the source + base on the async side, then load
 /// `QwenEdit` once + generate each image on the blocking thread. The provider condition-resizes the
 /// reference internally, so the source is passed as-is (no render-size pre-fit). `request.count` edits
@@ -189,10 +301,42 @@ async fn generate_candle_qwen_edit_stream(
     let (width, height) = (request.width, request.height);
     let reference = load_qwen_edit_source(request, project_path, settings)?;
 
+    let lightning = is_qwen_edit_lightning(&request.model);
     let steps = qwen_edit_candle_steps(request);
-    let guidance = qwen_edit_candle_guidance(request);
+    // Lightning is CFG-distilled → run CFG-off (guidance 1.0); the provider forces a single forward when
+    // `lightning` is set, so guidance is recorded for telemetry only there.
+    let guidance = if lightning {
+        1.0
+    } else {
+        qwen_edit_candle_guidance(request)
+    };
     let repo = qwen_edit_candle_repo(request);
-    let raw_settings = qwen_edit_candle_raw_settings(request, &repo, steps, guidance);
+    // The lightx2v distill LoRA, lazily fetched into the HF cache — `QwenEdit` folds it into the MMDiT at
+    // load (sc-6220). Empty for the production (multi-step true-CFG) variants.
+    let adapters: Vec<AdapterSpec> = if lightning {
+        let lora = ensure_qwen_lightning_lora_cached(
+            api,
+            settings,
+            job,
+            QWEN_EDIT_CANDLE_LIGHTNING_LORA_REPO,
+            QWEN_EDIT_CANDLE_LIGHTNING_LORA_FILE,
+        )
+        .await?;
+        vec![AdapterSpec::new(lora, 1.0, AdapterKind::Lora)]
+    } else {
+        Vec::new()
+    };
+    let mut raw_settings = qwen_edit_candle_raw_settings(request, &repo, steps, guidance);
+    // Record the Lightning recipe for telemetry / A-B parity (matches the MLX `distillLora` key format).
+    if lightning {
+        raw_settings.insert("sampler".to_owned(), Value::String("lightning".to_owned()));
+        raw_settings.insert(
+            "distillLora".to_owned(),
+            Value::String(format!(
+                "{QWEN_EDIT_CANDLE_LIGHTNING_LORA_REPO}/{QWEN_EDIT_CANDLE_LIGHTNING_LORA_FILE}"
+            )),
+        );
+    }
 
     // Per-image work items: (seed, prompt) — `request.count` edits of the same source.
     let work: Vec<(i64, String)> = (0..request.count as usize)
@@ -206,8 +350,11 @@ async fn generate_candle_qwen_edit_stream(
         "qwen_edit",
         0,
         move || {
-            let model = QwenEdit::load(&QwenEditPaths { root: qwen_base })
-                .map_err(|error| WorkerError::Engine(format!("Qwen edit load failed: {error}")))?;
+            let model = QwenEdit::load(&QwenEditPaths {
+                root: qwen_base,
+                adapters,
+            })
+            .map_err(|error| WorkerError::Engine(format!("Qwen edit load failed: {error}")))?;
             Ok((model, reference))
         },
         move |(model, reference), tx, cancel| {
@@ -223,9 +370,11 @@ async fn generate_candle_qwen_edit_stream(
                     steps: steps as usize,
                     guidance,
                     seed: seed as u64,
+                    lightning,
                     cancel: cancel.clone(),
                 };
-                let result = model.generate(&req, std::slice::from_ref(&reference), &mut *on_progress);
+                let result =
+                    model.generate(&req, std::slice::from_ref(&reference), &mut *on_progress);
                 let out = match result {
                     Ok(out) => out,
                     Err(_) if cancel.is_cancelled() => return Ok(None),


### PR DESCRIPTION
## sc-6220 (epic 5480) — worker route for candle Qwen-Image-Edit-2511-Lightning

Wires the **Qwen-Image-Edit-2511-Lightning** few-step distill into the candle worker edit lane. The provider half ([candle-gen#103](https://github.com/SceneWorks/candle-gen/pull/103)) adds the LoRA merge + lightning schedule to `QwenEdit`; this PR routes the variant to that lane and re-pins candle-gen.

### What
- **`image_jobs/qwen_edit_candle.rs`:**
  - `is_qwen_edit_candle_model` now accepts `qwen_image_edit_2511_lightning`; `is_qwen_edit_lightning` drives a lightning-aware **base repo** (`Qwen/Qwen-Image-Edit-2511`), **steps** (4), and **guidance** (1.0, CFG-off).
  - `ensure_qwen_lightning_lora_cached` lazily fetches the lightx2v 4-step distill LoRA (`lightx2v/Qwen-Image-Edit-2511-Lightning/…-4steps-V1.0-bf16.safetensors`) into the HF cache — the candle off-Mac twin of `qwen.rs`'s MLX `ensure_distill_lora_cached` (fully qualified, since this file is `include!`d into the candle `image_jobs` build).
  - Stacks the LoRA as an `AdapterSpec` into `QwenEditPaths.adapters` and sets `QwenEditRequest.lightning` (static-shift schedule). Production (non-lightning) variants are unchanged — empty adapters → the mmap fast path.
- **`jobs_store`:** `image_job_is_candle_eligible` claims the lightning edit too; the candle-routing unit test flips lightning from torch-only to candle-claimed.
- **`Cargo.toml`:** re-pin candle-gen `c4641cb → c683c43` (candle-gen #103). `c683c43` re-pins candle-gen's gen-core `51a6792 → e23a8b7` to MATCH this worker's `e23a8b7` mlx pin (the gen-core tree is byte-identical), so `--features backend-candle` resolves a **single** gen-core rev `e23a8b7` (the skew gate).

### Validation
- `--features backend-candle` build **green** (CUDA, sm_120, MSVC 14.44); `clippy -D warnings` clean; the `jobs_store` candle-routing test passes.
- The lightning **inference** (merged **720/720** MMDiT LoRA targets; 4-step CFG-off edit coherent, std 58/68, prompt A-vs-B diff 74) is **GPU-validated on the RTX PRO 6000** in [candle-gen#103](https://github.com/SceneWorks/candle-gen/pull/103); this worker route constructs the identical `QwenEdit` call (base + `adapters=[lora]` + `lightning`), so it produces the same result.

Depends on [candle-gen#103](https://github.com/SceneWorks/candle-gen/pull/103) (the pinned `c683c43` is its content commit, a durable ancestor of the merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)