### PR TITLE
chore(release): 0.3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ concurrency:
 jobs:
   macos:
     # Self-hosted macOS 26.2 runner; same-repo only — never run fork code.
-    if: ${{ github.repository == 'michaeltrefry/SceneWorks' }}
+    if: ${{ github.repository == 'SceneWorks/SceneWorks' }}
     runs-on: [self-hosted, macOS, ARM64, nax]
     env:
       APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sceneworks/desktop",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sceneworks/desktop",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sceneworks/desktop",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "SceneWorks desktop shell (Tauri).",
   "scripts": {
     "dev": "tauri dev",

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SceneWorks",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "identifier": "net.trefry.sceneworks",
   "build": {
     "frontendDist": "ui",

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sceneworks/web",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sceneworks/web",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "konva": "^9.3.22",
         "react": "18.3.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sceneworks/web",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite --host 0.0.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sceneworks",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Local AI image and video generation studio runtime skeleton.",
   "license": "SEE LICENSE IN LICENSE",
   "scripts": {


### PR DESCRIPTION
Cuts the **0.3.0** macOS desktop release.

## Changes
- **Version bump 0.2.0 → 0.3.0** across root `package.json`, `apps/desktop/tauri.conf.json` (the artifact-critical field naming the bundled .app/DMG), and `apps/web` / `apps/desktop` package + lockfiles, via `npm version` + `scripts/sync-version.mjs`.
- **Fix `release.yml` build guard.** The repo was transferred to the org, so `github.repository` is now `SceneWorks/SceneWorks`; the guard still pinned the old `michaeltrefry/SceneWorks`, which would evaluate false at tag time and **skip** the macOS build job (no DMG, no release). Updated to `SceneWorks/SceneWorks`.

## Why this must merge before tagging
Tag-triggered workflow runs read `release.yml` from the tagged commit. The fixed guard has to be on `main` first, then `v0.3.0` is tagged on the merged commit so the build actually runs on the `nax` self-hosted runner.

## Release path after merge
Tag `v0.3.0` on the merged commit → push → `release.yml` builds + signs + notarizes + staples the DMG → creates a **draft** GitHub Release for manual review/publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)