### PR TITLE
feat(image-editor): layer-stack document model + compositing core (sc-6117)

### DIFF
--- a/apps/web/src/imageLayers.js
+++ b/apps/web/src/imageLayers.js
@@ -1,0 +1,236 @@
+// Layer-stack model for the Image Editor (sc-6117, Workstream E of epic 6087).
+//
+// The editor's working document is an ordered raster layer stack composited
+// bottom→top. A SINGLE-layer stack is the degenerate case that reproduces the
+// pre-layers single-bitmap editor exactly (visually + dimensionally + same Save
+// asset). This module is pure — no React, no Konva, no DOM beyond the 2D-canvas
+// context the compositor draws into — so the state model and the compositor can
+// be unit-tested without mounting the editor.
+//
+// Shapes:
+//   working = { width, height, source, layers: [Layer, …], activeLayerId }
+//   Layer   = { id, name, image, objectUrl, blob,
+//               visible, opacity, blendMode, transform }
+//   transform = { x, y, scaleX, scaleY, rotation }  // rotation in degrees
+//
+// `image`/`objectUrl` are the LIVE decoded representation (a layer's object URL is
+// revoked when the layer is evicted — see the editor's revoke discipline). `blob`
+// is the immutable source of truth: it is shared by reference into undo snapshots,
+// so retained bitmaps stay bounded the same way the single-bitmap history did.
+// A snapshot layer carries only metadata + blob (no image/objectUrl) — see
+// `snapshotLayer`.
+
+export const DEFAULT_BLEND_MODE = "source-over";
+
+// Identity transform for a layer that sits 1:1 over the document (the only kind
+// sc-6117 produces; non-identity transforms arrive with sc-6120, but the model +
+// compositor honor the fields now so the stack is forward-complete).
+export function identityTransform() {
+  return { x: 0, y: 0, scaleX: 1, scaleY: 1, rotation: 0 };
+}
+
+function clampOpacity(opacity) {
+  if (typeof opacity !== "number" || Number.isNaN(opacity)) return 1;
+  return Math.max(0, Math.min(1, opacity));
+}
+
+// Normalize a layer spec into a full Layer, filling defaults. Callers supply the
+// id (the editor owns a monotonic counter so ids survive undo without colliding).
+export function createLayer({
+  id,
+  name = "Layer",
+  image = null,
+  objectUrl = null,
+  blob = null,
+  visible = true,
+  opacity = 1,
+  blendMode = DEFAULT_BLEND_MODE,
+  transform = null,
+}) {
+  return {
+    id,
+    name,
+    image,
+    objectUrl,
+    blob,
+    visible: visible !== false,
+    opacity: clampOpacity(opacity),
+    blendMode: blendMode || DEFAULT_BLEND_MODE,
+    transform: transform ? { ...identityTransform(), ...transform } : identityTransform(),
+  };
+}
+
+// Build the degenerate single-layer document from one decoded bitmap. The doc
+// dimensions are the bitmap's natural size; the lone layer is the active layer.
+export function singleLayerWorking({ id, name = "Background", image, objectUrl, blob, source }) {
+  const layer = createLayer({ id, name, image, objectUrl, blob });
+  return {
+    width: image?.naturalWidth ?? 0,
+    height: image?.naturalHeight ?? 0,
+    source,
+    layers: [layer],
+    activeLayerId: layer.id,
+  };
+}
+
+// The active layer (by id), falling back to the bottom layer, or null.
+export function activeLayerOf(working) {
+  if (!working || !working.layers?.length) return null;
+  return working.layers.find((layer) => layer.id === working.activeLayerId) ?? working.layers[0];
+}
+
+export function layerById(working, id) {
+  return working?.layers?.find((layer) => layer.id === id) ?? null;
+}
+
+function withLayers(working, layers, activeLayerId = working.activeLayerId) {
+  return { ...working, layers, activeLayerId };
+}
+
+// Insert a new layer on TOP of the stack and make it active (the natural "Add
+// layer" semantics — new content lands above and becomes the edit target).
+export function addLayer(working, layer) {
+  return withLayers(working, [...working.layers, layer], layer.id);
+}
+
+// Remove a layer. The last layer cannot be removed (a document always has ≥1
+// layer). Returns { working, removed } so the caller can revoke the evicted
+// layer's object URL; `removed` is null when the delete was a no-op. When the
+// active layer is removed, the active pointer moves to the layer that takes its
+// slot (or the new top).
+export function removeLayer(working, id) {
+  if (!working || working.layers.length <= 1) return { working, removed: null };
+  const index = working.layers.findIndex((layer) => layer.id === id);
+  if (index < 0) return { working, removed: null };
+  const removed = working.layers[index];
+  const layers = working.layers.filter((layer) => layer.id !== id);
+  let activeLayerId = working.activeLayerId;
+  if (activeLayerId === id) {
+    const neighbor = layers[Math.min(index, layers.length - 1)];
+    activeLayerId = neighbor.id;
+  }
+  return { working: withLayers(working, layers, activeLayerId), removed };
+}
+
+// Duplicate a layer, inserting the clone directly ABOVE the source and making it
+// active. The clone shares the source's immutable `blob` by reference but carries
+// its OWN freshly-decoded image + object URL (passed in by the caller, which owns
+// the decode), so the two layers can later diverge and the URL-revoke-on-evict
+// discipline stays one-URL-per-live-layer.
+export function duplicateLayer(working, id, { id: cloneId, image, objectUrl }) {
+  const index = working.layers.findIndex((layer) => layer.id === id);
+  if (index < 0) return working;
+  const src = working.layers[index];
+  const clone = createLayer({
+    id: cloneId,
+    name: `${src.name} copy`,
+    image,
+    objectUrl,
+    blob: src.blob,
+    visible: src.visible,
+    opacity: src.opacity,
+    blendMode: src.blendMode,
+    transform: { ...src.transform },
+  });
+  const layers = [...working.layers.slice(0, index + 1), clone, ...working.layers.slice(index + 1)];
+  return withLayers(working, layers, clone.id);
+}
+
+// Move a layer to a new stack index (clamped). Index 0 = bottom.
+export function moveLayer(working, id, toIndex) {
+  const from = working.layers.findIndex((layer) => layer.id === id);
+  if (from < 0) return working;
+  const target = Math.max(0, Math.min(working.layers.length - 1, toIndex));
+  if (from === target) return working;
+  const layers = [...working.layers];
+  const [moved] = layers.splice(from, 1);
+  layers.splice(target, 0, moved);
+  return withLayers(working, layers);
+}
+
+// Patch a single layer's metadata (visible / opacity / name / blendMode /
+// transform). Pixel data (image/blob) is never patched here.
+export function setLayerProps(working, id, patch) {
+  const layers = working.layers.map((layer) => {
+    if (layer.id !== id) return layer;
+    const next = { ...layer, ...patch };
+    if (patch.opacity !== undefined) next.opacity = clampOpacity(patch.opacity);
+    if (patch.transform) next.transform = { ...layer.transform, ...patch.transform };
+    return next;
+  });
+  return withLayers(working, layers);
+}
+
+export function setActiveLayer(working, id) {
+  if (!layerById(working, id)) return working;
+  return { ...working, activeLayerId: id };
+}
+
+// Strip a live layer down to the snapshot representation: metadata + the shared
+// blob, no live image/objectUrl. Undo snapshots hold these (blobs shared by
+// reference), so an evicted snapshot is plain garbage with nothing to revoke.
+export function snapshotLayer(layer) {
+  return {
+    id: layer.id,
+    name: layer.name,
+    blob: layer.blob,
+    visible: layer.visible,
+    opacity: layer.opacity,
+    blendMode: layer.blendMode,
+    transform: { ...layer.transform },
+  };
+}
+
+export function snapshotLayers(layers) {
+  return (layers ?? []).map(snapshotLayer);
+}
+
+function sameTransform(a, b) {
+  const x = a ?? identityTransform();
+  const y = b ?? identityTransform();
+  return x.x === y.x && x.y === y.y && x.scaleX === y.scaleX && x.scaleY === y.scaleY && x.rotation === y.rotation;
+}
+
+// Whether two layer lists are pixel- and metadata-identical (same ids/order, same
+// blob by reference, same visible/opacity/blend/transform). Used by restore to
+// tell an overlay-only step (no decode, no refit) from a bitmap/structure change.
+// Ignores live image identity — only the blob (source of truth) matters.
+export function sameLayerStack(a, b) {
+  if (!a || !b || a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    const x = a[i];
+    const y = b[i];
+    if (
+      x.id !== y.id ||
+      x.blob !== y.blob ||
+      x.visible !== y.visible ||
+      x.opacity !== y.opacity ||
+      x.blendMode !== y.blendMode ||
+      !sameTransform(x.transform, y.transform)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Composite a layer stack into a 2D-canvas context, bottom→top, honoring
+// visibility, opacity, blend mode, and per-layer transform. The shared flatten
+// behind Save / Download / Download-as-source for AI ops. `visibleOnly` (default)
+// skips hidden and fully-transparent layers. The context must already be sized to
+// the document; layers' `image` must be decoded (HTMLImageElement / canvas).
+export function compositeLayersToCanvas(ctx, layers, { visibleOnly = true } = {}) {
+  for (const layer of layers ?? []) {
+    if (!layer.image) continue;
+    if (visibleOnly && (!layer.visible || layer.opacity <= 0)) continue;
+    const t = layer.transform ?? identityTransform();
+    ctx.save();
+    ctx.globalAlpha = clampOpacity(layer.opacity);
+    ctx.globalCompositeOperation = layer.blendMode || DEFAULT_BLEND_MODE;
+    ctx.translate(t.x || 0, t.y || 0);
+    if (t.rotation) ctx.rotate((t.rotation * Math.PI) / 180);
+    ctx.scale(t.scaleX ?? 1, t.scaleY ?? 1);
+    ctx.drawImage(layer.image, 0, 0);
+    ctx.restore();
+  }
+}

--- a/apps/web/src/imageLayers.test.js
+++ b/apps/web/src/imageLayers.test.js
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_BLEND_MODE,
+  identityTransform,
+  createLayer,
+  singleLayerWorking,
+  activeLayerOf,
+  layerById,
+  addLayer,
+  removeLayer,
+  duplicateLayer,
+  moveLayer,
+  setLayerProps,
+  setActiveLayer,
+  snapshotLayer,
+  snapshotLayers,
+  sameLayerStack,
+  compositeLayersToCanvas,
+} from "./imageLayers.js";
+
+// A minimal stand-in for a decoded bitmap — only naturalWidth/Height are read by
+// the model, and the compositor passes the object straight to ctx.drawImage.
+const fakeImage = (w = 100, h = 80) => ({ naturalWidth: w, naturalHeight: h });
+
+const liveLayer = (id, overrides = {}) =>
+  createLayer({ id, image: fakeImage(), objectUrl: `blob:${id}`, blob: { id }, ...overrides });
+
+describe("layer model — creation + degenerate single-layer document (sc-6117)", () => {
+  it("createLayer fills defaults and clamps opacity", () => {
+    const layer = createLayer({ id: "a", blob: {}, opacity: 5 });
+    expect(layer.name).toBe("Layer");
+    expect(layer.visible).toBe(true);
+    expect(layer.opacity).toBe(1); // clamped from 5
+    expect(layer.blendMode).toBe(DEFAULT_BLEND_MODE);
+    expect(layer.transform).toEqual(identityTransform());
+    expect(createLayer({ id: "b", blob: {}, opacity: -2 }).opacity).toBe(0);
+  });
+
+  it("singleLayerWorking mirrors the old single-bitmap document", () => {
+    const image = fakeImage(640, 480);
+    const work = singleLayerWorking({ id: "bg", image, objectUrl: "blob:x", blob: {}, source: { kind: "upload", name: "p.png" } });
+    expect(work.width).toBe(640);
+    expect(work.height).toBe(480);
+    expect(work.layers).toHaveLength(1);
+    expect(work.activeLayerId).toBe("bg");
+    expect(activeLayerOf(work).id).toBe("bg");
+    expect(work.layers[0].name).toBe("Background");
+  });
+
+  it("activeLayerOf falls back to the bottom layer, then null", () => {
+    const work = { layers: [liveLayer("a"), liveLayer("b")], activeLayerId: "missing" };
+    expect(activeLayerOf(work).id).toBe("a");
+    expect(activeLayerOf({ layers: [], activeLayerId: null })).toBeNull();
+    expect(activeLayerOf(null)).toBeNull();
+  });
+});
+
+describe("layer operations — add / delete / duplicate / reorder (sc-6117)", () => {
+  const base = () => ({
+    width: 100,
+    height: 80,
+    source: { kind: "blank", name: "x" },
+    layers: [liveLayer("a"), liveLayer("b")],
+    activeLayerId: "a",
+  });
+
+  it("addLayer inserts on top and activates the new layer", () => {
+    const next = addLayer(base(), liveLayer("c"));
+    expect(next.layers.map((l) => l.id)).toEqual(["a", "b", "c"]);
+    expect(next.activeLayerId).toBe("c");
+  });
+
+  it("removeLayer drops the layer, returns it for URL revocation, and reseats active", () => {
+    const { working, removed } = removeLayer(base(), "a");
+    expect(working.layers.map((l) => l.id)).toEqual(["b"]);
+    expect(removed.id).toBe("a");
+    expect(removed.objectUrl).toBe("blob:a"); // caller revokes this
+    expect(working.activeLayerId).toBe("b"); // active followed off the deleted layer
+  });
+
+  it("removeLayer refuses to delete the last layer (a document keeps ≥1)", () => {
+    const single = { ...base(), layers: [liveLayer("a")], activeLayerId: "a" };
+    const { working, removed } = removeLayer(single, "a");
+    expect(removed).toBeNull();
+    expect(working.layers).toHaveLength(1);
+  });
+
+  it("duplicateLayer clones metadata above the source, shares blob, takes a fresh image/url", () => {
+    const src = base();
+    src.layers[0] = liveLayer("a", { name: "Sky", opacity: 0.5, blendMode: "multiply" });
+    const cloneImage = fakeImage();
+    const next = duplicateLayer(src, "a", { id: "a2", image: cloneImage, objectUrl: "blob:a2" });
+    expect(next.layers.map((l) => l.id)).toEqual(["a", "a2", "b"]);
+    const clone = layerById(next, "a2");
+    expect(clone.name).toBe("Sky copy");
+    expect(clone.opacity).toBe(0.5);
+    expect(clone.blendMode).toBe("multiply");
+    expect(clone.blob).toBe(src.layers[0].blob); // shared by reference
+    expect(clone.image).toBe(cloneImage); // its own decoded bitmap
+    expect(clone.objectUrl).toBe("blob:a2");
+    expect(next.activeLayerId).toBe("a2");
+  });
+
+  it("moveLayer reorders with clamping and is a no-op at the same index", () => {
+    expect(moveLayer(base(), "a", 1).layers.map((l) => l.id)).toEqual(["b", "a"]);
+    expect(moveLayer(base(), "b", 99).layers.map((l) => l.id)).toEqual(["a", "b"]); // clamped to top
+    expect(moveLayer(base(), "a", 0)).toEqual(base()); // unchanged
+  });
+
+  it("setLayerProps patches metadata (clamping opacity, merging transform) without touching pixels", () => {
+    const next = setLayerProps(base(), "b", { visible: false, opacity: 9, transform: { x: 10 } });
+    const b = layerById(next, "b");
+    expect(b.visible).toBe(false);
+    expect(b.opacity).toBe(1);
+    expect(b.transform).toEqual({ ...identityTransform(), x: 10 });
+    expect(b.image).toBe(layerById(base(), "b") ? next.layers[1].image : null); // image untouched
+  });
+
+  it("setActiveLayer ignores unknown ids", () => {
+    expect(setActiveLayer(base(), "b").activeLayerId).toBe("b");
+    expect(setActiveLayer(base(), "ghost").activeLayerId).toBe("a");
+  });
+});
+
+describe("snapshot representation + equality (sc-6117 undo integration)", () => {
+  it("snapshotLayer keeps metadata + shared blob, drops live image/url", () => {
+    const blob = { tag: 1 };
+    const snap = snapshotLayer(liveLayer("a", { blob, opacity: 0.3, name: "n" }));
+    expect(snap).toEqual({
+      id: "a",
+      name: "n",
+      blob,
+      visible: true,
+      opacity: 0.3,
+      blendMode: DEFAULT_BLEND_MODE,
+      transform: identityTransform(),
+    });
+    expect(snap.blob).toBe(blob); // shared by reference → bounded memory
+    expect("image" in snap).toBe(false);
+    expect("objectUrl" in snap).toBe(false);
+  });
+
+  it("sameLayerStack tells overlay-only steps from pixel/structure changes", () => {
+    const a = liveLayer("a");
+    const b = liveLayer("b");
+    const live = [a, b];
+    // Identical content (snapshot of the same blobs) → equal.
+    expect(sameLayerStack(live, snapshotLayers(live))).toBe(true);
+    // A different blob (a bitmap edit) → not equal.
+    expect(sameLayerStack(live, [{ ...snapshotLayer(a), blob: { other: 1 } }, snapshotLayer(b)])).toBe(false);
+    // A metadata change (opacity) → not equal.
+    expect(sameLayerStack(live, [{ ...snapshotLayer(a), opacity: 0.5 }, snapshotLayer(b)])).toBe(false);
+    // Reorder → not equal.
+    expect(sameLayerStack(live, [snapshotLayer(b), snapshotLayer(a)])).toBe(false);
+    // Different length → not equal.
+    expect(sameLayerStack(live, [snapshotLayer(a)])).toBe(false);
+  });
+});
+
+describe("compositor — bottom→top, honoring visibility / opacity / blend / order (sc-6117)", () => {
+  // A recording 2D-context stand-in: drawImage logs the image drawn and the alpha
+  // + blend in force at draw time, so the test sees exactly what was composited.
+  const recordingCtx = () => {
+    const calls = [];
+    let alpha = 1;
+    let gco = "source-over";
+    return {
+      calls,
+      get globalAlpha() {
+        return alpha;
+      },
+      set globalAlpha(v) {
+        alpha = v;
+      },
+      get globalCompositeOperation() {
+        return gco;
+      },
+      set globalCompositeOperation(v) {
+        gco = v;
+      },
+      save() {},
+      restore() {},
+      translate() {},
+      rotate() {},
+      scale() {},
+      drawImage(image) {
+        calls.push({ image, alpha, gco });
+      },
+    };
+  };
+
+  it("draws every visible layer bottom→top with its alpha + blend", () => {
+    const bottom = liveLayer("a");
+    const top = liveLayer("b", { opacity: 0.4, blendMode: "multiply" });
+    const ctx = recordingCtx();
+    compositeLayersToCanvas(ctx, [bottom, top]);
+    expect(ctx.calls).toHaveLength(2);
+    expect(ctx.calls[0]).toMatchObject({ image: bottom.image, alpha: 1, gco: "source-over" });
+    expect(ctx.calls[1]).toMatchObject({ image: top.image, alpha: 0.4, gco: "multiply" });
+  });
+
+  it("skips hidden and fully-transparent layers (visibleOnly), but draws them when asked", () => {
+    const visible = liveLayer("a");
+    const hidden = liveLayer("b", { visible: false });
+    const transparent = liveLayer("c", { opacity: 0 });
+    const ctx = recordingCtx();
+    compositeLayersToCanvas(ctx, [visible, hidden, transparent]);
+    expect(ctx.calls.map((c) => c.image)).toEqual([visible.image]);
+
+    const all = recordingCtx();
+    compositeLayersToCanvas(all, [visible, hidden, transparent], { visibleOnly: false });
+    expect(all.calls).toHaveLength(3);
+  });
+
+  it("skips layers with no decoded image", () => {
+    const ctx = recordingCtx();
+    compositeLayersToCanvas(ctx, [createLayer({ id: "x", blob: {} })]);
+    expect(ctx.calls).toHaveLength(0);
+  });
+});

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -8,6 +8,14 @@ import { assetUrl, assetCanRenderAsImage } from "../components/assetMedia.jsx";
 import { DatasetAddDialog } from "../components/DatasetAddDialog.jsx";
 import { FitModeControl, effectiveFitMode } from "../components/FitModeControl.jsx";
 import { makeObjElement, makeTextElement, normalizeHexColor } from "../ideogramCaption.js";
+import {
+  activeLayerOf,
+  compositeLayersToCanvas,
+  createLayer,
+  sameLayerStack,
+  singleLayerWorking,
+  snapshotLayers,
+} from "../imageLayers.js";
 
 const MIN_SCALE = 0.05;
 const MAX_SCALE = 16;
@@ -739,6 +747,16 @@ export function historyRedo(history, present, limit = HISTORY_LIMIT) {
 export const canUndo = (history) => history.past.length > 0;
 export const canRedo = (history) => history.future.length > 0;
 
+// Revoke the object URLs of a set of live layers (sc-6117). Undo snapshots hold
+// only blobs (no URLs), so the only URLs that ever need revoking are the live
+// ones, when their layer is evicted — on delete, on a session replace, and on
+// unmount. Tolerant of null/missing URLs so callers don't have to guard.
+function revokeLayerUrls(layers) {
+  for (const layer of layers ?? []) {
+    if (layer?.objectUrl) URL.revokeObjectURL(layer.objectUrl);
+  }
+}
+
 export function ImageEditor() {
   const {
     activeProject,
@@ -764,9 +782,12 @@ export function ImageEditor() {
   // the mask tool shows only the hand brush (graceful degradation).
   const smartSelectSupported = macCapabilities?.features?.imageSegment?.supported === true;
 
-  // The working-image session: the single bitmap every tool operates on, plus its
-  // provenance. This state is the contract consumed by crop/upscale/save and the
-  // later AI tools (epic 2427). `objectUrl` is tracked so we can revoke it.
+  // The working document (sc-6117): an ordered raster layer stack composited
+  // bottom→top — `{ width, height, source, layers:[Layer], activeLayerId }` (see
+  // ../imageLayers.js). A single-layer stack is the degenerate case that behaves
+  // exactly like the pre-layers single bitmap, so the existing tools keep operating
+  // on the active layer; the per-layer tool matrix + the panel land in sc-6118/6119.
+  // Each live layer owns its decoded `image` + `objectUrl` (revoked on eviction).
   const [working, setWorking] = useState(null);
   const [status, setStatus] = useState({ loading: false, error: "" });
   const [pickerOpen, setPickerOpen] = useState(false);
@@ -913,8 +934,10 @@ export function ImageEditor() {
   const [aiOp, setAiOp] = useState(null);
 
   const containerRef = useRef(null);
-  const objectUrlRef = useRef(null);
   const needsFitRef = useRef(false);
+  // Monotonic layer-id source: ids survive an undo (the seq is snapshotted, like
+  // boxIdSeq) so a layer added after an undo never collides with a recycled id.
+  const layerIdRef = useRef(0);
   const cropRectRef = useRef(null);
   const transformerRef = useRef(null);
   const imageNodeRef = useRef(null); // Konva image node — cached for color-grade filtering
@@ -925,9 +948,10 @@ export function ImageEditor() {
   // can-undo/redo flags are mirrored into state so the toolbar buttons re-render.
   const historyRef = useRef(emptyHistory());
   const [historyFlags, setHistoryFlags] = useState({ canUndo: false, canRedo: false });
-  // The Blob of the current working bitmap — a snapshot reuses it (no re-encode) and
-  // restore() compares against it to skip a needless decode/refit for overlay-only steps.
-  const workingBlobRef = useRef(null);
+  // Live mirror of the working document for synchronous reads inside the commit
+  // handlers (a checkpoint captures the pre-operation stack; restore reuses the
+  // live decoded images for unchanged layers and revokes the URLs it drops).
+  const workingRef = useRef(null);
   // Live mirrors of the snapshot-relevant state so a synchronous checkpoint can
   // capture the pre-operation state without stale-closure surprises.
   const editsRef = useRef(edits);
@@ -935,7 +959,6 @@ export function ImageEditor() {
   const savedAssetIdRef = useRef(savedAssetId);
   const boxesRef = useRef(boxes);
   const boxColorRef = useRef(boxColor);
-  const workingSourceRef = useRef(null);
   const aiOpRef = useRef(aiOp);
   useEffect(() => { editsRef.current = edits; }, [edits]);
   useEffect(() => { dirtyRef.current = dirty; }, [dirty]);
@@ -943,7 +966,7 @@ export function ImageEditor() {
   useEffect(() => { boxesRef.current = boxes; }, [boxes]);
   useEffect(() => { boxColorRef.current = boxColor; }, [boxColor]);
   useEffect(() => { aiOpRef.current = aiOp; }, [aiOp]);
-  useEffect(() => { if (working) workingSourceRef.current = working.source; }, [working]);
+  useEffect(() => { workingRef.current = working; }, [working]);
 
   const imageAssets = (assets ?? []).filter(assetCanRenderAsImage);
 
@@ -961,10 +984,8 @@ export function ImageEditor() {
     return () => observer.disconnect();
   }, []);
 
-  // Revoke the live object URL when the editor unmounts.
-  useEffect(() => () => {
-    if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
-  }, []);
+  // Revoke every live layer's object URL when the editor unmounts.
+  useEffect(() => () => revokeLayerUrls(workingRef.current?.layers), []);
 
   const fitToView = useCallback(() => {
     if (!working || !stageSize.width || !stageSize.height) return;
@@ -989,10 +1010,12 @@ export function ImageEditor() {
     }
   }, [working, stageSize.width, stageSize.height, fitToView]);
 
-  const installWorkingImage = useCallback((image, objectUrl, source) => {
-    if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
-    objectUrlRef.current = objectUrl;
-    needsFitRef.current = true;
+  const nextLayerId = () => `layer_${(layerIdRef.current += 1)}`;
+
+  // Reset the per-bitmap editor overlays/tool state that a new working bitmap
+  // invalidates (tool, crop, color preview, mask, references, boxes). Shared by
+  // installWorkingImage (open/crop/AI result) and a bitmap-changing undo restore.
+  const resetEditorOverlays = useCallback(() => {
     setTool("move");
     setCropRect(null);
     setColorAdjust(IDENTITY_COLOR_ADJUST);
@@ -1013,53 +1036,63 @@ export function ImageEditor() {
     setBoxDraft(null);
     boxNodeRefs.current.clear();
     boxDrawingRef.current = false;
-    setWorking({
-      image,
-      width: image.naturalWidth,
-      height: image.naturalHeight,
-      source,
-    });
   }, []);
 
-  // ── Undo/redo plumbing (sc-6106) ──────────────────────────────────────────
-  // A snapshot is the working bitmap blob plus the overlay/provenance state that
-  // installWorkingImage would otherwise reset (boxes, edit chain, dirty flag).
-  const captureSnapshot = useCallback(
-    () => ({
-      blob: workingBlobRef.current,
-      source: workingSourceRef.current,
+  // Replace the whole working document with a fresh single-layer stack from one
+  // decoded bitmap (open / blank / crop / color / AI result). Revokes the evicted
+  // layers' object URLs first. The single-layer stack is the degenerate case that
+  // reproduces the pre-layers single-bitmap behavior; multi-layer creation is the
+  // layers panel (sc-6118).
+  const installWorkingImage = useCallback(
+    (image, objectUrl, blob, source) => {
+      revokeLayerUrls(workingRef.current?.layers);
+      needsFitRef.current = true;
+      resetEditorOverlays();
+      setWorking(singleLayerWorking({ id: nextLayerId(), image, objectUrl, blob, source }));
+    },
+    [resetEditorOverlays],
+  );
+
+  // ── Undo/redo plumbing (sc-6106, extended to the layer stack sc-6117) ──────
+  // A snapshot is the layer stack (each layer as metadata + its shared blob, no
+  // live image/URL) plus the overlay/provenance state that a re-install would
+  // otherwise reset (boxes, edit chain, dirty flag). Blobs are shared by reference
+  // across snapshots, so retained bitmaps stay bounded like the single-bitmap days.
+  const captureSnapshot = useCallback(() => {
+    const work = workingRef.current;
+    return {
+      layers: snapshotLayers(work?.layers),
+      activeLayerId: work?.activeLayerId ?? null,
+      width: work?.width ?? 0,
+      height: work?.height ?? 0,
+      source: work?.source ?? null,
+      layerIdSeq: layerIdRef.current,
       edits: editsRef.current,
       dirty: dirtyRef.current,
       savedAssetId: savedAssetIdRef.current,
       boxes: boxesRef.current,
       boxColor: boxColorRef.current,
       boxIdSeq: boxIdRef.current,
-    }),
-    [],
-  );
+    };
+  }, []);
 
   const syncHistoryFlags = useCallback(() => {
     setHistoryFlags({ canUndo: canUndo(historyRef.current), canRedo: canRedo(historyRef.current) });
   }, []);
 
   // Record a step: push the pre-operation snapshot onto the undo stack. Call this
-  // BEFORE the working state mutates (crop/color/AI result, or a box change).
+  // BEFORE the working state mutates (crop/color/AI result, layer op, or a box change).
   const checkpoint = useCallback(() => {
-    if (!workingBlobRef.current) return;
+    if (!workingRef.current) return;
     historyRef.current = historyCheckpoint(historyRef.current, captureSnapshot());
     syncHistoryFlags();
   }, [captureSnapshot, syncHistoryFlags]);
 
   // Start a fresh history for a newly opened session (clears both stacks).
-  const resetHistory = useCallback(
-    (blob, source) => {
-      workingBlobRef.current = blob;
-      workingSourceRef.current = source;
-      historyRef.current = emptyHistory();
-      syncHistoryFlags();
-    },
-    [syncHistoryFlags],
-  );
+  const resetHistory = useCallback(() => {
+    historyRef.current = emptyHistory();
+    syncHistoryFlags();
+  }, [syncHistoryFlags]);
 
   // Re-apply a snapshot's overlay/provenance state, keeping the live mirrors in
   // sync immediately so an undo→undo chain reads the right "present" each step.
@@ -1076,30 +1109,77 @@ export function ImageEditor() {
     boxColorRef.current = snap.boxColor;
     setSelectedBoxId(null);
     boxIdRef.current = snap.boxIdSeq;
+    // Restore the layer-id counter so a layer added after this undo can't recycle
+    // an id that a redo would bring back (mirrors boxIdSeq).
+    if (typeof snap.layerIdSeq === "number") layerIdRef.current = snap.layerIdSeq;
   }, []);
 
   const restoreSnapshot = useCallback(
     async (snap) => {
       if (!snap) return;
       try {
-        // Overlay-only steps (box edits) keep the same bitmap → skip the decode and
-        // the view refit; only bitmap ops (crop/color/AI) re-install the image.
-        if (snap.blob && snap.blob !== workingBlobRef.current) {
-          const { image, objectUrl } = await blobToImage(snap.blob);
-          installWorkingImage(image, objectUrl, snap.source);
-          workingBlobRef.current = snap.blob;
-          workingSourceRef.current = snap.source;
+        const live = workingRef.current;
+        // Overlay-only steps (box edits) keep the stack pixel- and metadata-identical
+        // → skip the rebuild, the decode, and the view refit; only a bitmap/structure
+        // change (crop/color/AI/layer op) re-installs the stack.
+        const stackChanged =
+          !live ||
+          !sameLayerStack(live.layers, snap.layers) ||
+          live.activeLayerId !== snap.activeLayerId ||
+          live.width !== snap.width ||
+          live.height !== snap.height;
+        if (stackChanged) {
+          // Rebuild the live stack from the snapshot: reuse a live layer's decoded
+          // image when its blob is unchanged (decode ONLY changed/new layers), and
+          // revoke the object URLs of live layers the restore drops.
+          const liveById = new Map((live?.layers ?? []).map((layer) => [layer.id, layer]));
+          const reused = new Set();
+          const layers = [];
+          for (const sl of snap.layers) {
+            const prev = liveById.get(sl.id);
+            if (prev && prev.blob === sl.blob && prev.image) {
+              reused.add(sl.id);
+              layers.push({
+                ...prev,
+                name: sl.name,
+                visible: sl.visible,
+                opacity: sl.opacity,
+                blendMode: sl.blendMode,
+                transform: { ...sl.transform },
+              });
+            } else {
+              const { image, objectUrl } = await blobToImage(sl.blob);
+              layers.push(createLayer({ ...sl, image, objectUrl }));
+            }
+          }
+          for (const layer of live?.layers ?? []) {
+            if (!reused.has(layer.id) && layer.objectUrl) URL.revokeObjectURL(layer.objectUrl);
+          }
+          // Reset the per-bitmap overlays (the snapshot's overlay state is re-applied
+          // by applyHistoryAux below); refit only when the document size changed (a
+          // pure opacity/visibility/reorder undo keeps the current pan/zoom).
+          resetEditorOverlays();
+          if (!live || live.width !== snap.width || live.height !== snap.height) needsFitRef.current = true;
+          const nextWorking = {
+            width: snap.width,
+            height: snap.height,
+            source: snap.source,
+            layers,
+            activeLayerId: snap.activeLayerId,
+          };
+          workingRef.current = nextWorking;
+          setWorking(nextWorking);
         }
         applyHistoryAux(snap);
       } catch (err) {
         setStatus({ loading: false, error: err.message || "Could not restore that step." });
       }
     },
-    [installWorkingImage, applyHistoryAux],
+    [resetEditorOverlays, applyHistoryAux],
   );
 
   const undo = useCallback(async () => {
-    if (aiOpRef.current || !workingBlobRef.current) return;
+    if (aiOpRef.current || !workingRef.current) return;
     const { history: next, restore } = historyUndo(historyRef.current, captureSnapshot());
     if (!restore) return;
     historyRef.current = next;
@@ -1108,7 +1188,7 @@ export function ImageEditor() {
   }, [captureSnapshot, restoreSnapshot, syncHistoryFlags]);
 
   const redo = useCallback(async () => {
-    if (aiOpRef.current || !workingBlobRef.current) return;
+    if (aiOpRef.current || !workingRef.current) return;
     const { history: next, restore } = historyRedo(historyRef.current, captureSnapshot());
     if (!restore) return;
     historyRef.current = next;
@@ -1143,13 +1223,13 @@ export function ImageEditor() {
       setStatus({ loading: true, error: "" });
       try {
         const { image, objectUrl } = await blobToImage(blob);
-        installWorkingImage(image, objectUrl, source);
+        installWorkingImage(image, objectUrl, blob, source);
         // A freshly opened image is a clean session — clear edit/provenance state
         // and start a fresh undo/redo history rooted at this bitmap (sc-6106).
         setEdits([]);
         setDirty(false);
         setSavedAssetId(null);
-        resetHistory(blob, source);
+        resetHistory();
         setStatus({ loading: false, error: "" });
       } catch (err) {
         setStatus({ loading: false, error: err.message || "Could not open image" });
@@ -1320,7 +1400,8 @@ export function ImageEditor() {
   // bitmap is blob-backed (never tainted), so reading pixels back is safe. The
   // result keeps the same source provenance so lineage survives to Save (sc-2434).
   const applyCrop = useCallback(async () => {
-    if (!working || !cropRect) return;
+    const layer = activeLayerOf(working);
+    if (!working || !cropRect || !layer) return;
     const sx = clamp(Math.round(cropRect.x), 0, working.width - 1);
     const sy = clamp(Math.round(cropRect.y), 0, working.height - 1);
     const sw = clamp(Math.round(cropRect.width), 1, working.width - sx);
@@ -1328,13 +1409,14 @@ export function ImageEditor() {
     const canvas = document.createElement("canvas");
     canvas.width = sw;
     canvas.height = sh;
-    canvas.getContext("2d").drawImage(working.image, sx, sy, sw, sh, 0, 0, sw, sh);
+    // Single-layer document (sc-6117): crop the lone layer and rebuild the stack at
+    // the new size. Document-level crop across a multi-layer stack is sc-6119.
+    canvas.getContext("2d").drawImage(layer.image, sx, sy, sw, sh, 0, 0, sw, sh);
     const blob = await new Promise((resolve) => canvas.toBlob(resolve, "image/png"));
     if (!blob) return;
     const { image, objectUrl } = await blobToImage(blob);
     checkpoint();
-    installWorkingImage(image, objectUrl, working.source);
-    workingBlobRef.current = blob;
+    installWorkingImage(image, objectUrl, blob, working.source);
     setEdits((prev) => [...prev, { op: "crop", width: sw, height: sh }]);
     setDirty(true);
   }, [working, cropRect, installWorkingImage, checkpoint]);
@@ -1380,12 +1462,16 @@ export function ImageEditor() {
   // preview (a 2D-canvas pass, no Konva-cache readback). Keeps the source provenance
   // so lineage survives to Save; records the grade in the edit chain.
   const applyColorGrade = useCallback(async () => {
-    if (!working || isIdentityAdjust(colorAdjust)) return;
+    const layer = activeLayerOf(working);
+    if (!working || !layer || isIdentityAdjust(colorAdjust)) return;
     const canvas = document.createElement("canvas");
     canvas.width = working.width;
     canvas.height = working.height;
     const ctx = canvas.getContext("2d");
-    ctx.drawImage(working.image, 0, 0);
+    // Single-layer document (sc-6117): bake the grade into the lone layer. Grading
+    // the active layer of a multi-layer stack is sc-6119 (the live preview already
+    // caches the active layer's node, below).
+    ctx.drawImage(layer.image, 0, 0);
     const imageData = ctx.getImageData(0, 0, working.width, working.height);
     applyColorAdjustments(imageData.data, colorAdjust);
     ctx.putImageData(imageData, 0, 0);
@@ -1394,8 +1480,7 @@ export function ImageEditor() {
     const baked = { ...colorAdjust };
     const { image, objectUrl } = await blobToImage(blob);
     checkpoint();
-    installWorkingImage(image, objectUrl, working.source);
-    workingBlobRef.current = blob;
+    installWorkingImage(image, objectUrl, blob, working.source);
     setEdits((prev) => [...prev, { op: "color", ...baked }]);
     setDirty(true);
   }, [working, colorAdjust, installWorkingImage, checkpoint]);
@@ -1514,17 +1599,25 @@ export function ImageEditor() {
     setBoxDraft(null);
   }
 
-  // Rasterize the working image + the colored boxes into one PNG File (sc-6093).
+  // Flatten the visible layer stack onto a fresh canvas at the document size
+  // (sc-6117). The layers' images are already decoded, so this is synchronous;
+  // callers toBlob it (Save / Download / AI-op source) or paint overlays on top
+  // first (the box-keyed edit). The shared composite behind every editor export.
+  function compositeToCanvas(work = working) {
+    const canvas = document.createElement("canvas");
+    canvas.width = work.width;
+    canvas.height = work.height;
+    compositeLayersToCanvas(canvas.getContext("2d"), work.layers, { visibleOnly: true });
+    return canvas;
+  }
+
+  // Rasterize the composited document + the colored boxes into one PNG File (sc-6093).
   // This is an ephemeral pass-through reference — staged as scratch, never saved
   // to the Library — that the edit model reads as color-keyed regions.
   function bakeBoxesToFile() {
     return new Promise((resolve, reject) => {
-      const canvas = document.createElement("canvas");
-      canvas.width = working.width;
-      canvas.height = working.height;
-      const ctx = canvas.getContext("2d");
-      ctx.drawImage(working.image, 0, 0);
-      paintBoxesOnContext(ctx, boxes);
+      const canvas = compositeToCanvas();
+      paintBoxesOnContext(canvas.getContext("2d"), boxes);
       canvas.toBlob((blob) => {
         if (!blob) {
           reject(new Error("Could not bake the boxes."));
@@ -1718,8 +1811,8 @@ export function ImageEditor() {
   }
 
   // ── AI ops on the working image (sc-2432 seam) ────────────────────────────
-  // Rasterize the current working image to a PNG File. `filename` overrides the
-  // name (Save/Download use the "-edited" name; the AI-op scratch upload doesn't care).
+  // Flatten the composited document to a PNG File. `filename` overrides the name
+  // (Save/Download use the "-edited" name; the AI-op scratch upload doesn't care).
   const workingImageToFile = useCallback(
     (filename) => {
       return new Promise((resolve, reject) => {
@@ -1727,10 +1820,7 @@ export function ImageEditor() {
           reject(new Error("No working image."));
           return;
         }
-        const canvas = document.createElement("canvas");
-        canvas.width = working.width;
-        canvas.height = working.height;
-        canvas.getContext("2d").drawImage(working.image, 0, 0);
+        const canvas = compositeToCanvas(working);
         const base = (working.source.name || "image").replace(/\.[^./\\]+$/, "");
         const name = filename || `${base}.png`;
         canvas.toBlob((blob) => {
@@ -1742,6 +1832,7 @@ export function ImageEditor() {
         }, "image/png");
       });
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [working],
   );
 
@@ -1958,8 +2049,7 @@ export function ImageEditor() {
         const blob = await res.blob();
         const { image, objectUrl } = await blobToImage(blob);
         checkpoint();
-        installWorkingImage(image, objectUrl, source);
-        workingBlobRef.current = blob;
+        installWorkingImage(image, objectUrl, blob, source);
         if (edit) setEdits((prev) => [...prev, edit]);
         setDirty(true);
       } catch (err) {
@@ -2164,17 +2254,32 @@ export function ImageEditor() {
                 x={0}
                 y={0}
               />
-              <KonvaImage
-                colorAdjust={colorAdjust}
-                filters={[konvaColorFilter]}
-                height={working.height}
-                image={working.image}
-                name="editor-image"
-                ref={imageNodeRef}
-                width={working.width}
-                x={0}
-                y={0}
-              />
+              {/* Editor layers (sc-6117): one <KonvaImage> per raster layer, bottom→top,
+                  honoring per-layer visibility / opacity / blend / transform. The ACTIVE
+                  layer carries the color-grade filter + the cached node ref (the live
+                  preview) — multi-layer creation + selection arrive with sc-6118/6119. */}
+              {working.layers.map((layer) => {
+                const isActive = layer.id === working.activeLayerId;
+                const t = layer.transform;
+                return (
+                  <KonvaImage
+                    key={layer.id}
+                    globalCompositeOperation={layer.blendMode}
+                    height={layer.image.naturalHeight}
+                    image={layer.image}
+                    name="editor-image"
+                    opacity={layer.opacity}
+                    rotation={t.rotation}
+                    scaleX={t.scaleX}
+                    scaleY={t.scaleY}
+                    visible={layer.visible}
+                    width={layer.image.naturalWidth}
+                    x={t.x}
+                    y={t.y}
+                    {...(isActive ? { colorAdjust, filters: [konvaColorFilter], ref: imageNodeRef } : {})}
+                  />
+                );
+              })}
               {tool === "crop" && cropRect ? (
                 <>
                   {cropOverlayRects(working.width, working.height, cropRect).map((rect, index) => (


### PR DESCRIPTION
## What

First implementation story of **Workstream E (Layers)** in epic [6087](https://app.shortcut.com/trefry/epic/6087), built to the sc-6108 architecture spike. Replaces the Image Editor's single working bitmap with an **ordered raster layer stack** composited bottom→top.

`working` → `{ width, height, source, layers: [Layer], activeLayerId }` where `Layer = { id, name, image, objectUrl, blob, visible, opacity, blendMode, transform }`. A **single-layer stack is the degenerate case** that reproduces the pre-layers editor exactly — visually identical, same dimensions, identical Save asset (the spike's corrected acceptance wording; a one-layer PNG re-encode need not be byte-identical).

## Changes

- **New pure model — `apps/web/src/imageLayers.js`** (React/Konva/DOM-free except the 2D context the compositor draws into): `createLayer`, `singleLayerWorking`, `addLayer`/`removeLayer`/`duplicateLayer`/`moveLayer`, `setLayerProps`/`setActiveLayer`, the snapshot representation (`snapshotLayers` — metadata + shared blob, no live image/URL), `sameLayerStack`, and `compositeLayersToCanvas` (bottom→top, honoring visibility/opacity/blend/transform). 15 unit tests.
- **Render** — `ImageEditor` maps the stack to **N `<KonvaImage>` nodes inside the existing image Konva-`<Layer>`** (per-node `visible`/`opacity`/`globalCompositeOperation`/transform), *not* N Konva layers. The active layer carries the color-grade filter + cached node ref. Mask + boxes Konva-layers unchanged.
- **Undo/redo** — snapshot extended to the stack: layers carry their `blob` (shared by reference → bounded memory like before); restore decodes **only changed-blob layers**, reuses live images otherwise, and revokes the object URLs it drops. Object-URL discipline generalized to **per-layer revoke-on-evict** (replaces the single `objectUrlRef`). Layer-id counter is snapshotted like `boxIdSeq`.
- **Flatten** — Save / Download / AI-op source and the box-keyed edit now flatten through `compositeToCanvas` (the visible composite).
- Existing tools (crop / color / AI) keep operating on the **active layer = the lone layer** — no behavior change. The per-layer tool matrix and the layers panel are **sc-6119 / sc-6118** (the spike's slice boundary).

## Scope boundary

This story is the **state model + compositing core**. The layer-operation *handlers + panel UI* (add/delete/duplicate/reorder/visibility/opacity buttons) land with the panel in **sc-6118**; the per-layer tool-interaction matrix (document-level crop-all-layers, active-layer color/mask, flatten-on-upscale/outpaint) lands in **sc-6119**. The operations themselves ship here as tested pure functions (`removeLayer` already returns the evicted layer so the 6118 delete button revokes its URL).

## Verification

- ✅ **570 web tests** pass (incl. 68 existing editor tests + 15 new model tests); lint + build clean.
- ✅ **Compositor validated against a real browser canvas** (jsdom can't run canvas): 50%-opacity blue-over-red → `[127,0,128,255]`; hidden top layer → pure red `[255,0,0,255]`; `singleLayerWorking` → 4×4 / 1 layer / active "bg".
- ✅ **Full mounted-editor live smoke** (rust-api up, workspace created, real browser): new blank 1024² layout renders through the layer-map path; **Crop** 1024²→819² (active-layer read + rebuild + re-render); **Undo→1024² / Redo→819²** (stack-aware restore both directions); **Save** flattens via the composite to a new `…-edited.png` Library asset; zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)