### PR TITLE
feat(image-editor): layer-stack flatten on Save + layers provenance (sc-6121)

### DIFF
--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -355,8 +355,8 @@ export function editedFilename(source) {
 // Provenance for a saved edit, stored under the new asset's top-level `extra`
 // (sc-2434): which source it was derived from + the ordered edit chain
 // (crop/upscale/…) applied this session. Pure for unit testing.
-export function buildSaveProvenance({ source, edits, width, height }) {
-  return {
+export function buildSaveProvenance({ source, edits, width, height, layers }) {
+  const provenance = {
     editor: "image_editor",
     source: source?.assetId
       ? { kind: "asset", assetId: source.assetId, name: source.name ?? null }
@@ -365,6 +365,19 @@ export function buildSaveProvenance({ source, edits, width, height }) {
     width: width ?? null,
     height: height ?? null,
   };
+  // Layer summary (sc-6121): record what the flattened asset was composited from —
+  // bottom→top name / opacity / blend / visibility. Omitted for the degenerate
+  // single-layer document (it adds nothing over the flat bitmap, and keeps a plain
+  // non-layered save's provenance byte-for-byte as it was before layers).
+  if (Array.isArray(layers) && layers.length > 1) {
+    provenance.layers = layers.map((layer) => ({
+      name: layer.name,
+      opacity: layer.opacity,
+      blendMode: layer.blendMode,
+      visible: layer.visible,
+    }));
+  }
+  return provenance;
 }
 
 // Predefined crop ratios (width / height). Rotate swaps to the transpose; 1:1 and
@@ -2355,6 +2368,7 @@ export function ImageEditor() {
           edits,
           width: working.width,
           height: working.height,
+          layers: working.layers,
         }),
       });
       setSavedAssetId(saved?.id ?? null);

--- a/apps/web/src/screens/ImageEditor.test.jsx
+++ b/apps/web/src/screens/ImageEditor.test.jsx
@@ -643,6 +643,21 @@ describe("save / export", () => {
     expect(provenance.source).toEqual({ kind: "upload", name: "drag.png" });
     expect(provenance.edits).toEqual([]);
   });
+
+  it("summarizes a multi-layer stack into provenance, omitting it for single-layer (sc-6121)", () => {
+    const layers = [
+      { name: "Background", opacity: 1, blendMode: "source-over", visible: true, image: {}, blob: {} },
+      { name: "Sky", opacity: 0.5, blendMode: "multiply", visible: false, image: {}, blob: {} },
+    ];
+    const multi = buildSaveProvenance({ source: { kind: "upload", name: "x.png" }, edits: [], width: 4, height: 4, layers });
+    expect(multi.layers).toEqual([
+      { name: "Background", opacity: 1, blendMode: "source-over", visible: true },
+      { name: "Sky", opacity: 0.5, blendMode: "multiply", visible: false },
+    ]);
+    // A single-layer document (or no layers) carries no summary — the flat bitmap is enough.
+    expect(buildSaveProvenance({ source: { kind: "upload" }, edits: [], width: 4, height: 4, layers: [layers[0]] })).not.toHaveProperty("layers");
+    expect(buildSaveProvenance({ source: { kind: "upload" }, edits: [], width: 4, height: 4 })).not.toHaveProperty("layers");
+  });
 });
 
 describe("color grade", () => {


### PR DESCRIPTION
## What

The **final Workstream E (Layers)** story of epic [6087](https://app.shortcut.com/trefry/epic/6087). Implements the sc-6108 **persistence decision: flatten-on-save only** — the editable layer stack stays session-only; a reopenable layered-project format is deferred to [sc-6377](https://app.shortcut.com/trefry/story/6377) (blocked-by this story).

## Changes

- **Flatten on Save / Download** — already landed in sc-6117: `workingImageToFile → compositeToCanvas` flattens the visible stack, and `runSave` lands a new Library asset with `sourceAssetId` lineage. No change needed here.
- **`buildSaveProvenance` gains a `layers` summary** — bottom→top `{ name, opacity, blendMode, visible }`, so a flattened asset records what it was composited from. `runSave` passes `working.layers`. **Omitted for a single-layer document**, so a plain non-layered save's provenance is byte-for-byte unchanged (no regression).
- **Layer ops are undoable** — confirmed all mutating ops (add / delete / duplicate / reorder / rename / visibility / opacity / blend / transform / reset) already `checkpoint()` via sc-6106; selection is intentionally not an undoable edit.
- **No new on-disk format, no `project.db` change.** Reopenable editable stacks → sc-6377.

## Verification

- ✅ **584 web tests** (+1: the provenance layers summary — present for multi-layer, omitted for single/no layers); lint **0 errors**; build clean.
- ✅ **Live smoke** (rust-api up, real browser): a 2-layer document **Saved** to a flattened `Untitled layout-edited.png` Library asset; querying `/api/v1/projects/{id}/assets` showed `extra.provenance` carrying the **`layers` summary** (`[{Background, screen}, {Layer 2, source-over}]`, 1024², source lineage). The flatten compositor itself was pixel-verified on a real canvas in sc-6117/6119/6120. Zero console errors.

## Workstream E complete

Spike (6108) + core (6117) + panel (6118) + tool matrix (6119) + blend/transform (6120) + this. The non-destructive layer editor ships flatten-on-save; the reopenable PSD-like format is the tracked follow-up [sc-6377](https://app.shortcut.com/trefry/story/6377).

🤖 Generated with [Claude Code](https://claude.com/claude-code)