### PR TITLE
Route candle SCAIL-2 animation + replace_person off-Mac (sc-6837)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb#715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb#715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb#715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb#715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb#715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb#715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -523,7 +523,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb#715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -535,7 +535,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb#715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb#715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb#715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb#715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -585,7 +585,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb#715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -596,7 +596,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb#715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -613,7 +613,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb#715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -628,7 +628,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb#715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -637,9 +637,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "candle-gen-scail2"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
+dependencies = [
+ "candle-gen",
+ "candle-gen-wan",
+ "inventory",
+ "rand 0.9.4",
+ "rand_distr 0.5.1",
+ "safetensors 0.7.0",
+ "serde_json",
+ "tokenizers 0.22.2",
+]
+
+[[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb#715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -657,7 +672,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb#715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -668,7 +683,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb#715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -681,7 +696,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb#715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -692,7 +707,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb#715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -705,7 +720,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb#715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -5309,6 +5324,7 @@ dependencies = [
  "candle-gen-pulid",
  "candle-gen-qwen-image",
  "candle-gen-sam3",
+ "candle-gen-scail2",
  "candle-gen-sdxl",
  "candle-gen-seedvr2",
  "candle-gen-sensenova",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -4032,18 +4032,30 @@ const CANDLE_VIDEO_I2V_ROUTED_MODELS: &[&str] = &["wan_2_2_i2v_14b", "svd"];
 /// text-to-video, the 14B I2V's single source-image conditioning (sc-5175), SVD image→video (sc-5493),
 /// **and** the Wan-VACE advanced modes — replace_person / extend / bridge (sc-5494, the `PersonReplace`
 /// / `VideoExtend` / `VideoBridge` job types → the candle `wan_vace` engine). Every other shape
-/// (reference/mask/first-last-frame conditioning, LoRAs, SCAIL-2 replace) must fall back to the Python
-/// torch worker, so the candle worker refuses it here. The per-model shape gates are
-/// [`video_request_candle_eligible`] (base) and [`video_request_candle_vace_eligible`] (VACE modes).
+/// (reference/mask/first-last-frame conditioning, LoRAs) must fall back to the Python torch worker, so
+/// the candle worker refuses it here. SCAIL-2 (`scail2_14b`) adds a DISTINCT candle engine off-Mac —
+/// `animate_character` + `replace_person` (sc-6837, epic 6563) — gated separately (it is not a VACE
+/// model). The per-model shape gates are [`video_request_candle_eligible`] (base),
+/// [`video_request_candle_vace_eligible`] (VACE modes), and
+/// [`scail2_animate_candle_eligible`] / [`scail2_replace_candle_eligible`].
 fn video_job_is_candle_eligible(job: &JobSnapshot) -> bool {
     let Some(model) = job.payload.get("model").and_then(Value::as_str) else {
         return false;
     };
     match job.job_type {
-        // The base txt2video / image→video lane (sc-5097 / sc-5175 / sc-5493).
-        JobType::VideoGenerate => video_request_candle_eligible(model, &job.payload),
-        // The Wan-VACE advanced modes (sc-5494): replace_person / extend_clip / video_bridge.
-        JobType::PersonReplace | JobType::VideoExtend | JobType::VideoBridge => {
+        // The base txt2video / image→video lane (sc-5097 / sc-5175 / sc-5493), plus SCAIL-2 standalone
+        // character animation (`animate_character`, sc-6837 — a distinct candle engine, not VACE).
+        JobType::VideoGenerate => {
+            video_request_candle_eligible(model, &job.payload)
+                || scail2_animate_candle_eligible(model, &job.payload)
+        }
+        // replace_person → candle Wan-VACE (sc-5494) OR candle SCAIL-2 (sc-6837, routed by model id).
+        JobType::PersonReplace => {
+            video_request_candle_vace_eligible(model, &job.payload, &job.job_type)
+                || scail2_replace_candle_eligible(model, &job.payload)
+        }
+        // extend_clip / video_bridge → candle Wan-VACE only (sc-5494).
+        JobType::VideoExtend | JobType::VideoBridge => {
             video_request_candle_vace_eligible(model, &job.payload, &job.job_type)
         }
         _ => false,
@@ -4151,6 +4163,89 @@ fn video_request_candle_vace_eligible(
         _ => return false,
     }
     // LoRAs / on-the-fly quant are not in the candle video lane (the VACE provider rejects them).
+    if payload
+        .get("loras")
+        .and_then(Value::as_array)
+        .is_some_and(|loras| !loras.is_empty())
+    {
+        return false;
+    }
+    if candle_request_wants_quant(payload) {
+        return false;
+    }
+    true
+}
+
+/// Candle SCAIL-2 `animate_character` eligibility (sc-6837, epic 6563). SCAIL-2 is a DISTINCT candle
+/// engine (NOT Wan-VACE), so it has its own gate rather than membership in [`CANDLE_VIDEO_VACE_MODELS`]:
+/// the `scail2_14b` model + the `animate_character` mode + a reference character image
+/// (`referenceAssetId` / `referenceAssetIds` / `sourceAssetId`) + a driving clip (`sourceClipAssetId`).
+/// LoRA / on-the-fly quant are not on the candle path (the provider rejects them; inference LoRA is the
+/// follow-up sc-6838). Mirrors the MLX `video_mode_is_mlx_eligible(scail2_14b, animate_character)` shape,
+/// expressed as a candle-claim gate. Factored out so the routing tests can probe it with synthetic
+/// payloads (parity with [`video_request_candle_eligible`]).
+fn scail2_animate_candle_eligible(model: &str, payload: &Map<String, Value>) -> bool {
+    if model != "scail2_14b" {
+        return false;
+    }
+    if payload.get("mode").and_then(Value::as_str) != Some("animate_character") {
+        return false;
+    }
+    let has_nonempty_id = |key: &str| {
+        payload
+            .get(key)
+            .and_then(Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty())
+    };
+    let has_reference = has_nonempty_id("referenceAssetId")
+        || has_nonempty_id("sourceAssetId")
+        || payload
+            .get("referenceAssetIds")
+            .and_then(Value::as_array)
+            .is_some_and(|ids| {
+                ids.iter()
+                    .any(|v| v.as_str().is_some_and(|s| !s.trim().is_empty()))
+            });
+    if !has_reference {
+        return false;
+    }
+    if !has_nonempty_id("sourceClipAssetId") {
+        return false;
+    }
+    if payload
+        .get("loras")
+        .and_then(Value::as_array)
+        .is_some_and(|loras| !loras.is_empty())
+    {
+        return false;
+    }
+    if candle_request_wants_quant(payload) {
+        return false;
+    }
+    true
+}
+
+/// Candle SCAIL-2 `replace_person` eligibility (sc-6837, epic 6563). The `scail2_14b` model behind a
+/// `PersonReplace` job: the source control clip + the tracked person + the character references (the
+/// same per-mode assets the Wan-VACE replace gate requires). No LoRA / on-the-fly quant (the provider
+/// rejects them; inference LoRA is sc-6838). A distinct candle engine, so it is gated here rather than
+/// added to [`CANDLE_VIDEO_VACE_MODELS`]. Factored out so the routing tests can probe it.
+fn scail2_replace_candle_eligible(model: &str, payload: &Map<String, Value>) -> bool {
+    if model != "scail2_14b" {
+        return false;
+    }
+    let has_nonempty_id = |key: &str| {
+        payload
+            .get(key)
+            .and_then(Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty())
+    };
+    if !has_nonempty_id("sourceClipAssetId")
+        || !has_nonempty_id("personTrackId")
+        || !has_nonempty_id("characterId")
+    {
+        return false;
+    }
     if payload
         .get("loras")
         .and_then(Value::as_array)
@@ -6249,7 +6344,8 @@ mod candle_routing_tests {
             &object(json!({ "sourceClipAssetId": "l" })), // bridge needs the right clip too
             &JobType::VideoBridge
         ));
-        // SCAIL-2 (MLX-only) is not a candle VACE model → torch.
+        // SCAIL-2 is a DISTINCT candle engine, not a VACE model → the VACE gate rejects it (the SCAIL-2
+        // candle replace path is `scail2_replace_candle_eligible`, sc-6837).
         assert!(!video_request_candle_vace_eligible(
             "scail2_14b",
             &object(json!({ "sourceClipAssetId": "c", "personTrackId": "t", "characterId": "ch" })),
@@ -6271,6 +6367,134 @@ mod candle_routing_tests {
             "wan_2_2",
             &object(json!({ "sourceClipAssetId": "c", "personTrackId": "t", "characterId": "ch" })),
             &JobType::VideoGenerate
+        ));
+    }
+
+    // ---- Candle SCAIL-2 character animation + replace_person (sc-6837, epic 6563) ----
+
+    /// A queued `person_replace` job carrying `payload` (the PersonReplace job type the API stamps for
+    /// the integrated replace_person pipeline).
+    fn person_replace_job(payload: Value) -> JobSnapshot {
+        serde_json::from_value(json!({
+            "id": "job_pr",
+            "type": "person_replace",
+            "status": "queued",
+            "payload": payload,
+            "result": {},
+            "requestedGpu": "auto",
+            "progress": 0,
+            "stage": "queued",
+            "message": "",
+            "attempts": 1,
+            "cancelRequested": false,
+            "createdAt": "2026-06-20T00:00:00Z",
+            "updatedAt": "2026-06-20T00:00:00Z",
+        }))
+        .expect("valid JobSnapshot")
+    }
+
+    #[test]
+    fn scail2_candle_serves_animation_and_replace_in_native_shape() {
+        // Standalone character animation: scail2_14b + animate_character + a reference + a driving clip.
+        // The reference can be referenceAssetIds, a bare referenceAssetId, or the i2v sourceAssetId.
+        for reference in [
+            json!({ "referenceAssetIds": ["ref_1"] }),
+            json!({ "referenceAssetId": "ref_1" }),
+            json!({ "sourceAssetId": "img_1" }),
+        ] {
+            let mut payload = object(reference);
+            payload.insert("mode".into(), json!("animate_character"));
+            payload.insert("sourceClipAssetId".into(), json!("clip_1"));
+            assert!(
+                scail2_animate_candle_eligible("scail2_14b", &payload),
+                "scail2 animate_character must be candle-eligible: {payload:?}"
+            );
+        }
+        // Cross-identity replacement: scail2_14b PersonReplace with the clip + track + character.
+        assert!(scail2_replace_candle_eligible(
+            "scail2_14b",
+            &object(json!({
+                "sourceClipAssetId": "clip_1",
+                "personTrackId": "track_1",
+                "characterId": "char_1"
+            }))
+        ));
+        // Through the full video claim gate: animate_character (VideoGenerate) + replace (PersonReplace).
+        assert!(video_job_is_candle_eligible(&video_generate_job(json!({
+            "model": "scail2_14b",
+            "mode": "animate_character",
+            "referenceAssetIds": ["ref_1"],
+            "sourceClipAssetId": "clip_1"
+        }))));
+        assert!(video_job_is_candle_eligible(&person_replace_job(json!({
+            "model": "scail2_14b",
+            "sourceClipAssetId": "clip_1",
+            "personTrackId": "track_1",
+            "characterId": "char_1"
+        }))));
+    }
+
+    #[test]
+    fn scail2_candle_rejects_incomplete_or_wrong_shape() {
+        // animate_character needs BOTH a reference image and a driving clip.
+        assert!(!scail2_animate_candle_eligible(
+            "scail2_14b",
+            &object(json!({ "mode": "animate_character", "referenceAssetIds": ["ref_1"] }))
+        ));
+        assert!(!scail2_animate_candle_eligible(
+            "scail2_14b",
+            &object(json!({ "mode": "animate_character", "sourceClipAssetId": "clip_1" }))
+        ));
+        // Wrong mode / wrong model never claim the SCAIL-2 candle lane.
+        assert!(!scail2_animate_candle_eligible(
+            "scail2_14b",
+            &object(json!({
+                "mode": "text_to_video",
+                "sourceAssetId": "i",
+                "sourceClipAssetId": "c"
+            }))
+        ));
+        assert!(!scail2_animate_candle_eligible(
+            "wan_2_2",
+            &object(json!({
+                "mode": "animate_character",
+                "sourceAssetId": "i",
+                "sourceClipAssetId": "c"
+            }))
+        ));
+        // LoRA / on-the-fly quant defer to torch (the candle SCAIL-2 path has no LoRA yet — sc-6838).
+        for extra in [
+            json!({ "loras": [{ "name": "x" }] }),
+            json!({ "advanced": { "mlxQuantize": 8 } }),
+        ] {
+            let mut payload = object(json!({
+                "mode": "animate_character",
+                "sourceAssetId": "i",
+                "sourceClipAssetId": "c"
+            }));
+            for (k, v) in object(extra) {
+                payload.insert(k, v);
+            }
+            assert!(
+                !scail2_animate_candle_eligible("scail2_14b", &payload),
+                "scail2 animate with LoRA/quant must defer to torch: {payload:?}"
+            );
+        }
+        // replace_person needs the clip + track + character; missing any → torch.
+        for case in [
+            json!({ "sourceClipAssetId": "c", "personTrackId": "t" }),
+            json!({ "sourceClipAssetId": "c", "characterId": "ch" }),
+            json!({ "personTrackId": "t", "characterId": "ch" }),
+        ] {
+            assert!(
+                !scail2_replace_candle_eligible("scail2_14b", &object(case.clone())),
+                "incomplete scail2 replace must defer to torch: {case}"
+            );
+        }
+        // A non-SCAIL-2 model never claims the SCAIL-2 replace lane (it routes via Wan-VACE instead).
+        assert!(!scail2_replace_candle_eligible(
+            "wan_2_2",
+            &object(json!({ "sourceClipAssetId": "c", "personTrackId": "t", "characterId": "ch" }))
         ));
     }
 

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -318,6 +318,11 @@ backend-candle = [
     # sc-5493 (epic 5481): the candle SVD-XT image→video provider (`svd_xt`). The worker candle video
     # lane maps `svd` -> `svd_xt` and conditions on the single source image.
     "dep:candle-gen-svd",
+    # sc-6837 (epic 6563): the candle SCAIL-2 character-animation + cross-identity replace_person
+    # provider (`scail2_14b`) — the Windows/CUDA sibling of `mlx-gen-scail2`. Self-registers
+    # `scail2_14b` into the shared gen_core inventory; the worker candle video lane reaches it via
+    # `gen_core::load` (`generate_candle_scail2` / `generate_candle_scail2_replace`).
+    "dep:candle-gen-scail2",
     # sc-5098 (epic 5095): the candle JoyCaption captioner (image->text), wired into the worker's
     # caption job path via the neutral `gen_core::load_captioner` seam.
     "dep:candle-gen-joycaption",
@@ -923,43 +928,52 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4d3a
 # byte-identical (gen-core adds the constrained-decoding contract the twin consumes), but the worker's
 # `--features backend-candle` skew gate still resolves the SINGLE gen-core rev 4d3aa49 shared with the
 # mlx pin. (Pre-merge branch SHA; flip to the merged candle-gen `main` rev once #113 lands.)
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
+# Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
+# the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
+# FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
+# color masks, f32 DiT). Self-registers `scail2_14b` into the shared gen_core inventory; force-linked in
+# video_jobs.rs (`use candle_gen_scail2 as _;`) and reached via `gen_core::load("scail2_14b")`. Same git
+# rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
+# provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
+# --target all` resolves ONE gen-core rev (no skew).
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -968,19 +982,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -989,12 +1003,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1002,7 +1016,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "715c5
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1011,7 +1025,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1019,7 +1033,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1028,7 +1042,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1055,7 +1069,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "715c5f56e0c97aaa3d1bf1eb223c5a1b19bae7eb", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -195,9 +195,14 @@ mod segment_jobs;
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 mod person_segment_sam3_candle;
 // SCAIL-2 color-coded segmentation-mask painting (epic 5439, sc-5448): turns native SAM3
-// per-person masks into the palette-painted RGB masks the SCAIL-2 engine consumes. macOS-only
-// like its SAM3 dependency.
-#[cfg(target_os = "macos")]
+// per-person masks into the palette-painted RGB masks the SCAIL-2 engine consumes. Backend-neutral
+// (pure pixel painting over `AllPersonMasks`); available on both the macOS MLX lane (sc-5448) and the
+// off-Mac candle lane (sc-6837, the candle SCAIL-2 sibling), each over its own SAM3 module's
+// structurally-identical `AllPersonMasks`.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 mod scail2_masks;
 use downloads::*;
 #[cfg(any(

--- a/crates/sceneworks-worker/src/person_segment_sam3_candle.rs
+++ b/crates/sceneworks-worker/src/person_segment_sam3_candle.rs
@@ -346,6 +346,149 @@ pub(crate) fn segment_track_blocking(
     Ok(masks)
 }
 
+/// Every tracked person's per-frame mask + a stable left-to-right paint order — the candle sibling of
+/// `crate::person_segment_sam3::AllPersonMasks` (sc-6837, the off-Mac SCAIL-2 lane). Field-identical to
+/// the MLX twin so [`crate::scail2_masks`]'s painters compile against either. Unlike
+/// [`segment_track_blocking`] (which selects ONE person via ByteTrack anchors for replace_person), this
+/// keeps EVERY SAM3 object so each person can be painted a distinct palette color.
+pub(crate) struct AllPersonMasks {
+    /// SAM3 object ids in left-to-right paint order (ascending centroid-x in the frame where each
+    /// object first appears); person index 0 = leftmost = the SCAIL-2 palette's first color.
+    pub order: Vec<i32>,
+    /// `per_frame[f]` = `(obj_id, binary mask row-major width*height, 0/255)` for every object present
+    /// on frame `f` (empty masks dropped). Object ids index into [`AllPersonMasks::order`].
+    pub per_frame: Vec<Vec<(i32, Vec<u8>)>>,
+    pub width: u32,
+    pub height: u32,
+}
+
+/// Normalized centroid-x (0..1) of a SAM3 low-res mask's foreground (logit `> 0`); `None` if the mask
+/// is empty. Sorts tracked people left-to-right for deterministic palette assignment. Shared verbatim
+/// with the MLX module.
+fn mask_centroid_x(mask_logits: &[f32], grid: usize) -> Option<f64> {
+    let (mut sum_x, mut n) = (0f64, 0u64);
+    for my in 0..grid {
+        for mx in 0..grid {
+            if mask_logits[my * grid + mx] > 0.0 {
+                sum_x += (mx as f64 + 0.5) / grid as f64;
+                n += 1;
+            }
+        }
+    }
+    (n > 0).then(|| sum_x / n as f64)
+}
+
+/// Segment + track every "person" across already-decoded RGB `frames` with the off-Mac candle SAM3
+/// text-concept (PCS) video pipeline (sc-6837), returning all objects' per-frame masks + the
+/// left-to-right paint order — the input to [`crate::scail2_masks`]. The candle sibling of
+/// `crate::person_segment_sam3::segment_all_persons_in_memory`; in-memory (no temp frame files, unlike
+/// [`segment_track_blocking`]) since the SCAIL-2 reference / driving frames are already decoded
+/// `Image`s. `frames` must be non-empty and uniform-sized. The checkpoint parses once and is cached
+/// process-wide; a fresh `Sam3VideoModel` is built per call (clean tracking state). Run under
+/// `spawn_blocking` (GPU inference is blocking).
+pub(crate) fn segment_all_persons_in_memory(
+    model_path: &Path,
+    tokenizer_path: &Path,
+    frames: &[image::RgbImage],
+) -> WorkerResult<AllPersonMasks> {
+    let first = frames.first().ok_or_else(|| {
+        WorkerError::InvalidPayload("scail2 segmentation: no frames to segment".into())
+    })?;
+    let (width, height) = (first.width(), first.height());
+    if frames
+        .iter()
+        .any(|f| f.width() != width || f.height() != height)
+    {
+        return Err(WorkerError::InvalidPayload(
+            "scail2 segmentation: frames are not all the same size".into(),
+        ));
+    }
+
+    let device = default_device().map_err(|e| WorkerError::Engine(format!("sam3 device: {e}")))?;
+    let tensors: Vec<Tensor> = frames
+        .iter()
+        .map(|f| input_tensor(f, &device))
+        .collect::<WorkerResult<Vec<_>>>()?;
+
+    // Cached checkpoint; recover from a poisoned lock by dropping + reloading (mirrors
+    // `segment_track_blocking`).
+    let cell = WEIGHTS.get_or_init(|| Mutex::new(None));
+    let mut guard = cell.lock().unwrap_or_else(|poisoned| {
+        let mut guard = poisoned.into_inner();
+        *guard = None;
+        guard
+    });
+    if guard.is_none() {
+        let weights = Weights::from_file(model_path, &device)
+            .map_err(|e| WorkerError::Engine(format!("sam3 weights load: {e}")))?;
+        *guard = Some(weights);
+    }
+    let weights = guard.as_ref().expect("weights loaded");
+
+    // Fresh model per call (clean tracking state) + tokenize the concept once. Off-Mac defaults to
+    // dense (sc-6361); `SCENEWORKS_SAM3_QUANT` opts back in.
+    let mut model = Sam3VideoModel::from_weights(weights)
+        .map_err(|e| WorkerError::Engine(format!("sam3 model build: {e}")))?;
+    if let Some(quant) = quant_level() {
+        model
+            .quantize(quant)
+            .map_err(|e| WorkerError::Engine(format!("sam3 quantize: {e}")))?;
+    }
+    let tokenizer = Sam3Tokenizer::from_file(tokenizer_path, &Sam3TextConfig::sam3())
+        .map_err(|e| WorkerError::Engine(format!("sam3 tokenizer load: {e}")))?;
+    let (input_ids, text_mask) = tokenizer
+        .encode(CONCEPT_PROMPT, &device)
+        .map_err(|e| WorkerError::Engine(format!("sam3 tokenize: {e}")))?;
+
+    let outputs = model
+        .propagate(&tensors, &input_ids, &text_mask)
+        .map_err(|e| WorkerError::Engine(format!("sam3 propagate: {e}")))?;
+
+    // Paint order: each object's centroid-x in the FIRST frame it appears, ascending (tie-break on
+    // first-seen frame, then object id, so repeated runs agree). Shared with the MLX module.
+    use std::collections::BTreeMap;
+    let mut first_seen: BTreeMap<i32, (usize, f64)> = BTreeMap::new();
+    for (f, frame) in outputs.iter().enumerate() {
+        for (oid, logits) in frame.obj_ids.iter().zip(&frame.masks) {
+            if first_seen.contains_key(oid) {
+                continue;
+            }
+            if let Some(cx) = mask_centroid_x(logits, MASK_GRID) {
+                first_seen.insert(*oid, (f, cx));
+            }
+        }
+    }
+    let mut order: Vec<i32> = first_seen.keys().copied().collect();
+    order.sort_by(|a, b| {
+        let (fa, xa) = first_seen[a];
+        let (fb, xb) = first_seen[b];
+        xa.partial_cmp(&xb)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(fa.cmp(&fb))
+            .then(a.cmp(b))
+    });
+
+    let per_frame = outputs
+        .iter()
+        .map(|frame| {
+            frame
+                .obj_ids
+                .iter()
+                .zip(&frame.masks)
+                .map(|(oid, logits)| (*oid, mask_to_frame(logits, MASK_GRID, width, height)))
+                .filter(|(_, mask)| !mask.is_empty())
+                .collect()
+        })
+        .collect();
+
+    Ok(AllPersonMasks {
+        order,
+        per_frame,
+        width,
+        height,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/sceneworks-worker/src/scail2_masks.rs
+++ b/crates/sceneworks-worker/src/scail2_masks.rs
@@ -16,7 +16,13 @@
 use gen_core::Image;
 use image::RgbImage;
 
+// `AllPersonMasks` comes from whichever native SAM3 module the build links: the MLX twin on macOS
+// (sc-5448), the candle twin off-Mac (sc-6837). The two structs are field-identical, so the painters
+// below compile against either.
+#[cfg(target_os = "macos")]
 use crate::person_segment_sam3::AllPersonMasks;
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+use crate::person_segment_sam3_candle::AllPersonMasks;
 use crate::{WorkerError, WorkerResult};
 
 /// Person palette in RGB, person 0 = leftmost. Maps onto the engine's six chromatic color classes

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -90,6 +90,13 @@ use candle_gen_wan as _;
 // `run_video_upscale_job`. Force-linked so the MSVC release linker keeps the `inventory::submit!`.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_seedvr2 as _;
+// Candle SCAIL-2 (sc-6837, epic 6563): the character-animation + cross-identity replace_person
+// `Generator` registers under `scail2_14b` via `inventory::submit!`; force-link so the registration
+// survives the MSVC release linker (reached only through `gen_core::load("scail2_14b")`, no direct type
+// contact — the "no generator registered" trap). The off-Mac sibling of the macOS `mlx_gen_scail2`
+// anchor above.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+use candle_gen_scail2 as _;
 #[cfg(any(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
@@ -439,53 +446,100 @@ pub(crate) async fn run_video_generate_job(
     // off → routing unchanged until parity). Conditioning shapes never reach here — the router's
     // `video_job_is_candle_eligible` confines the candle worker to txt2video.
     #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-    let (decoded, adapter, raw_settings, replacement_status) = if settings.backend_candle_enabled
-        && request.mode == "replace_person"
-    {
-        // Candle Wan-VACE person replacement (sc-5494) — the candle equivalent of the MLX `wan_vace`
-        // path. The router (`video_request_candle_eligible`) already confirmed the candle-VACE model +
-        // the source clip + person track before this job reached the candle worker; `generate_candle_
-        // wan_vace` resolves-or-errors loudly (a person-replace must never silently degrade to a stub).
-        let (decoded, status) =
-            generate_candle_wan_vace(api, settings, job, &request, &project_path, backend).await?;
-        (
-            decoded,
-            CANDLE_WAN_VACE_ADAPTER,
-            wan_vace_raw_settings(&request, "wan_vace"),
-            Some(status),
-        )
-    } else if settings.backend_candle_enabled
-        && matches!(request.mode.as_str(), "extend_clip" | "video_bridge")
-    {
-        // Candle Wan-VACE extend/bridge (sc-5494): real source frames pinned at the kept positions +
-        // a generated span (the candle equivalent of the MLX `generate_wan_vace_extend_bridge`).
-        let decoded = generate_candle_wan_vace_extend_bridge(
-            api,
-            settings,
-            job,
-            &request,
-            &project_path,
-            backend,
-        )
-        .await?;
-        (
-            decoded,
-            CANDLE_WAN_VACE_ADAPTER,
-            wan_vace_extend_raw_settings(&request),
-            None::<Value>,
-        )
-    } else if settings.backend_candle_enabled && is_candle_video_engine(&request.model) {
-        let (decoded, adapter, raw_settings) =
-            generate_candle_video(api, settings, job, &request, &project_path, backend).await?;
-        (decoded, adapter, raw_settings, None::<Value>)
-    } else {
-        (
-            generate_stub_video(&request, seed),
-            STUB_ADAPTER,
-            stub_raw_settings(&request),
-            None::<Value>,
-        )
-    };
+    let (decoded, adapter, raw_settings, replacement_status) =
+        if settings.backend_candle_enabled && request.mode == "replace_person" {
+            // sc-6837 (epic 6563): SCAIL-2 is a distinct cross-identity replacement backend (NOT Wan-VACE)
+            // behind the same person-track pipeline. A `scail2_14b` replace_person job routes to the candle
+            // SCAIL-2 engine (the character reference + the tracked person's color masks, `replace_flag`),
+            // mirroring the macOS `generate_scail2_replace` dispatch; every other replace-capable model
+            // keeps candle Wan-VACE. Routed by model id, not weight availability — `generate_candle_scail2_
+            // replace` resolves-or-errors loudly (a person-replace must never silently degrade to a stub).
+            if let Some(engine_id) = candle_scail2_engine_id(&request.model) {
+                let (decoded, status) = generate_candle_scail2_replace(
+                    api,
+                    settings,
+                    job,
+                    &request,
+                    &project_path,
+                    engine_id,
+                    backend,
+                )
+                .await?;
+                (
+                    decoded,
+                    CANDLE_SCAIL2_ADAPTER,
+                    candle_scail2_raw_settings(&request),
+                    Some(status),
+                )
+            } else {
+                // Candle Wan-VACE person replacement (sc-5494) — the candle equivalent of the MLX
+                // `wan_vace` path. The router (`video_request_candle_vace_eligible`) already confirmed the
+                // candle-VACE model + the source clip + person track before this job reached the candle
+                // worker; `generate_candle_wan_vace` resolves-or-errors loudly (a person-replace must never
+                // silently degrade to a stub).
+                let (decoded, status) =
+                    generate_candle_wan_vace(api, settings, job, &request, &project_path, backend)
+                        .await?;
+                (
+                    decoded,
+                    CANDLE_WAN_VACE_ADAPTER,
+                    wan_vace_raw_settings(&request, "wan_vace"),
+                    Some(status),
+                )
+            }
+        } else if settings.backend_candle_enabled
+            && request.mode == "animate_character"
+            && candle_scail2_engine_id(&request.model).is_some()
+        {
+            // sc-6837: SCAIL-2 standalone character animation — a reference character + a driving video →
+            // an animated clip. `generate_candle_scail2` segments the reference + driving frames with the
+            // candle SAM3 segmenter, paints the color-coded masks, and runs the `scail2_14b` engine
+            // (`animate_character` → engine task `animation`). The candle sibling of the macOS
+            // `generate_scail2`; resolves-or-errors loudly (no torch fallback — a distinct candle engine).
+            let engine_id = candle_scail2_engine_id(&request.model).expect("scail2 model");
+            let (decoded, adapter, raw_settings) = generate_candle_scail2(
+                api,
+                settings,
+                job,
+                &request,
+                &project_path,
+                engine_id,
+                backend,
+            )
+            .await?;
+            (decoded, adapter, raw_settings, None::<Value>)
+        } else if settings.backend_candle_enabled
+            && matches!(request.mode.as_str(), "extend_clip" | "video_bridge")
+        {
+            // Candle Wan-VACE extend/bridge (sc-5494): real source frames pinned at the kept positions +
+            // a generated span (the candle equivalent of the MLX `generate_wan_vace_extend_bridge`).
+            let decoded = generate_candle_wan_vace_extend_bridge(
+                api,
+                settings,
+                job,
+                &request,
+                &project_path,
+                backend,
+            )
+            .await?;
+            (
+                decoded,
+                CANDLE_WAN_VACE_ADAPTER,
+                wan_vace_extend_raw_settings(&request),
+                None::<Value>,
+            )
+        } else if settings.backend_candle_enabled && is_candle_video_engine(&request.model) {
+            let (decoded, adapter, raw_settings) =
+                generate_candle_video(api, settings, job, &request, &project_path, backend).await?;
+            (decoded, adapter, raw_settings, None::<Value>)
+        } else {
+            (
+                generate_stub_video(&request, seed),
+                STUB_ADAPTER,
+                stub_raw_settings(&request),
+                None::<Value>,
+            )
+        };
     #[cfg(not(any(
         target_os = "macos",
         all(not(target_os = "macos"), feature = "backend-candle")
@@ -3079,6 +3133,405 @@ async fn generate_candle_video(
     let raw_settings = candle_video_raw_settings(request, &repo);
     let decoded = generate_video(api, settings, job, backend, input).await?;
     Ok((decoded, adapter, raw_settings))
+}
+
+// ---------------------------------------------------------------------------
+// Candle (Windows/CUDA) SCAIL-2 generation (sc-6837, epic 6563): the off-Mac sibling of the macOS
+// `generate_scail2` / `generate_scail2_replace` (epic 5439). Same end-to-end shape — a reference
+// character image + a driving video → an animated clip (`animate_character`), or cross-identity
+// `replace_person` (engine `replace_flag`) over the saved YOLO11 → ByteTrack → SAM3 person track. The
+// worker paints the color-coded masks from the candle SAM3 segmenter (`person_segment_sam3_candle`);
+// the painters (`scail2_masks`) are shared with the MLX lane. A distinct candle engine, NOT VACE — no
+// torch fallback (`gen_core::load("scail2_14b")` resolves the `candle_gen_scail2` provider, sc-6836).
+// ---------------------------------------------------------------------------
+
+/// Adapter id recorded on a real candle SCAIL-2 asset (the candle sibling of `mlx_scail2`).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+const CANDLE_SCAIL2_ADAPTER: &str = "candle_scail2";
+
+/// SceneWorks SCAIL-2 model id → candle registry id, or `None` if `model` is not SCAIL-2.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn candle_scail2_engine_id(model: &str) -> Option<&'static str> {
+    (model == "scail2_14b").then_some("scail2_14b")
+}
+
+/// Map a SceneWorks video mode to the SCAIL-2 engine `video_mode` task string. `replace_person`
+/// (cross-identity) flips the engine `replace_flag`; everything else (`animate_character`) is plain
+/// animation. Mirrors the macOS `scail2_engine_video_mode`.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn candle_scail2_engine_video_mode(mode: &str) -> &'static str {
+    match mode {
+        "replace_person" => "replacement",
+        _ => "animation",
+    }
+}
+
+/// Resolve the candle SCAIL-2 snapshot dir from the `SCENEWORKS_CANDLE_SCAIL2_DIR` override, else the
+/// app-managed `<data>/models/candle/scail2`. The sentinel is the `transformer/` subdir (the converted
+/// SCAIL2Model DiT): the `candle_gen_scail2` provider builds its `Scail2Config` from hardcoded
+/// Wan2.1-14B dims and reads only the component subdirs (transformer, vae, text_encoder, clip, and
+/// `tokenizer/tokenizer.json`), not a root `config.json`, so that is the right marker. Errors loudly
+/// when absent — like the candle Wan-VACE resolver, a missing checkpoint surfaces a clear error
+/// instead of degrading to a stub (a character animation / replacement must never silently produce
+/// meaningless output). The provider's `load` then validates each subdir and reports the precise gap.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn resolve_candle_scail2_model_dir(settings: &Settings) -> WorkerResult<PathBuf> {
+    if let Ok(dir) = std::env::var("SCENEWORKS_CANDLE_SCAIL2_DIR") {
+        let path = PathBuf::from(dir.trim());
+        if path.join("transformer").is_dir() {
+            return Ok(path);
+        }
+    }
+    let managed = settings
+        .data_dir
+        .join("models")
+        .join("candle")
+        .join("scail2");
+    if managed.join("transformer").is_dir() {
+        return Ok(managed);
+    }
+    Err(WorkerError::InvalidPayload(format!(
+        "scail2 (candle): no weights found. Place a candle-layout SCAIL-2 snapshot (transformer/ + \
+         vae/ + text_encoder/ + clip/ + tokenizer/) at {} or set $SCENEWORKS_CANDLE_SCAIL2_DIR.",
+        managed.display(),
+    )))
+}
+
+/// Raw-settings recorded on a candle SCAIL-2 asset (mirrors `candle_video_raw_settings` + the macOS
+/// `scail2_raw_settings`, trimmed to the no-LoRA candle surface — inference LoRA is sc-6838).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn candle_scail2_raw_settings(request: &VideoRequest) -> Value {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("model".to_owned(), Value::String(request.model.clone()));
+    raw.insert("frameCount".to_owned(), json!(request.frame_count()));
+    raw.insert("fps".to_owned(), json!(request.fps));
+    raw.insert(
+        "scail2Task".to_owned(),
+        Value::String(candle_scail2_engine_video_mode(&request.mode).to_owned()),
+    );
+    Value::Object(raw)
+}
+
+/// Resolve a candle SCAIL-2 `animate_character` request into the engine conditioning — the candle
+/// sibling of the macOS `resolve_scail2_conditioning`. Loads the reference character image + the
+/// driving clip, segments both with the candle SAM3 PCS segmenter (every person → a palette color,
+/// left-to-right), paints the color-coded masks (animation: reference bg white, driving bg black), and
+/// assembles `Reference` + `Mask` + `ControlClip`. Segmentation + painting run on the blocking pool.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+async fn resolve_candle_scail2_conditioning(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &VideoRequest,
+    project_path: &Path,
+) -> WorkerResult<Vec<Conditioning>> {
+    // The character: a reference image (referenceAssetIds first, else the i2v sourceAssetId).
+    let ref_id = request
+        .reference_asset_ids
+        .first()
+        .map(String::as_str)
+        .or(request.source_asset_id.as_deref())
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload(
+                "scail2 animate_character requires a reference character image (referenceAssetIds \
+                 or sourceAssetId)."
+                    .into(),
+            )
+        })?;
+    let reference = crate::image_jobs::load_reference_image(
+        &settings.data_dir,
+        &request.project_id,
+        ref_id,
+        project_path,
+    )?;
+
+    // The driving video → frames at the output size (the engine re-resizes internally). Reuses the
+    // candle Wan-VACE source-clip loader (`load_source_video_frames`, which reads `sourceClipAssetId`
+    // and aspect-fits to W×H) — the candle-lane sibling of the macOS path's `extract_clip_frames`
+    // (that helper is macOS-only).
+    if request
+        .source_clip_asset_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .is_none()
+    {
+        return Err(WorkerError::InvalidPayload(
+            "scail2 animate_character requires a driving video (sourceClipAssetId).".into(),
+        ));
+    }
+    let driving = load_source_video_frames(
+        api,
+        settings,
+        job,
+        request,
+        project_path,
+        wan_frame_count(request.raw_frame_count()) as usize,
+    )
+    .await?;
+
+    // SAM3 segmenter weights (download-on-first-use), shared by both segmentation passes.
+    let client = reqwest::Client::new();
+    let context = crate::downloads::DownloadContext {
+        api,
+        client: &client,
+        settings,
+        job_id: &job.id,
+        cancel_message: "SCAIL-2 canceled while fetching the SAM3 segmenter weights.",
+        fresh_download: false,
+    };
+    let (sam_model, sam_tokenizer) =
+        crate::person_segment_sam3_candle::ensure_segmenter_weights(settings, &context).await?;
+
+    // Decode the engine `Image`s to `RgbImage`s for SAM3 (it normalizes RGB internally).
+    let ref_rgb =
+        image::RgbImage::from_raw(reference.width, reference.height, reference.pixels.clone())
+            .ok_or_else(|| {
+                WorkerError::InvalidPayload("scail2 reference image is malformed".into())
+            })?;
+    let driving_rgb: Vec<image::RgbImage> = driving
+        .iter()
+        .map(|f| image::RgbImage::from_raw(f.width, f.height, f.pixels.clone()))
+        .collect::<Option<Vec<_>>>()
+        .ok_or_else(|| WorkerError::InvalidPayload("scail2 driving frame is malformed".into()))?;
+
+    // Segment + paint the reference mask (animation keeps the reference's world → white background).
+    let (rm, rt) = (sam_model.clone(), sam_tokenizer.clone());
+    let ref_mask = tokio::task::spawn_blocking(move || -> WorkerResult<Image> {
+        let masks = crate::person_segment_sam3_candle::segment_all_persons_in_memory(
+            &rm,
+            &rt,
+            std::slice::from_ref(&ref_rgb),
+        )?;
+        crate::scail2_masks::paint_reference_mask(&masks, crate::scail2_masks::BG_WHITE)
+    })
+    .await
+    .map_err(|error| WorkerError::Io(std::io::Error::other(error)))??;
+
+    // Segment + paint the per-frame driving masks (animation → black background).
+    let driving_mask = tokio::task::spawn_blocking(move || -> WorkerResult<Vec<Image>> {
+        let masks = crate::person_segment_sam3_candle::segment_all_persons_in_memory(
+            &sam_model,
+            &sam_tokenizer,
+            &driving_rgb,
+        )?;
+        Ok(crate::scail2_masks::paint_driving_masks(
+            &masks,
+            crate::scail2_masks::BG_BLACK,
+        ))
+    })
+    .await
+    .map_err(|error| WorkerError::Io(std::io::Error::other(error)))??;
+
+    Ok(vec![
+        Conditioning::Reference {
+            image: reference,
+            strength: None,
+        },
+        Conditioning::Mask { image: ref_mask },
+        Conditioning::ControlClip {
+            frames: driving,
+            mask: driving_mask,
+            masking_strength: 1.0,
+            start_frame: 0,
+            mode: ReplacementMode::default(),
+        },
+    ])
+}
+
+/// Real candle SCAIL-2 character animation (sc-6837): build the `VideoGenInput` and run the shared
+/// `generate_video` path. `animate_character` → engine task `animation`; the source media becomes the
+/// SAM3-painted conditioning. No LoRA / quant on the candle path (the provider rejects them — inference
+/// LoRA is sc-6838); steps/guidance stay at the engine defaults. Frame count uses the Wan 1-mod-4
+/// stride (the renderer is Wan2.1); the engine stitches > 81-frame clips into overlapping segments.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+async fn generate_candle_scail2(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &VideoRequest,
+    project_path: &Path,
+    engine_id: &'static str,
+    backend: &str,
+) -> WorkerResult<(DecodedVideo, &'static str, Value)> {
+    let negative_prompt = {
+        let trimmed = request.negative_prompt.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_owned())
+    };
+    let conditioning =
+        resolve_candle_scail2_conditioning(api, settings, job, request, project_path).await?;
+    let input = VideoGenInput {
+        engine_id,
+        model_dir: resolve_candle_scail2_model_dir(settings)?,
+        conditioning,
+        prompt: request.prompt.clone(),
+        negative_prompt,
+        width: request.width,
+        height: request.height,
+        frames: wan_frame_count(request.raw_frame_count()),
+        fps: request.fps,
+        seed: resolve_video_seed(request) as u64,
+        video_mode: Some(candle_scail2_engine_video_mode(&request.mode).to_owned()),
+        ..VideoGenInput::default()
+    };
+    let decoded = generate_video(api, settings, job, backend, input).await?;
+    Ok((
+        decoded,
+        CANDLE_SCAIL2_ADAPTER,
+        candle_scail2_raw_settings(request),
+    ))
+}
+
+/// Resolve a candle SCAIL-2 `replace_person` request into cross-identity replacement conditioning — the
+/// candle sibling of the macOS `resolve_scail2_replace_conditioning` (sc-5452). Reuses the masks
+/// SceneWorks already computed: the saved person track (YOLO11 → ByteTrack → SAM3, corrections applied)
+/// supplies the per-frame driving masks; the character's approved reference is the identity. Driving
+/// frames load exactly as the candle Wan-VACE backend loads them (`load_source_video_frames`) so the
+/// resampled track masks stay frame-aligned 1:1. Replacement keeps the driving clip's world (driving
+/// mask bg white, reference mask bg black); `video_mode = "replacement"` flips the engine `replace_flag`.
+/// SCAIL-2 replaces the whole tracked person, so face_only/full_person + maskingStrength are inert.
+/// Returns the conditioning plus the honest `replacementStatus`.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+async fn resolve_candle_scail2_replace_conditioning(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &VideoRequest,
+    project_path: &Path,
+) -> WorkerResult<(Vec<Conditioning>, Value)> {
+    let track_id = request.person_track_id.as_deref().ok_or_else(|| {
+        WorkerError::InvalidPayload(
+            "replace_person requires a person track (personTrackId).".to_owned(),
+        )
+    })?;
+    let track = ProjectStore::new(settings.data_dir.clone(), "worker")
+        .get_person_track(&request.project_id, track_id)
+        .map_err(|error| {
+            WorkerError::InvalidPayload(format!("person track {track_id}: {error}"))
+        })?;
+
+    // Driving frames + their per-frame binary person masks — the same source the candle Wan-VACE
+    // backend consumes, loaded identically so the resampled masks align 1:1 with the frames.
+    let frame_count = wan_frame_count(request.raw_frame_count()) as usize;
+    let driving =
+        load_source_video_frames(api, settings, job, request, project_path, frame_count).await?;
+    let frame_total = driving.len();
+    let (binary_masks, mask_mode) = crate::person_replace::person_track_masks(
+        project_path,
+        &track,
+        request.width,
+        request.height,
+        frame_total,
+    )?;
+    // The tracked person → blue (person 0); replacement keeps the driving's world → white bg.
+    let driving_masks = crate::scail2_masks::paint_track_driving_masks(
+        &binary_masks,
+        crate::scail2_masks::BG_WHITE,
+    );
+
+    // The character identity: the first approved reference image (multi-ref = the engine-contract
+    // extension, sc-5583 on the MLX side).
+    let references = resolve_character_references(settings, request, project_path)?;
+    let reference_count = references.len();
+    let reference = references.into_iter().next().ok_or_else(|| {
+        WorkerError::InvalidPayload(
+            "Replace Person requires at least one approved character reference image.".to_owned(),
+        )
+    })?;
+
+    // The reference color mask: a candle SAM3 pass on the reference image → the primary person painted
+    // blue on a black background (replacement discards the reference's surrounding world).
+    let client = reqwest::Client::new();
+    let context = crate::downloads::DownloadContext {
+        api,
+        client: &client,
+        settings,
+        job_id: &job.id,
+        cancel_message: "SCAIL-2 canceled while fetching the SAM3 segmenter weights.",
+        fresh_download: false,
+    };
+    let (sam_model, sam_tokenizer) =
+        crate::person_segment_sam3_candle::ensure_segmenter_weights(settings, &context).await?;
+    let ref_rgb =
+        image::RgbImage::from_raw(reference.width, reference.height, reference.pixels.clone())
+            .ok_or_else(|| {
+                WorkerError::InvalidPayload("scail2 reference image is malformed".into())
+            })?;
+    let ref_mask = tokio::task::spawn_blocking(move || -> WorkerResult<Image> {
+        let masks = crate::person_segment_sam3_candle::segment_all_persons_in_memory(
+            &sam_model,
+            &sam_tokenizer,
+            std::slice::from_ref(&ref_rgb),
+        )?;
+        crate::scail2_masks::paint_reference_mask(&masks, crate::scail2_masks::BG_BLACK)
+    })
+    .await
+    .map_err(|error| WorkerError::Io(std::io::Error::other(error)))??;
+
+    let conditioning = vec![
+        Conditioning::Reference {
+            image: reference,
+            strength: None,
+        },
+        Conditioning::Mask { image: ref_mask },
+        Conditioning::ControlClip {
+            frames: driving,
+            mask: driving_masks,
+            masking_strength: 1.0,
+            start_frame: 0,
+            mode: ReplacementMode::default(),
+        },
+    ];
+    let status = replacement_status_value(
+        &track,
+        track_id,
+        mask_mode,
+        1.0,
+        reference_count,
+        frame_total,
+        CANDLE_SCAIL2_ADAPTER,
+    );
+    Ok((conditioning, status))
+}
+
+/// Real candle SCAIL-2 cross-identity replacement (sc-6837): the candle sibling of the MLX
+/// `generate_scail2_replace`. Builds the replacement conditioning from the saved person track +
+/// character reference and runs the shared `generate_video` path with `video_mode = "replacement"`
+/// (engine `replace_flag = true`). Returns the decoded video + the honest `replacementStatus`.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+async fn generate_candle_scail2_replace(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &VideoRequest,
+    project_path: &Path,
+    engine_id: &'static str,
+    backend: &str,
+) -> WorkerResult<(DecodedVideo, Value)> {
+    let negative_prompt = {
+        let trimmed = request.negative_prompt.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_owned())
+    };
+    let (conditioning, status) =
+        resolve_candle_scail2_replace_conditioning(api, settings, job, request, project_path)
+            .await?;
+    let input = VideoGenInput {
+        engine_id,
+        model_dir: resolve_candle_scail2_model_dir(settings)?,
+        conditioning,
+        prompt: request.prompt.clone(),
+        negative_prompt,
+        width: request.width,
+        height: request.height,
+        frames: wan_frame_count(request.raw_frame_count()),
+        fps: request.fps,
+        seed: resolve_video_seed(request) as u64,
+        video_mode: Some("replacement".to_owned()),
+        ..VideoGenInput::default()
+    };
+    let decoded = generate_video(api, settings, job, backend, input).await?;
+    Ok((decoded, status))
 }
 
 /// Resolve the candle Wan-VACE diffusers snapshot dir (sc-5494): `SCENEWORKS_CANDLE_WAN_VACE_DIR`


### PR DESCRIPTION
**Story 2 of 3** for the candle/CUDA SCAIL-2 port (epic [6563](https://app.shortcut.com/trefry/epic/6563)). Wires the candle SCAIL-2 provider (`candle-gen-scail2`, engine `scail2_14b`, merged in candle-gen [#114](https://github.com/SceneWorks/candle-gen/pull/114) / sc-6836) into the SceneWorks worker so **character animation** (`animate_character`) and **cross-identity `replace_person`** run on the candle backend off-Mac (Windows/Linux NVIDIA) — the CUDA sibling of the MLX worker routing (sc-5448 / sc-5452, epic 5439).

## What changed
- **Cargo**: bump the worker's candle-gen pin `715c5f5` → `fad2539` (candle-gen main HEAD = the merged #114 SCAIL-2 provider). `fad2539`'s gen-core pin (`4d3aa49`) **matches the worker's mlx-gen pin**, so `--features backend-candle --target all` resolves **one** gen-core rev (no skew). Adds the `candle-gen-scail2` dep + `backend-candle` feature entry + force-link (`use candle_gen_scail2 as _;`).
- **`video_jobs.rs`**: `generate_candle_scail2` (animate) + `generate_candle_scail2_replace` (`replace_flag`) + their conditioning resolvers. The worker paints SCAIL-2's color-coded masks from the candle SAM3 PCS segmenter (`person_segment_sam3_candle`) + the shared `scail2_masks` painters, assembles `Reference` + `Mask` + `ControlClip`, and runs `gen_core::load("scail2_14b")` via the shared `generate_video` path. Dispatch routes scail2 as a **distinct candle engine, NOT Wan-VACE** (errors loudly if the snapshot is unprovisioned — no torch/stub fallback).
- **`person_segment_sam3_candle.rs`**: add `segment_all_persons_in_memory` + `AllPersonMasks` (the candle sibling of the MLX twin) for the standalone animate mask pass (every person → a stable left-to-right palette color via the SAM3 video tracker).
- **`scail2_masks.rs`**: un-gate to the candle lane (cfg'd `AllPersonMasks` import — the two SAM3 modules' structs are field-identical).
- **`jobs_store.rs`**: `scail2_animate_candle_eligible` / `scail2_replace_candle_eligible` gates wired into `video_job_is_candle_eligible` (distinct from the VACE gate); routing tests.

## Validation
- `--features backend-candle` (RTX PRO 6000 toolchain, VS2022 14.44 + CUDA_COMPUTE_CAP=120): **clippy clean**, worker candle unit tests green (`scail2_masks` painters compile + pass against the candle `AllPersonMasks`).
- `sceneworks-core` tests green incl. the new `scail2_candle_*` routing tests; `cargo fmt` clean.
- Single gen-core rev (`4d3aa49`) across the candle + mlx lanes.

## Merge gate (follow-up)
**GPU E2E validation** on the RTX PRO 6000 (real mp4, streamed assetWrites/progress/cancel for animate + replace) — needs a driving video and is naturally paired with the sc-6836 engine smoke (the candle SCAIL-2 engine itself is not yet GPU-validated; its turnkey weights are Q4-dequant smoke-grade). Inference LoRA is **Story 3 (sc-6838)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)