### PR TITLE
feat(ideogram): candle bf16 weights repo + off-Mac resolution (sc-6859)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -855,6 +855,17 @@
           "files": ["q4/*"],
           "platforms": ["macos"],
           "estimatedSizeBytes": 15400562623
+        },
+        {
+          // Candle (Windows/Linux CUDA) bf16 snapshot (epic 6561 / sc-6859): the candle provider can't
+          // read the MLX-quantized turnkey above, so off-Mac loads bf16 from a separate repo. Weights
+          // live under the `bf16/` subdir (the worker's `candle_ideogram_subdir`) so quant variants can
+          // slot in later without a rename. Same gated non-commercial license; Windows/Linux download.
+          "provider": "huggingface",
+          "repo": "SceneWorks/ideogram-4",
+          "files": ["bf16/*"],
+          "platforms": ["windows", "linux"],
+          "estimatedSizeBytes": 54760833024
         }
       ],
       "paths": {
@@ -952,6 +963,16 @@
           "files": ["q4/*", "q4/turbo_lora.safetensors"],
           "platforms": ["macos"],
           "estimatedSizeBytes": 16247340792
+        },
+        {
+          // Candle (Windows/Linux CUDA) bf16 snapshot (epic 6561 / sc-6859): off-Mac loads bf16 from
+          // `SceneWorks/ideogram-4`'s `bf16/` subdir, which carries `turbo_lora.safetensors` alongside
+          // the base weights (the turbo loader merges it at load). Same gated license; Win/Linux only.
+          "provider": "huggingface",
+          "repo": "SceneWorks/ideogram-4",
+          "files": ["bf16/*"],
+          "platforms": ["windows", "linux"],
+          "estimatedSizeBytes": 54760833024
         }
       ],
       "paths": {

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -1573,6 +1573,59 @@ fn candle_adapter_label(model: &str) -> &'static str {
     }
 }
 
+/// The candle Ideogram 4 weights repo (bf16). Ideogram is the lone candle image family whose upstream
+/// isn't candle-readable — the published `SceneWorks/ideogram-4-mlx` turnkey (the MODEL_TABLE default +
+/// the macOS MLX repo) is MLX-quantized — so the candle lane loads bf16 from a separate repo (sc-6859),
+/// the image sibling of the video `CANDLE_WAN_5B_REPO`. The bf16 weights live under the repo's `bf16/`
+/// subdir so quant variants (`q4/`/`q8/`) can slot in later without a rename (cf. the MLX turnkey).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+const CANDLE_IDEOGRAM_REPO: &str = "SceneWorks/ideogram-4";
+
+/// Resolve the candle Ideogram weights repo: the off-Mac (`std::env::consts::OS`) download entry's
+/// `repo` from the manifest (the bf16 repo) — the single source of truth, also driving the downloader —
+/// else the [`CANDLE_IDEOGRAM_REPO`] default. Deliberately NOT the entry-level `repo`, which is the
+/// macOS MLX turnkey. Mirrors how `candle_video_repo` overrides the MLX repo with the diffusers one.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn candle_ideogram_repo(request: &ImageRequest) -> String {
+    let os = std::env::consts::OS;
+    request
+        .model_manifest_entry
+        .get("downloads")
+        .and_then(Value::as_array)
+        .and_then(|downloads| {
+            downloads.iter().find_map(|entry| {
+                let matches_os = entry
+                    .get("platforms")
+                    .and_then(Value::as_array)
+                    .is_some_and(|platforms| platforms.iter().any(|p| p.as_str() == Some(os)));
+                if !matches_os {
+                    return None;
+                }
+                entry
+                    .get("repo")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|repo| !repo.is_empty())
+                    .map(str::to_owned)
+            })
+        })
+        .unwrap_or_else(|| CANDLE_IDEOGRAM_REPO.to_owned())
+}
+
+/// The precision subdir within the candle Ideogram repo snapshot. Candle is bf16-only today (the
+/// provider rejects on-the-fly quant), so this resolves the `bf16/` subdir (mirroring the MLX turnkey's
+/// `q4/`/`q8/`); a future candle quant variant slots in alongside it. Falls back to the snapshot root so
+/// a flat (subdir-less) layout still loads.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn candle_ideogram_subdir(root: &Path) -> PathBuf {
+    let bf16 = root.join("bf16");
+    if bf16.join("transformer").join("model.safetensors").is_file() {
+        bf16
+    } else {
+        root.to_path_buf()
+    }
+}
+
 /// Windows/CUDA candle execution path (sc-3675 SDXL, generalized in sc-5096). The macOS dispatch is
 /// MLX-bound; candle is a narrow **txt2img-only** lane, so this is a trimmed sibling of
 /// [`generate_stream`] that drives the SAME neutral streaming harness (`start_cached_gen_stream` →
@@ -1618,10 +1671,25 @@ async fn generate_candle_stream(
     } else {
         model.backend()
     };
-    let repo = model_repo(request, &model);
-    let weights_dir = huggingface_snapshot_dir(&settings.data_dir, &repo).ok_or_else(|| {
+    let is_ideogram = crate::ideogram_caption::is_ideogram_model(&request.model);
+    // Ideogram is the lone candle image family whose upstream isn't candle-readable: the published
+    // turnkey `SceneWorks/ideogram-4-mlx` (the MODEL_TABLE default + the macOS MLX repo) is
+    // MLX-quantized, so the candle lane loads bf16 from `SceneWorks/ideogram-4` (the `bf16/` subdir)
+    // instead — the image sibling of the candle video `candle_video_repo` override (sc-6859). macOS
+    // keeps the MLX turnkey. Every other candle family shares its upstream diffusers repo via `model_repo`.
+    let repo = if is_ideogram {
+        candle_ideogram_repo(request)
+    } else {
+        model_repo(request, &model)
+    };
+    let snapshot = huggingface_snapshot_dir(&settings.data_dir, &repo).ok_or_else(|| {
         WorkerError::InvalidPayload(format!("candle weights snapshot not found for {repo}"))
     })?;
+    let weights_dir = if is_ideogram {
+        candle_ideogram_subdir(&snapshot)
+    } else {
+        snapshot
+    };
 
     // Descriptor-derived denoise/guidance surface (distilled families → no guidance/negative; guided
     // families → the scale + negative prompt). Identical to the MLX path; quant + LoRA are omitted.
@@ -1669,7 +1737,7 @@ async fn generate_candle_stream(
     // distribution and stochastically renders the "Image blocked by safety filter" placeholder. Wrap a
     // non-caption prompt into a minimal valid caption — the same worker-side guarantee the macOS path
     // applies via `ideogram_caption::ensure_caption_prompt`. No-op (a clone) for every other family.
-    let is_ideogram = crate::ideogram_caption::is_ideogram_model(&request.model);
+    // (`is_ideogram` was resolved above with the weights repo.)
     let prompt = if is_ideogram {
         crate::ideogram_caption::ensure_caption_prompt(&request.prompt)
     } else {


### PR DESCRIPTION
**Epic [6561](https://app.shortcut.com/trefry/epic/6561)** — the last item to make the candle Ideogram lane production-ready off-Mac.

**Why Ideogram is special.** Every other candle image family resolves its `MODEL_TABLE` `default_repo` to the original **upstream diffusers/safetensors** repo, read by *both* the MLX and candle providers (SDXL→`stabilityai/...`, FLUX→`black-forest-labs/...`, Qwen→`Qwen/...`, etc.) — there is no separate Mac vs candle model. Ideogram's upstream (`ideogram-ai/ideogram-4-fp8`) is gated + fp8, so the only published repo is the **MLX-quantized turnkey** `SceneWorks/ideogram-4-mlx`, which the candle provider can't read. So candle needs its own bf16 repo.

## Change (mirrors the candle **video** precedent `candle_video_repo`/`CANDLE_WAN_5B_REPO`)
- `generate_candle_stream` resolves ideogram weights from `SceneWorks/ideogram-4` (bf16) + its `bf16/` subdir via `candle_ideogram_repo` (reads the off-Mac `downloads[]` entry's `repo` from the manifest — single source of truth, also driving the downloader — else the `CANDLE_IDEOGRAM_REPO` default; deliberately **not** the entry-level `repo`, which is the macOS MLX turnkey) + `candle_ideogram_subdir` (picks `bf16/`, root fallback). macOS keeps the MLX turnkey; every other family unchanged.
- `builtin.models.jsonc`: add a `windows`/`linux` `downloads` entry for `ideogram_4` + `ideogram_4_turbo` (`repo: SceneWorks/ideogram-4`, `files: ["bf16/*"]`); `retain_downloads_for_os` keeps the right one per OS. macOS MLX `q4/*` entry unchanged.

The `bf16/` subdir (mirroring the MLX turnkey's `q4/`/`q8/`) lets candle quant variants slot in later **without a repo rename** — candle is bf16-only today (the provider rejects on-the-fly quant; candle GGUF quant NaNs on Blackwell, sc-6361).

## Published + validated
Published **`SceneWorks/ideogram-4`** (private, gated) with the bf16 snapshot under `bf16/` — ~51 GB verified on HF (transformer 18.6 GB + unconditional 18.6 GB + Qwen3-VL TE 16.3 GB + VAE + tokenizer + turbo_lora). GPU-validated on the **deployed** candle worker (RTX PRO 6000, API serving this manifest): an `ideogram_4` 1024² T2I resolved `repo=SceneWorks/ideogram-4` (recorded in the asset recipe — **not** the MLX turnkey) + the `bf16/` subdir and rendered a coherent image on `backend:candle`. `clippy --features backend-candle -- -D warnings` + fmt clean; single gen-core rev.

⟹ With this, the candle Ideogram lane no longer needs hand-staged weights — closes epic 6561.

🤖 Generated with [Claude Code](https://claude.com/claude-code)