### PR TITLE
sc-5502: default backend_candle_enabled ON for candle builds (Phase-7 cutover)

### DIFF
--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -333,9 +333,14 @@ pub struct Settings {
     /// Whether the MLX (Apple Silicon) tensor backend is enabled when deriving the worker's
     /// advertised capabilities from the linked engine registry (sc-3723). Default `true`.
     pub backend_mlx_enabled: bool,
-    /// Whether the candle (Windows/CUDA) tensor backend is enabled for capability derivation
-    /// (sc-3723). Default `false` — no candle provider crate ships yet; flipping this on once
-    /// one is linked lights up its descriptors with no further worker change.
+    /// Whether the candle (Windows/CUDA + Linux/NVIDIA) tensor backend is enabled for capability
+    /// derivation (sc-3723). **Defaults to on whenever the worker is built `--features
+    /// backend-candle`** (sc-5502, epic 5483 Phase-7 cutover): the candle providers are at parity
+    /// off-Mac, so a candle build advertises them by default — no `SCENEWORKS_BACKEND_CANDLE_ENABLED`
+    /// needed. A non-candle build (Mac mlx, the desktop installer with no CUDA, any CPU/Linux build
+    /// without the feature) defaults `false` and links no candle crate, so this is inert there. The
+    /// env var still overrides either way (set `0` to force a candle build back onto the Python
+    /// torch fallback during a staged rollout).
     pub backend_candle_enabled: bool,
 }
 
@@ -391,7 +396,12 @@ impl Settings {
                 .is_ok_and(|value| value.trim() == "1"),
             utility_workers: env_u64_any(&["SCENEWORKS_UTILITY_WORKERS"], 4).max(1) as usize,
             backend_mlx_enabled: env_bool("SCENEWORKS_BACKEND_MLX_ENABLED", true),
-            backend_candle_enabled: env_bool("SCENEWORKS_BACKEND_CANDLE_ENABLED", false),
+            // Phase-7 cutover (sc-5502): a candle build defaults the backend ON (the providers are at
+            // off-Mac parity); a non-candle build defaults it off. The env var overrides either way.
+            backend_candle_enabled: env_bool(
+                "SCENEWORKS_BACKEND_CANDLE_ENABLED",
+                cfg!(feature = "backend-candle"),
+            ),
         }
     }
 }


### PR DESCRIPTION
Part of **epic 5483 (Candle Phase 7)**, story [sc-5502](https://app.shortcut.com/trefry/story/5502) — the first, safe step of the off-Mac candle cutover.

## What
Flip the worker's `backend_candle_enabled` default from a hardcoded `false` to `cfg!(feature = "backend-candle")`. A worker built `--features backend-candle` now advertises the candle providers **by default** — Phase 5 (epic 5482) closed, so the off-Mac candle surface is at parity. A non-candle build (Mac mlx, the no-CUDA desktop installer, any build without the feature) still defaults `false` and links no candle crate, so this is inert there. `SCENEWORKS_BACKEND_CANDLE_ENABLED` still overrides either way (set `0` to fall a candle build back onto the Python torch worker during a staged rollout).

## Safety
**Behavior-neutral for existing deployments** — the desktop candle worker (`setup.rs`) and the server lane already set `SCENEWORKS_BACKEND_CANDLE_ENABLED=true` explicitly. This just removes that requirement for headless candle workers, and makes "candle is the default off-Mac GPU backend" true without env plumbing.

## Scope — this is the *flip*, not the *teardown*
The other half of sc-5502 ("stop spawning the Python worker") is per-surface and staged separately because the surfaces are at different readiness:
- **Server / headless** — cutover-ready now: run the candle worker, don't run Python, set `SCENEWORKS_CANDLE_REQUIRED=1` so the slice-1 sweeps ([PR #801](https://github.com/SceneWorks/SceneWorks/pull/801)) fail-loudly anything unsupported instead of silently degrading.
- **Desktop** — `gate_window` still spawns the Python worker alongside candle (Wave A). Pulling it (mirroring the macOS sc-3492 precedent) is gated on **epic 5558 Wave B** packaging — the installer must bundle the full candle runtime first.
- **Docker** — the `worker` (Python) service retirement is [sc-5503](https://app.shortcut.com/trefry/story/5503) (it also needs a candle GPU image; none exists in compose today).

## Validation
`cargo clippy -p sceneworks-worker --all-targets` + `cargo fmt` clean (default features). The change is a `cfg!`-gated default; the candle-feature build is unchanged except the default value, which existing deployments already set explicitly. A candle-feature build + deployed-worker "registers candle with no env" smoke can follow on the RTX PRO 6000 box.