### PR TITLE
feat(image-editor): layers panel UI — list, reorder, visibility, opacity, active selection (sc-6118)

### DIFF
--- a/apps/web/src/components/LayersPanel.jsx
+++ b/apps/web/src/components/LayersPanel.jsx
@@ -1,0 +1,225 @@
+import React, { useRef, useState } from "react";
+
+// The layers panel (sc-6118, Workstream E of epic 6087): the user-facing control
+// surface for the sc-6117 raster layer stack. Presentational — it reflects the
+// `layers` / `activeLayerId` it is given and calls the handler props, which the
+// editor wires to the layer-stack ops (each checkpointed for undo, sc-6106).
+//
+// Rows render TOP layer first (the reverse of the bottom→top stack array) — the
+// standard layers-panel convention where the top of the list is the top of the
+// stack. Thumbnails reuse each layer's live object URL, which the editor already
+// lifecycle-manages (revoked when the layer is evicted), so the panel creates and
+// revokes nothing itself.
+export function LayersPanel({
+  layers,
+  activeLayerId,
+  busy = false,
+  onSelect,
+  onToggleVisible,
+  onSetOpacity,
+  onRename,
+  onReorder,
+  onAdd,
+  onDelete,
+  onDuplicate,
+}) {
+  const [renamingId, setRenamingId] = useState(null);
+  const [renameDraft, setRenameDraft] = useState("");
+  const [dragId, setDragId] = useState(null);
+  // One undo checkpoint per opacity DRAG, not per tick: the first change of a
+  // gesture commits (checkpoints), the rest just preview. Reset when the gesture
+  // ends (pointer up / blur / key up), covering both mouse and keyboard input.
+  const opacityGestureRef = useRef(false);
+
+  const count = layers.length;
+  const rows = layers.map((layer, index) => ({ layer, index })).reverse();
+
+  const startRename = (layer) => {
+    setRenamingId(layer.id);
+    setRenameDraft(layer.name);
+  };
+  const commitRename = () => {
+    if (renamingId) {
+      const name = renameDraft.trim();
+      if (name) onRename(renamingId, name);
+    }
+    setRenamingId(null);
+  };
+
+  const handleOpacityChange = (id, value) => {
+    const start = !opacityGestureRef.current;
+    opacityGestureRef.current = true;
+    onSetOpacity(id, Number(value) / 100, start);
+  };
+  const endOpacityGesture = () => {
+    opacityGestureRef.current = false;
+  };
+
+  // Drop row `dragId` onto `targetId` → move it to that target's stack index.
+  const handleDrop = (targetId) => {
+    if (dragId && dragId !== targetId) {
+      const toIndex = layers.findIndex((layer) => layer.id === targetId);
+      if (toIndex >= 0) onReorder(dragId, toIndex);
+    }
+    setDragId(null);
+  };
+
+  return (
+    <aside className="image-editor-layers" aria-label="Layers">
+      <div className="image-editor-layers-head">
+        <span className="image-editor-layers-title">Layers</span>
+        <button
+          className="image-editor-layers-add"
+          disabled={busy}
+          onClick={onAdd}
+          title="Add a blank layer"
+          aria-label="Add layer"
+          type="button"
+        >
+          + Layer
+        </button>
+      </div>
+      <div className="image-editor-layers-list" role="list">
+        {rows.map(({ layer, index }) => {
+          const isActive = layer.id === activeLayerId;
+          const pct = Math.round(layer.opacity * 100);
+          return (
+            <div
+              key={layer.id}
+              role="listitem"
+              className={isActive ? "image-editor-layer active" : "image-editor-layer"}
+              aria-current={isActive ? "true" : undefined}
+              draggable={!busy && renamingId !== layer.id}
+              onDragStart={() => setDragId(layer.id)}
+              onDragOver={(event) => event.preventDefault()}
+              onDrop={() => handleDrop(layer.id)}
+              onDragEnd={() => setDragId(null)}
+              onClick={() => onSelect(layer.id)}
+            >
+              <button
+                className="image-editor-layer-vis"
+                aria-label={layer.visible ? "Hide layer" : "Show layer"}
+                aria-pressed={layer.visible}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onToggleVisible(layer.id);
+                }}
+                title={layer.visible ? "Hide layer" : "Show layer"}
+                type="button"
+              >
+                {layer.visible ? "●" : "○"}
+              </button>
+              {layer.objectUrl ? (
+                <img
+                  className="image-editor-layer-thumb"
+                  src={layer.objectUrl}
+                  alt=""
+                  draggable={false}
+                />
+              ) : (
+                <span className="image-editor-layer-thumb image-editor-layer-thumb-empty" />
+              )}
+              <span className="image-editor-layer-body">
+                {renamingId === layer.id ? (
+                  <input
+                    className="image-editor-layer-rename"
+                    value={renameDraft}
+                    autoFocus
+                    onChange={(event) => setRenameDraft(event.target.value)}
+                    onBlur={commitRename}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter") commitRename();
+                      else if (event.key === "Escape") setRenamingId(null);
+                    }}
+                    onClick={(event) => event.stopPropagation()}
+                    aria-label="Layer name"
+                  />
+                ) : (
+                  <span
+                    className="image-editor-layer-name"
+                    title="Double-click to rename"
+                    onDoubleClick={(event) => {
+                      event.stopPropagation();
+                      startRename(layer);
+                    }}
+                  >
+                    {layer.name}
+                  </span>
+                )}
+                <label className="image-editor-layer-opacity" onClick={(event) => event.stopPropagation()}>
+                  <input
+                    type="range"
+                    min={0}
+                    max={100}
+                    step={1}
+                    value={pct}
+                    aria-label={`${layer.name} opacity`}
+                    onChange={(event) => handleOpacityChange(layer.id, event.target.value)}
+                    onPointerUp={endOpacityGesture}
+                    onKeyUp={endOpacityGesture}
+                    onBlur={endOpacityGesture}
+                  />
+                  <span className="image-editor-layer-opacity-val">{pct}%</span>
+                </label>
+              </span>
+              <span className="image-editor-layer-ops">
+                <button
+                  className="image-editor-layer-op"
+                  disabled={busy || index === count - 1}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onReorder(layer.id, index + 1);
+                  }}
+                  title="Move up"
+                  aria-label="Move layer up"
+                  type="button"
+                >
+                  ▲
+                </button>
+                <button
+                  className="image-editor-layer-op"
+                  disabled={busy || index === 0}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onReorder(layer.id, index - 1);
+                  }}
+                  title="Move down"
+                  aria-label="Move layer down"
+                  type="button"
+                >
+                  ▼
+                </button>
+                <button
+                  className="image-editor-layer-op"
+                  disabled={busy}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onDuplicate(layer.id);
+                  }}
+                  title="Duplicate layer"
+                  aria-label="Duplicate layer"
+                  type="button"
+                >
+                  ⧉
+                </button>
+                <button
+                  className="image-editor-layer-op"
+                  disabled={busy || count <= 1}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onDelete(layer.id);
+                  }}
+                  title="Delete layer"
+                  aria-label="Delete layer"
+                  type="button"
+                >
+                  ✕
+                </button>
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/src/components/LayersPanel.test.jsx
+++ b/apps/web/src/components/LayersPanel.test.jsx
@@ -1,0 +1,173 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LayersPanel } from "./LayersPanel.jsx";
+
+// Two-layer stack: bottom "Background", top "Sky" (active). Rows render top-first.
+const stack = () => [
+  { id: "a", name: "Background", objectUrl: "blob:a", visible: true, opacity: 1 },
+  { id: "b", name: "Sky", objectUrl: "blob:b", visible: true, opacity: 0.5 },
+];
+
+const noopHandlers = () => ({
+  onSelect: vi.fn(),
+  onToggleVisible: vi.fn(),
+  onSetOpacity: vi.fn(),
+  onRename: vi.fn(),
+  onReorder: vi.fn(),
+  onAdd: vi.fn(),
+  onDelete: vi.fn(),
+  onDuplicate: vi.fn(),
+});
+
+describe("LayersPanel (sc-6118)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  const mount = (props) =>
+    act(() => {
+      root.render(<LayersPanel layers={stack()} activeLayerId="b" {...noopHandlers()} {...props} />);
+    });
+
+  const rows = () => [...container.querySelectorAll('[role="listitem"]')];
+  const rowByName = (name) =>
+    rows().find((r) => r.querySelector(".image-editor-layer-name")?.textContent === name);
+
+  it("renders the stack top-first, marking the active layer", async () => {
+    await mount();
+    const names = [...container.querySelectorAll(".image-editor-layer-name")].map((n) => n.textContent);
+    expect(names).toEqual(["Sky", "Background"]); // top of stack first
+    expect(rowByName("Sky").getAttribute("aria-current")).toBe("true");
+    expect(rowByName("Background").getAttribute("aria-current")).toBeNull();
+  });
+
+  it("thumbnails use each layer's live object URL", async () => {
+    await mount();
+    const srcs = [...container.querySelectorAll("img.image-editor-layer-thumb")].map((i) => i.getAttribute("src"));
+    expect(srcs).toEqual(["blob:b", "blob:a"]);
+  });
+
+  it("clicking a row selects that layer", async () => {
+    const h = noopHandlers();
+    await act(() => root.render(<LayersPanel layers={stack()} activeLayerId="b" {...h} />));
+    await act(() => rowByName("Background").click());
+    expect(h.onSelect).toHaveBeenCalledWith("a");
+  });
+
+  it("the visibility button toggles + reflects state, without selecting the row", async () => {
+    const h = noopHandlers();
+    const layers = stack();
+    layers[0].visible = false; // Background hidden
+    await act(() => root.render(<LayersPanel layers={layers} activeLayerId="b" {...h} />));
+    const bg = rowByName("Background");
+    const vis = bg.querySelector(".image-editor-layer-vis");
+    expect(vis.getAttribute("aria-pressed")).toBe("false");
+    expect(vis.textContent).toBe("○");
+    await act(() => vis.click());
+    expect(h.onToggleVisible).toHaveBeenCalledWith("a");
+    expect(h.onSelect).not.toHaveBeenCalled(); // stopPropagation
+  });
+
+  it("opacity slider flags the first change of a gesture as a checkpoint, the rest not", async () => {
+    const h = noopHandlers();
+    await act(() => root.render(<LayersPanel layers={stack()} activeLayerId="b" {...h} />));
+    const slider = rowByName("Sky").querySelector('input[type="range"]');
+    const nativeSet = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
+    const setVal = (v) =>
+      act(() => {
+        nativeSet.call(slider, String(v)); // React tracks the controlled value
+        slider.dispatchEvent(new Event("input", { bubbles: true }));
+      });
+    await setVal(40);
+    await setVal(30);
+    expect(h.onSetOpacity).toHaveBeenNthCalledWith(1, "b", 0.4, true); // gesture start
+    expect(h.onSetOpacity).toHaveBeenNthCalledWith(2, "b", 0.3, false);
+    // Releasing ends the gesture → the next change starts a fresh checkpoint.
+    await act(() => slider.dispatchEvent(new Event("pointerup", { bubbles: true })));
+    await setVal(20);
+    expect(h.onSetOpacity).toHaveBeenNthCalledWith(3, "b", 0.2, true);
+  });
+
+  it("double-click → rename input → Enter commits; Escape cancels", async () => {
+    const h = noopHandlers();
+    await act(() => root.render(<LayersPanel layers={stack()} activeLayerId="b" {...h} />));
+    await act(() => rowByName("Sky").querySelector(".image-editor-layer-name").dispatchEvent(new MouseEvent("dblclick", { bubbles: true })));
+    let input = container.querySelector(".image-editor-layer-rename");
+    expect(input).toBeTruthy();
+    // React tracks the controlled value, so set it via the native setter (a direct
+    // `input.value =` is ignored by React's change tracker).
+    const setInputValue = (el, value) => {
+      Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set.call(el, value);
+      el.dispatchEvent(new Event("input", { bubbles: true }));
+    };
+    await act(() => setInputValue(input, "Clouds"));
+    await act(() => input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true })));
+    expect(h.onRename).toHaveBeenCalledWith("b", "Clouds");
+
+    // Escape discards.
+    await act(() => rowByName("Background").querySelector(".image-editor-layer-name").dispatchEvent(new MouseEvent("dblclick", { bubbles: true })));
+    input = container.querySelector(".image-editor-layer-rename");
+    await act(() => input.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true })));
+    expect(h.onRename).toHaveBeenCalledTimes(1); // not called again
+  });
+
+  it("add / duplicate / delete wire to their handlers", async () => {
+    const h = noopHandlers();
+    await act(() => root.render(<LayersPanel layers={stack()} activeLayerId="b" {...h} />));
+    await act(() => container.querySelector(".image-editor-layers-add").click());
+    expect(h.onAdd).toHaveBeenCalled();
+    await act(() => rowByName("Sky").querySelector('[aria-label="Duplicate layer"]').click());
+    expect(h.onDuplicate).toHaveBeenCalledWith("b");
+    await act(() => rowByName("Background").querySelector('[aria-label="Delete layer"]').click());
+    expect(h.onDelete).toHaveBeenCalledWith("a");
+  });
+
+  it("delete is disabled when only one layer remains", async () => {
+    await act(() =>
+      root.render(
+        <LayersPanel
+          layers={[{ id: "a", name: "Background", objectUrl: "blob:a", visible: true, opacity: 1 }]}
+          activeLayerId="a"
+          {...noopHandlers()}
+        />,
+      ),
+    );
+    expect(container.querySelector('[aria-label="Delete layer"]').disabled).toBe(true);
+  });
+
+  it("reorder buttons move within the stack and disable at the ends", async () => {
+    const h = noopHandlers();
+    await act(() => root.render(<LayersPanel layers={stack()} activeLayerId="b" {...h} />));
+    // Top row "Sky" (stack index 1): up disabled, down enabled.
+    const sky = rowByName("Sky");
+    expect(sky.querySelector('[aria-label="Move layer up"]').disabled).toBe(true);
+    await act(() => sky.querySelector('[aria-label="Move layer down"]').click());
+    expect(h.onReorder).toHaveBeenCalledWith("b", 0);
+    // Bottom row "Background" (index 0): down disabled, up enabled.
+    const bg = rowByName("Background");
+    expect(bg.querySelector('[aria-label="Move layer down"]').disabled).toBe(true);
+    await act(() => bg.querySelector('[aria-label="Move layer up"]').click());
+    expect(h.onReorder).toHaveBeenCalledWith("a", 1);
+  });
+
+  it("busy disables structural ops (add / reorder / duplicate / delete)", async () => {
+    await act(() => root.render(<LayersPanel layers={stack()} activeLayerId="b" busy {...noopHandlers()} />));
+    expect(container.querySelector(".image-editor-layers-add").disabled).toBe(true);
+    for (const op of container.querySelectorAll(".image-editor-layer-op")) {
+      expect(op.disabled).toBe(true);
+    }
+  });
+});

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -10,12 +10,20 @@ import { FitModeControl, effectiveFitMode } from "../components/FitModeControl.j
 import { makeObjElement, makeTextElement, normalizeHexColor } from "../ideogramCaption.js";
 import {
   activeLayerOf,
+  addLayer,
   compositeLayersToCanvas,
   createLayer,
+  duplicateLayer,
+  layerById,
+  moveLayer,
+  removeLayer,
   sameLayerStack,
+  setActiveLayer,
+  setLayerProps,
   singleLayerWorking,
   snapshotLayers,
 } from "../imageLayers.js";
+import { LayersPanel } from "../components/LayersPanel.jsx";
 
 const MIN_SCALE = 0.05;
 const MAX_SCALE = 16;
@@ -1485,6 +1493,95 @@ export function ImageEditor() {
     setDirty(true);
   }, [working, colorAdjust, installWorkingImage, checkpoint]);
 
+  // ── Layer stack ops (sc-6118) ─────────────────────────────────────────────
+  // Wire the layers panel to the pure layer-stack ops (../imageLayers.js). Each
+  // mutating op checkpoints first (sc-6106 → undoable) and marks the session dirty.
+  // Structural ops manage object URLs: delete revokes the evicted layer's URL;
+  // add/duplicate decode a fresh blob into the new layer's own image + URL.
+  function selectLayer(id) {
+    setWorking((prev) => (prev ? setActiveLayer(prev, id) : prev));
+  }
+
+  function toggleLayerVisible(id) {
+    if (!workingRef.current) return;
+    checkpoint();
+    setWorking((prev) => {
+      const layer = layerById(prev, id);
+      return layer ? setLayerProps(prev, id, { visible: !layer.visible }) : prev;
+    });
+    setDirty(true);
+  }
+
+  // One undo step per opacity DRAG: the panel flags the first change of a gesture
+  // (`isGestureStart`) → checkpoint once, then the rest of the drag just updates.
+  function changeLayerOpacity(id, opacity, isGestureStart) {
+    if (!workingRef.current) return;
+    if (isGestureStart) checkpoint();
+    setWorking((prev) => setLayerProps(prev, id, { opacity }));
+    setDirty(true);
+  }
+
+  function renameLayer(id, name) {
+    const work = workingRef.current;
+    const layer = work && layerById(work, id);
+    if (!layer || layer.name === name) return;
+    checkpoint();
+    setWorking((prev) => setLayerProps(prev, id, { name }));
+    setDirty(true);
+  }
+
+  function reorderLayer(id, toIndex) {
+    if (!workingRef.current) return;
+    checkpoint();
+    setWorking((prev) => moveLayer(prev, id, toIndex));
+    setDirty(true);
+  }
+
+  function deleteLayer(id) {
+    const work = workingRef.current;
+    if (!work || work.layers.length <= 1) return;
+    checkpoint();
+    const { working: next, removed } = removeLayer(work, id);
+    if (!removed) return;
+    setWorking(next);
+    if (removed.objectUrl) URL.revokeObjectURL(removed.objectUrl);
+    setDirty(true);
+  }
+
+  async function duplicateLayerById(id) {
+    const work = workingRef.current;
+    const src = work && layerById(work, id);
+    if (!src) return;
+    const { image, objectUrl } = await blobToImage(src.blob);
+    checkpoint();
+    setWorking((prev) => duplicateLayer(prev, id, { id: nextLayerId(), image, objectUrl }));
+    setDirty(true);
+  }
+
+  async function addBlankLayer() {
+    const work = workingRef.current;
+    if (!work) return;
+    // A new transparent layer at the document size — a fresh surface above the
+    // active layer. The tools begin targeting it with the sc-6119 per-layer matrix.
+    const canvas = document.createElement("canvas");
+    canvas.width = work.width;
+    canvas.height = work.height;
+    const blob = await new Promise((resolve) => canvas.toBlob(resolve, "image/png"));
+    if (!blob) {
+      setStatus({ loading: false, error: "Could not create the layer." });
+      return;
+    }
+    const { image, objectUrl } = await blobToImage(blob);
+    checkpoint();
+    setWorking((prev) =>
+      addLayer(
+        prev,
+        createLayer({ id: nextLayerId(), name: `Layer ${prev.layers.length + 1}`, image, objectUrl, blob }),
+      ),
+    );
+    setDirty(true);
+  }
+
   // ── Box layout tool (sc-6090) ─────────────────────────────────────────────
   function selectBoxTool() {
     if (working) setTool("boxes");
@@ -2432,6 +2529,22 @@ export function ImageEditor() {
             )}
           </div>
         )}
+
+        {working ? (
+          <LayersPanel
+            layers={working.layers}
+            activeLayerId={working.activeLayerId}
+            busy={Boolean(aiOp)}
+            onSelect={selectLayer}
+            onToggleVisible={toggleLayerVisible}
+            onSetOpacity={changeLayerOpacity}
+            onRename={renameLayer}
+            onReorder={reorderLayer}
+            onAdd={addBlankLayer}
+            onDelete={deleteLayer}
+            onDuplicate={duplicateLayerById}
+          />
+        ) : null}
 
         {working ? (
           <aside className="image-editor-toolbar" aria-label="Editor tools">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5999,6 +5999,136 @@ details[open] > summary.lora-scope-group-heading::before,
   color: var(--accent);
 }
 
+/* Layers panel (sc-6118): floating top-left, mirroring the tool palette. */
+.image-editor-layers {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  width: 232px;
+  max-height: calc(100% - 24px);
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.18);
+  overflow: hidden;
+}
+
+.image-editor-layers-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+.image-editor-layers-title {
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.image-editor-layers-add {
+  font-size: 12px;
+  padding: 2px 8px;
+}
+
+.image-editor-layers-list {
+  overflow-y: auto;
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.image-editor-layer {
+  display: grid;
+  grid-template-columns: auto 36px 1fr auto;
+  align-items: center;
+  gap: 6px;
+  padding: 4px;
+  border: 1px solid transparent;
+  border-radius: var(--r-sm);
+  cursor: pointer;
+}
+
+.image-editor-layer:hover {
+  background: var(--surface-2);
+}
+
+.image-editor-layer.active {
+  border-color: var(--accent);
+  background: var(--surface-2);
+}
+
+.image-editor-layer-vis {
+  min-width: 24px;
+  padding: 2px 4px;
+  line-height: 1;
+}
+
+.image-editor-layer-thumb {
+  width: 36px;
+  height: 36px;
+  object-fit: contain;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  /* Checkerboard so a transparent layer reads as transparent, not blank. */
+  background: repeating-conic-gradient(var(--surface-2) 0% 25%, var(--surface) 0% 50%) 50% / 10px 10px;
+}
+
+.image-editor-layer-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.image-editor-layer-name {
+  font-size: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.image-editor-layer-rename {
+  font-size: 12px;
+  width: 100%;
+}
+
+.image-editor-layer-opacity {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.image-editor-layer-opacity input[type="range"] {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.image-editor-layer-opacity-val {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+  min-width: 30px;
+  text-align: right;
+}
+
+.image-editor-layer-ops {
+  display: grid;
+  grid-template-columns: auto auto;
+  gap: 2px;
+}
+
+.image-editor-layer-op {
+  min-width: 22px;
+  padding: 2px 4px;
+  font-size: 11px;
+  line-height: 1;
+}
+
 .image-editor-canvas-wrap {
   position: relative;
   flex: 1 1 auto;


### PR DESCRIPTION
## What

The user-facing control surface for the sc-6117 raster layer stack — **Workstream E (Layers)** of epic [6087](https://app.shortcut.com/trefry/epic/6087), built to the sc-6108 spike. A floating **Layers panel** (top-left, mirroring the tool palette) that reflects and mutates the stack.

## Changes

- **New `apps/web/src/components/LayersPanel.jsx`** — presentational, plain DOM (jsdom-testable, keeps the editor god-module from growing). Rows render **top layer first**; each row has:
  - **visibility toggle** (● / ○), **thumbnail** (reuses the layer's live object URL — already lifecycle-managed, so the panel creates/revokes nothing), **rename** (double-click → inline input, Enter commits / Escape cancels), **opacity slider** (0–100%), **reorder** (▲/▼ buttons, disabled at the ends, + HTML5 drag-to-reorder), **duplicate**, **delete** (disabled at 1 layer).
  - **"+ Layer"** add control in the header.
  - `busy` (an in-flight AI op) disables structural ops.
- **Wired handlers in `ImageEditor.jsx`** driving the pure ops from `imageLayers.js`: `selectLayer` / `toggleLayerVisible` / `changeLayerOpacity` / `renameLayer` / `reorderLayer` / `addBlankLayer` / `deleteLayer` / `duplicateLayerById`. Each mutating op **`checkpoint()`s first (sc-6106 → undoable)** and marks the session dirty. Opacity drags checkpoint **once per gesture, not per tick** (the panel flags the first change of a gesture). Object-URL discipline: delete revokes the evicted layer's URL; add/duplicate decode a fresh blob into the new layer's own image + URL.
- **Panel styles** in `styles.css`.

## Verification

- ✅ **580 web tests** pass (+10 `LayersPanel.test.jsx`: top-first order, active marking, thumbnails-from-objectUrl, select, visibility toggle w/ stopPropagation, opacity gesture-checkpoint flagging, rename commit/cancel, add/duplicate/delete wiring, delete-disabled-at-1, reorder + end-disabling, busy-disables-ops); lint **0 errors**; build clean.
- ✅ **Full live smoke** in a real browser (rust-api up, workspace created): added a blank "Layer 2", duplicated → "Layer 2 copy" inserted above the source and made active, hid a layer (● → ○), set opacity to 35%, reordered via ▲/▼, deleted the top layer, and **Undo restored the deleted layer** (the stack-aware sc-6117 restore decoded it back). Zero console errors.

## Scope

The per-layer tool-interaction matrix (which tools act on the active layer vs document; flatten-on-upscale/outpaint) is the next story, **sc-6119**. Today the tools still operate on the active-as-lone-layer per sc-6117 — adding layers + selecting an active layer is now possible from the panel, and 6119 makes the tools honor it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)