### PR TITLE
feat(image-editor): mask refinement — feather / grow / shrink / invert (sc-6110)

### DIFF
--- a/apps/web/src/maskRefine.js
+++ b/apps/web/src/maskRefine.js
@@ -1,0 +1,106 @@
+// Mask refinement (sc-6110, Workstream F of epic 6087). Pure morphology / blur /
+// invert over a single-channel mask — white (255) = edit region, black (0) = keep —
+// represented as a flat Uint8 intensity array of length w*h. The editor flattens its
+// current mask (smart-select base + brush strokes) to white-on-black, extracts the
+// intensity with maskAlphaFromRgba, applies one of these ops, then writes it back as
+// the new mask base. React/DOM-free so the pixel math is unit-tested in isolation.
+
+// Extract mask intensity (the R channel — the mask is grayscale) from an RGBA buffer.
+export function maskAlphaFromRgba(data) {
+  const out = new Uint8ClampedArray(data.length / 4);
+  for (let i = 0, j = 0; i < data.length; i += 4, j += 1) out[j] = data[i];
+  return out;
+}
+
+// Write a single-channel mask back to RGBA (R=G=B=value, opaque).
+export function writeMaskAlphaToRgba(data, alpha) {
+  for (let i = 0, j = 0; i < data.length; i += 4, j += 1) {
+    data[i] = alpha[j];
+    data[i + 1] = alpha[j];
+    data[i + 2] = alpha[j];
+    data[i + 3] = 255;
+  }
+}
+
+// Invert the selection (255 - v): selected ↔ unselected.
+export function invertAlpha(alpha) {
+  const out = new Uint8ClampedArray(alpha.length);
+  for (let i = 0; i < alpha.length; i += 1) out[i] = 255 - alpha[i];
+  return out;
+}
+
+// Separable grayscale morphology over a (2r+1) window — extreme = Math.max (dilate /
+// grow the white selection) or Math.min (erode / shrink). Edges clamp.
+function morph(alpha, w, h, radius, extreme) {
+  const r = Math.max(0, Math.round(radius));
+  if (r === 0) return Uint8ClampedArray.from(alpha);
+  const seed = extreme === Math.max ? 0 : 255;
+  const tmp = new Uint8ClampedArray(alpha.length);
+  for (let y = 0; y < h; y += 1) {
+    const row = y * w;
+    for (let x = 0; x < w; x += 1) {
+      let v = seed;
+      const x0 = Math.max(0, x - r);
+      const x1 = Math.min(w - 1, x + r);
+      for (let xx = x0; xx <= x1; xx += 1) v = extreme(v, alpha[row + xx]);
+      tmp[row + x] = v;
+    }
+  }
+  const out = new Uint8ClampedArray(alpha.length);
+  for (let x = 0; x < w; x += 1) {
+    for (let y = 0; y < h; y += 1) {
+      let v = seed;
+      const y0 = Math.max(0, y - r);
+      const y1 = Math.min(h - 1, y + r);
+      for (let yy = y0; yy <= y1; yy += 1) v = extreme(v, tmp[yy * w + x]);
+      out[y * w + x] = v;
+    }
+  }
+  return out;
+}
+
+// Grow / shrink the selection by `radius` px.
+export function dilateAlpha(alpha, w, h, radius) {
+  return morph(alpha, w, h, radius, Math.max);
+}
+export function erodeAlpha(alpha, w, h, radius) {
+  return morph(alpha, w, h, radius, Math.min);
+}
+
+// Separable box-blur pass over a (2r+1) window with edge clamping (averaged over the
+// in-bounds count so edges don't darken).
+function blurPass(src, w, h, r) {
+  const tmp = new Float32Array(src.length);
+  for (let y = 0; y < h; y += 1) {
+    const row = y * w;
+    for (let x = 0; x < w; x += 1) {
+      let sum = 0;
+      const x0 = Math.max(0, x - r);
+      const x1 = Math.min(w - 1, x + r);
+      for (let xx = x0; xx <= x1; xx += 1) sum += src[row + xx];
+      tmp[row + x] = sum / (x1 - x0 + 1);
+    }
+  }
+  const out = new Float32Array(src.length);
+  for (let x = 0; x < w; x += 1) {
+    for (let y = 0; y < h; y += 1) {
+      let sum = 0;
+      const y0 = Math.max(0, y - r);
+      const y1 = Math.min(h - 1, y + r);
+      for (let yy = y0; yy <= y1; yy += 1) sum += tmp[yy * w + x];
+      out[y * w + x] = sum / (y1 - y0 + 1);
+    }
+  }
+  return out;
+}
+
+// Feather (Gaussian-approx edge softening): `passes` box blurs (3 ≈ Gaussian).
+export function blurAlpha(alpha, w, h, radius, passes = 3) {
+  const r = Math.max(0, Math.round(radius));
+  if (r === 0) return Uint8ClampedArray.from(alpha);
+  let src = Float32Array.from(alpha);
+  for (let p = 0; p < passes; p += 1) src = blurPass(src, w, h, r);
+  const out = new Uint8ClampedArray(src.length);
+  for (let i = 0; i < src.length; i += 1) out[i] = Math.round(src[i]);
+  return out;
+}

--- a/apps/web/src/maskRefine.test.js
+++ b/apps/web/src/maskRefine.test.js
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+  maskAlphaFromRgba,
+  writeMaskAlphaToRgba,
+  invertAlpha,
+  dilateAlpha,
+  erodeAlpha,
+  blurAlpha,
+} from "./maskRefine.js";
+
+// Build a w*h single-channel mask from a 2D array of 0/255 rows.
+const mask = (rows) => Uint8ClampedArray.from(rows.flat());
+
+describe("mask refine (sc-6110)", () => {
+  it("round-trips a single-channel mask through RGBA", () => {
+    const alpha = mask([[0, 255, 128]]);
+    const rgba = new Uint8ClampedArray(3 * 4);
+    writeMaskAlphaToRgba(rgba, alpha);
+    expect([...rgba]).toEqual([0, 0, 0, 255, 255, 255, 255, 255, 128, 128, 128, 255]);
+    expect([...maskAlphaFromRgba(rgba)]).toEqual([0, 255, 128]);
+  });
+
+  it("invert swaps selected and unselected", () => {
+    expect([...invertAlpha(mask([[0, 255, 64]]))]).toEqual([255, 0, 191]);
+  });
+
+  it("dilate (grow) spreads the white selection by the radius", () => {
+    // 5x5, a single white pixel in the center.
+    const w = 5;
+    const h = 5;
+    const a = new Uint8ClampedArray(w * h);
+    a[2 * w + 2] = 255;
+    const grown = dilateAlpha(a, w, h, 1);
+    // A radius-1 dilate fills the 3x3 block around the center (square structuring elt).
+    for (let y = 1; y <= 3; y += 1) for (let x = 1; x <= 3; x += 1) expect(grown[y * w + x]).toBe(255);
+    expect(grown[0]).toBe(0); // far corner untouched
+    // The grown selection has strictly more white than the seed.
+    const count = (m) => m.reduce((n, v) => n + (v === 255 ? 1 : 0), 0);
+    expect(count(grown)).toBeGreaterThan(count(a));
+  });
+
+  it("erode (shrink) eats the selection edges and can clear a thin region", () => {
+    const w = 5;
+    const h = 5;
+    const a = new Uint8ClampedArray(w * h).fill(0);
+    // a 3x3 white block centered.
+    for (let y = 1; y <= 3; y += 1) for (let x = 1; x <= 3; x += 1) a[y * w + x] = 255;
+    const eroded = erodeAlpha(a, w, h, 1);
+    // Only the very center survives a radius-1 erode of a 3x3 block.
+    expect(eroded[2 * w + 2]).toBe(255);
+    expect(eroded[1 * w + 1]).toBe(0);
+    const count = (m) => m.reduce((n, v) => n + (v === 255 ? 1 : 0), 0);
+    expect(count(eroded)).toBeLessThan(count(a));
+  });
+
+  it("dilate then erode (radius 0) are no-ops", () => {
+    const a = mask([[0, 255, 0, 255]]);
+    expect([...dilateAlpha(a, 4, 1, 0)]).toEqual([...a]);
+    expect([...erodeAlpha(a, 4, 1, 0)]).toEqual([...a]);
+    expect([...blurAlpha(a, 4, 1, 0)]).toEqual([...a]);
+  });
+
+  it("feather (blur) softens a hard edge into a ramp, bounded 0..255", () => {
+    const w = 8;
+    const h = 1;
+    const a = mask([[0, 0, 0, 0, 255, 255, 255, 255]]);
+    const soft = blurAlpha(a, w, h, 2, 1);
+    // The hard 0→255 step becomes intermediate values straddling the boundary.
+    expect(soft[3]).toBeGreaterThan(0);
+    expect(soft[3]).toBeLessThan(255);
+    expect(soft[4]).toBeGreaterThan(0);
+    expect(soft[4]).toBeLessThan(255);
+    // Still monotonic non-decreasing left→right and in range.
+    for (let i = 1; i < w; i += 1) {
+      expect(soft[i]).toBeGreaterThanOrEqual(soft[i - 1]);
+      expect(soft[i]).toBeGreaterThanOrEqual(0);
+      expect(soft[i]).toBeLessThanOrEqual(255);
+    }
+  });
+});

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -36,6 +36,14 @@ import {
   applyCurves,
   computeHistogram,
 } from "../colorGrade.js";
+import {
+  maskAlphaFromRgba,
+  writeMaskAlphaToRgba,
+  invertAlpha,
+  dilateAlpha,
+  erodeAlpha,
+  blurAlpha,
+} from "../maskRefine.js";
 
 const MIN_SCALE = 0.05;
 const MAX_SCALE = 16;
@@ -897,6 +905,8 @@ export function ImageEditor() {
   const [maskBrush, setMaskBrush] = useState(64);
   const [maskErase, setMaskErase] = useState(false);
   const maskPaintingRef = useRef(false);
+  // Mask refinement (sc-6110): feather / grow / shrink radius in px for the post-process ops.
+  const [maskRefineRadius, setMaskRefineRadius] = useState(6);
 
   // Smart-select (sc-3751): a box-drag sub-mode of the mask tool that runs the SAM3 `image_segment`
   // job (sc-6105) and loads the returned binary mask as an editable base UNDER the brush strokes.
@@ -2118,44 +2128,51 @@ export function ImageEditor() {
   // white = edit region on black. Erase strokes punch holes (destination-out on a
   // transparent scratch), then it's flattened onto black so the worker's convert("L")
   // reads white-on-black. Mirrors the same compositing as the on-canvas preview.
+  // Composite the current mask (smart-select base + brush strokes) onto a fresh
+  // white-on-black canvas at working dims. Shared by the inpaint upload + the mask
+  // refine ops (sc-6110). White = edit region; erased holes flatten to black (=keep).
+  function rasterizeMaskToCanvas() {
+    const scratch = document.createElement("canvas");
+    scratch.width = working.width;
+    scratch.height = working.height;
+    const sctx = scratch.getContext("2d");
+    // Smart-select base first (sc-3751): the white-on-black SAM3 mask underlays the brush strokes,
+    // so paint strokes add to it and erase strokes (destination-out) carve it back. Its opaque
+    // black areas are harmless — the final flatten is onto black anyway.
+    if (maskBaseImage) sctx.drawImage(maskBaseImage, 0, 0);
+    sctx.lineCap = "round";
+    sctx.lineJoin = "round";
+    sctx.strokeStyle = "#ffffff";
+    sctx.fillStyle = "#ffffff";
+    for (const line of maskLines) {
+      sctx.globalCompositeOperation = line.erase ? "destination-out" : "source-over";
+      sctx.lineWidth = line.size;
+      const p = line.points;
+      if (p.length === 2) {
+        sctx.beginPath();
+        sctx.arc(p[0], p[1], line.size / 2, 0, Math.PI * 2);
+        sctx.fill();
+        continue;
+      }
+      sctx.beginPath();
+      sctx.moveTo(p[0], p[1]);
+      for (let i = 2; i < p.length; i += 2) sctx.lineTo(p[i], p[i + 1]);
+      sctx.stroke();
+    }
+    // Flatten onto black so erased/holes read as black (= keep).
+    const out = document.createElement("canvas");
+    out.width = working.width;
+    out.height = working.height;
+    const octx = out.getContext("2d");
+    octx.fillStyle = "#000000";
+    octx.fillRect(0, 0, out.width, out.height);
+    octx.drawImage(scratch, 0, 0);
+    return out;
+  }
+
   function rasterizeMaskToFile() {
     return new Promise((resolve, reject) => {
-      const scratch = document.createElement("canvas");
-      scratch.width = working.width;
-      scratch.height = working.height;
-      const sctx = scratch.getContext("2d");
-      // Smart-select base first (sc-3751): the white-on-black SAM3 mask underlays the brush strokes,
-      // so paint strokes add to it and erase strokes (destination-out) carve it back. Its opaque
-      // black areas are harmless — the final flatten is onto black anyway.
-      if (maskBaseImage) sctx.drawImage(maskBaseImage, 0, 0);
-      sctx.lineCap = "round";
-      sctx.lineJoin = "round";
-      sctx.strokeStyle = "#ffffff";
-      sctx.fillStyle = "#ffffff";
-      for (const line of maskLines) {
-        sctx.globalCompositeOperation = line.erase ? "destination-out" : "source-over";
-        sctx.lineWidth = line.size;
-        const p = line.points;
-        if (p.length === 2) {
-          sctx.beginPath();
-          sctx.arc(p[0], p[1], line.size / 2, 0, Math.PI * 2);
-          sctx.fill();
-          continue;
-        }
-        sctx.beginPath();
-        sctx.moveTo(p[0], p[1]);
-        for (let i = 2; i < p.length; i += 2) sctx.lineTo(p[i], p[i + 1]);
-        sctx.stroke();
-      }
-      // Flatten onto black so erased/holes read as black (= keep).
-      const out = document.createElement("canvas");
-      out.width = working.width;
-      out.height = working.height;
-      const octx = out.getContext("2d");
-      octx.fillStyle = "#000000";
-      octx.fillRect(0, 0, out.width, out.height);
-      octx.drawImage(scratch, 0, 0);
-      out.toBlob((blob) => {
+      rasterizeMaskToCanvas().toBlob((blob) => {
         if (!blob) {
           reject(new Error("Could not encode the mask."));
           return;
@@ -2370,6 +2387,45 @@ export function ImageEditor() {
     octx.putImageData(data, 0, 0);
     setMaskBaseImage(base);
     setMaskOverlay(overlay);
+  }
+
+  // Install a refined white-on-black mask canvas as the new mask base (sc-6110): it
+  // becomes the base + a fresh pink overlay, and the brush strokes are cleared (they
+  // are now baked into the canvas). Mirrors loadMaskBase but from a canvas.
+  function applyRefinedMask(maskCanvas) {
+    const overlay = document.createElement("canvas");
+    overlay.width = working.width;
+    overlay.height = working.height;
+    const octx = overlay.getContext("2d");
+    octx.drawImage(maskCanvas, 0, 0);
+    const data = octx.getImageData(0, 0, overlay.width, overlay.height);
+    tintMaskRgbaInPlace(data.data);
+    octx.putImageData(data, 0, 0);
+    setMaskBaseImage(maskCanvas);
+    setMaskOverlay(overlay);
+    setMaskLines([]);
+  }
+
+  // Mask refinement (sc-6110): flatten the current mask, run a pure pixel op
+  // (feather / grow / shrink / invert), and reinstall it as the base. No-op when no
+  // mask exists, except invert (empty mask → select-all).
+  function refineMask(op) {
+    if (!working) return;
+    if (op !== "invert" && !maskHasContent(maskLines) && !maskBaseImage) return;
+    const canvas = rasterizeMaskToCanvas();
+    const w = canvas.width;
+    const h = canvas.height;
+    const ctx = canvas.getContext("2d");
+    const imageData = ctx.getImageData(0, 0, w, h);
+    const alpha = maskAlphaFromRgba(imageData.data);
+    let refined;
+    if (op === "invert") refined = invertAlpha(alpha);
+    else if (op === "grow") refined = dilateAlpha(alpha, w, h, maskRefineRadius);
+    else if (op === "shrink") refined = erodeAlpha(alpha, w, h, maskRefineRadius);
+    else refined = blurAlpha(alpha, w, h, maskRefineRadius);
+    writeMaskAlphaToRgba(imageData.data, refined);
+    ctx.putImageData(imageData, 0, 0);
+    applyRefinedMask(canvas);
   }
 
   // Run the SAM3 image_segment job over the selection box (sc-3751): stage the working image, post
@@ -3347,6 +3403,47 @@ export function ImageEditor() {
                           type="button"
                         >
                           Clear
+                        </button>
+                        {/* Mask refinement (sc-6110): post-process the current mask. */}
+                        <label className="image-editor-slider" title="Feather / grow / shrink radius (px)">
+                          <span className="image-editor-slider-label">Refine</span>
+                          <input
+                            aria-label="Mask refine radius"
+                            max={40}
+                            min={1}
+                            onChange={(event) => setMaskRefineRadius(Number(event.target.value))}
+                            step={1}
+                            type="range"
+                            value={maskRefineRadius}
+                          />
+                          <span className="image-editor-slider-value">{maskRefineRadius}</span>
+                        </label>
+                        <button
+                          disabled={!maskHasContent(maskLines) && !maskBaseImage}
+                          onClick={() => refineMask("feather")}
+                          title="Feather (soften) the mask edges"
+                          type="button"
+                        >
+                          Feather
+                        </button>
+                        <button
+                          disabled={!maskHasContent(maskLines) && !maskBaseImage}
+                          onClick={() => refineMask("grow")}
+                          title="Grow the selection (dilate)"
+                          type="button"
+                        >
+                          Grow
+                        </button>
+                        <button
+                          disabled={!maskHasContent(maskLines) && !maskBaseImage}
+                          onClick={() => refineMask("shrink")}
+                          title="Shrink the selection (erode)"
+                          type="button"
+                        >
+                          Shrink
+                        </button>
+                        <button onClick={() => refineMask("invert")} title="Invert the selection" type="button">
+                          Invert
                         </button>
                       </>
                     ) : null}


### PR DESCRIPTION
## What

**Workstream F (polish)** of epic [6087](https://app.shortcut.com/trefry/epic/6087). Post-processing for the inpaint mask — works on both the manual brush and Workstream B smart-select masks, before the mask is rasterized to `maskAssetId`.

## Changes

- **New pure `apps/web/src/maskRefine.js`** (React/DOM-free): separable grayscale **dilate/erode** (grow/shrink the white selection by N px), a 3-pass box-blur **feather** (Gaussian-approx edge softening), **invert**, and the RGBA↔single-channel adapters. 6 unit tests.
- **Extracted `rasterizeMaskToCanvas()`** from `rasterizeMaskToFile()` (the shared white-on-black flatten of smart-select base + brush strokes). **`refineMask(op)`** flattens the current mask, runs the pure op, and reinstalls it via **`applyRefinedMask`** (new base + pink overlay; strokes are cleared since they're now baked in).
- **UI**: a "Refine" radius slider + **Feather / Grow / Shrink / Invert** buttons in the mask controls (AI Edit → Mask). Grow/shrink/feather are gated on a mask existing; Invert is always available (empty mask → select-all). The refined mask drives inpaint through the **unchanged `maskAssetId` seam**.

## Verification

- ✅ **605 web tests** (+6 mask-refine math); lint **0 errors**; build clean.
- ✅ **Real-canvas pipeline check** (restarted the dev server for a clean module graph): a 20×20 white mask on black → **grow 400px→900**, **shrink→100**, **invert→9600** (10000−400), **feather** adds soft-edge intermediate pixels, and the grown mask **write→read round-trips** on a real `CanvasRenderingContext2D` (900). This is exactly the path the editor uses (`rasterizeMaskToCanvas` → `maskAlphaFromRgba` → op → `writeMaskAlphaToRgba` → `putImageData` → `applyRefinedMask`).
- ⚠️ The **in-app refine gesture** (draw/smart-select a mask → click a refine button → see the overlay update) isn't headlessly drivable: it needs an inpaint-capable model **and** a mask authored via canvas-drag or the SAM3 worker — the same constraint as the existing brush mask (never headlessly testable). The wiring is mechanical and reuses the canvas round-trip verified above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)