### PR TITLE
sc-6247: wire candle SAM3 into the off-Mac person-track (replace SAM2 stub)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=db47ed55b3fa5a6a0b69413bb4f5726007441030#db47ed55b3fa5a6a0b69413bb4f5726007441030"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -444,7 +444,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_distr 0.5.1",
  "safetensors 0.7.0",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=51a6792db3a1c94d23a9ae00e2414665b8c2c9f7)",
+ "sceneworks-gen-core",
  "serde_json",
  "thiserror 2.0.18",
 ]
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=db47ed55b3fa5a6a0b69413bb4f5726007441030#db47ed55b3fa5a6a0b69413bb4f5726007441030"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=db47ed55b3fa5a6a0b69413bb4f5726007441030#db47ed55b3fa5a6a0b69413bb4f5726007441030"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=db47ed55b3fa5a6a0b69413bb4f5726007441030#db47ed55b3fa5a6a0b69413bb4f5726007441030"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=db47ed55b3fa5a6a0b69413bb4f5726007441030#db47ed55b3fa5a6a0b69413bb4f5726007441030"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=db47ed55b3fa5a6a0b69413bb4f5726007441030#db47ed55b3fa5a6a0b69413bb4f5726007441030"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -519,7 +519,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=db47ed55b3fa5a6a0b69413bb4f5726007441030#db47ed55b3fa5a6a0b69413bb4f5726007441030"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -530,7 +530,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=db47ed55b3fa5a6a0b69413bb4f5726007441030#db47ed55b3fa5a6a0b69413bb4f5726007441030"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=db47ed55b3fa5a6a0b69413bb4f5726007441030#db47ed55b3fa5a6a0b69413bb4f5726007441030"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -557,7 +557,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=db47ed55b3fa5a6a0b69413bb4f5726007441030#db47ed55b3fa5a6a0b69413bb4f5726007441030"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -569,7 +569,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=db47ed55b3fa5a6a0b69413bb4f5726007441030#db47ed55b3fa5a6a0b69413bb4f5726007441030"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -580,7 +580,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=db47ed55b3fa5a6a0b69413bb4f5726007441030#db47ed55b3fa5a6a0b69413bb4f5726007441030"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -597,7 +597,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=db47ed55b3fa5a6a0b69413bb4f5726007441030#db47ed55b3fa5a6a0b69413bb4f5726007441030"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -609,9 +609,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "candle-gen-sam3"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=db47ed55b3fa5a6a0b69413bb4f5726007441030#db47ed55b3fa5a6a0b69413bb4f5726007441030"
+dependencies = [
+ "candle-core",
+ "candle-gen",
+ "candle-nn",
+ "tokenizers 0.22.2",
+]
+
+[[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=db47ed55b3fa5a6a0b69413bb4f5726007441030#db47ed55b3fa5a6a0b69413bb4f5726007441030"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -629,7 +640,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=db47ed55b3fa5a6a0b69413bb4f5726007441030#db47ed55b3fa5a6a0b69413bb4f5726007441030"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -640,7 +651,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=db47ed55b3fa5a6a0b69413bb4f5726007441030#db47ed55b3fa5a6a0b69413bb4f5726007441030"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -653,7 +664,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=db47ed55b3fa5a6a0b69413bb4f5726007441030#db47ed55b3fa5a6a0b69413bb4f5726007441030"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -664,7 +675,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=db47ed55b3fa5a6a0b69413bb4f5726007441030#db47ed55b3fa5a6a0b69413bb4f5726007441030"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -677,7 +688,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c4641cbe7be1668a3507809a76dabf6aa0baf850#c4641cbe7be1668a3507809a76dabf6aa0baf850"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=db47ed55b3fa5a6a0b69413bb4f5726007441030#db47ed55b3fa5a6a0b69413bb4f5726007441030"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -3303,7 +3314,7 @@ source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7)",
+ "sceneworks-gen-core",
  "thiserror 2.0.18",
  "tokenizers 0.21.4",
 ]
@@ -5211,18 +5222,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sceneworks-gen-core"
-version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=51a6792db3a1c94d23a9ae00e2414665b8c2c9f7#51a6792db3a1c94d23a9ae00e2414665b8c2c9f7"
-dependencies = [
- "inventory",
- "safetensors 0.4.5",
- "serde_json",
- "thiserror 2.0.18",
- "tokenizers 0.21.4",
-]
-
-[[package]]
 name = "sceneworks-rust-api"
 version = "0.2.0"
 dependencies = [
@@ -5275,6 +5274,7 @@ dependencies = [
  "candle-gen-prompt-refine",
  "candle-gen-pulid",
  "candle-gen-qwen-image",
+ "candle-gen-sam3",
  "candle-gen-sdxl",
  "candle-gen-seedvr2",
  "candle-gen-sensenova",
@@ -5315,7 +5315,7 @@ dependencies = [
  "pmetal-mlx-rs",
  "reqwest 0.12.28",
  "sceneworks-core",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7)",
+ "sceneworks-gen-core",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -318,6 +318,11 @@ backend-candle = [
     # `gen_core::load` from upscale_jobs.rs (image) + video_jobs.rs (video). Real-ESRGAN stays the fast
     # default; SeedVR2 is the additional high-fidelity / video choice.
     "dep:candle-gen-seedvr2",
+    # sc-6247 (epic 5482 under sc-5062): the candle SAM3 text-concept person segmenter — the Windows/CUDA
+    # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB in the person-track. A bespoke
+    # utility segmenter (NOT inventory-registered), called directly from `person_segment_sam3_candle.rs`
+    # (`Sam3VideoModel::propagate("person")`). Retires the off-Mac `maskState = "missing"` box-only path.
+    "dep:candle-gen-sam3",
     # sc-5496 (epic 5482): DWPose pose detection off-Mac via the `ort` (onnxruntime) crate with the CUDA
     # execution provider — the Windows/Linux sibling of the macOS sc-3487 `ort`/CoreML path; `zip` unpacks
     # the openmmlab weight bundles. Both are Mac-non-optional but off-Mac optional + candle-gated (declared
@@ -871,38 +876,38 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517e
 # (the delta is the single additive sc-6038 mlx-gen-instantid commit), so behavior-neutral. The candle
 # SDXL edit worker route (`image_jobs/sdxl_edit_candle.rs`) drives candle-gen-sdxl's `SdxlEdit` off-Mac.
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "db47ed55b3fa5a6a0b69413bb4f5726007441030", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "db47ed55b3fa5a6a0b69413bb4f5726007441030", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "db47ed55b3fa5a6a0b69413bb4f5726007441030", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "db47ed55b3fa5a6a0b69413bb4f5726007441030", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "db47ed55b3fa5a6a0b69413bb4f5726007441030", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "db47ed55b3fa5a6a0b69413bb4f5726007441030", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "db47ed55b3fa5a6a0b69413bb4f5726007441030", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "db47ed55b3fa5a6a0b69413bb4f5726007441030", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "db47ed55b3fa5a6a0b69413bb4f5726007441030", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "db47ed55b3fa5a6a0b69413bb4f5726007441030", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -911,19 +916,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "db47ed55b3fa5a6a0b69413bb4f5726007441030", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "db47ed55b3fa5a6a0b69413bb4f5726007441030", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "db47ed55b3fa5a6a0b69413bb4f5726007441030", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -932,12 +937,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "db47ed55b3fa5a6a0b69413bb4f5726007441030", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "db47ed55b3fa5a6a0b69413bb4f5726007441030", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -945,7 +950,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "db47ed55b3fa5a6a0b69413bb4f5726007441030", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -954,7 +959,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "db47ed55b3fa5a6a0b69413bb4f5726007441030", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -962,7 +967,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "db47ed55b3fa5a6a0b69413bb4f5726007441030", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -971,7 +976,19 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c4641cbe7be1668a3507809a76dabf6aa0baf850", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "db47ed55b3fa5a6a0b69413bb4f5726007441030", features = ["cuda"], optional = true }
+# Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
+# sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
+# "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
+# candle-gen-face): the worker's `person_segment_sam3_candle.rs` calls `Sam3VideoModel::from_weights`
+# / `propagate("person")` / `quantize(Quant)` directly (mirrors how `person_segment_sam3.rs` drives
+# the MLX twin on Mac). This rev (db47ed5) is the sc-6247 candle-gen de-skew, which carries the whole
+# candle-gen-sam3 port (vision / text / detr / mask / geometry / tracker+video / quant, sc-6240..6246)
+# AND re-pins gen-core 51a6792 -> 517ef11f. Same git rev as every candle-gen provider above — the
+# c4641cbe -> db47ed5 lockstep bump moves all candle-gen-* to a rev whose gen-core (517ef11f) MATCHES
+# the worker's mlx pin (517ef11f), so `--features backend-candle` resolves ONE gen-core build again
+# (the #490 Ideogram-4 mlx bump had silently re-opened the skew that broke instantid.rs / sdxl_ipadapter.rs).
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "db47ed55b3fa5a6a0b69413bb4f5726007441030", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -171,8 +171,8 @@ mod person_track;
 #[cfg(target_os = "macos")]
 mod person_segment;
 // SAM3 text-concept (PCS) person segmenter — the box-prompt-free upgrade of `person_segment`
-// (epic 4910, sc-4926). macOS-only like its SAM2 sibling. The Python SAM2 path stays the
-// Windows/Linux backend until a parallel candle backport (cf. epic 3792).
+// (epic 4910, sc-4926). macOS-only (native MLX `mlx-gen-sam3`); the off-Mac Windows/CUDA candle
+// sibling is `person_segment_sam3_candle` below.
 #[cfg(target_os = "macos")]
 mod person_segment_sam3;
 // Smart-select image segmentation (epic 6087, sc-6105): the `image_segment` job runs SAM3
@@ -180,6 +180,11 @@ mod person_segment_sam3;
 // macOS-only like its `person_segment_sam3` (SAM3) dependency; no torch/candle image-segment path.
 #[cfg(target_os = "macos")]
 mod segment_jobs;
+// Off-Mac candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the
+// Windows/CUDA sibling of `person_segment_sam3`, driving `candle-gen-sam3`'s `Sam3VideoModel` to
+// replace the SAM2 box-prompt STUB in the off-Mac person-track (`media_jobs` `maskState = "missing"`).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+mod person_segment_sam3_candle;
 // SCAIL-2 color-coded segmentation-mask painting (epic 5439, sc-5448): turns native SAM3
 // per-person masks into the palette-painted RGB masks the SCAIL-2 engine consumes. macOS-only
 // like its SAM3 dependency.

--- a/crates/sceneworks-worker/src/media_jobs.rs
+++ b/crates/sceneworks-worker/src/media_jobs.rs
@@ -825,8 +825,12 @@ async fn assemble_real_person_track(
 }
 
 /// Render dimensions of the sampled track frames (`render_frame_png` above), and therefore the
-/// size of the masks the SAM2 video predictor emits.
-#[cfg(target_os = "macos")]
+/// size of the masks the SAM segmenter emits. Shared by the macOS (SAM2/SAM3) and off-Mac candle
+/// (SAM3, sc-6247) segmentation passes.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 const TRACK_FRAME_SIZE: (u32, u32) = (1280, 720);
 
 /// Generate the selected person's track masks with the native-MLX SAM2 **video predictor**
@@ -1004,8 +1008,11 @@ async fn segment_assembly_frames(
 /// Encode each `(assembly_idx, rel, out_path, pixels)` mask as an `L` (8-bit grayscale) PNG,
 /// returning the `(assembly_idx, rel)` of the frames that were written. A single frame's failure is
 /// non-fatal (matches Python's per-frame `except: continue`); it keeps `mask: null` and falls back
-/// to a box mask at replacement time.
-#[cfg(target_os = "macos")]
+/// to a box mask at replacement time. Shared by the macOS and off-Mac candle segmentation passes.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 fn write_track_mask_pngs(
     width: u32,
     height: u32,
@@ -1023,14 +1030,145 @@ fn write_track_mask_pngs(
     written
 }
 
+/// Off-Mac candle SAM3 segmentation pass (sc-6247): the Windows/CUDA sibling of the macOS
+/// [`segment_assembly_frames`], driving `candle-gen-sam3`'s text-concept (PCS) video pipeline to
+/// write a per-frame mask for each detected target frame. SAM3 is the only off-Mac segmenter (no
+/// SAM2 box-prompt fallback — that's the native-MLX `mlx-gen-sam2`); any unavailability degrades to
+/// box-derived masks (handled by the replacement loader), never failing a track that already located
+/// the person. Mirrors the macOS orchestration exactly.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[allow(clippy::too_many_arguments)]
+async fn segment_assembly_frames(
+    api: &ApiClient,
+    settings: &Settings,
+    http_client: &reqwest::Client,
+    job: &JobSnapshot,
+    project_path: &std::path::Path,
+    track_id: &str,
+    frames: &[crate::person_track::TrackFrame],
+    frame_paths: &[PathBuf],
+    frames_json: &mut [Value],
+    segment_enabled: bool,
+) -> WorkerResult<&'static str> {
+    let detected_total = frames.iter().filter(|frame| frame.detected).count();
+    if detected_total == 0 || !segment_enabled {
+        return Ok("missing");
+    }
+
+    let download_context = DownloadContext {
+        api,
+        client: http_client,
+        settings,
+        job_id: &job.id,
+        cancel_message: "Person segmentation canceled while fetching segmenter weights.",
+        fresh_download: false,
+    };
+    let masks_dir = project_path
+        .join("person-tracks")
+        .join(track_id)
+        .join("masks");
+    if tokio::fs::create_dir_all(&masks_dir).await.is_err() {
+        return Ok("degraded");
+    }
+
+    let Some(first) = frames.iter().position(|f| f.detected) else {
+        return Ok("missing");
+    };
+    let last = frames.iter().rposition(|f| f.detected).unwrap_or(first);
+    if frame_paths.len() <= last {
+        return Ok("degraded");
+    }
+    let mut clip_paths = Vec::with_capacity(last - first + 1);
+    let mut anchors = Vec::with_capacity(last - first + 1);
+    for (frame, path) in frames[first..=last].iter().zip(&frame_paths[first..=last]) {
+        clip_paths.push(path.clone());
+        anchors.push(frame.detected.then_some((
+            frame.box_.x,
+            frame.box_.y,
+            frame.box_.width,
+            frame.box_.height,
+        )));
+    }
+
+    check_cancel(
+        api,
+        &job.id,
+        "Person tracking canceled during segmentation.",
+    )
+    .await?;
+
+    let (model, tokenizer) = match crate::person_segment_sam3_candle::ensure_segmenter_weights(
+        settings,
+        &download_context,
+    )
+    .await
+    {
+        Ok(pair) => pair,
+        Err(WorkerError::Canceled(message)) => return Err(WorkerError::Canceled(message)),
+        Err(_) => return Ok("degraded"),
+    };
+    let masks = match tokio::task::spawn_blocking(move || {
+        crate::person_segment_sam3_candle::segment_track_blocking(
+            model, tokenizer, clip_paths, anchors,
+        )
+    })
+    .await
+    {
+        Ok(Ok(masks)) => masks,
+        _ => return Ok("degraded"),
+    };
+
+    // Write every clip frame's non-empty mask (detected + gap) and set its sidecar `mask`.
+    let pending: Vec<(usize, String, PathBuf, Vec<u8>)> = masks
+        .into_iter()
+        .enumerate()
+        .filter(|(_, pixels)| pixels.iter().any(|&p| p > 127))
+        .map(|(clip_idx, pixels)| {
+            let assembly_idx = first + clip_idx;
+            let rel = format!(
+                "person-tracks/{track_id}/masks/frame_{:06}.png",
+                assembly_idx + 1
+            );
+            let out_path = project_path.join(&rel);
+            (assembly_idx, rel, out_path, pixels)
+        })
+        .collect();
+    let (width, height) = TRACK_FRAME_SIZE;
+    let written =
+        match tokio::task::spawn_blocking(move || write_track_mask_pngs(width, height, pending))
+            .await
+        {
+            Ok(written) => written,
+            Err(_) => return Ok("degraded"),
+        };
+
+    let mut generated = 0usize;
+    for (assembly_idx, rel) in written {
+        if let Some(entry) = frames_json.get_mut(assembly_idx) {
+            entry["mask"] = Value::String(rel);
+        }
+        if frames
+            .get(assembly_idx)
+            .map(|f| f.detected)
+            .unwrap_or(false)
+        {
+            generated += 1;
+        }
+    }
+
+    Ok(crate::person_segment_sam3_candle::rollup_mask_state(
+        generated,
+        detected_total,
+    ))
+}
+
 /// Track the selected person through real source content on the off-Mac candle GPU-worker lane
 /// (sc-5498): sample frames at the 2-FPS cadence, run the `ort`/CUDA YOLO11 detector on each,
 /// associate the boxes into track identities with the pure-Rust SORT/ByteTrack tracker
-/// (sc-3634, `person_track`), and resample the chosen identity onto the sample cadence. Person
-/// *segmentation* (SAM masks) is NOT ported off-Mac yet (epic 3792, sc-5062), so candle tracks
-/// are box-only — `maskState = "missing"` and the replacement loader derives box masks from the
-/// frames. Mirrors the macOS path minus the SAM pass; the Python Ultralytics path is the
-/// fallback on a candle-disabled box.
+/// (sc-3634, `person_track`), and resample the chosen identity onto the sample cadence. The candle
+/// SAM3 text-concept segmenter then fills per-frame masks (sc-6247) — at parity with the macOS SAM3
+/// path — so off-Mac tracks are no longer box-only. Mirrors the macOS `assemble_real_person_track`;
+/// the Python Ultralytics path is the fallback on a candle-disabled box.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 #[allow(clippy::too_many_arguments)]
 async fn assemble_real_person_track(
@@ -1038,14 +1176,14 @@ async fn assemble_real_person_track(
     settings: &Settings,
     http_client: &reqwest::Client,
     job: &JobSnapshot,
-    _project_path: &std::path::Path,
+    project_path: &std::path::Path,
     source_media_path: &std::path::Path,
     detection: &Value,
-    _track_id: &str,
+    track_id: &str,
     selected_timestamp: f64,
     duration: f64,
     confidence: f64,
-    _segment_enabled: bool,
+    segment_enabled: bool,
 ) -> WorkerResult<RealPersonTrack> {
     use crate::person_track as pt;
 
@@ -1066,7 +1204,10 @@ async fn assemble_real_person_track(
     tokio::fs::create_dir_all(&work_dir).await?;
 
     // The detector reports its real execution device per frame (cuda / cpu, per the `ort` EP).
+    // Keep each rendered frame (don't delete in-loop): the SAM3 segmentation pass re-reads them by
+    // the same sample index (assembly frame `i` ↔ `timestamps[i]` ↔ `frame_paths[i]`).
     let mut device = "cuda";
+    let mut frame_paths: Vec<PathBuf> = Vec::with_capacity(timestamps.len());
     let mut per_frame: Vec<(f64, Vec<(pt::NormalizedBox, f64)>)> =
         Vec::with_capacity(timestamps.len());
     for (index, &timestamp) in timestamps.iter().enumerate() {
@@ -1114,31 +1255,50 @@ async fn assemble_real_person_track(
             })
             .collect::<Vec<_>>();
         per_frame.push((timestamp, boxes));
+        frame_paths.push(frame_path);
     }
-    let _ = tokio::fs::remove_dir_all(&work_dir).await;
 
     let observations = pt::observe(per_frame);
     let assembly = pt::assemble_track(&observations, selected_box, selected_timestamp, &timestamps);
     if assembly.target_track_id.is_none() || assembly.detected_frames == 0 {
+        let _ = tokio::fs::remove_dir_all(&work_dir).await;
         return Err(WorkerError::InvalidPayload(
             "Selected person was not found in the source video. Re-run detection or adjust the selection."
                 .to_owned(),
         ));
     }
 
+    // Candle SAM3 segmentation pass (sc-6247): write a per-frame mask for each detected target frame
+    // and fold the result into `maskState`. Any segmenter unavailability degrades gracefully to
+    // box-derived masks (handled by the replacement loader), never failing a track that already
+    // located the person.
+    let mut frames_json = pt::frames_to_json(&assembly.frames);
+    let mask_state = segment_assembly_frames(
+        api,
+        settings,
+        http_client,
+        job,
+        project_path,
+        track_id,
+        &assembly.frames,
+        &frame_paths,
+        &mut frames_json,
+        segment_enabled,
+    )
+    .await?;
+    let _ = tokio::fs::remove_dir_all(&work_dir).await;
+
     Ok(RealPersonTrack {
-        frames: pt::frames_to_json(&assembly.frames),
+        frames: frames_json,
         average_confidence: pt::average_confidence(&assembly.frames),
-        // Segmentation (SAM masks) is not ported off-Mac yet (epic 3792, sc-5062), so the track
-        // is box-only; the replacement loader derives box masks from these frames.
-        mask_state: "missing",
+        mask_state,
         quality: assembly.quality,
         tracker_meta: json!({
             "backend": "candle",
             "device": device,
             "model": "yolo11m",
             "tracker": "sort_bytetrack",
-            "segmenter": "disabled",
+            "segmenter": if segment_enabled { "sam3" } else { "disabled" },
         }),
     })
 }

--- a/crates/sceneworks-worker/src/person_segment_sam3_candle.rs
+++ b/crates/sceneworks-worker/src/person_segment_sam3_candle.rs
@@ -1,0 +1,452 @@
+//! Off-Mac (Windows/CUDA) **SAM3** text-concept person segmentation on the Rust worker — the candle
+//! sibling of [`crate::person_segment_sam3`] (epic 5482, sc-6247 under sc-5062).
+//!
+//! Drives `candle-gen-sam3`'s `Sam3VideoModel::propagate("person")` exactly as the macOS path drives
+//! the MLX twin: SAM3 detects + tracks *every* person across the clip with its own memory bank, and
+//! we pick the object whose masks best fall inside the selected ByteTrack track's boxes (the per-frame
+//! box is an *association hint*, never a segmenter prompt) and emit that object's per-frame binary
+//! mask. The downstream contract is identical to the Mac SAM3 / SAM2 paths — one `L` mask per clip
+//! frame, written under `person-tracks/{track_id}/masks/` by `media_jobs::segment_assembly_frames` —
+//! so this **replaces the off-Mac SAM2 box-prompt stub** (`maskState = "missing"`) with real masks.
+//!
+//! Off-Mac + `backend-candle` only (`candle-gen-sam3` builds candle/CUDA). It loads the **stock
+//! `facebook/sam3` checkpoint directly** (`model.safetensors` + `tokenizer.json`; no conversion) and
+//! affine-quantizes after load (`Sam3VideoModel::quantize`, sc-6246) — **Q8 by default** (near-
+//! lossless), tunable via `SCENEWORKS_SAM3_QUANT` (`q8`/`q4`/`off`). The pure association/mask helpers
+//! are shared line-for-line with the MLX module; only the tensor/inference seam is candle.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+use candle_gen::candle_core::{Device, Tensor};
+use candle_gen::default_device;
+use candle_gen::gen_core::Quant;
+use candle_gen_sam3::{Sam3TextConfig, Sam3Tokenizer, Sam3VideoModel, VideoFrameOutput, Weights};
+
+use crate::downloads::{ensure_hf_cached_file, DownloadContext};
+use crate::{Settings, WorkerError, WorkerResult};
+
+/// SAM3 checkpoint files (loaded stock from `facebook/sam3`, no conversion).
+const MODEL_FILE: &str = "model.safetensors";
+const TOKENIZER_FILE: &str = "tokenizer.json";
+
+/// Download-on-first-use repo: the stock `facebook/sam3` checkpoint mirror owned by SceneWorks (the
+/// same `model.safetensors` + `tokenizer.json` the MLX path uses — no MLX-specific conversion, despite
+/// the `-mlx` name). Until the public mirror is signed off, point `SCENEWORKS_SAM3_WEIGHTS` at a local
+/// `facebook/sam3` snapshot dir.
+const SEG_REPO: &str = "SceneWorks/sam3-mlx";
+
+/// SAM3 model input is a square 1008×1008 (the processor resizes to a fixed square, not
+/// aspect-preserving — `Sam3VideoProcessor` `size={1008,1008}`).
+const INPUT_SIZE: u32 = 1008;
+
+/// SAM3 mask logits come back on a 288×288 low-res grid (`Sam3VideoModel` `LOW_RES`).
+const MASK_GRID: usize = 288;
+
+/// The text concept driving PCS — the whole point of SAM3 (no manual box).
+const CONCEPT_PROMPT: &str = "person";
+
+/// A normalized `(x, y, width, height)` box (0..1), the per-frame ByteTrack anchor — used here only to
+/// *associate* a SAM3 object id with the selected track, never as a segmenter prompt.
+pub(crate) type BoxNorm = (f64, f64, f64, f64);
+
+/// Affine-quantization level for the segmenter, from `SCENEWORKS_SAM3_QUANT`: **Q8 by default**
+/// (near-lossless), `q4` for the smaller/lossier Q4, or `off`/`f32` to keep dense F32. `None` = no
+/// quantization.
+fn quant_level() -> Option<Quant> {
+    parse_quant(&std::env::var("SCENEWORKS_SAM3_QUANT").unwrap_or_default())
+}
+
+/// Parse the `SCENEWORKS_SAM3_QUANT` value (split out so the mapping is unit-testable). Unset or
+/// unrecognized → the safe Q8 default.
+fn parse_quant(value: &str) -> Option<Quant> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "off" | "f32" | "none" | "0" => None,
+        "q4" | "4" => Some(Quant::Q4),
+        _ => Some(Quant::Q8),
+    }
+}
+
+/// The parsed SAM3 checkpoint is cached process-wide (the multi-GB safetensors parse is the expensive
+/// part). A **fresh** `Sam3VideoModel` is assembled from it per clip: the model carries per-session
+/// tracking state (obj ids, memory banks) with no reset, so reusing one across clips would leak
+/// identities. Mirrors the MLX module's cache + poison-recovery idiom.
+static WEIGHTS: OnceLock<Mutex<Option<Weights>>> = OnceLock::new();
+
+/// Resolve already-present SAM3 weights: an explicit env pin (`SCENEWORKS_SAM3_WEIGHTS`, a dir or the
+/// `model.safetensors` inside it), then the app cache `<data_dir>/cache/person-segment-sam3/`, then the
+/// model dir `<data_dir>/models/person-segment-sam3/`. Both files must be present. Returns
+/// `(model_path, tokenizer_path)` or `None` (then [`ensure_segmenter_weights`] downloads them).
+pub(crate) fn resolve_segmenter_weights(settings: &Settings) -> Option<(PathBuf, PathBuf)> {
+    let pair_in = |dir: &Path| -> Option<(PathBuf, PathBuf)> {
+        let model = dir.join(MODEL_FILE);
+        let tokenizer = dir.join(TOKENIZER_FILE);
+        (model.exists() && tokenizer.exists()).then_some((model, tokenizer))
+    };
+    if let Ok(pinned) = std::env::var("SCENEWORKS_SAM3_WEIGHTS") {
+        let p = PathBuf::from(pinned);
+        let dir = if p.is_file() {
+            p.parent().map(Path::to_path_buf).unwrap_or(p)
+        } else {
+            p
+        };
+        if let Some(pair) = pair_in(&dir) {
+            return Some(pair);
+        }
+    }
+    for sub in ["cache/person-segment-sam3", "models/person-segment-sam3"] {
+        if let Some(pair) = pair_in(&settings.data_dir.join(sub)) {
+            return Some(pair);
+        }
+    }
+    None
+}
+
+/// Resolve the SAM3 weights, downloading `model.safetensors` + `tokenizer.json` from HuggingFace on
+/// first use (into the app cache) with streaming progress/cancel and size-aware resume.
+pub(crate) async fn ensure_segmenter_weights(
+    settings: &Settings,
+    context: &DownloadContext<'_>,
+) -> WorkerResult<(PathBuf, PathBuf)> {
+    if let Some(pair) = resolve_segmenter_weights(settings) {
+        return Ok(pair);
+    }
+    let dir = settings.data_dir.join("cache").join("person-segment-sam3");
+    let model =
+        ensure_hf_cached_file(context, SEG_REPO, "main", MODEL_FILE, &dir.join(MODEL_FILE)).await?;
+    let tokenizer = ensure_hf_cached_file(
+        context,
+        SEG_REPO,
+        "main",
+        TOKENIZER_FILE,
+        &dir.join(TOKENIZER_FILE),
+    )
+    .await?;
+    Ok((model, tokenizer))
+}
+
+/// Roll the per-clip mask outcome into the sidecar `maskState`: `degraded` (no frame masked → box
+/// fallback), `active` (every detected frame masked), else `generated`. Mirrors
+/// `person_segment::rollup_mask_state` (Mac-only) so the off-Mac contract is identical.
+pub(crate) fn rollup_mask_state(generated: usize, detected_total: usize) -> &'static str {
+    if generated == 0 {
+        "degraded"
+    } else if generated >= detected_total {
+        "active"
+    } else {
+        "generated"
+    }
+}
+
+/// Preprocess an RGB frame to the SAM3 input tensor: resize to a 1008×1008 square (bilinear, fixed-
+/// square — *not* aspect-preserving), normalize by mean/std `0.5` to `[-1,1]`, packed NCHW
+/// `[1,3,1008,1008]` f32 on `device`.
+fn input_tensor(img: &image::RgbImage, device: &Device) -> WorkerResult<Tensor> {
+    let resized = image::imageops::resize(
+        img,
+        INPUT_SIZE,
+        INPUT_SIZE,
+        image::imageops::FilterType::Triangle,
+    );
+    let chw = normalize_chw(resized.as_raw(), INPUT_SIZE as usize);
+    let n = INPUT_SIZE as usize;
+    Tensor::from_vec(chw, (1, 3, n, n), device)
+        .map_err(|e| WorkerError::Engine(format!("sam3 input tensor: {e}")))
+}
+
+/// Pack a `size×size` interleaved-RGB `u8` buffer into a channel-major `[3·size·size]` f32 vector with
+/// the SAM3 normalization `x/127.5 − 1` (mean=std=0.5 → range `[-1,1]`). Split out so the
+/// normalization is unit-testable without an image decode. Shared verbatim with the MLX module.
+fn normalize_chw(rgb: &[u8], size: usize) -> Vec<f32> {
+    let plane = size * size;
+    let mut out = vec![0f32; 3 * plane];
+    for (p, px) in rgb.chunks_exact(3).enumerate() {
+        for c in 0..3 {
+            out[c * plane + p] = px[c] as f32 / 127.5 - 1.0;
+        }
+    }
+    out
+}
+
+/// Fraction of a SAM3 object's foreground (mask logit `> 0`) on the `grid×grid` low-res mask whose
+/// pixel center falls inside the normalized `box_norm`. `0.0` when the mask is empty. The association
+/// score: how much of a candidate object sits under the selected person's box.
+fn mask_box_containment(mask_logits: &[f32], grid: usize, box_norm: BoxNorm) -> f64 {
+    let (bx, by, bw, bh) = box_norm;
+    let (x1, y1, x2, y2) = (bx, by, bx + bw, by + bh);
+    let (mut fg, mut inside) = (0u64, 0u64);
+    for my in 0..grid {
+        for mx in 0..grid {
+            if mask_logits[my * grid + mx] > 0.0 {
+                fg += 1;
+                let (cx, cy) = (
+                    (mx as f64 + 0.5) / grid as f64,
+                    (my as f64 + 0.5) / grid as f64,
+                );
+                if cx >= x1 && cx < x2 && cy >= y1 && cy < y2 {
+                    inside += 1;
+                }
+            }
+        }
+    }
+    if fg == 0 {
+        0.0
+    } else {
+        inside as f64 / fg as f64
+    }
+}
+
+/// Pick the SAM3 object id that best matches the selected track: accumulate each present object's
+/// `mask_box_containment` over every anchored clip frame, then take the id with the greatest total.
+/// `None` when no object ever overlaps an anchor (→ degraded to box masks). Shared with the MLX module.
+fn select_object(outputs: &[VideoFrameOutput], anchors: &[Option<BoxNorm>]) -> Option<i32> {
+    use std::collections::HashMap;
+    let mut score: HashMap<i32, f64> = HashMap::new();
+    for (frame, anchor) in outputs.iter().zip(anchors) {
+        let Some(box_norm) = anchor else { continue };
+        for (oid, mask) in frame.obj_ids.iter().zip(&frame.masks) {
+            let c = mask_box_containment(mask, MASK_GRID, *box_norm);
+            if c > 0.0 {
+                *score.entry(*oid).or_insert(0.0) += c;
+            }
+        }
+    }
+    // Deterministic tie-break on the object id so repeated runs agree.
+    score
+        .into_iter()
+        .max_by(|a, b| {
+            a.1.partial_cmp(&b.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(b.0.cmp(&a.0))
+        })
+        .map(|(oid, _)| oid)
+}
+
+/// Binarize a `grid×grid` SAM3 mask (logit `> 0`) to 0/255, resize it to `width×height` (bilinear) and
+/// re-threshold to a clean binary `L` mask — the per-clip-frame output the orchestrator writes.
+fn mask_to_frame(mask_logits: &[f32], grid: usize, width: u32, height: u32) -> Vec<u8> {
+    let bin: Vec<u8> = mask_logits
+        .iter()
+        .map(|&v| if v > 0.0 { 255 } else { 0 })
+        .collect();
+    let Some(small) = image::GrayImage::from_raw(grid as u32, grid as u32, bin) else {
+        return Vec::new();
+    };
+    let resized =
+        image::imageops::resize(&small, width, height, image::imageops::FilterType::Triangle);
+    resized
+        .into_raw()
+        .into_iter()
+        .map(|v| if v > 127 { 255 } else { 0 })
+        .collect()
+}
+
+/// Segment the selected person across a clip with the off-Mac candle SAM3 **text-concept (PCS) video
+/// pipeline** (sc-6247). `clip_frame_paths` is the contiguous detected span (clip-local frame `0` =
+/// first detected frame); `anchors[i]` is the frame's ByteTrack box in normalized `(x, y, width,
+/// height)` when frame `i` was detected, else `None`. At least one anchor must be `Some` — it is the
+/// association hint, not a prompt.
+///
+/// Returns one binary mask (row-major `width*height`, `0`/`255`) per clip frame, in clip order; an
+/// empty vec for a frame where the selected object was absent (orchestrator skips empties → box
+/// fallback). The checkpoint parses once and is cached process-wide; run under `spawn_blocking` (image
+/// decode + GPU inference are blocking).
+pub(crate) fn segment_track_blocking(
+    model_path: PathBuf,
+    tokenizer_path: PathBuf,
+    clip_frame_paths: Vec<PathBuf>,
+    anchors: Vec<Option<BoxNorm>>,
+) -> WorkerResult<Vec<Vec<u8>>> {
+    assert_eq!(
+        clip_frame_paths.len(),
+        anchors.len(),
+        "frames/anchors mismatch"
+    );
+    if !anchors.iter().any(Option::is_some) {
+        return Err(WorkerError::InvalidPayload(
+            "person segmentation clip needs at least one detected frame to associate".into(),
+        ));
+    }
+
+    let device = default_device().map_err(|e| WorkerError::Engine(format!("sam3 device: {e}")))?;
+
+    // Decode every clip frame to RGB8 (shared rendered size) and build the SAM3 input tensors.
+    let mut frames: Vec<Tensor> = Vec::with_capacity(clip_frame_paths.len());
+    let (mut width, mut height) = (0u32, 0u32);
+    for path in &clip_frame_paths {
+        let img = crate::image_decode::decode_image_any(path)
+            .map_err(|e| WorkerError::InvalidPayload(format!("person frame open: {e}")))?
+            .to_rgb8();
+        if width == 0 {
+            (width, height) = (img.width(), img.height());
+        } else if img.width() != width || img.height() != height {
+            return Err(WorkerError::InvalidPayload(
+                "person clip frames are not all the same size".into(),
+            ));
+        }
+        frames.push(input_tensor(&img, &device)?);
+    }
+
+    // Cached checkpoint; recover from a poisoned lock by dropping the cached weights and reloading.
+    let cell = WEIGHTS.get_or_init(|| Mutex::new(None));
+    let mut guard = cell.lock().unwrap_or_else(|poisoned| {
+        let mut guard = poisoned.into_inner();
+        *guard = None;
+        guard
+    });
+    if guard.is_none() {
+        let weights = Weights::from_file(&model_path, &device)
+            .map_err(|e| WorkerError::Engine(format!("sam3 weights load: {e}")))?;
+        *guard = Some(weights);
+    }
+    let weights = guard.as_ref().expect("weights loaded");
+
+    // Fresh model per clip (clean tracking state) + tokenize the concept once.
+    let mut model = Sam3VideoModel::from_weights(weights)
+        .map_err(|e| WorkerError::Engine(format!("sam3 model build: {e}")))?;
+    // Quantize (Q8 default) for a smaller footprint; the dense path is parity-preserving, so
+    // `SCENEWORKS_SAM3_QUANT=off` leaves the F32 result unchanged.
+    if let Some(quant) = quant_level() {
+        model
+            .quantize(quant)
+            .map_err(|e| WorkerError::Engine(format!("sam3 quantize: {e}")))?;
+    }
+    let tokenizer = Sam3Tokenizer::from_file(&tokenizer_path, &Sam3TextConfig::sam3())
+        .map_err(|e| WorkerError::Engine(format!("sam3 tokenizer load: {e}")))?;
+    let (input_ids, text_mask) = tokenizer
+        .encode(CONCEPT_PROMPT, &device)
+        .map_err(|e| WorkerError::Engine(format!("sam3 tokenize: {e}")))?;
+
+    let outputs = model
+        .propagate(&frames, &input_ids, &text_mask)
+        .map_err(|e| WorkerError::Engine(format!("sam3 propagate: {e}")))?;
+
+    // Associate SAM3's identities to the selected track, then emit that object's per-frame mask.
+    let Some(selected) = select_object(&outputs, &anchors) else {
+        // SAM3 found no "person" overlapping any anchor → no masks (degrade to box fallback).
+        return Ok(vec![Vec::new(); clip_frame_paths.len()]);
+    };
+    let masks = outputs
+        .iter()
+        .map(|frame| {
+            frame
+                .obj_ids
+                .iter()
+                .position(|&o| o == selected)
+                .map(|i| mask_to_frame(&frame.masks[i], MASK_GRID, width, height))
+                .unwrap_or_default()
+        })
+        .collect();
+    Ok(masks)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quant_defaults_to_q8_and_honors_overrides() {
+        assert_eq!(parse_quant(""), Some(Quant::Q8), "unset → Q8 default");
+        assert_eq!(parse_quant("q8"), Some(Quant::Q8));
+        assert_eq!(parse_quant("8"), Some(Quant::Q8));
+        assert_eq!(
+            parse_quant(" Q4 "),
+            Some(Quant::Q4),
+            "trimmed + case-insensitive"
+        );
+        assert_eq!(parse_quant("4"), Some(Quant::Q4));
+        assert_eq!(parse_quant("off"), None);
+        assert_eq!(parse_quant("F32"), None);
+        assert_eq!(parse_quant("none"), None);
+        assert_eq!(
+            parse_quant("garbage"),
+            Some(Quant::Q8),
+            "unrecognized → safe Q8"
+        );
+    }
+
+    #[test]
+    fn rollup_maps_generated_counts() {
+        assert_eq!(rollup_mask_state(0, 5), "degraded");
+        assert_eq!(rollup_mask_state(3, 5), "generated");
+        assert_eq!(rollup_mask_state(5, 5), "active");
+        assert_eq!(rollup_mask_state(6, 5), "active");
+    }
+
+    #[test]
+    fn normalize_maps_to_signed_unit_range_channel_major() {
+        // 2×2 RGB: black, white, mid-gray, red. mean=std=0.5 → x/127.5 − 1.
+        let rgb = [0, 0, 0, 255, 255, 255, 128, 128, 128, 255, 0, 0];
+        let chw = normalize_chw(&rgb, 2);
+        let plane = 4;
+        assert!((chw[0] - (-1.0)).abs() < 1e-6); // R of black
+        assert!((chw[1] - 1.0).abs() < 1e-6); // R of white
+        assert!((chw[plane] - (-1.0)).abs() < 1e-6); // G of black
+        assert!((chw[2 * plane + 3] - (-1.0)).abs() < 1e-6); // B of red = 0 → -1
+        assert!((chw[3] - 1.0).abs() < 1e-6); // R of red = 255 → 1
+    }
+
+    #[test]
+    fn containment_measures_foreground_inside_box() {
+        let grid = 10;
+        let mut logits = vec![-1.0f32; grid * grid];
+        for my in 2..6 {
+            for mx in 2..6 {
+                logits[my * grid + mx] = 1.0;
+            }
+        }
+        let full = mask_box_containment(&logits, grid, (0.2, 0.2, 0.4, 0.4));
+        assert!((full - 1.0).abs() < 1e-9, "full was {full}");
+        let none = mask_box_containment(&logits, grid, (0.0, 0.0, 0.1, 0.1));
+        assert!(none.abs() < 1e-9, "disjoint was {none}");
+        let half = mask_box_containment(&logits, grid, (0.0, 0.0, 0.4, 1.0));
+        assert!((half - 0.5).abs() < 1e-9, "half was {half}");
+    }
+
+    /// Two-object clip: object 7 sits under the anchor every frame, object 9 elsewhere. The selector
+    /// must return 7, aggregating containment across the span.
+    #[test]
+    fn select_object_picks_the_id_overlapping_the_anchor() {
+        let grid = MASK_GRID;
+        let block = |r: std::ops::Range<usize>, c: std::ops::Range<usize>| -> Vec<f32> {
+            let mut m = vec![-1.0f32; grid * grid];
+            for y in r.clone() {
+                for x in c.clone() {
+                    m[y * grid + x] = 1.0;
+                }
+            }
+            m
+        };
+        let left = block(0..grid / 2, 0..grid / 2);
+        let right = block(grid / 2..grid, grid / 2..grid);
+        let outputs = vec![
+            VideoFrameOutput {
+                obj_ids: vec![7, 9],
+                masks: vec![left.clone(), right.clone()],
+            },
+            VideoFrameOutput {
+                obj_ids: vec![7, 9],
+                masks: vec![left, right],
+            },
+        ];
+        let anchors = vec![Some((0.0, 0.0, 0.5, 0.5)), Some((0.0, 0.0, 0.5, 0.5))];
+        assert_eq!(select_object(&outputs, &anchors), Some(7));
+        assert_eq!(select_object(&outputs, &[None, None]), None);
+    }
+
+    #[test]
+    fn mask_to_frame_binarizes_and_resizes() {
+        let grid = 4;
+        let mut logits = vec![-1.0f32; grid * grid];
+        for y in 0..2 {
+            for x in 0..2 {
+                logits[y * grid + x] = 1.0;
+            }
+        }
+        let out = mask_to_frame(&logits, grid, 8, 8);
+        assert_eq!(out.len(), 64);
+        assert!(out.iter().all(|&v| v == 0 || v == 255), "output is binary");
+        assert_eq!(out[0], 255, "top-left corner is foreground");
+        assert_eq!(out[63], 0, "bottom-right corner is background");
+    }
+}


### PR DESCRIPTION
﻿## sc-6247 — wire candle SAM3 into the off-Mac person-track

Slice 8 of 9 of the SAM3 backport (sc-5062, epic 5482): replace the off-Mac (Windows/CUDA, `--features backend-candle`) **SAM2 box-prompt stub** in the person-track with the real candle SAM3 text-concept person segmenter.

> ⚠️ **Depends on candle-gen [#104](https://github.com/SceneWorks/candle-gen/pull/104)** (the gen-core de-skew). Merge that first — this PR pins the de-skew commit `db47ed5`.

### Before
The off-Mac `media_jobs::assemble_real_person_track` ran YOLO + ByteTrack only and returned `maskState = "missing"` / `segmenter = "disabled"` — person *segmentation* was Mac-only (epic 3792), so off-Mac tracks were box-only (the replacement loader derived box masks).

### After (mirrors the macOS SAM3 path, driving `candle-gen-sam3`)
- **New `person_segment_sam3_candle.rs`** — the candle twin of `person_segment_sam3.rs`. `segment_track_blocking` runs `Sam3VideoModel::propagate("person")`, associates SAM3's object ids to the selected ByteTrack track (the per-frame box is an association *hint*, not a prompt), and emits that object's per-frame binary mask. The pure assoc/mask helpers are shared line-for-line; only the tensor/inference seam is candle (`candle_gen::{candle_core, default_device, gen_core::Quant}`). Stock `facebook/sam3` checkpoint, **Q8 by default** (`SCENEWORKS_SAM3_QUANT`).
- **Off-Mac `segment_assembly_frames`** (SAM3-only — no `mlx-gen-sam2` branch) + rewired `assemble_real_person_track` to keep the rendered frames, run the segmenter, write `person-tracks/{track_id}/masks/frame_{:06}.png`, and report the rolled-up `maskState` + `segmenter = "sam3"`.
- Un-gated `TRACK_FRAME_SIZE` / `write_track_mask_pngs` to the shared `any(macos, not(macos)+candle)` cfg.

### Cargo / gen-core
Bump all candle-gen-* pins `c4641cbe → db47ed5` + add `candle-gen-sam3` (cuda, optional) + `dep:candle-gen-sam3` in `backend-candle`. `db47ed5` pins gen-core `517ef11f` = the worker's mlx pin → a **single** gen-core rev, fixing the pre-existing backend-candle breakage (mlx #490 bumped the worker mlx to `517ef11f` without the candle-gen lockstep; the workflow_dispatch-only lane never caught it — `instantid.rs`/`sdxl_ipadapter.rs` were mixing two gen-core builds).

### Validation (the backend-candle lane is workflow_dispatch-only, not a PR gate → built locally)
`cargo check` + `clippy -D warnings` `--features backend-candle`, the non-candle check, `fmt --check`, and the 6 pure-helper unit tests — all green; the lock resolves a single gen-core rev. Real GPU E2E (segment a person end-to-end) is **sc-6248**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
