### PR TITLE
worker: load HF-cached models on Windows via hardlinks (fix os error 448)

### DIFF
--- a/crates/sceneworks-worker/src/downloads.rs
+++ b/crates/sceneworks-worker/src/downloads.rs
@@ -503,7 +503,8 @@ pub(crate) async fn download_snapshot(
 /// Download a Hugging Face snapshot into the standard hub cache layout under
 /// `repo_dir` (`models--<org>--<name>`): content lands in `blobs/<etag>`, the
 /// checkpoint is materialized as `snapshots/<commit>/<path>` (a relative symlink to
-/// its blob, or a copy where symlinks are unavailable), and `refs/<rev>` records the
+/// its blob on Unix, a hardlink to the blob on Windows — see [`link_blob`] — or a
+/// copy where neither is available), and `refs/<rev>` records the
 /// commit. This matches `huggingface_hub`, so HF-sourced downloads dedupe with other
 /// tools and the Python loader instead of duplicating into the private app store
 /// (sc-1904).
@@ -580,7 +581,7 @@ pub(crate) async fn download_snapshot_into_cache(
         }
         rel_target.push("blobs");
         rel_target.push(etag);
-        if !link_blob(&rel_target, &link).await {
+        if !link_blob(&blobs_dir.join(etag), &rel_target, &link).await {
             tokio::fs::copy(blobs_dir.join(etag), &link).await?;
         }
     }
@@ -620,21 +621,31 @@ fn blob_fallback_name(path: &str) -> String {
         .collect()
 }
 
-/// Create a relative symlink from `link` to its blob, returning whether it
-/// succeeded. Mirrors huggingface_hub: symlink where supported, and the caller
-/// copies instead when this returns false (Windows without privilege).
-async fn link_blob(rel_target: &Path, link: &Path) -> bool {
-    #[cfg(unix)]
-    {
-        tokio::fs::symlink(rel_target, link).await.is_ok()
-    }
+/// Materialize a snapshot entry pointing at its blob, returning whether it
+/// succeeded (the caller copies when it does not). On Unix this is a relative
+/// symlink, mirroring huggingface_hub so HF tools dedupe with this cache. On
+/// Windows it is a **hardlink** to the absolute blob instead: the candle worker
+/// process cannot traverse the relative `snapshots/<rev>/… -> ../blobs/<etag>`
+/// symlinks — the open fails with `ERROR_UNTRUSTED_MOUNT_POINT` (os error 448, see
+/// [`crate::model_jobs::downloaded_model_detection_io_error_is_inconclusive`]) — so
+/// every model load died at the first file read. A hardlink is a plain directory
+/// entry to the same blob data (no reparse point, same volume by construction, still
+/// deduped) and reads fine. (`model_jobs::huggingface_snapshot_dir` repairs caches
+/// that were already downloaded as symlinks, e.g. by `huggingface_hub`.)
+async fn link_blob(blob_abs: &Path, rel_target: &Path, link: &Path) -> bool {
     #[cfg(windows)]
     {
-        tokio::fs::symlink_file(rel_target, link).await.is_ok()
+        let _ = rel_target;
+        tokio::fs::hard_link(blob_abs, link).await.is_ok()
+    }
+    #[cfg(unix)]
+    {
+        let _ = blob_abs;
+        tokio::fs::symlink(rel_target, link).await.is_ok()
     }
     #[cfg(not(any(unix, windows)))]
     {
-        let _ = (rel_target, link);
+        let _ = (blob_abs, rel_target, link);
         false
     }
 }

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -918,7 +918,27 @@ pub(crate) async fn run_model_convert_job(
 /// actually holds the checkpoint files). Prefers the commit referenced by
 /// `refs/main`, else the first snapshot directory. Returns `None` when the repo is
 /// not present in the cache.
+///
+/// On Windows the resolved snapshot is repaired in place
+/// ([`materialize_snapshot_hardlinks`]): the candle worker process cannot traverse
+/// the relative `snapshots/<rev>/… -> ../blobs/<etag>` symlinks that `huggingface_hub`
+/// (and, before this fix, our own downloader) create — the open fails with
+/// `ERROR_UNTRUSTED_MOUNT_POINT` (os error 448), so every model load died at the first
+/// file read. The repair replaces those symlinks with hardlinks to the same blob (no
+/// reparse point, same volume, still deduped); it is idempotent and best-effort, and a
+/// no-op on every other platform.
 pub(crate) fn huggingface_snapshot_dir(data_dir: &Path, repo: &str) -> Option<PathBuf> {
+    let dir = resolve_huggingface_snapshot_dir(data_dir, repo)?;
+    // Windows-only in production (the symlink-traversal defect is Windows-specific); the
+    // function itself is still compiled under `test` so the conversion is unit-testable
+    // off-Windows, but it must not run against a developer's real HF cache during an
+    // unrelated `cargo test` on Unix — hence the call, not just the body, is gated.
+    #[cfg(windows)]
+    materialize_snapshot_hardlinks(&dir);
+    Some(dir)
+}
+
+fn resolve_huggingface_snapshot_dir(data_dir: &Path, repo: &str) -> Option<PathBuf> {
     let repo_dir = huggingface_repo_cache_path(data_dir, repo)?;
     let snapshots = repo_dir.join("snapshots");
     if let Ok(rev) = std::fs::read_to_string(repo_dir.join("refs").join("main")) {
@@ -932,6 +952,65 @@ pub(crate) fn huggingface_snapshot_dir(data_dir: &Path, repo: &str) -> Option<Pa
         .flatten()
         .map(|entry| entry.path())
         .find(|path| path.is_dir())
+}
+
+/// Replace the relative `snapshots/<rev>/… -> ../blobs/<etag>` symlinks under a resolved
+/// HF snapshot dir with hardlinks to the same blob. **Windows-only** (a no-op
+/// elsewhere): the candle worker process cannot traverse those reparse points — the
+/// open fails with `ERROR_UNTRUSTED_MOUNT_POINT` (os error 448, see
+/// [`downloaded_model_detection_io_error_is_inconclusive`]) — but a hardlink is a plain
+/// directory entry to the blob data (no reparse, same volume, still deduped) and reads
+/// fine. Caches our downloader writes now hardlink from the start
+/// ([`crate::downloads`]); this repairs caches already materialized as symlinks (e.g. by
+/// `huggingface_hub`). Best-effort and idempotent: once converted there is nothing left
+/// to do, and any per-file failure leaves that entry untouched for the loader to
+/// surface. Compiled on `test` too so the conversion is unit-testable off-Windows.
+#[cfg(any(windows, test))]
+fn materialize_snapshot_hardlinks(dir: &Path) {
+    fn repair(dir: &Path) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            let path = entry.path();
+            if file_type.is_symlink() {
+                relink_to_blob(&path);
+            } else if file_type.is_dir() {
+                repair(&path);
+            }
+        }
+    }
+    repair(dir);
+}
+
+/// Replace a single snapshot symlink with a hardlink (or, failing that, a copy) to its
+/// blob, so the entry is always present afterward. The symlink target is read **without
+/// traversing it** (`read_link`), so resolving the blob never hits the os-448 path; the
+/// symlink is removed only once its blob is confirmed to exist.
+#[cfg(any(windows, test))]
+fn relink_to_blob(link: &Path) {
+    let Ok(target) = std::fs::read_link(link) else {
+        return;
+    };
+    let Some(parent) = link.parent() else {
+        return;
+    };
+    // `canonicalize` resolves the `..` segments and confirms the blob exists; it opens
+    // the blob (a plain file, not a reparse point) so it does not hit the os-448 path.
+    let Ok(blob) = std::fs::canonicalize(parent.join(target)) else {
+        return;
+    };
+    if std::fs::remove_file(link).is_err() {
+        return;
+    }
+    if std::fs::hard_link(&blob, link).is_err() {
+        // Cross-volume or a filesystem without hardlinks: fall back to a real copy so
+        // the entry is never left missing.
+        let _ = std::fs::copy(&blob, link);
+    }
 }
 
 /// Atomically promote a freshly converted temp directory to its final location,
@@ -2020,5 +2099,67 @@ mod tests {
         }
 
         let _ = std::fs::remove_dir_all(&out);
+    }
+}
+
+// Cross-platform (not macOS-gated like the module above): exercises the Windows
+// symlink-repair logic, which is compiled under `test` on every platform.
+#[cfg(test)]
+mod hardlink_tests {
+    use super::*;
+
+    /// The HF-cache symlink-traversal fix: a `snapshots/<rev>/<sub>/file ->
+    /// ../blobs/<etag>` symlink is replaced in place by a non-reparse entry (hardlink,
+    /// or a copy fallback) pointing at the same bytes, and the blob is left untouched.
+    /// Recurses into component sub-dirs. Skips when the platform won't let the test
+    /// create a symlink (e.g. Windows without Developer Mode).
+    #[test]
+    fn materialize_snapshot_hardlinks_replaces_symlinks_with_real_files() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let blobs = root.path().join("blobs");
+        std::fs::create_dir_all(&blobs).expect("blobs dir");
+        let blob = blobs.join("deadbeef");
+        std::fs::write(&blob, b"tokenizer-bytes").expect("write blob");
+
+        let snapshot = root.path().join("snapshots").join("rev");
+        let tokenizer_dir = snapshot.join("tokenizer");
+        std::fs::create_dir_all(&tokenizer_dir).expect("tokenizer dir");
+        let link = tokenizer_dir.join("tokenizer.json");
+        // Relative, like huggingface_hub: snapshots/rev/tokenizer/ -> ../../../blobs.
+        let rel_target: PathBuf = ["..", "..", "..", "blobs", "deadbeef"].iter().collect();
+
+        #[cfg(unix)]
+        let made = std::os::unix::fs::symlink(&rel_target, &link).is_ok();
+        #[cfg(windows)]
+        let made = std::os::windows::fs::symlink_file(&rel_target, &link).is_ok();
+        #[cfg(not(any(unix, windows)))]
+        let made = false;
+        if !made {
+            return; // no privilege to create a symlink — nothing to convert
+        }
+        assert!(
+            std::fs::symlink_metadata(&link)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "precondition: entry is a symlink before repair"
+        );
+
+        materialize_snapshot_hardlinks(&snapshot);
+
+        let meta = std::fs::symlink_metadata(&link).expect("metadata after repair");
+        assert!(
+            !meta.file_type().is_symlink(),
+            "the symlink must be replaced by a non-reparse entry"
+        );
+        assert_eq!(
+            std::fs::read(&link).expect("read repaired entry"),
+            b"tokenizer-bytes"
+        );
+        assert_eq!(
+            std::fs::read(&blob).expect("read blob"),
+            b"tokenizer-bytes",
+            "the blob itself must be untouched"
+        );
     }
 }


### PR DESCRIPTION
## Problem

On the Windows desktop, candle generation fails at model load:

```
generation failed: lens: load tokenizer: tokenizer: The path cannot be traversed
because it contains an untrusted mount point. (os error 448)
```

`os error 448` = `ERROR_UNTRUSTED_MOUNT_POINT`. The candle worker process cannot **traverse** the relative `snapshots/<rev>/… -> ../blobs/<etag>` symlinks that `huggingface_hub` (and our own `downloads.rs`) create — opening one fails, so the very first file read (`tokenizer.json`, then every `.safetensors`) dies. It reproduces only in the spawned worker process (a plain process reads the same symlink fine; the blob itself is a normal file), so it affects **every candle family** on Windows, not just Lens — Lens-Turbo is just what was tried first.

Prior work only made the *download family-check* ([`cbfd6d25`]) and the *cache-health UI* ([`6867bacd`]) tolerant of 448; the **generation read path** still hard-failed. This fixes that path.

## Fix (worker-side, feature-agnostic — no candle-gen change)

A hardlink is a plain directory entry to the same blob data: no reparse point, same volume by construction, still deduped, and it reads fine.

- **`downloads::link_blob`** — on Windows, materialize new snapshot entries as **hardlinks** to the absolute blob instead of relative symlinks. Unix keeps relative symlinks (so HF tools still dedupe); a copy stays the last-resort fallback.
- **`model_jobs::huggingface_snapshot_dir`** — on Windows, **repair caches already written as symlinks** (e.g. by `huggingface_hub`) by converting them to hardlinks before handing the dir to the loaders, so existing installs self-heal on the next load. It funnels every candle image/video/aux-repo (ControlNet / IP-Adapter / PuLID / face) load, so one chokepoint covers them all. Idempotent + best-effort: the symlink target is read **without traversing it**, the symlink is removed only once its blob is confirmed, and a copy fallback ensures an entry is never left missing. The call is `#[cfg(windows)]` so an unrelated `cargo test` on Unix never rewrites a developer's real HF cache; the function still compiles under `test` for cross-platform unit coverage.

## Verification

Windows (this box): `cargo check -p sceneworks-worker` ✓, `cargo clippy --all-targets` ✓ (zero warnings), new unit test ✓ — `materialize_snapshot_hardlinks` converts a real relative symlink into a non-reparse entry with identical bytes and leaves the blob untouched.

Change is in always-compiled, non-candle worker files, so the `--features backend-candle` lane compiles the same paths. End-to-end check: rebuild/reinstall the desktop candle sidecar and retry a `lens_turbo` generation — the existing symlinked cache is repaired in place on resolve and the load succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)