### PR TITLE
sc-6560: backend-neutral GPU routing log events (off-Mac no longer reads as "MLX missing")

### DIFF
--- a/apps/rust-api/src/jobs.rs
+++ b/apps/rust-api/src/jobs.rs
@@ -215,17 +215,17 @@ fn emit_candle_unavailable(job: &JobSnapshot) {
     );
 }
 
-/// Emit the MLX↔torch routing decision as a structured JSON line on the API's stdout
+/// Emit the GPU routing decision as a structured JSON line on the API's stdout
 /// (sc-3449). The desktop wrapper captures this into `api.log` + the in-app Logs buffer,
-/// so an MLX-eligible job that lands on torch is explained at claim time rather than
-/// inferred from archaeology. Shape mirrors the worker's `emit_worker_event` events
+/// so *which backend ran a job* is explained at claim time rather than inferred from
+/// archaeology. Shape mirrors the worker's `emit_worker_event` events
 /// (`event` + `reportedAt` + payload).
 fn emit_route_decision(decision: &RouteDecision) {
     let mut value = serde_json::to_value(decision).unwrap_or_else(|_| json!({}));
     if let Some(object) = value.as_object_mut() {
         object.insert(
             "event".to_owned(),
-            Value::String("mlx_route_decision".to_owned()),
+            Value::String("gpu_route_decision".to_owned()),
         );
     }
     // Emitted through the tracing backbone: the stdout JSON layer reaches the desktop

--- a/apps/rust-api/src/logs.rs
+++ b/apps/rust-api/src/logs.rs
@@ -38,9 +38,9 @@ mod tests {
         api_session_log().push_line(
             "api",
             &json!({
-                "event": "mlx_route_decision",
-                "decision": "fell_back_to_torch",
-                "reason": "no_idle_mlx_worker",
+                "event": "gpu_route_decision",
+                "decision": "claimed_by_candle",
+                "reason": "candle_worker",
                 "model": marker,
                 "level": "info",
                 "reportedAt": "2026-06-07T00:00:00Z"
@@ -53,7 +53,7 @@ mod tests {
         });
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].source, "api");
-        assert!(hits[0].message.contains("decision=fell_back_to_torch"));
+        assert!(hits[0].message.contains("decision=claimed_by_candle"));
         assert!(hits[0].event.is_some());
     }
 }

--- a/apps/web/src/screens/LogsScreen.jsx
+++ b/apps/web/src/screens/LogsScreen.jsx
@@ -4,8 +4,8 @@ import { apiFetch } from "../api.js";
 import { useAppContext } from "../context/AppContext.js";
 
 // In-app Logs viewer (sc-3452). Shows the current session's activity — most
-// importantly the MLX↔torch routing decisions (`mlx_route_decision`) and claim
-// contention (`claim_lock_contention`) — so "why did this run on MPS not MLX?" is
+// importantly the GPU routing decisions (`gpu_route_decision`) and claim
+// contention (`claim_lock_contention`) — so "which backend ran this job?" is
 // answerable from inside the app instead of by tailing ~/Library/Logs/SceneWorks.
 //
 // Data source: on the desktop the rich multi-source buffer (api + worker +
@@ -20,7 +20,7 @@ const POLL_MS = 2000;
 const MAX_ROWS = 2000;
 
 // Events that answer the routing question get visual emphasis.
-const HIGHLIGHT_EVENTS = new Set(["mlx_route_decision", "claim_lock_contention"]);
+const HIGHLIGHT_EVENTS = new Set(["gpu_route_decision", "claim_lock_contention"]);
 
 async function fetchLogs(token, { afterSeq, limit, source, level, search }) {
   if (isDesktop) {

--- a/apps/web/src/screens/LogsScreen.test.jsx
+++ b/apps/web/src/screens/LogsScreen.test.jsx
@@ -39,8 +39,8 @@ describe("LogsScreen", () => {
         0,
         "api",
         "info",
-        "mlx_route_decision decision=fell_back_to_torch reason=no_idle_mlx_worker model=qwen_image_edit_2511_lightning",
-        { event: "mlx_route_decision", decision: "fell_back_to_torch", reason: "no_idle_mlx_worker" },
+        "gpu_route_decision decision=claimed_by_candle reason=candle_worker model=ltx_2_3",
+        { event: "gpu_route_decision", decision: "claimed_by_candle", reason: "candle_worker" },
       ),
       row(1, "worker", "error", "image_inference_failed error=boom", { event: "image_inference_failed", error: "boom" }),
       row(2, "mlx-worker", "info", "claimed jobId=j1", { event: "claimed", jobId: "j1" }),
@@ -70,7 +70,7 @@ describe("LogsScreen", () => {
   it("renders captured log entries with their messages", async () => {
     await render();
     expect(container.querySelectorAll(".logs-row").length).toBe(3);
-    expect(container.textContent).toContain("fell_back_to_torch");
+    expect(container.textContent).toContain("claimed_by_candle");
     expect(container.textContent).toContain("image_inference_failed");
   });
 
@@ -78,7 +78,7 @@ describe("LogsScreen", () => {
     await render();
     const highlighted = container.querySelector(".logs-row.highlighted");
     expect(highlighted).toBeTruthy();
-    expect(highlighted.textContent).toContain("fell_back_to_torch");
+    expect(highlighted.textContent).toContain("claimed_by_candle");
   });
 
   it("requests server-side filtering when a source is selected", async () => {

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -1223,7 +1223,7 @@ impl JobsStore {
         )?;
         let job = self.get_job_on_connection(&transaction, &queued.id)?;
         transaction.commit()?;
-        let decision = route_decision_for_claim(&queued, &worker_gpu_id, worker_id);
+        let decision = route_decision_for_claim(&queued, &worker);
         Ok((Some(job), decision))
     }
 
@@ -1971,9 +1971,11 @@ fn is_non_gpu_job_type(job_type: &str) -> bool {
     NON_GPU_JOB_TYPES.contains(&job_type)
 }
 
-/// The MLX↔torch routing decision for a single claim, emitted as a structured log
-/// event (`mlx_route_decision`) by the API so operators can see *why* a job ran where
-/// it did (sc-3449) — the line that answers "why did this MLX-eligible job run on torch?".
+/// The GPU routing decision for a single claim, emitted as a structured log event
+/// (`gpu_route_decision`) by the API so operators can see *which backend ran a job, and
+/// why* (sc-3449). Every label is named after the backend that actually claimed the job,
+/// never as a deficiency: on Windows/Linux a candle (CUDA) claim is the normal happy path,
+/// so the line must never read like an MLX worker is missing.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct RouteDecision {
     pub job_id: String,
@@ -1982,10 +1984,11 @@ pub struct RouteDecision {
     pub requested_gpu: String,
     pub worker_id: String,
     pub gpu_id: String,
-    /// `deferred_to_mlx` | `claimed_by_mlx` | `fell_back_to_torch` | `explicit_gpu`.
+    /// `deferred_to_mlx` | `claimed_by_mlx` | `claimed_by_candle` | `claimed_by_gpu` |
+    /// `explicit_gpu`.
     pub decision: &'static str,
-    /// Machine-readable cause: `idle_mlx_available`, `mlx_worker`, `no_idle_mlx_worker`,
-    /// or `explicit_gpu`.
+    /// Machine-readable cause: `idle_mlx_available`, `mlx_worker`, `candle_worker`,
+    /// `gpu_worker`, or `explicit_gpu`.
     pub reason: &'static str,
 }
 
@@ -3170,21 +3173,24 @@ fn classify_convert_gap(payload: &Map<String, Value>) -> Result<(), UnsupportedR
     ))
 }
 
-/// Classify a *successful* claim for routing observability. `None` means the claim was
-/// routing-neutral (the job is not MLX-eligible, so no `mlx` worker would have wanted
-/// it). When a non-`mlx` worker claims an MLX-eligible job, the reason distinguishes a
-/// user pinning a specific GPU (`explicit_gpu`) from the case the team cares about — no
-/// idle `mlx` worker was available to take it (`fell_back_to_torch`/`no_idle_mlx_worker`).
-/// The deferral path (a non-mlx worker yielding to an idle mlx worker) is reported
-/// separately inside `claim_next_job_routed` as `deferred_to_mlx`.
-fn route_decision_for_claim(
-    job: &JobSnapshot,
-    gpu_id: &str,
-    worker_id: &str,
-) -> Option<RouteDecision> {
+/// Classify a *successful* claim for routing observability, named after the backend that
+/// actually took the job. `None` means the claim was routing-neutral (nothing an `mlx`
+/// worker would ever want, so there is nothing to explain). Every label describes what
+/// happened, never a deficiency: an `mlx` worker claim is `claimed_by_mlx`, a candle
+/// (Windows/Linux CUDA) claim is `claimed_by_candle`, and a user-pinned GPU is
+/// `explicit_gpu`. Candle is identified by the `candle` capability marker
+/// (`worker_is_candle`) — it runs on a real GPU index, so `gpu_id` alone can't distinguish
+/// it. Any other GPU worker falls to the generic `claimed_by_gpu` catch-all: with the
+/// Python torch worker retired from every surface, nothing else should claim these jobs, so
+/// the label names no specific backend. The deferral path (a non-mlx worker yielding to an
+/// idle mlx worker on Mac) is reported separately inside `claim_next_job_routed` as
+/// `deferred_to_mlx`.
+fn route_decision_for_claim(job: &JobSnapshot, worker: &WorkerSnapshot) -> Option<RouteDecision> {
     if !job_is_any_mlx_eligible(job) {
         return None;
     }
+    let gpu_id = worker.gpu_id.as_str();
+    let worker_id = worker.id.as_str();
     if gpu_id.eq_ignore_ascii_case("mlx") {
         return Some(RouteDecision::new(
             job,
@@ -3194,21 +3200,36 @@ fn route_decision_for_claim(
             "mlx_worker",
         ));
     }
-    if job.requested_gpu == "auto" {
+    // An explicit (non-`auto`) GPU pin is always honoured as the user asked.
+    if job.requested_gpu != "auto" {
+        return Some(RouteDecision::new(
+            job,
+            gpu_id,
+            worker_id,
+            "explicit_gpu",
+            "explicit_gpu",
+        ));
+    }
+    // An `auto` claim by a non-mlx GPU worker. On Windows/Linux the candle (CUDA) lane is
+    // the expected home, not a fallback. The `else` is a defensive catch-all for any other
+    // GPU worker — with the Python torch worker retired from every surface it should not
+    // fire in practice, so it is named generically rather than after a backend that no
+    // longer exists.
+    if worker_is_candle(worker) {
         Some(RouteDecision::new(
             job,
             gpu_id,
             worker_id,
-            "fell_back_to_torch",
-            "no_idle_mlx_worker",
+            "claimed_by_candle",
+            "candle_worker",
         ))
     } else {
         Some(RouteDecision::new(
             job,
             gpu_id,
             worker_id,
-            "explicit_gpu",
-            "explicit_gpu",
+            "claimed_by_gpu",
+            "gpu_worker",
         ))
     }
 }
@@ -3565,7 +3586,7 @@ fn image_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
     // type (`run_image_generate_job`), and the per-model arms below already gate
     // `edit_image` (qwen/flux2/sdxl edit → eligible; torch-only edit models aren't
     // in `MLX_ROUTED_MODELS` → torch). Without `image_edit` in this gate, plain
-    // Image Edit fell through to torch silently with no `mlx_route_decision`
+    // Image Edit fell through to torch silently with no `gpu_route_decision`
     // (sc-3513).
     if !matches!(job.job_type, JobType::ImageGenerate | JobType::ImageEdit) {
         return false;

--- a/crates/sceneworks-core/src/session_log.rs
+++ b/crates/sceneworks-core/src/session_log.rs
@@ -1,8 +1,8 @@
 //! In-memory session log buffer (epic 3447 / sc-3451, sc-3453).
 //!
 //! A bounded ring buffer of captured output lines that the app can read back to
-//! show "what happened this session" — most importantly the MLX↔torch routing
-//! decisions (`mlx_route_decision`), claim contention (`claim_lock_contention`)
+//! show "what happened this session" — most importantly the GPU routing
+//! decisions (`gpu_route_decision`), claim contention (`claim_lock_contention`)
 //! and the worker generation phases — without log-archaeology across the three
 //! append-only files in `~/Library/Logs/SceneWorks/`.
 //!
@@ -24,7 +24,7 @@ use crate::time::utc_now;
 /// One captured log line, tagged with its origin and severity (the **declared**
 /// `level` from the tracing backbone when present, else inferred), plus the parsed
 /// structured event when the line was a JSON object (the worker's `emit_worker_event`
-/// output or the API's `mlx_route_decision`).
+/// output or the API's `gpu_route_decision`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LogEntry {
@@ -334,9 +334,9 @@ mod tests {
         log.push_line(
             "api",
             &json!({
-                "event": "mlx_route_decision",
-                "decision": "fell_back_to_torch",
-                "reason": "no_idle_mlx_worker",
+                "event": "gpu_route_decision",
+                "decision": "claimed_by_candle",
+                "reason": "candle_worker",
                 "model": "qwen_image_edit_2511_lightning",
                 "jobId": "job_1",
                 "reportedAt": "2026-06-07T00:00:00Z"
@@ -349,9 +349,9 @@ mod tests {
         assert_eq!(entry.source, "api");
         assert_eq!(entry.level, "info");
         assert_eq!(entry.timestamp, "2026-06-07T00:00:00Z");
-        assert!(entry.message.contains("mlx_route_decision"));
-        assert!(entry.message.contains("decision=fell_back_to_torch"));
-        assert!(entry.message.contains("reason=no_idle_mlx_worker"));
+        assert!(entry.message.contains("gpu_route_decision"));
+        assert!(entry.message.contains("decision=claimed_by_candle"));
+        assert!(entry.message.contains("reason=candle_worker"));
         assert!(entry.event.is_some());
     }
 
@@ -368,7 +368,7 @@ mod tests {
         // A declared error level is honored even when the text has no error markers.
         log.push_line(
             "api",
-            &json!({ "event": "mlx_route_decision", "level": "error" }).to_string(),
+            &json!({ "event": "gpu_route_decision", "level": "error" }).to_string(),
         );
         // No declared level -> fall back to the heuristic (legacy / Python worker line).
         log.push_line(

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -2966,10 +2966,13 @@ fn fail_unsupported_mlx_jobs_noop_when_warn_or_off() {
 // sc-3449 — claim_next_job_routed reports *why* an MLX-eligible job landed where it did.
 
 #[test]
-fn routing_decision_reports_fell_back_to_torch_with_no_mlx_worker() {
-    let store = store("route-decision-fallback");
-    // No mlx worker registered — the diagnostic case from the qwen-lightning report.
-    register_gpu_worker(&store, "worker-torch", "cuda:0", image_caps());
+fn routing_decision_reports_claimed_by_gpu_for_uncategorized_worker() {
+    let store = store("route-decision-gpu");
+    // Defensive catch-all: a GPU worker that is neither `mlx` nor candle (no `candle` marker)
+    // claims an MLX-eligible auto job. With the Python torch worker retired from every surface
+    // this should not happen in practice, so the decision is named generically
+    // (`claimed_by_gpu`) rather than after a backend that no longer exists.
+    register_gpu_worker(&store, "worker-gpu", "cuda:0", image_caps());
     let job = store
         .create_job(image_job_with(
             json!({
@@ -2983,17 +2986,41 @@ fn routing_decision_reports_fell_back_to_torch_with_no_mlx_worker() {
         .expect("job creates");
 
     let (claimed, decision) = store
-        .claim_next_job_routed("worker-torch", false)
-        .expect("torch claim ok");
-    assert_eq!(claimed.expect("torch claims it").id, job.id);
+        .claim_next_job_routed("worker-gpu", false)
+        .expect("gpu claim ok");
+    assert_eq!(claimed.expect("gpu worker claims it").id, job.id);
     let decision = decision.expect("routing decision present");
-    assert_eq!(decision.decision, "fell_back_to_torch");
-    assert_eq!(decision.reason, "no_idle_mlx_worker");
+    assert_eq!(decision.decision, "claimed_by_gpu");
+    assert_eq!(decision.reason, "gpu_worker");
     assert_eq!(decision.gpu_id, "cuda:0");
     assert_eq!(
         decision.model.as_deref(),
         Some("qwen_image_edit_2511_lightning")
     );
+}
+
+#[test]
+fn routing_decision_reports_claimed_by_candle() {
+    let store = store("route-decision-candle");
+    // The Windows/Linux happy path: the candle (CUDA) worker — identified by the `candle`
+    // capability marker, on a real gpu index ("0") — claims an MLX-eligible auto job. The
+    // decision names candle, never "fell back to torch": nothing is missing here.
+    register_candle_worker(&store, "worker-candle");
+    let job = store
+        .create_job(image_job_with(
+            json!({ "model": "z_image_turbo", "prompt": "p" }),
+            "auto",
+        ))
+        .expect("job creates");
+
+    let (claimed, decision) = store
+        .claim_next_job_routed("worker-candle", false)
+        .expect("candle claim ok");
+    assert_eq!(claimed.expect("candle claims it").id, job.id);
+    let decision = decision.expect("routing decision present");
+    assert_eq!(decision.decision, "claimed_by_candle");
+    assert_eq!(decision.reason, "candle_worker");
+    assert_eq!(decision.gpu_id, "0");
 }
 
 #[test]
@@ -3066,7 +3093,7 @@ fn routing_decision_is_none_for_non_mlx_model() {
 // engine dispatches edits on payload model+mode, not job type, so the edit-capable families
 // (qwen/flux2/sdxl) must route to the in-process mlx worker exactly like the generate flow;
 // torch-only edit models stay on torch. Before sc-3513 the routing gate excluded every
-// non-ImageGenerate type, so these jobs ran on torch silently with no `mlx_route_decision`.
+// non-ImageGenerate type, so these jobs ran on torch silently with no `gpu_route_decision`.
 
 #[test]
 fn qwen_image_edit_job_type_defers_to_mlx_worker() {
@@ -3258,7 +3285,7 @@ fn routing_decision_reports_claimed_by_mlx_for_image_edit() {
         ))
         .expect("job creates");
 
-    // The fix makes the claim non-routing-neutral: an mlx_route_decision is now emitted.
+    // The fix makes the claim non-routing-neutral: a gpu_route_decision is now emitted.
     let (claimed, decision) = store
         .claim_next_job_routed("worker-mlx", false)
         .expect("mlx claim ok");
@@ -3303,7 +3330,7 @@ fn torch_only_image_model_stays_on_torch() {
     assert_eq!(claimed.assigned_gpu.as_deref(), Some("mps"));
     assert!(
         decision.is_none(),
-        "a torch-only image model is routing-neutral (no mlx_route_decision)"
+        "a torch-only image model is routing-neutral (no gpu_route_decision)"
     );
 }
 

--- a/crates/sceneworks-worker/ARCHITECTURE.md
+++ b/crates/sceneworks-worker/ARCHITECTURE.md
@@ -48,7 +48,7 @@ Routing is by **capability advertisement**, not by queue or static config:
 4. CPU-utility kinds (`NON_GPU_JOB_TYPES`: `model_download`, `model_import`,
    `model_convert`, `lora_import`) never route to GPU workers.
 5. Route decisions are logged (`RouteDecision`:
-   `deferred_to_mlx | claimed_by_mlx | fell_back_to_torch | explicit_gpu`).
+   `deferred_to_mlx | claimed_by_mlx | claimed_by_candle | claimed_by_gpu | explicit_gpu`).
 
 > "Rust ✅" in the matrix means **"in its capable configuration"** — CPU-utility
 > off macOS, MLX GPU on macOS. Off-macOS, GPU arms in `lib.rs` are

--- a/crates/sceneworks-worker/src/generator_cache.rs
+++ b/crates/sceneworks-worker/src/generator_cache.rs
@@ -157,7 +157,7 @@ fn run_generator_cache_worker(rx: mpsc::Receiver<GeneratorJob>, idle_timeout: Op
                     // Documented event (docs/observability.md): expected idle-timeout
                     // eviction, so info level with the engine + idle window.
                     tracing::info!(
-                        event = "mlx_generator_cache_idle_evicted",
+                        event = "generator_cache_idle_evicted",
                         engine = %key.engine_id,
                         idleSeconds = idle_timeout.map_or(0, |timeout| timeout.as_secs()),
                     );

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -11,7 +11,7 @@ to a per-process file under the platform log dir (`apps/desktop/src/setup.rs::lo
 
 | File | Process | Content |
 | --- | --- | --- |
-| `api.log` | `sceneworks-api` | API events incl. `mlx_route_decision`, plus axum/startup output |
+| `api.log` | `sceneworks-api` | API events incl. `gpu_route_decision`, plus axum/startup output |
 | `worker.log` | Python torch worker | `emit_worker_event` JSON (load/lora/inference + `backend`) |
 | `mlx-worker.log` | Rust MLX GPU worker | `claim_lock_contention`, `image_inference_*`, supervisor events |
 
@@ -72,7 +72,7 @@ persisted or surfaced.
 
 **System → Logs** (`apps/web/src/screens/LogsScreen.jsx`). Read-only, live-tailing,
 filter by source (api / worker / mlx-worker) and level (info / warn / error), free-text
-search. Routing (`mlx_route_decision`) and contention (`claim_lock_contention`) events
+search. Routing (`gpu_route_decision`) and contention (`claim_lock_contention`) events
 are visually highlighted. Click a row to expand its raw structured event.
 
 Data source:
@@ -92,21 +92,24 @@ shape minus the declared `level`). `LogEntry` reads the declared `level` when pr
 (`error`/`warn`/`info`/`debug`), falling back to a heuristic otherwise, and derives a
 compact `message` summary from each line.
 
-### Routing — `mlx_route_decision` (API, sc-3449)
+### Routing — `gpu_route_decision` (API, sc-3449)
 
 Emitted at claim time whenever a claim is routing-relevant. **This is the line that
-answers "why did this run on torch instead of MLX?"**
+answers "which backend ran this job?"** Every label is named after the backend that
+actually claimed the job — never as a deficiency, so the line never reads as if a worker
+is missing on a platform that never had one (e.g. there is no MLX worker off-Mac).
 
 | field | meaning |
 | --- | --- |
-| `decision` | `deferred_to_mlx` \| `claimed_by_mlx` \| `fell_back_to_torch` \| `explicit_gpu` |
-| `reason` | `idle_mlx_available` \| `mlx_worker` \| `no_idle_mlx_worker` \| `explicit_gpu` |
+| `decision` | `deferred_to_mlx` \| `claimed_by_mlx` \| `claimed_by_candle` \| `claimed_by_gpu` \| `explicit_gpu` |
+| `reason` | `idle_mlx_available` \| `mlx_worker` \| `candle_worker` \| `gpu_worker` \| `explicit_gpu` |
 | `model`, `jobType`, `requestedGpu`, `workerId`, `gpuId` | context |
 
-- `deferred_to_mlx` / `idle_mlx_available` — a torch worker yielded the job to an idle MLX worker.
-- `claimed_by_mlx` / `mlx_worker` — the MLX worker took an MLX-eligible job (the happy path).
-- `fell_back_to_torch` / `no_idle_mlx_worker` — **an MLX-eligible job ran on torch because no idle MLX worker was available** (restart churn, busy, or down).
-- `explicit_gpu` — the user pinned a specific GPU, so MLX routing was intentionally bypassed.
+- `claimed_by_mlx` / `mlx_worker` — the MLX worker took the job (the Mac GPU path).
+- `claimed_by_candle` / `candle_worker` — the candle (Windows/Linux CUDA) worker took the job. **The expected off-Mac happy path**, not a fallback. Candle is identified by the `candle` capability marker (it runs on a real GPU index, so `gpuId` alone can't distinguish it).
+- `claimed_by_gpu` / `gpu_worker` — a defensive catch-all: a GPU worker that is neither MLX nor candle took the job. With the Python torch worker retired from every surface, this should not appear in practice; it names no specific backend.
+- `deferred_to_mlx` / `idle_mlx_available` — a non-mlx worker yielded the job to an idle MLX worker (Mac only).
+- `explicit_gpu` — the user pinned a specific GPU, so backend auto-routing was intentionally bypassed.
 
 ### Claim contention — `claim_lock_contention` (Rust worker, sc-3448)
 
@@ -138,14 +141,14 @@ two is the signature of a cold-weight load — the prime suspect when an MLX job
 > information, accurate to the Rust engine's architecture, rather than fabricated
 > zero-duration sub-phase events.
 
-### MLX generator cache idle eviction — `mlx_generator_cache_idle_evicted`
+### Generator cache idle eviction — `generator_cache_idle_evicted`
 
-Emitted by the Rust MLX worker when the shared generator cache drops its
-resident generator after the idle timeout: `engine`, `idleSeconds`. This is
-expected after the worker has been idle for
-`SCENEWORKS_GENERATOR_CACHE_IDLE_SECONDS` seconds (default 300). It should
-correlate with the worker releasing cached Metal/MLX allocations before the
-next generation cold-loads weights again.
+Emitted by the Rust worker (MLX on Mac, candle/CUDA off-Mac — the generator cache is
+shared code) when it drops its resident generator after the idle timeout: `engine`,
+`idleSeconds`. This is **expected** after the worker has been idle for
+`SCENEWORKS_GENERATOR_CACHE_IDLE_SECONDS` seconds (default 300) and is logged at info
+level. It correlates with the worker releasing cached GPU allocations (Metal/MLX or
+CUDA) before the next generation cold-loads weights again.
 
 ### API errors — `api_error` (API)
 
@@ -164,11 +167,17 @@ query string), `reason` (`missing_or_invalid_token`), `status` (401). The token 
 secret is deliberately **never** logged. Previously these rejections returned 401
 with no server-side trace.
 
-## Diagnosing "MLX-eligible job ran on torch/MPS"
+## Diagnosing "which backend ran this job?"
 
-1. Open **System → Logs**, filter source = `api`, search `mlx_route_decision`.
-2. Find the decision for the job's model. `fell_back_to_torch` + `no_idle_mlx_worker`
-   means the MLX worker wasn't idle/claimable at claim time — check `mlx-worker.log`
-   (filter source = `mlx-worker`) for restarts or `claim_lock_contention`.
-3. `claimed_by_mlx` plus `image_inference_*` on `mlx-worker` confirms a true MLX run.
-4. The asset's recorded `backend` (`mlx` vs `mps`/`cuda`) is the ground truth for where it ran.
+1. Open **System → Logs**, filter source = `api`, search `gpu_route_decision`.
+2. Find the decision for the job's model. The `decision`/`reason` names the backend
+   that claimed it: `claimed_by_candle` (Windows/Linux CUDA), `claimed_by_mlx` (Mac),
+   or `deferred_to_mlx` (Mac, yielded to the MLX worker). None of these means anything
+   is missing. (`claimed_by_gpu` is a generic catch-all that should not appear on a
+   shipped surface.)
+3. **On Mac, to confirm a true MLX run:** `claimed_by_mlx` plus `image_inference_*` on
+   `mlx-worker`. If you instead see `claimed_by_gpu` for an MLX-eligible model, the MLX
+   worker wasn't idle/claimable at claim time — check `mlx-worker.log` for restarts or
+   `claim_lock_contention`.
+4. The asset's recorded `backend` (`mlx` / `mps` / `cuda`) is the ground truth for where
+   it ran.

--- a/documents/GOAL_OBSERVABILITY_FOUNDATIONS.md
+++ b/documents/GOAL_OBSERVABILITY_FOUNDATIONS.md
@@ -55,9 +55,9 @@ Introduce `tracing` + `tracing-subscriber` as the single logging backbone for al
 
 ### WS3 — Declared levels replace inference
 
-- Migrate the structured-event helpers (`sceneworks_worker::emit_json` / `emit_event`, the API's `mlx_route_decision` emitter) and the **high-value error/warn `eprintln!` sites** to `tracing::{error,warn,info,debug}!` with structured fields. The full ~200 `println!` sweep is **not** required — prioritize: (a) every existing structured event, (b) every `*_failed`/`*_error` site, (c) anything currently relied on by `docs/observability.md`.
+- Migrate the structured-event helpers (`sceneworks_worker::emit_json` / `emit_event`, the API's `gpu_route_decision` emitter — renamed from `mlx_route_decision` in the sc-3449 follow-up so the off-Mac candle lane isn't mislabelled) and the **high-value error/warn `eprintln!` sites** to `tracing::{error,warn,info,debug}!` with structured fields. The full ~200 `println!` sweep is **not** required — prioritize: (a) every existing structured event, (b) every `*_failed`/`*_error` site, (c) anything currently relied on by `docs/observability.md`.
 - **Preserve event names** as a field/target so the vocabulary in `docs/observability.md` stays valid, e.g.
-  `info!(event = "mlx_route_decision", decision = ?d, reason = %r, model = %m, job_id = %id);`
+  `info!(event = "gpu_route_decision", decision = ?d, reason = %r, model = %m, job_id = %id);`
 - Update `session_log::infer_level` so that when a line carries a **declared `level`**, that level is used verbatim; fall back to the existing heuristic only for legacy/plain lines that lack one. The Logs-screen `level` filter must become trustworthy.
 
 ### WS4 — Make API 500s and auth rejections visible
@@ -74,7 +74,7 @@ Introduce `tracing` + `tracing-subscriber` as the single logging backbone for al
 
 1. Secret redaction still scrubs tokens / api-keys / bearer / authorization before anything is persisted or surfaced.
 2. The `LogEntry` shape and the Logs-screen source/level/search filters keep working; expanding a row still shows the raw structured event.
-3. Every event documented in `docs/observability.md` is still emitted under its existing name (`mlx_route_decision`, `claim_lock_contention`, `image_inference_*`, `image_pipeline_load_*`, `mlx_generator_cache_idle_evicted`).
+3. Every event documented in `docs/observability.md` is still emitted under its documented name (`gpu_route_decision`, `claim_lock_contention`, `image_inference_*`, `image_pipeline_load_*`, `generator_cache_idle_evicted`).
 4. `job_id` / `worker_id` remain present on job-lifecycle events for cross-process correlation.
 5. No new heavyweight runtime dependency beyond the `tracing` ecosystem.
 6. `cargo fmt --check`, `cargo clippy`, and the existing test suites pass. (Repo has a rustfmt pre-commit hook — keep it green.)
@@ -85,7 +85,7 @@ Introduce `tracing` + `tracing-subscriber` as the single logging backbone for al
 - [x] `tracing` + `tracing-subscriber` are workspace dependencies; a single `init_logging()` is called from every Rust binary's `main`.
 - [x] `SCENEWORKS_LOG_FORMAT=json|pretty|auto` works; `auto` selects JSON for non-TTY stdout and pretty for a TTY. `RUST_LOG` filtering works.
 - [x] Running the API headless and hitting `GET /api/v1/logs` returns entries whose `level` is the **declared** level (not inferred). Forcing an internal error produces an `error`-level `api_error` entry visible in the logs; an unauthorized request produces a `warn`-level `auth_rejected` entry. *(Verified live: a 401 yields `warn` `auth_rejected`; a typed 4xx yields `debug` `api_error` that is **not** re-promoted to error; 5xx logs at `error` via the same `IntoResponse` branch.)*
-- [x] In the desktop build, the **System → Logs** screen still tails, filters by source/level (accurately now), searches, and expands raw events — and `mlx_route_decision` / `claim_lock_contention` rows are still highlighted. *(No frontend change; `LogEntry` shape unchanged, levels now declared.)*
+- [x] In the desktop build, the **System → Logs** screen still tails, filters by source/level (accurately now), searches, and expands raw events — and `gpu_route_decision` / `claim_lock_contention` rows are still highlighted. *(No frontend change; `LogEntry` shape unchanged, levels now declared.)*
 - [x] All structured events from `docs/observability.md` still appear under their documented names with their documented fields. Secrets are still redacted.
 - [x] `cargo fmt --check`, `cargo clippy`, and `cargo test` (all crates) pass; web tests (`apps/web`) unaffected.
 - [x] `docs/observability.md` updated (Logging backbone section + `api_error`/`auth_rejected` events); this doc's Status set to Done.

--- a/scripts/smoke-lens.ps1
+++ b/scripts/smoke-lens.ps1
@@ -10,8 +10,8 @@
   sidecar (the sc-5126 teardown). Companion to docs/sc-5099/candle-lane-smoke.md.
 
   The candle worker claims Lens jobs via the "candle" capability marker + worker_supports_job; the
-  API's mlx_route_decision log (which only knows about MLX) will say fell_back_to_torch -- ignore it,
-  the candle_lens asset label is the proof the candle lane ran.
+  API's gpu_route_decision log names the backend that ran it (decision=claimed_by_candle /
+  reason=candle_worker); the candle_lens asset label is the proof the candle lane ran.
 
 .PREREQUISITES
   - Build the binaries (VS2022 v143 BuildTools / CUDA 12.9; sm_120 native PTX shown):


### PR DESCRIPTION
## Why

On Windows/Linux the routing-observability log read as if something were broken on a box that never had an MLX worker. The reported line:

```
mlx_route_decision decision=fell_back_to_torch reason=no_idle_mlx_worker model=ltx_2_3
```

The `mlx_` event prefix plus `fell_back_to_torch` / `no_idle_mlx_worker` were Mac-centric: the classifier only knew "mlx vs not-mlx" and stamped every non-mlx `auto` claim as a torch *fallback* — even though off-Mac the candle (CUDA) lane is the normal happy path, and the Python torch worker is now **retired from every shipped surface** (Phase 7 / `78386916`). The companion `mlx_generator_cache_idle_evicted` carried the same misleading prefix (the generator cache is shared code the candle worker uses too).

## What

Name every label after the backend that **actually claimed the job**, never as a deficiency:

| | old | new |
|---|---|---|
| event | `mlx_route_decision` | `gpu_route_decision` |
| event | `mlx_generator_cache_idle_evicted` | `generator_cache_idle_evicted` |
| MLX claim (Mac) | `claimed_by_mlx` / `mlx_worker` | *(unchanged)* |
| candle/CUDA claim | `fell_back_to_torch` / `no_idle_mlx_worker` | `claimed_by_candle` / `candle_worker` |
| other GPU worker | `fell_back_to_torch` / `no_idle_mlx_worker` | `claimed_by_gpu` / `gpu_worker` *(defensive catch-all)* |
| Mac yield to idle MLX | `deferred_to_mlx` / `idle_mlx_available` | *(unchanged)* |
| explicit GPU pin | `explicit_gpu` | *(unchanged)* |

Candle is told apart from a bare GPU worker via the existing `candle` capability marker (`worker_is_candle`) — both run on a real GPU index, so `gpu_id` can't distinguish them. `claimed_by_gpu` is a defensive catch-all that should never fire on a shipped surface now that torch is gone, and it names no dead backend.

The reported line now reads: `gpu_route_decision decision=claimed_by_candle reason=candle_worker model=ltx_2_3` — normal operation, nothing missing.

## Touched

`jobs_store.rs` (`RouteDecision` classifier now takes `&WorkerSnapshot` to read the candle marker) · rust-api emitter + logs test · `session_log` docs/tests · `LogsScreen.jsx` highlight set + test · `generator_cache.rs` event · `docs/observability.md` · worker `ARCHITECTURE.md` · `GOAL_OBSERVABILITY_FOUNDATIONS.md` · `smoke-lens.ps1` (dropped the now-obsolete "ignore the fell_back_to_torch line" caveat). No parity-snapshot impact (route-decision strings aren't captured in `snapshots.json`).

## Validation

- `cargo fmt --all -- --check` ✅ · `cargo clippy -D warnings` (core + rust-api + worker) ✅
- core routing 6/6 (incl. new `claimed_by_candle` + `claimed_by_gpu` tests), session_log 7/7, rust-api lib 113/113, web LogsScreen 4/4 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)