### PR TITLE
feat(prompt-refine): make Boogu's prompt guide its rewriter context (sc-6401)

### DIFF
--- a/apps/web/public/prompt-guides/boogu-image.md
+++ b/apps/web/public/prompt-guides/boogu-image.md
@@ -5,7 +5,8 @@
 General-purpose **still images** from natural-language prompts — Boogu-Image-0.1 is a flow-matching
 model (a ~10.3B DiT paired with a Qwen3-VL-8B condition encoder) that reads your prompt as plain
 language, so describe the image the way you'd describe it to a person. It is especially strong at
-**rendering legible text in the image** (signs, labels, posters) in both **English and Chinese**.
+**rendering legible text in the image** (signs, labels, posters, diagrams) in both **English and
+Chinese**.
 
 > Three variants ship: **Boogu Image** (full quality, true-CFG, ~50 steps), **Boogu Image Turbo**
 > (few-step, ~4 steps, much faster — best for iteration), and **Boogu Image Edit** (instruction-driven
@@ -33,6 +34,23 @@ Tips per mode:
 Boogu reads the whole prompt as intent, so natural descriptive language works better than a pile of
 disconnected tags.
 
+## How Boogu Reads A Prompt (keep it faithful and concise)
+
+The goal is a clear prompt, not a long one:
+
+- **Already clear → barely change it.** A short, well-defined prompt ("a cup of coffee", "a kingfisher
+  on a branch") needs little more than maybe one style word. Don't invent scenes, props, actions, or
+  mood the prompt didn't mention. Only genuinely abstract prompts ("fruit destined with Newton") need
+  real expansion.
+- **Be concise.** Short sentences; don't repeat ideas, pile up synonyms ("realistic, photographic,
+  ultra-real"), or add empty praise ("stunning", "premium", "high-end", "tech feel"). Quality words
+  like `cinematic` or `refined texture` are fine.
+- **Don't add camera/photography parameters** the prompt didn't ask for (`35mm`, `f/1.8`, `bokeh`,
+  `shallow depth of field`, `cinematic lighting`) — keep them only if you wrote them.
+- **Describe what you want, not what you don't.** Boogu doesn't use a negative prompt (it manages
+  classifier-free guidance internally), so avoid negations ("no chopsticks", "without text") — state
+  the positive scene instead; a thing you don't name simply won't appear.
+
 ## Build The Prompt
 
 ### Subject
@@ -44,30 +62,39 @@ subjects render more coherently than a crowded frame.
 
 Describe background, foreground, lighting, weather, and time of day. A focused scene reads cleaner.
 
+### Counts, layout & relationships
+
+- **Exact counts:** if you ask for a specific number or arrangement ("seven", "three rows of four"),
+  honor it exactly and describe each subject in a fixed order (left-to-right, top-to-bottom).
+- **Relationships:** keep logical structure explicit — "a food chain on the grassland" should describe
+  the arrows and each icon, not just the words.
+- **Diagrams, infographics, posters, menus, UI:** the conciseness advice flips — be *exhaustive*. Spell
+  out every node's text, arrow direction, connections, module hierarchy, colors, and layout positions.
+
 ### Text In The Image
 
-Boogu renders typography well. Put the exact words in quotes and say where they go:
+Boogu renders typography well. Put the **exact** words in quotes, say where they go, and don't add
+text the prompt didn't ask for:
 
-- `a storefront with a neon sign that reads "OPEN 24 HOURS"`
+- `a storefront with a neon sign that reads "OPEN 24 HOURS"` (give position/color/font/size when it
+  matters: top-left, brush script, medium-brown)
 - `a book cover titled "山海经" in elegant brush calligraphy`
 
-Keep the quoted string short and explicit; long paragraphs of in-image text degrade.
+Make vague text concrete: "the invitation has a name and date" → `the lower invitation reads "Name:
+Zhang San — Date: July 2025"`. Keep each quoted string short and explicit; long paragraphs of in-image
+text degrade. (For a real existing logo, name it — don't transcribe its text.)
 
 ### Composition & Framing
 
 Direct framing language works: `low angle`, `wide shot`, `medium close-up`, `centered subject`,
-`rule of thirds`, `shallow depth of field`, `bokeh background`.
+`rule of thirds`.
 
 ### Style
 
 Concise style labels work well: `cinematic`, `photorealistic`, `watercolor`, `flat illustration`,
-`studio portrait`, `film noir`.
-
-### Negative Prompt (full Boogu Image only)
-
-The full model uses true classifier-free guidance, so a negative prompt helps reduce artifacts:
-`blurry, low quality, distorted hands, extra limbs, watermark, jpeg artifacts, garbled text`. Turbo is
-CFG-free — the negative prompt and guidance scale have no effect there.
+`studio portrait`, `film noir`. Name a known style by its name only (e.g. `Ghibli`, `ukiyo-e`,
+`cyberpunk`) — you don't need to describe what the style looks like. For everyday realistic subjects
+you don't need to say "photorealistic"; that's already the default.
 
 ## Quality & Speed Notes
 
@@ -83,10 +110,14 @@ CFG-free — the negative prompt and guidance scale have no effect there.
 ## Example Prompts
 
 `A weathered lighthouse on a rocky cliff at golden hour, waves breaking below, gulls in the distance.
-Wide shot, low angle, warm directional light, shallow depth of field. Photorealistic, cinematic.`
+Wide shot, low angle, warm directional light. Photorealistic, cinematic.`
 
 `A cozy bakery storefront at dusk, warm window glow, a chalkboard sign that reads "FRESH BREAD".
-Medium shot, centered, soft bokeh. Photorealistic.`
+Medium shot, centered. Photorealistic.`
+
+`Hand-drawn water-cycle diagram on light paper: green mountains and a river flowing into a blue ocean,
+a sun top-left and clouds top-right; a blue upward arrow labeled "Evaporation", an arrow to the clouds
+labeled "Condensation", a downward arrow labeled "Precipitation". Clear labels, bright colors.`
 
 `Edit: change the season to winter — snow on the rooftops, bare trees, cold blue light — keep the
 buildings and street layout.`
@@ -95,3 +126,4 @@ buildings and street layout.`
 
 - [Boogu-Image-0.1 (Hugging Face)](https://huggingface.co/Boogu)
 - [SceneWorks/boogu-image-mlx (MLX weights)](https://huggingface.co/SceneWorks/boogu-image-mlx)
+- [Boogu-Image GitHub (prompt rewriter)](https://github.com/boogu-project/Boogu-Image)

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -651,6 +651,18 @@ describe("ImageStudio model picker capability gating", () => {
     expect(field(container, "Model").value).toBe("boogu_image_edit");
     expect(modelOptionValues()).toEqual(["boogu_image_edit"]);
   });
+
+  it("offers the Refine-my-prompt control for Boogu — prompt enhancement reuses prompt_refine (sc-6401)", async () => {
+    await render(baseContext({ imageModels: [BOOGU_BASE, BOOGU_TURBO], macCapabilities: MAC_CAPS }));
+
+    // Boogu is non-structured, so the plain-prompt path renders RefinePromptControl ("Refine my
+    // prompt"). It drives the prompt_refine utility with Boogu's prompt guide as the rewriter context
+    // (S4) — the optional, user-editable enhancement step; raw prompt remains the fallback.
+    const refineButton = [...container.querySelectorAll("button")].find((b) =>
+      b.textContent.includes("Refine my prompt"),
+    );
+    expect(refineButton).toBeTruthy();
+  });
 });
 
 describe("ImageStudio structured-prompt recipe round-trip (sc-6147)", () => {


### PR DESCRIPTION
## S4 — Optional prompt-enhancement for Boogu (epic 6387)

Boogu ships an optional Qwen3-VL-32B instruction rewriter. Rather than port a 32B model, SceneWorks reuses the native `prompt_refine` utility (sc-5605). The existing **"Refine my prompt"** control already renders for every non-structured model (boogu, from S1/S3) and the worker builds its rewriter system prompt as `base_rules + the model's prompt guide` — so **no new wiring or model download** is needed. In SceneWorks, "Boogu's rewriter system prompt" *is* boogu's prompt guide.

### What this changes
- **`prompt-guides/boogu-image.md`** — enriched to be Boogu's rewriter context. Fetched Boogu's actual rewriter (`utils/t2i_external_prompt_rewriter.py`, `T2I_REWRITE_SYSTEM_PROMPT_EN`, adapted from Qwen-Image's). The generic `base_rules` already cover its core (minimal-edit, preserve-intent, match-language), so I folded in the **deltas**: exact counts + fixed order, preserve logical relationships (arrows), quote in-image text exactly with position/style + no extra text, be exhaustive for diagrams/infographics/posters, don't add unrequested camera params, name known styles by name only, stay concise. **Dropped** Boogu's "default to Chinese context / classical-Chinese" locale bias (wrong for SceneWorks' general audience; base rules already match the user's language).
  - Also **fixed an S1 error**: the guide had a "Negative Prompt" section, but boogu's descriptor is `supports_negative_prompt:false` (no user negative — the CFG-negative is the fixed empty/drop instruction). Replaced with "describe what you want, not what you don't" (also Boogu rewriter rule 8).
- **`ImageStudio.test.jsx`** — assert boogu surfaces the "Refine my prompt" control (the optional, user-editable enhancement; raw prompt remains the fallback).

### Why no code wiring
`RefinePromptControl` is rendered for all non-structured models, fetches the guide from `ui.promptGuide.path`, and passes it to `/api/v1/prompts/refine` → `run_prompt_refine_job` → `build_refine_system_prompt(guide)`. boogu (no `structuredPrompt`) already flows through this. The enhanced prompt is shown as a "Suggested rewrite" the user applies/edits; not applying leaves the raw prompt.

### Validation
- `node scripts/check-scaffold.mjs` — passed (guide readable + `ui.promptGuide` wired)
- `vitest --environment jsdom ImageStudio.test.jsx` — 16/16 (incl. the new refine-toggle test)
- `npm run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)