### PR TITLE
feat(image-editor): SAM3 fg/bg point smart-select backend (sc-6346)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3a4f3453647e8b058bd96d712be03a070b16f79f#3a4f3453647e8b058bd96d712be03a070b16f79f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3a4f3453647e8b058bd96d712be03a070b16f79f#3a4f3453647e8b058bd96d712be03a070b16f79f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3a4f3453647e8b058bd96d712be03a070b16f79f#3a4f3453647e8b058bd96d712be03a070b16f79f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3a4f3453647e8b058bd96d712be03a070b16f79f#3a4f3453647e8b058bd96d712be03a070b16f79f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3a4f3453647e8b058bd96d712be03a070b16f79f#3a4f3453647e8b058bd96d712be03a070b16f79f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3a4f3453647e8b058bd96d712be03a070b16f79f#3a4f3453647e8b058bd96d712be03a070b16f79f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -519,7 +519,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3a4f3453647e8b058bd96d712be03a070b16f79f#3a4f3453647e8b058bd96d712be03a070b16f79f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -530,7 +530,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3a4f3453647e8b058bd96d712be03a070b16f79f#3a4f3453647e8b058bd96d712be03a070b16f79f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3a4f3453647e8b058bd96d712be03a070b16f79f#3a4f3453647e8b058bd96d712be03a070b16f79f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -557,7 +557,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3a4f3453647e8b058bd96d712be03a070b16f79f#3a4f3453647e8b058bd96d712be03a070b16f79f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -569,7 +569,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3a4f3453647e8b058bd96d712be03a070b16f79f#3a4f3453647e8b058bd96d712be03a070b16f79f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -580,7 +580,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3a4f3453647e8b058bd96d712be03a070b16f79f#3a4f3453647e8b058bd96d712be03a070b16f79f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -597,7 +597,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3a4f3453647e8b058bd96d712be03a070b16f79f#3a4f3453647e8b058bd96d712be03a070b16f79f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -612,7 +612,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3a4f3453647e8b058bd96d712be03a070b16f79f#3a4f3453647e8b058bd96d712be03a070b16f79f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -623,7 +623,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3a4f3453647e8b058bd96d712be03a070b16f79f#3a4f3453647e8b058bd96d712be03a070b16f79f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -641,7 +641,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3a4f3453647e8b058bd96d712be03a070b16f79f#3a4f3453647e8b058bd96d712be03a070b16f79f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -652,7 +652,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3a4f3453647e8b058bd96d712be03a070b16f79f#3a4f3453647e8b058bd96d712be03a070b16f79f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -665,7 +665,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3a4f3453647e8b058bd96d712be03a070b16f79f#3a4f3453647e8b058bd96d712be03a070b16f79f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -676,7 +676,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3a4f3453647e8b058bd96d712be03a070b16f79f#3a4f3453647e8b058bd96d712be03a070b16f79f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -689,7 +689,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3a4f3453647e8b058bd96d712be03a070b16f79f#3a4f3453647e8b058bd96d712be03a070b16f79f"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -3311,7 +3311,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3323,7 +3323,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
 dependencies = [
  "image",
  "inventory",
@@ -3337,7 +3337,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3349,7 +3349,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3358,7 +3358,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3370,7 +3370,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3381,7 +3381,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3393,7 +3393,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3404,7 +3404,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3414,7 +3414,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
 dependencies = [
  "image",
  "inventory",
@@ -3426,7 +3426,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
 dependencies = [
  "image",
  "inventory",
@@ -3439,7 +3439,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
 dependencies = [
  "image",
  "inventory",
@@ -3451,7 +3451,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3462,7 +3462,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3474,7 +3474,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3484,7 +3484,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3493,7 +3493,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3502,7 +3502,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3514,7 +3514,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
 dependencies = [
  "image",
  "inventory",
@@ -3527,7 +3527,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3538,7 +3538,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3549,7 +3549,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3560,7 +3560,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
 dependencies = [
  "image",
  "inventory",
@@ -3574,7 +3574,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
 dependencies = [
  "image",
  "inventory",
@@ -5213,7 +5213,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=517ef11f59e03f064112f5015bde81399e4e03c7#517ef11f59e03f064112f5015bde81399e4e03c7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
 dependencies = [
  "inventory",
  "safetensors 0.4.5",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -209,7 +209,14 @@ sceneworks-core = { path = "../sceneworks-core" }
 # identical when no edit conditioning. Bumps EVERY mlx-gen crate + gen-core in lockstep (skew gate
 # single-rev). (#791 originally pinned the e23a8b7 branch tip; this re-pins to the #490 merge commit on
 # main per convention — 517ef11's ideogram tree == e23a8b7, so the build is byte-identical.)
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
+# Rev 517ef11 -> 4740225 (mlx-gen #499, sc-6346): surfaces the SAM3 TRACKER's fg/bg point-prompt path
+# (`Sam3Tracker::segment_points` + `PromptEncoder::encode_points`) for Image-Editor smart-select
+# clicks — points route to the tracker's single-frame PVS, the box path (sc-6105) stays on the
+# concept detector. PURE mlx-gen-sam3 Rust (only tracker.rs): gen-core BYTE-IDENTICAL 517ef11 ->
+# 4740225 (skew gate stays green at one rev), mlx-rs unchanged (44929a0); box behavior unchanged
+# (`segment_encoded_multimask` signature preserved, dynmask/quant_smoke parity unaffected). Bumps
+# EVERY mlx-gen crate in lockstep.
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -526,7 +533,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -538,59 +545,59 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e
 # internal pin (the Lens engine PRs #407–#414 did not move it; nor did the seedvr2 engine #416/#419/
 # #421 or the softness PR #422, so the 1a97909 bump above leaves mlx-rs at 44929a0).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "44929a001ab8a8837403a71c65cf064224de0cdc" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -599,12 +606,12 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef1
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -613,7 +620,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef1
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -621,7 +628,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "5
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -632,7 +639,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517e
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -643,7 +650,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -658,7 +665,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef1
 # converted in-memory at load (no Python); the precomputed neg-prompt embedding is bundled in-crate. No
 # LoRA/guidance/CFG (one-step). 3B fp16 only here — 7B (sc-5197) + int8 (sc-5198) are engine-side and
 # unwired. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -669,7 +676,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
 # Prompt-refine provider (sc-5552, the MLX twin of candle-gen-prompt-refine / sc-5500). An
 # inventory-registered `TextLlm` under id `prompt_refine` (`backend="mlx"`, `mac_only`): a native MLX
 # Llama-3.2-3B-Instruct that rewrites a user's prompt, replacing the Python `prompt_refine.py`
@@ -679,7 +686,7 @@ mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517
 # textllm registered" trap). Weights = a stock Llama-3.2-3B-Instruct HF snapshot (config.json +
 # tokenizer.json + model-*.safetensors; default `huihui-ai/Llama-3.2-3B-Instruct-abliterated`). Same
 # git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
+mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
 # SCAIL-2 (zai-org) end-to-end character-animation provider (epic 5439, sc-5448). An inventory-registered
 # `Generator` under id `scail2_14b` (`Modality::Video`): a Wan2.1-14B I2V DiT that animates a reference
 # character with a driving video's motion (`video_mode == "replacement"` flips the cross-identity
@@ -691,7 +698,7 @@ mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev 
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517ef11f59e03f064112f5015bde81399e4e03c7" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -877,38 +884,38 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "517e
 # (`image_jobs/qwen_edit_candle.rs`) drives candle-gen-qwen-image's `QwenEdit` (incl. the lightning
 # distill) off-Mac; the candle SAM3 path (`person_segment_sam3_candle.rs`) drives candle-gen-sam3.
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3a4f3453647e8b058bd96d712be03a070b16f79f", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3a4f3453647e8b058bd96d712be03a070b16f79f", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3a4f3453647e8b058bd96d712be03a070b16f79f", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3a4f3453647e8b058bd96d712be03a070b16f79f", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3a4f3453647e8b058bd96d712be03a070b16f79f", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3a4f3453647e8b058bd96d712be03a070b16f79f", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3a4f3453647e8b058bd96d712be03a070b16f79f", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3a4f3453647e8b058bd96d712be03a070b16f79f", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3a4f3453647e8b058bd96d712be03a070b16f79f", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3a4f3453647e8b058bd96d712be03a070b16f79f", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -917,19 +924,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3a4f3453647e8b058bd96d712be03a070b16f79f", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3a4f3453647e8b058bd96d712be03a070b16f79f", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3a4f3453647e8b058bd96d712be03a070b16f79f", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -938,12 +945,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3a4f3453647e8b058bd96d712be03a070b16f79f", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3a4f3453647e8b058bd96d712be03a070b16f79f", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -951,7 +958,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3a4f3
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3a4f3453647e8b058bd96d712be03a070b16f79f", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -960,7 +967,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3a4f3453647e8b058bd96d712be03a070b16f79f", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -968,7 +975,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3a4f3453647e8b058bd96d712be03a070b16f79f", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -977,7 +984,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3a4f3453647e8b058bd96d712be03a070b16f79f", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -990,7 +997,12 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # resolve to a rev whose gen-core (517ef11f) MATCHES the worker's mlx pin (517ef11f), so
 # `--features backend-candle` resolves ONE gen-core build (the #490 Ideogram-4 mlx bump had silently
 # re-opened the skew that broke instantid.rs / sdxl_ipadapter.rs).
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3a4f3453647e8b058bd96d712be03a070b16f79f", features = ["cuda"], optional = true }
+# Bumped `3a4f345` -> `2d2ebfc` (sc-6346, candle-gen #107): lockstep with the worker's mlx pin moving
+# 517ef11 -> 4740225 (mlx-gen #499, the SAM3 tracker fg/bg point-prompt path). candle-gen #107 re-pins
+# gen-core 517ef11 -> 4740225 (BYTE-IDENTICAL tree — #499 is pure mlx-gen-sam3/tracker.rs), so
+# `--features backend-candle --target all` resolves ONE gen-core rev. Behavior-neutral; candle builds
+# nothing new.
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/person_segment_sam3.rs
+++ b/crates/sceneworks-worker/src/person_segment_sam3.rs
@@ -29,7 +29,8 @@ use std::sync::{Mutex, OnceLock};
 use crate::downloads::{ensure_hf_cached_file, DownloadContext};
 use mlx_gen::weights::Weights;
 use mlx_gen_sam3::{
-    Sam3ImageSegmenter, Sam3TextConfig, Sam3Tokenizer, Sam3VideoModel, VideoFrameOutput,
+    Sam3ImageSegmenter, Sam3TextConfig, Sam3Tokenizer, Sam3Tracker, Sam3VideoModel,
+    VideoFrameOutput,
 };
 use mlx_rs::Array;
 
@@ -478,6 +479,83 @@ pub(crate) fn segment_box_blocking(
     Ok(mask_to_frame(&grid_mask, grid, width, height))
 }
 
+/// Smart-select POINT path (epic 6087, sc-6346): segment whatever lies under fg/bg click points on
+/// ONE still image with the native-MLX SAM3 **tracker's** single-frame PVS point prompt
+/// ([`Sam3Tracker::segment_points`]). SAM3 does interactive point refinement via its tracker (the
+/// SAM2-lineage promptable mask decoder); the box smart-select (sc-6105) uses the concept *detector*
+/// (`Sam3ImageSegmenter::segment_with_boxes`) while points use the *tracker* — but both load from the
+/// SAME `facebook/sam3` checkpoint, so no second model/download. `points` are `(x, y, label)` in
+/// source-image pixel coords, `label` `1` = foreground / `0` = background. Returns one binary mask
+/// (row-major `width*height`, `0`/`255`, white = the selected region) at the source dims — the same
+/// `maskAssetId` shape the box path returns for the editor's inpaint flow (sc-2436/2476). Loads the
+/// tracker from the shared (cached) SAM3 checkpoint + quantizes it (Q8 default); run under
+/// `spawn_blocking` (MLX is synchronous + holds the autorelease pool).
+pub(crate) fn segment_points_blocking(
+    model_path: PathBuf,
+    image: image::RgbImage,
+    points: Vec<(f32, f32, i32)>,
+) -> WorkerResult<Vec<u8>> {
+    let (width, height) = (image.width(), image.height());
+    if width == 0 || height == 0 {
+        return Err(WorkerError::InvalidPayload(
+            "smart-select source image has zero dimension".into(),
+        ));
+    }
+    if points.is_empty() {
+        return Err(WorkerError::InvalidPayload(
+            "smart-select point path needs at least one point".into(),
+        ));
+    }
+    let pixels = input_tensor(&image);
+
+    // SAM3 squashes the image to a fixed 1008² square (uniform, NOT aspect-preserving), so a source
+    // point maps to model-input space by the per-axis scale 1008/W, 1008/H (mirrors the box path's
+    // normalize_box_cxcywh — no letterbox math).
+    let (sx, sy) = (
+        INPUT_SIZE as f32 / width as f32,
+        INPUT_SIZE as f32 / height as f32,
+    );
+    let coords: Vec<(f32, f32)> = points.iter().map(|&(x, y, _)| (x * sx, y * sy)).collect();
+    let labels: Vec<i32> = points.iter().map(|&(_, _, l)| l).collect();
+
+    // Cached checkpoint (poison-recovery), shared with the box/video paths — all consume the same
+    // facebook/sam3 weight map (mirrors segment_box_blocking).
+    let cell = WEIGHTS.get_or_init(|| Mutex::new(None));
+    let mut guard = cell.lock().unwrap_or_else(|poisoned| {
+        let mut guard = poisoned.into_inner();
+        *guard = None;
+        guard
+    });
+    if guard.is_none() {
+        let weights = Weights::from_file(&model_path)
+            .map_err(|e| WorkerError::Engine(format!("sam3 weights load: {e}")))?;
+        *guard = Some(weights);
+    }
+    let weights = guard.as_ref().expect("weights loaded");
+
+    let mut tracker = Sam3Tracker::from_weights(weights)
+        .map_err(|e| WorkerError::Engine(format!("sam3 tracker build: {e}")))?;
+    if let Some(bits) = quant_bits() {
+        tracker
+            .quantize(bits)
+            .map_err(|e| WorkerError::Engine(format!("sam3 tracker quantize q{bits}: {e}")))?;
+    }
+
+    let mask = tracker
+        .segment_points(&pixels, &coords, &labels)
+        .map_err(|e| WorkerError::Engine(format!("sam3 tracker segment_points: {e}")))?;
+
+    // Low-res mask logits `[mg, mg]` → binarize `> 0` + resize to source dims (inverts the squash).
+    let grid = mask.low_res.shape()[0] as usize;
+    let logits = mask
+        .low_res
+        .as_dtype(mlx_rs::Dtype::Float32)
+        .map_err(|e| WorkerError::Engine(format!("sam3 mask read: {e}")))?
+        .as_slice::<f32>()
+        .to_vec();
+    Ok(mask_to_frame(&logits, grid, width, height))
+}
+
 /// Every tracked person's per-frame mask + a stable left-to-right paint order — the input to the
 /// SCAIL-2 color-mask painter (sc-5448). Unlike [`segment_track_blocking`] (which selects ONE person
 /// via ByteTrack anchors for replace_person), this keeps EVERY SAM3 object so each person can be
@@ -899,5 +977,67 @@ mod tests {
             "mask containment in box {containment:.3} too low (wrong object?)"
         );
         eprintln!("box-segment smoke: fg_frac={frac:.3} containment={containment:.3} dims={w}x{h}");
+    }
+
+    /// Real-weights smoke for the smart-select POINT path (sc-6346): decode an image → a single
+    /// foreground click on the subject → `segment_points_blocking` (SAM3 tracker single-frame PVS) →
+    /// a binary mask at the source dims, against the stock `facebook/sam3` checkpoint. Proves a
+    /// positive click segments the object under it (the engine half of the sc-3751 click tool).
+    /// `#[ignore]`d (needs the 3.2 GB weights + GPU); run with:
+    ///   SCENEWORKS_SAM3_WEIGHTS=<facebook/sam3 snapshot dir> \
+    ///   SCENEWORKS_SAM3_SMOKE_IMAGE=<jpg/png with a clear subject, e.g. zidane.jpg 1280×720> \
+    ///   [SCENEWORKS_SAM3_SMOKE_POINT="x,y"] \
+    ///   cargo test -p sceneworks-worker --release sam3_real_weights_point_segment_smoke -- --ignored --nocapture
+    #[test]
+    #[ignore = "real SAM3 weights + GPU; set SCENEWORKS_SAM3_WEIGHTS + SCENEWORKS_SAM3_SMOKE_IMAGE"]
+    fn sam3_real_weights_point_segment_smoke() {
+        let snap = std::env::var("SCENEWORKS_SAM3_WEIGHTS")
+            .expect("set SCENEWORKS_SAM3_WEIGHTS to a facebook/sam3 snapshot dir");
+        let dir = {
+            let p = PathBuf::from(&snap);
+            if p.is_file() {
+                p.parent().unwrap().to_path_buf()
+            } else {
+                p
+            }
+        };
+        let model = dir.join(MODEL_FILE);
+        let image_path = PathBuf::from(
+            std::env::var("SCENEWORKS_SAM3_SMOKE_IMAGE")
+                .expect("set SCENEWORKS_SAM3_SMOKE_IMAGE to an image with a clear subject"),
+        );
+        let image = crate::image_decode::decode_image_any(&image_path)
+            .expect("decode smoke image")
+            .to_rgb8();
+        let (w, h) = (image.width(), image.height());
+
+        // A single positive click on the prominent subject (default = image center; override with
+        // SCENEWORKS_SAM3_SMOKE_POINT="x,y" in source pixels for a different image).
+        let (px, py) = std::env::var("SCENEWORKS_SAM3_SMOKE_POINT")
+            .ok()
+            .and_then(|s| {
+                let v: Vec<f32> = s.split(',').filter_map(|p| p.trim().parse().ok()).collect();
+                (v.len() == 2).then(|| (v[0], v[1]))
+            })
+            .unwrap_or((w as f32 * 0.5, h as f32 * 0.5));
+        let mask = segment_points_blocking(model, image, vec![(px, py, 1)])
+            .expect("segment_points_blocking");
+
+        assert_eq!(mask.len(), (w * h) as usize, "mask size = source dims");
+        assert!(mask.iter().all(|&v| v == 0 || v == 255), "mask is binary");
+        let fg = mask.iter().filter(|&&v| v == 255).count();
+        let frac = fg as f64 / (w * h) as f64;
+        // A real subject mask covers a non-trivial, non-whole region.
+        assert!(
+            (0.001..0.95).contains(&frac),
+            "foreground fraction {frac:.3} is implausible (empty or whole-frame)"
+        );
+        // A positive click must land inside its own selected region.
+        let idx = (py as u32).min(h - 1) * w + (px as u32).min(w - 1);
+        assert_eq!(
+            mask[idx as usize], 255,
+            "the clicked pixel must be foreground in the mask"
+        );
+        eprintln!("point-segment smoke: fg_frac={frac:.3} at click ({px},{py}) dims={w}x{h}");
     }
 }

--- a/crates/sceneworks-worker/src/segment_jobs.rs
+++ b/crates/sceneworks-worker/src/segment_jobs.rs
@@ -7,11 +7,16 @@
 //! (`upscale_jobs`): resolve the `sourceAssetId` against its project, decode, run the engine under
 //! `spawn_blocking`, write one child asset with lineage back to the source.
 //!
-//! Engine: native-MLX **SAM3** box-prompted PVS via `person_segment_sam3::segment_box_blocking`
-//! (the box path of the sc-4926 SAM3 stack — `Sam3ImageSegmenter::segment_with_boxes`, epic 4910
-//! sc-4923). macOS-only, like the SAM3 dependency; the capability is advertised only by the MLX
-//! worker (`gpu.rs mlx_gpu`), so a segment job never routes off-Mac. There is no torch/candle SAM3
-//! image path yet (a Windows/Linux backport is tracked separately).
+//! Engine (native-MLX **SAM3**, prompt-driven, one checkpoint): a **box** prompt runs SAM3's
+//! concept *detector* (`person_segment_sam3::segment_box_blocking` →
+//! `Sam3ImageSegmenter::segment_with_boxes`, sc-4923/sc-6105); **fg/bg click points** run SAM3's
+//! *tracker* single-frame PVS (`person_segment_sam3::segment_points_blocking` →
+//! `Sam3Tracker::segment_points`, sc-6346). Both load from the same `facebook/sam3` checkpoint —
+//! SAM3 does interactive point refinement via its SAM2-lineage tracker, so no second model/download.
+//! Points take precedence when both are present; exactly one path runs per job and both return the
+//! same `maskAssetId` shape. macOS-only, like the SAM3 dependency; the capability is advertised only
+//! by the MLX worker (`gpu.rs mlx_gpu`), so a segment job never routes off-Mac. There is no
+//! torch/candle SAM3 image path yet (a Windows/Linux backport is tracked separately).
 
 use std::path::{Path, PathBuf};
 
@@ -20,7 +25,9 @@ use serde_json::{json, Value};
 use gen_core::CancelFlag;
 
 use crate::downloads::DownloadContext;
-use crate::person_segment_sam3::{ensure_segmenter_weights, segment_box_blocking};
+use crate::person_segment_sam3::{
+    ensure_segmenter_weights, segment_box_blocking, segment_points_blocking,
+};
 use crate::{
     cancel_requested_peek, fresh_asset_id, heartbeat, mark_job_canceled, now_rfc3339,
     progress_payload, progress_report_interval, task_join_error, update_job, ApiClient, Settings,
@@ -92,6 +99,46 @@ fn parse_box(payload: &JsonObject) -> WorkerResult<[f32; 4]> {
     ))
 }
 
+/// Parse `payload.points` (fg/bg click prompts in source-image pixel coords) for the SAM3 tracker
+/// point path (sc-6346). Each entry is `{x, y, label}` — `label` `1` = foreground / `0` = background
+/// (accepts an integer `label`, or a boolean `fg`; defaults to foreground). Returns `None` when
+/// `points` is absent or an empty array (→ the caller falls back to the box path), `Err` on a
+/// malformed entry. Points and box are alternative prompt modes; when both are present, points win.
+fn parse_points(payload: &JsonObject) -> WorkerResult<Option<Vec<(f32, f32, i32)>>> {
+    let Some(value) = payload.get("points") else {
+        return Ok(None);
+    };
+    let arr = value.as_array().ok_or_else(|| {
+        WorkerError::InvalidPayload("Smart-select 'points' must be an array.".to_owned())
+    })?;
+    if arr.is_empty() {
+        return Ok(None);
+    }
+    let mut out = Vec::with_capacity(arr.len());
+    for entry in arr {
+        let obj = entry.as_object().ok_or_else(|| {
+            WorkerError::InvalidPayload(
+                "Smart-select point must be an object {x, y, label}.".to_owned(),
+            )
+        })?;
+        let coord = |key: &str| obj.get(key).and_then(Value::as_f64).map(|v| v as f32);
+        let (Some(x), Some(y)) = (coord("x"), coord("y")) else {
+            return Err(WorkerError::InvalidPayload(
+                "Smart-select point needs numeric 'x' and 'y'.".to_owned(),
+            ));
+        };
+        // label: 1 = foreground (default), 0 = background. Accept an int `label` or a bool `fg`.
+        let label = obj
+            .get("label")
+            .and_then(Value::as_i64)
+            .map(|v| i32::from(v != 0))
+            .or_else(|| obj.get("fg").and_then(Value::as_bool).map(i32::from))
+            .unwrap_or(1);
+        out.push((x, y, label));
+    }
+    Ok(Some(out))
+}
+
 /// Heartbeat + cancel poll while the blocking segmentation task runs (mirrors
 /// `upscale_jobs::run_upscale_with_heartbeat`): keeps the worker live during the model load +
 /// inference and propagates a user cancel.
@@ -160,7 +207,14 @@ pub(crate) async fn run_image_segment_job(
             WorkerError::InvalidPayload("Smart-select requires a source image asset.".to_owned())
         })?
         .to_owned();
-    let box_xyxy = parse_box(payload)?;
+    // Smart-select prompt: fg/bg points (SAM3 tracker — the interactive-click path) take precedence;
+    // else a box (SAM3 concept detector, sc-6105). Both use the same SAM3 checkpoint (sc-6346).
+    // Exactly one prompt mode runs per job.
+    let points = parse_points(payload)?;
+    let box_xyxy = match &points {
+        Some(_) => None,
+        None => Some(parse_box(payload)?),
+    };
     // The optional text concept paired with the box (SAM3 PVS is text⊕box). Empty = rely on the
     // geometric prompt — the smart-select default, since the user draws a box around any object.
     let concept = payload
@@ -178,6 +232,26 @@ pub(crate) async fn run_image_segment_job(
         .and_then(Value::as_f64)
         .map(|v| v.clamp(0.0, 1.0) as f32)
         .unwrap_or(SEGMENT_MASK_THRESHOLD);
+
+    // The prompt recorded on the mask asset's `rawAdapterSettings` (both modes are engine "sam3"):
+    // the click points for the point path, the box + thresholds for the box path. Built now, before
+    // the prompt is moved into the segmentation task below.
+    let segment_settings = if let Some(points) = &points {
+        json!({
+            "engine": "sam3",
+            "points": points
+                .iter()
+                .map(|&(x, y, label)| json!({ "x": x, "y": y, "label": label }))
+                .collect::<Vec<_>>(),
+        })
+    } else {
+        json!({
+            "engine": "sam3",
+            "box": box_xyxy.expect("box prompt present when there are no points"),
+            "threshold": threshold,
+            "maskThreshold": mask_threshold,
+        })
+    };
 
     let project_id = payload
         .get("projectId")
@@ -226,6 +300,7 @@ pub(crate) async fn run_image_segment_job(
         cancel_message: "Smart-select canceled while fetching SAM3 weights.",
         fresh_download: false,
     };
+    // Both prompt modes load the same facebook/sam3 checkpoint — one resolve/download.
     let (model_path, tokenizer_path) = ensure_segmenter_weights(settings, &context).await?;
 
     update_job(
@@ -243,24 +318,39 @@ pub(crate) async fn run_image_segment_job(
     )
     .await?;
     let cancel = CancelFlag::new();
-    let mask = run_with_heartbeat(
-        api,
-        settings,
-        &job.id,
-        cancel.clone(),
-        tokio::task::spawn_blocking(move || {
-            segment_box_blocking(
-                model_path,
-                tokenizer_path,
-                source_image,
-                box_xyxy,
-                &concept,
-                threshold,
-                mask_threshold,
-            )
-        }),
-    )
-    .await?;
+    // Points → SAM3 tracker single-frame PVS (interactive clicks); box → SAM3 concept detector.
+    let mask = if let Some(points) = points {
+        run_with_heartbeat(
+            api,
+            settings,
+            &job.id,
+            cancel.clone(),
+            tokio::task::spawn_blocking(move || {
+                segment_points_blocking(model_path, source_image, points)
+            }),
+        )
+        .await?
+    } else {
+        let box_xyxy = box_xyxy.expect("box prompt present when there are no points");
+        run_with_heartbeat(
+            api,
+            settings,
+            &job.id,
+            cancel.clone(),
+            tokio::task::spawn_blocking(move || {
+                segment_box_blocking(
+                    model_path,
+                    tokenizer_path,
+                    source_image,
+                    box_xyxy,
+                    &concept,
+                    threshold,
+                    mask_threshold,
+                )
+            }),
+        )
+        .await?
+    };
 
     // The mask is a row-major `src_w*src_h` 0/255 grayscale buffer (white = the selected region).
     let mask_image = image::GrayImage::from_raw(src_w, src_h, mask)
@@ -317,12 +407,7 @@ pub(crate) async fn run_image_segment_job(
         "stylePreset": "",
         "sourceAssetId": source_asset_id,
         "rawAdapterSettings": {
-            "segment": {
-                "engine": "sam3",
-                "box": box_xyxy,
-                "threshold": threshold,
-                "maskThreshold": mask_threshold,
-            }
+            "segment": segment_settings,
         },
         "parents": [source_asset_id],
         "extra": {

--- a/crates/sceneworks-worker/src/segment_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/segment_jobs/tests.rs
@@ -31,3 +31,54 @@ fn parse_box_rejects_missing_or_malformed() {
     assert!(parse_box(&obj(json!({ "box": "nope" }))).is_err());
     assert!(parse_box(&obj(json!({ "box": { "x": 1.0, "y": 2.0 } }))).is_err());
 }
+
+// --- sc-6346: fg/bg point prompts (SAM3 tracker path) ---
+
+#[test]
+fn parse_points_absent_or_empty_is_none() {
+    // Absent → None (caller falls back to the box path).
+    assert_eq!(
+        parse_points(&obj(json!({ "box": [1, 2, 3, 4] }))).unwrap(),
+        None
+    );
+    // Empty array → None too.
+    assert_eq!(parse_points(&obj(json!({ "points": [] }))).unwrap(), None);
+}
+
+#[test]
+fn parse_points_reads_xy_and_label() {
+    // Explicit int label 1=fg / 0=bg, and a default (no label) = fg.
+    let payload = obj(json!({
+        "points": [
+            { "x": 10.0, "y": 20.0, "label": 1 },
+            { "x": 30, "y": 40, "label": 0 },
+            { "x": 5.5, "y": 6.5 }
+        ]
+    }));
+    let pts = parse_points(&payload).unwrap().unwrap();
+    assert_eq!(pts, vec![(10.0, 20.0, 1), (30.0, 40.0, 0), (5.5, 6.5, 1)]);
+}
+
+#[test]
+fn parse_points_accepts_fg_bool_and_clamps_label() {
+    // `fg: false` → background; any non-zero `label` → foreground (1).
+    let payload = obj(json!({
+        "points": [
+            { "x": 1.0, "y": 2.0, "fg": false },
+            { "x": 3.0, "y": 4.0, "fg": true },
+            { "x": 5.0, "y": 6.0, "label": 7 }
+        ]
+    }));
+    let pts = parse_points(&payload).unwrap().unwrap();
+    assert_eq!(pts, vec![(1.0, 2.0, 0), (3.0, 4.0, 1), (5.0, 6.0, 1)]);
+}
+
+#[test]
+fn parse_points_rejects_malformed() {
+    // Not an array.
+    assert!(parse_points(&obj(json!({ "points": "nope" }))).is_err());
+    // Entry not an object.
+    assert!(parse_points(&obj(json!({ "points": [[1.0, 2.0]] }))).is_err());
+    // Missing y.
+    assert!(parse_points(&obj(json!({ "points": [{ "x": 1.0 }] }))).is_err());
+}


### PR DESCRIPTION
The point-prompt half of the Image Editor smart-select tool ([sc-6346](https://app.shortcut.com/trefry/story/6346), epic 6087 — deferred from sc-6105's box backend). A click (or an fg/bg point list) now produces a pixel-accurate inpaint mask alongside the existing box prompt.

## Engine choice: SAM3 tracker (not SAM2)
SAM3 **does** interactive point refinement — via its tracker (the SAM2-lineage promptable mask decoder). So points route to `Sam3Tracker` while box stays on the concept detector (`Sam3ImageSegmenter`, sc-6105, untouched). Both load the **same `facebook/sam3` checkpoint** → no second model/download. (An earlier SAM2 approach was built then discarded after confirming SAM3's own tracker is the right home — see story for the investigation trail.)

## Changes
- `person_segment_sam3::segment_points_blocking` — cached `Sam3Tracker` (shared `WEIGHTS` map); source points → 1008-input space by the uniform squash; reuses `mask_to_frame`. Real-weight `#[ignore]` smoke.
- `segment_jobs.rs`: `parse_points` + routing (points→tracker / box→detector, points win; one `ensure_segmenter_weights` since both are SAM3). `model`/`adapter` stay `"sam3"`; only `rawAdapterSettings.segment` varies.
- 4 new `parse_points` unit tests.
- **No API/contract/jobs_store change** — the `image_segment` payload is opaque pass-through, routing is by `JobType::ImageSegment` (engine-agnostic). New payload field: `points: [{x,y,label}]` (label `1`=fg/`0`=bg, also accepts `fg` bool). The frontend click tool is sc-3751.

## Lockstep pin bumps
- mlx-gen `517ef11` → `4740225` (every pin) — [mlx-gen #499](https://github.com/SceneWorks/mlx-gen/pull/499) surfaces `Sam3Tracker::segment_points` / `PromptEncoder::encode_points`.
- candle-gen `3a4f345` → `2d2ebfc` — [candle-gen #107](https://github.com/SceneWorks/candle-gen/pull/107) re-pins gen-core to `4740225` in lockstep.
- gen-core is **byte-identical** across the range (#499 is pure `mlx-gen-sam3/tracker.rs`; mlx-rs unchanged `44929a0`), so the `--target all` skew gate resolves a single gen-core rev.

**Merge order:** mlx-gen #499 and candle-gen #107 first (they're pinned by SHA, so they don't strictly need to merge before this builds, but should land for a clean main).

## Validation
- 344 worker lib tests pass (4 new), `clippy -Dwarnings` + `fmt --check` clean, gen-core skew gate green.
- Real-weight SAM3-tracker point smoke on zidane.jpg: fg click → 16.5% foreground, clicked pixel in-mask (within 0.001 of a SAM2 reference point path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)