### PR TITLE
desktop: resilient candle sidecar build (intermittent nvcc spawn deaths)

### DIFF
--- a/apps/desktop/scripts/build-sidecar.mjs
+++ b/apps/desktop/scripts/build-sidecar.mjs
@@ -13,6 +13,7 @@ import {
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import process from "node:process";
+import os from "node:os";
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const desktopDir = resolve(scriptDir, ".."); // apps/desktop
@@ -105,7 +106,40 @@ if (candle) {
   console.log(
     `build-sidecar: candle backend ON (CUDA_COMPUTE_CAP=${process.env.CUDA_COMPUTE_CAP ?? "80"})`,
   );
-  run(npmCmd, ["run", "api:build:embedded:candle"], candleEnv);
+  // candle-kernels compiles its CUDA kernels with `cudaforge`, which fans out one
+  // nvcc per .cu over a rayon pool sized to ~half the CPU count. On a high-core
+  // Windows box (e.g. 48 logical CPUs → ~24 parallel nvcc, each spawning
+  // cl/cicc/ptxas) that process-spawn storm — concurrent with the rest of the
+  // cargo build — INTERMITTENTLY gets an nvcc child killed with NO output. It
+  // surfaces as `CompilationFailed { path: "...affine.cu", message: "nvcc error:\n\n" }`
+  // (empty on both streams) — a teardown symptom, NOT a real compile error: every
+  // kernel compiles cleanly for compute_80 AND sm_120a in isolation, and the build
+  // succeeds at low concurrency (CI's 4-core runner, cache hits). Two mitigations:
+  //   1) cap cudaforge's nvcc fan-out (CUDAFORGE_THREADS) so the storm is bounded
+  //      regardless of core count (honored by cudaforge's ParallelConfig).
+  //   2) if it still fails, retry ONCE fully serial (CUDAFORGE_THREADS=1): the
+  //      serial recompile only redoes the kernels the killed run left missing, and
+  //      it both clears the spawn contention AND — were the failure ever a genuine
+  //      per-file nvcc error — surfaces the true (non-empty) message instead of the
+  //      swallowed empty one. NOTE: CUDAFORGE_THREADS is not in candle-kernels'
+  //      rerun-if-env-changed set, so toggling it never forces a needless rebuild.
+  const nvccCap = String(Math.min(8, Math.max(1, os.cpus().length)));
+  try {
+    run(npmCmd, ["run", "api:build:embedded:candle"], {
+      ...candleEnv,
+      CUDAFORGE_THREADS: nvccCap,
+    });
+  } catch (err) {
+    console.warn(
+      `build-sidecar: candle build failed (${err?.message ?? err}); retrying once ` +
+        `with serial CUDA kernel compilation (CUDAFORGE_THREADS=1) to clear nvcc ` +
+        `spawn contention / surface the real nvcc error`,
+    );
+    run(npmCmd, ["run", "api:build:embedded:candle"], {
+      ...candleEnv,
+      CUDAFORGE_THREADS: "1",
+    });
+  }
 } else {
   run(npmCmd, ["run", "api:build:embedded"], { VITE_API_BASE_URL: "" });
 }


### PR DESCRIPTION
## Problem

The candle-by-default Windows desktop build intermittently dies during the candle sidecar compile:

```
Error: CompilationFailed { path: "src\affine.cu", message: "nvcc error:\n\n" }
warning: build failed, waiting for other jobs to finish...
...
beforeBuildCommand `node scripts/build-sidecar.mjs` failed with exit code 1
```

The nvcc message is **empty on both stdout and stderr** — an nvcc child that exited non-zero having printed nothing (abnormal termination), **not** a compile diagnostic.

## Root cause (it is not a real kernel error)

Verified on the RTX PRO 6000 box (48 logical CPUs, 511 GB RAM) and against CI:

- single-file `affine.cu` compiles clean (exit 0) for `compute_80` **and** `sm_120a`;
- all 11 PTX + 3 moe `candle-kernels` `.cu` compile clean for both archs;
- 11-wide parallel PTX stress (6 rounds) → 0 failures;
- full clean candle builds succeed locally **and** in CI's `build-windows` job (NSIS + MSI packaged).

`candle-kernels` builds its CUDA kernels with `cudaforge`, which fans out one `nvcc` per `.cu` over a rayon pool sized to ~half the CPU count. On a high-core Windows box (48 CPUs → ~24 parallel `nvcc`, each spawning `cl`/`cicc`/`ptxas`), that process-spawn storm — running concurrently with the rest of the cargo graph — occasionally gets an `nvcc` child killed with no output. cudaforge's `try_for_each` returns that empty error first, and the build script fails. CI never hits it because its 4-core runner keeps concurrency low.

## Fix (`build-sidecar.mjs`, Windows candle build only)

1. **Bound the fan-out** — set `CUDAFORGE_THREADS = min(8, cpus)` so the spawn storm is capped regardless of core count.
2. **Self-heal + self-diagnose** — if the build still fails, retry **once fully serial** (`CUDAFORGE_THREADS=1`). The serial recompile only redoes the kernels the killed run left missing, and it both clears the spawn contention **and** — were the failure ever a genuine per-file `nvcc` error — surfaces the true (non-empty) message instead of the swallowed empty one.

`CUDAFORGE_THREADS` is not in `candle-kernels`' `rerun-if-env-changed` set, so this never forces a needless rebuild. Non-candle and macOS builds are unchanged.

## Notes

- Separate from the earlier CI fix (`Jimver/cuda-toolkit` `v0.2.21`→`v0.2.35`, already on `main` via #816) — that only affected the CI runner's CUDA install, not local builds.
- I could not make the failure reproduce on demand (it's intermittent and concurrency-dependent), so this is built to be correct regardless of root cause: the serial retry resolves spawn contention and exposes any real error. If it ever recurs, the retry's serial output will show the actual failing kernel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)