### PR TITLE
feat(boogu): mark Base + Turbo recommended, no auto-download (sc-6616)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1002,6 +1002,12 @@
     },
     {
       "id": "boogu_image",
+      // Recommended (sc-6616): render quality validated real-weight in S5 (sc-6402). autoDownload:false
+      // because the Q8 turnkey is ~23 GB/variant — surfaced in the Models Recommended section +
+      // SetupWizard (with its size) so users discover it, but they opt in rather than the wizard
+      // auto-pulling it on first run (mirrors ltx_2_3 / prompt_refine_anubis_8b).
+      "recommended": true,
+      "autoDownload": false,
       "name": "Boogu Image",
       "family": "boogu",
       "type": "image",
@@ -1089,6 +1095,10 @@
     },
     {
       "id": "boogu_image_turbo",
+      // Recommended (sc-6616): the fast few-step variant (S5-validated); same autoDownload:false opt-in
+      // as Base. Edit is intentionally NOT recommended (a specialized mode, only shown in the Edit tab).
+      "recommended": true,
+      "autoDownload": false,
       "name": "Boogu Image Turbo",
       "family": "boogu",
       "type": "image",


### PR DESCRIPTION
## Boogu `recommended` flag (sc-6616, epic 6387 — final item)

Post-S5 render quality is validated (sc-6402), so surface Boogu in the Models **Recommended** section + the **SetupWizard**.

### Change (data-only)
`config/manifests/builtin.models.jsonc`: `recommended: true` + `autoDownload: false` on `boogu_image` and `boogu_image_turbo` (placed after `"id"`, mirroring `ltx_2_3` / `prompt_refine_anubis_8b`). `boogu_image_edit` is intentionally **not** recommended — a specialized mode that only appears in the Edit tab.

### Behavior
Base + Turbo appear as recommended (Models page + SetupWizard, with their size) and as recommended options in Image Studio — but `autoDownload: false` means the wizard leaves them **unchecked**, so a fresh install never auto-pulls the ~23 GB/variant turnkey (~46 GB for both). The user opts in.

### Validation
- `node scripts/check-scaffold.mjs` PASS.
- Strict JSON parse confirms `boogu_image` rec=true/autoDl=false, `boogu_image_turbo` rec=true/autoDl=false, `boogu_image_edit` unchanged.
- Web: `vitest --environment jsdom main.test.jsx ImageStudio.test.jsx` **198 passed / 0 failed** — the recommend + `autoDownload:false` SetupWizard behavior is already covered generically by the `ltx_2_3` case, so no fixture surgery was needed.

No Rust/JS code change. With this merged, **epic 6387 is complete**: native-MLX Boogu port (E1–E9) + SceneWorks integration (S1–S5) + bf16 on-demand (sc-6568) + recommended flag (sc-6616).

🤖 Generated with [Claude Code](https://claude.com/claude-code)