### PR TITLE
feat(ideogram): candle T2I placeholder detect-and-reseed parity (sc-6858)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -1669,7 +1669,8 @@ async fn generate_candle_stream(
     // distribution and stochastically renders the "Image blocked by safety filter" placeholder. Wrap a
     // non-caption prompt into a minimal valid caption — the same worker-side guarantee the macOS path
     // applies via `ideogram_caption::ensure_caption_prompt`. No-op (a clone) for every other family.
-    let prompt = if crate::ideogram_caption::is_ideogram_model(&request.model) {
+    let is_ideogram = crate::ideogram_caption::is_ideogram_model(&request.model);
+    let prompt = if is_ideogram {
         crate::ideogram_caption::ensure_caption_prompt(&request.prompt)
     } else {
         request.prompt.clone()
@@ -1680,7 +1681,7 @@ async fn generate_candle_stream(
     // it is gated to the ideogram family so a stray non-ideogram job reaching this generic lane is
     // untouched. Other candle edit families have their own bespoke streams (checked before this dispatch).
     let (ideogram_reference, ideogram_mask) =
-        if crate::ideogram_caption::is_ideogram_model(&request.model) {
+        if is_ideogram {
             match resolve_ideogram_edit(request, settings, project_path)? {
                 Some((source, strength, mask)) => (Some((source, strength)), mask),
                 None => (None, None),
@@ -1705,29 +1706,66 @@ async fn generate_candle_stream(
         format!("candle {engine_id} load failed"),
         move |generator, tx, cancel| {
             drive_gen_items(tx, seeds, move |_index, seed, on_progress| {
-                let (out_w, out_h, pixels) = generate_one(
-                    generator,
-                    &prompt,
-                    width,
-                    height,
-                    seed,
-                    steps,
-                    guidance,
-                    negative_prompt.clone(),
-                    ideogram_reference.as_ref(),
-                    ideogram_mask.as_ref(),
-                    true_cfg,
-                    // The candle txt2img families don't advertise sampler/scheduler selection (each uses
-                    // its family default), so no override is forwarded — matching this path's behavior
-                    // before sc-5392 added those params to `generate_one` for the macOS Chroma path.
-                    None,
-                    None,
-                    None,
-                    &enhance,
-                    &cancel,
-                    on_progress,
-                )?;
-                Ok(Some((seed, out_w, out_h, pixels)))
+                let render = |seed: i64, on_progress: &mut dyn FnMut(Progress)| {
+                    generate_one(
+                        generator,
+                        &prompt,
+                        width,
+                        height,
+                        seed,
+                        steps,
+                        guidance,
+                        negative_prompt.clone(),
+                        ideogram_reference.as_ref(),
+                        ideogram_mask.as_ref(),
+                        true_cfg,
+                        // The candle txt2img families don't advertise sampler/scheduler selection (each
+                        // uses its family default), so no override is forwarded — matching this path's
+                        // behavior before sc-5392 added those params for the macOS Chroma path.
+                        None,
+                        None,
+                        None,
+                        &enhance,
+                        &cancel,
+                        on_progress,
+                    )
+                };
+                let (mut out_w, mut out_h, mut pixels) = render(seed, on_progress)?;
+                let mut final_seed = seed;
+                // Ideogram 4 placeholder detect-and-reseed (sc-6858, parity with the macOS
+                // `generate_stream` net, sc-6501): the caption guard above makes it rare, but a residual
+                // "Image blocked by safety filter" placeholder can still occur even with a caption.
+                // Detect via the baked-text heuristic and reseed transparently, keeping the first clean
+                // render. Gated to Ideogram 4; a no-op for every other candle family, for turbo (CFG-free,
+                // cannot produce it), and for an edit (the output is anchored to a real source latent, so
+                // `looks_like_placeholder` returns false).
+                if is_ideogram
+                    && crate::ideogram_caption::looks_like_placeholder(&pixels, out_w, out_h)
+                {
+                    let retries = crate::ideogram_caption::placeholder_recovery_retries();
+                    for attempt in 0..retries {
+                        if cancel.is_cancelled() {
+                            break;
+                        }
+                        let retry_seed = crate::ideogram_caption::recovery_seed(seed, attempt);
+                        tracing::warn!(
+                            "ideogram 4 placeholder detected (seed {seed}); reseeding {retry_seed} \
+                             (attempt {}/{retries})",
+                            attempt + 1,
+                        );
+                        let (rw, rh, rpixels) = render(retry_seed, on_progress)?;
+                        let recovered =
+                            !crate::ideogram_caption::looks_like_placeholder(&rpixels, rw, rh);
+                        out_w = rw;
+                        out_h = rh;
+                        pixels = rpixels;
+                        final_seed = retry_seed;
+                        if recovered {
+                            break;
+                        }
+                    }
+                }
+                Ok(Some((final_seed, out_w, out_h, pixels)))
             })
         },
     );


### PR DESCRIPTION
**Epic [6561](https://app.shortcut.com/trefry/epic/6561)** follow-up (found during the sc-6598 deployed-worker E2E smoke).

The candle image lane (`generate_candle_stream`) wraps Ideogram prompts via `ensure_caption_prompt` (sc-6597) but — unlike the macOS `generate_stream` — lacked the **placeholder detect-and-reseed** net (sc-6501). So a residual Ideogram 4 "Image blocked by safety filter" placeholder on candle T2I was emitted as the final image instead of being recovered.

## Change
Port the macOS reseed loop into `generate_candle_stream`'s render closure: detect a residual flat-gray placeholder via `ideogram_caption::looks_like_placeholder`, reseed up to `placeholder_recovery_retries` (`recovery_seed`), keeping the first clean render. Gated to `is_ideogram`; a no-op for every other candle family, for turbo (CFG-free — can't produce it), and for an edit (output anchored to a real source latent → never detected). The helpers are already `pub(crate)` + cross-platform (sc-6610), so no new gating.

## Validation (deployed candle worker, RTX PRO 6000)
Native API + native candle worker. A **768² `ideogram_4` T2I at seed 42** (a resolution/seed that reliably renders the flat-gray placeholder) logged:
```
ideogram 4 placeholder detected (seed 42); reseeding … (attempt 1/12)
… (attempt 2/12)
… (attempt 3/12)
```
then **recovered** — the 3rd reseed produced a clean red-apple image and the job completed with the real render (not the placeholder). Full macOS parity (fires → recovers → keeps clean).

`clippy -p sceneworks-worker --features backend-candle -- -D warnings` + fmt clean. Pure worker change (no provider / no candle-gen re-pin / single gen-core rev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)