### PR TITLE
feat(pose-library): whole-body DWPose skeleton for the Qwen-Edit pose tier (sc-6599)

### DIFF
--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -39,7 +39,7 @@ from .character_studio_angles import (
     augment_prompt_for_angle,
     augment_prompt_for_pose,
 )
-from .openpose_skeleton import draw_bodypose, draw_wholebody, normalize_face, normalize_hands, normalize_keypoints
+from .openpose_skeleton import draw_wholebody, normalize_face, normalize_hands, normalize_keypoints
 from .sampler_registry import apply_sampler, sampler_selection_from_advanced
 from .hf_cache import huggingface_cache_roots, huggingface_repo_cache_path
 from .lora_adapters import (
@@ -1760,10 +1760,18 @@ class QwenImageAdapter(DiffusersImageAdapterBase):
         # image-capable), so the pose comes from the skeleton while identity comes from
         # the reference. No pose ControlNet exists for the edit model (sc-2250); this is
         # the native multi-image approximation. Pose takes precedence over angleSet.
+        # sc-6599: render the full DWPose whole-body skeleton (body + hands 21x2 + face 68)
+        # so whole-body library poses pass the hand/face articulation through to the edit
+        # model. An A/B (whole-body vs body-only) confirmed the open-hand / gesture detail
+        # transfers and firms hand fidelity with no identity or artifact regression. Zero
+        # risk for today's body-only bundled poses: draw_wholebody with no hands/face is
+        # byte-identical to the old draw_bodypose path.
         raw_poses = request.advanced.get("poses")
         pose_entries = [p for p in raw_poses if isinstance(p, dict)] if isinstance(raw_poses, list) else []
         pose_set = self._use_reference(request) and len(pose_entries) > 0
         pose_keypoints = [normalize_keypoints(p.get("keypoints")) for p in pose_entries] if pose_set else []
+        pose_hands = [normalize_hands(p.get("hands")) for p in pose_entries] if pose_set else []
+        pose_face = [normalize_face(p.get("face")) for p in pose_entries] if pose_set else []
         angle_set = self._use_reference(request) and bool(request.advanced.get("angleSet")) and not pose_set
         angles = list(CHARACTER_ANGLE_SET_ORDER) if angle_set else []
         grouped = angle_set or pose_set
@@ -1780,7 +1788,10 @@ class QwenImageAdapter(DiffusersImageAdapterBase):
             pose_skeleton = None
             if pose_set:
                 pose_skeleton = Image.fromarray(
-                    draw_bodypose(request.width, request.height, pose_keypoints[index])
+                    draw_wholebody(
+                        request.width, request.height, pose_keypoints[index],
+                        hands=pose_hands[index], face=pose_face[index],
+                    )
                 )
                 prompt_override = augment_prompt_for_pose(request.prompt)
             else:

--- a/crates/sceneworks-worker/src/image_jobs/qwen.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen.rs
@@ -570,19 +570,18 @@ async fn generate_qwen_edit_stream(
     // seed, each a `[reference, skeleton]` set) / else the plain per-image reference path.
     let grouping = flux2_grouping(request);
     let set_seed = resolve_seed(request, 0);
-    let (seeds, prompts, pose_keypoints): (
+    let (seeds, prompts, pose_inputs): (
         Vec<i64>,
         Vec<String>,
-        Option<Vec<Vec<crate::openpose_skeleton::Keypoint>>>,
+        Option<Vec<PoseInput>>,
     ) = match &grouping {
         Flux2Grouping::Poses(count) => {
             // Shared seed so only the pose changes across the set (Python parity).
-            let keypoints = parse_poses(request)
-                .into_iter()
-                .map(|pose| pose.keypoints)
-                .collect();
+            // Keep the full PoseInput (keypoints + hands + face) so whole-body poses
+            // thread their hand/face articulation into the skeleton below (sc-6599).
+            let poses = parse_poses(request);
             let prompts = vec![augment_prompt_for_pose(&request.prompt); *count];
-            (vec![set_seed; *count], prompts, Some(keypoints))
+            (vec![set_seed; *count], prompts, Some(poses))
         }
         Flux2Grouping::Angles => {
             // Shared seed so noise-derived attributes (hair, lighting) stay constant
@@ -652,18 +651,22 @@ async fn generate_qwen_edit_stream(
                 tx,
                 seeds.into_iter().zip(prompts),
                 move |index, (seed, prompt), on_progress| {
-                    // Pose tier: pair the reference with this pose's body-only skeleton (DWPose
-                    // body, no hands/face — Python `draw_bodypose`) as a `[reference, skeleton]`
-                    // multi-image set. Reference FIRST: the engine VL-encodes references[0] for
-                    // the prompt embeds (identity), the skeleton is added dual-latent geometry.
-                    let conditioning = match &pose_keypoints {
-                        Some(keypoints) => {
+                    // Pose tier: pair the reference with this pose's DWPose whole-body skeleton
+                    // (body + hands 21x2 + face 68 when the pose carries them — sc-6599) as a
+                    // `[reference, skeleton]` multi-image set. Reference FIRST: the engine
+                    // VL-encodes references[0] for the prompt embeds (identity), the skeleton is
+                    // added dual-latent geometry. A real-weight A/B confirmed the hand/gesture
+                    // detail transfers; body-only poses render identically to the old path
+                    // (draw_wholebody with no hands/face == draw_bodypose).
+                    let conditioning = match &pose_inputs {
+                        Some(poses) => {
+                            let pose = &poses[index];
                             let skeleton = crate::openpose_skeleton::draw_wholebody(
                                 width,
                                 height,
-                                &keypoints[index],
-                                None,
-                                None,
+                                &pose.keypoints,
+                                pose.hands.as_deref(),
+                                pose.face.as_deref(),
                                 stickwidth,
                             );
                             vec![Conditioning::MultiReference {

--- a/tests/test_worker_image_adapters.py
+++ b/tests/test_worker_image_adapters.py
@@ -3938,14 +3938,23 @@ def test_qwen_image_adapter_pose_loop_renders_skeleton_and_passes_multi_image(mo
     monkeypatch.setattr(ia, "activate_torch_device", lambda *args, **kwargs: None)
     monkeypatch.setattr(ia, "select_torch_device", lambda *args, **kwargs: "cpu")
     monkeypatch.setattr(ia, "gpu_memory_snapshot", lambda *args, **kwargs: None)
-    # draw_bodypose needs cv2 (not in the requirements-dev CI venv); the actual
-    # render is covered by test_draw_bodypose_renders_colored. Here we only verify
-    # dispatch, so stub it to a tiny array Image.fromarray can consume.
+    # sc-6599: the pose tier now renders the DWPose whole-body skeleton. draw_wholebody
+    # needs cv2 (not in the requirements-dev CI venv); the actual render is covered
+    # elsewhere, so stub it — capturing the hands/face it receives to prove whole-body
+    # poses thread their articulation through (and body-only poses pass None).
     import numpy as _np
-    monkeypatch.setattr(ia, "draw_bodypose", lambda w, h, kps: _np.zeros((h, w, 3), dtype=_np.uint8))
+    wholebody_calls: list[dict] = []
+
+    def fake_draw_wholebody(w, h, kps, hands=None, face=None, stickwidth=4):
+        wholebody_calls.append({"hands": hands, "face": face})
+        return _np.zeros((h, w, 3), dtype=_np.uint8)
+
+    monkeypatch.setattr(ia, "draw_wholebody", fake_draw_wholebody)
 
     # Two library poses; flat 18-point COCO skeletons (values arbitrary but valid).
     kp = [[0.5, 0.1 + 0.04 * i] for i in range(18)]
+    hands = [[[0.4, 0.4]] * 21, [[0.6, 0.4]] * 21]
+    face = [[0.5, 0.3]] * 68
     request = ia.ImageRequest(
         project_id="p",
         mode="character_image",
@@ -3964,7 +3973,10 @@ def test_qwen_image_adapter_pose_loop_renders_skeleton_and_passes_multi_image(mo
         source_asset_id=None,
         reference_asset_id="ref-asset-id",
         # angleSet also set to prove pose takes precedence (no angle loop runs).
-        advanced={"poses": [{"id": "sit_01", "keypoints": kp}, {"id": "stand_01", "keypoints": kp}], "angleSet": True},
+        advanced={"poses": [
+            {"id": "sit_01", "keypoints": kp},  # body-only
+            {"id": "stand_01", "keypoints": kp, "hands": hands, "face": face},  # whole-body
+        ], "angleSet": True},
         model_manifest_entry={},
     )
     QwenImageAdapter().generate(
@@ -3981,6 +3993,12 @@ def test_qwen_image_adapter_pose_loop_renders_skeleton_and_passes_multi_image(mo
     for entry in captured:
         assert entry["pose_skeleton"] is not None
         assert POSE_SKELETON_PROMPT in (entry["prompt_override"] or "")
+    # sc-6599: whole-body hands/face thread through to the edit model (validated by the
+    # whole-body-vs-body-only A/B); body-only poses pass None (rendered identically to
+    # the old draw_bodypose path).
+    assert len(wholebody_calls) == 2
+    assert wholebody_calls[0]["hands"] is None and wholebody_calls[0]["face"] is None
+    assert wholebody_calls[1]["hands"] is not None and len(wholebody_calls[1]["face"]) == 68
 
 def test_load_state_dict_requires_weights_only(tmp_path):
     """sc-4230 / F-WORKER-6: .pth upscaler weights load with weights_only=True


### PR DESCRIPTION
## What

The Qwen-Image-Edit best-effort pose tier (`QwenImageAdapter`) rendered a **body-only** OpenPose skeleton (`draw_bodypose`) as its second edit image. This swaps it to the full **DWPose whole-body** skeleton (`draw_wholebody` — body 18 + hands 21×2 + face 68), threading `normalize_hands`/`normalize_face` per pose entry. Mirrors the Kolors sc-2289 change.

## Why — real-weight A/B (sc-6599)

Ran a real-weight A/B on Qwen-Image-Edit-2511 (identical seed/prompt/cfg per pose; the only variable is whether the skeleton carries hands+face):

| Pose | body-only | whole-body |
|---|---|---|
| Wave | raised arm, **closed fist** | raised arm, **open palm** ✓ matches donor |
| Point | right arm **relaxed at side** (gesture lost) | right arm **raised, gesturing** ✓ + hand-on-hip kept |

Whole-body firms hand/gesture fidelity; identity (hair/freckles/clothing) preserved in all renders and the 68-pt face landmarks caused no facial distortion. Full method + montage on [sc-6599](https://app.shortcut.com/trefry/story/6599).

## Risk

**Zero risk for today's body-only bundled poses** — `draw_wholebody` with no hands/face is byte-identical to `draw_bodypose`. The hands/face only ever flow when a (user-created) whole-body pose carries them.

## Tests

- Updated `test_qwen_image_adapter_pose_loop_...` to stub `draw_wholebody` and assert hands/face thread through for whole-body poses and pass `None` for body-only.
- Removed the now-unused `draw_bodypose` import from `image_adapters.py`.

Closes sc-6599.

🤖 Generated with [Claude Code](https://claude.com/claude-code)