### PR TITLE
feat(boogu): bf16 on-demand download + Image Studio precision toggle (sc-6568)

### DIFF
--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -389,6 +389,9 @@ export function ImageStudio() {
   // the prompt before encoding — text-only for txt2img, reference-aware for edit. Per-payload
   // (`advanced.enhancePrompt`); only flux2_dev acts on it. Sticky pref (persisted), default off.
   const [enhancePrompt, setEnhancePrompt] = useState(saved.enhancePrompt ?? false);
+  // Boogu precision toggle (sc-6568): off = the packed Q8 default; on emits `advanced.mlxQuantize: 0`
+  // (the full-precision bf16 build, fetched on demand by the worker). Sticky pref, default off (Q8).
+  const [bf16Precision, setBf16Precision] = useState(saved.bf16Precision ?? false);
   const [faceRestore, setFaceRestore] = useState(false);
   // User-created poses (reserved global project) join the built-in library in both
   // the picker and the id→keypoints resolver below, so saved poses can generate.
@@ -583,6 +586,9 @@ export function ImageStudio() {
   const poseLibrary = Boolean(selectedModel?.ui?.poseLibrary);
   // Whether the model exposes its built-in prompt upsampler ("Enhance prompt" toggle) — FLUX.2-dev.
   const promptEnhance = Boolean(selectedModel?.ui?.promptEnhance);
+  // Whether the model ships a packed default + a hosted full-precision bf16 build, exposing the
+  // Studio "Full precision (bf16)" toggle (sc-6568) — Boogu Base/Turbo/Edit.
+  const precisionToggle = Boolean(selectedModel?.ui?.precisionToggle);
   // Whether the model supports multi-image reference editing (sc-6211) — edit_image mode shows a
   // multi-select reference picker (plural `referenceAssetIds`) instead of the single source picker.
   // FLUX.2-dev only (its DiT sequence-gated chunking keeps the multi-reference edit under 96 GB).
@@ -1004,6 +1010,7 @@ export function ImageStudio() {
     guidanceScale: guidanceOverride,
     flashAttn,
     enhancePrompt,
+    bf16Precision,
   });
 
   // Snapshot the current working config into a named recipe preset in the
@@ -1229,6 +1236,10 @@ export function ImageStudio() {
           // FLUX.2-dev caption upsampling (sc-6135): emitted only when the model declares the
           // toggle AND it's on (off-by-default; the worker/engine ignore it for other models).
           ...(promptEnhance && enhancePrompt ? { enhancePrompt: true } : {}),
+          // Boogu precision (sc-6568): emit mlxQuantize:0 (full-precision bf16) only when the model
+          // exposes the precision toggle AND bf16 is selected; the default Q8 emits nothing (the
+          // worker reads manifest mlx.quantize and fetches the `<variant>-bf16/` subfolder on demand).
+          ...(precisionToggle && bf16Precision ? { mlxQuantize: 0 } : {}),
           // IP-Adapter / InstantID reference strength only applies when a character
           // reference is attached AND the model uses the IP-Adapter knob; Qwen's
           // edit pipeline ignores this scalar (hideReferenceStrength gates it out).
@@ -1822,6 +1833,19 @@ export function ImageStudio() {
                       type="checkbox"
                     />
                     Enhance prompt
+                  </label>
+                ) : null}
+                {precisionToggle ? (
+                  <label
+                    className="checkline boogu-precision-toggle"
+                    title="Use the full-precision bf16 build instead of the default Q8. Higher fidelity, but a much larger download (~38 GB per variant, fetched on demand) that needs a larger Mac (≈96 GB unified memory). Off = the Q8 default (~23 GB, 64 GB-class Mac)."
+                  >
+                    <input
+                      checked={bf16Precision}
+                      onChange={(event) => setBf16Precision(event.target.checked)}
+                      type="checkbox"
+                    />
+                    Full precision (bf16)
                   </label>
                 ) : null}
                 <label className="checkline upscale-toggle">

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -663,6 +663,35 @@ describe("ImageStudio model picker capability gating", () => {
     );
     expect(refineButton).toBeTruthy();
   });
+
+  const precisionLabel = (root) =>
+    [...root.querySelectorAll("label")].find((l) =>
+      l.textContent.includes("Full precision (bf16)"),
+    );
+  const openAdvanced = async (root) =>
+    click([...root.querySelectorAll("button")].find((b) => b.textContent === "Advanced"));
+
+  it("exposes the Full-precision (bf16) toggle for Boogu in Advanced when ui.precisionToggle is set (sc-6568)", async () => {
+    await render(
+      baseContext({
+        imageModels: [{ ...BOOGU_BASE, ui: { precisionToggle: true } }],
+        macCapabilities: MAC_CAPS,
+      }),
+    );
+    await openAdvanced(container);
+    await act(async () => {});
+    const toggle = precisionLabel(container);
+    expect(toggle).toBeTruthy();
+    // Default off → the packed Q8 build (no mlxQuantize emitted).
+    expect(toggle.querySelector('input[type="checkbox"]').checked).toBe(false);
+  });
+
+  it("hides the precision toggle when the model omits ui.precisionToggle — catalog-gated, not family-hardcoded (sc-6568)", async () => {
+    await render(baseContext({ imageModels: [BOOGU_BASE], macCapabilities: MAC_CAPS }));
+    await openAdvanced(container);
+    await act(async () => {});
+    expect(precisionLabel(container)).toBeFalsy();
+  });
 });
 
 describe("ImageStudio structured-prompt recipe round-trip (sc-6147)", () => {

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1071,6 +1071,10 @@
       "licenseUrl": "https://huggingface.co/Boogu/Boogu-Image-0.1-Base",
       "ui": {
         "label": "Boogu Image",
+        // Exposes the Image Studio "Full precision (bf16)" toggle (sc-6568): off = the packed Q8
+        // default (the downloaded `base/` subfolder); on sends advanced `mlxQuantize: 0` and the
+        // worker fetches the `base-bf16/` subfolder on demand. Needs a larger Mac (~96 GB).
+        "precisionToggle": true,
         "description": "Boogu-Image-0.1 — a Lumina-Image-2.0 / OmniGen2-lineage flow-matching text-to-image model (~10.3B DiT + Qwen3-VL-8B condition encoder + FLUX.1 VAE), native MLX (Apple Silicon). True-CFG, natural-language prompting with strong bilingual (English/Chinese) in-image text rendering. Pre-quantized Q8 (~23 GB, default; full-precision bf16 also hosted). Apache-2.0 (ungated). Needs a 64 GB-class Mac.",
         "recommendedFor": ["text_to_image"],
         "promptGuide": {
@@ -1138,6 +1142,9 @@
       "licenseUrl": "https://huggingface.co/Boogu/Boogu-Image-0.1-Turbo",
       "ui": {
         "label": "Boogu Image Turbo",
+        // Full-precision bf16 opt-in (sc-6568): on sends `mlxQuantize: 0`; the worker fetches the
+        // `turbo-bf16/` subfolder on demand. Off = the packed Q8 `turbo/` default.
+        "precisionToggle": true,
         "description": "Boogu-Image-0.1 Turbo — the few-step (~4), CFG-free fast variant of Boogu Image: the same ~10.3B flow-matching model distilled (DMD) for much faster renders, native MLX (Apple Silicon). Best for quick iteration. Pre-quantized Q8 (~23 GB, default). Apache-2.0 (ungated). Needs a 64 GB-class Mac.",
         "recommendedFor": ["text_to_image"],
         "promptGuide": {
@@ -1208,6 +1215,9 @@
       "licenseUrl": "https://huggingface.co/Boogu/Boogu-Image-0.1-Edit",
       "ui": {
         "label": "Boogu Image Edit",
+        // Full-precision bf16 opt-in (sc-6568): on sends `mlxQuantize: 0`; the worker fetches the
+        // `edit-bf16/` subfolder on demand. Off = the packed Q8 `edit/` default.
+        "precisionToggle": true,
         "description": "Boogu-Image-0.1 Edit — instruction-driven image editing: give a source image and a text instruction and Boogu produces a faithful edited image (the source is read by the Qwen3-VL vision tower). Native MLX (Apple Silicon). Pre-quantized Q8 (~23 GB, default). Apache-2.0 (ungated). Needs a 64 GB-class Mac.",
         "recommendedFor": ["edit_image"],
         "promptGuide": {

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -261,8 +261,9 @@ fn ideogram_model_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
 /// explicit advanced `mlxQuantize <= 4` selects the full-precision `<variant>-bf16/` build instead —
 /// the source the engine quantizes at load (no packed Q4 is shipped) or runs dense. Falls back to
 /// whichever subfolder is present, then `root`, so a partially-downloaded bundle surfaces as a load
-/// error rather than a silent half-load. (The `*-bf16/` files are an on-demand download — sc tracked;
-/// when absent the bf16 request resolves the Q8 folder.)
+/// error rather than a silent half-load. (The `*-bf16/` files are an on-demand download fetched by
+/// [`ensure_boogu_bf16_present`] before this resolves, sc-6568; if that fetch was skipped/failed the
+/// bf16 request falls back to the Q8 folder.)
 fn boogu_model_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
     let variant = match request.model.as_str() {
         "boogu_image_turbo" => "turbo",
@@ -289,6 +290,77 @@ fn boogu_model_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
     present(variant)
         .or_else(|| present(&bf16))
         .unwrap_or_else(|| root.to_path_buf())
+}
+
+/// On-demand fetch of the full-precision `<variant>-bf16/` Boogu subfolder (sc-6568). The S1 catalog
+/// download pulls only the packed Q8 `<variant>/` subfolder, so when a job opts into the bf16 build
+/// (advanced `mlxQuantize <= 4` — the same gate [`boogu_model_subdir`] uses to select it) and that
+/// subfolder isn't present yet, pull just its files into the HF cache so `boogu_model_subdir` resolves
+/// it. No-op when bf16 isn't requested, the model isn't Boogu, the turnkey snapshot isn't downloaded
+/// yet (`boogu_model_subdir` then falls back to Q8 / surfaces the load error), or the bf16 subfolder
+/// is already complete. Fails loud on a real download error — fast, before any compute; a missing `hf`
+/// CLI leaves the subfolder absent so the request gracefully falls back to Q8. Mirrors
+/// [`crate::video_jobs::ensure_ltx_q8_present`].
+#[cfg(target_os = "macos")]
+async fn ensure_boogu_bf16_present(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &ImageRequest,
+) -> WorkerResult<()> {
+    let variant = match request.model.as_str() {
+        "boogu_image" => "base",
+        "boogu_image_turbo" => "turbo",
+        "boogu_image_edit" => "edit",
+        _ => return Ok(()),
+    };
+    let wants_bf16 = request
+        .advanced
+        .get("mlxQuantize")
+        .and_then(quant_int)
+        .is_some_and(|bits| bits <= 4);
+    if !wants_bf16 {
+        return Ok(());
+    }
+    let Some(model) = mlx_model(&request.model) else {
+        return Ok(());
+    };
+    let Some(root) = huggingface_snapshot_dir(&settings.data_dir, &model_repo(request, &model))
+    else {
+        // Turnkey not downloaded at all → leave it to the load path's "weights not found" error.
+        return Ok(());
+    };
+    let bf16 = format!("{variant}-bf16");
+    if root
+        .join(&bf16)
+        .join("transformer/diffusion_pytorch_model.safetensors")
+        .is_file()
+    {
+        return Ok(());
+    }
+    let scratch = settings
+        .data_dir
+        .join("cache")
+        .join(format!(".boogu-bf16-fetch-{}", job.id));
+    tokio::fs::create_dir_all(&scratch).await?;
+    // The bf16 subfolder nests transformer/mllm/vae (leaf-dir globs, like the catalog Q8 entry).
+    let files = vec![
+        format!("{bf16}/transformer/*"),
+        format!("{bf16}/mllm/*"),
+        format!("{bf16}/vae/*"),
+    ];
+    let result = crate::model_jobs::download_model_with_hf_cli(
+        api,
+        settings,
+        job,
+        &model_repo(request, &model),
+        "main",
+        &files,
+        &scratch,
+    )
+    .await;
+    let _ = tokio::fs::remove_dir_all(&scratch).await;
+    result.map(|_| ())
 }
 
 #[cfg(any(
@@ -1154,6 +1226,10 @@ async fn generate_stream(
     let request = &plan.request;
     let model = mlx_model(&request.model)
         .ok_or_else(|| WorkerError::InvalidPayload("not an MLX-backed model".to_owned()))?;
+    // sc-6568: a bf16 opt-in for Boogu fetches the full-precision `<variant>-bf16/` subfolder on
+    // demand (the catalog ships only the Q8 default) before snapshot resolution. No-op for every
+    // other model / the default Q8 path.
+    ensure_boogu_bf16_present(api, settings, job, request).await?;
     let weights_dir = resolve_weights_dir(request, settings)?
         .ok_or_else(|| WorkerError::InvalidPayload("model weights not found".to_owned()))?;
     // sc-3723: surface the descriptor-derived backend ("mlx" for every linked family today; a


### PR DESCRIPTION
## Boogu bf16 on-demand + Studio precision toggle (sc-6568, epic 6387)

Makes the hosted full-precision **bf16** Boogu build user-selectable end-to-end. The S1 catalog ships only the packed Q8 `<variant>/` subfolder; the bf16 selection logic landed in S2 (`boogu_model_subdir`) but the `<variant>-bf16/` files were never downloaded, so a bf16 request silently fell back to Q8. This closes the gap.

### Worker — on-demand bf16 fetch
`ensure_boogu_bf16_present` (`crates/sceneworks-worker/src/image_jobs/base.rs`), mirroring the proven `video_jobs::ensure_ltx_q8_present` LTX-Q8 pattern: when a boogu job opts into bf16 (advanced `mlxQuantize <= 4` — the same gate `boogu_model_subdir` uses) and the `<variant>-bf16/` subfolder isn't cached, it pulls just `{<variant>-bf16/transformer,mllm,vae}/*` via `download_model_with_hf_cli`. Called from `generate_stream` **before** `resolve_weights_dir`, so the subdir picker resolves the freshly-downloaded build. No-op for non-boogu / the default Q8 path / when the turnkey isn't downloaded / when bf16 is already present; a missing `hf` CLI leaves it absent → graceful fall-back to Q8.

### Web — catalog-gated precision toggle
- `ui.precisionToggle: true` on the three boogu catalog entries (data-driven gate, like `ui.promptEnhance` — not a hardcoded family check).
- `ImageStudio.jsx`: a sticky "Full precision (bf16)" checkbox in the Advanced panel, shown only when the model declares the flag; default off (Q8). Emits `advanced.mlxQuantize: 0` only when bf16 is selected (default Q8 emits nothing → worker reads manifest `mlx.quantize`).
- Memory guidance for the bf16 path lives in the toggle's tooltip (~38 GB/variant on-demand download, ≈96 GB Mac) — the manifest `minMemoryGb` is single-value with no per-quant field.

### Validation
- Worker: `cargo fmt --check` clean, `clippy --tests -Dwarnings` clean, lib suite **359 passed / 0 failed / 76 ignored**.
- Web: `vitest --environment jsdom ImageStudio.test.jsx` **18/18** (2 new — toggle present when `ui.precisionToggle` set + default off; hidden when absent), `npm run lint` **0 errors**, `check-scaffold.mjs` PASS.
- The `mlxQuantize: 0` selection + quant resolution are already unit-covered by S2's `boogu_subdir_prefers_q8_and_opts_into_bf16` + `boogu_engine_defaults_and_quant_resolution`; the on-demand fetch is integration-only (like `ensure_ltx_q8_present`).

Not real-weight e2e'd: that needs the ~38 GB/variant bf16 download + a ≥96 GB Mac (the Q8 default is what sc-6402/S5 validated). The download mechanism is the established LTX-Q8 pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)