### PR TITLE
fix(worker): restore macOS cfg gate on resolve_ideogram_edit (sc-6588)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -873,18 +873,6 @@ const IDEOGRAM_EDIT_STRENGTH: f32 = 0.6;
 #[cfg(target_os = "macos")]
 const IDEOGRAM_INPAINT_STRENGTH: f32 = 0.85;
 
-/// Resolve the Ideogram 4 `edit_image` conditioning (sc-6303) into the base MLX path's
-/// `(source, strength, optional-mask)` shape (→ the engine's `Conditioning::Reference` +
-/// `Conditioning::Mask`). Three sub-shapes, mirroring the sdxl edit classification:
-///   * **img2img / Remix** — `sourceAssetId`, no mask: pre-fit the source to the output W×H
-///     (crop/pad, never stretch) → `(source, 0.6, None)`.
-///   * **masked inpaint** — `+ maskAssetId`: the mask fit with the same geometry → `(source, 0.85,
-///     Some(mask))` (white = repaint).
-///   * **outpaint** — `fit_mode == "outpaint"`: contain-pad the source onto the canvas and generate
-///     the border via [`gen_core::imageops::outpaint_border_mask`] (using the ORIGINAL source dims so
-///     it lines up), unioning any user mask (white wins).
-///
-/// `None` when not an edit job or no source asset (the caller falls back to plain txt2img).
 #[cfg(target_os = "macos")]
 /// Resolve the Boogu instruction-edit source: the `sourceAssetId` image, fit to the output W×H (so
 /// it satisfies the engine's multiple-of-16 guard and aligns to the target aspect). Returns
@@ -917,6 +905,19 @@ fn resolve_boogu_edit(
     Ok(Some((source, 1.0)))
 }
 
+/// Resolve the Ideogram 4 `edit_image` conditioning (sc-6303) into the base MLX path's
+/// `(source, strength, optional-mask)` shape (→ the engine's `Conditioning::Reference` +
+/// `Conditioning::Mask`). Three sub-shapes, mirroring the sdxl edit classification:
+///   * **img2img / Remix** — `sourceAssetId`, no mask: pre-fit the source to the output W×H
+///     (crop/pad, never stretch) → `(source, 0.6, None)`.
+///   * **masked inpaint** — `+ maskAssetId`: the mask fit with the same geometry → `(source, 0.85,
+///     Some(mask))` (white = repaint).
+///   * **outpaint** — `fit_mode == "outpaint"`: contain-pad the source onto the canvas and generate
+///     the border via [`gen_core::imageops::outpaint_border_mask`] (using the ORIGINAL source dims so
+///     it lines up), unioning any user mask (white wins).
+///
+/// `None` when not an edit job or no source asset (the caller falls back to plain txt2img).
+#[cfg(target_os = "macos")]
 fn resolve_ideogram_edit(
     request: &ImageRequest,
     settings: &Settings,


### PR DESCRIPTION
## Problem
The off-Mac `--features backend-candle` worker build is broken on `main`:

```
error[E0425]: cannot find value `IDEOGRAM_INPAINT_STRENGTH` in this scope
error[E0425]: cannot find value `IDEOGRAM_EDIT_STRENGTH` in this scope
note: found an item that was configured out (gated behind the `macos` feature)
```

## Root cause
`7ffd79d2` (sc-6399 / #828, Boogu worker routing, merged 2026-06-19) inserted `fn resolve_boogu_edit` between the `#[cfg(target_os = "macos")]` attribute and `fn resolve_ideogram_edit`. The new function absorbed the gate (and the ideogram doc comment), leaving `resolve_ideogram_edit` ungated — so it compiles off-Mac, where its Mac-only `IDEOGRAM_EDIT_STRENGTH` / `IDEOGRAM_INPAINT_STRENGTH` consts don't exist.

Its only caller, `generate_stream`, is itself `#[cfg(target_os = "macos")]`, so the function is Mac-only by design; it just lost the attribute. Same class as sc-6231 — a Mac-only item used from shared worker code, which the PR gate misses because the `backend-candle` lane is `workflow_dispatch`-only, not a required check.

## Fix
- Restore `#[cfg(target_os = "macos")]` on `resolve_ideogram_edit`.
- Move its doc comment back onto it (sc-6399 had stranded it on `resolve_boogu_edit`).

## Validation
`cargo check -p sceneworks-worker` clean on the Windows host — the errors are `target_os`-gated (not feature-gated), so the default check reproduces and validates the fix without the CUDA toolchain. Confirmed the candle desktop sidecar build now compiles past the worker crate.

## Follow-up (not this PR)
Make `backend-candle` a required PR gate (or a cross-target `cargo check --features backend-candle` on a non-Mac host) so this recurring Mac-only-symbol-from-shared-code class fails before merge instead of breaking every off-Mac build after a pull.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
