### PR TITLE
feat(ideogram): switch prompt-refine + magic-prompt to Anubis-8B (sc-6550/sc-6546)

### DIFF
--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -8797,8 +8797,8 @@ fn builtin_manifest_registers_the_prompt_refine_model() {
         .as_array()
         .expect("models array")
         .iter()
-        .find(|entry| entry["id"] == "prompt_refine_llama_3_2_3b")
-        .expect("prompt_refine_llama_3_2_3b is registered in the catalog");
+        .find(|entry| entry["id"] == "prompt_refine_anubis_8b")
+        .expect("prompt_refine_anubis_8b is registered in the catalog");
     // A non-generation utility entry (mirrors the upscalers): absent from the image/video
     // studio pickers, present + downloadable in Model Manager.
     assert_eq!(model["type"], "utility");
@@ -8810,13 +8810,13 @@ fn builtin_manifest_registers_the_prompt_refine_model() {
     // Must match the worker's DEFAULT_REFINE_MODEL (prompt_refine_jobs.rs) — the string the
     // worker passes to huggingface_snapshot_dir.
     assert_eq!(
-        download["repo"], "huihui-ai/Llama-3.2-3B-Instruct-abliterated",
+        download["repo"], "TheDrummer/Anubis-Mini-8B-v1",
         "manifest repo must match the worker's DEFAULT_REFINE_MODEL"
     );
     // The catalog install-state path must resolve the same HF repo the worker does.
     assert_eq!(
         model["paths"]["model"],
-        "${HF_CACHE}/huihui-ai/Llama-3.2-3B-Instruct-abliterated"
+        "${HF_CACHE}/TheDrummer/Anubis-Mini-8B-v1"
     );
 }
 

--- a/apps/web/src/components/RefinePrompt.test.jsx
+++ b/apps/web/src/components/RefinePrompt.test.jsx
@@ -152,7 +152,7 @@ describe("RefinePromptControl", () => {
         workflow="image"
         refinePrompt={refinePrompt}
         onApply={vi.fn()}
-        refineModel={{ id: "prompt_refine_llama_3_2_3b", name: "Prompt Refiner", installState: "missing", downloadSizeBytes: 7222715642 }}
+        refineModel={{ id: "prompt_refine_anubis_8b", name: "Prompt Refiner", installState: "missing", downloadSizeBytes: 16077901824 }}
         onDownloadRefineModel={onDownloadRefineModel}
       />,
     );
@@ -164,7 +164,7 @@ describe("RefinePromptControl", () => {
 
     // The raw worker error is replaced by a download affordance with a size hint.
     expect(container.querySelector(".refine-missing-model").textContent).toContain("isn’t installed");
-    expect(container.querySelector(".refine-missing-model").textContent).toContain("7.2 GB");
+    expect(container.querySelector(".refine-missing-model").textContent).toContain("16.1 GB");
     const downloadButton = buttonByText(container, "Download refinement model");
     expect(downloadButton).toBeTruthy();
 
@@ -189,7 +189,7 @@ describe("RefinePromptControl", () => {
         workflow="image"
         refinePrompt={refinePrompt}
         onApply={vi.fn()}
-        refineModel={{ id: "prompt_refine_llama_3_2_3b", name: "Prompt Refiner", installState: "installed" }}
+        refineModel={{ id: "prompt_refine_anubis_8b", name: "Prompt Refiner", installState: "installed" }}
         onDownloadRefineModel={vi.fn()}
       />,
     );

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -16,11 +16,13 @@ export const INTERLEAVE_RESOLUTION_OPTIONS = [
 ];
 export const DEFAULT_INTERLEAVE_RESOLUTION = "2048x1152";
 
-// Catalog id of the prompt-refinement LLM (sc-5605, builtin.models.jsonc). The native
-// worker resolves the model by repo string, not this id; the web uses it to look up the
-// catalog entry's install state and to enqueue its ModelDownload job when "Refine my
-// prompt" fails because the model isn't provisioned.
-export const PROMPT_REFINE_MODEL_ID = "prompt_refine_llama_3_2_3b";
+// Catalog id of the prompt-refinement / magic-prompt LLM (sc-5605 / sc-6550, builtin.models.jsonc):
+// one coherent Anubis-8B serves BOTH the free-text "Refine my prompt" rewrite AND Ideogram 4's
+// magic-prompt (plain idea -> structured JSON caption) — the sc-6550 bake-off found the old 3B / plain
+// Llama-3.1-8B emit degenerate captions that placeholder. The native worker resolves the model by repo
+// string, not this id; the web uses it to look up the catalog entry's install state and to enqueue its
+// ModelDownload job when refine / magic-prompt needs it.
+export const PROMPT_REFINE_MODEL_ID = "prompt_refine_anubis_8b";
 
 // Catalog id of the dataset-captioning model (sc-5620, builtin.models.jsonc). Same pattern
 // as PROMPT_REFINE_MODEL_ID — the native captioner resolves it by repo string; the web uses

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -3354,25 +3354,37 @@
       }
     },
     {
-      // Prompt-refinement LLM (sc-5605). The native worker (`prompt_refine_jobs.rs`)
-      // refines a user's prompt with a small in-process Llama-3.2-3B instruction model
-      // through the gen-core `TextLlm` contract — MLX on macOS (sc-5552) and candle on
-      // the Windows/CUDA build (sc-5525). Unlike the retired Python `PromptRefiner`
-      // (`from_pretrained` auto-downloaded on first use), the native path only *resolves*
-      // an already-cached snapshot via `huggingface_snapshot_dir`, so the model has to be
-      // a provisionable catalog artifact. Cataloging it here lets Model Manager download
-      // it into the HF cache the worker reads from; the worker still references it by repo
-      // string (`DEFAULT_REFINE_MODEL`), not by this id.
+      // Prompt-refinement / magic-prompt LLM (sc-5605 / sc-6550). The native worker
+      // (`prompt_refine_jobs.rs`) serves BOTH the free-text "Refine my prompt" rewrite AND Ideogram 4's
+      // magic-prompt (plain idea -> structured JSON caption) with this single coherent Anubis-8B,
+      // through the gen-core `TextLlm` contract — MLX on macOS (sc-5552) and candle on Windows/CUDA
+      // (sc-5525). The native path only *resolves* an already-cached snapshot, so the model has to be a
+      // provisionable catalog artifact; the worker references it by repo string (`DEFAULT_REFINE_MODEL`),
+      // not by this id.
       //
-      // Stock repo, pulled as-is: it is a standard transformers safetensors checkpoint —
-      // NOT MLX-converted and NOT requiring conversion (the mlx-gen-prompt-refine provider
-      // reads the stock config/safetensors/tokenizer directly; mlx-gen #457 validated
-      // against this exact repo), so the epic-5594 re-host pattern (conversion-required
-      // models) does not apply. `files: []` pulls the repo's own LICENSE.txt + USE_POLICY
-      // (Llama community license) alongside the weights.
-      "id": "prompt_refine_llama_3_2_3b",
+      // Why Anubis (replaced the old Llama-3.2-3B refiner): the sc-6550 real-weight bake-off found the
+      // 3B AND the plain Llama-3.1-8B (stock + abliterated) stochastically emit SEMANTICALLY-DEGENERATE
+      // captions (the subject placed as a `text` element, a reflexive `background:"on a transparent
+      // background"`) that placeholder Ideogram 4 at 1024^2/48 ~70-83% of the time, while Anubis (a
+      // coherent Llama-3.3-8B community finetune) was the only model that avoids them (~26%, mostly
+      // malformed JSON the reseed net + future constrained decoding catch).
+      //
+      // Stock transformers safetensors checkpoint loaded AS-IS by the mlx-gen-prompt-refine /
+      // candle-gen-prompt-refine provider (config-driven Llama, bf16, NO MLX conversion / quantization).
+      //
+      // recommended but `autoDownload: false` + `minMemoryGb: 64`: ~15 GB bf16 / ~16 GB resident, so it
+      // is badged-but-unchecked (pulled on demand via the refine/magic download affordance / Model
+      // Manager) and gated to 64 GB+ machines. When absent, refine surfaces a download prompt and the
+      // Ideogram magic-prompt API degrades to the plain prompt + reseed net.
+      //
+      // LICENSE: the repo declares no own license; it is a finetune of a Llama-3.3-8B base, governed by
+      // the Meta Llama community license (same posture as the retired huihui abliterated 3B, which also
+      // declared no own license). `files: []` pulls whatever license/policy files the repo ships.
+      "id": "prompt_refine_anubis_8b",
       "recommended": true,
-      "name": "Prompt Refiner (Llama-3.2-3B)",
+      "autoDownload": false,
+      "minMemoryGb": 64,
+      "name": "Prompt Refiner (Anubis-8B)",
       "family": "prompt-refine",
       "type": "utility",
       "adapter": "prompt-refine",
@@ -3380,13 +3392,13 @@
       "downloads": [
         {
           "provider": "huggingface",
-          "repo": "huihui-ai/Llama-3.2-3B-Instruct-abliterated",
+          "repo": "TheDrummer/Anubis-Mini-8B-v1",
           "files": [],
-          "estimatedSizeBytes": 7222715642
+          "estimatedSizeBytes": 16077901824
         }
       ],
       "paths": {
-        "model": "${HF_CACHE}/huihui-ai/Llama-3.2-3B-Instruct-abliterated"
+        "model": "${HF_CACHE}/TheDrummer/Anubis-Mini-8B-v1"
       },
       "defaults": {},
       "limits": {},
@@ -3395,15 +3407,14 @@
         "types": []
       },
       "ui": {
-        "label": "Prompt Refiner (Llama-3.2-3B)",
-        "description": "Optional small instruction LLM used by the \"Refine my prompt\" control to rewrite prompts to follow the selected model's guide. Runs in-process on the native worker (MLX on macOS, candle on Windows/CUDA).",
+        "label": "Prompt Refiner (Anubis-8B)",
+        "description": "Instruction LLM used by the \"Refine my prompt\" control and by Ideogram 4's magic-prompt (plain idea -> structured JSON caption). Runs in-process on the native worker (MLX on macOS, candle on Windows/CUDA).",
         "recommendedFor": ["prompt_refine"],
         "promptGuide": {
           "title": "Prompt Refiner Guide",
           "path": "/prompt-guides/prompt-refine.md",
           "sources": [
-            { "label": "huihui-ai Llama-3.2-3B-Instruct-abliterated model card", "url": "https://huggingface.co/huihui-ai/Llama-3.2-3B-Instruct-abliterated" },
-            { "label": "Meta Llama-3.2-3B-Instruct", "url": "https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct" }
+            { "label": "TheDrummer Anubis-Mini-8B-v1 model card", "url": "https://huggingface.co/TheDrummer/Anubis-Mini-8B-v1" }
           ]
         }
       }

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -398,7 +398,7 @@ string_enum! {
         // macOS (sc-5552) and candle on the Windows/CUDA build when `backend_candle_enabled`
         // (sc-5525). The torch `PromptRefiner` remains only as the fallback on platforms with neither
         // native provider (e.g. the candle-less Desktop installer / Linux). The model is provisioned
-        // from the catalog (`prompt_refine_llama_3_2_3b`, sc-5605) into the HF cache the worker
+        // from the catalog (`prompt_refine_anubis_8b`, sc-5605/sc-6550) into the HF cache the worker
         // resolves; the native path does not auto-download. Routed by capability match. See
         // apps/worker/scene_worker/runtime.py and crates/sceneworks-worker/src/prompt_refine_jobs.rs.
         PromptRefine => "prompt_refine",

--- a/crates/sceneworks-worker/src/prompt_refine_jobs.rs
+++ b/crates/sceneworks-worker/src/prompt_refine_jobs.rs
@@ -35,13 +35,17 @@ use mlx_gen_prompt_refine as _;
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 const PROMPT_REFINE_ENGINE_ID: &str = "prompt_refine";
-// Default refinement checkpoint — the small abliterated Llama-3.2-3B instruction model, parity with
-// the Python `DEFAULT_REFINE_MODEL`. Overridable per-job via `payload.model`.
+// The prompt-refinement / magic-prompt checkpoint — the coherent Anubis-8B (sc-6550 bake-off). It
+// serves BOTH the free-text "Refine my prompt" rewrite AND the Ideogram magic-prompt JSON caption:
+// the bake-off found the old 3B (and plain Llama-3.1-8B, stock + abliterated) stochastically emit
+// SEMANTICALLY-DEGENERATE captions (subject as a `text` element, a reflexive transparent background)
+// that placeholder Ideogram 4 at 1024²/48, while Anubis avoids them. Loads on this same config-driven
+// Llama seam with no conversion (stock bf16, ~16GB). Overridable per-job via `payload.model`.
 #[cfg(any(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
-const DEFAULT_REFINE_MODEL: &str = "huihui-ai/Llama-3.2-3B-Instruct-abliterated";
+const DEFAULT_REFINE_MODEL: &str = "TheDrummer/Anubis-Mini-8B-v1";
 #[cfg(any(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
@@ -361,6 +365,14 @@ pub(crate) async fn run_prompt_refine_job(
         .get("workflow")
         .and_then(Value::as_str)
         .map(str::to_owned);
+    // Magic-prompt expansion (sc-5997) drives the same TextLlm seam with Ideogram's caption system
+    // prompt instead of the rewrite rules; captions run longer than a one-line prompt, so allow more
+    // tokens and sample cooler for steadier JSON.
+    let is_magic = payload
+        .get("task")
+        .and_then(Value::as_str)
+        .map(|task| task.trim().eq_ignore_ascii_case("magic_prompt"))
+        .unwrap_or(false);
     let model = payload
         .get("model")
         .and_then(Value::as_str)
@@ -368,14 +380,6 @@ pub(crate) async fn run_prompt_refine_job(
         .filter(|value| !value.is_empty())
         .unwrap_or(DEFAULT_REFINE_MODEL)
         .to_owned();
-    // Magic-prompt expansion (sc-5997) drives the same model with Ideogram's caption system prompt
-    // instead of the rewrite rules; captions run longer than a one-line prompt, so allow more tokens
-    // and sample cooler for steadier JSON.
-    let is_magic = payload
-        .get("task")
-        .and_then(Value::as_str)
-        .map(|task| task.trim().eq_ignore_ascii_case("magic_prompt"))
-        .unwrap_or(false);
     let max_new_tokens = payload
         .get("maxNewTokens")
         .and_then(Value::as_u64)
@@ -791,5 +795,274 @@ mod tests {
             clean_refine_output("<think>no close here"),
             "<think>no close here"
         );
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Magic-prompt model bake-off (sc-6550) — a parameterized harness + degeneracy rubric for
+    // choosing the magic-prompt model that fixes the sc-6546 caption-quality ceiling. The 3B
+    // (`huihui-ai/Llama-3.2-3B-Instruct-abliterated`) stochastically emits SEMANTICALLY-DEGENERATE
+    // captions (the subject placed as a `type:"text"` element, or `background` set to a transparent
+    // cutout for a prompt that never asked for one) which placeholder at 1024²/48. This harness runs
+    // Ideogram's magic-prompt v1 system prompt (the SHIPPING `build_magic_prompt_messages`) over a
+    // fixed prompt set through the REAL `prompt_refine` provider and scores the degeneracy from the
+    // caption JSON alone — the root-cause signal, no Ideogram render needed (metric (c), the
+    // placeholder-escape render confirmation, is the gated downstream step).
+    // ------------------------------------------------------------------------------------------
+
+    /// One bake-off prompt + what a CORRECT caption looks like for it, so the analyzer can tell a
+    /// degeneracy (subject-as-text / unrequested transparent cutout) apart from a legitimate use of
+    /// those features.
+    // `text` / `edgy` are read only by the macOS-gated real-weight bakeoff test below; on the Linux
+    // clippy lane that test is cfg'd out, so suppress the cross-platform dead-code lint.
+    #[allow(dead_code)]
+    struct BakeoffPrompt {
+        text: &'static str,
+        /// The prompt legitimately calls for `type:"text"` (typography / rendered words), so a text
+        /// element is NOT degenerate here.
+        wants_text: bool,
+        /// The prompt legitimately calls for a transparent background (product cutout / sticker), so
+        /// `background:"…transparent…"` is NOT degenerate here.
+        wants_transparent: bool,
+        /// An edgy prompt — present to measure refusals (an uncensored model must still emit a
+        /// caption). A refusal shows up as `!caption_valid`.
+        edgy: bool,
+    }
+
+    /// The fixed bake-off prompt set: the sc-6546 failing prompt + diverse plain subjects (the
+    /// degeneracy measurement), two CONTROLS that legitimately want a text element / transparent
+    /// background, and two edgy prompts (refusal test for the uncensored requirement).
+    const BAKEOFF_PROMPTS: &[BakeoffPrompt] = &[
+        // The sc-6546 failing prompt.
+        BakeoffPrompt { text: "a red fox sitting in a snowy forest at golden hour", wants_text: false, wants_transparent: false, edgy: false },
+        // Diverse plain subjects — none ask for text or transparency, so ANY text element or
+        // transparent background is the sc-6546 degeneracy.
+        BakeoffPrompt { text: "a steaming bowl of ramen on a rustic wooden table", wants_text: false, wants_transparent: false, edgy: false },
+        BakeoffPrompt { text: "a vintage red bicycle leaning against a weathered brick wall", wants_text: false, wants_transparent: false, edgy: false },
+        BakeoffPrompt { text: "a snow leopard walking across a rocky mountain ridge", wants_text: false, wants_transparent: false, edgy: false },
+        BakeoffPrompt { text: "an astronaut floating above the earth in low orbit", wants_text: false, wants_transparent: false, edgy: false },
+        BakeoffPrompt { text: "a cozy log cabin in a pine forest during a snowstorm", wants_text: false, wants_transparent: false, edgy: false },
+        BakeoffPrompt { text: "a golden retriever puppy playing in a pile of autumn leaves", wants_text: false, wants_transparent: false, edgy: false },
+        BakeoffPrompt { text: "a futuristic city skyline at night lit by neon signs", wants_text: false, wants_transparent: false, edgy: false },
+        BakeoffPrompt { text: "a single sunflower in a glass vase on a sunlit windowsill", wants_text: false, wants_transparent: false, edgy: false },
+        BakeoffPrompt { text: "a lone samurai standing in a misty bamboo forest at dawn", wants_text: false, wants_transparent: false, edgy: false },
+        // CONTROL: legitimately wants text — the model SHOULD emit a `type:"text"` element here.
+        BakeoffPrompt { text: "a bold motivational poster with the headline NEVER GIVE UP in large letters", wants_text: true, wants_transparent: false, edgy: false },
+        // CONTROL: legitimately wants a transparent background — a product cutout.
+        BakeoffPrompt { text: "a product cutout of a red running sneaker on a transparent background", wants_text: false, wants_transparent: true, edgy: false },
+        // Edgy (refusal test for the uncensored requirement).
+        BakeoffPrompt { text: "a gritty film-noir crime scene, a detective examining a body under a harsh streetlight", wants_text: false, wants_transparent: false, edgy: true },
+        BakeoffPrompt { text: "a fierce barbarian warrior, bloodied and scarred, standing over a fallen foe after battle", wants_text: false, wants_transparent: false, edgy: true },
+    ];
+
+    /// Degeneracy metrics for a single caption reply, scored against what the prompt legitimately
+    /// expected. This is the sc-6546 rubric in code — pure, so it is unit-tested without weights.
+    #[derive(Clone, Copy, Debug, Default)]
+    // `parse_ok` is read only by the macOS-gated bakeoff test; suppress the Linux-lane dead-code lint.
+    #[allow(dead_code)]
+    struct CaptionMetrics {
+        /// The cleaned reply parses as JSON.
+        parse_ok: bool,
+        /// A structured caption — a JSON object with a `compositional_deconstruction` object
+        /// (mirrors `sceneworks_core::ideogram_caption::is_caption`).
+        caption_valid: bool,
+        n_obj: usize,
+        n_text: usize,
+        has_transparent_bg: bool,
+        /// A text element appeared where the prompt did not ask for one (subject-as-`text`
+        /// degeneracy).
+        text_when_unwanted: bool,
+        /// A transparent background appeared where the prompt did not ask for one.
+        transparent_when_unwanted: bool,
+    }
+
+    impl CaptionMetrics {
+        /// The headline placeholder-risk proxy: a malformed/non-caption reply, an unrequested
+        /// transparent cutout, an unrequested text element, or a caption with NO object subject.
+        fn degenerate(&self) -> bool {
+            !self.caption_valid
+                || self.transparent_when_unwanted
+                || self.text_when_unwanted
+                || self.n_obj == 0
+        }
+    }
+
+    /// Score a raw model reply for `prompt` (applies the shipping `clean_json_output` first).
+    fn analyze_caption(prompt: &BakeoffPrompt, raw: &str) -> CaptionMetrics {
+        let cleaned = clean_json_output(raw);
+        let Ok(value) = serde_json::from_str::<Value>(&cleaned) else {
+            return CaptionMetrics::default();
+        };
+        let mut m = CaptionMetrics {
+            parse_ok: true,
+            ..Default::default()
+        };
+        let Some(cd) = value
+            .get("compositional_deconstruction")
+            .and_then(Value::as_object)
+        else {
+            return m; // parsed, but not a caption (caption_valid stays false)
+        };
+        m.caption_valid = true;
+        if let Some(bg) = cd.get("background").and_then(Value::as_str) {
+            m.has_transparent_bg = bg.to_ascii_lowercase().contains("transparent");
+        }
+        if let Some(elements) = cd.get("elements").and_then(Value::as_array) {
+            for el in elements {
+                match el.get("type").and_then(Value::as_str) {
+                    Some("text") => m.n_text += 1,
+                    _ => m.n_obj += 1, // obj (or an untyped element defaults to obj per the serializer)
+                }
+            }
+        }
+        m.text_when_unwanted = m.n_text > 0 && !prompt.wants_text;
+        m.transparent_when_unwanted = m.has_transparent_bg && !prompt.wants_transparent;
+        m
+    }
+
+    #[test]
+    fn analyze_caption_flags_the_sc6546_degeneracies() {
+        // Healthy: one obj subject, opaque scene background, no text → not degenerate.
+        let plain = &BAKEOFF_PROMPTS[0];
+        let healthy = analyze_caption(
+            plain,
+            r#"{"compositional_deconstruction": {"background": "a snowy forest at golden hour", "elements": [{"type": "obj", "desc": "a red fox"}]}}"#,
+        );
+        assert!(healthy.caption_valid && healthy.n_obj == 1 && !healthy.degenerate());
+
+        // Subject-as-text degeneracy: the fox emitted as a `type:"text"` element.
+        let subj_text = analyze_caption(
+            plain,
+            r#"{"compositional_deconstruction": {"background": "a snowy forest", "elements": [{"type": "text", "text": "a red fox", "desc": "a red fox"}]}}"#,
+        );
+        assert!(subj_text.text_when_unwanted && subj_text.n_obj == 0 && subj_text.degenerate());
+
+        // Transparent-background degeneracy for a scene prompt that never asked for one.
+        let transp = analyze_caption(
+            plain,
+            r#"{"compositional_deconstruction": {"background": "on a transparent background", "elements": [{"type": "obj", "desc": "a red fox"}]}}"#,
+        );
+        assert!(transp.transparent_when_unwanted && transp.degenerate());
+
+        // A refusal / non-JSON reply is degenerate (parse fails).
+        assert!(analyze_caption(plain, "I cannot help with that request.").degenerate());
+
+        // CONTROL: the transparent-cutout prompt legitimately uses a transparent background.
+        let cutout = &BAKEOFF_PROMPTS[11];
+        assert!(cutout.wants_transparent);
+        let ok_transp = analyze_caption(
+            cutout,
+            r#"{"compositional_deconstruction": {"background": "on a transparent background", "elements": [{"type": "obj", "desc": "a red sneaker"}]}}"#,
+        );
+        assert!(!ok_transp.transparent_when_unwanted && !ok_transp.degenerate());
+
+        // CONTROL: the poster prompt legitimately uses a text element.
+        let poster = &BAKEOFF_PROMPTS[10];
+        assert!(poster.wants_text);
+        let ok_text = analyze_caption(
+            poster,
+            r#"{"compositional_deconstruction": {"background": "a plain studio backdrop", "elements": [{"type": "obj", "desc": "a poster"}, {"type": "text", "text": "NEVER GIVE UP", "desc": "the headline"}]}}"#,
+        );
+        assert!(!ok_text.text_when_unwanted && !ok_text.degenerate());
+    }
+
+    /// Real-weight magic-prompt bake-off (sc-6550). Runs the shipping magic-prompt system prompt over
+    /// `BAKEOFF_PROMPTS` × N seeds through the REAL `prompt_refine` provider and prints per-run +
+    /// aggregate degeneracy metrics. `#[ignore]` — the weights live outside CI. Point it at any
+    /// snapshot dir (the 3B baseline, a Llama-3.1-8B, an Anubis-8B …); the provider is config-driven
+    /// Llama, so any Llama-3.x-Instruct shape loads as-is. Measure footprint by wrapping the TEST
+    /// BINARY with `/usr/bin/time -l` (NOT `cargo test`, which reports the cargo parent's peak):
+    ///   BAKEOFF_MODEL_DIR=~/.cache/huggingface/hub/models--huihui-ai--Meta-Llama-3.1-8B-Instruct-abliterated/snapshots/<rev> \
+    ///   BAKEOFF_SEEDS=3 cargo test -p sceneworks-worker --lib -- --ignored --nocapture magic_prompt_bakeoff
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "real-weight: set BAKEOFF_MODEL_DIR to a Llama-3.x-Instruct snapshot dir"]
+    fn magic_prompt_bakeoff() {
+        use gen_core::{
+            CancelFlag, LoadSpec, Progress, TextLlmRequest, TextLlmSampling, WeightsSource,
+        };
+        use std::time::Instant;
+
+        let weights_dir = std::path::PathBuf::from(
+            std::env::var("BAKEOFF_MODEL_DIR").expect("set BAKEOFF_MODEL_DIR to a snapshot dir"),
+        );
+        let seeds: u64 = std::env::var("BAKEOFF_SEEDS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(3);
+        eprintln!("BAKEOFF model_dir={}", weights_dir.display());
+
+        let refiner = gen_core::load_textllm(
+            PROMPT_REFINE_ENGINE_ID,
+            &LoadSpec::new(WeightsSource::Dir(weights_dir)),
+        )
+        .expect("load prompt_refine");
+
+        let (mut runs, mut parse_ok, mut caption_valid, mut degenerate) = (0u32, 0u32, 0u32, 0u32);
+        let (mut text_bad, mut transp_bad, mut no_obj) = (0u32, 0u32, 0u32);
+        // Refusal tracking on the edgy prompts only.
+        let (mut edgy_runs, mut edgy_valid) = (0u32, 0u32);
+        let mut total_ms = 0u128;
+
+        for prompt in BAKEOFF_PROMPTS {
+            let (system, user) = build_magic_prompt_messages(prompt.text, "1:1");
+            for seed in 0..seeds {
+                let request = TextLlmRequest {
+                    system: system.clone(),
+                    prompt: user.clone(),
+                    sampling: TextLlmSampling {
+                        temperature: 0.4, // matches the worker's magic-prompt sampling
+                        top_p: 0.9,
+                        max_new_tokens: 2048,
+                        seed: Some(seed),
+                    },
+                    cancel: CancelFlag::new(),
+                };
+                let mut noop = |_p: Progress| {};
+                let start = Instant::now();
+                let output = refiner.generate(&request, &mut noop).expect("generate");
+                let ms = start.elapsed().as_millis();
+                total_ms += ms;
+
+                let m = analyze_caption(prompt, &output.text);
+                runs += 1;
+                parse_ok += m.parse_ok as u32;
+                caption_valid += m.caption_valid as u32;
+                degenerate += m.degenerate() as u32;
+                text_bad += m.text_when_unwanted as u32;
+                transp_bad += m.transparent_when_unwanted as u32;
+                no_obj += (m.caption_valid && m.n_obj == 0) as u32;
+                if prompt.edgy {
+                    edgy_runs += 1;
+                    edgy_valid += m.caption_valid as u32;
+                }
+                eprintln!(
+                    "BAKEOFF run seed={seed} {}ms valid={} obj={} text={} transp_bg={} degen={} :: {}",
+                    ms, m.caption_valid, m.n_obj, m.n_text, m.has_transparent_bg, m.degenerate(),
+                    prompt.text
+                );
+                // Surface the cleaned JSON so degeneracies are eyeball-auditable.
+                eprintln!("BAKEOFF json :: {}", clean_json_output(&output.text));
+            }
+        }
+
+        let pct = |n: u32| 100.0 * n as f64 / runs.max(1) as f64;
+        eprintln!(
+            "\nBAKEOFF SUMMARY ({runs} runs, {seeds} seeds × {} prompts)",
+            BAKEOFF_PROMPTS.len()
+        );
+        eprintln!("  parse_ok           {:.1}%", pct(parse_ok));
+        eprintln!("  caption_valid      {:.1}%", pct(caption_valid));
+        eprintln!(
+            "  DEGENERATE         {:.1}%  <- headline placeholder-risk proxy",
+            pct(degenerate)
+        );
+        eprintln!("    text_when_unwanted   {:.1}%", pct(text_bad));
+        eprintln!("    transp_when_unwanted {:.1}%", pct(transp_bad));
+        eprintln!("    valid_but_no_obj     {:.1}%", pct(no_obj));
+        eprintln!(
+            "  edgy_caption_valid {:.1}% ({edgy_valid}/{edgy_runs})  (refusal proxy)",
+            100.0 * edgy_valid as f64 / edgy_runs.max(1) as f64
+        );
+        eprintln!("  avg_latency        {}ms", total_ms / runs.max(1) as u128);
     }
 }


### PR DESCRIPTION
## What

Replace the Llama-3.2-3B prompt refiner with the coherent **Anubis-Mini-8B** as the **single** prompt-refinement model, serving **both** the free-text "Refine my prompt" rewrite **and** Ideogram 4's magic-prompt (plain idea → structured JSON caption).

## Why (sc-6550 real-weight bake-off)

42-run bake-off scoring caption degeneracy (subject placed as a `text` element / reflexive `background:"on a transparent background"` — both placeholder Ideogram 4 at 1024²/48):

| DEGENERATE | 3B | Llama-3.1-8B ablit | stock Llama-3.1-8B | **Anubis-8B** |
|---|---|---|---|---|
| | 81% | 69% | 83% | **26%** |

3 of 4 models fail ~70-83%; only the coherent Anubis finetune passes (it's also a stronger free-text rewriter). Residual ~26% is mostly malformed JSON — closed later by native constrained decoding (**sc-6585**); the reseed net backstops meanwhile.

## Changes (6 files)

- **worker**: `DEFAULT_REFINE_MODEL = TheDrummer/Anubis-Mini-8B-v1` (overridable via `payload.model`). **No conversion** — loads as-is on the existing config-driven Llama seam (stock bf16).
- **manifest**: prompt-refine utility entry is now `prompt_refine_anubis_8b` (`recommended` + `autoDownload:false` + `minMemoryGb:64` — ~15 GB, on-demand, 64 GB+). Old 3B entry retired.
- **web**: `PROMPT_REFINE_MODEL_ID → prompt_refine_anubis_8b` (Image/Video Studio + RefinePromptControl follow it).
- **tests/contract**: catalog guard test + contract comment + RefinePrompt fixtures updated to the Anubis id/repo/size.
- **harness (sc-6550, test-only)**: `analyze_caption` degeneracy rubric (unit-tested) + parameterized `#[ignore] magic_prompt_bakeoff`.

## Verification (the CI gates, run locally)
- `cargo fmt --all -- --check` ✅, `cargo clippy --all-targets -- -D warnings` ✅ (fixes the earlier parity dead-code from the macOS-gated harness)
- rust-api catalog guard test ✅, worker `prompt_refine` tests ✅
- web lint 0 errors ✅, full suite **624 passed** ✅

## Heads-up: `build-windows` is red on a PRE-EXISTING main bug (not this PR)
`build-windows` fails on `crates/sceneworks-worker/src/image_jobs/base.rs` (`IDEOGRAM_EDIT_STRENGTH` / `IDEOGRAM_INPAINT_STRENGTH` are `#[cfg(target_os="macos")]` but used on the candle build) — a file this PR doesn't touch. **main's own Desktop (Windows) build is already failing** (e.g. the #828 merge), and GitHub builds this PR merged into current main, so the breakage surfaces here. Flagging rather than absorbing it; happy to fix it in a separate PR (a small cfg gate) on request.

## Open items (follow-on)
- **License sign-off** for bundling Anubis (no own license; governed by its Llama-3.3 base — same posture as the retired 3B).
- **sc-6585**: native grammar/JSON-constrained decoding for the malformed-JSON tail.
- Ideogram render confirmation at 1024²/48 against Anubis.

Spike: sc-6550 (Done). Fix: sc-6546 (In Progress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)