### PR TITLE
feat(image-editor): curves + levels in the Color tool (sc-6109)

### DIFF
--- a/apps/web/src/colorGrade.js
+++ b/apps/web/src/colorGrade.js
@@ -1,0 +1,200 @@
+// Curves + levels color grading for the Image Editor (sc-6109, Workstream F of
+// epic 6087). Pure, LUT-based per-channel tone math — no React/DOM beyond the flat
+// RGBA buffer it mutates. Shared by the live Konva preview and the Apply bake, so
+// the preview is exactly the baked result (same discipline as the brightness/
+// contrast grade in ImageEditor.jsx).
+//
+// Channels: a grade carries a `master` map plus per-channel `r`/`g`/`b` maps.
+// Composition is per-channel FIRST, then master on top: out = masterLut[channelLut[v]].
+
+const CHANNELS = ["master", "r", "g", "b"];
+
+function clampInt(v, lo, hi) {
+  v = Math.round(v);
+  return v < lo ? lo : v > hi ? hi : v;
+}
+
+// An identity 256→256 LUT (out === in).
+function identityLut() {
+  const lut = new Uint8ClampedArray(256);
+  for (let v = 0; v < 256; v += 1) lut[v] = v;
+  return lut;
+}
+
+// Apply a {master,r,g,b} set of 256-entry LUTs to a flat RGBA buffer in place
+// (alpha untouched): per-channel LUT first, then the master LUT on its output.
+export function applyChannelLuts(data, { master, r, g, b }) {
+  for (let i = 0; i < data.length; i += 4) {
+    data[i] = master[r[data[i]]];
+    data[i + 1] = master[g[data[i + 1]]];
+    data[i + 2] = master[b[data[i + 2]]];
+  }
+}
+
+// ── Levels ────────────────────────────────────────────────────────────────
+// Per channel: input black point, white point, and gamma (midtone). The default
+// is the identity (black 0, white 255, gamma 1).
+const IDENTITY_LEVELS_CHANNEL = { black: 0, white: 255, gamma: 1 };
+
+export const IDENTITY_LEVELS = {
+  master: { ...IDENTITY_LEVELS_CHANNEL },
+  r: { ...IDENTITY_LEVELS_CHANNEL },
+  g: { ...IDENTITY_LEVELS_CHANNEL },
+  b: { ...IDENTITY_LEVELS_CHANNEL },
+};
+
+export function isIdentityLevelsChannel(ch) {
+  const { black = 0, white = 255, gamma = 1 } = ch ?? {};
+  return black === 0 && white === 255 && gamma === 1;
+}
+
+export function isIdentityLevels(levels) {
+  return CHANNELS.every((c) => isIdentityLevelsChannel(levels?.[c]));
+}
+
+// LUT[256] for one channel's input black/white/gamma. Values below black map to 0,
+// above white to 255; the span is gamma-corrected (gamma>1 lifts midtones).
+export function levelsChannelLut(channel) {
+  const lut = new Uint8ClampedArray(256);
+  const black = clampInt(channel?.black ?? 0, 0, 254);
+  const white = clampInt(channel?.white ?? 255, black + 1, 255);
+  const gamma = Math.min(9.99, Math.max(0.01, channel?.gamma ?? 1));
+  const invGamma = 1 / gamma;
+  const span = white - black;
+  for (let v = 0; v < 256; v += 1) {
+    let t = (v - black) / span;
+    t = t < 0 ? 0 : t > 1 ? 1 : t;
+    lut[v] = Math.round(255 * Math.pow(t, invGamma));
+  }
+  return lut;
+}
+
+// Apply the full levels grade (master + per-channel) to an RGBA buffer in place.
+export function applyLevels(data, levels) {
+  if (isIdentityLevels(levels)) return;
+  applyChannelLuts(data, {
+    master: levelsChannelLut(levels.master),
+    r: levelsChannelLut(levels.r),
+    g: levelsChannelLut(levels.g),
+    b: levelsChannelLut(levels.b),
+  });
+}
+
+// ── Curves ──────────────────────────────────────────────────────────────────
+// A tone curve is an ordered list of control points {x,y} in [0,255]; the default
+// is the identity diagonal. Interpolated with monotone cubic (Fritsch–Carlson) so
+// the curve is smooth AND never overshoots / reverses between points.
+export const IDENTITY_CURVE = [
+  { x: 0, y: 0 },
+  { x: 255, y: 255 },
+];
+
+export const IDENTITY_CURVES = {
+  master: IDENTITY_CURVE.map((p) => ({ ...p })),
+  r: IDENTITY_CURVE.map((p) => ({ ...p })),
+  g: IDENTITY_CURVE.map((p) => ({ ...p })),
+  b: IDENTITY_CURVE.map((p) => ({ ...p })),
+};
+
+export function isIdentityCurve(points) {
+  if (!Array.isArray(points) || points.length !== 2) return false;
+  return points[0].x === 0 && points[0].y === 0 && points[1].x === 255 && points[1].y === 255;
+}
+
+export function isIdentityCurves(curves) {
+  return CHANNELS.every((c) => isIdentityCurve(curves?.[c]));
+}
+
+// Sort + de-dupe control points by x (a later point at the same x wins), clamped
+// to [0,255]. Returns a fresh array.
+export function normalizeCurvePoints(points) {
+  const byX = new Map();
+  for (const p of points ?? []) {
+    byX.set(clampInt(p.x, 0, 255), clampInt(p.y, 0, 255));
+  }
+  return [...byX.entries()].sort((a, b) => a[0] - b[0]).map(([x, y]) => ({ x, y }));
+}
+
+// Build a 256-entry LUT from control points via monotone cubic interpolation.
+// Fewer than two distinct points → identity.
+export function buildCurveLut(points) {
+  const pts = normalizeCurvePoints(points);
+  const lut = new Uint8ClampedArray(256);
+  if (pts.length < 2) return identityLut();
+
+  const n = pts.length;
+  const xs = pts.map((p) => p.x);
+  const ys = pts.map((p) => p.y);
+  // Secant slopes + monotone tangents (Fritsch–Carlson).
+  const delta = new Array(n - 1);
+  for (let i = 0; i < n - 1; i += 1) delta[i] = (ys[i + 1] - ys[i]) / (xs[i + 1] - xs[i]);
+  const m = new Array(n);
+  m[0] = delta[0];
+  m[n - 1] = delta[n - 2];
+  for (let i = 1; i < n - 1; i += 1) m[i] = (delta[i - 1] + delta[i]) / 2;
+  for (let i = 0; i < n - 1; i += 1) {
+    if (delta[i] === 0) {
+      m[i] = 0;
+      m[i + 1] = 0;
+    } else {
+      const a = m[i] / delta[i];
+      const b = m[i + 1] / delta[i];
+      const s = a * a + b * b;
+      if (s > 9) {
+        const tau = 3 / Math.sqrt(s);
+        m[i] = tau * a * delta[i];
+        m[i + 1] = tau * b * delta[i];
+      }
+    }
+  }
+
+  let seg = 0;
+  for (let v = 0; v < 256; v += 1) {
+    if (v <= xs[0]) {
+      lut[v] = Math.round(ys[0]);
+      continue;
+    }
+    if (v >= xs[n - 1]) {
+      lut[v] = Math.round(ys[n - 1]);
+      continue;
+    }
+    while (seg < n - 1 && v > xs[seg + 1]) seg += 1;
+    const h = xs[seg + 1] - xs[seg];
+    const t = (v - xs[seg]) / h;
+    const t2 = t * t;
+    const t3 = t2 * t;
+    const h00 = 2 * t3 - 3 * t2 + 1;
+    const h10 = t3 - 2 * t2 + t;
+    const h01 = -2 * t3 + 3 * t2;
+    const h11 = t3 - t2;
+    lut[v] = Math.round(h00 * ys[seg] + h10 * h * m[seg] + h01 * ys[seg + 1] + h11 * h * m[seg + 1]);
+  }
+  return lut;
+}
+
+// Apply the full curves grade (master + per-channel) to an RGBA buffer in place.
+export function applyCurves(data, curves) {
+  if (isIdentityCurves(curves)) return;
+  applyChannelLuts(data, {
+    master: buildCurveLut(curves.master),
+    r: buildCurveLut(curves.r),
+    g: buildCurveLut(curves.g),
+    b: buildCurveLut(curves.b),
+  });
+}
+
+// ── Histogram ────────────────────────────────────────────────────────────────
+// Per-channel + luma counts over an RGBA buffer, for the levels display.
+export function computeHistogram(data) {
+  const r = new Array(256).fill(0);
+  const g = new Array(256).fill(0);
+  const b = new Array(256).fill(0);
+  const luma = new Array(256).fill(0);
+  for (let i = 0; i < data.length; i += 4) {
+    r[data[i]] += 1;
+    g[data[i + 1]] += 1;
+    b[data[i + 2]] += 1;
+    luma[Math.round(0.299 * data[i] + 0.587 * data[i + 1] + 0.114 * data[i + 2])] += 1;
+  }
+  return { r, g, b, luma };
+}

--- a/apps/web/src/colorGrade.test.js
+++ b/apps/web/src/colorGrade.test.js
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import {
+  IDENTITY_LEVELS,
+  IDENTITY_CURVE,
+  IDENTITY_CURVES,
+  isIdentityLevels,
+  isIdentityLevelsChannel,
+  isIdentityCurve,
+  isIdentityCurves,
+  levelsChannelLut,
+  applyLevels,
+  normalizeCurvePoints,
+  buildCurveLut,
+  applyCurves,
+  applyChannelLuts,
+  computeHistogram,
+} from "./colorGrade.js";
+
+// A 1-pixel RGBA buffer for one (r,g,b); alpha 255.
+const px = (r, g, b) => Uint8ClampedArray.from([r, g, b, 255]);
+
+describe("levels (sc-6109)", () => {
+  it("identity levels leave a pixel untouched", () => {
+    expect(isIdentityLevels(IDENTITY_LEVELS)).toBe(true);
+    expect(isIdentityLevelsChannel({ black: 0, white: 255, gamma: 1 })).toBe(true);
+    const data = px(10, 128, 240);
+    applyLevels(data, IDENTITY_LEVELS);
+    expect([...data]).toEqual([10, 128, 240, 255]);
+  });
+
+  it("the identity LUT maps every value to itself", () => {
+    const lut = levelsChannelLut({ black: 0, white: 255, gamma: 1 });
+    expect(lut[0]).toBe(0);
+    expect(lut[128]).toBe(128);
+    expect(lut[255]).toBe(255);
+  });
+
+  it("black/white points clip and rescale the span", () => {
+    const lut = levelsChannelLut({ black: 64, white: 192, gamma: 1 });
+    expect(lut[64]).toBe(0); // at/below black → 0
+    expect(lut[32]).toBe(0);
+    expect(lut[192]).toBe(255); // at/above white → 255
+    expect(lut[224]).toBe(255);
+    expect(lut[128]).toBe(128); // midpoint of [64,192] → 128
+  });
+
+  it("gamma lifts (>1) or lowers (<1) the midtones, endpoints fixed", () => {
+    const lift = levelsChannelLut({ black: 0, white: 255, gamma: 2 });
+    const lower = levelsChannelLut({ black: 0, white: 255, gamma: 0.5 });
+    expect(lift[0]).toBe(0);
+    expect(lift[255]).toBe(255);
+    expect(lift[128]).toBeGreaterThan(128); // gamma>1 brightens midtones
+    expect(lower[128]).toBeLessThan(128); // gamma<1 darkens midtones
+  });
+
+  it("applies the master gamma uniformly across channels (midtones move, endpoints fixed)", () => {
+    const data = px(128, 128, 128);
+    applyLevels(data, { ...IDENTITY_LEVELS, master: { black: 0, white: 255, gamma: 0.5 } });
+    expect(data[0]).toBeLessThan(128); // gamma<1 darkens the midtone
+    expect(data[0]).toBe(data[1]); // applied uniformly per channel
+    expect(data[1]).toBe(data[2]);
+    // Endpoints are untouched by gamma.
+    const white = px(255, 255, 255);
+    applyLevels(white, { ...IDENTITY_LEVELS, master: { black: 0, white: 255, gamma: 0.5 } });
+    expect([...white]).toEqual([255, 255, 255, 255]);
+  });
+});
+
+describe("curves (sc-6109)", () => {
+  it("identity curve maps every value to itself", () => {
+    expect(isIdentityCurve(IDENTITY_CURVE)).toBe(true);
+    expect(isIdentityCurves(IDENTITY_CURVES)).toBe(true);
+    const lut = buildCurveLut(IDENTITY_CURVE);
+    expect(lut[0]).toBe(0);
+    expect(lut[128]).toBe(128);
+    expect(lut[255]).toBe(255);
+  });
+
+  it("normalizeCurvePoints sorts, clamps, and de-dupes by x", () => {
+    expect(normalizeCurvePoints([{ x: 255, y: 255 }, { x: 0, y: 0 }, { x: 300, y: -5 }])).toEqual([
+      { x: 0, y: 0 },
+      { x: 255, y: 0 }, // x clamped to 255, y clamped to 0; later point at x=255 wins over the first
+    ]);
+  });
+
+  it("respects control points exactly and stays monotonic between them", () => {
+    // Lift the midtone: (128 → 180).
+    const lut = buildCurveLut([{ x: 0, y: 0 }, { x: 128, y: 180 }, { x: 255, y: 255 }]);
+    expect(lut[0]).toBe(0);
+    expect(lut[128]).toBe(180);
+    expect(lut[255]).toBe(255);
+    // Monotonic non-decreasing (Fritsch–Carlson never reverses).
+    for (let v = 1; v < 256; v += 1) expect(lut[v]).toBeGreaterThanOrEqual(lut[v - 1]);
+    // Midtone lift brightens the lower half.
+    expect(lut[64]).toBeGreaterThan(64);
+  });
+
+  it("a flat segment never overshoots (monotone, no ringing)", () => {
+    const lut = buildCurveLut([{ x: 0, y: 0 }, { x: 100, y: 200 }, { x: 150, y: 200 }, { x: 255, y: 255 }]);
+    for (let v = 0; v < 256; v += 1) {
+      expect(lut[v]).toBeGreaterThanOrEqual(0);
+      expect(lut[v]).toBeLessThanOrEqual(255);
+    }
+    // Between the two y=200 points the curve holds ~200 without exceeding it much.
+    expect(lut[125]).toBeGreaterThanOrEqual(195);
+    expect(lut[125]).toBeLessThanOrEqual(205);
+  });
+
+  it("fewer than two distinct points falls back to identity", () => {
+    const lut = buildCurveLut([{ x: 5, y: 250 }]);
+    expect(lut[0]).toBe(0);
+    expect(lut[255]).toBe(255);
+  });
+
+  it("applyCurves skips the identity and otherwise transforms pixels", () => {
+    const same = px(10, 20, 30);
+    applyCurves(same, IDENTITY_CURVES);
+    expect([...same]).toEqual([10, 20, 30, 255]);
+
+    // An inverting master curve (0→255, 255→0) negates every channel.
+    const data = px(0, 128, 255);
+    applyCurves(data, { ...IDENTITY_CURVES, master: [{ x: 0, y: 255 }, { x: 255, y: 0 }] });
+    expect(data[0]).toBe(255);
+    expect(data[2]).toBe(0);
+  });
+});
+
+describe("LUT composition + histogram", () => {
+  it("applyChannelLuts composes per-channel first, then master", () => {
+    const id = new Uint8ClampedArray(256);
+    for (let v = 0; v < 256; v += 1) id[v] = v;
+    const plus10 = new Uint8ClampedArray(256);
+    for (let v = 0; v < 256; v += 1) plus10[v] = Math.min(255, v + 10);
+    const data = px(100, 100, 100);
+    // master +10 over a red channel of +10 → red = 120, g/b = 110.
+    applyChannelLuts(data, { master: plus10, r: plus10, g: id, b: id });
+    expect(data[0]).toBe(120);
+    expect(data[1]).toBe(110);
+    expect(data[2]).toBe(110);
+  });
+
+  it("computeHistogram counts per channel + luma", () => {
+    const data = Uint8ClampedArray.from([0, 0, 0, 255, 255, 255, 255, 255]); // black + white pixels
+    const h = computeHistogram(data);
+    expect(h.r[0]).toBe(1);
+    expect(h.r[255]).toBe(1);
+    expect(h.luma[0]).toBe(1);
+    expect(h.luma[255]).toBe(1);
+    expect(h.g.reduce((a, b) => a + b, 0)).toBe(2);
+  });
+});

--- a/apps/web/src/components/CurveEditor.jsx
+++ b/apps/web/src/components/CurveEditor.jsx
@@ -1,0 +1,115 @@
+import React, { useEffect, useRef } from "react";
+import { buildCurveLut, normalizeCurvePoints } from "../colorGrade.js";
+
+// An editable tone-curve widget (sc-6109): a square graph over input→output in
+// [0,255] (y up). Drag a control point to reshape the curve, click empty space to
+// add a point, double-click an interior point to remove it. The endpoints' x is
+// locked (0 and 255); interior points stay ordered (clamped between neighbors), so
+// the point list never reorders mid-drag. Pure-math (the LUT + normalization) lives
+// in colorGrade.js; this is just the interaction surface. `onChange` receives the
+// normalized point list.
+const SIZE = 220; // on-screen px (the SVG viewBox is 0..255 in curve space)
+
+export function CurveEditor({ points, onChange, stroke = "var(--accent)" }) {
+  const svgRef = useRef(null);
+  const dragRef = useRef(null); // index of the point being dragged, or null
+
+  const pts = normalizeCurvePoints(points);
+  const lut = buildCurveLut(pts);
+  // Curve polyline in SVG space (y flipped: 0 at bottom → 255-y at top).
+  const path = Array.from({ length: 256 }, (_, x) => `${x},${255 - lut[x]}`).join(" ");
+
+  // Convert a pointer event to clamped curve coords (x,y in 0..255, y up).
+  const toCurve = (event) => {
+    const rect = svgRef.current.getBoundingClientRect();
+    const x = ((event.clientX - rect.left) / rect.width) * 255;
+    const y = 255 - ((event.clientY - rect.top) / rect.height) * 255;
+    const clamp = (v) => (v < 0 ? 0 : v > 255 ? 255 : Math.round(v));
+    return { x: clamp(x), y: clamp(y) };
+  };
+
+  // Drag a point, keeping the list ordered: endpoints move in y only; interior
+  // points clamp x strictly between their neighbors so the index stays stable.
+  useEffect(() => {
+    const onMove = (event) => {
+      const i = dragRef.current;
+      if (i == null) return;
+      const next = pts.map((p) => ({ ...p }));
+      const c = toCurve(event);
+      if (i === 0) next[i] = { x: 0, y: c.y };
+      else if (i === next.length - 1) next[i] = { x: 255, y: c.y };
+      else {
+        const lo = next[i - 1].x + 1;
+        const hi = next[i + 1].x - 1;
+        next[i] = { x: Math.min(hi, Math.max(lo, c.x)), y: c.y };
+      }
+      onChange(next);
+    };
+    const onUp = () => {
+      dragRef.current = null;
+    };
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+    return () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+    };
+  });
+
+  // Click empty space → add a control point there (ignored if it lands on an x that
+  // already has a point — normalizeCurvePoints would dedupe it anyway).
+  const handleBackgroundPointerDown = (event) => {
+    if (event.target.dataset.handle) return; // a handle starts a drag instead
+    const c = toCurve(event);
+    onChange(normalizeCurvePoints([...pts, c]));
+  };
+
+  const removePoint = (index) => {
+    if (index === 0 || index === pts.length - 1) return; // keep the endpoints
+    onChange(pts.filter((_, i) => i !== index));
+  };
+
+  return (
+    <svg
+      ref={svgRef}
+      className="image-editor-curve"
+      width={SIZE}
+      height={SIZE}
+      viewBox="0 0 255 255"
+      preserveAspectRatio="none"
+      onPointerDown={handleBackgroundPointerDown}
+      role="application"
+      aria-label="Tone curve editor"
+    >
+      <rect x={0} y={0} width={255} height={255} className="image-editor-curve-bg" />
+      {[64, 128, 191].map((g) => (
+        <g key={g}>
+          <line x1={g} y1={0} x2={g} y2={255} className="image-editor-curve-grid" />
+          <line x1={0} y1={g} x2={255} y2={g} className="image-editor-curve-grid" />
+        </g>
+      ))}
+      <line x1={0} y1={255} x2={255} y2={0} className="image-editor-curve-diagonal" />
+      <polyline points={path} fill="none" stroke={stroke} strokeWidth={2} vectorEffect="non-scaling-stroke" />
+      {pts.map((p, i) => (
+        <circle
+          key={i}
+          data-handle="1"
+          data-index={i}
+          cx={p.x}
+          cy={255 - p.y}
+          r={5}
+          className="image-editor-curve-handle"
+          stroke={stroke}
+          onPointerDown={(event) => {
+            event.stopPropagation();
+            dragRef.current = i;
+          }}
+          onDoubleClick={(event) => {
+            event.stopPropagation();
+            removePoint(i);
+          }}
+        />
+      ))}
+    </svg>
+  );
+}

--- a/apps/web/src/components/CurveEditor.test.jsx
+++ b/apps/web/src/components/CurveEditor.test.jsx
@@ -1,0 +1,59 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CurveEditor } from "./CurveEditor.jsx";
+
+describe("CurveEditor (sc-6109)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  const handles = () => [...container.querySelectorAll(".image-editor-curve-handle")];
+
+  it("renders a draggable handle per control point and a 256-point curve polyline", async () => {
+    const points = [
+      { x: 0, y: 0 },
+      { x: 128, y: 180 },
+      { x: 255, y: 255 },
+    ];
+    await act(() => root.render(<CurveEditor points={points} onChange={vi.fn()} />));
+    expect(handles()).toHaveLength(3);
+    const poly = container.querySelector("polyline");
+    expect(poly.getAttribute("points").trim().split(/\s+/)).toHaveLength(256);
+    // The middle handle reflects the lifted midtone, drawn y-flipped (255 - y).
+    const mid = handles()[1];
+    expect(Number(mid.getAttribute("cx"))).toBe(128);
+    expect(Number(mid.getAttribute("cy"))).toBe(255 - 180);
+  });
+
+  it("double-clicking an interior point removes it; endpoints are kept", async () => {
+    const onChange = vi.fn();
+    const points = [
+      { x: 0, y: 0 },
+      { x: 128, y: 180 },
+      { x: 255, y: 255 },
+    ];
+    await act(() => root.render(<CurveEditor points={points} onChange={onChange} />));
+    await act(() => handles()[1].dispatchEvent(new MouseEvent("dblclick", { bubbles: true })));
+    expect(onChange).toHaveBeenCalledWith([
+      { x: 0, y: 0 },
+      { x: 255, y: 255 },
+    ]);
+
+    onChange.mockClear();
+    await act(() => handles()[0].dispatchEvent(new MouseEvent("dblclick", { bubbles: true })));
+    expect(onChange).not.toHaveBeenCalled(); // endpoint not removable
+  });
+});

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -26,6 +26,16 @@ import {
   snapshotLayers,
 } from "../imageLayers.js";
 import { LayersPanel } from "../components/LayersPanel.jsx";
+import { CurveEditor } from "../components/CurveEditor.jsx";
+import {
+  IDENTITY_LEVELS,
+  IDENTITY_CURVES,
+  isIdentityLevels,
+  isIdentityCurves,
+  applyLevels,
+  applyCurves,
+  computeHistogram,
+} from "../colorGrade.js";
 
 const MIN_SCALE = 0.05;
 const MAX_SCALE = 16;
@@ -229,10 +239,15 @@ export function applyColorAdjustments(data, adjust) {
   }
 }
 
-// Konva custom filter for the live preview — reads the grade from the node's
-// `colorAdjust` attr (set declaratively by react-konva) and runs the shared math.
+// Konva custom filter for the live preview — reads the grade from the node's attrs
+// (set declaratively by react-konva) and runs the shared math, so preview === bake.
+// `gradeMode` selects which grade is previewed (sc-6109): the brightness/contrast
+// "adjust", levels, or curves.
 function konvaColorFilter(imageData) {
-  applyColorAdjustments(imageData.data, this.getAttr("colorAdjust"));
+  const mode = this.getAttr("gradeMode");
+  if (mode === "levels") applyLevels(imageData.data, this.getAttr("gradeLevels"));
+  else if (mode === "curves") applyCurves(imageData.data, this.getAttr("gradeCurves"));
+  else applyColorAdjustments(imageData.data, this.getAttr("colorAdjust"));
 }
 
 // Upscale engines + their valid factors (sc-2433). Real-ESRGAN 2x/4x is the cross-platform default
@@ -845,6 +860,15 @@ export function ImageEditor() {
   // Color grade (sc-2439): non-destructive −1..1 adjustments previewed live via a
   // Konva filter, baked into the working image on Apply.
   const [colorAdjust, setColorAdjust] = useState(IDENTITY_COLOR_ADJUST);
+  // Curves + levels (sc-6109): the Color tool has three modes — the brightness/
+  // contrast "adjust" (above), per-channel levels, and an editable tone curve. Each
+  // previews via the same Konva filter and bakes via the same Canvas-2D pass. The
+  // active channel ("master" | "r" | "g" | "b") is shared by the levels + curves UI.
+  const [colorMode, setColorMode] = useState("adjust"); // "adjust" | "levels" | "curves"
+  const [levels, setLevels] = useState(IDENTITY_LEVELS);
+  const [curves, setCurves] = useState(IDENTITY_CURVES);
+  const [colorChannel, setColorChannel] = useState("master");
+  const histogramRef = useRef(null);
 
   // AI prompt edit (sc-2435): an edit-capable model + instruction + optional seed,
   // run against the working image through the existing edit_image flow.
@@ -1043,6 +1067,10 @@ export function ImageEditor() {
     setTool("move");
     setCropRect(null);
     setColorAdjust(IDENTITY_COLOR_ADJUST);
+    setColorMode("adjust");
+    setLevels(IDENTITY_LEVELS);
+    setCurves(IDENTITY_CURVES);
+    setColorChannel("master");
     // A new working bitmap invalidates the mask (dims/content changed) — strokes + smart-select base.
     setMaskLines([]);
     setMaskMode(false);
@@ -1379,7 +1407,10 @@ export function ImageEditor() {
   function cancelCrop() {
     setTool("move");
     setCropRect(null);
-    setColorAdjust(IDENTITY_COLOR_ADJUST); // discard any unbaked color preview
+    // Discard any unbaked color preview (adjust / levels / curves).
+    setColorAdjust(IDENTITY_COLOR_ADJUST);
+    setLevels(IDENTITY_LEVELS);
+    setCurves(IDENTITY_CURVES);
   }
 
   function chooseRatio(key) {
@@ -1546,63 +1577,133 @@ export function ImageEditor() {
     transformer.getLayer()?.batchDraw();
   }, [tool, working]);
 
-  // ── Color grade (sc-2439) ─────────────────────────────────────────────────
+  // ── Color grade (sc-2439; curves + levels sc-6109) ─────────────────────────
   function startColorGrade() {
     if (!working) return;
     setTool("color");
+    setColorMode("adjust");
+    setColorChannel("master");
     setColorAdjust(IDENTITY_COLOR_ADJUST);
+    setLevels(IDENTITY_LEVELS);
+    setCurves(IDENTITY_CURVES);
   }
 
   const setAdjustValue = (key, value) => setColorAdjust((prev) => ({ ...prev, [key]: value }));
   const resetAdjust = (key) => setAdjustValue(key, 0);
-  const resetAllAdjust = () => setColorAdjust(IDENTITY_COLOR_ADJUST);
+
+  // Patch the active channel's levels (sc-6109).
+  const setLevelsValue = (key, value) =>
+    setLevels((prev) => ({ ...prev, [colorChannel]: { ...prev[colorChannel], [key]: value } }));
+
+  // Reset the currently-selected color mode (all channels) to its identity.
+  function resetActiveColorMode() {
+    if (colorMode === "levels") setLevels(IDENTITY_LEVELS);
+    else if (colorMode === "curves") setCurves(IDENTITY_CURVES);
+    else setColorAdjust(IDENTITY_COLOR_ADJUST);
+  }
+
+  // Stroke for the curve editor / channel cue.
+  const channelStroke = { master: "var(--accent)", r: "#d44", g: "#4a4", b: "#46d" }[colorChannel];
+
+  // Whether the currently-selected color mode is at its identity (gates Apply + the
+  // live-preview cache).
+  function activeGradeIsIdentity() {
+    if (colorMode === "levels") return isIdentityLevels(levels);
+    if (colorMode === "curves") return isIdentityCurves(curves);
+    return isIdentityAdjust(colorAdjust);
+  }
 
   // Live preview: Konva applies filters only on a cached node, and re-running them
-  // needs a re-cache. Cache the image node (re-caching when the grade changes) while
-  // the color tool is active with a non-identity grade; clear it otherwise so Move/
-  // other tools see the untouched bitmap. The filter reads the `colorAdjust` attr.
+  // needs a re-cache. Cache the active layer's node (re-caching when ANY grade input
+  // changes) while the color tool is active with a non-identity grade; clear it
+  // otherwise so Move/other tools see the untouched bitmap. The filter reads the
+  // gradeMode + colorAdjust/levels/curves attrs.
   useEffect(() => {
     const node = imageNodeRef.current;
     if (!node) return;
-    const active = tool === "color" && !isIdentityAdjust(colorAdjust);
-    if (active) {
+    if (tool === "color" && !activeGradeIsIdentity()) {
       node.cache();
     } else {
       node.clearCache();
     }
     node.getLayer()?.batchDraw();
-  }, [tool, colorAdjust, working]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tool, colorMode, colorAdjust, levels, curves, working]);
 
-  // Apply: bake the grade into a fresh working image using the SAME pixel math as the
-  // preview (a 2D-canvas pass, no Konva-cache readback). Keeps the source provenance
-  // so lineage survives to Save; records the grade in the edit chain.
+  // Draw the active layer's histogram for the levels mode (sc-6109). Recomputed when
+  // the layer or selected channel changes; cheap (one pass over the layer bitmap).
+  useEffect(() => {
+    const canvas = histogramRef.current;
+    if (!canvas || tool !== "color" || colorMode !== "levels") return;
+    const layer = activeLayerOf(working);
+    if (!layer) return;
+    const off = document.createElement("canvas");
+    off.width = layer.image.naturalWidth;
+    off.height = layer.image.naturalHeight;
+    const octx = off.getContext("2d");
+    octx.drawImage(layer.image, 0, 0);
+    const hist = computeHistogram(octx.getImageData(0, 0, off.width, off.height).data);
+    const series = colorChannel === "master" ? hist.luma : hist[colorChannel];
+    const peak = Math.max(1, ...series);
+    const ctx = canvas.getContext("2d");
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = colorChannel === "r" ? "#d44" : colorChannel === "g" ? "#4a4" : colorChannel === "b" ? "#46d" : "#888";
+    const bw = canvas.width / 256;
+    for (let i = 0; i < 256; i += 1) {
+      const h = (series[i] / peak) * canvas.height;
+      ctx.fillRect(i * bw, canvas.height - h, Math.max(1, bw), h);
+    }
+  }, [tool, colorMode, colorChannel, working]);
+
+  // Apply: bake the active mode's grade (adjust / levels / curves) into the ACTIVE
+  // layer using the SAME pixel math as the live preview (a 2D-canvas pass), writing
+  // it back in place — stack + dims preserved (sc-6119). Records the grade in the
+  // edit chain (sc-6109).
   const applyColorGrade = useCallback(async () => {
     const layer = activeLayerOf(working);
-    if (!working || !layer || isIdentityAdjust(colorAdjust)) return;
+    if (!working || !layer) return;
+    // Resolve the active mode's transform + provenance entry; bail if it's identity.
+    let transform;
+    let edit;
+    if (colorMode === "levels") {
+      if (isIdentityLevels(levels)) return;
+      const baked = levels;
+      transform = (data) => applyLevels(data, baked);
+      edit = { op: "levels", levels: baked };
+    } else if (colorMode === "curves") {
+      if (isIdentityCurves(curves)) return;
+      const baked = curves;
+      transform = (data) => applyCurves(data, baked);
+      edit = { op: "curves", curves: baked };
+    } else {
+      if (isIdentityAdjust(colorAdjust)) return;
+      const baked = { ...colorAdjust };
+      transform = (data) => applyColorAdjustments(data, baked);
+      edit = { op: "color", ...baked };
+    }
     const w = layer.image.naturalWidth;
     const h = layer.image.naturalHeight;
     const canvas = document.createElement("canvas");
     canvas.width = w;
     canvas.height = h;
     const ctx = canvas.getContext("2d");
-    // Active-layer op (sc-6119): bake the grade into the ACTIVE layer's pixels and
-    // write it back, preserving the rest of the stack + the doc dims. The live
-    // preview already caches the active layer's node (below).
     ctx.drawImage(layer.image, 0, 0);
     const imageData = ctx.getImageData(0, 0, w, h);
-    applyColorAdjustments(imageData.data, colorAdjust);
+    transform(imageData.data);
     ctx.putImageData(imageData, 0, 0);
     const blob = await new Promise((resolve) => canvas.toBlob(resolve, "image/png"));
     if (!blob) return;
-    const baked = { ...colorAdjust };
     const { image, objectUrl } = await blobToImage(blob);
     checkpoint();
     replaceLayerImage(layer.id, image, objectUrl, blob);
-    setColorAdjust(IDENTITY_COLOR_ADJUST); // the grade is baked; drop the live preview
+    // The grade is baked; drop every live preview.
+    setColorAdjust(IDENTITY_COLOR_ADJUST);
+    setLevels(IDENTITY_LEVELS);
+    setCurves(IDENTITY_CURVES);
     setTool("move");
-    setEdits((prev) => [...prev, { op: "color", ...baked }]);
+    setEdits((prev) => [...prev, edit]);
     setDirty(true);
-  }, [working, colorAdjust, replaceLayerImage, checkpoint]);
+  }, [working, colorMode, colorAdjust, levels, curves, replaceLayerImage, checkpoint]);
 
   // ── Layer stack ops (sc-6118) ─────────────────────────────────────────────
   // Wire the layers panel to the pure layer-stack ops (../imageLayers.js). Each
@@ -2565,7 +2666,16 @@ export function ImageEditor() {
                     width={layer.image.naturalWidth}
                     x={t.x}
                     y={t.y}
-                    {...(isActive ? { colorAdjust, filters: [konvaColorFilter], ref: imageNodeRef } : {})}
+                    {...(isActive
+                      ? {
+                          colorAdjust,
+                          gradeMode: colorMode,
+                          gradeLevels: levels,
+                          gradeCurves: curves,
+                          filters: [konvaColorFilter],
+                          ref: imageNodeRef,
+                        }
+                      : {})}
                     {...(isActive && tool === "transform"
                       ? { draggable: true, onDragEnd: commitActiveLayerTransform, onTransformEnd: commitActiveLayerTransform }
                       : {})}
@@ -2995,26 +3105,113 @@ export function ImageEditor() {
 
         {tool === "color" && working ? (
           <div className="image-editor-cropbar image-editor-colorbar">
-            {COLOR_ADJUSTMENTS.map(({ key, label }) => (
-              <label className="image-editor-slider" key={key} title="Double-click the slider to reset">
-                <span className="image-editor-slider-label">{label}</span>
-                <input
-                  aria-label={label}
-                  max={1}
-                  min={-1}
-                  onChange={(event) => setAdjustValue(key, Number(event.target.value))}
-                  onDoubleClick={() => resetAdjust(key)}
-                  step={0.01}
-                  type="range"
-                  value={colorAdjust[key]}
-                />
-                <span className="image-editor-slider-value">{Math.round(colorAdjust[key] * 100)}</span>
-              </label>
-            ))}
-            <button disabled={isIdentityAdjust(colorAdjust)} onClick={resetAllAdjust} type="button">
+            <div className="image-editor-color-modes" role="group" aria-label="Color mode">
+              {[
+                ["adjust", "Adjust"],
+                ["levels", "Levels"],
+                ["curves", "Curves"],
+              ].map(([mode, label]) => (
+                <button
+                  key={mode}
+                  className={colorMode === mode ? "active" : ""}
+                  onClick={() => setColorMode(mode)}
+                  type="button"
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+
+            {colorMode === "adjust"
+              ? COLOR_ADJUSTMENTS.map(({ key, label }) => (
+                  <label className="image-editor-slider" key={key} title="Double-click the slider to reset">
+                    <span className="image-editor-slider-label">{label}</span>
+                    <input
+                      aria-label={label}
+                      max={1}
+                      min={-1}
+                      onChange={(event) => setAdjustValue(key, Number(event.target.value))}
+                      onDoubleClick={() => resetAdjust(key)}
+                      step={0.01}
+                      type="range"
+                      value={colorAdjust[key]}
+                    />
+                    <span className="image-editor-slider-value">{Math.round(colorAdjust[key] * 100)}</span>
+                  </label>
+                ))
+              : null}
+
+            {colorMode === "levels" || colorMode === "curves" ? (
+              <select
+                aria-label="Channel"
+                className="image-editor-editmodel"
+                onChange={(event) => setColorChannel(event.target.value)}
+                value={colorChannel}
+              >
+                <option value="master">Master</option>
+                <option value="r">Red</option>
+                <option value="g">Green</option>
+                <option value="b">Blue</option>
+              </select>
+            ) : null}
+
+            {colorMode === "levels" ? (
+              <>
+                <canvas className="image-editor-histogram" height={56} ref={histogramRef} width={200} />
+                <label className="image-editor-slider" title="Black point">
+                  <span className="image-editor-slider-label">Black</span>
+                  <input
+                    aria-label="Black point"
+                    max={254}
+                    min={0}
+                    onChange={(event) => setLevelsValue("black", Number(event.target.value))}
+                    step={1}
+                    type="range"
+                    value={levels[colorChannel].black}
+                  />
+                  <span className="image-editor-slider-value">{levels[colorChannel].black}</span>
+                </label>
+                <label className="image-editor-slider" title="Gamma (midtones)">
+                  <span className="image-editor-slider-label">Gamma</span>
+                  <input
+                    aria-label="Gamma"
+                    max={2.5}
+                    min={0.1}
+                    onChange={(event) => setLevelsValue("gamma", Number(event.target.value))}
+                    step={0.01}
+                    type="range"
+                    value={levels[colorChannel].gamma}
+                  />
+                  <span className="image-editor-slider-value">{levels[colorChannel].gamma.toFixed(2)}</span>
+                </label>
+                <label className="image-editor-slider" title="White point">
+                  <span className="image-editor-slider-label">White</span>
+                  <input
+                    aria-label="White point"
+                    max={255}
+                    min={1}
+                    onChange={(event) => setLevelsValue("white", Number(event.target.value))}
+                    step={1}
+                    type="range"
+                    value={levels[colorChannel].white}
+                  />
+                  <span className="image-editor-slider-value">{levels[colorChannel].white}</span>
+                </label>
+              </>
+            ) : null}
+
+            {colorMode === "curves" ? (
+              <CurveEditor
+                points={curves[colorChannel]}
+                stroke={channelStroke}
+                onChange={(points) => setCurves((prev) => ({ ...prev, [colorChannel]: points }))}
+              />
+            ) : null}
+
+            <button disabled={activeGradeIsIdentity()} onClick={resetActiveColorMode} type="button">
               Reset
             </button>
-            <button className="primary" disabled={isIdentityAdjust(colorAdjust)} onClick={applyColorGrade} type="button">
+            <button className="primary" disabled={activeGradeIsIdentity()} onClick={applyColorGrade} type="button">
               Apply
             </button>
             <button onClick={cancelCrop} type="button">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -6255,6 +6255,77 @@ details[open] > summary.lora-scope-group-heading::before,
   color: var(--text-muted);
 }
 
+/* Color tool (sc-6109): a vertical panel with Adjust / Levels / Curves modes. */
+.image-editor-colorbar {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+  max-width: 260px;
+}
+
+.image-editor-colorbar .image-editor-slider {
+  flex-direction: row;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.image-editor-colorbar .image-editor-slider input[type="range"] {
+  flex: 1 1 auto;
+  width: auto;
+}
+
+.image-editor-color-modes {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 4px;
+}
+
+.image-editor-color-modes button.active {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.image-editor-histogram {
+  width: 100%;
+  height: 56px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface-2);
+}
+
+.image-editor-curve {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 1 / 1;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  touch-action: none;
+}
+
+.image-editor-curve-bg {
+  fill: var(--surface-2);
+}
+
+.image-editor-curve-grid {
+  stroke: var(--border);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+
+.image-editor-curve-diagonal {
+  stroke: var(--text-muted);
+  stroke-dasharray: 4 4;
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+  opacity: 0.5;
+}
+
+.image-editor-curve-handle {
+  fill: var(--surface);
+  stroke-width: 2;
+  cursor: grab;
+}
+
 /* AI prompt-edit bar (sc-2435): model picker + prompt + seed inline. */
 .image-editor-editbar .image-editor-editprompt {
   min-width: 260px;


### PR DESCRIPTION
## What

**Workstream F (polish)** of epic [6087](https://app.shortcut.com/trefry/epic/6087). Extends the client-side Color tool (brightness / contrast / saturation / temperature) with **per-channel levels** and an **editable tone curve**, reusing the existing live-preview + Canvas-2D bake pipeline.

## Changes

- **New pure module `apps/web/src/colorGrade.js`** (React/DOM-free): 
  - **Levels** — per-channel + master black/white/gamma → input-levels LUT.
  - **Curves** — a 256-entry LUT from control points via **monotone cubic (Fritsch–Carlson)** interpolation (smooth, never overshoots/reverses).
  - `computeHistogram` (per-channel + luma) and the shared `applyChannelLuts` (master ∘ per-channel). 13 unit tests.
- **New `CurveEditor` component** (SVG): drag a control point, click empty space to add one, double-click to remove; endpoints are x-locked and points stay ordered. 2 tests.
- **Color tool gains an `Adjust | Levels | Curves` mode switch**:
  - *Levels*: channel picker (Master/R/G/B) + a live histogram of the active layer + black/gamma/white sliders.
  - *Curves*: channel picker + the curve editor.
  - All three **preview via one mode-driven Konva filter** (`konvaColorFilter` now reads a `gradeMode` attr) and **bake via `applyColorGrade` into the ACTIVE layer** (the sc-6119 write-back), recorded in the edit chain as `op:"levels"` / `"curves"` / `"color"`.

## Verification

- ✅ **599 web tests** (+15: 13 colorGrade math + 2 CurveEditor); lint **0 errors**; build clean.
- ✅ **Live smoke** (rust-api up, real browser): all three modes render (mode tabs; Levels histogram + Black/Gamma/White sliders; Curves graph with grid + diagonal + endpoint handles). A **Levels gamma=0.5 Apply** re-encoded the active layer's bitmap (src changed, tool→Move, Save/dirty enabled) and **Undo** reverted it. **Real-canvas** checks confirmed the transforms: curve invert `64→191`, levels gamma `128→64`. Screenshot-confirmed; zero console errors.

## Scope

Client-side, baked to the active layer via the existing rasterization path; consistent with the brightness/contrast grade pipeline. Master ∘ per-channel composition is documented + tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)