### PR TITLE
feat(candle): wire Z-Image img2img / edit lane off-Mac (sc-6595)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -519,7 +519,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -530,7 +530,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -557,7 +557,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -569,7 +569,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -580,7 +580,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -597,7 +597,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -612,7 +612,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -623,7 +623,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -641,7 +641,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -652,7 +652,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -665,7 +665,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -676,7 +676,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -689,7 +689,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7281da5efa28f6b8c464b17df2a64294323e31c0#7281da5efa28f6b8c464b17df2a64294323e31c0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
 dependencies = [
  "candle-core",
  "candle-gen",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3839,6 +3839,18 @@ fn image_job_is_candle_eligible(job: &JobSnapshot) -> bool {
     {
         return true;
     }
+    // Z-Image img2img / edit (sc-6595, epic 5480): a z-image-family `edit_image` job with a source image
+    // is the bespoke candle `ZImageEdit` lane (`generate_candle_zimage_edit_stream`), NOT txt2img — the
+    // gate below rejects the whole `edit_image` family, and the dedicated `z_image_edit` id isn't even a
+    // candle txt2img id (so a `z_image_edit` job would otherwise hit the "model not routed" gap and
+    // misattribute to epic 3692). Branch it out first; disjoint from the Z-Image strict-pose control lane
+    // below (that one is `advanced.poses`, not `edit_image`). Mirrors the worker's
+    // `zimage_edit_candle_available`.
+    if matches!(model, "z_image_turbo" | "z_image_edit")
+        && zimage_edit_candle_eligible(&job.payload)
+    {
+        return true;
+    }
     // SDXL IP-Adapter-Plus reference conditioning (sc-5488, epic 5480): an sdxl-family model with a
     // reference image is a bespoke candle lane (`generate_candle_sdxl_ipadapter_stream`), NOT txt2img —
     // the `image_request_candle_eligible` gate below rejects `referenceAssetId`. Branch it out first
@@ -4208,6 +4220,22 @@ fn flux2_edit_candle_eligible(payload: &Map<String, Value>) -> bool {
 /// caller. Mirrors the worker's `qwen_edit_candle_available` gate (minus the local weight-resolve check)
 /// so the router and worker agree. Candle-only — macOS keeps the MLX `qwen_image_edit` registry path.
 fn qwen_edit_candle_eligible(payload: &Map<String, Value>) -> bool {
+    if payload.get("mode").and_then(Value::as_str) != Some("edit_image") {
+        return false;
+    }
+    payload
+        .get("sourceAssetId")
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.trim().is_empty())
+}
+
+/// Z-Image img2img / edit candle-routing conditions (sc-6595, epic 5480). The candle `ZImageEdit`
+/// provider serves `edit_image` mode with a `sourceAssetId` on the z-image family — the Turbo weights'
+/// img2img path (no mask / inpaint / outpaint). Same payload predicate as the other edit gates, gated to
+/// the z-image family (`z_image_turbo` + the dedicated `z_image_edit` id) by the caller. Mirrors the
+/// worker's `zimage_edit_candle_available` gate (minus the local weight-resolve check) so the router and
+/// worker agree. Candle-only — macOS keeps the MLX `z_image_turbo` registry generator's `Reference` path.
+fn zimage_edit_candle_eligible(payload: &Map<String, Value>) -> bool {
     if payload.get("mode").and_then(Value::as_str) != Some("edit_image") {
         return false;
     }
@@ -6788,6 +6816,34 @@ mod candle_routing_tests {
     }
 
     #[test]
+    fn zimage_edit_jobs_route_to_candle() {
+        // Z-Image img2img / edit jobs (sc-6595) route to the bespoke candle `ZImageEdit` lane via the new
+        // branch, NOT the txt2img `image_request_candle_eligible` gate (which rejects `edit_image`). Both
+        // the txt2img id in edit mode (`z_image_turbo`) and the dedicated `z_image_edit` id are served.
+        for model in ["z_image_turbo", "z_image_edit"] {
+            let edit = json!({ "model": model, "mode": "edit_image", "sourceAssetId": "src_1" });
+            assert!(zimage_edit_candle_eligible(&object(edit.clone())));
+            assert!(image_job_is_candle_eligible(&image_generate_job(
+                edit.clone()
+            )));
+            // Reached through the real `image_edit` job type too (the type the Image Editor submits).
+            assert!(image_job_is_candle_eligible(&image_edit_job(edit)));
+        }
+        // `edit_image` WITHOUT a source → not this lane (nothing to edit).
+        assert!(!zimage_edit_candle_eligible(&object(json!({
+            "model": "z_image_turbo", "mode": "edit_image"
+        }))));
+        // A plain txt2img z_image_turbo job → not the edit lane (it routes via the txt2img gate instead).
+        assert!(!zimage_edit_candle_eligible(&object(
+            json!({ "model": "z_image_turbo" })
+        )));
+        // A z_image_turbo strict-pose job (advanced.poses, not edit_image) is the control lane, not edit.
+        assert!(!zimage_edit_candle_eligible(&object(json!({
+            "model": "z_image_turbo", "advanced": { "poses": [{}] }
+        }))));
+    }
+
+    #[test]
     fn image_edit_job_type_routes_through_candle_edit_lane() {
         // Regression for the sc-5487 edit lanes being unreachable through the actual `image_edit` job
         // type the Image Editor submits (the prior tests only exercised `image_generate` jobs with
@@ -6812,11 +6868,13 @@ mod candle_routing_tests {
             worker_supports_job(&gpu_worker(CANDLE_CAPS), &image_edit_job(sdxl_edit.clone())),
             "the candle worker (advertising `image_edit`) must claim the SDXL edit job"
         );
-        // The FLUX.2-klein and Qwen-Image-Edit lanes are reached through the same job type.
+        // The FLUX.2-klein, Qwen-Image-Edit, and Z-Image edit lanes are reached through the same job type.
         for model in [
             "flux2_klein_9b",
             "qwen_image_edit",
             "qwen_image_edit_2511_lightning",
+            "z_image_turbo",
+            "z_image_edit",
         ] {
             let job = image_edit_job(json!({
                 "model": model, "mode": "edit_image", "sourceAssetId": "asset_1"

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -889,38 +889,38 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0b86
 # (`image_jobs/qwen_edit_candle.rs`) drives candle-gen-qwen-image's `QwenEdit` (incl. the lightning
 # distill) off-Mac; the candle SAM3 path (`person_segment_sam3_candle.rs`) drives candle-gen-sam3.
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -929,19 +929,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -950,12 +950,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -963,7 +963,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281d
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -972,7 +972,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -980,7 +980,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -989,7 +989,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1012,7 +1012,11 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # #108 re-pins gen-core 4740225 -> 0b86fad (BYTE-IDENTICAL tree — the range is pure mlx-gen-boogu, a
 # macOS-only image family with no candle sibling), so `--features backend-candle --target all` resolves
 # ONE gen-core rev. Behavior-neutral; candle builds nothing new.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7281da5efa28f6b8c464b17df2a64294323e31c0", features = ["cuda"], optional = true }
+# Bumped `7281da5` -> `72beadb` (sc-6595, epic 5480, candle-gen z-image edit branch): adds the bespoke
+# `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
+# candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
+# `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -227,6 +227,13 @@ use candle_gen_kolors::{KolorsControl, KolorsControlPaths, KolorsControlRequest}
 // drives.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_z_image::{ZImageControl, ZImageControlPaths, ZImageControlRequest};
+// Z-Image img2img / edit provider (sc-6595, epic 5480) — the candle (Windows/CUDA) sibling of the MLX
+// `z_image_turbo` `Conditioning::Reference` img2img route, living in `candle-gen-z-image` (the Turbo DiT
+// + a strength-derived source-latent init). Candle-only: macOS keeps the registered MLX generator's
+// img2img path. `candle_gen_z_image` is already force-link anchored above; this is the named-type import
+// the bespoke edit route (`image_jobs/zimage_edit_candle.rs`) drives.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+use candle_gen_z_image::{ZImageEdit, ZImageEditPaths, ZImageEditRequest};
 // PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the candle (Windows/CUDA) sibling of the
 // macOS `pulid_flux` registry generator, living in `candle-gen-pulid` (the EVA02-CLIP tower + IDFormer
 // + the 20 PerceiverAttentionCA modules injected into the forked FLUX DiT via the post-block
@@ -577,6 +584,23 @@ pub(crate) async fn run_image_generate_job(
         // candle `QwenEdit` stream. Off-Mac this was a torch fallback; candle now serves it. Disjoint
         // from the Qwen strict-pose control lane below (that one is `qwen_image` + `advanced.poses`).
         generate_candle_qwen_edit_stream(
+            api,
+            settings,
+            job,
+            &plan,
+            &project_path,
+            backend,
+            &mut asset_writes,
+        )
+        .await?;
+        true
+    } else if settings.backend_candle_enabled && zimage_edit_candle_available(&request, settings) {
+        // Z-Image img2img / edit (sc-6595) — checked BEFORE `is_candle_engine` because `z_image_turbo` IS
+        // a candle txt2img id (and `z_image_edit` is a distinct id the txt2img branch doesn't know), so
+        // without this an `edit_image` job would be caught by the txt2img branch (which can't honor a
+        // source) or fall through entirely. Grouped with the other edit lanes; disjoint from the Z-Image
+        // strict-pose control lane below (that one is `advanced.poses`, not `edit_image`).
+        generate_candle_zimage_edit_stream(
             api,
             settings,
             job,
@@ -1234,6 +1258,11 @@ include!("image_jobs/kolors_control.rs");
 // MLX `z_image_turbo_control` registry generator; the candle `ZImageControl` is a bespoke provider.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 include!("image_jobs/zimage_control.rs");
+// Z-Image img2img / edit — the Windows/CUDA candle lane ONLY (sc-6595). macOS keeps the MLX
+// `z_image_turbo` registry generator's `Conditioning::Reference` img2img path; the candle `ZImageEdit`
+// is a bespoke provider.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+include!("image_jobs/zimage_edit_candle.rs");
 // PuLID-FLUX face identity — the Windows/CUDA candle lane ONLY (sc-5492). macOS keeps the
 // inventory-registered `pulid_flux` MLX generator (image_jobs/pulid.rs); the candle `PulidFlux` is a
 // bespoke provider, so this file is candle-gated and distinct from the macOS route.

--- a/crates/sceneworks-worker/src/image_jobs/zimage_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage_edit_candle.rs
@@ -1,0 +1,235 @@
+// Candle (Windows/CUDA) Z-Image img2img / edit route (sc-6595, epic 5480) — pixel-conditioned editing
+// on Z-Image-Turbo off-Mac via `candle_gen_z_image::ZImageEdit`. The candle sibling of the MLX z-image
+// img2img path (the registered `z_image_turbo` generator's `Conditioning::Reference` route, driven by
+// `resolve_zimage_edit_init` in zimage.rs). Both `z_image_edit` and `z_image_turbo` (mode `edit_image`)
+// reach this one lane — two ids, one engine (the Turbo weights with a source-latent init).
+//
+// **Candle-only.** macOS keeps the MLX `z_image_turbo` registry generator (img2img via the engine's
+// `Reference` conditioning); the candle `z_image_turbo` descriptor is txt2img-only, so the candle
+// `ZImageEdit` is a bespoke provider — this whole file is gated to the Windows/CUDA candle build (the
+// `include!` in image_jobs.rs carries the cfg). It is `include!`d into the `image_jobs` module, so it
+// shares that module's imports (`ImageRequest`/`Settings`/`WorkerResult`/`advanced`/`load_reference_image`/
+// `fit_engine_image`/`huggingface_snapshot_dir`/`resolve_app_managed_model_dir`/`resolve_seed`/
+// `start_gen_stream`/`drive_gen_items`/`consume_gen_events`/`non_empty`/`gen_core`/… all in scope).
+
+/// img2img strength default — the worker's `advanced.strength` default (`resolve_zimage_edit_init`,
+/// torch `ZImageImg2ImgPipeline` 0.6). With Z-Image's `init_time_step`, higher ⇒ closer to the source
+/// (the structure-preservation convention; the inverse of the SDXL knob — see `candle_gen_z_image::edit`).
+const ZIMAGE_EDIT_CANDLE_DEFAULT_STRENGTH: f32 = 0.6;
+/// Denoise-steps default — the distilled 4-step Turbo schedule (the txt2img / MLX z-image default).
+const ZIMAGE_EDIT_CANDLE_DEFAULT_STEPS: u32 = 4;
+/// The Z-Image base diffusers repo when the manifest omits `repo`.
+const ZIMAGE_EDIT_CANDLE_DEFAULT_REPO: &str = "Tongyi-MAI/Z-Image-Turbo";
+/// The adapter/engine id recorded on candle Z-Image edit assets + telemetry (distinct from the txt2img
+/// `candle_z_image` and the `candle_zimage_control` lanes).
+const ZIMAGE_EDIT_CANDLE_ENGINE: &str = "candle_zimage_edit";
+
+/// Model ids the candle Z-Image edit route accepts: the txt2img `z_image_turbo` (in `edit_image` mode)
+/// and the dedicated `z_image_edit` id — both drive the Turbo weights' img2img path.
+fn is_zimage_edit_candle_model(model: &str) -> bool {
+    matches!(model, "z_image_turbo" | "z_image_edit")
+}
+
+/// Resolve the Z-Image base (diffusers) snapshot: an explicit `modelPath` (advanced or manifest) → the
+/// HF cache snapshot for the manifest `repo` (default `Tongyi-MAI/Z-Image-Turbo`). `None` ⇒ not present
+/// locally (the job is not candle-runnable, falls through to torch). Mirrors `resolve_zimage_control_base`.
+fn resolve_zimage_edit_candle_base(
+    request: &ImageRequest,
+    settings: &Settings,
+) -> WorkerResult<Option<PathBuf>> {
+    if let Some(path) = request
+        .advanced
+        .get("modelPath")
+        .or_else(|| request.model_manifest_entry.get("modelPath"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+    {
+        return resolve_app_managed_model_dir(settings, &path, "Z-Image edit modelPath").map(Some);
+    }
+    let repo = request
+        .model_manifest_entry
+        .get("repo")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(ZIMAGE_EDIT_CANDLE_DEFAULT_REPO);
+    Ok(huggingface_snapshot_dir(&settings.data_dir, repo))
+}
+
+/// True when this is a candle-eligible Z-Image edit job: a z-image-family `edit_image` job with a source
+/// image whose base resolves locally. Mirrors `jobs_store::zimage_edit_candle_eligible` so the worker and
+/// router agree.
+fn zimage_edit_candle_available(request: &ImageRequest, settings: &Settings) -> bool {
+    is_zimage_edit_candle_model(&request.model)
+        && request.mode == "edit_image"
+        && non_empty(&request.source_asset_id)
+        && matches!(
+            resolve_zimage_edit_candle_base(request, settings),
+            Ok(Some(_))
+        )
+}
+
+/// Resolve denoise steps: `advanced.steps` (clamped 1..=50) → manifest `steps` → default (4, distilled).
+fn zimage_edit_candle_steps(request: &ImageRequest) -> u32 {
+    let parse = |value: &Value| {
+        value
+            .as_u64()
+            .or_else(|| value.as_str()?.trim().parse().ok())
+    };
+    request
+        .advanced
+        .get("steps")
+        .and_then(parse)
+        .or_else(|| request.model_manifest_entry.get("steps").and_then(parse))
+        .map(|steps| steps.clamp(1, 50) as u32)
+        .unwrap_or(ZIMAGE_EDIT_CANDLE_DEFAULT_STEPS)
+}
+
+/// Load the source asset (required for an edit) — mirrors the MLX `resolve_zimage_edit_init` source load.
+fn load_zimage_edit_source(
+    request: &ImageRequest,
+    project_path: &Path,
+    settings: &Settings,
+) -> WorkerResult<Image> {
+    let source_id = request
+        .source_asset_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload("Z-Image edit requires a source image".to_owned())
+        })?;
+    load_reference_image(
+        &settings.data_dir,
+        &request.project_id,
+        source_id,
+        project_path,
+    )
+}
+
+/// Flat telemetry recorded on candle Z-Image edit assets. No guidance — Z-Image-Turbo is
+/// guidance-distilled.
+fn zimage_edit_candle_raw_settings(
+    request: &ImageRequest,
+    repo: &str,
+    steps: u32,
+    strength: f32,
+) -> JsonObject {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("repo".to_owned(), Value::String(repo.to_owned()));
+    raw.insert("numInferenceSteps".to_owned(), json!(steps));
+    raw.insert("strength".to_owned(), json!(strength));
+    raw.insert("mode".to_owned(), Value::String("edit_image".to_owned()));
+    raw.insert(
+        "editEngine".to_owned(),
+        Value::String(ZIMAGE_EDIT_CANDLE_ENGINE.to_owned()),
+    );
+    raw
+}
+
+/// Real candle Z-Image img2img generation: resolve the source + base on the async side, fit the source to
+/// the render size (honoring `fit_mode`), then load `ZImageEdit` once + generate each image on the blocking
+/// thread. `request.count` images, each its own seed, all editing the same source. Z-Image-Turbo is
+/// distilled (no CFG / negative prompt), so the request carries no guidance. `ZImageEdit::generate` takes
+/// `&self`, so the per-item closure needs no `mut`. Reuses [`consume_gen_events`].
+async fn generate_candle_zimage_edit_stream(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+    let base = resolve_zimage_edit_candle_base(request, settings)?.ok_or_else(|| {
+        WorkerError::InvalidPayload("Z-Image base (Z-Image-Turbo) weights not found".to_owned())
+    })?;
+
+    let (width, height) = (request.width, request.height);
+    // Load + fit the source to the render geometry honoring `fit_mode` (crop/pad/stretch — the provider
+    // also resizes internally, but pre-fitting here is what avoids stretching an off-aspect source).
+    let source = load_zimage_edit_source(request, project_path, settings)?;
+    let source = fit_engine_image(source, width, height, &request.fit_mode)?;
+
+    let steps = zimage_edit_candle_steps(request);
+    let strength = advanced::f32_clamped(
+        &request.advanced,
+        "strength",
+        ZIMAGE_EDIT_CANDLE_DEFAULT_STRENGTH,
+        0.05..=1.0,
+    );
+    let repo = request
+        .model_manifest_entry
+        .get("repo")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(ZIMAGE_EDIT_CANDLE_DEFAULT_REPO)
+        .to_owned();
+    let raw_settings = zimage_edit_candle_raw_settings(request, &repo, steps, strength);
+
+    // Per-image work items: (seed, prompt) — `request.count` edits of the same source.
+    let work: Vec<(i64, String)> = (0..request.count as usize)
+        .map(|index| (resolve_seed(request, index), request.prompt.clone()))
+        .collect();
+    let total = work.len();
+
+    let (cancel, rx, blocking) = start_gen_stream(
+        job.id.clone(),
+        "zimage_edit",
+        0,
+        move || {
+            let model = ZImageEdit::load(&ZImageEditPaths { base }).map_err(|error| {
+                WorkerError::Engine(format!("Z-Image edit load failed: {error}"))
+            })?;
+            Ok((model, source))
+        },
+        move |(model, source), tx, cancel| {
+            drive_gen_items(tx, work, move |_index, (seed, prompt), on_progress| {
+                if cancel.is_cancelled() {
+                    return Ok(None);
+                }
+                let req = ZImageEditRequest {
+                    prompt,
+                    width,
+                    height,
+                    steps: steps as usize,
+                    strength,
+                    seed: seed as u64,
+                    cancel: cancel.clone(),
+                };
+                let out = match model.generate(&req, &source, &mut *on_progress) {
+                    Ok(out) => out,
+                    Err(_) if cancel.is_cancelled() => return Ok(None),
+                    Err(error) => {
+                        return Err(WorkerError::Engine(format!(
+                            "Z-Image edit generation failed: {error}"
+                        )));
+                    }
+                };
+                Ok(Some((seed, out.width, out.height, out.pixels)))
+            })
+        },
+    );
+
+    consume_gen_events(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        ZIMAGE_EDIT_CANDLE_ENGINE,
+        &raw_settings,
+        total,
+        rx,
+        cancel,
+        blocking,
+        asset_writes,
+    )
+    .await
+}


### PR DESCRIPTION
## sc-6595 — candle Z-Image img2img / edit worker lane (epic 5480)

Routes `z_image_edit` (and `z_image_turbo` + `edit_image`) to the new candle `ZImageEdit` provider off-Mac. Before this, both **enforce-failed** `candle_unsupported` on the enforce-deployed candle worker (`z_image_edit` isn't a candle txt2img id → the misleading `[epic 3692]` "model not routed" attribution; `z_image_turbo`+`edit_image` hit the txt2img branch which can't honor a source). sc-5487 wired sdxl/flux2/qwen edit only — z-image was the remaining gap, surfaced by PROGRESS-31 / the sc-6594 fix.

Pairs with the provider half **[candle-gen#109](https://github.com/SceneWorks/candle-gen/pull/109)** (merge that first — this PR pins it).

### Changes
- **worker** `image_jobs/zimage_edit_candle.rs` — `generate_candle_zimage_edit_stream` + `zimage_edit_candle_available` gate (mirrors the SDXL-edit + Z-Image-control recipes). Loads + fits the source honoring `fit_mode`, then drives the bespoke `candle_gen_z_image::ZImageEdit` (`request.count` edits, one seed each). Distilled (no guidance), `&self` generate. `advanced.strength` default **0.6** (clamp 0.05..=1.0), matching the MLX `resolve_zimage_edit_init`. Dispatch branch sits with the other edit lanes, before `is_candle_engine`; disjoint from the Z-Image strict-pose control lane (`advanced.poses`).
- **router** `jobs_store::zimage_edit_candle_eligible` + the branch in `image_job_is_candle_eligible` (`z_image_turbo`/`z_image_edit` + `edit_image` + `sourceAssetId`). Builds on sc-6594, so the real `image_edit` job type reaches the lane.
- **tests** `zimage_edit_jobs_route_to_candle` (both ids, image_generate + image_edit job types, the negatives) + z-image added to `image_edit_job_type_routes_through_candle_edit_lane` (the real job type + enforce + claim path).
- **pin** candle-gen `7281da5` → `72beadb` (the ZImageEdit branch). gen-core stays `0b86fad` == the worker mlx pin → **single gen-core rev, no skew**.

### Strength = Z-Image's "structure-preservation" convention
Z-Image's `init_time_step` makes **higher strength → closer to the source** (the *inverse* of SDXL), matched here for Mac/Windows parity — the strength knob means the same thing on both backends. (Detail in the provider PR.)

### Validation
- `sceneworks-core` routing tests green (CPU): the new + updated routing tests pass.
- `cargo build -p sceneworks-worker --features backend-candle` **green** (1m11s).
- Provider **GPU-validated on RTX PRO 6000** (see candle-gen#109): monotonic inverse strength (6.79/3.15/1.23), prompt A-vs-B 4.76, pre+mid cancel.

### Pre-existing, unrelated (NOT this PR)
The candle `clippy -D warnings` lane has a pre-existing dead-code failure in `ideogram_caption.rs` (macOS-only placeholder helpers dead off-Mac) — filed as **sc-6610**. sc-6595's own code is clippy-clean; the candle clippy lane is workflow_dispatch-only (not a PR gate), and the default parity CI (candle off) is unaffected (all worker additions are `#[cfg(backend-candle)]`-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)