### PR TITLE
feat(image-editor): per-layer blend modes + transform tool (sc-6120)

### DIFF
--- a/apps/web/src/components/LayersPanel.jsx
+++ b/apps/web/src/components/LayersPanel.jsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState } from "react";
+import { BLEND_MODES } from "../imageLayers.js";
 
 // The layers panel (sc-6118, Workstream E of epic 6087): the user-facing control
 // surface for the sc-6117 raster layer stack. Presentational — it reflects the
@@ -17,6 +18,7 @@ export function LayersPanel({
   onSelect,
   onToggleVisible,
   onSetOpacity,
+  onSetBlend,
   onRename,
   onReorder,
   onAdd,
@@ -161,6 +163,19 @@ export function LayersPanel({
                   />
                   <span className="image-editor-layer-opacity-val">{pct}%</span>
                 </label>
+                <select
+                  className="image-editor-layer-blend"
+                  value={layer.blendMode || "source-over"}
+                  aria-label={`${layer.name} blend mode`}
+                  onClick={(event) => event.stopPropagation()}
+                  onChange={(event) => onSetBlend(layer.id, event.target.value)}
+                >
+                  {BLEND_MODES.map((mode) => (
+                    <option key={mode.value} value={mode.value}>
+                      {mode.label}
+                    </option>
+                  ))}
+                </select>
               </span>
               <span className="image-editor-layer-ops">
                 <button

--- a/apps/web/src/components/LayersPanel.test.jsx
+++ b/apps/web/src/components/LayersPanel.test.jsx
@@ -13,6 +13,7 @@ const noopHandlers = () => ({
   onSelect: vi.fn(),
   onToggleVisible: vi.fn(),
   onSetOpacity: vi.fn(),
+  onSetBlend: vi.fn(),
   onRename: vi.fn(),
   onReorder: vi.fn(),
   onAdd: vi.fn(),
@@ -161,6 +162,23 @@ describe("LayersPanel (sc-6118)", () => {
     expect(bg.querySelector('[aria-label="Move layer down"]').disabled).toBe(true);
     await act(() => bg.querySelector('[aria-label="Move layer up"]').click());
     expect(h.onReorder).toHaveBeenCalledWith("a", 1);
+  });
+
+  it("the blend dropdown reflects the layer and changes its blend mode", async () => {
+    const h = noopHandlers();
+    const layers = stack();
+    layers[1].blendMode = "multiply"; // Sky
+    await act(() => root.render(<LayersPanel layers={layers} activeLayerId="b" {...h} />));
+    const select = rowByName("Sky").querySelector(".image-editor-layer-blend");
+    expect(select.value).toBe("multiply");
+    // Background defaults to Normal when unset.
+    expect(rowByName("Background").querySelector(".image-editor-layer-blend").value).toBe("source-over");
+    await act(() => {
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLSelectElement.prototype, "value").set;
+      setter.call(select, "screen");
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    expect(h.onSetBlend).toHaveBeenCalledWith("b", "screen");
   });
 
   it("busy disables structural ops (add / reorder / duplicate / delete)", async () => {

--- a/apps/web/src/imageLayers.js
+++ b/apps/web/src/imageLayers.js
@@ -22,6 +22,29 @@
 
 export const DEFAULT_BLEND_MODE = "source-over";
 
+// The blend modes offered per layer (sc-6120). Each `value` is a canvas / Konva
+// `globalCompositeOperation` token, so the live render (the layer's <KonvaImage>
+// node) and the flatten (compositeLayersToCanvas) apply them identically. "Normal"
+// is the default source-over.
+export const BLEND_MODES = [
+  { value: "source-over", label: "Normal" },
+  { value: "multiply", label: "Multiply" },
+  { value: "screen", label: "Screen" },
+  { value: "overlay", label: "Overlay" },
+  { value: "darken", label: "Darken" },
+  { value: "lighten", label: "Lighten" },
+  { value: "color-dodge", label: "Color Dodge" },
+  { value: "color-burn", label: "Color Burn" },
+  { value: "hard-light", label: "Hard Light" },
+  { value: "soft-light", label: "Soft Light" },
+  { value: "difference", label: "Difference" },
+  { value: "exclusion", label: "Exclusion" },
+  { value: "hue", label: "Hue" },
+  { value: "saturation", label: "Saturation" },
+  { value: "color", label: "Color" },
+  { value: "luminosity", label: "Luminosity" },
+];
+
 // Identity transform for a layer that sits 1:1 over the document (the only kind
 // sc-6117 produces; non-identity transforms arrive with sc-6120, but the model +
 // compositor honor the fields now so the stack is forward-complete).

--- a/apps/web/src/imageLayers.test.js
+++ b/apps/web/src/imageLayers.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  BLEND_MODES,
   DEFAULT_BLEND_MODE,
   identityTransform,
   createLayer,
@@ -25,6 +26,19 @@ const fakeImage = (w = 100, h = 80) => ({ naturalWidth: w, naturalHeight: h });
 
 const liveLayer = (id, overrides = {}) =>
   createLayer({ id, image: fakeImage(), objectUrl: `blob:${id}`, blob: { id }, ...overrides });
+
+describe("blend modes (sc-6120)", () => {
+  it("leads with Normal=source-over and exposes the common canvas blend tokens", () => {
+    expect(BLEND_MODES[0]).toEqual({ value: "source-over", label: "Normal" });
+    const values = BLEND_MODES.map((m) => m.value);
+    expect(values).toContain("multiply");
+    expect(values).toContain("screen");
+    expect(values).toContain("overlay");
+    // Every entry has a non-empty token + label, and tokens are unique.
+    expect(BLEND_MODES.every((m) => m.value && m.label)).toBe(true);
+    expect(new Set(values).size).toBe(values.length);
+  });
+});
 
 describe("layer model — creation + degenerate single-layer document (sc-6117)", () => {
   it("createLayer fills defaults and clamps opacity", () => {

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -14,6 +14,7 @@ import {
   compositeLayersToCanvas,
   createLayer,
   duplicateLayer,
+  identityTransform,
   layerById,
   moveLayer,
   removeLayer,
@@ -949,7 +950,8 @@ export function ImageEditor() {
   const layerIdRef = useRef(0);
   const cropRectRef = useRef(null);
   const transformerRef = useRef(null);
-  const imageNodeRef = useRef(null); // Konva image node — cached for color-grade filtering
+  const layerTransformerRef = useRef(null); // Konva transformer bound to the active layer (sc-6120)
+  const imageNodeRef = useRef(null); // Konva image node — cached for color-grade filtering + transform
   const [stageSize, setStageSize] = useState({ width: 0, height: 0 });
 
   // Undo/redo (sc-6106): a bounded snapshot history over the working-image session.
@@ -1164,11 +1166,18 @@ export function ImageEditor() {
           for (const layer of live?.layers ?? []) {
             if (!reused.has(layer.id) && layer.objectUrl) URL.revokeObjectURL(layer.objectUrl);
           }
-          // Reset the per-bitmap overlays (the snapshot's overlay state is re-applied
-          // by applyHistoryAux below); refit only when the document size changed (a
-          // pure opacity/visibility/reorder undo keeps the current pan/zoom).
-          resetEditorOverlays();
-          if (!live || live.width !== snap.width || live.height !== snap.height) needsFitRef.current = true;
+          // A true PIXEL change = dims changed, a layer added/removed, or a layer's
+          // blob differs. Metadata-only undos (opacity / visibility / blend / transform
+          // / reorder — same id→blob set, same dims) keep the current tool, mask, boxes
+          // and view; only a pixel change resets the per-bitmap overlays + refits.
+          const dimsChanged = !live || live.width !== snap.width || live.height !== snap.height;
+          const liveBlobs = new Map((live?.layers ?? []).map((layer) => [layer.id, layer.blob]));
+          const bitmapChanged =
+            dimsChanged ||
+            liveBlobs.size !== snap.layers.length ||
+            snap.layers.some((sl) => liveBlobs.get(sl.id) !== sl.blob);
+          if (bitmapChanged) resetEditorOverlays();
+          if (dimsChanged) needsFitRef.current = true;
           const nextWorking = {
             width: snap.width,
             height: snap.height,
@@ -1513,6 +1522,17 @@ export function ImageEditor() {
     }
   }, [tool, cropRect]);
 
+  // Bind the layer transformer to the ACTIVE layer's node whenever the Transform
+  // tool is active (sc-6120); re-bind when the active layer changes. `working` in
+  // the deps covers an active-layer switch (imageNodeRef reattaches to the new node).
+  useEffect(() => {
+    const transformer = layerTransformerRef.current;
+    if (!transformer) return;
+    const node = tool === "transform" ? imageNodeRef.current : null;
+    transformer.nodes(node ? [node] : []);
+    transformer.getLayer()?.batchDraw();
+  }, [tool, working]);
+
   // ── Color grade (sc-2439) ─────────────────────────────────────────────────
   function startColorGrade() {
     if (!working) return;
@@ -1657,6 +1677,49 @@ export function ImageEditor() {
         createLayer({ id: nextLayerId(), name: `Layer ${prev.layers.length + 1}`, image, objectUrl, blob }),
       ),
     );
+    setDirty(true);
+  }
+
+  // Per-layer blend mode (sc-6120): metadata only — the layer's <KonvaImage> node +
+  // the flatten compositor both apply it via globalCompositeOperation.
+  function setLayerBlend(id, blendMode) {
+    if (!workingRef.current) return;
+    checkpoint();
+    setWorking((prev) => setLayerProps(prev, id, { blendMode }));
+    setDirty(true);
+  }
+
+  // ── Per-layer transform (sc-6120) ─────────────────────────────────────────
+  // The Transform tool binds a Konva Transformer to the ACTIVE layer's node. The
+  // node renders from `layer.transform` (x/y/scale/rotation); on drag/transform end
+  // we read the node back into the layer's transform metadata. The bitmap is never
+  // resampled — the transform is baked only at flatten time (compositeLayersToCanvas
+  // already honors it, matching the live node 1:1).
+  function startTransform() {
+    if (working) setTool("transform");
+  }
+
+  function commitActiveLayerTransform() {
+    const node = imageNodeRef.current;
+    const layer = activeLayerOf(workingRef.current);
+    if (!node || !layer) return;
+    const transform = {
+      x: node.x(),
+      y: node.y(),
+      scaleX: node.scaleX(),
+      scaleY: node.scaleY(),
+      rotation: node.rotation(),
+    };
+    checkpoint();
+    setWorking((prev) => setLayerProps(prev, layer.id, { transform }));
+    setDirty(true);
+  }
+
+  function resetActiveLayerTransform() {
+    const layer = activeLayerOf(workingRef.current);
+    if (!layer) return;
+    checkpoint();
+    setWorking((prev) => setLayerProps(prev, layer.id, { transform: identityTransform() }));
     setDirty(true);
   }
 
@@ -2435,7 +2498,7 @@ export function ImageEditor() {
       >
         {working && stageSize.width > 0 && stageSize.height > 0 ? (
           <Stage
-            draggable={tool !== "crop" && tool !== "boxes" && !maskMode}
+            draggable={tool !== "crop" && tool !== "boxes" && tool !== "transform" && !maskMode}
             height={stageSize.height}
             onDragEnd={(event) => {
               if (event.target !== event.target.getStage()) return;
@@ -2489,9 +2552,16 @@ export function ImageEditor() {
                     x={t.x}
                     y={t.y}
                     {...(isActive ? { colorAdjust, filters: [konvaColorFilter], ref: imageNodeRef } : {})}
+                    {...(isActive && tool === "transform"
+                      ? { draggable: true, onDragEnd: commitActiveLayerTransform, onTransformEnd: commitActiveLayerTransform }
+                      : {})}
                   />
                 );
               })}
+              {tool === "transform" ? (
+                // Per-layer transform (sc-6120): move / scale / rotate the active layer.
+                <Transformer anchorSize={8} borderStroke="#ffffff" ref={layerTransformerRef} rotateEnabled />
+              ) : null}
               {tool === "crop" && cropRect ? (
                 <>
                   {cropOverlayRects(working.width, working.height, cropRect).map((rect, index) => (
@@ -2653,6 +2723,7 @@ export function ImageEditor() {
             onSelect={selectLayer}
             onToggleVisible={toggleLayerVisible}
             onSetOpacity={changeLayerOpacity}
+            onSetBlend={setLayerBlend}
             onRename={renameLayer}
             onReorder={reorderLayer}
             onAdd={addBlankLayer}
@@ -2670,6 +2741,15 @@ export function ImageEditor() {
               type="button"
             >
               Move
+            </button>
+            <button
+              className={tool === "transform" ? "image-editor-tool active" : "image-editor-tool"}
+              disabled={!!aiOp}
+              onClick={startTransform}
+              title="Transform the active layer (move / scale / rotate)"
+              type="button"
+            >
+              Transform
             </button>
             <button
               className={tool === "crop" ? "image-editor-tool active" : "image-editor-tool"}
@@ -2770,6 +2850,20 @@ export function ImageEditor() {
             </button>
             <button onClick={cancelCrop} type="button">
               Cancel
+            </button>
+          </div>
+        ) : null}
+
+        {tool === "transform" && working ? (
+          <div className="image-editor-cropbar">
+            <span className="image-editor-cropdims">
+              Drag, scale or rotate <strong>{activeLayerOf(working)?.name}</strong> on the canvas
+            </span>
+            <button onClick={resetActiveLayerTransform} type="button">
+              Reset transform
+            </button>
+            <button onClick={() => setTool("move")} type="button">
+              Done
             </button>
           </div>
         ) : null}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -6116,6 +6116,12 @@ details[open] > summary.lora-scope-group-heading::before,
   text-align: right;
 }
 
+.image-editor-layer-blend {
+  width: 100%;
+  font-size: 11px;
+  padding: 1px 4px;
+}
+
 .image-editor-layer-ops {
   display: grid;
   grid-template-columns: auto auto;


### PR DESCRIPTION
## What

Compositing richness on the sc-6117 layer stack — **Workstream E (Layers)** of epic [6087](https://app.shortcut.com/trefry/epic/6087), per the sc-6108 spike. The data model, compositor, and Konva nodes already honored `blendMode`/`transform` (reserved in sc-6117); this PR adds the **UI to set them**.

## Changes

- **Per-layer blend modes** — a dropdown on each layers-panel row (the common 16-mode set, shared as `BLEND_MODES` in `imageLayers.js`; each value is a canvas/Konva `globalCompositeOperation` token, so the live `<KonvaImage>` node and the flatten compositor apply it **identically**). `setLayerBlend` checkpoints (undoable).
- **Per-layer transform** — a new **"Transform" tool** binds a Konva `Transformer` to the **active** layer's node (move/scale/rotate). The node renders from `layer.transform`; on drag/transform end it's read back into the layer's `transform` metadata (`commitActiveLayerTransform`). **The bitmap is never resampled** — the transform is baked only at flatten time (`compositeLayersToCanvas` already honors it, matching the live node 1:1). A **"Reset transform"** returns the active layer to identity. The tool is excluded from Stage panning (like crop/boxes).
- **Undo refinement** — a metadata-only undo (opacity / visibility / blend / transform / reorder — same id→blob set, same dims) now **keeps the current tool, mask, boxes, and view**; only a true pixel/dims change resets the per-bitmap overlays + refits. (Previously any stack change reset to Move + cleared overlays, which was jarring for a blend/transform undo.)
- New pure `BLEND_MODES` (+ unit test) and a panel blend-select test.

## Verification

- ✅ **583 web tests** (+2); lint **0 errors**; build clean.
- ✅ **Full live smoke** (rust-api up, real browser):
  - **Blend**: the active layer's dropdown source-over→**multiply**; **Undo** restored source-over (metadata undo, tool/overlays preserved).
  - **Transform**: the tool bound a `Transformer` + showed its bar; a moved/scaled/rotated active layer (**x=60, y=40, 1.4×, 12°**) **persisted through a re-render** (state round-trip) while the other layer stayed identity (per-layer); **Reset** returned it to identity.
  - **Flatten**: on a real canvas, a 2×2 red layer translated by (2,0) over a 4×4 white bg composited to **white left / red shifted right** — the flatten bakes the transform.
  - Screenshot-confirmed (blend dropdowns on each row; Transform tool active with handles on the canvas). Zero console errors.

## Scope

This completes the compositing surface. Next is **sc-6121** (flatten / Save / export + provenance). "Edit → new layer" (non-destructive) and a reopenable layered-project format ([sc-6377](https://app.shortcut.com/trefry/story/6377)) remain future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)