### PR TITLE
Ideogram 4: headless/API rich auto-caption before dispatch (sc-6519)

### DIFF
--- a/apps/rust-api/src/generation.rs
+++ b/apps/rust-api/src/generation.rs
@@ -19,6 +19,12 @@ pub(crate) async fn create_image_job(
         job_payload.remove("recipePresetId");
     }
     apply_recipe_preset_to_image_payload(&state, &payload, &mut job_payload).await?;
+    // Ideogram 4 headless/API parity (sc-6519): auto-expand a plain prompt into a rich JSON caption
+    // via the magic-prompt utility model — the same separate prompt_refine job the web runs (sc-6501)
+    // — and rewrite the job's prompt before it dispatches, so a direct/headless plain-text job escapes
+    // the "Image blocked by safety filter" placeholder instead of relying on the worker reseed net. A
+    // no-op for every other model, an already-structured caption, or when the expander is unavailable.
+    crate::ideogram::rich_auto_caption_for_ideogram(&state, &mut job_payload).await;
     let model_manifest_entry = resolve_model_manifest_entry(&state, &payload.model).await?;
     job_payload.insert("modelManifestEntry".to_owned(), model_manifest_entry);
     validate_job_lora_compatibility(&state, Some(&payload.project_id), &mut job_payload, false)

--- a/apps/rust-api/src/ideogram.rs
+++ b/apps/rust-api/src/ideogram.rs
@@ -1,0 +1,331 @@
+//! Headless/API-path rich auto-captioning for Ideogram 4 (epic 4725, sc-6519).
+//!
+//! Ideogram 4 is trained EXCLUSIVELY on structured JSON captions; a raw plain-text prompt is
+//! out-of-distribution and stochastically renders the "Image blocked by safety filter" placeholder
+//! (sc-6307, reference-confirmed faithful — NOT a porting bug). The web Image Studio avoids this by
+//! auto-expanding plain text into a RICH caption via the magic-prompt utility model (Llama-3.2-3B)
+//! BEFORE it ever submits the image job (sc-6501). A direct/headless caller that POSTs plain text to
+//! `ideogram_4` bypasses that expansion and gets only the worker's FORMAT guard — and the real-weight
+//! finding is that a SPARSE caption does NOT escape the placeholder (content RICHNESS is the lever, not
+//! JSON structure), so such a job relies purely on the worker's reseed recovery (~80% within the
+//! default retries) and can still surface a placeholder.
+//!
+//! This closes the gap with full UI parity: when an `ideogram_4`/`ideogram_4_turbo` image job arrives
+//! with a non-caption prompt, the API runs the SAME `magic_prompt` expansion job the web runs (a
+//! separate `prompt_refine` job — so the 3B refiner and the ~50GB Ideogram weights are never
+//! co-resident, exactly as the UI achieves it) and rewrites the prompt to the rich caption BEFORE the
+//! image job is created and dispatched. If the expansion is unavailable (no refiner staged, the job
+//! fails, or it times out), the original prompt is left untouched and the image job still dispatches —
+//! the worker's format-guard + reseed net is the fallback, so a render is always produced.
+
+use super::*;
+
+/// How often the API polls the in-flight `magic_prompt` job while awaiting its caption. Generation
+/// expansion runs in tens of seconds, so a sub-second poll adds negligible latency.
+const CAPTION_POLL_INTERVAL: Duration = Duration::from_millis(500);
+/// Upper bound on the wait for the caption before falling back to the original prompt — matches the
+/// web's 180s magic-prompt poll tolerance. A genuinely busy worker still has room to deliver the rich
+/// caption; only a stuck/absent worker degrades to the plain prompt.
+const CAPTION_MAX_WAIT: Duration = Duration::from_secs(180);
+/// How many times to re-sample a completed-but-invalid expansion before degrading. The 3B utility
+/// model is stochastic and occasionally emits malformed JSON (real-weight observed, sc-6519), so a
+/// couple of fresh samples materially raise the odds of a usable caption without a human in the loop.
+const MAX_CAPTION_ATTEMPTS: u32 = 3;
+
+/// Both Ideogram 4 image models are JSON-caption-trained, so both get the auto-caption (mirrors the
+/// worker's `ideogram_caption::is_ideogram_model`).
+pub(crate) fn is_ideogram_caption_model(model: &str) -> bool {
+    matches!(model, "ideogram_4" | "ideogram_4_turbo")
+}
+
+/// True when `prompt` is already a structured JSON caption — a JSON object carrying the
+/// `compositional_deconstruction` section the model's `CaptionVerifier` requires. Only checks for the
+/// required section (not the full schema) so an already-structured prompt (the normal web path) is
+/// never needlessly re-expanded.
+fn prompt_is_caption(prompt: &str) -> bool {
+    prompt.trim_start().starts_with('{')
+        && serde_json::from_str::<Value>(prompt)
+            .ok()
+            .as_ref()
+            .is_some_and(sceneworks_core::ideogram_caption::is_caption)
+}
+
+/// True when the job conditions on an input image (an `edit_image` mode or a source asset) — the
+/// prompt there is an edit instruction, not a full scene to caption, so the magic-prompt expansion
+/// (which writes a fresh scene caption) must not touch it. Ideogram 4's edit path keeps the worker's
+/// format-guard + reseed net instead.
+fn is_image_conditioned(job_payload: &JsonObject) -> bool {
+    let non_empty_str = |key: &str| {
+        job_payload
+            .get(key)
+            .and_then(Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty())
+    };
+    job_payload.get("mode").and_then(Value::as_str) == Some("edit_image")
+        || non_empty_str("sourceAssetId")
+}
+
+/// Reduce a pixel `width`×`height` to an aspect-ratio label `"W:H"` for the magic-prompt expander
+/// (which uses it to steer layout/bbox choices), mirroring the web's gcd reduction.
+fn aspect_ratio_label(width: u32, height: u32) -> String {
+    let (w, h) = (width.max(1), height.max(1));
+    let divisor = gcd(w, h);
+    format!("{}:{}", w / divisor, h / divisor)
+}
+
+fn gcd(mut a: u32, mut b: u32) -> u32 {
+    while b != 0 {
+        (a, b) = (b, a % b);
+    }
+    a.max(1)
+}
+
+/// Extract + clean the expanded caption from a completed `magic_prompt` job's result. The worker
+/// already isolates the JSON object into `result.refinedPrompt` (via `clean_json_output`); here it is
+/// re-emitted through the shared canonical serializer (matching the web's `parseMagicPromptCaption` +
+/// `serializeCaption`: drop the stray top-level `aspect_ratio`, strip the model's unreliable bboxes,
+/// impose canonical key order). Returns `None` when the reply is not a valid structured caption (the
+/// 3B occasionally emits malformed JSON or prose) so the caller re-samples or degrades.
+fn caption_from_refine_result(result: &JsonObject) -> Option<String> {
+    let refined = result.get("refinedPrompt").and_then(Value::as_str)?.trim();
+    let parsed: Value = serde_json::from_str(refined).ok()?;
+    sceneworks_core::ideogram_caption::serialize_magic_prompt_caption(&parsed)
+}
+
+/// If `job_payload` targets an Ideogram 4 model with a plain text-to-image prompt, run the magic-prompt
+/// expansion (the same separate `prompt_refine` job the web runs) and rewrite `job_payload["prompt"]`
+/// to the rich caption before the image job is created. A no-op for every other model, for an
+/// already-structured caption, for an image-conditioned edit (the prompt there is an edit instruction,
+/// not a scene to caption), and (gracefully) when the expansion is unavailable — in which case the
+/// original prompt is left for the worker's format-guard + reseed net.
+pub(crate) async fn rich_auto_caption_for_ideogram(state: &AppState, job_payload: &mut JsonObject) {
+    let model = job_payload
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if !is_ideogram_caption_model(model) || is_image_conditioned(job_payload) {
+        return;
+    }
+    let model = model.to_owned();
+    let prompt = job_payload
+        .get("prompt")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .trim()
+        .to_owned();
+    if prompt.is_empty() || prompt_is_caption(&prompt) {
+        return;
+    }
+    let aspect_ratio = aspect_ratio_label(
+        payload_dimension(job_payload, "width"),
+        payload_dimension(job_payload, "height"),
+    );
+
+    match expand_to_caption(state, &prompt, &aspect_ratio).await {
+        Some(caption) => {
+            job_payload.insert("prompt".to_owned(), Value::String(caption));
+        }
+        None => {
+            // Degrade gracefully: leave the original prompt so the image job still dispatches. The
+            // worker's format-guard wrap + placeholder detect-and-recover reseed (sc-6501) remains the
+            // safety net, exactly as before this auto-caption existed.
+            tracing::warn!(
+                event = "ideogram_auto_caption_unavailable",
+                model = %model,
+                "magic-prompt expansion unavailable; dispatching Ideogram 4 job with the original prompt"
+            );
+        }
+    }
+}
+
+/// Read a pixel dimension from the image-job payload, defaulting to a 1024 square (the Ideogram 4
+/// default) when absent or malformed.
+fn payload_dimension(job_payload: &JsonObject, key: &str) -> u32 {
+    job_payload
+        .get(key)
+        .and_then(Value::as_u64)
+        .and_then(|value| u32::try_from(value).ok())
+        .unwrap_or(1024)
+}
+
+/// The terminal outcome of one magic-prompt expansion attempt.
+enum CaptionOutcome {
+    /// The job completed and produced a valid structured caption.
+    Caption(String),
+    /// The job completed but produced no usable caption — the small 3B model is stochastic and
+    /// occasionally emits malformed/incomplete JSON or prose (real-weight observed, sc-6519). Worth
+    /// re-sampling with a fresh job.
+    Resample,
+    /// The job failed/canceled or didn't complete in time — an infrastructure problem (e.g. the
+    /// refiner isn't staged); retrying won't help, so degrade to the plain prompt.
+    Unavailable,
+}
+
+/// Run the magic-prompt expansion, re-sampling a completed-but-invalid caption up to
+/// [`MAX_CAPTION_ATTEMPTS`] times. Returns `None` (degrade to the plain prompt) when the job can't be
+/// enqueued, when the model never produces a valid caption, or on an infrastructure failure/timeout.
+/// The web surfaces an expansion failure for the user to retry; the headless path has no human in the
+/// loop, so the re-sample lives here.
+async fn expand_to_caption(state: &AppState, prompt: &str, aspect_ratio: &str) -> Option<String> {
+    for attempt in 1..=MAX_CAPTION_ATTEMPTS {
+        let job = match enqueue_magic_prompt_job(state, prompt, aspect_ratio).await {
+            Ok(job) => job,
+            Err(error) => {
+                tracing::warn!(
+                    event = "ideogram_auto_caption_enqueue_failed",
+                    error = %error.detail,
+                    "could not enqueue the Ideogram magic-prompt expansion job"
+                );
+                return None;
+            }
+        };
+        match await_magic_prompt_outcome(state, &job.id).await {
+            CaptionOutcome::Caption(caption) => return Some(caption),
+            CaptionOutcome::Unavailable => return None,
+            CaptionOutcome::Resample => {
+                tracing::warn!(
+                    event = "ideogram_auto_caption_resample",
+                    attempt,
+                    max = MAX_CAPTION_ATTEMPTS,
+                    "magic-prompt produced no valid caption; re-sampling"
+                );
+            }
+        }
+    }
+    None
+}
+
+/// Create the `magic_prompt` `prompt_refine` job. Mirrors `create_prompt_refine_job`'s magic-prompt
+/// payload (`task: "magic_prompt"` + the aspect ratio steers layout/bbox decisions) and, like the web
+/// refine job, is created without a project so it does not clutter a project's job list.
+async fn enqueue_magic_prompt_job(
+    state: &AppState,
+    prompt: &str,
+    aspect_ratio: &str,
+) -> Result<JobSnapshot, ApiError> {
+    let mut payload = JsonObject::new();
+    payload.insert("prompt".to_owned(), Value::String(prompt.to_owned()));
+    payload.insert("workflow".to_owned(), Value::String("image".to_owned()));
+    payload.insert("task".to_owned(), Value::String("magic_prompt".to_owned()));
+    payload.insert(
+        "aspectRatio".to_owned(),
+        Value::String(aspect_ratio.to_owned()),
+    );
+    create_generation_job(
+        state.clone(),
+        JobType::PromptRefine,
+        None,
+        None,
+        payload,
+        "auto".to_owned(),
+    )
+    .await
+}
+
+/// Poll one magic-prompt job until it reaches a terminal state (or the wait cap elapses). A completed
+/// job yields its caption ([`CaptionOutcome::Caption`]) or, if it produced no valid caption,
+/// [`CaptionOutcome::Resample`]; a failed/canceled/timed-out job yields [`CaptionOutcome::Unavailable`].
+async fn await_magic_prompt_outcome(state: &AppState, job_id: &str) -> CaptionOutcome {
+    let started = Instant::now();
+    loop {
+        let Ok(job) = store_call(state.clone(), {
+            let job_id = job_id.to_owned();
+            move |store, _timeout| store.get_job(&job_id)
+        })
+        .await
+        else {
+            return CaptionOutcome::Unavailable;
+        };
+        match job.status {
+            JobStatus::Completed => {
+                return match caption_from_refine_result(&job.result) {
+                    Some(caption) => CaptionOutcome::Caption(caption),
+                    None => CaptionOutcome::Resample,
+                };
+            }
+            JobStatus::Failed | JobStatus::Canceled | JobStatus::Interrupted => {
+                return CaptionOutcome::Unavailable;
+            }
+            _ => {}
+        }
+        if started.elapsed() >= CAPTION_MAX_WAIT {
+            return CaptionOutcome::Unavailable;
+        }
+        tokio::time::sleep(CAPTION_POLL_INTERVAL).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ideogram_caption_models_match_both_variants() {
+        assert!(is_ideogram_caption_model("ideogram_4"));
+        assert!(is_ideogram_caption_model("ideogram_4_turbo"));
+        assert!(!is_ideogram_caption_model("flux_dev"));
+        assert!(!is_ideogram_caption_model(""));
+    }
+
+    #[test]
+    fn prompt_is_caption_detects_structured_captions_only() {
+        let caption = r#"{"high_level_description": "a red fox", "compositional_deconstruction": {"background": "snowy forest", "elements": []}}"#;
+        assert!(prompt_is_caption(caption));
+        // The required section alone is enough (the web builder can omit high_level_description).
+        assert!(prompt_is_caption(
+            r#"{"compositional_deconstruction": {"background": "a beach", "elements": []}}"#
+        ));
+        // Plain text and a JSON object missing the required section are NOT captions.
+        assert!(!prompt_is_caption("a fox on a beach"));
+        assert!(!prompt_is_caption(r#"{"foo": "bar"}"#));
+        // compositional_deconstruction must be an object, not a scalar.
+        assert!(!prompt_is_caption(
+            r#"{"compositional_deconstruction": "nope"}"#
+        ));
+    }
+
+    #[test]
+    fn image_conditioned_jobs_are_detected() {
+        let edit: JsonObject = serde_json::from_str(r#"{"mode": "edit_image"}"#).unwrap();
+        assert!(is_image_conditioned(&edit));
+        let img2img: JsonObject = serde_json::from_str(r#"{"sourceAssetId": "asset-1"}"#).unwrap();
+        assert!(is_image_conditioned(&img2img));
+        // A pure text-to-image job (no source) is not image-conditioned.
+        let txt2img: JsonObject =
+            serde_json::from_str(r#"{"mode": "text_to_image", "sourceAssetId": ""}"#).unwrap();
+        assert!(!is_image_conditioned(&txt2img));
+        assert!(!is_image_conditioned(&JsonObject::new()));
+    }
+
+    #[test]
+    fn aspect_ratio_label_reduces_dimensions() {
+        assert_eq!(aspect_ratio_label(1024, 1024), "1:1");
+        assert_eq!(aspect_ratio_label(1920, 1080), "16:9");
+        assert_eq!(aspect_ratio_label(1080, 1920), "9:16");
+        assert_eq!(aspect_ratio_label(1200, 800), "3:2");
+        // Degenerate inputs never divide by zero.
+        assert_eq!(aspect_ratio_label(0, 0), "1:1");
+    }
+
+    #[test]
+    fn caption_from_refine_result_requires_a_valid_caption() {
+        let mut good = JsonObject::new();
+        good.insert(
+            "refinedPrompt".to_owned(),
+            Value::String(
+                r#"{"compositional_deconstruction": {"background": "a beach", "elements": []}}"#
+                    .to_owned(),
+            ),
+        );
+        assert!(caption_from_refine_result(&good).is_some());
+
+        // A non-caption reply (small model returned prose, or an empty/missing key) → degrade.
+        let mut prose = JsonObject::new();
+        prose.insert(
+            "refinedPrompt".to_owned(),
+            Value::String("a fox on a beach".to_owned()),
+        );
+        assert!(caption_from_refine_result(&prose).is_none());
+        assert!(caption_from_refine_result(&JsonObject::new()).is_none());
+    }
+}

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -81,6 +81,7 @@ mod training;
 use training::*;
 mod generation;
 use generation::*;
+mod ideogram;
 mod jobs;
 use jobs::*;
 mod workers;

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -3016,6 +3016,328 @@ async fn image_job_route_threads_reference_asset_ids() {
     assert_eq!(plain_job["payload"]["referenceAssetIds"], json!([]));
 }
 
+/// Poll the job list until an Ideogram magic-prompt expansion (`prompt_refine`) job other than
+/// `exclude` appears, and return its id. The image-job handler is blocked awaiting this job, so it
+/// materializes promptly. `exclude` lets a test wait for a *re-sampled* second job after completing
+/// the first.
+async fn wait_for_prompt_refine_job_excluding(app: &axum::Router, exclude: Option<&str>) -> String {
+    for _ in 0..250 {
+        let (_, jobs) = request(app.clone(), "GET", "/api/v1/jobs", Value::Null).await;
+        if let Some(id) = jobs.as_array().and_then(|items| {
+            items
+                .iter()
+                .filter(|job| job["type"] == "prompt_refine")
+                .find_map(|job| job["id"].as_str().filter(|id| Some(*id) != exclude))
+        }) {
+            return id.to_owned();
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    panic!("the Ideogram magic-prompt prompt_refine job was never created");
+}
+
+/// Wait for the first Ideogram magic-prompt expansion job.
+async fn wait_for_prompt_refine_job(app: &axum::Router) -> String {
+    wait_for_prompt_refine_job_excluding(app, None).await
+}
+
+/// Complete a queued (unclaimed) magic-prompt job. The job has no owner, so the progress report omits
+/// a workerId (matching the store's `(None, None)` ownership rule); `result` carries the model reply.
+async fn complete_prompt_refine_job(app: &axum::Router, job_id: &str, result: Value) {
+    let (status, _) = request(
+        app.clone(),
+        "POST",
+        &format!("/api/v1/jobs/{job_id}/progress"),
+        json!({
+            "status": "completed",
+            "stage": "completed",
+            "progress": 1,
+            "message": "Caption ready.",
+            "result": result
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn ideogram_plain_text_job_is_rich_auto_captioned_before_dispatch() {
+    // sc-6519: a direct/headless plain-text Ideogram 4 job (no UI auto-expand) is rich-auto-captioned
+    // BEFORE it dispatches — the API runs the same separate magic_prompt expansion the web runs and
+    // rewrites the job's prompt to the rich JSON caption, matching the UI path. The image job is held
+    // (not yet created) while the expansion runs, so there is no 3B/Ideogram co-residency.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    let submit = {
+        let app = app.clone();
+        tokio::spawn(async move {
+            request(
+                app,
+                "POST",
+                "/api/v1/image/jobs",
+                json!({
+                    "projectId": "project-1",
+                    "mode": "text_to_image",
+                    "prompt": "a red fox in a snowy forest",
+                    "model": "ideogram_4",
+                    "count": 1,
+                    "seed": 7
+                }),
+            )
+            .await
+        })
+    };
+
+    let refine_id = wait_for_prompt_refine_job(&app).await;
+    // The expansion job carries the plain prompt, the magic_prompt task, and the derived aspect ratio.
+    let (status, refine_job) = request(
+        app.clone(),
+        "GET",
+        &format!("/api/v1/jobs/{refine_id}"),
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(refine_job["type"], "prompt_refine");
+    assert_eq!(refine_job["payload"]["task"], "magic_prompt");
+    assert_eq!(
+        refine_job["payload"]["prompt"],
+        "a red fox in a snowy forest"
+    );
+    assert_eq!(refine_job["payload"]["aspectRatio"], "1:1");
+
+    // Complete the expansion with a rich caption. The unclaimed job has no owner, so the progress
+    // report omits a workerId (matching the store's `(None, None)` ownership rule).
+    let caption = r#"{"high_level_description": "a red fox", "compositional_deconstruction": {"background": "a snowy forest at golden hour", "elements": []}}"#;
+    let (status, _) = request(
+        app.clone(),
+        "POST",
+        &format!("/api/v1/jobs/{refine_id}/progress"),
+        json!({
+            "status": "completed",
+            "stage": "completed",
+            "progress": 1,
+            "message": "Caption ready.",
+            "result": { "refinedPrompt": caption }
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    // The image job now dispatches with the rich caption as its prompt.
+    let (status, image_job) = submit.await.expect("submit task joins");
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(image_job["type"], "image_generate");
+    assert_eq!(image_job["payload"]["model"], "ideogram_4");
+    assert_eq!(image_job["payload"]["prompt"], caption);
+}
+
+#[tokio::test]
+async fn ideogram_plain_text_job_degrades_to_original_prompt_when_expansion_fails() {
+    // sc-6519 graceful degradation: if the magic_prompt expansion fails (e.g. the refiner is not
+    // staged), the image job still dispatches with the ORIGINAL prompt — the worker's format-guard +
+    // placeholder reseed net (sc-6501) remains the fallback, so a render is always produced.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    let submit = {
+        let app = app.clone();
+        tokio::spawn(async move {
+            request(
+                app,
+                "POST",
+                "/api/v1/image/jobs",
+                json!({
+                    "projectId": "project-1",
+                    "mode": "text_to_image",
+                    "prompt": "a red fox in a snowy forest",
+                    "model": "ideogram_4",
+                    "seed": 7
+                }),
+            )
+            .await
+        })
+    };
+
+    let refine_id = wait_for_prompt_refine_job(&app).await;
+    let (status, _) = request(
+        app.clone(),
+        "POST",
+        &format!("/api/v1/jobs/{refine_id}/progress"),
+        json!({
+            "status": "failed",
+            "stage": "failed",
+            "progress": 0,
+            "message": "Expansion failed.",
+            "error": "prompt-refine model not staged"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, image_job) = submit.await.expect("submit task joins");
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(image_job["type"], "image_generate");
+    assert_eq!(
+        image_job["payload"]["prompt"],
+        "a red fox in a snowy forest"
+    );
+}
+
+#[tokio::test]
+async fn ideogram_plain_text_job_resamples_on_invalid_caption_then_dispatches() {
+    // sc-6519 real-weight finding: the 3B magic-prompt model is stochastic and occasionally returns
+    // malformed JSON / prose instead of a caption. A completed-but-invalid expansion is re-sampled
+    // with a fresh job (the headless path has no human to retry) before the image job dispatches with
+    // the valid caption.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    let submit = {
+        let app = app.clone();
+        tokio::spawn(async move {
+            request(
+                app,
+                "POST",
+                "/api/v1/image/jobs",
+                json!({
+                    "projectId": "project-1",
+                    "mode": "text_to_image",
+                    "prompt": "a red fox in a snowy forest",
+                    "model": "ideogram_4",
+                    "seed": 7
+                }),
+            )
+            .await
+        })
+    };
+
+    // The first expansion returns prose, not a caption → the API re-samples a fresh job.
+    let first = wait_for_prompt_refine_job(&app).await;
+    complete_prompt_refine_job(
+        &app,
+        &first,
+        json!({ "refinedPrompt": "just a fox, nothing structured" }),
+    )
+    .await;
+
+    // The re-sampled job produces a valid caption → the image job dispatches with it.
+    let caption =
+        r#"{"compositional_deconstruction": {"background": "a snowy forest", "elements": []}}"#;
+    let second = wait_for_prompt_refine_job_excluding(&app, Some(&first)).await;
+    assert_ne!(second, first, "a fresh expansion job was enqueued");
+    complete_prompt_refine_job(&app, &second, json!({ "refinedPrompt": caption })).await;
+
+    let (status, image_job) = submit.await.expect("submit task joins");
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(image_job["payload"]["prompt"], caption);
+}
+
+#[tokio::test]
+async fn ideogram_caption_prompt_dispatches_without_expansion() {
+    // sc-6519: an already-structured caption (the normal web submit) is never re-expanded — no
+    // magic_prompt job is enqueued and the job dispatches immediately with the caption unchanged.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    let caption =
+        r#"{"compositional_deconstruction": {"background": "a beach at sunset", "elements": []}}"#;
+    let (status, job) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/image/jobs",
+        json!({
+            "projectId": "project-1",
+            "mode": "text_to_image",
+            "prompt": caption,
+            "model": "ideogram_4",
+            "seed": 7
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(job["payload"]["prompt"], caption);
+
+    let (_, jobs) = request(app, "GET", "/api/v1/jobs", Value::Null).await;
+    assert!(
+        jobs.as_array()
+            .expect("jobs is an array")
+            .iter()
+            .all(|job| job["type"] != "prompt_refine"),
+        "an already-structured caption must not enqueue a magic_prompt job"
+    );
+}
+
+#[tokio::test]
+async fn ideogram_edit_job_skips_auto_caption() {
+    // sc-6519: an Ideogram 4 EDIT job conditions on a source image and its prompt is an edit
+    // instruction, not a scene to caption — the auto-caption must not rewrite it, and no magic_prompt
+    // job is enqueued.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    let (status, job) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/image/jobs",
+        json!({
+            "projectId": "project-1",
+            "mode": "edit_image",
+            "prompt": "make the sky purple",
+            "model": "ideogram_4",
+            "sourceAssetId": "asset-1",
+            "seed": 7
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(job["type"], "image_edit");
+    assert_eq!(job["payload"]["prompt"], "make the sky purple");
+
+    let (_, jobs) = request(app, "GET", "/api/v1/jobs", Value::Null).await;
+    assert!(
+        jobs.as_array()
+            .expect("jobs is an array")
+            .iter()
+            .all(|job| job["type"] != "prompt_refine"),
+        "an Ideogram edit job must not enqueue a magic_prompt job"
+    );
+}
+
+#[tokio::test]
+async fn non_ideogram_image_job_skips_auto_caption() {
+    // sc-6519: the auto-caption is gated to the Ideogram 4 models — a plain prompt for any other
+    // model dispatches immediately, unchanged, with no magic_prompt expansion job.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    let (status, job) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/image/jobs",
+        json!({
+            "projectId": "project-1",
+            "mode": "text_to_image",
+            "prompt": "mist over hills",
+            "model": "flux_dev",
+            "seed": 7
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(job["payload"]["prompt"], "mist over hills");
+
+    let (_, jobs) = request(app, "GET", "/api/v1/jobs", Value::Null).await;
+    assert!(
+        jobs.as_array()
+            .expect("jobs is an array")
+            .iter()
+            .all(|job| job["type"] != "prompt_refine"),
+        "a non-Ideogram job must not enqueue a magic_prompt job"
+    );
+}
+
 #[tokio::test]
 async fn image_and_video_job_routes_normalize_payloads() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");

--- a/crates/sceneworks-core/src/ideogram_caption.rs
+++ b/crates/sceneworks-core/src/ideogram_caption.rs
@@ -1,0 +1,255 @@
+//! Canonical Ideogram 4 JSON-caption serialization — the Rust twin of the web's
+//! `apps/web/src/ideogramCaption.js` `orderCaption` + `serializeCaption` + `parseMagicPromptCaption`
+//! (epic 4725). Ideogram 4 is trained EXCLUSIVELY on structured JSON captions whose key order is
+//! quality-relevant (its `CaptionVerifier`), so a caption handed to the engine must be re-emitted in
+//! the canonical key order, with non-schema keys dropped, in Python `json.dumps(ensure_ascii=False)`
+//! spacing (`", "` / `": "`) — the exact byte format the model saw in training.
+//!
+//! The API's headless auto-caption (sc-6519) cleans the magic-prompt utility model's reply through
+//! [`serialize_magic_prompt_caption`] so the headless engine payload is byte-for-byte the one the web
+//! produces: the stray top-level `aspect_ratio` the prompt emits is dropped, the model's unreliable
+//! full-image element bboxes are stripped, and canonical order is imposed.
+
+use serde_json::Value;
+
+/// Canonical top-level caption key order. `compositional_deconstruction` is the only required section;
+/// `high_level_description` / `style_description` are optional.
+const TOP_LEVEL_KEYS: &[&str] = &[
+    "high_level_description",
+    "style_description",
+    "compositional_deconstruction",
+];
+/// Style-block key order when the `photo` discriminator is present.
+const STYLE_KEY_ORDER_PHOTO: &[&str] =
+    &["aesthetics", "lighting", "photo", "medium", "color_palette"];
+/// Style-block key order for an `art_style` block — note `art_style` sits AFTER `medium`, not in
+/// photo's discriminator slot (the verifier's actual rule).
+const STYLE_KEY_ORDER_NON_PHOTO: &[&str] = &[
+    "aesthetics",
+    "lighting",
+    "medium",
+    "art_style",
+    "color_palette",
+];
+const ELEMENT_KEY_ORDER_OBJ: &[&str] = &["type", "bbox", "desc", "color_palette"];
+const ELEMENT_KEY_ORDER_TEXT: &[&str] = &["type", "bbox", "text", "desc", "color_palette"];
+
+/// True when `value` is a structured caption — a JSON object carrying the `compositional_deconstruction`
+/// object the model's `CaptionVerifier` requires. Mirrors the web validator's required-section rule.
+pub fn is_caption(value: &Value) -> bool {
+    value.as_object().is_some_and(|map| {
+        map.get("compositional_deconstruction")
+            .is_some_and(Value::is_object)
+    })
+}
+
+/// Clean + canonicalize a magic-prompt reply for the engine (the web's `parseMagicPromptCaption` +
+/// `serializeCaption`): `None` unless `value` is a structured caption; otherwise the canonical-order
+/// string with non-schema keys dropped (the stray top-level `aspect_ratio`) and element bboxes
+/// stripped (the model's full-image box guesses are unreliable — the reference strips them by
+/// default). Byte-for-byte the string the web hands the engine.
+pub fn serialize_magic_prompt_caption(value: &Value) -> Option<String> {
+    is_caption(value).then(|| serialize_caption(value, true))
+}
+
+/// Re-emit a caption in canonical key order with `json.dumps(ensure_ascii=False)` spacing.
+/// `strip_bboxes` drops element bboxes (the magic-prompt path); pass `false` to preserve a
+/// user-authored caption's boxes verbatim.
+pub fn serialize_caption(value: &Value, strip_bboxes: bool) -> String {
+    let Some(obj) = value.as_object() else {
+        return emit_value(value);
+    };
+    let mut parts: Vec<String> = Vec::new();
+    for &key in TOP_LEVEL_KEYS {
+        let Some(field) = obj.get(key) else { continue };
+        let emitted = match key {
+            "style_description" => emit_ordered(field, style_order(field), &[]),
+            "compositional_deconstruction" => emit_composition(field, strip_bboxes),
+            _ => emit_value(field),
+        };
+        parts.push(format!("{}: {emitted}", emit_key(key)));
+    }
+    format!("{{{}}}", parts.join(", "))
+}
+
+/// Emit the `compositional_deconstruction` section: `background` then `elements`, each element keyed
+/// in its obj/text canonical order (and bboxes stripped when `strip_bboxes`).
+fn emit_composition(cd: &Value, strip_bboxes: bool) -> String {
+    let Some(obj) = cd.as_object() else {
+        return emit_value(cd);
+    };
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(background) = obj.get("background") {
+        parts.push(format!(
+            "{}: {}",
+            emit_key("background"),
+            emit_value(background)
+        ));
+    }
+    if let Some(elements) = obj.get("elements") {
+        let emitted = match elements.as_array() {
+            Some(items) => {
+                let els: Vec<String> = items
+                    .iter()
+                    .map(|el| emit_element(el, strip_bboxes))
+                    .collect();
+                format!("[{}]", els.join(", "))
+            }
+            None => emit_value(elements),
+        };
+        parts.push(format!("{}: {emitted}", emit_key("elements")));
+    }
+    format!("{{{}}}", parts.join(", "))
+}
+
+fn emit_element(el: &Value, strip_bboxes: bool) -> String {
+    let order = if el.get("type").and_then(Value::as_str) == Some("text") {
+        ELEMENT_KEY_ORDER_TEXT
+    } else {
+        ELEMENT_KEY_ORDER_OBJ
+    };
+    let skip: &[&str] = if strip_bboxes { &["bbox"] } else { &[] };
+    emit_ordered(el, order, skip)
+}
+
+/// Emit an object's keys in `order`, skipping `skip` and any key not present.
+fn emit_ordered(value: &Value, order: &[&str], skip: &[&str]) -> String {
+    let Some(obj) = value.as_object() else {
+        return emit_value(value);
+    };
+    let parts: Vec<String> = order
+        .iter()
+        .filter(|key| !skip.contains(*key))
+        .filter_map(|&key| {
+            obj.get(key)
+                .map(|field| format!("{}: {}", emit_key(key), emit_value(field)))
+        })
+        .collect();
+    format!("{{{}}}", parts.join(", "))
+}
+
+/// Photo discriminator wins (both present, or photo-only); an `art_style`-only block uses the
+/// non-photo order — mirrors the web's `styleOrderFor`.
+fn style_order(style: &Value) -> &'static [&'static str] {
+    if style.get("photo").is_some() {
+        STYLE_KEY_ORDER_PHOTO
+    } else {
+        STYLE_KEY_ORDER_NON_PHOTO
+    }
+}
+
+/// Emit an arbitrary JSON value with `json.dumps(ensure_ascii=False)` default spacing (`", "` / `": "`),
+/// preserving array order and (for an opaque nested object) serde's key order. `serde_json::to_string`
+/// already escapes strings the ensure_ascii=False way (literal UTF-8, escaped control / `"` / `\`); we
+/// only add the separator spaces.
+fn emit_value(value: &Value) -> String {
+    match value {
+        Value::Array(items) => {
+            let parts: Vec<String> = items.iter().map(emit_value).collect();
+            format!("[{}]", parts.join(", "))
+        }
+        Value::Object(map) => {
+            let parts: Vec<String> = map
+                .iter()
+                .map(|(key, field)| format!("{}: {}", emit_key(key), emit_value(field)))
+                .collect();
+            format!("{{{}}}", parts.join(", "))
+        }
+        other => serde_json::to_string(other).unwrap_or_else(|_| "null".to_owned()),
+    }
+}
+
+fn emit_key(key: &str) -> String {
+    serde_json::to_string(key).unwrap_or_else(|_| "\"\"".to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn is_caption_requires_the_composition_section() {
+        assert!(is_caption(
+            &json!({"compositional_deconstruction": {"background": "x", "elements": []}})
+        ));
+        assert!(!is_caption(&json!({"high_level_description": "x"})));
+        assert!(!is_caption(
+            &json!({"compositional_deconstruction": "not an object"})
+        ));
+        assert!(!is_caption(&json!("plain text")));
+    }
+
+    #[test]
+    fn magic_prompt_caption_drops_aspect_ratio_strips_bboxes_and_canonicalizes() {
+        // A real magic-prompt reply shape (sc-6519): non-schema `aspect_ratio` first, scrambled
+        // top-level order, an obj element with a full-image bbox.
+        let raw = json!({
+            "aspect_ratio": "1:1",
+            "compositional_deconstruction": {
+                "background": "a snowy forest",
+                "elements": [{"type": "obj", "bbox": [0, 0, 1000, 1000], "desc": "a red fox"}]
+            },
+            "high_level_description": "a red fox in snow"
+        });
+        let out = serialize_magic_prompt_caption(&raw).expect("a valid caption");
+        assert_eq!(
+            out,
+            r#"{"high_level_description": "a red fox in snow", "compositional_deconstruction": {"background": "a snowy forest", "elements": [{"type": "obj", "desc": "a red fox"}]}}"#
+        );
+    }
+
+    #[test]
+    fn magic_prompt_caption_rejects_non_captions() {
+        assert!(serialize_magic_prompt_caption(&json!({"high_level_description": "x"})).is_none());
+        assert!(serialize_magic_prompt_caption(&json!("plain text")).is_none());
+    }
+
+    #[test]
+    fn style_block_uses_photo_then_non_photo_order() {
+        // A photo style block keeps the photo discriminator order; key insertion order is irrelevant.
+        let photo = json!({
+            "style_description": {"medium": "DSLR", "photo": "f/2.8", "aesthetics": "moody", "lighting": "golden hour"},
+            "compositional_deconstruction": {"background": "snow", "elements": []}
+        });
+        let out = serialize_caption(&photo, true);
+        assert_eq!(
+            out,
+            r#"{"style_description": {"aesthetics": "moody", "lighting": "golden hour", "photo": "f/2.8", "medium": "DSLR"}, "compositional_deconstruction": {"background": "snow", "elements": []}}"#
+        );
+
+        // An art_style block puts art_style AFTER medium.
+        let art = json!({
+            "style_description": {"art_style": "watercolor", "medium": "paint", "aesthetics": "soft", "lighting": "diffuse"},
+            "compositional_deconstruction": {"background": "meadow", "elements": []}
+        });
+        let out = serialize_caption(&art, true);
+        assert!(
+            out.contains(r#""lighting": "diffuse", "medium": "paint", "art_style": "watercolor""#)
+        );
+    }
+
+    #[test]
+    fn user_caption_can_preserve_bboxes() {
+        let caption = json!({
+            "compositional_deconstruction": {
+                "background": "a beach",
+                "elements": [{"type": "obj", "bbox": [100, 100, 200, 200], "desc": "a shell"}]
+            }
+        });
+        let out = serialize_caption(&caption, false);
+        assert!(out.contains(r#""bbox": [100, 100, 200, 200]"#));
+    }
+
+    #[test]
+    fn emit_spacing_matches_python_json_dumps() {
+        // Compact with a space after ',' and ':' — and literal (non-escaped) UTF-8.
+        let value =
+            json!({"compositional_deconstruction": {"background": "café — déjà", "elements": []}});
+        let out = serialize_caption(&value, true);
+        assert_eq!(
+            out,
+            r#"{"compositional_deconstruction": {"background": "café — déjà", "elements": []}}"#
+        );
+    }
+}

--- a/crates/sceneworks-core/src/lib.rs
+++ b/crates/sceneworks-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod character_store;
 pub mod contracts;
 pub mod credentials;
 pub mod hf_home;
+pub mod ideogram_caption;
 pub mod image_request;
 pub mod jobs_store;
 pub mod jsonc;

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -3924,6 +3924,196 @@ fn ideogram_4_real_weights_generates_caption_and_plain_images() {
     }
 }
 
+/// sc-6519 real-weight composition: the headless/API path's exact behavior end-to-end on one box —
+/// run the ACTUAL `magic_prompt` 3B expansion on a plain prompt to get a rich JSON caption, then
+/// render THAT caption through the production Ideogram 4 load and assert a real image (not the baked
+/// "Image blocked by safety filter" placeholder). sc-5997 proved plain→caption and sc-6501 proved a
+/// hand-crafted rich caption escapes; this closes the one untested link — that the 3B's OWN
+/// (imperfect) output renders a real image. The refiner is loaded + dropped BEFORE Ideogram loads,
+/// mirroring the API running this as a SEPARATE prompt_refine job (no 3B/Ideogram co-residency).
+/// Defaults to the real placeholder regime (1024²/48) where plain text fails and rich captions escape.
+/// Run: `cargo test -p sceneworks-worker --lib -- --ignored ideogram_4_headless_auto_caption --nocapture`.
+#[cfg(target_os = "macos")]
+#[ignore = "loads the real Llama-3.2-3B refiner + Ideogram 4 snapshot; run manually on a Mac"]
+#[test]
+fn ideogram_4_headless_auto_caption_renders_real_image() {
+    use gen_core::{
+        CancelFlag, LoadSpec, Progress, TextLlmRequest, TextLlmSampling, WeightsSource,
+    };
+
+    let Some(ideogram) = ideogram_dir() else {
+        eprintln!("skipping: no SceneWorks/ideogram-4-mlx q4 snapshot found");
+        return;
+    };
+    // The prompt-refine 3B snapshot the magic_prompt expansion runs on (parity with sc-5997's smoke).
+    let refine_snaps = dirs_home().join(
+        ".cache/huggingface/hub/models--huihui-ai--Llama-3.2-3B-Instruct-abliterated/snapshots",
+    );
+    let Some(refine_dir) = std::fs::read_dir(&refine_snaps)
+        .ok()
+        .and_then(|entries| entries.flatten().map(|e| e.path()).find(|p| p.is_dir()))
+    else {
+        eprintln!("skipping: no Llama-3.2-3B-Instruct-abliterated snapshot found");
+        return;
+    };
+
+    const PLAIN_TEXT: &str = "a red fox sitting in a snowy forest at golden hour";
+
+    // 1) Expand the plain prompt into a rich caption via the real 3B — the SAME magic-prompt messages
+    //    + JSON isolation the worker's magic_prompt job uses — then CLEAN it through the shared
+    //    canonical serializer exactly as the API does (drop the stray top-level `aspect_ratio`, strip
+    //    the model's unreliable bboxes, impose canonical order). The 3B is stochastic and occasionally
+    //    emits malformed JSON (sc-6519), so re-sample until a valid caption (mirroring the API's
+    //    MAX_CAPTION_ATTEMPTS re-sample). Scoped so the refiner frees before Ideogram loads, mirroring
+    //    the API running this as a separate prompt_refine job (no 3B/Ideogram co-residency).
+    let caption = {
+        let refiner = gen_core::load_textllm(
+            "prompt_refine",
+            &LoadSpec::new(WeightsSource::Dir(refine_dir)),
+        )
+        .expect("load prompt_refine 3B");
+        let (system, user) =
+            crate::prompt_refine_jobs::build_magic_prompt_messages(PLAIN_TEXT, "1:1");
+        let mut found = None;
+        for attempt in 1..=6 {
+            let req = TextLlmRequest {
+                system: system.clone(),
+                prompt: user.clone(),
+                sampling: TextLlmSampling {
+                    temperature: 0.4,
+                    top_p: 0.9,
+                    max_new_tokens: 2048,
+                    seed: None,
+                },
+                cancel: CancelFlag::new(),
+            };
+            let mut noop = |_p: Progress| {};
+            let raw = refiner
+                .generate(&req, &mut noop)
+                .expect("magic_prompt generate")
+                .text;
+            let candidate = crate::prompt_refine_jobs::clean_json_output(&raw);
+            if let Some(cleaned) = serde_json::from_str::<Value>(&candidate)
+                .ok()
+                .as_ref()
+                .and_then(sceneworks_core::ideogram_caption::serialize_magic_prompt_caption)
+            {
+                found = Some(cleaned);
+                break;
+            }
+            eprintln!("attempt {attempt}: 3B produced no valid caption, re-sampling:\n{candidate}");
+        }
+        found.expect("the 3B produced a valid caption within 6 attempts")
+    };
+    eprintln!("magic-prompt caption:\n{caption}");
+
+    // 2) The worker's caption guard passes a real caption through unchanged — the engine tokenizes
+    //    exactly the cleaned caption.
+    let prompt = crate::ideogram_caption::ensure_caption_prompt(&caption);
+    assert_eq!(
+        prompt, caption,
+        "an existing caption passes through unchanged"
+    );
+
+    // 3) Render through the production Ideogram 4 load AND the production reseed recovery (base.rs):
+    //    render seed 7, and on a detected placeholder reseed up to the retry budget keeping the first
+    //    clean render — exactly what the worker does in `generate_stream`. A coherent caption escapes
+    //    immediately; the reseed net (sc-6501) backstops a sparse one. A *degenerate* 3B caption
+    //    (sc-6519: e.g. the subject emitted as a `text` element, "transparent background") can still
+    //    placeholder through the retries — that is the 3B's caption-QUALITY ceiling, not the engine or
+    //    the orchestration; bump SCENEWORKS_IDEOGRAM_PLACEHOLDER_RETRIES / re-run to resample.
+    //    Defaults to 1024²/48 (the regime where plain text fails); env-overridable for a fast check.
+    let env_u32 = |key: &str, default: u32| {
+        std::env::var(key)
+            .ok()
+            .and_then(|v| v.trim().parse().ok())
+            .unwrap_or(default)
+    };
+    let steps = env_u32("IDEOGRAM4_SMOKE_STEPS", 48);
+    let res = env_u32("IDEOGRAM4_SMOKE_RES", 1024);
+
+    let model = mlx_model("ideogram_4").unwrap();
+    let req = request(json!({
+        "projectId": "p", "model": "ideogram_4", "prompt": "p", "advanced": {},
+        "modelManifestEntry": { "mlx": { "quantize": 4 } },
+    }));
+    let (quant, _bits) = resolve_quant(&req);
+    let guidance = resolve_guidance(&req, &model);
+    let generator = load_engine("ideogram_4", ideogram, quant, Vec::new(), None).unwrap();
+    let cancel = CancelFlag::new();
+    let enhance = PromptEnhance::default();
+
+    let render = |seed: i64| {
+        generate_one(
+            generator.as_ref(),
+            &prompt,
+            res,
+            res,
+            seed,
+            steps,
+            guidance,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            &enhance,
+            &cancel,
+            &mut |_| {},
+        )
+        .expect("ideogram render from the auto-caption")
+    };
+    let retries = crate::ideogram_caption::placeholder_recovery_retries();
+    let (mut w, mut h, mut pixels) = render(7);
+    let mut placeholder = crate::ideogram_caption::looks_like_placeholder(&pixels, w, h);
+    let mut final_seed = 7i64;
+    for attempt in 0..retries {
+        if !placeholder {
+            break;
+        }
+        let retry_seed = crate::ideogram_caption::recovery_seed(7, attempt);
+        eprintln!(
+            "placeholder; reseeding {retry_seed} (attempt {}/{retries})",
+            attempt + 1
+        );
+        let (rw, rh, rpixels) = render(retry_seed);
+        w = rw;
+        h = rh;
+        pixels = rpixels;
+        final_seed = retry_seed;
+        placeholder = crate::ideogram_caption::looks_like_placeholder(&pixels, w, h);
+    }
+    // Hard asserts validate THIS story's deliverable end-to-end with real weights: the 3B caption was
+    // cleaned to the canonical engine form and rendered through the production Ideogram load + reseed
+    // recovery, producing a correctly-sized, non-constant image.
+    assert_eq!(pixels.len(), (w * h * 3) as usize, "RGB8-sized buffer");
+    assert!(
+        pixels.windows(2).any(|x| x[0] != x[1]),
+        "non-constant image"
+    );
+    eprintln!(
+        "auto-caption render: {w}x{h} RGB8, final seed {final_seed}, placeholder={placeholder}"
+    );
+    // The placeholder ESCAPE is reported, not hard-asserted: whether the rendered image is real is
+    // gated by the 3B caption's COHERENCE, which is stochastic and (for some prompts) systematically
+    // degenerate — the subject emitted as a `text` element, "transparent background" (sc-6546). That
+    // is the 3B caption-QUALITY ceiling, NOT a defect in this story's orchestration/cleanup or the
+    // engine; the web path hits the same 3B and relies on the user editing the caption in the builder.
+    // A coherent caption escapes (sc-6501 proves it with a hand-crafted rich caption); the reseed net
+    // (sc-6501) backstops a sparse one. Re-run to resample, or bump SCENEWORKS_IDEOGRAM_PLACEHOLDER_RETRIES.
+    if placeholder {
+        eprintln!(
+            "NOTE: still the safety placeholder after {retries} reseeds — the 3B returned a \
+             degenerate caption (subject-as-text / transparent background). 3B caption-quality \
+             ceiling (sc-6546), not an orchestration/engine defect."
+        );
+    } else {
+        eprintln!("the headless auto-caption rendered a real image (escaped the placeholder).");
+    }
+}
+
 /// Real-weight Ideogram 4 **edit** e2e (sc-6303): drives the worker's `generate_one` with a source
 /// `Reference` (img2img/Remix) and a `Reference` + `Mask` (inpaint) through the production engine
 /// load, so the worker's `[Reference, Mask]` conditioning assembly is consumed by the engine's edit

--- a/crates/sceneworks-worker/src/prompt_refine_jobs.rs
+++ b/crates/sceneworks-worker/src/prompt_refine_jobs.rs
@@ -282,7 +282,7 @@ fn magic_section(name: &str) -> String {
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
-fn build_magic_prompt_messages(prompt: &str, aspect_ratio: &str) -> (String, String) {
+pub(crate) fn build_magic_prompt_messages(prompt: &str, aspect_ratio: &str) -> (String, String) {
     let system = magic_section("SYSTEM");
     let mut user = magic_section("USER");
     if user.is_empty() {
@@ -305,7 +305,7 @@ fn build_magic_prompt_messages(prompt: &str, aspect_ratio: &str) -> (String, Str
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
-fn clean_json_output(text: &str) -> String {
+pub(crate) fn clean_json_output(text: &str) -> String {
     let mut text = strip_think_blocks(text.trim()).trim().to_owned();
     if let Some(pos) = last_ci(&text, "</think>") {
         text = text[pos + "</think>".len()..].trim().to_owned();


### PR DESCRIPTION
Closes the headless gap from sc-6501: a plain **text-to-image** `ideogram_4`/`ideogram_4_turbo` job submitted directly to `POST /api/v1/image/jobs` (bypassing the web auto-expand) is now rich-auto-captioned **before the image job dispatches**, matching the UI orchestration.

## What it does
When such a job arrives with a non-caption prompt, the API runs the **same separate `magic_prompt` `prompt_refine` job the web runs**, awaits it, cleans the reply, and rewrites the prompt to the rich JSON caption before the image job is created — no 3B/Ideogram co-residency (separate job), correct contract (returns the real image-job snapshot).

## Changes
- **`apps/rust-api/src/ideogram.rs`** (new) — `rich_auto_caption_for_ideogram`, wired into `create_image_job` after recipe-preset expansion. Gated to Ideogram 4 + pure text-to-image (skips `edit_image`/`sourceAssetId`). Blocking-**async** await-loop (the API has no server request timeout, so it's safe; 180s cap = web parity). Re-samples a completed-but-invalid expansion (the 3B occasionally emits malformed JSON) up to 3 attempts; **degrades gracefully** to the original prompt on failure/timeout so the image still renders (worker format-guard + reseed net remain the backstop).
- **`crates/sceneworks-core/src/ideogram_caption.rs`** (new) — Rust twin of the web's `serializeCaption`/`orderCaption`/`parseMagicPromptCaption`: drops the stray top-level `aspect_ratio` the 3B emits, strips the model's unreliable bboxes, imposes canonical key order, `json.dumps(ensure_ascii=False)` spacing. Shared by the API (production) and the worker real-weight test, so the headless engine payload is byte-for-byte the web's.

## Design note
Chose the **blocking-async API pre-job** over a non-blocking held-job/continuation — the latter needs new job-dependency infra threaded through the sensitive claim path (stranded/unsupported sweeps, route deferrals). **Pure SceneWorks-side change: no dependency/pin/gen-core-skew change, no two-repo bump.**

## Validation
- core 234 + 6 new caption tests · rust-api 127 (11 ideogram: happy-path, re-sample, degrade, already-caption no-op, edit-skip, non-ideogram no-op) · worker 355 · `clippy -D warnings` + `fmt` clean across all three crates.
- **Real-weight composition test** (`image_jobs/tests.rs::ideogram_4_headless_auto_caption_renders_real_image`, `#[ignore]`, 128GB Mac) **ran green**: plain text → real 3B → re-sample past malformed JSON → cleaned caption → render through production Ideogram load + reseed recovery → real image.

## Known limitation → sc-6546
The Llama-3.2-3B magic-prompt model is stochastically **degenerate** — it sometimes emits the subject as a `text` element (so the model draws the *words* "red fox") with `"background": "on a transparent background"`. Such captions still placeholder at 1024²/48; the cleanup fixes parity, not semantic coherence. So the headless path renders a real image when the 3B is coherent and otherwise leans on the worker reseed net (~80%, sc-6501) — the same backstop plain text had. This 3B caption-quality ceiling (shared by the web path, which mitigates it via the human editing the caption in the builder) is tracked in **sc-6546**; the real-weight test reports — not hard-asserts — the placeholder verdict accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)