### PR TITLE
feat(worker): route Boogu-Image-0.1 Base/Turbo/Edit through the MLX worker (sc-6399)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -519,7 +519,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -530,7 +530,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -557,7 +557,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -569,7 +569,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -580,7 +580,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -597,7 +597,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -612,7 +612,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -623,7 +623,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -641,7 +641,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -652,7 +652,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -665,7 +665,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -676,7 +676,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -689,7 +689,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2#2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -3311,7 +3311,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0b86fad4fb98a3b2a73d0a38e47616cd505094ca#0b86fad4fb98a3b2a73d0a38e47616cd505094ca"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3323,7 +3323,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0b86fad4fb98a3b2a73d0a38e47616cd505094ca#0b86fad4fb98a3b2a73d0a38e47616cd505094ca"
 dependencies = [
  "image",
  "inventory",
@@ -3335,9 +3335,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "mlx-gen-boogu"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0b86fad4fb98a3b2a73d0a38e47616cd505094ca#0b86fad4fb98a3b2a73d0a38e47616cd505094ca"
+dependencies = [
+ "image",
+ "inventory",
+ "mlx-gen",
+ "mlx-gen-z-image",
+ "pmetal-mlx-rs",
+ "serde_json",
+]
+
+[[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0b86fad4fb98a3b2a73d0a38e47616cd505094ca#0b86fad4fb98a3b2a73d0a38e47616cd505094ca"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3349,7 +3362,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0b86fad4fb98a3b2a73d0a38e47616cd505094ca#0b86fad4fb98a3b2a73d0a38e47616cd505094ca"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3358,7 +3371,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0b86fad4fb98a3b2a73d0a38e47616cd505094ca#0b86fad4fb98a3b2a73d0a38e47616cd505094ca"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3370,7 +3383,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0b86fad4fb98a3b2a73d0a38e47616cd505094ca#0b86fad4fb98a3b2a73d0a38e47616cd505094ca"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3381,7 +3394,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0b86fad4fb98a3b2a73d0a38e47616cd505094ca#0b86fad4fb98a3b2a73d0a38e47616cd505094ca"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3393,7 +3406,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0b86fad4fb98a3b2a73d0a38e47616cd505094ca#0b86fad4fb98a3b2a73d0a38e47616cd505094ca"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3404,7 +3417,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0b86fad4fb98a3b2a73d0a38e47616cd505094ca#0b86fad4fb98a3b2a73d0a38e47616cd505094ca"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3414,7 +3427,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0b86fad4fb98a3b2a73d0a38e47616cd505094ca#0b86fad4fb98a3b2a73d0a38e47616cd505094ca"
 dependencies = [
  "image",
  "inventory",
@@ -3426,7 +3439,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0b86fad4fb98a3b2a73d0a38e47616cd505094ca#0b86fad4fb98a3b2a73d0a38e47616cd505094ca"
 dependencies = [
  "image",
  "inventory",
@@ -3439,7 +3452,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0b86fad4fb98a3b2a73d0a38e47616cd505094ca#0b86fad4fb98a3b2a73d0a38e47616cd505094ca"
 dependencies = [
  "image",
  "inventory",
@@ -3451,7 +3464,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0b86fad4fb98a3b2a73d0a38e47616cd505094ca#0b86fad4fb98a3b2a73d0a38e47616cd505094ca"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3462,7 +3475,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0b86fad4fb98a3b2a73d0a38e47616cd505094ca#0b86fad4fb98a3b2a73d0a38e47616cd505094ca"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3474,7 +3487,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0b86fad4fb98a3b2a73d0a38e47616cd505094ca#0b86fad4fb98a3b2a73d0a38e47616cd505094ca"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3484,7 +3497,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0b86fad4fb98a3b2a73d0a38e47616cd505094ca#0b86fad4fb98a3b2a73d0a38e47616cd505094ca"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3493,7 +3506,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0b86fad4fb98a3b2a73d0a38e47616cd505094ca#0b86fad4fb98a3b2a73d0a38e47616cd505094ca"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3502,7 +3515,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0b86fad4fb98a3b2a73d0a38e47616cd505094ca#0b86fad4fb98a3b2a73d0a38e47616cd505094ca"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3514,7 +3527,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0b86fad4fb98a3b2a73d0a38e47616cd505094ca#0b86fad4fb98a3b2a73d0a38e47616cd505094ca"
 dependencies = [
  "image",
  "inventory",
@@ -3527,7 +3540,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0b86fad4fb98a3b2a73d0a38e47616cd505094ca#0b86fad4fb98a3b2a73d0a38e47616cd505094ca"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3538,7 +3551,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0b86fad4fb98a3b2a73d0a38e47616cd505094ca#0b86fad4fb98a3b2a73d0a38e47616cd505094ca"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3549,7 +3562,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0b86fad4fb98a3b2a73d0a38e47616cd505094ca#0b86fad4fb98a3b2a73d0a38e47616cd505094ca"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3560,7 +3573,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0b86fad4fb98a3b2a73d0a38e47616cd505094ca#0b86fad4fb98a3b2a73d0a38e47616cd505094ca"
 dependencies = [
  "image",
  "inventory",
@@ -3574,7 +3587,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0b86fad4fb98a3b2a73d0a38e47616cd505094ca#0b86fad4fb98a3b2a73d0a38e47616cd505094ca"
 dependencies = [
  "image",
  "inventory",
@@ -4219,7 +4232,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -5216,7 +5229,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4740225c95e7e36748ede115f82a04a57c9d8c5a#4740225c95e7e36748ede115f82a04a57c9d8c5a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0b86fad4fb98a3b2a73d0a38e47616cd505094ca#0b86fad4fb98a3b2a73d0a38e47616cd505094ca"
 dependencies = [
  "inventory",
  "safetensors 0.4.5",
@@ -5292,6 +5305,7 @@ dependencies = [
  "inventory",
  "mlx-gen",
  "mlx-gen-bernini",
+ "mlx-gen-boogu",
  "mlx-gen-chroma",
  "mlx-gen-face",
  "mlx-gen-flux",
@@ -7508,7 +7522,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3564,6 +3564,14 @@ const MLX_ROUTED_MODELS: &[&str] = &[
     // edit surface as the base (the shared denoise serves both); registered so it reaches the picker
     // and routes to MLX for both T2I and edit (sc-6303). macOS-only (no torch backend).
     "ideogram_4_turbo",
+    // Boogu-Image-0.1 (epic 6387): ~10.3B Lumina-Image-2.0 / OmniGen2-lineage flow DiT + Qwen3-VL-8B
+    // condition encoder + FLUX.1 VAE on the native `mlx-gen-boogu` engine (adapter `mlx_boogu`),
+    // macOS-only (no torch backend, Apache-2.0 ungated). All three route to MLX; mirror
+    // `boogu_mlx_eligible`. Base + Turbo are text-to-image only; Edit adds the instruction
+    // image-edit `Reference` path (`resolve_boogu_edit`).
+    "boogu_image",
+    "boogu_image_turbo",
+    "boogu_image_edit",
 ];
 
 /// Epic 3018 routing — does this image job belong on the in-process Rust MLX
@@ -3625,6 +3633,7 @@ fn image_request_mlx_eligible(model: &str, payload: &Map<String, Value>) -> bool
         "lens" | "lens_turbo" => lens_mlx_eligible(payload),
         "bernini_image" => bernini_image_mlx_eligible(payload),
         "ideogram_4" | "ideogram_4_turbo" => ideogram_mlx_eligible(payload),
+        "boogu_image" | "boogu_image_turbo" | "boogu_image_edit" => boogu_mlx_eligible(payload),
         // Every model in MLX_ROUTED_MODELS must have an arm.
         _ => false,
     }
@@ -4578,6 +4587,20 @@ fn bernini_image_mlx_eligible(payload: &Map<String, Value>) -> bool {
 /// stranding it.) macOS-only (the catalog flags `macOnly`); on Windows/Linux no `mlx` worker is
 /// registered, so nothing defers.
 fn ideogram_mlx_eligible(_payload: &Map<String, Value>) -> bool {
+    true
+}
+
+/// Boogu Image / Turbo / Edit (epic 6387) MLX-eligibility. Text-to-image (and any non-edit mode) is
+/// always eligible. `edit_image` is the **Edit checkpoint's** capability only — Base/Turbo are
+/// text-to-image (their semantic-edit path is incoherent without the Edit fine-tune, E7b-3), so an
+/// edit request is eligible for `boogu_image_edit` alone. This keeps `model_mac_support`'s `features.edit`
+/// false for Base/Turbo (it probes with `mode: edit_image`). macOS-only (the catalog flags `macOnly`);
+/// off-Mac no `mlx` worker registers.
+fn boogu_mlx_eligible(payload: &Map<String, Value>) -> bool {
+    let is_edit = payload.get("mode").and_then(Value::as_str) == Some("edit_image");
+    if is_edit {
+        return payload.get("model").and_then(Value::as_str) == Some("boogu_image_edit");
+    }
     true
 }
 
@@ -7205,6 +7228,67 @@ mod mlx_routing_tests {
         let turbo = model_mac_support("ideogram_4_turbo", "image");
         assert!(turbo.supported, "ideogram_4_turbo must be Mac-supported");
         assert!(turbo.features.edit, "ideogram_4_turbo supports edit");
+    }
+
+    #[test]
+    fn boogu_text_to_image_and_edit_route_to_mlx() {
+        // sc-6399 (epic 6387): the three Boogu ids are in MLX_ROUTED_MODELS and route to the native
+        // `mlx-gen-boogu` engine. Base + Turbo are text-to-image; Edit is the instruction image-edit.
+        for model in ["boogu_image", "boogu_image_turbo", "boogu_image_edit"] {
+            assert!(
+                image_request_mlx_eligible(
+                    model,
+                    &object(json!({ "model": model, "prompt": "p" }))
+                ),
+                "{model} text-to-image must route to MLX"
+            );
+            assert!(
+                image_request_mlx_eligible(model, &Map::new()),
+                "{model} bare payload"
+            );
+        }
+
+        // Edit routes to MLX for the Edit checkpoint only — Base/Turbo are text-to-image (their
+        // semantic-edit path is incoherent without the Edit fine-tune, E7b-3).
+        let edit_payload = |model: &str| {
+            object(json!({ "model": model, "mode": "edit_image", "sourceAssetId": "asset_1" }))
+        };
+        assert!(image_request_mlx_eligible(
+            "boogu_image_edit",
+            &edit_payload("boogu_image_edit")
+        ));
+        assert!(!image_request_mlx_eligible(
+            "boogu_image",
+            &edit_payload("boogu_image")
+        ));
+        assert!(!image_request_mlx_eligible(
+            "boogu_image_turbo",
+            &edit_payload("boogu_image_turbo")
+        ));
+
+        // UI gating oracle: all three are Mac-supported (reach the Text → Image picker); only Edit
+        // advertises `features.edit` (Base/Turbo are T2I — the catalog `edit_image` capability +
+        // this flag both gate the Edit tab to `boogu_image_edit`).
+        for model in ["boogu_image", "boogu_image_turbo", "boogu_image_edit"] {
+            assert!(
+                model_mac_support(model, "image").supported,
+                "{model} must be Mac-supported"
+            );
+        }
+        assert!(
+            model_mac_support("boogu_image_edit", "image").features.edit,
+            "boogu_image_edit supports edit"
+        );
+        assert!(
+            !model_mac_support("boogu_image", "image").features.edit,
+            "boogu_image (Base) is text-to-image only"
+        );
+        assert!(
+            !model_mac_support("boogu_image_turbo", "image")
+                .features
+                .edit,
+            "boogu_image_turbo is text-to-image only"
+        );
     }
 
     #[test]

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -216,7 +216,7 @@ sceneworks-core = { path = "../sceneworks-core" }
 # 4740225 (skew gate stays green at one rev), mlx-rs unchanged (44929a0); box behavior unchanged
 # (`segment_encoded_multimask` signature preserved, dynmask/quant_smoke parity unaffected). Bumps
 # EVERY mlx-gen crate in lockstep.
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0b86fad4fb98a3b2a73d0a38e47616cd505094ca" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -533,7 +533,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0b86fad4fb98a3b2a73d0a38e47616cd505094ca" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -545,59 +545,64 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e
 # internal pin (the Lens engine PRs #407–#414 did not move it; nor did the seedvr2 engine #416/#419/
 # #421 or the softness PR #422, so the 1a97909 bump above leaves mlx-rs at 44929a0).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "44929a001ab8a8837403a71c65cf064224de0cdc" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0b86fad4fb98a3b2a73d0a38e47616cd505094ca" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0b86fad4fb98a3b2a73d0a38e47616cd505094ca" }
+# Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
+# Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
+# `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
+# in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0b86fad4fb98a3b2a73d0a38e47616cd505094ca" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0b86fad4fb98a3b2a73d0a38e47616cd505094ca" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0b86fad4fb98a3b2a73d0a38e47616cd505094ca" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0b86fad4fb98a3b2a73d0a38e47616cd505094ca" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0b86fad4fb98a3b2a73d0a38e47616cd505094ca" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0b86fad4fb98a3b2a73d0a38e47616cd505094ca" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0b86fad4fb98a3b2a73d0a38e47616cd505094ca" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0b86fad4fb98a3b2a73d0a38e47616cd505094ca" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0b86fad4fb98a3b2a73d0a38e47616cd505094ca" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0b86fad4fb98a3b2a73d0a38e47616cd505094ca" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0b86fad4fb98a3b2a73d0a38e47616cd505094ca" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0b86fad4fb98a3b2a73d0a38e47616cd505094ca" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -606,12 +611,12 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "474022
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0b86fad4fb98a3b2a73d0a38e47616cd505094ca" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0b86fad4fb98a3b2a73d0a38e47616cd505094ca" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -620,7 +625,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "474022
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0b86fad4fb98a3b2a73d0a38e47616cd505094ca" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -628,7 +633,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0b86fad4fb98a3b2a73d0a38e47616cd505094ca" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -639,7 +644,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0b86fad4fb98a3b2a73d0a38e47616cd505094ca" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -650,7 +655,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "47402
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0b86fad4fb98a3b2a73d0a38e47616cd505094ca" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -665,7 +670,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "474022
 # converted in-memory at load (no Python); the precomputed neg-prompt embedding is bundled in-crate. No
 # LoRA/guidance/CFG (one-step). 3B fp16 only here — 7B (sc-5197) + int8 (sc-5198) are engine-side and
 # unwired. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0b86fad4fb98a3b2a73d0a38e47616cd505094ca" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -676,7 +681,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "474
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0b86fad4fb98a3b2a73d0a38e47616cd505094ca" }
 # Prompt-refine provider (sc-5552, the MLX twin of candle-gen-prompt-refine / sc-5500). An
 # inventory-registered `TextLlm` under id `prompt_refine` (`backend="mlx"`, `mac_only`): a native MLX
 # Llama-3.2-3B-Instruct that rewrites a user's prompt, replacing the Python `prompt_refine.py`
@@ -686,7 +691,7 @@ mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "474
 # textllm registered" trap). Weights = a stock Llama-3.2-3B-Instruct HF snapshot (config.json +
 # tokenizer.json + model-*.safetensors; default `huihui-ai/Llama-3.2-3B-Instruct-abliterated`). Same
 # git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
+mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0b86fad4fb98a3b2a73d0a38e47616cd505094ca" }
 # SCAIL-2 (zai-org) end-to-end character-animation provider (epic 5439, sc-5448). An inventory-registered
 # `Generator` under id `scail2_14b` (`Modality::Video`): a Wan2.1-14B I2V DiT that animates a reference
 # character with a driving video's motion (`video_mode == "replacement"` flips the cross-identity
@@ -698,7 +703,7 @@ mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev 
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740225c95e7e36748ede115f82a04a57c9d8c5a" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0b86fad4fb98a3b2a73d0a38e47616cd505094ca" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -884,38 +889,38 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4740
 # (`image_jobs/qwen_edit_candle.rs`) drives candle-gen-qwen-image's `QwenEdit` (incl. the lightning
 # distill) off-Mac; the candle SAM3 path (`person_segment_sam3_candle.rs`) drives candle-gen-sam3.
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -924,19 +929,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -945,12 +950,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -958,7 +963,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2eb
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -967,7 +972,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -975,7 +980,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -984,7 +989,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1002,7 +1007,12 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # gen-core 517ef11 -> 4740225 (BYTE-IDENTICAL tree — #499 is pure mlx-gen-sam3/tracker.rs), so
 # `--features backend-candle --target all` resolves ONE gen-core rev. Behavior-neutral; candle builds
 # nothing new.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2d2ebfc3eb67c05d1dcde24e2cd0e5ba6229b8a2", features = ["cuda"], optional = true }
+# Bumped `2d2ebfc` -> `7281da5` (sc-6399, epic 6387, candle-gen #108): lockstep with the worker's mlx
+# pin moving 4740225 -> 0b86fad (mlx-gen #504, the Boogu-Image-0.1 Generator registration). candle-gen
+# #108 re-pins gen-core 4740225 -> 0b86fad (BYTE-IDENTICAL tree — the range is pure mlx-gen-boogu, a
+# macOS-only image family with no candle sibling), so `--features backend-candle --target all` resolves
+# ONE gen-core rev. Behavior-neutral; candle builds nothing new.
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -365,6 +365,44 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
         default_guidance: 4.0,
         adapter_label: "mlx_bernini",
     },
+    // Boogu-Image-0.1 (epic 6387) — native MLX, ungated (Apache-2.0). ~10.3B Lumina-Image-2.0 /
+    // OmniGen2-lineage flow-matching DiT + Qwen3-VL-8B condition encoder + FLUX.1 VAE. Three variants,
+    // one engine crate (`mlx-gen-boogu`); each id maps 1:1 to its gen_core descriptor id. The turnkey
+    // `SceneWorks/boogu-image-mlx` ships pre-packed Q8 `base/ turbo/ edit/` subfolders (default) +
+    // `*-bf16/`; `resolve_boogu_model_dir` (image_jobs/base.rs) points the engine at the variant
+    // subfolder. The packed weights auto-detect their quant on load, so the worker's Q8 quant spec is
+    // a no-op there. Base = true-CFG T2I (50 steps / guidance 4.0).
+    ModelRow {
+        sceneworks_id: "boogu_image",
+        engine_id: "boogu_image",
+        default_repo: "SceneWorks/boogu-image-mlx",
+        default_steps: 50,
+        default_guidance: 4.0,
+        adapter_label: "mlx_boogu",
+    },
+    // Boogu Turbo — the DMD few-step, CFG-free distilled variant (`turbo/` checkpoint). 4 steps;
+    // guidance is INERT (the `boogu_image_turbo` descriptor advertises supports_guidance=false, so
+    // `resolve_guidance` returns None and never forwards a value).
+    ModelRow {
+        sceneworks_id: "boogu_image_turbo",
+        engine_id: "boogu_image_turbo",
+        default_repo: "SceneWorks/boogu-image-mlx",
+        default_steps: 4,
+        default_guidance: 0.0,
+        adapter_label: "mlx_boogu",
+    },
+    // Boogu Edit — instruction image-edit (`edit/` checkpoint). The source image is read by the
+    // Qwen3-VL vision tower + VAE-encoded into the DiT's spatial reference latent; the prompt is the
+    // edit instruction. true-CFG (50 steps / guidance 4.0). The worker's `resolve_boogu_edit` builds
+    // the source `Conditioning::Reference` (no mask path).
+    ModelRow {
+        sceneworks_id: "boogu_image_edit",
+        engine_id: "boogu_image_edit",
+        default_repo: "SceneWorks/boogu-image-mlx",
+        default_steps: 50,
+        default_guidance: 4.0,
+        adapter_label: "mlx_boogu",
+    },
 ];
 
 /// The mlx-gen registry ids of the video generators this worker serves (the engine ids

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -49,6 +49,11 @@ use mlx_gen_flux2 as _;
 // Ideogram 4 (epic 4725) — force-link so `inventory::submit!` registers `ideogram_4`.
 #[cfg(target_os = "macos")]
 use mlx_gen_ideogram as _;
+// Boogu-Image-0.1 (epic 6387) — force-link so `inventory::submit!` registers `boogu_image`,
+// `boogu_image_turbo`, and `boogu_image_edit` (else linker GC drops their `ModelRegistration` and
+// `gen_core::load("boogu_image")` returns "no generator registered").
+#[cfg(target_os = "macos")]
+use mlx_gen_boogu as _;
 #[cfg(target_os = "macos")]
 use mlx_gen_kolors as _;
 // Lens / Lens-Turbo (epic 3164 engine / sc-5105) — an inventory-registered `Generator` under the ids

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -216,6 +216,15 @@ pub(crate) fn resolve_weights_dir(
     if request.model == "ideogram_4" || request.model == "ideogram_4_turbo" {
         return Ok(snapshot.map(|root| ideogram_model_subdir(&root, request)));
     }
+    // Boogu (epic 6387) ships a turnkey with pre-packed Q8 `base/ turbo/ edit/` subfolders (default) +
+    // full-precision `*-bf16/`; point the engine at the variant's subfolder rather than the repo root
+    // (the packed weights auto-detect their quant on load).
+    if matches!(
+        request.model.as_str(),
+        "boogu_image" | "boogu_image_turbo" | "boogu_image_edit"
+    ) {
+        return Ok(snapshot.map(|root| boogu_model_subdir(&root, request)));
+    }
     Ok(snapshot)
 }
 
@@ -243,6 +252,42 @@ fn ideogram_model_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
     }
     present("q4")
         .or_else(|| present("q8"))
+        .unwrap_or_else(|| root.to_path_buf())
+}
+
+/// Pick the engine-complete subfolder of a Boogu turnkey `root` for the requested variant. Each
+/// catalog id maps to a variant folder: `boogu_image`→`base`, `boogu_image_turbo`→`turbo`,
+/// `boogu_image_edit`→`edit`. **Q8 is the shipped default** (the pre-packed `<variant>/` folder); an
+/// explicit advanced `mlxQuantize <= 4` selects the full-precision `<variant>-bf16/` build instead —
+/// the source the engine quantizes at load (no packed Q4 is shipped) or runs dense. Falls back to
+/// whichever subfolder is present, then `root`, so a partially-downloaded bundle surfaces as a load
+/// error rather than a silent half-load. (The `*-bf16/` files are an on-demand download — sc tracked;
+/// when absent the bf16 request resolves the Q8 folder.)
+fn boogu_model_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
+    let variant = match request.model.as_str() {
+        "boogu_image_turbo" => "turbo",
+        "boogu_image_edit" => "edit",
+        _ => "base",
+    };
+    let bf16 = format!("{variant}-bf16");
+    let wants_bf16 = request
+        .advanced
+        .get("mlxQuantize")
+        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()))
+        .is_some_and(|bits| bits <= 4);
+    let present = |name: &str| -> Option<PathBuf> {
+        let dir = root.join(name);
+        dir.join("transformer/diffusion_pytorch_model.safetensors")
+            .is_file()
+            .then_some(dir)
+    };
+    if wants_bf16 {
+        if let Some(dir) = present(&bf16) {
+            return dir;
+        }
+    }
+    present(variant)
+        .or_else(|| present(&bf16))
         .unwrap_or_else(|| root.to_path_buf())
 }
 
@@ -841,6 +886,37 @@ const IDEOGRAM_INPAINT_STRENGTH: f32 = 0.85;
 ///
 /// `None` when not an edit job or no source asset (the caller falls back to plain txt2img).
 #[cfg(target_os = "macos")]
+/// Resolve the Boogu instruction-edit source: the `sourceAssetId` image, fit to the output W×H (so
+/// it satisfies the engine's multiple-of-16 guard and aligns to the target aspect). Returns
+/// `(source, strength)`; `None` when not an edit / no source. The `strength` is inert for Boogu (the
+/// edit is structural — the engine ignores `Conditioning::Reference.strength`), so a full-strength
+/// 1.0 is returned for the contract. No mask / outpaint path (the descriptor accepts only `Reference`).
+fn resolve_boogu_edit(
+    request: &ImageRequest,
+    settings: &Settings,
+    project_path: &Path,
+) -> WorkerResult<Option<(Image, f32)>> {
+    if request.mode != "edit_image" {
+        return Ok(None);
+    }
+    let Some(asset_id) = request
+        .source_asset_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+    else {
+        return Ok(None);
+    };
+    let source = load_reference_image(
+        &settings.data_dir,
+        &request.project_id,
+        asset_id,
+        project_path,
+    )?;
+    let source = fit_engine_image(source, request.width, request.height, &request.fit_mode)?;
+    Ok(Some((source, 1.0)))
+}
+
 fn resolve_ideogram_edit(
     request: &ImageRequest,
     settings: &Settings,
@@ -1228,6 +1304,14 @@ async fn generate_stream(
                 ideogram_edit_mask = mask;
                 (Some((source, strength)), None, None)
             }
+            None => (None, None, None),
+        }
+    } else if request.model == "boogu_image_edit" && request.mode == "edit_image" {
+        // Boogu instruction edit (epic 6387): `sourceAssetId` → the engine's `Reference` (the Qwen3-VL
+        // vision tower reads it + it VAE-encodes into the DiT spatial latent); the prompt is the edit
+        // instruction. No mask / IP-Adapter (the `boogu_image_edit` descriptor accepts only `Reference`).
+        match resolve_boogu_edit(request, settings, project_path)? {
+            Some((source, strength)) => (Some((source, strength)), None, None),
             None => (None, None, None),
         }
     } else {

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -3775,6 +3775,115 @@ fn ideogram_subdir_prefers_q4_and_opts_into_q8() {
     );
 }
 
+/// Boogu (epic 6387) resolves each of its three ids to its own engine + the reference defaults, and
+/// quant resolution returns Q8 — the catalog declares `mlx.quantize: 8` (the pre-packed Q8 turnkey
+/// default). Turbo is CFG-free so `resolve_guidance` returns None. Runs in CI on Mac (no weights).
+#[cfg(target_os = "macos")]
+#[test]
+fn boogu_engine_defaults_and_quant_resolution() {
+    let base = mlx_model("boogu_image").expect("boogu_image in MODEL_TABLE");
+    assert_eq!(base.engine_id(), "boogu_image");
+    assert_eq!(base.adapter_label(), "mlx_boogu");
+    assert_eq!(base.default_steps(), 50);
+    let turbo = mlx_model("boogu_image_turbo").expect("boogu_image_turbo in MODEL_TABLE");
+    assert_eq!(turbo.engine_id(), "boogu_image_turbo");
+    assert_eq!(turbo.default_steps(), 4);
+    let edit = mlx_model("boogu_image_edit").expect("boogu_image_edit in MODEL_TABLE");
+    assert_eq!(edit.engine_id(), "boogu_image_edit");
+
+    let req = |model: &str, advanced: Value| {
+        request(json!({
+            "projectId": "p", "model": model, "prompt": "p", "advanced": advanced,
+            "modelManifestEntry": { "mlx": { "quantize": 8 } },
+        }))
+    };
+    // Base: true-CFG guidance 4.0 from the model row. Turbo: CFG-free → resolve_guidance None.
+    assert_eq!(
+        resolve_guidance(&req("boogu_image", json!({})), &base),
+        Some(4.0)
+    );
+    assert_eq!(
+        resolve_guidance(&req("boogu_image_turbo", json!({})), &turbo),
+        None
+    );
+    // Default → Q8 (the shipped pre-packed turnkey); advanced.mlxQuantize overrides to Q4 / bf16-dense.
+    assert!(matches!(
+        resolve_quant(&req("boogu_image", json!({}))),
+        (Some(Quant::Q8), Some(8))
+    ));
+    assert!(matches!(
+        resolve_quant(&req("boogu_image", json!({ "mlxQuantize": 4 }))),
+        (Some(Quant::Q4), Some(4))
+    ));
+    assert!(matches!(
+        resolve_quant(&req("boogu_image", json!({ "mlxQuantize": 0 }))),
+        (None, None)
+    ));
+}
+
+/// `boogu_model_subdir` maps each id to its variant folder (`base`/`turbo`/`edit`), picks the
+/// pre-packed Q8 `<variant>/` by default, and the full-precision `<variant>-bf16/` only when
+/// `mlxQuantize <= 4` AND it is present — falling back to the Q8 folder (then root), so a request for
+/// a not-yet-downloaded bf16 build resolves the Q8 default rather than half-loading.
+#[cfg(target_os = "macos")]
+#[test]
+fn boogu_subdir_prefers_q8_and_opts_into_bf16() {
+    let root = tempfile::tempdir().unwrap();
+    let touch = |sub: &str| {
+        let dir = root.path().join(sub).join("transformer");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("diffusion_pytorch_model.safetensors"), b"stub").unwrap();
+    };
+    let req = |model: &str, advanced: Value| {
+        request(json!({ "projectId": "p", "model": model, "prompt": "p", "advanced": advanced }))
+    };
+    // Variant mapping + Q8 default.
+    touch("base");
+    touch("turbo");
+    touch("edit");
+    assert_eq!(
+        boogu_model_subdir(root.path(), &req("boogu_image", json!({}))),
+        root.path().join("base")
+    );
+    assert_eq!(
+        boogu_model_subdir(root.path(), &req("boogu_image_turbo", json!({}))),
+        root.path().join("turbo")
+    );
+    assert_eq!(
+        boogu_model_subdir(root.path(), &req("boogu_image_edit", json!({}))),
+        root.path().join("edit")
+    );
+    // bf16 opt-in falls back to the Q8 folder when `base-bf16/` is absent (not yet downloaded).
+    assert_eq!(
+        boogu_model_subdir(
+            root.path(),
+            &req("boogu_image", json!({ "mlxQuantize": 0 }))
+        ),
+        root.path().join("base"),
+        "bf16 opt-in falls back to Q8 when base-bf16 absent",
+    );
+    // With the bf16 folder present, `mlxQuantize <= 4` selects it; Q8 stays the default.
+    touch("base-bf16");
+    assert_eq!(
+        boogu_model_subdir(
+            root.path(),
+            &req("boogu_image", json!({ "mlxQuantize": 0 }))
+        ),
+        root.path().join("base-bf16")
+    );
+    assert_eq!(
+        boogu_model_subdir(
+            root.path(),
+            &req("boogu_image", json!({ "mlxQuantize": 4 }))
+        ),
+        root.path().join("base-bf16")
+    );
+    assert_eq!(
+        boogu_model_subdir(root.path(), &req("boogu_image", json!({}))),
+        root.path().join("base")
+    );
+}
+
 /// Raw-settings lineage: the Ideogram recipe records the real-inference flag, repo, resolved
 /// steps/guidance/quant, AND the sc-6147 structured-prompt blob passes through verbatim
 /// (`mlx_raw_settings` clones `advanced`, so the asset recipe can rehydrate the builder).

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -700,6 +700,12 @@ fn model_table_rows_resolve_and_flags_match_descriptor() {
         // maps to the SAME `bernini` engine the video id uses (`Modality::Both`). Standard guidance
         // family — `supports_guidance=true` (omega_txt) + `supports_negative_prompt=true`.
         ("bernini_image", true, true),
+        // Boogu-Image-0.1 (epic 6387 / sc-6399): Base + Edit are true-CFG (supports_guidance=true)
+        // with no user negative prompt (the CFG-negative is a fixed empty/drop instruction). Turbo is
+        // the DMD few-step, CFG-free distill (supports_guidance=false). None take a negative prompt.
+        ("boogu_image", true, false),
+        ("boogu_image_turbo", false, false),
+        ("boogu_image_edit", true, false),
     ];
     // Every row is covered by the expectation table (no row added without a flag pair here).
     assert_eq!(MODEL_TABLE.len(), expected.len());


### PR DESCRIPTION
## S2 — Boogu worker routing (epic 6387)

Wires the native-MLX Boogu engine ([mlx-gen #504](https://github.com/SceneWorks/mlx-gen/pull/504)) into the SceneWorks worker, so the three catalog ids from S1 become **live Studio pickers on Mac** (this flips their `macSupport.supported` → true). Final PR of the S2 cross-repo chain (mlx-gen #504 ✅ → [candle-gen #108](https://github.com/SceneWorks/candle-gen/pull/108) ✅ → this).

### Changes
- **`engines.rs`** — `MODEL_TABLE` rows: `boogu_image` (true-CFG T2I, 50 steps / guidance 4.0), `boogu_image_turbo` (DMD few-step, CFG-free, 4 steps), `boogu_image_edit` (instruction edit, 50 / 4.0); adapter `mlx_boogu`.
- **`image_jobs.rs`** — force-link `mlx_gen_boogu` so the three `inventory` registrations resolve via `gen_core::load`.
- **`image_jobs/base.rs`** — `boogu_model_subdir` (variant `base`/`turbo`/`edit`; pre-packed Q8 `<variant>/` default, full-precision `<variant>-bf16/` on advanced `mlxQuantize<=4`, fallback Q8→root) + snapshot routing; `resolve_boogu_edit` (`sourceAssetId` → `Conditioning::Reference`, fit to output W×H, no mask) + the edit-dispatch arm. **Not** added to `is_ideogram_model` (Boogu is natural-language, not JSON-caption).
- **`jobs_store.rs`** — the three ids in `MLX_ROUTED_MODELS` + an `image_request_mlx_eligible` arm + `boogu_mlx_eligible`, which gates `edit_image` to `boogu_image_edit` only (Base/Turbo are text-to-image — their semantic-edit path is incoherent without the Edit fine-tune, E7b-3), so `model_mac_support.features.edit` is true only for Edit.
- **`Cargo.toml`** — add `mlx-gen-boogu`; bump all mlx-gen pins `4740225`→`0b86fad` and the candle-gen pins `2d2ebfc`→`7281da5` (candle-gen #108) in lockstep, so the gen-core skew gate resolves a single rev on the `backend-candle` lane.

### bf16
The bf16 *selection* logic is wired (`<variant>-bf16/` via `mlxQuantize<=4`), but the bf16 files aren't auto-downloaded yet (only Q8 is in the S1 catalog), so a bf16 request currently falls back to Q8. The on-demand download + Studio precision toggle is tracked in [sc-6568](https://app.shortcut.com/trefry/story/6568).

### Validation
- `cargo check` / `cargo clippy -p sceneworks-worker -p sceneworks-core --all-targets -- -D warnings` / `cargo fmt --check` — clean.
- **gen-core skew gate passes** for both `sceneworks-worker` and `sceneworks-rust-api` (`--features backend-candle`): exactly one `sceneworks-gen-core` (`0b86fad`).
- Unit tests: `boogu_text_to_image_and_edit_route_to_mlx` (core — routing/eligibility/macSupport incl. the edit-only-on-Edit gate), `boogu_engine_defaults_and_quant_resolution` + `boogu_subdir_prefers_q8_and_opts_into_bf16` (worker).
- The engine path is covered by mlx-gen #504's real-weight conformance (Base/Turbo/Edit through `registry::load → Generator::generate`). The full worker→engine→image on the published Q8 turnkey is S5 (sc-6402).

🤖 Generated with [Claude Code](https://claude.com/claude-code)