### PR TITLE
feat(image-editor): batch operations across multiple assets (sc-6112)

### DIFF
--- a/apps/web/src/batchOps.js
+++ b/apps/web/src/batchOps.js
@@ -1,0 +1,126 @@
+// Batch operations across multiple assets (sc-6112, Workstream F of epic 6087).
+// Pure orchestration: turn a multi-asset selection + one op (upscale / detail / edit)
+// + shared params into one job body PER asset, and summarize the fan-out's progress
+// from the global jobs feed. React/DOM-free (reuses the konva-free imageJobs.js
+// builders) so the fan-out math is unit-tested in isolation and the Library bundle
+// never pulls in the editor / react-konva.
+
+import { terminalStatuses } from "./constants.js";
+import { buildDetailJobBody, buildEditJobBody, buildUpscaleJobBody } from "./imageJobs.js";
+
+// The three batch-capable ops + the endpoint each posts to (mirrors the editor:
+// upscale/detail are generic jobs, edit is the image-jobs route). `needsPrompt`
+// flags the op whose shared params include a text prompt.
+export const BATCH_OPS = [
+  { key: "upscale", label: "Upscale", endpoint: "/api/v1/jobs", needsPrompt: false },
+  { key: "detail", label: "Detail enhance", endpoint: "/api/v1/jobs", needsPrompt: false },
+  { key: "edit", label: "AI edit", endpoint: "/api/v1/image/jobs", needsPrompt: true },
+];
+
+export function batchOpByKey(key) {
+  return BATCH_OPS.find((op) => op.key === key) ?? null;
+}
+
+// Assets a raster op can run on — images (by type or image/* mime), never clips.
+export function batchEligibleAssets(assets) {
+  return (assets ?? []).filter((asset) => {
+    if (asset?.type === "video") return false;
+    const mime = asset?.file?.mimeType ?? "";
+    return asset?.type === "image" || mime.startsWith("image/");
+  });
+}
+
+// Build the `{ endpoint, body }` for one asset under the chosen op + shared params.
+// `dims` (the asset's native width/height) is REQUIRED for edit — the worker fits the
+// source to width×height — and ignored by upscale/detail. Throws on an unknown op or
+// missing edit dims so a bad fan-out fails loudly rather than posting a malformed job.
+export function buildBatchJob({ op, asset, params = {}, project, requestedGpu, dims = null }) {
+  const sourceAssetId = asset.id;
+  const displayName = asset.displayName ?? asset.id;
+  if (op === "upscale") {
+    return {
+      endpoint: "/api/v1/jobs",
+      body: buildUpscaleJobBody({
+        project,
+        requestedGpu,
+        sourceAssetId,
+        factor: params.factor,
+        engine: params.engine,
+        displayName,
+        softness: params.softness,
+      }),
+    };
+  }
+  if (op === "detail") {
+    return {
+      endpoint: "/api/v1/jobs",
+      body: buildDetailJobBody({
+        project,
+        requestedGpu,
+        sourceAssetId,
+        model: params.model,
+        strength: params.strength,
+        cnScale: params.cnScale,
+        displayName,
+      }),
+    };
+  }
+  if (op === "edit") {
+    if (!dims?.width || !dims?.height) {
+      throw new Error("Batch edit needs the source image dimensions.");
+    }
+    return {
+      endpoint: "/api/v1/image/jobs",
+      body: buildEditJobBody({
+        project,
+        requestedGpu,
+        sourceAssetId,
+        model: params.model,
+        prompt: params.prompt,
+        seed: params.seed,
+        width: dims.width,
+        height: dims.height,
+        // Same-size edit (no canvas extend) — each image is edited at its native size.
+        fitMode: "crop",
+      }),
+    };
+  }
+  throw new Error(`Unknown batch op: ${op}`);
+}
+
+// One batch item's status, derived from the global jobs feed: "queued" until the job
+// surfaces (or while queued), "running" mid-flight, "completed"/"failed" once terminal.
+export function batchItemStatus(jobId, jobs) {
+  if (!jobId) return "queued";
+  const job = (jobs ?? []).find((item) => item.id === jobId);
+  if (!job) return "queued"; // submitted; not yet in the feed
+  if (job.status === "completed") return "completed";
+  if (terminalStatuses.has(job.status)) return "failed"; // failed / canceled / interrupted
+  if (job.status === "running") return "running";
+  return "queued";
+}
+
+// The completed result asset for a batch item (the worker returns it on `result.assets[0]`),
+// or null while pending / on failure.
+export function batchItemResultAsset(jobId, jobs) {
+  const job = (jobs ?? []).find((item) => item.id === jobId);
+  if (!job || job.status !== "completed") return null;
+  return job.result?.assets?.[0] ?? null;
+}
+
+// Aggregate a fan-out's progress. `items` = [{ assetId, jobId }]; returns the per-status
+// tallies plus `done` (terminal) and `allDone`. Items with no jobId (submission failed)
+// count as failed so the aggregate never claims more progress than really happened.
+export function summarizeBatchProgress(items, jobs) {
+  const summary = { total: items?.length ?? 0, queued: 0, running: 0, completed: 0, failed: 0 };
+  for (const item of items ?? []) {
+    if (!item.jobId) {
+      summary.failed += 1;
+      continue;
+    }
+    summary[batchItemStatus(item.jobId, jobs)] += 1;
+  }
+  summary.done = summary.completed + summary.failed;
+  summary.allDone = summary.total > 0 && summary.done === summary.total;
+  return summary;
+}

--- a/apps/web/src/batchOps.test.js
+++ b/apps/web/src/batchOps.test.js
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import {
+  BATCH_OPS,
+  batchOpByKey,
+  batchEligibleAssets,
+  buildBatchJob,
+  batchItemStatus,
+  batchItemResultAsset,
+  summarizeBatchProgress,
+} from "./batchOps.js";
+
+const project = { id: "project_1", name: "My Project" };
+const asset = { id: "asset_1", displayName: "shot.png" };
+
+describe("batch ops (sc-6112)", () => {
+  it("exposes the three ops + their endpoints", () => {
+    expect(BATCH_OPS.map((op) => op.key)).toEqual(["upscale", "detail", "edit"]);
+    expect(batchOpByKey("edit").endpoint).toBe("/api/v1/image/jobs");
+    expect(batchOpByKey("upscale").endpoint).toBe("/api/v1/jobs");
+    expect(batchOpByKey("nope")).toBeNull();
+  });
+
+  it("keeps only raster images as eligible (by type or image/* mime), never clips", () => {
+    const assets = [
+      { id: "a", type: "image" },
+      { id: "b", type: "video" },
+      { id: "c", type: "upload", file: { mimeType: "image/png" } },
+      { id: "d", type: "upload", file: { mimeType: "video/mp4" } },
+      { id: "e", type: "render", file: { mimeType: "image/jpeg" } },
+    ];
+    expect(batchEligibleAssets(assets).map((a) => a.id)).toEqual(["a", "c", "e"]);
+    expect(batchEligibleAssets(null)).toEqual([]);
+  });
+
+  it("builds an upscale job from an asset id (softness only for engines that take it)", () => {
+    const real = buildBatchJob({ op: "upscale", asset, params: { engine: "real-esrgan", factor: 4, softness: 0.5 }, project, requestedGpu: "auto" });
+    expect(real.endpoint).toBe("/api/v1/jobs");
+    expect(real.body.type).toBe("image_upscale");
+    expect(real.body.payload).toEqual({ projectId: "project_1", sourceAssetId: "asset_1", factor: 4, engine: "real-esrgan", displayName: "shot.png" });
+    // Real-ESRGAN ignores softness — it must be omitted.
+    expect(real.body.payload).not.toHaveProperty("softness");
+
+    const seed = buildBatchJob({ op: "upscale", asset, params: { engine: "seedvr2", factor: 2, softness: 0.3 }, project, requestedGpu: "auto" });
+    expect(seed.body.payload.softness).toBe(0.3);
+  });
+
+  it("builds a detail job with the recipe advanced params", () => {
+    const { endpoint, body } = buildBatchJob({
+      op: "detail",
+      asset,
+      params: { model: "realvisxl", strength: 0.55, cnScale: 0.7 },
+      project,
+      requestedGpu: "auto",
+    });
+    expect(endpoint).toBe("/api/v1/jobs");
+    expect(body.type).toBe("image_detail");
+    expect(body.payload.advanced).toEqual({ strength: 0.55, cnScale: 0.7 });
+    expect(body.payload.sourceAssetId).toBe("asset_1");
+  });
+
+  it("builds an edit job at the asset's native dims (fitMode crop), and requires dims", () => {
+    const { endpoint, body } = buildBatchJob({
+      op: "edit",
+      asset,
+      params: { model: "qwen_image_edit", prompt: "make it night", seed: 7 },
+      project,
+      requestedGpu: "auto",
+      dims: { width: 768, height: 1024 },
+    });
+    expect(endpoint).toBe("/api/v1/image/jobs");
+    expect(body.mode).toBe("edit_image");
+    expect(body.sourceAssetId).toBe("asset_1");
+    expect(body.prompt).toBe("make it night");
+    expect(body.width).toBe(768);
+    expect(body.height).toBe(1024);
+    expect(body.fitMode).toBe("crop");
+    expect(body.seed).toBe(7);
+    // No dims → loud failure rather than a malformed job.
+    expect(() => buildBatchJob({ op: "edit", asset, params: { model: "m", prompt: "x" }, project, requestedGpu: "auto" })).toThrow();
+  });
+
+  it("throws on an unknown op", () => {
+    expect(() => buildBatchJob({ op: "frobnicate", asset, project, requestedGpu: "auto" })).toThrow();
+  });
+
+  it("maps a job's feed status to a batch item status", () => {
+    const jobs = [
+      { id: "j1", status: "completed" },
+      { id: "j2", status: "running" },
+      { id: "j3", status: "failed" },
+      { id: "j4", status: "queued" },
+    ];
+    expect(batchItemStatus("j1", jobs)).toBe("completed");
+    expect(batchItemStatus("j2", jobs)).toBe("running");
+    expect(batchItemStatus("j3", jobs)).toBe("failed");
+    expect(batchItemStatus("j4", jobs)).toBe("queued");
+    // Submitted but not yet in the feed → queued; no job id → queued.
+    expect(batchItemStatus("missing", jobs)).toBe("queued");
+    expect(batchItemStatus(null, jobs)).toBe("queued");
+  });
+
+  it("returns a completed item's result asset, else null", () => {
+    const jobs = [
+      { id: "j1", status: "completed", result: { assets: [{ id: "out_1" }] } },
+      { id: "j2", status: "running" },
+    ];
+    expect(batchItemResultAsset("j1", jobs)).toEqual({ id: "out_1" });
+    expect(batchItemResultAsset("j2", jobs)).toBeNull();
+    expect(batchItemResultAsset("missing", jobs)).toBeNull();
+  });
+
+  it("aggregates fan-out progress (null jobId counts as failed)", () => {
+    const items = [
+      { asset: { id: "a" }, jobId: "j1" },
+      { asset: { id: "b" }, jobId: "j2" },
+      { asset: { id: "c" }, jobId: "j3" },
+      { asset: { id: "d" }, jobId: null }, // submission failed
+    ];
+    const jobs = [
+      { id: "j1", status: "completed" },
+      { id: "j2", status: "running" },
+      { id: "j3", status: "failed" },
+    ];
+    const summary = summarizeBatchProgress(items, jobs);
+    expect(summary).toMatchObject({ total: 4, completed: 1, running: 1, failed: 2, done: 3, allDone: false });
+
+    const allTerminal = summarizeBatchProgress(
+      [{ asset: { id: "a" }, jobId: "j1" }],
+      [{ id: "j1", status: "completed" }],
+    );
+    expect(allTerminal).toMatchObject({ total: 1, completed: 1, done: 1, allDone: true });
+  });
+});

--- a/apps/web/src/components/AssetGrid.test.jsx
+++ b/apps/web/src/components/AssetGrid.test.jsx
@@ -1,0 +1,71 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AssetGrid } from "./assetPanels.jsx";
+
+const assets = [
+  { id: "a", type: "image", displayName: "one.png", file: { path: "assets/one.png", mimeType: "image/png" }, projectId: "p1" },
+  { id: "b", type: "image", displayName: "two.png", file: { path: "assets/two.png", mimeType: "image/png" }, projectId: "p1" },
+];
+
+describe("AssetGrid multi-select (sc-6112)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  const tiles = () => [...container.querySelectorAll(".asset-tile")];
+  const checks = () => [...container.querySelectorAll(".asset-tile-check input")];
+
+  it("single-select mode (no onToggleSelect) renders no checkboxes and selects on tile click", async () => {
+    const setSelectedAssetId = vi.fn();
+    await act(() => {
+      root.render(<AssetGrid assets={assets} onPreview={vi.fn()} selectedAsset={null} setSelectedAssetId={setSelectedAssetId} />);
+    });
+    expect(checks()).toHaveLength(0);
+    await act(async () => tiles()[0].click());
+    expect(setSelectedAssetId).toHaveBeenCalledWith("a");
+  });
+
+  it("multi-select mode renders a checkbox per tile, reflects selectedIds, and toggles without single-selecting", async () => {
+    const onToggleSelect = vi.fn();
+    const setSelectedAssetId = vi.fn();
+    await act(() => {
+      root.render(
+        <AssetGrid
+          assets={assets}
+          onPreview={vi.fn()}
+          selectedAsset={null}
+          setSelectedAssetId={setSelectedAssetId}
+          selectedIds={new Set(["b"])}
+          onToggleSelect={onToggleSelect}
+        />,
+      );
+    });
+    const boxes = checks();
+    expect(boxes).toHaveLength(2);
+    expect(boxes[0].checked).toBe(false);
+    expect(boxes[1].checked).toBe(true); // "b" is in selectedIds
+    expect(container.querySelectorAll(".asset-tile-wrap.selected")).toHaveLength(1);
+
+    // Toggling the checkbox calls onToggleSelect, not the single-select handler.
+    await act(async () => boxes[0].click());
+    expect(onToggleSelect).toHaveBeenCalledWith("a");
+    expect(setSelectedAssetId).not.toHaveBeenCalled();
+
+    // The tile body still drives single-select (the detail flow is unchanged).
+    await act(async () => tiles()[0].click());
+    expect(setSelectedAssetId).toHaveBeenCalledWith("a");
+  });
+});

--- a/apps/web/src/components/BatchOperationsPanel.jsx
+++ b/apps/web/src/components/BatchOperationsPanel.jsx
@@ -1,0 +1,225 @@
+import React, { useState } from "react";
+import { Modal } from "./Modal.jsx";
+import { BATCH_OPS } from "../batchOps.js";
+
+// Batch operations panel (sc-6112): pick ONE op (upscale / detail / edit) + shared
+// params and apply it across the selected image assets. Presentational — it owns the
+// op/param form state and calls `onRun(op, params)`; the parent does the fan-out
+// (decode dims for edit, POST one job per asset) and feeds back per-item `items` +
+// the aggregate `progress` so this panel renders the live progress view.
+
+const STATUS_LABEL = { queued: "Queued", running: "Running…", completed: "Done", failed: "Failed" };
+
+export function BatchOperationsPanel({
+  assets,
+  editModels = [],
+  detailModels = [],
+  upscaleEngines = [],
+  busy = false,
+  items = null,
+  progress = null,
+  onRun,
+  onClose,
+}) {
+  const [op, setOp] = useState("upscale");
+  // Upscale params.
+  const [engine, setEngine] = useState(upscaleEngines[0]?.key ?? "real-esrgan");
+  const [factor, setFactor] = useState(4);
+  const [softness, setSoftness] = useState(0.5);
+  // Detail params.
+  const [detailModel, setDetailModel] = useState(detailModels[0]?.id ?? "");
+  const [strength, setStrength] = useState(0.55);
+  const [cnScale, setCnScale] = useState(0.7);
+  // Edit params.
+  const [editModel, setEditModel] = useState(editModels[0]?.id ?? "");
+  const [prompt, setPrompt] = useState("");
+  const [seed, setSeed] = useState("");
+
+  const count = assets.length;
+  const running = items != null;
+
+  // Resolve the active selections against the (async-loaded) option lists so a stale
+  // or empty default falls back to the first available entry.
+  const activeEngine = upscaleEngines.find((e) => e.key === engine) ?? upscaleEngines[0] ?? null;
+  const factors = activeEngine?.factors ?? [2, 4];
+  const effectiveFactor = factors.includes(factor) ? factor : factors[0];
+  const activeDetailModel = detailModels.find((m) => m.id === detailModel)?.id ?? detailModels[0]?.id ?? "";
+  const activeEditModel = editModels.find((m) => m.id === editModel)?.id ?? editModels[0]?.id ?? "";
+
+  const missingModel =
+    (op === "detail" && !activeDetailModel) || (op === "edit" && !activeEditModel) || (op === "upscale" && !activeEngine);
+  const missingPrompt = op === "edit" && !prompt.trim();
+  const canRun = count > 0 && !busy && !missingModel && !missingPrompt;
+
+  function run() {
+    if (!canRun) return;
+    if (op === "upscale") {
+      onRun(op, { engine: activeEngine.key, factor: effectiveFactor, softness });
+    } else if (op === "detail") {
+      onRun(op, { model: activeDetailModel, strength, cnScale });
+    } else {
+      onRun(op, { model: activeEditModel, prompt: prompt.trim(), seed });
+    }
+  }
+
+  return (
+    <Modal className="batch-ops-modal" label="Batch operations" onClose={onClose}>
+      <div className="batch-ops-head">
+        <h3>Batch: {count} image{count === 1 ? "" : "s"}</h3>
+        <button className="modal-close" onClick={onClose} title="Close" type="button">
+          ✕
+        </button>
+      </div>
+
+      {running ? (
+        <div className="batch-ops-progress">
+          <p className="batch-ops-summary" aria-live="polite">
+            {progress?.done ?? 0} / {progress?.total ?? count} done
+            {progress?.failed ? ` · ${progress.failed} failed` : ""}
+          </p>
+          <ul className="batch-ops-items">
+            {items.map((item) => (
+              <li className={`batch-ops-item batch-ops-item-${item.status}`} key={item.asset.id}>
+                <span className="batch-ops-item-name">{item.asset.displayName ?? item.asset.id}</span>
+                <span className="batch-ops-item-status">{STATUS_LABEL[item.status] ?? item.status}</span>
+              </li>
+            ))}
+          </ul>
+          <div className="batch-ops-actions">
+            <button onClick={onClose} type="button">
+              {progress?.allDone ? "Done" : "Close"}
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="batch-ops-form">
+          <div className="batch-ops-tabs" role="group" aria-label="Operation">
+            {BATCH_OPS.map((entry) => (
+              <button
+                aria-pressed={op === entry.key}
+                className={op === entry.key ? "active" : ""}
+                key={entry.key}
+                onClick={() => setOp(entry.key)}
+                type="button"
+              >
+                {entry.label}
+              </button>
+            ))}
+          </div>
+
+          {op === "upscale" ? (
+            <div className="batch-ops-params">
+              <label>
+                Engine
+                <select onChange={(e) => setEngine(e.target.value)} value={activeEngine?.key ?? ""}>
+                  {upscaleEngines.map((e) => (
+                    <option key={e.key} value={e.key}>
+                      {e.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Factor
+                <select onChange={(e) => setFactor(Number(e.target.value))} value={effectiveFactor}>
+                  {factors.map((f) => (
+                    <option key={f} value={f}>
+                      {f}×
+                    </option>
+                  ))}
+                </select>
+              </label>
+              {activeEngine?.softness ? (
+                <label>
+                  Softness {softness.toFixed(2)}
+                  <input
+                    max="1"
+                    min="0"
+                    onChange={(e) => setSoftness(Number(e.target.value))}
+                    step="0.05"
+                    type="range"
+                    value={softness}
+                  />
+                </label>
+              ) : null}
+            </div>
+          ) : null}
+
+          {op === "detail" ? (
+            <div className="batch-ops-params">
+              <label>
+                Model
+                {detailModels.length ? (
+                  <select onChange={(e) => setDetailModel(e.target.value)} value={activeDetailModel}>
+                    {detailModels.map((m) => (
+                      <option key={m.id} value={m.id}>
+                        {m.label ?? m.name ?? m.id}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <span className="batch-ops-empty">No detail-capable model installed.</span>
+                )}
+              </label>
+              <label>
+                Strength {strength.toFixed(2)}
+                <input max="1" min="0" onChange={(e) => setStrength(Number(e.target.value))} step="0.05" type="range" value={strength} />
+              </label>
+              <label>
+                ControlNet {cnScale.toFixed(2)}
+                <input max="1" min="0" onChange={(e) => setCnScale(Number(e.target.value))} step="0.05" type="range" value={cnScale} />
+              </label>
+            </div>
+          ) : null}
+
+          {op === "edit" ? (
+            <div className="batch-ops-params">
+              <label>
+                Model
+                {editModels.length ? (
+                  <select onChange={(e) => setEditModel(e.target.value)} value={activeEditModel}>
+                    {editModels.map((m) => (
+                      <option key={m.id} value={m.id}>
+                        {m.label ?? m.name ?? m.id}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <span className="batch-ops-empty">No edit-capable model installed.</span>
+                )}
+              </label>
+              <label>
+                Prompt
+                <textarea
+                  onChange={(e) => setPrompt(e.target.value)}
+                  placeholder="Describe the edit applied to every selected image…"
+                  rows={2}
+                  value={prompt}
+                />
+              </label>
+              <label>
+                Seed (optional)
+                <input
+                  onChange={(e) => setSeed(e.target.value)}
+                  placeholder="random"
+                  type="number"
+                  value={seed}
+                />
+              </label>
+              <p className="batch-ops-note">Each image is edited at its native size.</p>
+            </div>
+          ) : null}
+
+          <div className="batch-ops-actions">
+            <button onClick={onClose} type="button">
+              Cancel
+            </button>
+            <button className="primary" disabled={!canRun} onClick={run} type="button">
+              {busy ? "Starting…" : `Run on ${count} image${count === 1 ? "" : "s"}`}
+            </button>
+          </div>
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/apps/web/src/components/BatchOperationsPanel.test.jsx
+++ b/apps/web/src/components/BatchOperationsPanel.test.jsx
@@ -1,0 +1,110 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BatchOperationsPanel } from "./BatchOperationsPanel.jsx";
+
+const assets = [
+  { id: "a", displayName: "one.png" },
+  { id: "b", displayName: "two.png" },
+];
+const upscaleEngines = [
+  { key: "real-esrgan", label: "Real-ESRGAN", factors: [2, 4] },
+  { key: "seedvr2", label: "SeedVR2", factors: [2, 4], softness: true },
+];
+
+// React controlled inputs ignore a direct `.value =`; drive them via the native setter.
+function setValue(el, value) {
+  const proto = el instanceof window.HTMLTextAreaElement ? window.HTMLTextAreaElement.prototype : window.HTMLInputElement.prototype;
+  Object.getOwnPropertyDescriptor(proto, "value").set.call(el, value);
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+  el.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
+describe("BatchOperationsPanel (sc-6112)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  const mount = (props) =>
+    act(() => {
+      root.render(
+        <BatchOperationsPanel
+          assets={assets}
+          upscaleEngines={upscaleEngines}
+          editModels={[{ id: "m1", label: "Edit Model" }]}
+          detailModels={[{ id: "d1", label: "Detail Model" }]}
+          onRun={vi.fn()}
+          onClose={vi.fn()}
+          {...props}
+        />,
+      );
+    });
+
+  const tab = (label) => [...container.querySelectorAll(".batch-ops-tabs button")].find((b) => b.textContent.trim() === label);
+  const runButton = () => [...container.querySelectorAll(".batch-ops-actions button")].find((b) => /^Run on/.test(b.textContent));
+
+  it("shows the op tabs + upscale params, and the asset count in the head", async () => {
+    await mount();
+    expect(container.querySelector(".batch-ops-head h3").textContent).toContain("2 images");
+    expect([...container.querySelectorAll(".batch-ops-tabs button")].map((b) => b.textContent.trim())).toEqual([
+      "Upscale",
+      "Detail enhance",
+      "AI edit",
+    ]);
+    // Default op is upscale → an Engine + Factor select.
+    expect(container.querySelector(".batch-ops-params").textContent).toContain("Engine");
+    expect(container.querySelector(".batch-ops-params").textContent).toContain("Factor");
+  });
+
+  it("fans the upscale op + params back to onRun", async () => {
+    const onRun = vi.fn();
+    await mount({ onRun });
+    await act(async () => runButton().click());
+    expect(onRun).toHaveBeenCalledTimes(1);
+    const [op, params] = onRun.mock.calls[0];
+    expect(op).toBe("upscale");
+    expect(params).toMatchObject({ engine: "real-esrgan", factor: 4 });
+  });
+
+  it("requires a prompt for the edit op, then passes the prompt + model", async () => {
+    const onRun = vi.fn();
+    await mount({ onRun });
+    await act(async () => tab("AI edit").click());
+    // Empty prompt → Run disabled.
+    expect(runButton().disabled).toBe(true);
+    const textarea = container.querySelector(".batch-ops-params textarea");
+    await act(async () => setValue(textarea, "make it snow"));
+    expect(runButton().disabled).toBe(false);
+    await act(async () => runButton().click());
+    expect(onRun).toHaveBeenCalledWith("edit", expect.objectContaining({ model: "m1", prompt: "make it snow" }));
+  });
+
+  it("renders the per-item progress view (with statuses) when items are supplied", async () => {
+    await mount({
+      items: [
+        { asset: { id: "a", displayName: "one.png" }, status: "completed" },
+        { asset: { id: "b", displayName: "two.png" }, status: "running" },
+      ],
+      progress: { total: 2, done: 1, failed: 0, completed: 1, running: 1, queued: 0, allDone: false },
+    });
+    // Progress view replaces the form (no Run button) and lists per-item status.
+    expect(runButton()).toBeUndefined();
+    expect(container.querySelector(".batch-ops-summary").textContent).toContain("1 / 2 done");
+    const items = [...container.querySelectorAll(".batch-ops-item")];
+    expect(items).toHaveLength(2);
+    expect(items[0].textContent).toContain("Done");
+    expect(items[1].textContent).toContain("Running");
+  });
+});

--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -243,34 +243,56 @@ function CharacterAssetLinker({ asset, characters = [], onMoveToCharacter }) {
   );
 }
 
-export function AssetGrid({ assets, onPreview, selectedAsset, setSelectedAssetId }) {
+// `onToggleSelect` (sc-6112) opts the grid into multi-select: each tile gets a
+// checkbox (a sibling of the tile button, so no interactive element nests inside the
+// button) toggling membership in `selectedIds`. The tile-body click still drives the
+// single-select detail flow unchanged, so the default Library behavior is preserved.
+export function AssetGrid({ assets, onPreview, selectedAsset, setSelectedAssetId, selectedIds = null, onToggleSelect = null }) {
   if (!assets.length) {
     return <div className="empty-panel">No assets in this view</div>;
   }
+  const multi = typeof onToggleSelect === "function";
 
   return (
     <div className="asset-grid">
-      {assets.map((asset) => (
-        <button
-          className={selectedAsset?.id === asset.id ? "asset-tile active" : "asset-tile"}
-          key={asset.id}
-          onClick={() => setSelectedAssetId(asset.id)}
-          onDoubleClick={() => onPreview(asset)}
-          type="button"
-        >
-          <AssetMedia asset={asset} />
-          <strong>{asset.displayName}</strong>
-          {Array.isArray(asset.tags) && asset.tags.length ? (
-            <div className="asset-tile-tags">
-              {asset.tags.map((tag) => (
-                <span className="asset-tag compact" key={tag}>
-                  {tag}
-                </span>
-              ))}
-            </div>
-          ) : null}
-        </button>
-      ))}
+      {assets.map((asset) => {
+        const tile = (
+          <button
+            className={selectedAsset?.id === asset.id ? "asset-tile active" : "asset-tile"}
+            onClick={() => setSelectedAssetId(asset.id)}
+            onDoubleClick={() => onPreview(asset)}
+            type="button"
+          >
+            <AssetMedia asset={asset} />
+            <strong>{asset.displayName}</strong>
+            {Array.isArray(asset.tags) && asset.tags.length ? (
+              <div className="asset-tile-tags">
+                {asset.tags.map((tag) => (
+                  <span className="asset-tag compact" key={tag}>
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            ) : null}
+          </button>
+        );
+        if (!multi) {
+          return React.cloneElement(tile, { key: asset.id });
+        }
+        return (
+          <div className={selectedIds?.has(asset.id) ? "asset-tile-wrap selected" : "asset-tile-wrap"} key={asset.id}>
+            <label className="asset-tile-check">
+              <input
+                aria-label={`Select ${asset.displayName}`}
+                checked={Boolean(selectedIds?.has(asset.id))}
+                onChange={() => onToggleSelect(asset.id)}
+                type="checkbox"
+              />
+            </label>
+            {tile}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/apps/web/src/imageJobs.js
+++ b/apps/web/src/imageJobs.js
@@ -1,0 +1,124 @@
+// Pure image-job builders + model/engine helpers (extracted from ImageEditor.jsx,
+// sc-6112). React/Konva/DOM-free so they can be shared by the editor AND the Library
+// batch flow WITHOUT pulling react-konva into the eagerly-loaded Library bundle (the
+// editor is deliberately lazy-loaded to keep konva off the main/test path). ImageEditor.jsx
+// re-exports these so its public surface (and its tests) are unchanged.
+
+// Models that can edit an existing image with a prompt — the manifest tags them
+// with an `edit_image`/`image_edit` capability (same filter the Image Studio uses).
+export function editCapableModels(imageModels) {
+  return (imageModels ?? []).filter((model) => {
+    const caps = model.capabilities ?? [];
+    return caps.includes("edit_image") || caps.includes("image_edit");
+  });
+}
+
+// Models that can run the tile-ControlNet detail refine — the manifest tags them
+// `image_detail` (sc-2437/sc-2438; SDXL/RealVisXL only). RealVisXL is the recommended
+// photoreal backbone per the spike.
+export function detailCapableModels(imageModels) {
+  return (imageModels ?? []).filter((model) => (model.capabilities ?? []).includes("image_detail"));
+}
+
+// The `POST /api/v1/image/jobs` body for a prompt edit (sc-2435). Reuses the existing
+// `mode:"edit_image"` flow: a `sourceAssetId` image is edited to the new `width`×`height`
+// (the worker fits the source per `fitMode`). Pure for unit testing.
+export function buildEditJobBody({
+  project,
+  requestedGpu,
+  sourceAssetId,
+  maskAssetId,
+  referenceAssetIds = null,
+  model,
+  prompt,
+  seed,
+  width,
+  height,
+  fitMode = "crop",
+}) {
+  const body = {
+    projectId: project.id,
+    projectName: project.name ?? null,
+    requestedGpu,
+    mode: "edit_image",
+    sourceAssetId,
+    model,
+    prompt,
+    negativePrompt: "",
+    width,
+    height,
+    // How the source is fitted to width×height (epic 2551). For canvas-extend outpaint
+    // the dims are the larger target aspect and the worker generates the new border.
+    fitMode,
+    seed: seed == null || seed === "" ? null : Number(seed),
+    count: 1,
+    advanced: {},
+  };
+  // Inpaint mask (sc-2436): only sent for inpaint-capable models with a painted
+  // region; the worker confines the edit to it. Omitted entirely otherwise.
+  if (maskAssetId) body.maskAssetId = maskAssetId;
+  // Multi-reference edit (sc-6107): a FLUX.2 `multiReference` model conditions the edit jointly on
+  // the working image + the user's reference image(s). The list already leads with the working
+  // scratch id (see `editReferenceIds`); the worker prefers a non-empty `referenceAssetIds` over
+  // `sourceAssetId`, so the working image must ride in the list or it's dropped from the edit.
+  if (referenceAssetIds && referenceAssetIds.length) body.referenceAssetIds = referenceAssetIds;
+  return body;
+}
+
+// Upscale engines + their valid factors (sc-2433). Real-ESRGAN 2x/4x is the cross-platform default
+// (`ort`: CoreML on Mac / CUDA off-Mac, sc-3489 / sc-5499); SeedVR2 2x/4x is the one-step diffusion
+// upscaler (native MLX on Mac / candle off-Mac, epic 4811 / sc-5928 / sc-5160) and exposes a
+// detail/softness control (`softness: true`). `aura-sr` is kept here only so a stale saved selection
+// gracefully falls back — it is hidden on every platform (dropped, sc-3668 / sc-5499) via
+// `macUpscaleEngineBlocked`.
+export const UPSCALE_ENGINES = [
+  { key: "real-esrgan", label: "Real-ESRGAN", factors: [2, 4] },
+  { key: "seedvr2", label: "SeedVR2", factors: [2, 4], softness: true },
+  { key: "aura-sr", label: "AuraSR", factors: [4] },
+];
+
+export function upscaleFactorsForEngine(engineKey) {
+  const found = UPSCALE_ENGINES.find((entry) => entry.key === engineKey);
+  return found ? found.factors : [2, 4];
+}
+
+export function upscaleEngineHasSoftness(engineKey) {
+  return Boolean(UPSCALE_ENGINES.find((entry) => entry.key === engineKey)?.softness);
+}
+
+// The `POST /api/v1/jobs` body for a standalone image_upscale job (sc-2431). The
+// worker reads sourceAssetId/factor/engine from the payload; displayName names the
+// result. `softness` (0..1) is a SeedVR2-only detail knob (sc-4815) — omitted for engines
+// that ignore it. Pure for unit testing.
+export function buildUpscaleJobBody({ project, requestedGpu, sourceAssetId, factor, engine, displayName, softness }) {
+  const payload = { projectId: project.id, sourceAssetId, factor, engine, displayName };
+  if (upscaleEngineHasSoftness(engine) && typeof softness === "number") {
+    payload.softness = softness;
+  }
+  return {
+    type: "image_upscale",
+    projectId: project.id,
+    projectName: project.name ?? null,
+    requestedGpu,
+    payload,
+  };
+}
+
+// The `POST /api/v1/jobs` body for a standalone image_detail job (sc-2438). Same
+// generic-jobs shape as upscale; the worker reads model + advanced.strength/cnScale
+// from the payload (recipe defaults locked by the sc-2437 spike). Pure for testing.
+export function buildDetailJobBody({ project, requestedGpu, sourceAssetId, model, strength, cnScale, displayName }) {
+  return {
+    type: "image_detail",
+    projectId: project.id,
+    projectName: project.name ?? null,
+    requestedGpu,
+    payload: {
+      projectId: project.id,
+      sourceAssetId,
+      model,
+      displayName,
+      advanced: { strength, cnScale },
+    },
+  };
+}

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -44,6 +44,29 @@ import {
   erodeAlpha,
   blurAlpha,
 } from "../maskRefine.js";
+// Pure job builders + model/engine helpers (sc-6112) — extracted to a konva-free module
+// so the Library batch flow can reuse them; imported for internal use and re-exported
+// below to keep this module's public surface (and its tests) unchanged.
+import {
+  buildDetailJobBody,
+  buildEditJobBody,
+  buildUpscaleJobBody,
+  detailCapableModels,
+  editCapableModels,
+  UPSCALE_ENGINES,
+  upscaleEngineHasSoftness,
+  upscaleFactorsForEngine,
+} from "../imageJobs.js";
+
+export {
+  buildDetailJobBody,
+  buildEditJobBody,
+  buildUpscaleJobBody,
+  detailCapableModels,
+  editCapableModels,
+  upscaleEngineHasSoftness,
+  upscaleFactorsForEngine,
+};
 
 const MIN_SCALE = 0.05;
 const MAX_SCALE = 16;
@@ -96,68 +119,6 @@ const EDITOR_SHORTCUTS = [
 // next slices' insertion points stay in place. All current epic-2427 tools are live
 // (Move + Crop + Upscale + Color + AI Edit + Detail), so this is empty for now.
 const UPCOMING_TOOLS = [];
-
-// Models that can edit an existing image with a prompt — the manifest tags them
-// with an `edit_image`/`image_edit` capability (same filter the Image Studio uses).
-export function editCapableModels(imageModels) {
-  return (imageModels ?? []).filter((model) => {
-    const caps = model.capabilities ?? [];
-    return caps.includes("edit_image") || caps.includes("image_edit");
-  });
-}
-
-// Models that can run the tile-ControlNet detail refine — the manifest tags them
-// `image_detail` (sc-2437/sc-2438; SDXL/RealVisXL only). RealVisXL is the recommended
-// photoreal backbone per the spike.
-export function detailCapableModels(imageModels) {
-  return (imageModels ?? []).filter((model) => (model.capabilities ?? []).includes("image_detail"));
-}
-
-// The `POST /api/v1/image/jobs` body for an in-editor prompt edit (sc-2435). Reuses
-// the existing `mode:"edit_image"` flow: the working bitmap is staged as a scratch
-// asset (sc-2432) and referenced by `sourceAssetId`; the result is the new working
-// image at the same dimensions. Pure for unit testing.
-export function buildEditJobBody({
-  project,
-  requestedGpu,
-  sourceAssetId,
-  maskAssetId,
-  referenceAssetIds = null,
-  model,
-  prompt,
-  seed,
-  width,
-  height,
-  fitMode = "crop",
-}) {
-  const body = {
-    projectId: project.id,
-    projectName: project.name ?? null,
-    requestedGpu,
-    mode: "edit_image",
-    sourceAssetId,
-    model,
-    prompt,
-    negativePrompt: "",
-    width,
-    height,
-    // How the source is fitted to width×height (epic 2551). For canvas-extend outpaint
-    // the dims are the larger target aspect and the worker generates the new border.
-    fitMode,
-    seed: seed == null || seed === "" ? null : Number(seed),
-    count: 1,
-    advanced: {},
-  };
-  // Inpaint mask (sc-2436): only sent for inpaint-capable models with a painted
-  // region; the worker confines the edit to it. Omitted entirely otherwise.
-  if (maskAssetId) body.maskAssetId = maskAssetId;
-  // Multi-reference edit (sc-6107): a FLUX.2 `multiReference` model conditions the edit jointly on
-  // the working image + the user's reference image(s). The list already leads with the working
-  // scratch id (see `editReferenceIds`); the worker prefers a non-empty `referenceAssetIds` over
-  // `sourceAssetId`, so the working image must ride in the list or it's dropped from the edit.
-  if (referenceAssetIds && referenceAssetIds.length) body.referenceAssetIds = referenceAssetIds;
-  return body;
-}
 
 // Upper bound on images in a FLUX.2 multi-reference edit, matching the worker's MAX_EDIT_REFERENCES
 // (image_jobs/flux2.rs). The working image takes one slot, so the editor allows up to 3 user refs.
@@ -298,64 +259,6 @@ function konvaColorFilter(imageData) {
   if (mode === "levels") applyLevels(imageData.data, this.getAttr("gradeLevels"));
   else if (mode === "curves") applyCurves(imageData.data, this.getAttr("gradeCurves"));
   else applyColorAdjustments(imageData.data, this.getAttr("colorAdjust"));
-}
-
-// Upscale engines + their valid factors (sc-2433). Real-ESRGAN 2x/4x is the cross-platform default
-// (`ort`: CoreML on Mac / CUDA off-Mac, sc-3489 / sc-5499); SeedVR2 2x/4x is the one-step diffusion
-// upscaler (native MLX on Mac / candle off-Mac, epic 4811 / sc-5928 / sc-5160) and exposes a
-// detail/softness control (`softness: true`). `aura-sr` is kept here only so a stale saved selection
-// gracefully falls back — it is hidden on every platform (dropped, sc-3668 / sc-5499) via
-// `macUpscaleEngineBlocked`.
-const UPSCALE_ENGINES = [
-  { key: "real-esrgan", label: "Real-ESRGAN", factors: [2, 4] },
-  { key: "seedvr2", label: "SeedVR2", factors: [2, 4], softness: true },
-  { key: "aura-sr", label: "AuraSR", factors: [4] },
-];
-
-export function upscaleFactorsForEngine(engineKey) {
-  const found = UPSCALE_ENGINES.find((entry) => entry.key === engineKey);
-  return found ? found.factors : [2, 4];
-}
-
-export function upscaleEngineHasSoftness(engineKey) {
-  return Boolean(UPSCALE_ENGINES.find((entry) => entry.key === engineKey)?.softness);
-}
-
-// The `POST /api/v1/jobs` body for a standalone image_upscale job (sc-2431). The
-// worker reads sourceAssetId/factor/engine from the payload; displayName names the
-// result. `softness` (0..1) is a SeedVR2-only detail knob (sc-4815) — omitted for engines
-// that ignore it. Pure for unit testing.
-export function buildUpscaleJobBody({ project, requestedGpu, sourceAssetId, factor, engine, displayName, softness }) {
-  const payload = { projectId: project.id, sourceAssetId, factor, engine, displayName };
-  if (upscaleEngineHasSoftness(engine) && typeof softness === "number") {
-    payload.softness = softness;
-  }
-  return {
-    type: "image_upscale",
-    projectId: project.id,
-    projectName: project.name ?? null,
-    requestedGpu,
-    payload,
-  };
-}
-
-// The `POST /api/v1/jobs` body for a standalone image_detail job (sc-2438). Same
-// generic-jobs shape as upscale; the worker reads model + advanced.strength/cnScale
-// from the payload (recipe defaults locked by the sc-2437 spike). Pure for testing.
-export function buildDetailJobBody({ project, requestedGpu, sourceAssetId, model, strength, cnScale, displayName }) {
-  return {
-    type: "image_detail",
-    projectId: project.id,
-    projectName: project.name ?? null,
-    requestedGpu,
-    payload: {
-      projectId: project.id,
-      sourceAssetId,
-      model,
-      displayName,
-      advanced: { strength, cnScale },
-    },
-  };
 }
 
 // The `POST /api/v1/jobs` body for a smart-select image_segment job (sc-3751 / backend

--- a/apps/web/src/screens/LibraryScreen.jsx
+++ b/apps/web/src/screens/LibraryScreen.jsx
@@ -1,8 +1,14 @@
 import React, { useState } from "react";
+import { apiFetch } from "../api.js";
 import { foldUpscaledAssetVariants } from "../assetVariants.js";
+import { batchEligibleAssets, batchItemStatus, buildBatchJob, summarizeBatchProgress } from "../batchOps.js";
 import { AssetDetail, AssetGrid, emptyTrash } from "../components/assetPanels.jsx";
+import { assetUrl } from "../components/assetMedia.jsx";
+import { BatchOperationsPanel } from "../components/BatchOperationsPanel.jsx";
 import { terminalStatuses } from "../constants.js";
 import { useAppContext } from "../context/AppContext.js";
+import { detailCapableModels, editCapableModels, UPSCALE_ENGINES } from "../imageJobs.js";
+import { DEFAULT_MAC_CAPABILITIES, macUpscaleEngineBlocked } from "../macGating.js";
 
 export function LibraryScreen() {
   const {
@@ -24,6 +30,9 @@ export function LibraryScreen() {
     setActiveView,
     updateAssetStatus,
     updateAssetTags,
+    token = "",
+    requestedGpu = "auto",
+    macCapabilities = DEFAULT_MAC_CAPABILITIES,
   } = useAppContext();
   // Bind the fullscreen preview to the currently filtered library view so
   // navigation stays inside the same type/tag/trash scope the user is browsing.
@@ -51,6 +60,11 @@ export function LibraryScreen() {
   const [showRejected, setShowRejected] = useState(false);
   const [assetMode, setAssetMode] = useState("assets");
   const [isImporting, setIsImporting] = useState(false);
+  // Batch operations (sc-6112): a multi-asset selection + a fan-out of one job per asset.
+  const [selectedAssetIds, setSelectedAssetIds] = useState(() => new Set());
+  const [batchOpen, setBatchOpen] = useState(false);
+  // While/after a batch runs: { op, items: [{ asset, jobId }], submitting }.
+  const [batch, setBatch] = useState(null);
   // Asset Library hygiene (sc-2024): show only studio-generated and uploaded
   // media. Character Studio test outputs (origin "character_studio") live under
   // the character, not here. The backend also exposes `?scope=library`; we filter
@@ -116,6 +130,76 @@ export function LibraryScreen() {
   const videoCount = libraryAssets.filter((asset) => asset.type === "video").length;
   const uploadCount = libraryAssets.filter((asset) => asset.type === "upload").length;
   const availableTags = [...new Set(libraryAssets.flatMap((asset) => (Array.isArray(asset.tags) ? asset.tags : [])))].sort();
+
+  // ── Batch operations (sc-6112) ─────────────────────────────────────────────
+  // The current multi-selection, narrowed to the raster images a batch op can run on,
+  // and the upscale engines this platform actually supports.
+  const selectedAssetList = assets.filter((asset) => selectedAssetIds.has(asset.id));
+  const eligibleSelected = batchEligibleAssets(selectedAssetList);
+  const availableUpscaleEngines = UPSCALE_ENGINES.filter((engine) => !macUpscaleEngineBlocked(macCapabilities, engine.key));
+  // Per-item + aggregate progress for an in-flight/just-finished batch, read off the jobs feed.
+  const batchItems = batch
+    ? batch.items.map((item) => ({ asset: item.asset, status: batchItemStatus(item.jobId, jobs) }))
+    : null;
+  const batchProgress = batch ? summarizeBatchProgress(batch.items, jobs) : null;
+
+  const toggleSelect = (id) =>
+    setSelectedAssetIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  const clearSelection = () => setSelectedAssetIds(new Set());
+
+  // Decode an asset's native pixel size (needed for an edit job — the worker fits the
+  // source to width×height). Resolves null on a load failure so that item fails alone.
+  function loadImageDims(asset) {
+    return new Promise((resolve) => {
+      const img = new Image();
+      img.onload = () => resolve({ width: img.naturalWidth, height: img.naturalHeight });
+      img.onerror = () => resolve(null);
+      img.src = assetUrl(asset);
+    });
+  }
+
+  // Fan out one job per selected image (NOT one mega-job): each posts independently so
+  // the worker processes them serially with its between-item cache release (sc-5567).
+  // Library assets are persistent ids → no scratch upload and results persist as new
+  // assets (the auto asset-refresh on job completion surfaces them in the grid).
+  async function runBatch(op, params) {
+    if (!activeProject || !eligibleSelected.length) return;
+    const targets = eligibleSelected;
+    setBatch({ op, submitting: true, items: targets.map((asset) => ({ asset, jobId: null })) });
+    const items = [];
+    for (const asset of targets) {
+      try {
+        let dims = null;
+        if (op === "edit") {
+          dims = await loadImageDims(asset);
+          if (!dims) {
+            items.push({ asset, jobId: null });
+            continue;
+          }
+        }
+        const { endpoint, body } = buildBatchJob({ op, asset, params, project: activeProject, requestedGpu, dims });
+        const job = await apiFetch(endpoint, token, { method: "POST", body: JSON.stringify(body) });
+        items.push({ asset, jobId: job?.id ?? null });
+      } catch {
+        items.push({ asset, jobId: null });
+      }
+    }
+    setBatch({ op, submitting: false, items });
+  }
+
+  function closeBatch() {
+    setBatchOpen(false);
+    // Closing after a run clears the spent selection + progress; cancelling the form keeps it.
+    if (batch) {
+      setBatch(null);
+      clearSelection();
+    }
+  }
 
   return (
     <section className="main-surface library-surface">
@@ -190,12 +274,31 @@ export function LibraryScreen() {
         </div>
       </div>
 
+      {selectedAssetIds.size > 0 ? (
+        <div className="batch-selection-bar">
+          <span>
+            {selectedAssetIds.size} selected
+            {eligibleSelected.length !== selectedAssetIds.size
+              ? ` · ${eligibleSelected.length} image${eligibleSelected.length === 1 ? "" : "s"}`
+              : ""}
+          </span>
+          <button className="primary" disabled={!eligibleSelected.length} onClick={() => setBatchOpen(true)} type="button">
+            Batch…
+          </button>
+          <button onClick={clearSelection} type="button">
+            Clear
+          </button>
+        </div>
+      ) : null}
+
       <div className="library-layout">
         <AssetGrid
           assets={visibleAssets}
           onPreview={onPreview}
           selectedAsset={selectedAsset}
           setSelectedAssetId={setSelectedAssetId}
+          selectedIds={selectedAssetIds}
+          onToggleSelect={toggleSelect}
         />
         <AssetDetail
           asset={selectedAsset}
@@ -216,6 +319,20 @@ export function LibraryScreen() {
           createVqaJob={createVqaJob}
         />
       </div>
+
+      {batchOpen ? (
+        <BatchOperationsPanel
+          assets={eligibleSelected}
+          editModels={editCapableModels(imageModels)}
+          detailModels={detailCapableModels(imageModels)}
+          upscaleEngines={availableUpscaleEngines}
+          busy={Boolean(batch?.submitting)}
+          items={batchItems}
+          progress={batchProgress}
+          onRun={runBatch}
+          onClose={closeBatch}
+        />
+      ) : null}
     </section>
   );
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3556,6 +3556,53 @@ label {
   font-weight: 600;
 }
 
+/* Multi-select for batch ops (sc-6112): a checkbox overlaid on each tile + the
+   selected ring. The tile button keeps its own styles; the wrap is the grid cell. */
+.asset-tile-wrap {
+  position: relative;
+  display: grid;
+}
+
+.asset-tile-wrap.selected .asset-tile {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 28%, transparent);
+}
+
+.asset-tile-check {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  z-index: 2;
+  display: flex;
+  padding: 4px;
+  border-radius: var(--r-sm);
+  background: color-mix(in oklch, var(--surface) 70%, transparent);
+  cursor: pointer;
+}
+
+.asset-tile-check input {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+}
+
+/* Batch selection toolbar — shown above the grid while ≥1 asset is selected. */
+.batch-selection-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--gap-3);
+  margin-bottom: var(--gap-3);
+  padding: 8px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface);
+}
+
+.batch-selection-bar span {
+  margin-right: auto;
+  font-weight: 600;
+}
+
 .asset-detail {
   position: sticky;
   top: 86px;
@@ -7150,6 +7197,128 @@ details[open] > summary.lora-scope-group-heading::before,
 
 .modal-close {
   justify-self: end;
+}
+
+/* Batch operations modal (sc-6112). */
+.batch-ops-modal {
+  display: grid;
+  gap: 14px;
+  width: min(520px, 96vw);
+  max-height: 90vh;
+  overflow-y: auto;
+  padding: 18px 20px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: var(--surface);
+  box-shadow: var(--shadow-lg);
+}
+
+.batch-ops-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.batch-ops-head h3 {
+  margin: 0;
+}
+
+.batch-ops-form,
+.batch-ops-progress {
+  display: grid;
+  gap: 14px;
+}
+
+.batch-ops-tabs {
+  display: flex;
+  gap: 6px;
+}
+
+.batch-ops-tabs button {
+  flex: 1;
+}
+
+.batch-ops-tabs button.active {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.batch-ops-params {
+  display: grid;
+  gap: 10px;
+}
+
+.batch-ops-params label {
+  display: grid;
+  gap: 4px;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.batch-ops-note,
+.batch-ops-empty {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 400;
+}
+
+.batch-ops-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.batch-ops-summary {
+  margin: 0;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.batch-ops-items {
+  display: grid;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  max-height: 320px;
+  overflow-y: auto;
+  list-style: none;
+}
+
+.batch-ops-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  font-size: 13px;
+}
+
+.batch-ops-item-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.batch-ops-item-status {
+  flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-muted);
+}
+
+.batch-ops-item-completed .batch-ops-item-status {
+  color: var(--ok, #2e9e5b);
+}
+
+.batch-ops-item-failed .batch-ops-item-status {
+  color: var(--danger, #d4504e);
+}
+
+.batch-ops-item-running .batch-ops-item-status {
+  color: var(--accent);
 }
 
 .prompt-guide-modal {


### PR DESCRIPTION
Closes [sc-6112](https://app.shortcut.com/trefry/story/6112) — Workstream F (the larger item) of epic [6087](https://app.shortcut.com/trefry/epic/6087).

## Open question → decided
The batch UI lives in the **Library / Assets screen**, not the Image Editor. The editor is single-working-image/session-oriented; batch is inherently multi-asset, and the Library already has the grid + toolbar + selection. The editor's working-image/scratch/purge path is untouched (acceptance: "no regression to the single-image editor flow").

## What
Select N image assets in the Library and apply ONE op (**Upscale / Detail / Edit**, shared params) that fans out **one job per asset**, with aggregate + per-item progress.

- **`imageJobs.js`** (NEW, pure, konva-free) — **extracted** the job builders (`buildUpscale/Detail/EditJobBody`) + `UPSCALE_ENGINES`/`upscaleFactorsForEngine`/`upscaleEngineHasSoftness` + `editCapableModels`/`detailCapableModels` out of `ImageEditor.jsx`, which now imports + **re-exports** them (its public API + tests unchanged). Required so the eagerly-loaded Library doesn't transitively pull `react-konva` (the editor is deliberately lazy-loaded to keep konva off the main/test path) — confirmed: `ImageEditor` stays its own lazy chunk in the build.
- **`batchOps.js`** (NEW, pure) — `BATCH_OPS`, `batchEligibleAssets` (images only), `buildBatchJob({op,asset,params,project,requestedGpu,dims})→{endpoint,body}`, `batchItemStatus` / `batchItemResultAsset` / `summarizeBatchProgress`.
- **`BatchOperationsPanel.jsx`** (NEW) — op tabs + per-op params + per-item progress, using the shared `Modal`.
- **`LibraryScreen.jsx`** — multi-select (`selectedAssetIds`), a selection bar, the fan-out submit (decode each asset's **native dims** for edit → `fitMode: "crop"`, one `apiFetch` per asset), progress read off the SSE `jobs` feed.
- **`AssetGrid`** — optional per-tile checkbox multi-select; the tile-body click still drives the single-select detail flow **unchanged**.

## Design notes
- Fan-out = **N independent jobs**, not one mega-job → the worker's between-item MLX cache release ([sc-5567]) applies; the queue serializes per worker.
- Library assets are **persistent ids** → no scratch upload, and results **persist** as new assets (completed jobs auto-refresh the grid).
- Edit needs W×H (the worker fits the source to them) → batch edit decodes each asset's native size at submit.

## Verification
- **622 web tests** (+15: batchOps 9, BatchOperationsPanel 4, AssetGrid 2), `npm run lint` **0 errors**, `npm run build` clean.
- **Real-browser smoke** (rust-api up, 3 seeded images): multi-select → batch modal → **upscale fan-out created 2 `image_upscale` jobs**; **edit fan-out created 1 `image_edit` job** at `/api/v1/image/jobs` with the **decoded native dims (400×300)** + `fitMode: crop`; aggregate `0/N done` + per-item `Queued` rows; selection cleared after run; empty edit prompt correctly disables Run.

## Scope note
Job **execution** (the actual upscaled/detailed/edited results) needs a GPU worker + the relevant downloaded model — the same environment gate as sc-6097. Job **creation + tracking + the whole UI flow** is verified above without a worker (jobs sit `queued`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)