### PR TITLE
fix(qwen): materialize Qwen-Image fast tokenizer via hosted overlay (sc-6570)

### DIFF
--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -1116,6 +1116,10 @@ pub fn begin_shutdown(app: &AppHandle) -> bool {
         .expect("candle worker lock")
         .take();
     let api_child = managed.api.lock().expect("api lock").take();
+    // Take the credential IPC handle so its socket file can be unlinked on a graceful
+    // quit (sc-5891); see the clean-exit block below. macOS-only (the socket is too).
+    #[cfg(target_os = "macos")]
+    let cred_ipc = managed.cred_ipc.lock().expect("cred_ipc lock").take();
     let handle = app.clone();
     std::thread::spawn(move || {
         #[cfg(unix)]
@@ -1162,6 +1166,13 @@ pub fn begin_shutdown(app: &AppHandle) -> bool {
         // Clean exit: drop the pidfile so the next launch doesn't try to reap
         // PIDs we already terminated.
         let _ = std::fs::remove_file(sidecar_pidfile());
+        // Unlink the credential IPC socket (sc-5891) so a graceful quit doesn't leave a
+        // stale `cred-ipc.sock` in the data dir. A crash/force-quit skips this, but the
+        // next launch's bind reaps it (`cred_ipc::start` removes a stale socket first).
+        #[cfg(target_os = "macos")]
+        if let Some(cred_ipc) = cred_ipc {
+            let _ = std::fs::remove_file(&cred_ipc.socket);
+        }
         handle.exit(0);
     });
     true

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -59,7 +59,7 @@ pub(crate) async fn run_model_download_job(
     if let Some(cache_path) =
         download_model_with_hf_cli(api, settings, job, repo, revision, &files, &target_dir).await?
     {
-        overlay_kolors_tokenizer(api, settings, http_client, &job.id, repo, &cache_path).await?;
+        overlay_derived_tokenizer(api, settings, http_client, &job.id, repo, &cache_path).await?;
         if !reconcile_downloaded_model_family(api, job, &cache_path).await? {
             return Ok(());
         }
@@ -144,9 +144,9 @@ pub(crate) async fn run_model_download_job(
     )
     .await?;
     let cache_path = huggingface_snapshot_dir(&settings.data_dir, repo).unwrap_or(repo_dir);
-    // Kolors ships no fast `tokenizer.json`; overlay the derived one (sc-4764) so the in-process
-    // Rust Kolors generator + trainer can construct. No-op for every other repo.
-    overlay_kolors_tokenizer(api, settings, http_client, &job.id, repo, &cache_path).await?;
+    // Some upstreams (Kolors sc-4764, Qwen-Image sc-6570) ship no fast `tokenizer.json`; overlay the
+    // derived one so the in-process Rust generator/trainer can construct. No-op for every other repo.
+    overlay_derived_tokenizer(api, settings, http_client, &job.id, repo, &cache_path).await?;
     // A lightweight install marker stays in the app store (parity with the CLI
     // path's marker_dir) so the catalog's data/models pointer and bookkeeping
     // remain intact; the weights themselves live only in the shared HF cache.
@@ -320,33 +320,68 @@ pub(crate) async fn run_lora_download_job(
     Ok(())
 }
 
-/// Canonical upstream Kolors repo. Its snapshot ships only the ChatGLM3 **slow** SentencePiece
-/// tokenizer (`tokenizer.model`), NOT the fast `tokenizer.json` that the in-process Rust Kolors
-/// generator (sc-3875) and LoRA/LoKr trainer (sc-4732) require — both construct via
-/// `KolorsTokenizer::from_dir`, which reads only `tokenizer/tokenizer.json`.
-const KOLORS_BASE_REPO: &str = "Kwai-Kolors/Kolors-diffusers";
-/// SceneWorks-hosted derived fast tokenizer (sc-4764): a small public repo holding the
-/// `tokenizer.json` materialized from the ChatGLM3 SP model (mlx-gen `tools/build_kolors_tokenizer.py`,
-/// content-id-parity validated). Overlaid onto the upstream snapshot at install so a Python-free Mac
-/// never runs the SP→fast conversion locally.
-const KOLORS_TOKENIZER_REPO: &str = "SceneWorks/kolors-chatglm3-tokenizer";
-const KOLORS_TOKENIZER_FILE: &str = "tokenizer.json";
-
-/// Where the derived `tokenizer.json` overlay belongs for a just-downloaded model, or `None` when
-/// `repo` is not the Kolors base repo (the overlay is a no-op for every other model). Pure so the
-/// repo guard + target path are unit-testable without a download.
-pub(crate) fn kolors_tokenizer_overlay_dest(repo: &str, snapshot_dir: &Path) -> Option<PathBuf> {
-    (repo.trim() == KOLORS_BASE_REPO)
-        .then(|| snapshot_dir.join("tokenizer").join(KOLORS_TOKENIZER_FILE))
+/// A base model whose upstream snapshot omits the HF **fast** `tokenizer.json` the in-process Rust
+/// generators/trainers require, paired with the small public `SceneWorks/*` repo that hosts the
+/// derived `tokenizer.json` to overlay at install. Materializing once + hosting (rather than running
+/// a slow→fast conversion locally) keeps a Python-free desktop working out-of-box.
+struct DerivedTokenizerOverlay {
+    /// Upstream base-model repo whose snapshot ships only a *slow* tokenizer.
+    base_repo: &'static str,
+    /// SceneWorks-hosted repo holding the materialized fast `tokenizer.json`.
+    tokenizer_repo: &'static str,
 }
 
-/// After a Kolors base-model download, overlay the derived `tokenizer.json` (sc-4764) from the
-/// SceneWorks tokenizer repo into the snapshot's `tokenizer/` dir, so `gen_core::load("kolors", …)`
-/// and `load_trainer("kolors", …)` can construct (they read only `tokenizer/tokenizer.json`, which
-/// upstream omits). No-op for any other repo; idempotent — skips when the file is already present
-/// (a re-install, or a snapshot that already shipped it). Reuses the standard HF resolve + download
-/// path, so the SceneWorks repo's auth/size/resume handling matches every other download.
-pub(crate) async fn overlay_kolors_tokenizer(
+/// The single overlaid file (in every case the HF fast serialization) and its in-snapshot subdir.
+const DERIVED_TOKENIZER_FILE: &str = "tokenizer.json";
+
+/// Base models that need a derived fast-tokenizer overlay. Keep entries narrowly scoped to the exact
+/// base repo — sibling repos (IP-Adapter, Edit variants that ship their own `tokenizer.json`, etc.)
+/// must NOT match.
+const DERIVED_TOKENIZER_OVERLAYS: &[DerivedTokenizerOverlay] = &[
+    // Kolors (sc-4764): conditions on ChatGLM3-6B, which ships only the **slow** SentencePiece
+    // tokenizer (`tokenizer.model`). The Rust Kolors generator (sc-3875) + LoRA/LoKr trainer
+    // (sc-4732) construct via `KolorsTokenizer::from_dir`, which reads only `tokenizer/tokenizer.json`.
+    // Derived via mlx-gen `tools/build_kolors_tokenizer.py` (content-id-parity validated).
+    DerivedTokenizerOverlay {
+        base_repo: "Kwai-Kolors/Kolors-diffusers",
+        tokenizer_repo: "SceneWorks/kolors-chatglm3-tokenizer",
+    },
+    // Qwen-Image (sc-6570): ships the Qwen2 BPE tokenizer as `vocab.json` + `merges.txt` only. The MLX
+    // `qwen-image` provider's `load_tokenizer` reads `tokenizer/tokenizer.json`. Derived via mlx-gen
+    // `tools/build_qwen_tokenizer.py` (byte-identical to the fork's runtime fast tokenizer). Note:
+    // `Qwen/Qwen-Image-Edit-2511` already ships its own `tokenizer.json`, so it needs no overlay.
+    DerivedTokenizerOverlay {
+        base_repo: "Qwen/Qwen-Image",
+        tokenizer_repo: "SceneWorks/qwen-image-tokenizer",
+    },
+];
+
+/// The hosted tokenizer repo + overlay dest for a just-downloaded `repo`, or `None` when `repo` is not
+/// a base model that needs the overlay (a no-op for every other model). Pure so the repo guard +
+/// target path are unit-testable without a download.
+pub(crate) fn derived_tokenizer_overlay(
+    repo: &str,
+    snapshot_dir: &Path,
+) -> Option<(&'static str, PathBuf)> {
+    let trimmed = repo.trim();
+    DERIVED_TOKENIZER_OVERLAYS
+        .iter()
+        .find(|overlay| overlay.base_repo == trimmed)
+        .map(|overlay| {
+            (
+                overlay.tokenizer_repo,
+                snapshot_dir.join("tokenizer").join(DERIVED_TOKENIZER_FILE),
+            )
+        })
+}
+
+/// After a base-model download, overlay the derived `tokenizer.json` from its SceneWorks tokenizer
+/// repo into the snapshot's `tokenizer/` dir, so the in-process generator/trainer can construct (they
+/// read only `tokenizer/tokenizer.json`, which these upstreams omit). No-op for any other repo;
+/// idempotent — skips when the file is already present (a re-install, or a snapshot that already
+/// shipped it). Reuses the standard HF resolve + download path, so the SceneWorks repo's
+/// auth/size/resume handling matches every other download.
+pub(crate) async fn overlay_derived_tokenizer(
     api: &ApiClient,
     settings: &Settings,
     http_client: &reqwest::Client,
@@ -354,7 +389,7 @@ pub(crate) async fn overlay_kolors_tokenizer(
     repo: &str,
     snapshot_dir: &Path,
 ) -> WorkerResult<()> {
-    let Some(dest) = kolors_tokenizer_overlay_dest(repo, snapshot_dir) else {
+    let Some((tokenizer_repo, dest)) = derived_tokenizer_overlay(repo, snapshot_dir) else {
         return Ok(());
     };
     if dest.exists() {
@@ -366,13 +401,13 @@ pub(crate) async fn overlay_kolors_tokenizer(
     let snapshot = HuggingFaceSnapshot::resolve(
         http_client,
         settings,
-        KOLORS_TOKENIZER_REPO,
+        tokenizer_repo,
         "main",
-        &[KOLORS_TOKENIZER_FILE.to_owned()],
+        &[DERIVED_TOKENIZER_FILE.to_owned()],
     )
     .await?;
     let mut progress = DownloadProgress::new(
-        KOLORS_TOKENIZER_REPO,
+        tokenizer_repo,
         0,
         snapshot.total_bytes(),
         progress_report_interval(settings),
@@ -383,7 +418,7 @@ pub(crate) async fn overlay_kolors_tokenizer(
             client: http_client,
             settings,
             job_id,
-            cancel_message: "Kolors tokenizer overlay canceled by user.",
+            cancel_message: "Derived tokenizer overlay canceled by user.",
             fresh_download: false,
         },
         tokenizer_dir,

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -31,10 +31,10 @@ use super::media_jobs::{
     run_ffmpeg,
 };
 use super::model_jobs::{
-    check_downloaded_model_family, downloaded_model_detection_io_error_is_inconclusive,
-    finalize_converted_dir, hf_cli_encoding_failure, kolors_tokenizer_overlay_dest,
-    overlay_kolors_tokenizer, validate_hf_cli_download_inputs, DownloadFamilyCheck,
-    HF_CLI_UTF8_ENV,
+    check_downloaded_model_family, derived_tokenizer_overlay,
+    downloaded_model_detection_io_error_is_inconclusive, finalize_converted_dir,
+    hf_cli_encoding_failure, overlay_derived_tokenizer, validate_hf_cli_download_inputs,
+    DownloadFamilyCheck, HF_CLI_UTF8_ENV,
 };
 // `terminating_signal` is only exercised by a `#[cfg(unix)]` test (signal-death
 // attribution is uncatchable and only observable on Unix), so gate the import to
@@ -1434,25 +1434,36 @@ async fn download_snapshot_fresh_retry_discards_partial_blob() {
     assert_eq!(tokio::fs::read(&blob_path).await.unwrap(), b"weights!!");
 }
 
-// --- Kolors tokenizer overlay (sc-4764) -----------------------------------------------------
+// --- Derived fast-tokenizer overlay (Kolors sc-4764, Qwen-Image sc-6570) --------------------
 
 #[test]
-fn kolors_tokenizer_overlay_dest_targets_only_the_kolors_base_repo() {
+fn derived_tokenizer_overlay_targets_only_known_base_repos() {
     let snap = std::path::Path::new("/snap");
     let want = PathBuf::from("/snap/tokenizer/tokenizer.json");
+    // Kolors → its SceneWorks tokenizer repo + the snapshot's tokenizer/tokenizer.json.
     assert_eq!(
-        kolors_tokenizer_overlay_dest("Kwai-Kolors/Kolors-diffusers", snap),
-        Some(want.clone())
+        derived_tokenizer_overlay("Kwai-Kolors/Kolors-diffusers", snap),
+        Some(("SceneWorks/kolors-chatglm3-tokenizer", want.clone()))
+    );
+    // Qwen-Image (sc-6570) → its SceneWorks tokenizer repo, same dest.
+    assert_eq!(
+        derived_tokenizer_overlay("Qwen/Qwen-Image", snap),
+        Some(("SceneWorks/qwen-image-tokenizer", want.clone()))
     );
     // Whitespace from a manifest field is tolerated.
     assert_eq!(
-        kolors_tokenizer_overlay_dest("  Kwai-Kolors/Kolors-diffusers  ", snap),
-        Some(want)
+        derived_tokenizer_overlay("  Qwen/Qwen-Image  ", snap),
+        Some(("SceneWorks/qwen-image-tokenizer", want))
     );
-    // Every other model is a no-op.
-    assert_eq!(kolors_tokenizer_overlay_dest("owner/model", snap), None);
+    // Every other model is a no-op — including sibling repos that must NOT match.
+    assert_eq!(derived_tokenizer_overlay("owner/model", snap), None);
     assert_eq!(
-        kolors_tokenizer_overlay_dest("Kwai-Kolors/Kolors-IP-Adapter-Plus", snap),
+        derived_tokenizer_overlay("Kwai-Kolors/Kolors-IP-Adapter-Plus", snap),
+        None
+    );
+    // Qwen-Image-Edit-2511 ships its own tokenizer.json upstream → no overlay.
+    assert_eq!(
+        derived_tokenizer_overlay("Qwen/Qwen-Image-Edit-2511", snap),
         None
     );
 }
@@ -1460,7 +1471,7 @@ fn kolors_tokenizer_overlay_dest_targets_only_the_kolors_base_repo() {
 /// A single stub that serves both the HF tree resolve (for the SceneWorks tokenizer repo) and the
 /// file bytes (the catch-all), plus the job/progress routes `check_cancel`/progress need. The tree
 /// advertises one `tokenizer.json` file sized to `bytes`.
-async fn spawn_kolors_overlay_stub(bytes: Vec<u8>) -> String {
+async fn spawn_overlay_stub(bytes: Vec<u8>) -> String {
     let state = BinaryStubState {
         bytes,
         status: AxumStatusCode::OK,
@@ -1493,10 +1504,10 @@ async fn overlay_tree_stub(State(state): State<BinaryStubState>) -> Response {
 }
 
 #[tokio::test]
-async fn overlay_kolors_tokenizer_fetches_and_places_the_json() {
+async fn overlay_derived_tokenizer_fetches_and_places_the_kolors_json() {
     let temp = tempdir().expect("tempdir creates");
     let bytes = br#"{"version":"1.0","model":{"type":"BPE"}}"#.to_vec();
-    let base_url = spawn_kolors_overlay_stub(bytes.clone()).await;
+    let base_url = spawn_overlay_stub(bytes.clone()).await;
     let mut settings = test_settings(base_url.clone(), None);
     settings.api_url = base_url.clone();
     let api = ApiClient::new(&settings);
@@ -1508,7 +1519,7 @@ async fn overlay_kolors_tokenizer_fetches_and_places_the_json() {
         .await
         .unwrap();
 
-    overlay_kolors_tokenizer(
+    overlay_derived_tokenizer(
         &api,
         &settings,
         &client,
@@ -1526,13 +1537,45 @@ async fn overlay_kolors_tokenizer_fetches_and_places_the_json() {
 }
 
 #[tokio::test]
-async fn overlay_kolors_tokenizer_is_noop_for_other_repos() {
+async fn overlay_derived_tokenizer_overlays_qwen_image() {
+    // The Qwen-Image base repo (sc-6570) is overlaid exactly like Kolors — same dest, its own repo.
+    let temp = tempdir().expect("tempdir creates");
+    let bytes = br#"{"version":"1.0","model":{"type":"BPE"},"qwen":true}"#.to_vec();
+    let base_url = spawn_overlay_stub(bytes.clone()).await;
+    let mut settings = test_settings(base_url.clone(), None);
+    settings.api_url = base_url.clone();
+    let api = ApiClient::new(&settings);
+    let client = reqwest::Client::new();
+    let snapshot_dir = temp.path().join("snapshots").join("75e0b4b");
+    tokio::fs::create_dir_all(snapshot_dir.join("tokenizer"))
+        .await
+        .unwrap();
+
+    overlay_derived_tokenizer(
+        &api,
+        &settings,
+        &client,
+        "job-1",
+        "Qwen/Qwen-Image",
+        &snapshot_dir,
+    )
+    .await
+    .expect("qwen-image overlay fetches and places the tokenizer");
+
+    let placed = tokio::fs::read(snapshot_dir.join("tokenizer").join("tokenizer.json"))
+        .await
+        .expect("tokenizer.json was written");
+    assert_eq!(placed, bytes);
+}
+
+#[tokio::test]
+async fn overlay_derived_tokenizer_is_noop_for_other_repos() {
     // An unreachable base URL: if the guard failed to short-circuit, the resolve would error.
     let temp = tempdir().expect("tempdir creates");
     let settings = test_settings("http://127.0.0.1:1".to_owned(), None);
     let api = ApiClient::new(&settings);
     let client = reqwest::Client::new();
-    overlay_kolors_tokenizer(
+    overlay_derived_tokenizer(
         &api,
         &settings,
         &client,
@@ -1541,11 +1584,11 @@ async fn overlay_kolors_tokenizer_is_noop_for_other_repos() {
         temp.path(),
     )
     .await
-    .expect("non-kolors repo is a no-op");
+    .expect("unlisted repo is a no-op");
 }
 
 #[tokio::test]
-async fn overlay_kolors_tokenizer_skips_when_already_present() {
+async fn overlay_derived_tokenizer_skips_when_already_present() {
     // dest exists → return Ok before any network (unreachable URL proves no download is attempted).
     let temp = tempdir().expect("tempdir creates");
     let tokenizer_dir = temp.path().join("tokenizer");
@@ -1556,12 +1599,12 @@ async fn overlay_kolors_tokenizer_skips_when_already_present() {
     let settings = test_settings("http://127.0.0.1:1".to_owned(), None);
     let api = ApiClient::new(&settings);
     let client = reqwest::Client::new();
-    overlay_kolors_tokenizer(
+    overlay_derived_tokenizer(
         &api,
         &settings,
         &client,
         "job-1",
-        "Kwai-Kolors/Kolors-diffusers",
+        "Qwen/Qwen-Image",
         temp.path(),
     )
     .await


### PR DESCRIPTION
## Summary

Qwen-Image fails at **model load** on the desktop Mac (MLX) — and the candle/Windows path has the same latent requirement — because the upstream `Qwen/Qwen-Image` snapshot ships only `vocab.json` + `merges.txt`, while the native `qwen-image` provider's `load_tokenizer` reads the HF **fast** `tokenizer/tokenizer.json`. The app's model-download job did nothing to materialize it, so a fresh install could never generate with Qwen-Image (`sc-6570`, found in the sc-1353 64 GB Phase-5 validation).

This reuses the **Kolors precedent (sc-4764)**: materialize the fast tokenizer once, host it in a small public `SceneWorks/*` repo, and overlay it onto the snapshot at model-download time — no Python on the desktop, no per-machine slow→fast conversion. Chosen over re-deriving in Rust because the hosted file is provably **byte-identical** to the fork's runtime tokenizer (a from-scratch Rust rebuild risks special-token / pretokenizer drift).

New hosted artifact: [`SceneWorks/qwen-image-tokenizer`](https://huggingface.co/SceneWorks/qwen-image-tokenizer) (public, Apache-2.0), materialized via mlx-gen `tools/build_qwen_tokenizer.py`.

## Changes
- **`crates/sceneworks-worker/src/model_jobs.rs`** — generalize the Kolors-only overlay into a table-driven `DERIVED_TOKENIZER_OVERLAYS` (`derived_tokenizer_overlay` + `overlay_derived_tokenizer`); add `Qwen/Qwen-Image → SceneWorks/qwen-image-tokenizer`. Both call sites updated. Left **platform-agnostic** (the candle provider reads the same `tokenizer.json`; Windows only worked before because that run used the Python worker).
- **`crates/sceneworks-worker/src/tests.rs`** — generalize the 4 overlay tests + add a Qwen-Image placement test and Edit-2511 / sibling-repo no-op assertions.
- **`apps/desktop/src/setup.rs`** — folded-in cosmetic item from the story: macOS-gated unlink of the `cred-ipc.sock` (sc-5891) in `begin_shutdown`, so a graceful Cmd-Q no longer leaves a stale socket (a crash still relies on the existing next-launch reap).

## Scope
- **Only `Qwen/Qwen-Image` (T2I)** is affected — `Qwen/Qwen-Image-Edit-2511` already ships its own `tokenizer.json` upstream (verified on disk).

## Validation
- **Parity:** materialized `tokenizer.json` vs the fork's runtime `transformers` tokenizer → **0 mismatches** (EN / EN-long / CN / mixed CN-EN-numeric-punct / empty). vocab_size 151665, pad 151643.
- **Real-weight load smoke (the exact erroring path):** mlx-gen `load_tokenizer(<real Qwen-Image snapshot>)` now succeeds and `encode_ids` → **8 / 15 / 0** ids matching the reference, on the 128 GB host against the full cached snapshot.
- **Live delivery:** unauthenticated `resolve/main/tokenizer.json` from the new public repo downloads with the same sha256 as the validated artifact — the exact path the worker overlay resolves.
- **Unit tests:** 5/5 overlay tests green. `cargo fmt` + `clippy` clean on worker and desktop.

## Follow-up
On-device `.app` install→generate confirmation rolls into the open Phase-5 validation (**sc-1353**); the overlay reuses the same model-download path that already worked for Z-Image there, and the repo is public (no keychain/auth involved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)