### PR TITLE
Wire candle Ideogram 4 (ideogram_4 / ideogram_4_turbo) into the worker + fix candle clippy (sc-6597, sc-6610)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fe1489ed91b7b32dda10b281fe875407ec5fb8b#9fe1489ed91b7b32dda10b281fe875407ec5fb8b"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fe1489ed91b7b32dda10b281fe875407ec5fb8b#9fe1489ed91b7b32dda10b281fe875407ec5fb8b"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fe1489ed91b7b32dda10b281fe875407ec5fb8b#9fe1489ed91b7b32dda10b281fe875407ec5fb8b"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fe1489ed91b7b32dda10b281fe875407ec5fb8b#9fe1489ed91b7b32dda10b281fe875407ec5fb8b"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fe1489ed91b7b32dda10b281fe875407ec5fb8b#9fe1489ed91b7b32dda10b281fe875407ec5fb8b"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -505,9 +505,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "candle-gen-ideogram"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fe1489ed91b7b32dda10b281fe875407ec5fb8b#9fe1489ed91b7b32dda10b281fe875407ec5fb8b"
+dependencies = [
+ "candle-gen",
+ "candle-gen-flux2",
+ "candle-transformers",
+ "inventory",
+ "rand 0.9.4",
+ "rand_distr 0.5.1",
+ "safetensors 0.7.0",
+ "serde_json",
+ "tokenizers 0.22.2",
+]
+
+[[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fe1489ed91b7b32dda10b281fe875407ec5fb8b#9fe1489ed91b7b32dda10b281fe875407ec5fb8b"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -519,7 +535,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fe1489ed91b7b32dda10b281fe875407ec5fb8b#9fe1489ed91b7b32dda10b281fe875407ec5fb8b"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -530,7 +546,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fe1489ed91b7b32dda10b281fe875407ec5fb8b#9fe1489ed91b7b32dda10b281fe875407ec5fb8b"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -544,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fe1489ed91b7b32dda10b281fe875407ec5fb8b#9fe1489ed91b7b32dda10b281fe875407ec5fb8b"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -557,7 +573,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fe1489ed91b7b32dda10b281fe875407ec5fb8b#9fe1489ed91b7b32dda10b281fe875407ec5fb8b"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -569,7 +585,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fe1489ed91b7b32dda10b281fe875407ec5fb8b#9fe1489ed91b7b32dda10b281fe875407ec5fb8b"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -580,7 +596,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fe1489ed91b7b32dda10b281fe875407ec5fb8b#9fe1489ed91b7b32dda10b281fe875407ec5fb8b"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -597,7 +613,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fe1489ed91b7b32dda10b281fe875407ec5fb8b#9fe1489ed91b7b32dda10b281fe875407ec5fb8b"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -612,7 +628,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fe1489ed91b7b32dda10b281fe875407ec5fb8b#9fe1489ed91b7b32dda10b281fe875407ec5fb8b"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -623,7 +639,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fe1489ed91b7b32dda10b281fe875407ec5fb8b#9fe1489ed91b7b32dda10b281fe875407ec5fb8b"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -641,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fe1489ed91b7b32dda10b281fe875407ec5fb8b#9fe1489ed91b7b32dda10b281fe875407ec5fb8b"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -652,7 +668,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fe1489ed91b7b32dda10b281fe875407ec5fb8b#9fe1489ed91b7b32dda10b281fe875407ec5fb8b"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -665,7 +681,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fe1489ed91b7b32dda10b281fe875407ec5fb8b#9fe1489ed91b7b32dda10b281fe875407ec5fb8b"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -676,7 +692,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fe1489ed91b7b32dda10b281fe875407ec5fb8b#9fe1489ed91b7b32dda10b281fe875407ec5fb8b"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -689,7 +705,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc#72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=9fe1489ed91b7b32dda10b281fe875407ec5fb8b#9fe1489ed91b7b32dda10b281fe875407ec5fb8b"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -5283,6 +5299,7 @@ dependencies = [
  "candle-gen-face",
  "candle-gen-flux",
  "candle-gen-flux2",
+ "candle-gen-ideogram",
  "candle-gen-instantid",
  "candle-gen-joycaption",
  "candle-gen-kolors",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3750,6 +3750,13 @@ const CANDLE_ROUTED_MODELS: &[&str] = &[
     "kolors",
     "sensenova_u1_8b",
     "sensenova_u1_8b_fast",
+    // Ideogram 4 (sc-6597, epic 6561): the candle `candle-gen-ideogram` provider serves `ideogram_4`
+    // (asymmetric two-DiT CFG) and `ideogram_4_turbo` (CFG-free single DiT + bundled TurboTime LoRA).
+    // Pure **txt2img** on candle for now — edit / img2img / mask shapes are rejected below
+    // (`image_request_candle_eligible`) and fall back to the Python torch worker until the candle edit
+    // lane lands (sc-6598). These ids are also in `MLX_ROUTED_MODELS` (the macOS native engine).
+    "ideogram_4",
+    "ideogram_4_turbo",
 ];
 
 /// The candle image families that advertise on-the-fly Q4/Q8 quant AND LoRA/LoKr adapters — Lens /
@@ -5660,6 +5667,29 @@ mod candle_routing_tests {
                 !image_request_candle_eligible(model, &object(payload.clone())),
                 "{model} conditioning shape must fall back to torch: {payload}"
             );
+        }
+    }
+
+    #[test]
+    fn ideogram_candle_txt2img_eligible_but_edit_defers_to_torch() {
+        // sc-6597 (epic 6561): `ideogram_4` + `ideogram_4_turbo` route to the candle lane for plain
+        // text-to-image only. Edit / img2img / mask / reference shapes defer to the Python torch
+        // worker until the candle edit lane lands (sc-6598).
+        for model in ["ideogram_4", "ideogram_4_turbo"] {
+            assert!(
+                image_request_candle_eligible(model, &object(json!({ "prompt": "an aurora" }))),
+                "{model} plain txt2img must be candle-eligible"
+            );
+            for payload in [
+                json!({ "mode": "edit_image", "sourceAssetId": "a" }),
+                json!({ "referenceAssetId": "a" }),
+                json!({ "maskAssetId": "m", "sourceAssetId": "a" }),
+            ] {
+                assert!(
+                    !image_request_candle_eligible(model, &object(payload.clone())),
+                    "{model} edit shape must defer to torch: {payload}"
+                );
+            }
         }
     }
 

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -278,6 +278,8 @@ backend-candle = [
     "dep:candle-gen-flux",
     "dep:candle-gen-flux2",
     "dep:candle-gen-qwen-image",
+    # sc-6596 (epic 6561): the candle Ideogram 4 image provider (`ideogram_4` + `ideogram_4_turbo`).
+    "dep:candle-gen-ideogram",
     # sc-5484 (epic 3692): the candle Chroma image provider (chroma1_hd / chroma1_base / chroma1_flash).
     "dep:candle-gen-chroma",
     # sc-5576 (epic 3692): the candle Kolors image provider (`kolors` — SDXL UNet + ChatGLM3-6B
@@ -889,38 +891,43 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0b86
 # (`image_jobs/qwen_edit_candle.rs`) drives candle-gen-qwen-image's `QwenEdit` (incl. the lightning
 # distill) off-Mac; the candle SAM3 path (`person_segment_sam3_candle.rs`) drives candle-gen-sam3.
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fe1489ed91b7b32dda10b281fe875407ec5fb8b", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fe1489ed91b7b32dda10b281fe875407ec5fb8b", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fe1489ed91b7b32dda10b281fe875407ec5fb8b", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fe1489ed91b7b32dda10b281fe875407ec5fb8b", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fe1489ed91b7b32dda10b281fe875407ec5fb8b", features = ["cuda"], optional = true }
+# Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
+# Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
+# bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
+# (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fe1489ed91b7b32dda10b281fe875407ec5fb8b", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fe1489ed91b7b32dda10b281fe875407ec5fb8b", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fe1489ed91b7b32dda10b281fe875407ec5fb8b", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fe1489ed91b7b32dda10b281fe875407ec5fb8b", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fe1489ed91b7b32dda10b281fe875407ec5fb8b", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fe1489ed91b7b32dda10b281fe875407ec5fb8b", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -929,19 +936,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fe1489ed91b7b32dda10b281fe875407ec5fb8b", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fe1489ed91b7b32dda10b281fe875407ec5fb8b", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fe1489ed91b7b32dda10b281fe875407ec5fb8b", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -950,12 +957,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fe1489ed91b7b32dda10b281fe875407ec5fb8b", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fe1489ed91b7b32dda10b281fe875407ec5fb8b", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -963,7 +970,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72bea
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fe1489ed91b7b32dda10b281fe875407ec5fb8b", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -972,7 +979,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fe1489ed91b7b32dda10b281fe875407ec5fb8b", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -980,7 +987,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fe1489ed91b7b32dda10b281fe875407ec5fb8b", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -989,7 +996,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fe1489ed91b7b32dda10b281fe875407ec5fb8b", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1016,7 +1023,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72beadbdd9ec19ceb30153f6d0b8ca6b8028e0fc", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9fe1489ed91b7b32dda10b281fe875407ec5fb8b", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/ideogram_caption.rs
+++ b/crates/sceneworks-worker/src/ideogram_caption.rs
@@ -19,15 +19,11 @@
 //      is the caller's job.
 //
 // No engine change — the fix is entirely in the prompt we hand the engine, and a post-render check.
-
-// sc-6610: off-Mac, Ideogram routes to candle (txt2img) or the torch worker — neither uses this
-// caption-guard + placeholder detect-and-recover module (its only non-test callers are in the macOS
-// MLX `image_jobs/base.rs` `generate_one`). So every item here is dead off-Mac and the candle
-// `clippy -p sceneworks-worker --features backend-candle -- -D warnings` lane denies the lot. The
-// logic is platform-independent and exercised by the cross-platform tests below, so the whole module
-// is `allow(dead_code)` off-Mac (NOT cfg-gated to macOS) to keep that test coverage on the
-// Windows/CUDA box while the production callers stay macOS-only.
-#![cfg_attr(not(target_os = "macos"), allow(dead_code))]
+//
+// sc-6610: the off-Mac dead_code allowance for this whole module lives on the `mod ideogram_caption;`
+// declaration in `lib.rs` (`#[cfg_attr(not(target_os = "macos"), allow(dead_code))]`) — every item
+// here is dead on a non-macOS build (its only non-test callers are in the macOS MLX `generate_stream`
+// path), so it must NOT be repeated here (clippy::duplicated_attributes).
 
 /// Whether `model` is one of the Ideogram 4 image models (quality + turbo). Both are JSON-caption
 /// trained, so both get the caption guard; the placeholder is a quality-mode CFG behavior the turbo

--- a/crates/sceneworks-worker/src/ideogram_caption.rs
+++ b/crates/sceneworks-worker/src/ideogram_caption.rs
@@ -20,6 +20,15 @@
 //
 // No engine change — the fix is entirely in the prompt we hand the engine, and a post-render check.
 
+// sc-6610: off-Mac, Ideogram routes to candle (txt2img) or the torch worker — neither uses this
+// caption-guard + placeholder detect-and-recover module (its only non-test callers are in the macOS
+// MLX `image_jobs/base.rs` `generate_one`). So every item here is dead off-Mac and the candle
+// `clippy -p sceneworks-worker --features backend-candle -- -D warnings` lane denies the lot. The
+// logic is platform-independent and exercised by the cross-platform tests below, so the whole module
+// is `allow(dead_code)` off-Mac (NOT cfg-gated to macOS) to keep that test coverage on the
+// Windows/CUDA box while the production callers stay macOS-only.
+#![cfg_attr(not(target_os = "macos"), allow(dead_code))]
+
 /// Whether `model` is one of the Ideogram 4 image models (quality + turbo). Both are JSON-caption
 /// trained, so both get the caption guard; the placeholder is a quality-mode CFG behavior the turbo
 /// (CFG-free) path cannot trigger, but running the detector on turbo is a cheap, harmless no-op.

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -104,6 +104,10 @@ use candle_gen_flux as _;
 use candle_gen_flux2 as _;
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_qwen_image as _;
+// Candle Ideogram 4 (sc-6596, epic 6561): `ideogram_4` + `ideogram_4_turbo` self-register into the
+// shared gen_core inventory; `as _;` keeps the MSVC release linker from GC-ing the registrations.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+use candle_gen_ideogram as _;
 // Candle Chroma (sc-5484, epic 3692): chroma1_hd / chroma1_base / chroma1_flash self-register into the
 // shared gen_core inventory; the `as _;` keeps the MSVC release linker from GC-ing the registrations.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -82,12 +82,12 @@ mod image_jobs;
 use image_jobs::*;
 // Ideogram 4 mandatory JSON-caption conditioning + placeholder detect-and-recover (epic 4725,
 // sc-6501). Pure prompt-guard + post-render heuristic, compiled cross-platform so its unit tests run
-// on the Linux parity lane; its functions are called from the macOS/candle image base path
-// (`image_jobs/base.rs`), so they read as dead code only on a plain non-macOS, non-candle build.
-#[cfg_attr(
-    all(not(target_os = "macos"), not(feature = "backend-candle")),
-    allow(dead_code)
-)]
+// on the Linux parity lane. sc-6610: its functions are called only from the macOS MLX generate path
+// (`image_jobs/base.rs` `generate_stream`, `#[cfg(target_os = "macos")]`) — off-Mac, Ideogram routes
+// to candle (txt2img) or the torch worker, neither of which applies the caption guard, so they read
+// as dead code on EVERY non-macOS build (the candle `backend-candle` lane included; the prior
+// `not(feature = "backend-candle")` carve-out wrongly assumed the candle path called them).
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 mod ideogram_caption;
 // SenseNova-U1 understanding + interleave jobs (epic 3180, sc-3905 — Path B). VQA + Document
 // Studio (interleave) consume the concrete `T2iModel` directly (the `Generator` contract emits


### PR DESCRIPTION
**Epic [6561](https://app.shortcut.com/trefry/epic/6561)** — slice 2 of 3. Brings the off-Mac candle Ideogram 4 T2I lane to the worker (provider crate landed in candle-gen#110 / [sc-6596](https://app.shortcut.com/trefry/story/6596)). Folds in the pre-existing candle-clippy fix [sc-6610](https://app.shortcut.com/trefry/story/6610).

## [sc-6597](https://app.shortcut.com/trefry/story/6597) — worker wiring
- **`crates/sceneworks-worker/Cargo.toml`** — re-pin all candle-gen deps `72beadbd → 9fe1489` (the merged candle-gen#110 tip; **gen-core `0b86fad4` unchanged = the worker pin → single rev, zero skew**) and add `candle-gen-ideogram` (cuda, optional) to the deps + `backend-candle` feature.
- **`image_jobs.rs`** — force-link `use candle_gen_ideogram as _;` so the `ideogram_4` / `ideogram_4_turbo` inventory registrations survive the MSVC release linker.
- **`jobs_store.rs`** — add both ids to `CANDLE_ROUTED_MODELS`. Pure **txt2img** on candle; edit / img2img / mask / reference shapes defer to the Python torch worker until the candle edit lane (sc-6598). New routing test `ideogram_candle_txt2img_eligible_but_edit_defers_to_torch`; the `MODEL_TABLE` rows already exist (target-neutral).

## [sc-6610](https://app.shortcut.com/trefry/story/6610) — candle clippy red (folded in)
The candle `clippy -p sceneworks-worker --features backend-candle -- -D warnings` lane was pre-existing red. The **entire `ideogram_caption` module** (caption guard + placeholder detect-and-recover) is dead off-Mac — its only non-test callers are in the macOS MLX `generate_one` path; off-Mac Ideogram routes to candle/torch which don't use it. (The ticket's symbol list was stale — `wrap_plain_text`/`json_string` had since become dead too via `ensure_caption_prompt`.) Fix: a module-level `#![cfg_attr(not(target_os = "macos"), allow(dead_code))]` — chosen over `#[cfg(target_os="macos")]` because the logic is platform-independent and exercised by cross-platform tests that run on the Windows/CUDA box (hard-gating would lose that coverage).

## Validation
- `cargo clippy -p sceneworks-worker --features backend-candle -- -D warnings` → **green** (compiles, links candle-gen-ideogram, force-link present, no dead_code).
- `cargo test -p sceneworks-core` routing tests green (incl. the new ideogram test + the `candle_routed_models_plain_txt2img_are_eligible` loop now covering both ids).
- fmt clean; single gen-core rev.
- The provider itself is GPU-validated (candle-gen#110): `ideogram_4` 512²/1024² + `ideogram_4_turbo` rendered correct, prompt-faithful images on the RTX PRO 6000.

**Follow-up:** deployed-worker end-to-end smoke (submit an `ideogram_4` job → candle worker → streamed PNG) and sc-6598 (Remix/edit lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)