### PR TITLE
feat(video): register Wan2.2 VACE-Fun A14B + honest worker guard (sc-3458/sc-3459)

### DIFF
--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -8821,6 +8821,74 @@ fn builtin_manifest_registers_the_prompt_refine_model() {
 }
 
 #[test]
+fn builtin_manifest_registers_the_wan_vace_fun_model() {
+    // sc-3458 (epic 3456): Wan2.2 VACE-Fun A14B is a first-class native video model. Guard the
+    // catalog entry against accidental removal/drift and assert the honest, native-first shape:
+    // the wan-video adapter, ONLY the validated replace_person capability (no generic T2V/I2V on
+    // this control checkpoint), the diffusers-conversion download repo (NOT the raw VideoX-Fun
+    // alibaba-pai repo, which does not load), an MLX block, and NO Torch GGUF quantization.
+    let manifest_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../config/manifests/builtin.models.jsonc");
+    let raw = std::fs::read_to_string(&manifest_path).expect("read builtin.models.jsonc");
+    let manifest: Value =
+        serde_json::from_str(&strip_jsonc_comments(&raw)).expect("parse builtin.models.jsonc");
+    let model = manifest["models"]
+        .as_array()
+        .expect("models array")
+        .iter()
+        .find(|entry| entry["id"] == "wan_2_2_vace_fun_14b")
+        .expect("wan_2_2_vace_fun_14b is registered in the catalog");
+    assert_eq!(model["type"], "video");
+    assert_eq!(model["family"], "wan-video");
+    assert_eq!(model["adapter"], "wan_video");
+
+    // Only the validated VACE mode is exposed; generic T2V/I2V are NOT (control checkpoint).
+    let caps: Vec<&str> = model["capabilities"]
+        .as_array()
+        .expect("capabilities array")
+        .iter()
+        .filter_map(Value::as_str)
+        .collect();
+    assert_eq!(
+        caps,
+        vec!["replace_person"],
+        "expose only the validated VACE mode"
+    );
+
+    // Download = the diffusers conversion (loadable), never the raw VideoX-Fun upstream.
+    let download = model["downloads"]
+        .as_array()
+        .and_then(|downloads| downloads.first())
+        .expect("a download entry");
+    assert_eq!(download["provider"], "huggingface");
+    assert_eq!(download["repo"], "linoyts/Wan2.2-VACE-Fun-14B-diffusers");
+    assert_ne!(
+        download["repo"], "alibaba-pai/Wan2.2-VACE-Fun-A14B",
+        "must not point at the raw VideoX-Fun repo (it does not load via diffusers/native)"
+    );
+    let platforms: Vec<&str> = download["platforms"]
+        .as_array()
+        .expect("platforms array")
+        .iter()
+        .filter_map(Value::as_str)
+        .collect();
+    for os in ["macos", "windows", "linux"] {
+        assert!(platforms.contains(&os), "download should cover {os}");
+    }
+
+    // Native-only: an MLX block, and NO Torch GGUF quantization variants.
+    assert!(model["mlx"].is_object(), "native MLX engine block present");
+    assert!(
+        model["mlx"]["minMemoryGb"].as_u64().unwrap_or(0) >= 64,
+        "dual 14B needs a substantial memory floor"
+    );
+    assert!(
+        model.get("quantization").is_none(),
+        "native-first: no Torch GGUF quantization block"
+    );
+}
+
+#[test]
 fn builtin_manifest_registers_the_joycaption_model() {
     // sc-5620: the native captioner (caption_jobs.rs, the training_caption job) resolves an
     // already-cached HF snapshot via the same resolve_app_managed_model_dir seam and does NOT

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -519,4 +519,25 @@ export const fallbackModels = [
       promptGuide: { title: "Wan2.2 14B Image-to-Video Prompt Guide", path: "/prompt-guides/wan-2-2-i2v-14b.md" },
     },
   },
+  {
+    // Wan2.2 VACE-Fun A14B (epic 3456): native-only dual-expert VACE control model. First
+    // slice exposes replace_person (the validated VACE path); control-video preprocessing
+    // (pose/depth/canny) + extend/bridge are tracked follow-ups (sc-3460).
+    id: "wan_2_2_vace_fun_14b",
+    name: "Wan2.2 VACE-Fun (A14B)",
+    type: "video",
+    capabilities: ["replace_person"],
+    defaults: { duration: 5, fps: 16, resolution: "832x480", quality: "balanced" },
+    limits: {
+      durations: [3, 4, 5],
+      recommendedMaxDuration: 5,
+      fps: [16],
+      resolutions: ["832x480", "480x832", "1280x720", "720x1280"],
+    },
+    ui: {
+      description: "Wan2.2 A14B VACE control model (high/low-noise mixture-of-experts) for person replacement and controllable video.",
+      durationHint: "Heavy dual-expert control model — keep clips at 5s or less. Generates at 16fps.",
+      promptGuide: { title: "Wan2.2 VACE-Fun Prompt Guide", path: "/prompt-guides/wan-2-2-t2v-14b.md" },
+    },
+  },
 ];

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2929,6 +2929,102 @@
         }
       }
     },
+    {
+      // Wan2.2 VACE-Fun A14B (epic 3456): alibaba-pai's VACE-trained dual-expert
+      // (high/low-noise MoE) control model on the Wan2.2-T2V-A14B base — controllable
+      // video (replace_person / pose-depth control / extend-bridge) via a masked control
+      // clip + reference images. NATIVE-ONLY, no Torch path (the epic's native-first
+      // decision; mirrors bernini). macOS = native MLX (mlx-gen-wan engine id
+      // "wan2_2_vace_fun_14b", sc-6604, dual-expert sibling of "wan_vace"); Windows/Linux =
+      // native candle ("wan2_2_vace_fun_14b", sc-6605). The runtime loads BOTH experts
+      // (transformer/ high-noise + transformer_2/ low-noise), switched at boundary 0.875.
+      //
+      // Source: linoyts/Wan2.2-VACE-Fun-14B-diffusers — the community diffusers conversion
+      // of alibaba-pai/Wan2.2-VACE-Fun-A14B (the raw upstream is a VideoX-Fun layout that
+      // does NOT load via diffusers/native engines). ~81 GB; Apache-2.0 (base Wan2.2-T2V-
+      // A14B). sc-6608 (epic 5594) re-hosts this onto SceneWorks/wan2.2-vace-fun-a14b-{mlx,
+      // diffusers} for provenance and flips the downloads below. The macOS engine reads the
+      // diffusers transformer dirs directly + the shared native-converted UMT5/z16-VAE/
+      // tokenizer assembled from a base-Wan-14B snapshot (the worker resolves this — same
+      // convention as the Wan2.1 "wan_vace" replace_person backend).
+      "id": "wan_2_2_vace_fun_14b",
+      "name": "Wan2.2 VACE-Fun (A14B)",
+      "family": "wan-video",
+      "type": "video",
+      "adapter": "wan_video",
+      // VACE control surface, first slice: replace_person (the validated VACE path — the
+      // masked control clip + character references). Pose/Depth/Canny/MLSD control-video
+      // preprocessing and extend/bridge are tracked follow-ups (sc-3460), not exposed until
+      // their preprocessing lands, so the menu never offers a mode the runtime can't serve.
+      "capabilities": ["replace_person"],
+      "downloads": [
+        {
+          "provider": "huggingface",
+          "repo": "linoyts/Wan2.2-VACE-Fun-14B-diffusers",
+          "files": [],
+          "platforms": ["macos", "windows", "linux"],
+          "estimatedSizeBytes": 81200000000
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/linoyts/Wan2.2-VACE-Fun-14B-diffusers"
+      },
+      "defaults": {
+        "duration": 5,
+        "fps": 16,
+        "resolution": "832x480",
+        "quality": "balanced",
+        "sampler": "default",
+        "scheduler": "default"
+      },
+      "limits": {
+        // Upstream trained at 81 frames / 16 fps / multi-res 512·768·1024. Keep clips short
+        // (dual 14B is heavy); the VACE control clip resolution must match the generation
+        // resolution (the engine errors otherwise).
+        "durations": [3, 4, 5],
+        "recommendedMaxDuration": 5,
+        "hardMaxDuration": 5,
+        "fps": [16],
+        "resolutions": ["832x480", "480x832", "1280x720", "720x1280"],
+        // Native engines are default-sampler only (no flow-match swaps wired) — declared on
+        // mlx.limits too; there is no Torch backend for this model.
+        "samplers": ["default"],
+        "schedulers": ["default"]
+      },
+      "loraCompatibility": {
+        "families": ["wan-video"],
+        "types": ["style", "motion", "character", "enhance"]
+      },
+      "mlx": {
+        // Native MLX dual-expert VACE-Fun (mlx-gen-wan "wan2_2_vace_fun_14b", sc-6604). The
+        // worker resolves env override (SCENEWORKS_MLX_WAN_VACE_FUN_DIR) → local
+        // <data>/models/mlx/wan_2_2_vace_fun → the assembled snapshot (diffusers transformer/
+        // + transformer_2/ + native-converted UMT5/z16-VAE/tokenizer from a base-Wan-14B
+        // snapshot). Dual 14B bf16 ≈ 56 GB transformers + encoder/VAE → 133 GB floor (Q4/Q8
+        // at load). Runtime support lands with the mlx-gen pin bump (sc-3459).
+        "minMemoryGb": 133,
+        "repo": "linoyts/Wan2.2-VACE-Fun-14B-diffusers",
+        "limits": {
+          "samplers": ["default"],
+          "schedulers": ["default"]
+        }
+      },
+      "ui": {
+        "label": "Wan2.2 VACE-Fun (A14B)",
+        "description": "Wan2.2 A14B VACE control model (high/low-noise mixture-of-experts) for person replacement and controllable video. Native-only (no Torch); needs ample memory for both experts.",
+        "recommendedFor": ["replace_person"],
+        "durationHint": "Heavy dual-expert control model — keep clips at 5s or less. Generates at 16fps.",
+        "promptGuide": {
+          "title": "Wan2.2 VACE-Fun Prompt Guide",
+          "path": "/prompt-guides/wan-2-2-t2v-14b.md",
+          "sources": [
+            { "label": "Wan2.2 VACE-Fun model card", "url": "https://huggingface.co/alibaba-pai/Wan2.2-VACE-Fun-A14B" },
+            { "label": "VideoX-Fun (VACE-Fun) GitHub", "url": "https://github.com/aigc-apps/VideoX-Fun" },
+            { "label": "Wan2.2 GitHub repo", "url": "https://github.com/Wan-Video/Wan2.2" }
+          ]
+        }
+      }
+    },
     // Bernini (epic 4699): ByteDance's full pipeline — a Qwen2.5-VL-7B semantic
     // planner (Latent Semantic Planning / MAR loop) driving a Wan2.2-T2V-A14B
     // dual-expert renderer. macOS-only native MLX (mlx-gen-bernini, engine id

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -194,6 +194,23 @@ pub(crate) async fn run_video_generate_job(
         ),
     )
     .await?;
+    // sc-3459 (epic 3456): Wan2.2 VACE-Fun A14B is a NEW dual-expert VACE engine
+    // (`wan2_2_vace_fun_14b`; native MLX sc-6604, native candle sc-6605). Until those engines
+    // merge and the worker's mlx-gen/candle-gen pin is bumped, the runtime cannot serve it — and
+    // replace_person must NEVER fall through to the Wan2.1 `generate_wan_vace` backend below, which
+    // would silently render with the WRONG checkpoint (the exact failure the epic forbids). Fail
+    // honestly instead. When the engine pin lands, this guard is replaced by the real per-platform
+    // `generate_wan_vace_fun` dispatch (resolve the dual-expert snapshot → the `wan2_2_vace_fun_14b`
+    // engine).
+    if request.model == "wan_2_2_vace_fun_14b" {
+        return Err(WorkerError::InvalidPayload(
+            "wan_2_2_vace_fun_14b: the native Wan2.2 VACE-Fun engine is not yet available in this \
+             build (pending the mlx-gen/candle-gen integration, sc-6604/sc-6605). The job will not \
+             be routed to the Wan2.1 VACE backend. Choose another model, or update once the engine \
+             ships."
+                .to_owned(),
+        ));
+    }
     // Generate: real MLX on macOS for Wan (sc-3034) / LTX+audio (sc-3035) models with
     // resolvable weights, else the procedural stub (non-macOS or missing weights = stub).
     // replace_person (sc-3521) always routes to the native Wan-VACE provider regardless of the


### PR DESCRIPTION
Native-first SceneWorks wiring for **Wan2.2 VACE-Fun A14B** (epic [sc-3456](https://app.shortcut.com/trefry/epic/3456)). The native dual-expert engine ships in [SceneWorks/mlx-gen#505](https://github.com/SceneWorks/mlx-gen/pull/505) and will bump the worker pin; this PR is the registration + the honest-routing guard that can land now.

## Changes
- **`builtin.models.jsonc`** — new `wan_2_2_vace_fun_14b` model: `wan-video`/`wan_video`, capabilities **`[replace_person]` only** (the validated VACE mode; pose/depth/canny control-video preprocessing + extend/bridge are tracked follow-ups, sc-3460, so the menu never offers an unservable mode). **Native-only** (no Torch GGUF). Download = `linoyts/Wan2.2-VACE-Fun-14B-diffusers` — the diffusers conversion; the raw `alibaba-pai` repo is a VideoX-Fun layout that doesn't load (sc-6608 re-hosts onto `SceneWorks/`). 16 fps, 3–5 s, minMemoryGb 133.
- **`constants.js`** — matching Video Studio `fallbackModels` entry.
- **`tests.rs`** — `builtin_manifest_registers_the_wan_vace_fun_model` (asserts the entry, the replace_person-only capability set, the diffusers-not-raw download repo, platform coverage, MLX block, no GGUF).
- **`video_jobs.rs`** — a platform-agnostic **guard**: a `wan_2_2_vace_fun_14b` job now fails with a clear, actionable error instead of silently falling through to the **Wan2.1** `generate_wan_vace` backend (the wrong-checkpoint bug the epic forbids). The full dual-expert dispatch (`generate_wan_vace_fun` → the new engine) lands when the mlx-gen pin bumps (sc-3459, blocked by #505).

## Verification
- rust-api manifest tests **3/3 pass**; `sceneworks-worker` compiles clean; `constants.js` `node --check`; `videoModelUsable` recognizes `replace_person`.
- The native engine itself is real-weight-smoke validated in #505 (16 coherent frames @256², both 14B experts loaded, boundary switch fired).

Existing Wan2.2 TI2V/T2V/I2V entries are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)