### PR TITLE
feat(flux2): thread DWPose hands/face into best-effort pose skeleton (sc-6702)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/flux2.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2.rs
@@ -337,19 +337,18 @@ async fn generate_flux2_edit_stream(
     // `[skeleton, reference]` set) / else the plain per-image reference path.
     let grouping = flux2_grouping(request);
     let set_seed = resolve_seed(request, 0);
-    let (seeds, prompts, pose_keypoints): (
+    let (seeds, prompts, pose_inputs): (
         Vec<i64>,
         Vec<String>,
-        Option<Vec<Vec<crate::openpose_skeleton::Keypoint>>>,
+        Option<Vec<PoseInput>>,
     ) = match &grouping {
         Flux2Grouping::Poses(count) => {
             // Shared seed so only the pose changes across the set (Python parity).
-            let keypoints = parse_poses(request)
-                .into_iter()
-                .map(|pose| pose.keypoints)
-                .collect();
+            // Keep the full PoseInput (keypoints + hands + face) so whole-body poses
+            // thread their hand/face articulation into the skeleton below (sc-6702).
+            let poses = parse_poses(request);
             let prompts = vec![augment_prompt_for_pose(&request.prompt); *count];
-            (vec![set_seed; *count], prompts, Some(keypoints))
+            (vec![set_seed; *count], prompts, Some(poses))
         }
         Flux2Grouping::Angles => {
             // Shared seed so noise-derived attributes (hair, lighting) stay constant
@@ -411,17 +410,22 @@ async fn generate_flux2_edit_stream(
                 tx,
                 seeds.into_iter().zip(prompts),
                 move |index, (seed, prompt), on_progress| {
-                    // Pose tier: pair this pose's body-only skeleton (DWPose body, no
-                    // hands/face — Python `draw_bodypose`) with the reference as a
-                    // `[skeleton, reference]` multi-image set; else the plain reference set.
-                    let conditioning = match &pose_keypoints {
-                        Some(keypoints) => {
+                    // Pose tier: pair this pose's DWPose whole-body skeleton (body + hands
+                    // 21x2 + face 68 when the pose carries them — sc-6702) with the reference
+                    // as a `[skeleton, reference]` multi-image set; else the plain reference
+                    // set. A real-weight A/B confirmed the hand/gesture detail transfers
+                    // (wave → open palm vs fist; point → raised finger vs loose hand) with
+                    // identity intact; body-only poses render identically to the old path
+                    // (draw_wholebody with no hands/face == draw_bodypose).
+                    let conditioning = match &pose_inputs {
+                        Some(poses) => {
+                            let pose = &poses[index];
                             let skeleton = crate::openpose_skeleton::draw_wholebody(
                                 width,
                                 height,
-                                &keypoints[index],
-                                None,
-                                None,
+                                &pose.keypoints,
+                                pose.hands.as_deref(),
+                                pose.face.as_deref(),
                                 stickwidth,
                             );
                             vec![Conditioning::MultiReference {

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -3391,8 +3391,9 @@ fn flux2_pose_tier_real_weights_generates_one_image() {
         None,
     )
     .unwrap();
-    // A minimal standing skeleton (body only — the best-effort tier uses no
-    // hands/face) + a synthetic reference, paired as the pose multi-image set.
+    // A minimal standing skeleton (body only for this smoke — the production tier now
+    // threads hands/face per sc-6702, exercised by the A/B test below) + a synthetic
+    // reference, paired as the pose multi-image set.
     let kp = crate::openpose_skeleton::normalize_keypoints(&json!([
         [0.5, 0.2],
         [0.5, 0.35],
@@ -3458,6 +3459,146 @@ fn flux2_pose_tier_real_weights_generates_one_image() {
     assert_eq!(pixels.len(), 512 * 512 * 3);
     assert!(steps_seen >= 1, "expected denoise step progress");
     assert!(pixels.windows(2).any(|w| w[0] != w[1]));
+}
+
+/// sc-6702 A/B (real weights): does threading the pose's hands/face into the
+/// FLUX.2-klein best-effort skeleton improve hand/gesture fidelity (as it did for
+/// Qwen-Edit, sc-6599 = GO)? The best-effort tier feeds the skeleton as the *first*
+/// image of a `[skeleton, reference]` `MultiReference` edit (NOT a ControlNet), so
+/// there is no training-distribution argument either way — only a real A/B settles it.
+///
+/// This reuses the persistent sc-6599 harness assets at `~/sceneworks-pytorch-harness/`
+/// (the same auburn-haired reference + two whole-body pose donors with hands/face
+/// detected by production DWPose) so the result is directly comparable to the Qwen run.
+/// For each pose it renders the skeleton body-only vs whole-body and runs the exact
+/// production engine call with an identical seed/prompt/reference — the ONLY variable is
+/// whether the skeleton carries hands+face — writing `flux2_out_{pose}_{arm}.png` for
+/// visual judgment. Needs the HF cache (`black-forest-labs/FLUX.2-klein-9b`) + Metal:
+/// `cargo test -p sceneworks-worker --lib -- --ignored --nocapture flux2_pose_tier_ab_wholebody`.
+#[cfg(target_os = "macos")]
+#[test]
+#[ignore = "sc-6702 real-weight A/B: needs FLUX.2-klein-9b weights + Metal + the sc-6599 harness assets"]
+fn flux2_pose_tier_ab_wholebody_vs_body_real_weights() {
+    use crate::openpose_skeleton::{
+        body_stickwidth, draw_wholebody, normalize_face, normalize_hands, normalize_keypoints,
+    };
+
+    // Harness dir (override with SC6702_HARNESS for a relocated copy).
+    let harness = std::env::var("SC6702_HARNESS")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| dirs_home().join("sceneworks-pytorch-harness"));
+    assert!(
+        harness.join("ref.png").exists(),
+        "missing sc-6599 harness assets at {} — see sc_6599_qwen_edit_pose_wholebody_ab",
+        harness.display()
+    );
+
+    // SIDE matches the reference + the Qwen A/B (max hand/face scale). BASE is the same
+    // character description used for the reference image in the Qwen A/B, wrapped by the
+    // production pose-prompt augmenter (`augment_prompt_for_pose`).
+    const SIDE: u32 = 1024;
+    const BASE: &str = "The same woman with long wavy auburn hair, freckles, and a \
+        mustard-yellow turtleneck sweater, full body, standing, plain light background, \
+        photorealistic";
+    let prompt = augment_prompt_for_pose(BASE);
+    let stickwidth = body_stickwidth(SIDE, SIDE);
+
+    // Shared reference (identity), resized to the working square if needed.
+    let ref_rgb = {
+        let img = image::open(harness.join("ref.png")).unwrap().to_rgb8();
+        if img.width() == SIDE && img.height() == SIDE {
+            img
+        } else {
+            image::imageops::resize(&img, SIDE, SIDE, image::imageops::FilterType::Triangle)
+        }
+    };
+    let reference = gen_core::Image {
+        width: SIDE,
+        height: SIDE,
+        pixels: ref_rgb.into_raw(),
+    };
+
+    // Load the klein edit engine once; reuse for all four renders.
+    let snapshot = hf_snapshot("models--black-forest-labs--FLUX.2-klein-9b");
+    let generator = load_engine(
+        "flux2_klein_9b_edit",
+        snapshot,
+        Some(gen_core::Quant::Q8),
+        Vec::new(),
+        None,
+    )
+    .unwrap();
+
+    // Seeds mirror the Qwen A/B (pose1=8001, pose2=8002) for a clean cross-model comparison.
+    for (pose, seed) in [("pose1", 8001i64), ("pose2", 8002i64)] {
+        let raw = std::fs::read_to_string(harness.join(format!("{pose}.json"))).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let keypoints = normalize_keypoints(&v["keypoints"]);
+        let hands = normalize_hands(&v["hands"]);
+        let face = normalize_face(&v["face"]);
+        assert!(
+            hands.is_some() && face.is_some(),
+            "{pose}.json must carry hands + face for the A/B to mean anything"
+        );
+
+        // arm "body" = body-only (None/None — the current production behavior);
+        // arm "whole" = body + hands + face (the candidate fix).
+        for arm in ["body", "whole"] {
+            let (hands_arg, face_arg) = if arm == "whole" {
+                (hands.as_deref(), face.as_deref())
+            } else {
+                (None, None)
+            };
+            let skeleton = draw_wholebody(SIDE, SIDE, &keypoints, hands_arg, face_arg, stickwidth);
+            // Record the skeleton actually fed to the engine.
+            skeleton
+                .save(harness.join(format!("flux2_{pose}_skel_{arm}.png")))
+                .unwrap();
+            let skeleton_img = gen_core::Image {
+                width: SIDE,
+                height: SIDE,
+                pixels: skeleton.into_raw(),
+            };
+            // Production order: [skeleton, reference] (flux2.rs:419 — skeleton FIRST,
+            // unlike Qwen's [reference, skeleton]).
+            let conditioning = vec![gen_core::Conditioning::MultiReference {
+                images: vec![skeleton_img, reference.clone()],
+            }];
+            let cancel = gen_core::CancelFlag::new();
+            let mut steps_seen = 0u32;
+            eprintln!("[sc-6702] generating {pose}/{arm} (seed {seed}) ...");
+            let (w, h, pixels) = flux2_edit_generate_one(
+                generator.as_ref(),
+                &prompt,
+                SIDE,
+                SIDE,
+                seed,
+                4, // klein is a 4-step distill
+                Some(1.0),
+                conditioning,
+                &PromptEnhance::default(),
+                &cancel,
+                &mut |p| {
+                    if let gen_core::Progress::Step { current, .. } = p {
+                        steps_seen = steps_seen.max(current);
+                    }
+                },
+            )
+            .unwrap();
+            assert_eq!((w, h), (SIDE, SIDE));
+            assert!(steps_seen >= 1, "expected denoise step progress");
+            let out = harness.join(format!("flux2_out_{pose}_{arm}.png"));
+            image::RgbImage::from_raw(w, h, pixels)
+                .unwrap()
+                .save(&out)
+                .unwrap();
+            eprintln!("[sc-6702]   saved {}", out.display());
+        }
+    }
+    eprintln!(
+        "[sc-6702] A/B done — compare flux2_out_pose{{1,2}}_{{body,whole}}.png in {}",
+        harness.display()
+    );
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
## sc-6702 — Spike: A/B whole-body vs body-only for the FLUX.2-klein best-effort pose tier → **GO**

[sc-6702](https://app.shortcut.com/trefry/story/6702) (epic 2282), the FLUX.2 sibling of [sc-6599](https://app.shortcut.com/trefry/story/6599) / [#839](https://github.com/SceneWorks/SceneWorks/pull/839).

### The bug
The FLUX.2-klein **best-effort** pose tier feeds the skeleton as the first image of a `[skeleton, reference]` `MultiReference` edit (not a ControlNet). It built that skeleton **body-only** — `draw_wholebody(.., None, None)` at `flux2.rs:419` — and discarded the hands/face that `parse_poses` already extracts into `PoseInput` (via `.map(|pose| pose.keypoints)`). This is the identical pre-fix bug to the Qwen-Edit tier fixed in #839; the old "FLUX.2 N/A" verdict (sc-2289) was based on the Python adapter, which has no Flux pose path — the real macOS lane runs FLUX.2-klein on Rust MLX.

### Why a spike, not a blind flip
The skeleton is a loose *reference image*, not CN conditioning, so there's no training-distribution argument either way — only a real A/B settles whether hand/face detail helps the loose tier. FLUX.2-klein is a different model from Qwen, so it was validated independently.

### A/B method (faithful to the macOS production lane)
Ran directly against the **Rust MLX engine** (`flux2_klein_9b_edit`, Q8, 1024², 4-step) — the actual macOS path — reusing the persistent sc-6599 harness assets (same auburn-haired reference + the same two whole-body pose donors with hands/face from production DWPose, same seeds 8001/8002). The only variable per render is whether the skeleton carries hands+face.

### Result → GO
| Pose | Body-only | Whole-body |
|------|-----------|------------|
| 1 (wave) | closed fist | **open palm** (matches donor) |
| 2 (point) | loose hand at shoulder | **raised pointing finger** |

Identity (hair/freckles/turtleneck) preserved in all four; the 68-pt face landmarks caused no facial distortion. Directly consistent with the Qwen GO. Caveat: n=2 favorable poses on the 4-step distill — directional, but visually unambiguous with no downside.

### The fix (one-spot mirror of the Qwen change)
Carry the full `PoseInput` and thread `pose.hands.as_deref()` / `pose.face.as_deref()` into `draw_wholebody`. **Zero-risk** for today's body-only bundled poses: `draw_wholebody` with no hands/face is byte-identical to the old `draw_bodypose` path.

FLUX.2-klein is MLX-only (no torch fallback; candle flux2-edit has no pose path; Python has no Flux pose path), so the Rust MLX lane is the only one to touch — unlike Qwen's 3 lanes.

### Tests
- New `#[ignore]` real-weight A/B test (`flux2_pose_tier_ab_wholebody_vs_body_real_weights`) mirroring the existing pose-tier smoke; it produced the four renders above.
- `cargo fmt` + `cargo clippy -p sceneworks-worker --lib --tests -- -D warnings` clean.
- 359 worker unit tests pass (0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)