### PR TITLE
feat(catalog): add Boogu-Image-0.1 Base/Turbo/Edit to the model catalog (sc-6398)

### DIFF
--- a/apps/web/public/prompt-guides/boogu-image.md
+++ b/apps/web/public/prompt-guides/boogu-image.md
@@ -1,0 +1,97 @@
+# Boogu Image Prompt Guide
+
+## Best For
+
+General-purpose **still images** from natural-language prompts — Boogu-Image-0.1 is a flow-matching
+model (a ~10.3B DiT paired with a Qwen3-VL-8B condition encoder) that reads your prompt as plain
+language, so describe the image the way you'd describe it to a person. It is especially strong at
+**rendering legible text in the image** (signs, labels, posters) in both **English and Chinese**.
+
+> Three variants ship: **Boogu Image** (full quality, true-CFG, ~50 steps), **Boogu Image Turbo**
+> (few-step, ~4 steps, much faster — best for iteration), and **Boogu Image Edit** (instruction-driven
+> editing of a source image). They share prompting style; pick the variant by speed vs. task.
+
+## Task Modes
+
+| Mode | Variant | What it does | Inputs you provide |
+|---|---|---|---|
+| **Text → Image** | Boogu Image / Turbo | Generates an image from the prompt alone. | Prompt |
+| **Image → Image (Edit)** | Boogu Image Edit | Follows a text instruction to edit a source image, keeping its overall content. | Source image + instruction |
+
+Tips per mode:
+
+- **Text → Image:** start with **Turbo** to explore compositions quickly, then switch to the full
+  **Boogu Image** for the final render when you want maximum quality.
+- **Edit:** write the prompt as an *instruction* about what to change ("make it night", "add a red
+  scarf", "turn the sign into a neon sign reading OPEN"), not a full re-description of the image. The
+  source provides the content; the instruction provides the change.
+
+## Prompt Shape
+
+`subject + scene + composition + camera/framing + aesthetic/style`
+
+Boogu reads the whole prompt as intent, so natural descriptive language works better than a pile of
+disconnected tags.
+
+## Build The Prompt
+
+### Subject
+
+Name the main subject and its visible traits (color, material, clothing, expression). One or two clear
+subjects render more coherently than a crowded frame.
+
+### Scene Details
+
+Describe background, foreground, lighting, weather, and time of day. A focused scene reads cleaner.
+
+### Text In The Image
+
+Boogu renders typography well. Put the exact words in quotes and say where they go:
+
+- `a storefront with a neon sign that reads "OPEN 24 HOURS"`
+- `a book cover titled "山海经" in elegant brush calligraphy`
+
+Keep the quoted string short and explicit; long paragraphs of in-image text degrade.
+
+### Composition & Framing
+
+Direct framing language works: `low angle`, `wide shot`, `medium close-up`, `centered subject`,
+`rule of thirds`, `shallow depth of field`, `bokeh background`.
+
+### Style
+
+Concise style labels work well: `cinematic`, `photorealistic`, `watercolor`, `flat illustration`,
+`studio portrait`, `film noir`.
+
+### Negative Prompt (full Boogu Image only)
+
+The full model uses true classifier-free guidance, so a negative prompt helps reduce artifacts:
+`blurry, low quality, distorted hands, extra limbs, watermark, jpeg artifacts, garbled text`. Turbo is
+CFG-free — the negative prompt and guidance scale have no effect there.
+
+## Quality & Speed Notes
+
+- **Resolution:** use a native bucket (1024² / 768×1024 / 1024×768 / 1280×720 / 720×1280); width and
+  height must be multiples of 16. 1024² is the default.
+- **Steps:** Boogu Image ~25–50 (more = cleaner, slower); Boogu Image Turbo ~4 (few-step distilled —
+  more steps rarely help).
+- **Guidance:** Boogu Image ~2–5 (default 4); Turbo ignores guidance (CFG-free).
+- **Quantization:** Q8 is the default (~23 GB, fits a 64 GB-class Mac). The full-precision bf16 build
+  is also hosted for maximum quality if you have the memory.
+- **Count:** keep batches modest while iterating.
+
+## Example Prompts
+
+`A weathered lighthouse on a rocky cliff at golden hour, waves breaking below, gulls in the distance.
+Wide shot, low angle, warm directional light, shallow depth of field. Photorealistic, cinematic.`
+
+`A cozy bakery storefront at dusk, warm window glow, a chalkboard sign that reads "FRESH BREAD".
+Medium shot, centered, soft bokeh. Photorealistic.`
+
+`Edit: change the season to winter — snow on the rooftops, bare trees, cold blue light — keep the
+buildings and street layout.`
+
+## Sources
+
+- [Boogu-Image-0.1 (Hugging Face)](https://huggingface.co/Boogu)
+- [SceneWorks/boogu-image-mlx (MLX weights)](https://huggingface.co/SceneWorks/boogu-image-mlx)

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1001,6 +1001,226 @@
       }
     },
     {
+      "id": "boogu_image",
+      "name": "Boogu Image",
+      "family": "boogu",
+      "type": "image",
+      // Boogu-Image-0.1 Base (epic 6387) — a Lumina-Image-2.0 / OmniGen2-lineage flow-matching image
+      // model: a mixed single/double-stream DiT (hidden 3360, 40 layers = 8 double + 32 single + 2
+      // refiner, GQA 28q/7kv, 3-axis RoPE) + a Qwen3-VL-8B condition encoder + the FLUX.1 16-channel
+      // VAE. Native MLX only (mlx-gen-boogu, no torch backend) → macOnly. True-CFG text-to-image.
+      // Worker routing through engines::MODEL_TABLE / the gen_core registry lands in sc-6399 (until
+      // then macSupport.supported is false — the model is downloadable but not yet a Studio picker).
+      // `adapter` is the asset stamp (mirrors mlx_<family>).
+      "adapter": "mlx_boogu",
+      "capabilities": ["text_to_image"],
+      "macOnly": true,
+      "downloads": [
+        {
+          // Pre-converted MLX turnkey on the SceneWorks HF org (epic 6387 / sc-6397): ONE repo with
+          // Q8 `base/ turbo/ edit/` subfolders (the ship default) + `*-bf16/` full-precision
+          // subfolders. Each subfolder is a complete `transformer/` + `mllm/` (Qwen3-VL + tokenizer)
+          // + `vae/` snapshot loadable via BooguPipeline::from_snapshot. This entry pulls only the Q8
+          // `base/` subfolder (leaf-dir globs — the subfolder nests, so a single-level `base/*` would
+          // miss the files). Apache-2.0, ungated.
+          "provider": "huggingface",
+          "repo": "SceneWorks/boogu-image-mlx",
+          "files": ["base/transformer/*", "base/mllm/*", "base/vae/*"],
+          "platforms": ["macos"],
+          "estimatedSizeBytes": 23380234752
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/SceneWorks/boogu-image-mlx"
+      },
+      "defaults": {
+        // Reference __call__ defaults: 50 steps, true-CFG guidance 4.0 at native 1024² (clean in the
+        // 25-50 step / 2-5 guidance band).
+        "resolution": "1024x1024",
+        "steps": 50,
+        "guidanceScale": 4.0,
+        "count": 1,
+        "sampler": "default",
+        "scheduler": "default"
+      },
+      "limits": {
+        // W×H multiples of 16 (validate_multiple_of_16). Single static-v1 time-shift schedule → one
+        // sampler / scheduler.
+        "resolutions": ["1024x1024", "768x1024", "1024x768", "1280x720", "720x1280"],
+        "count": [1, 2, 4],
+        "samplers": ["default"],
+        "schedulers": ["default"]
+      },
+      "loraCompatibility": {
+        // No Boogu LoRA wired yet (the engine descriptor reports supports_lora: false). Family
+        // reserved for when/if adapters are added.
+        "families": ["boogu"],
+        "types": []
+      },
+      "mlx": {
+        // Pre-quantized turnkey — `base/` ships packed Q8 (group size 32: the DiT hidden 3360 is
+        // divisible by 32, not the usual 64 — E8), so there is NO bf16 load transient and no runtime
+        // quantize. quantize: 8 records the shipped Q8 in the asset recipe. MEASURED Q8 @1024²: ~35.5
+        // GB runtime peak (E8-2, largely activation-bound), so minMemoryGb 64 with headroom. The
+        // `base-bf16/` subfolder is the full-precision opt-in; its selection path is wired with worker
+        // routing (sc-6399).
+        "minMemoryGb": 64,
+        "quantize": 8,
+        "repo": "SceneWorks/boogu-image-mlx"
+      },
+      "licenseUrl": "https://huggingface.co/Boogu/Boogu-Image-0.1-Base",
+      "ui": {
+        "label": "Boogu Image",
+        "description": "Boogu-Image-0.1 — a Lumina-Image-2.0 / OmniGen2-lineage flow-matching text-to-image model (~10.3B DiT + Qwen3-VL-8B condition encoder + FLUX.1 VAE), native MLX (Apple Silicon). True-CFG, natural-language prompting with strong bilingual (English/Chinese) in-image text rendering. Pre-quantized Q8 (~23 GB, default; full-precision bf16 also hosted). Apache-2.0 (ungated). Needs a 64 GB-class Mac.",
+        "recommendedFor": ["text_to_image"],
+        "promptGuide": {
+          "title": "Boogu Image Prompt Guide",
+          "path": "/prompt-guides/boogu-image.md",
+          "sources": [
+            { "label": "Boogu-Image-0.1 (Hugging Face)", "url": "https://huggingface.co/Boogu" },
+            { "label": "SceneWorks/boogu-image-mlx", "url": "https://huggingface.co/SceneWorks/boogu-image-mlx" }
+          ]
+        }
+      }
+    },
+    {
+      "id": "boogu_image_turbo",
+      "name": "Boogu Image Turbo",
+      "family": "boogu",
+      "type": "image",
+      // Boogu-Image-0.1 Turbo (epic 6387) — the DMD few-step, CFG-free distilled variant: same
+      // architecture as Base but ~4 steps and no unconditional branch (guidance inert), so a render is
+      // several times faster — the variant to iterate with. Native MLX only; same gen_core engine
+      // code (BooguPipeline::generate_turbo), the `turbo/` checkpoint.
+      "adapter": "mlx_boogu",
+      "capabilities": ["text_to_image"],
+      "macOnly": true,
+      "downloads": [
+        {
+          // Q8 `turbo/` subfolder of the shared SceneWorks/boogu-image-mlx turnkey (sc-6397).
+          "provider": "huggingface",
+          "repo": "SceneWorks/boogu-image-mlx",
+          "files": ["turbo/transformer/*", "turbo/mllm/*", "turbo/vae/*"],
+          "platforms": ["macos"],
+          "estimatedSizeBytes": 23380234586
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/SceneWorks/boogu-image-mlx"
+      },
+      "defaults": {
+        // Few-step DMD default (4); CFG-free, so guidanceScale is inert (the turbo path never forwards
+        // a guidance value / negative prompt).
+        "resolution": "1024x1024",
+        "steps": 4,
+        "guidanceScale": 0,
+        "count": 1,
+        "sampler": "default",
+        "scheduler": "default"
+      },
+      "limits": {
+        "resolutions": ["1024x1024", "768x1024", "1024x768", "1280x720", "720x1280"],
+        "count": [1, 2, 4],
+        "samplers": ["default"],
+        "schedulers": ["default"]
+      },
+      "loraCompatibility": {
+        "families": ["boogu"],
+        "types": []
+      },
+      "mlx": {
+        // Same pre-quantized Q8 turnkey (turbo/ subfolder, same weights footprint as Base). Few-step +
+        // single forward per step → the lightest Boogu path; minMemoryGb 64 mirrors Base.
+        "minMemoryGb": 64,
+        "quantize": 8,
+        "repo": "SceneWorks/boogu-image-mlx"
+      },
+      "licenseUrl": "https://huggingface.co/Boogu/Boogu-Image-0.1-Turbo",
+      "ui": {
+        "label": "Boogu Image Turbo",
+        "description": "Boogu-Image-0.1 Turbo — the few-step (~4), CFG-free fast variant of Boogu Image: the same ~10.3B flow-matching model distilled (DMD) for much faster renders, native MLX (Apple Silicon). Best for quick iteration. Pre-quantized Q8 (~23 GB, default). Apache-2.0 (ungated). Needs a 64 GB-class Mac.",
+        "recommendedFor": ["text_to_image"],
+        "promptGuide": {
+          "title": "Boogu Image Prompt Guide",
+          "path": "/prompt-guides/boogu-image.md",
+          "sources": [
+            { "label": "Boogu-Image-0.1 (Hugging Face)", "url": "https://huggingface.co/Boogu" },
+            { "label": "SceneWorks/boogu-image-mlx", "url": "https://huggingface.co/SceneWorks/boogu-image-mlx" }
+          ]
+        }
+      }
+    },
+    {
+      "id": "boogu_image_edit",
+      "name": "Boogu Image Edit",
+      "family": "boogu",
+      "type": "image",
+      // Boogu-Image-0.1 Edit (epic 6387) — the instruction image-edit checkpoint: the source image is
+      // routed through the Qwen3-VL VISION tower so the MLLM "sees" it, and a text instruction drives a
+      // faithful semantic edit (BooguPipeline::generate_edit → forward_edit). The vision-tower
+      // semantic edit is an EDIT-checkpoint capability — Base produces incoherent output for it
+      // (verified against the reference pipeline, E7b-3), so editing ships on these dedicated weights
+      // only. Native MLX only; the `edit/` checkpoint (carries the lazily-loaded f32 vision tower).
+      "adapter": "mlx_boogu",
+      "capabilities": ["edit_image"],
+      "macOnly": true,
+      "downloads": [
+        {
+          // Q8 `edit/` subfolder of SceneWorks/boogu-image-mlx (sc-6397).
+          "provider": "huggingface",
+          "repo": "SceneWorks/boogu-image-mlx",
+          "files": ["edit/transformer/*", "edit/mllm/*", "edit/vae/*"],
+          "platforms": ["macos"],
+          "estimatedSizeBytes": 23380234314
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/SceneWorks/boogu-image-mlx"
+      },
+      "defaults": {
+        // Edit mirrors Base __call__: 50 steps, true-CFG guidance 4.0 at 1024². The source image's own
+        // dimensions (multiples of 16) drive the reference latent.
+        "resolution": "1024x1024",
+        "steps": 50,
+        "guidanceScale": 4.0,
+        "count": 1,
+        "sampler": "default",
+        "scheduler": "default"
+      },
+      "limits": {
+        "resolutions": ["1024x1024", "768x1024", "1024x768", "1280x720", "720x1280"],
+        "count": [1, 2, 4],
+        "samplers": ["default"],
+        "schedulers": ["default"]
+      },
+      "loraCompatibility": {
+        "families": ["boogu"],
+        "types": []
+      },
+      "mlx": {
+        // Pre-quantized Q8 turnkey (edit/ subfolder). MEASURED @1024²: Q8 runtime a touch above Base —
+        // the f32 Qwen3-VL vision tower loads lazily on the first edit (Q4 was 29.5 vs 27.1 GB in
+        // E8-2) — still comfortably within 64 GB.
+        "minMemoryGb": 64,
+        "quantize": 8,
+        "repo": "SceneWorks/boogu-image-mlx"
+      },
+      "licenseUrl": "https://huggingface.co/Boogu/Boogu-Image-0.1-Edit",
+      "ui": {
+        "label": "Boogu Image Edit",
+        "description": "Boogu-Image-0.1 Edit — instruction-driven image editing: give a source image and a text instruction and Boogu produces a faithful edited image (the source is read by the Qwen3-VL vision tower). Native MLX (Apple Silicon). Pre-quantized Q8 (~23 GB, default). Apache-2.0 (ungated). Needs a 64 GB-class Mac.",
+        "recommendedFor": ["edit_image"],
+        "promptGuide": {
+          "title": "Boogu Image Prompt Guide",
+          "path": "/prompt-guides/boogu-image.md",
+          "sources": [
+            { "label": "Boogu-Image-0.1 (Hugging Face)", "url": "https://huggingface.co/Boogu" },
+            { "label": "SceneWorks/boogu-image-mlx", "url": "https://huggingface.co/SceneWorks/boogu-image-mlx" }
+          ]
+        }
+      }
+    },
+    {
       "id": "flux2_klein_9b",
       "name": "FLUX.2 [klein] 9B",
       "family": "flux2-klein",


### PR DESCRIPTION
## S1 — SceneWorks catalog/manifest entries + prompt guide (epic 6387)

First SceneWorks-side slice of the Boogu-Image-0.1 native-MLX integration. **Data-only** (no Rust/JS code) — worker routing is S2 (sc-6399).

The engine port (E1–E9) is complete, merged in `mlx-gen`, and the turnkey weights are published at [`SceneWorks/boogu-image-mlx`](https://huggingface.co/SceneWorks/boogu-image-mlx) (Apache-2.0, public).

### What this adds
**`config/manifests/builtin.models.jsonc`** — three image-typed entries (after the Ideogram block):

| id | task | steps / guidance | Q8 subfolder | size |
|---|---|---|---|---|
| `boogu_image` | text-to-image (true-CFG) | 50 / 4.0 | `base/{transformer,mllm,vae}/*` | 23.38 GB |
| `boogu_image_turbo` | text-to-image (DMD few-step) | 4 / CFG-free | `turbo/…` | 23.38 GB |
| `boogu_image_edit` | instruction image edit | 50 / 4.0 | `edit/…` | 23.38 GB |

Common: `family boogu`, `adapter mlx_boogu`, `macOnly`, `mlx.minMemoryGb 64`, `mlx.quantize 8` (Q8 default — the turnkey ships pre-packed Q8), Apache-2.0 ungated, single sampler/scheduler, 1024² + 4 aspect buckets (multiples of 16). Defaults are read from the engine's `*Options::default` (not guessed); `estimatedSizeBytes` are exact bytes from `HfApi.repo_info`. Per-variant **leaf-dir globs** because the variant subfolders nest (`glob::Pattern` `*` doesn't cross `/`).

**`apps/web/public/prompt-guides/boogu-image.md`** (new) — T2I / Turbo / Edit prompting incl. bilingual in-image text rendering; wired via each entry's `ui.promptGuide`.

### Intermediate state (resolved by S2)
Until S2 (sc-6399) adds the three ids to `MLX_ROUTED_MODELS` + an eligibility arm, `model_mac_support` stamps `supported: false` → the entries are **downloadable on the Models page** but are **not yet Studio pickers**.

### Deliberate, tracked choices
- **`recommended` omitted** — story says "TBD on quality"; added after the S5 real-weight e2e.
- **bf16 hosted but not yet user-selectable** — the `*-bf16/` folders exist in-repo (E9); making them a reachable option is worker/UI resolution, folded explicitly into S2's scope (which also got its stale "Q4 default" corrected to Q8).

### Validation
- `node scripts/check-scaffold.mjs` — passed (schema + every model's `ui.promptGuide` present/readable)
- Strict-JSON parse of the real manifest (serde_json-equivalent) — all three entries parse
- `vitest --environment jsdom src/screens/ModelManagerScreen.test.jsx` — 21/21
- `npm run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)