### PR TITLE
fix(models): hide + disable model upload/import on both platforms (sc-7081)

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -2313,6 +2313,13 @@ impl ApiError {
         }
     }
 
+    fn forbidden(detail: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::FORBIDDEN,
+            detail: detail.into(),
+        }
+    }
+
     fn payload_too_large(detail: impl Into<String>) -> Self {
         Self {
             status: StatusCode::PAYLOAD_TOO_LARGE,

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -405,10 +405,32 @@ pub(crate) async fn delete_model(
     })))
 }
 
+/// Kill-switch for the model upload/import endpoint (sc-7081, epic 7080). Disabled on
+/// every platform until a real compatibility-check + conversion pipeline exists behind it:
+/// today an imported checkpoint never reaches a runnable engine. macOS dropped the torch
+/// worker (MLX-only, sc-3492) and resolves engines from a compile-time table a novel
+/// imported id is never in; the off-Mac diffusers path only loads full repos via
+/// `from_pretrained`, not the single files this endpoint accepts. Flip to `true` once the
+/// pipeline gates imports on an architecture-compatibility verdict (kept as a fn, not a
+/// `const`, so the guarded handler body stays reachable — no `unreachable_code`).
+fn model_import_enabled() -> bool {
+    false
+}
+
+const MODEL_IMPORT_DISABLED_DETAIL: &str = "Model import is temporarily disabled while native \
+     model support and conversion are being built. (LoRA import is unaffected.)";
+
 pub(crate) async fn create_model_import_job(
     State(state): State<AppState>,
     request: AxumRequest,
 ) -> Result<(StatusCode, Json<JobSnapshot>), Response> {
+    // sc-7081 (epic 7080): refuse before staging/queueing, covering both the JSON and
+    // multipart entrypoints. The route stays mounted so a direct API client gets an
+    // actionable 403 rather than a 404. See `model_import_enabled` for the rationale.
+    if !model_import_enabled() {
+        return Err(ApiError::forbidden(MODEL_IMPORT_DISABLED_DETAIL).into_response());
+    }
+
     let is_multipart = request
         .headers()
         .get(header::CONTENT_TYPE)

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -5052,192 +5052,72 @@ async fn request_multipart_model_upload(
 }
 
 #[tokio::test]
-async fn model_import_routes_handle_url_upload_and_family_detection() {
+async fn model_import_route_is_disabled_on_every_platform() {
+    // sc-7081 (epic 7080): model upload/import is intentionally disabled until a real
+    // compatibility + conversion pipeline exists. Both the JSON and multipart entrypoints
+    // must short-circuit with an actionable 403 before any staging/queueing. The deeper
+    // validation/family-detection logic still lives behind `create_model_import_job` (and is
+    // covered by lora_family + worker tests); restore the route-level assertions when the
+    // feature is re-enabled.
     std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let config_dir = temp_dir.path().join("config/manifests");
     std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
-    std::fs::write(
-            config_dir.join("builtin.models.jsonc"),
-            r#"
-            {
-              "schemaVersion": 1,
-              "models": [
-                { "id": "z_image_turbo", "name": "Z-Image Turbo", "family": "z-image", "type": "image", "loraCompatibility": { "families": ["z-image"] } }
-              ]
-            }
-            "#,
-        )
-        .expect("builtin models writes");
-    std::fs::write(
-        config_dir.join("user.models.jsonc"),
-        r#"{ "schemaVersion": 1, "models": [] }"#,
-    )
-    .expect("user models writes");
-    std::fs::write(
-        config_dir.join("builtin.loras.jsonc"),
-        r#"{ "schemaVersion": 1, "loras": [] }"#,
-    )
-    .expect("builtin loras writes");
-    std::fs::write(
-        config_dir.join("user.loras.jsonc"),
-        r#"{ "schemaVersion": 1, "loras": [] }"#,
-    )
-    .expect("user loras writes");
-    std::fs::write(
-        config_dir.join("builtin.recipe-presets.jsonc"),
-        r#"{ "schemaVersion": 1, "presets": [] }"#,
-    )
-    .expect("builtin presets writes");
-    std::fs::write(
-        config_dir.join("user.recipe-presets.jsonc"),
-        r#"{ "schemaVersion": 1, "presets": [] }"#,
-    )
-    .expect("user presets writes");
+    for (name, body) in [
+        (
+            "builtin.models.jsonc",
+            r#"{ "schemaVersion": 1, "models": [] }"#,
+        ),
+        (
+            "user.models.jsonc",
+            r#"{ "schemaVersion": 1, "models": [] }"#,
+        ),
+        (
+            "builtin.loras.jsonc",
+            r#"{ "schemaVersion": 1, "loras": [] }"#,
+        ),
+        ("user.loras.jsonc", r#"{ "schemaVersion": 1, "loras": [] }"#),
+        (
+            "builtin.recipe-presets.jsonc",
+            r#"{ "schemaVersion": 1, "presets": [] }"#,
+        ),
+        (
+            "user.recipe-presets.jsonc",
+            r#"{ "schemaVersion": 1, "presets": [] }"#,
+        ),
+    ] {
+        std::fs::write(config_dir.join(name), body).expect("manifest writes");
+    }
 
-    // URL import without supplied family is accepted, payload echoes
-    // the request fields, and target dir lives under data/models/imports.
+    // JSON path: refused before any validation or queueing.
     let app = create_app(test_settings(&temp_dir)).expect("app creates");
-    let (status, url_job) = request(
+    let (status, error) = request(
         app,
         "POST",
         "/api/v1/models/import",
         json!({
             "sourceUrl": "https://example.com/models/custom.safetensors",
-            "name": "Custom Model",
             "type": "image"
         }),
     )
     .await;
-    assert_eq!(status, StatusCode::CREATED);
-    assert_eq!(url_job["type"], "model_import");
-    assert_eq!(url_job["requestedGpu"], "auto");
-    assert_eq!(url_job["payload"]["modelId"], "custom_model");
-    assert_eq!(url_job["payload"]["modelName"], "Custom Model");
-    assert_eq!(
-        url_job["payload"]["manifestEntry"]["source"]["provider"],
-        "url"
-    );
-    assert_eq!(url_job["payload"]["manifestEntry"]["type"], "image");
-    assert!(url_job["payload"]["targetDir"]
-        .as_str()
-        .is_some_and(|value| value.contains("models/imports/custom_model")
-            || value.contains("models\\imports\\custom_model")));
-    assert!(url_job["payload"]["manifestEntry"].get("family").is_none());
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert!(error["detail"].as_str().unwrap_or("").contains("disabled"));
 
-    // Repo imports must be owner/name, not arbitrary path-like strings.
+    // Multipart path: refused before the upload is staged.
     let app = create_app(test_settings(&temp_dir)).expect("app creates");
-    let (bad_repo_status, bad_repo_error) = request(
+    let (mp_status, mp_error) = request_multipart_model_upload(
         app,
-        "POST",
-        "/api/v1/models/import",
-        json!({
-            "repo": "owner/nested/model",
-            "name": "Bad Repo",
-            "type": "image"
-        }),
-    )
-    .await;
-    assert_eq!(bad_repo_status, StatusCode::BAD_REQUEST);
-    assert!(bad_repo_error["detail"]
-        .as_str()
-        .unwrap_or("")
-        .contains("owner/name"));
-
-    // Duplicate id is rejected with an actionable error.
-    let app = create_app(test_settings(&temp_dir)).expect("app creates");
-    let (dup_status, dup_error) = request(
-        app,
-        "POST",
-        "/api/v1/models/import",
-        json!({
-            "modelId": "z_image_turbo",
-            "sourceUrl": "https://example.com/models/clone.safetensors",
-            "name": "Clone"
-        }),
-    )
-    .await;
-    assert_eq!(dup_status, StatusCode::BAD_REQUEST);
-    assert!(dup_error["detail"]
-        .as_str()
-        .unwrap_or("")
-        .contains("already exists"));
-
-    // Local upload stages bytes, queues an import job, and family
-    // detection from a diffusers-style header auto-fills the manifest.
-    let app = create_app(test_settings(&temp_dir)).expect("app creates");
-    let upload_bytes = test_safetensors_bytes_with_keys(&qwen_image_tensor_keys());
-    let (upload_status, upload_job) = request_multipart_model_upload(
-        app,
-        &[("name", "Auto Family"), ("type", "image")],
-        "auto-family.safetensors",
-        &upload_bytes,
-    )
-    .await;
-    assert_eq!(upload_status, StatusCode::CREATED);
-    assert_eq!(upload_job["type"], "model_import");
-    assert_eq!(upload_job["payload"]["modelId"], "auto_family");
-    assert_eq!(upload_job["payload"]["uploadedSourcePath"], true);
-    assert_eq!(
-        upload_job["payload"]["manifestEntry"]["family"],
-        "qwen-image"
-    );
-    assert_eq!(
-        upload_job["payload"]["manifestEntry"]["adapter"],
-        "qwen_image"
-    );
-    assert_eq!(
-        upload_job["payload"]["manifestEntry"]["capabilities"],
-        json!(["text_to_image", "style_variations"])
-    );
-    assert_eq!(
-        upload_job["payload"]["manifestEntry"]["loraCompatibility"]["families"],
-        json!(["qwen-image"])
-    );
-    let source_path = std::path::PathBuf::from(
-        upload_job["payload"]["sourcePath"]
-            .as_str()
-            .expect("source path"),
-    );
-    assert_eq!(
-        std::fs::read(&source_path).expect("staged upload reads"),
-        upload_bytes
-    );
-
-    // Declared family must match detected family when detection is
-    // confident — mismatch is rejected at the API boundary.
-    let app = create_app(test_settings(&temp_dir)).expect("app creates");
-    let (mismatch_status, mismatch_error) = request_multipart_model_upload(
-        app,
-        &[
-            ("name", "Mismatch"),
-            ("type", "image"),
-            ("family", "z-image"),
-        ],
-        "mismatch.safetensors",
+        &[("name", "Disabled"), ("type", "image")],
+        "disabled.safetensors",
         &test_safetensors_bytes_with_keys(&qwen_image_tensor_keys()),
     )
     .await;
-    assert_eq!(mismatch_status, StatusCode::BAD_REQUEST);
-    assert!(mismatch_error["detail"]
+    assert_eq!(mp_status, StatusCode::FORBIDDEN);
+    assert!(mp_error["detail"]
         .as_str()
         .unwrap_or("")
-        .contains("qwen-image"));
-
-    // Missing source produces an actionable error.
-    let app = create_app(test_settings(&temp_dir)).expect("app creates");
-    let (empty_status, empty_error) = request(
-        app,
-        "POST",
-        "/api/v1/models/import",
-        json!({ "name": "Nothing" }),
-    )
-    .await;
-    assert_eq!(empty_status, StatusCode::BAD_REQUEST);
-    assert!(empty_error["detail"]
-        .as_str()
-        .unwrap_or("")
-        .contains("Hugging Face repo"));
+        .contains("disabled"));
 }
 
 #[tokio::test]

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -5449,10 +5449,10 @@ describe("SceneWorks app shell", () => {
     expect(buttonInside(loraPanel(container), "Queue Import").disabled).toBe(false);
   });
 
-  it("queues model URL imports from the Models page", async () => {
-    const onImportModel = vi.fn(async (payload) => ({
-      payload: { ...payload, modelId: "custom_model", manifestEntry: { family: "z-image" } },
-    }));
+  it("hides the model import form while uploads are disabled pending conversion support (sc-7081)", async () => {
+    // The model upload/import form is gated off on every platform (MODEL_IMPORT_ENABLED)
+    // until the compatibility + conversion pipeline (epic 7080) lands — an imported
+    // checkpoint has no runnable engine today, and the API refuses the request too.
     root = createRoot(container);
     await act(async () => {
       root.render(
@@ -5463,61 +5463,17 @@ describe("SceneWorks app shell", () => {
           models: [{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }],
           onDownloadModel: () => {},
           onImportLora: () => {},
-          onImportModel,
+          onImportModel: () => {},
           onOpenQueue: () => {},
         }),
       );
     });
 
-    const panel = modelImportPanel(container);
-    await changeField(field(panel, "Source URL"), "https://example.com/models/custom.safetensors");
-    await changeField(field(panel, "Name"), "Custom Model");
-    await act(async () => {
-      buttonInside(panel, "Queue Import").click();
-    });
-
-    expect(onImportModel).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sourceUrl: "https://example.com/models/custom.safetensors",
-        name: "Custom Model",
-        modelType: "image",
-      }),
-    );
-    expect(onImportModel.mock.calls[0][0]).not.toHaveProperty("family");
-    expect(container.textContent).toContain("Model import queued for custom_model.");
-    expect(container.textContent).toContain("Detected family: z-image.");
-  });
-
-  it("sends an explicit family override on model imports when chosen", async () => {
-    const onImportModel = vi.fn(async (payload) => ({
-      payload: { ...payload, modelId: "custom_model", manifestEntry: { family: payload.family } },
-    }));
-    root = createRoot(container);
-    await act(async () => {
-      root.render(
-        withModelManagerContext({
-          activeProject: null,
-          jobs: [],
-          loras: [],
-          models: [{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }],
-          onDownloadModel: () => {},
-          onImportLora: () => {},
-          onImportModel,
-          onOpenQueue: () => {},
-        }),
-      );
-    });
-
-    const panel = modelImportPanel(container);
-    await changeField(field(panel, "Family"), "z-image");
-    await changeField(field(panel, "Source URL"), "https://example.com/models/custom.safetensors");
-    await act(async () => {
-      buttonInside(panel, "Queue Import").click();
-    });
-
-    expect(onImportModel.mock.calls[0][0]).toEqual(
-      expect.objectContaining({ family: "z-image" }),
-    );
+    expect(modelImportPanel(container)).toBeNull();
+    expect(container.textContent).not.toContain("Import model");
+    // LoRA import is unaffected, and the rest of the Models page still renders.
+    expect(loraPanel(container)).not.toBeNull();
+    expect(container.textContent).toContain("Z-Image Turbo");
   });
 
   it("renders unassociated models with a needs-family badge", async () => {

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -82,6 +82,14 @@ const MODEL_TYPE_OPTIONS = [
   { value: "utility", label: "Utility" },
 ];
 
+// sc-7081 (epic 7080): model upload/import is hidden + disabled on every platform until a
+// real compatibility + conversion pipeline exists behind it. Today an imported checkpoint
+// has no runnable engine (macOS is MLX-only with a compile-time engine table; off-Mac only
+// loads full diffusers repos), so the form is kept in source but not rendered. The API
+// refuses the request too. Flip to true once the pipeline gates imports on a compatibility
+// verdict.
+const MODEL_IMPORT_ENABLED = false;
+
 // Models render in type-grouped sections. Order is fixed; any model whose `type`
 // isn't listed here falls into a trailing "Other" group so nothing is hidden.
 const MODEL_TYPE_GROUPS = [
@@ -793,6 +801,7 @@ export function ModelManagerScreen() {
       {deleteMessage.text ? <p className={deleteMessage.tone === "success" ? "inline-success" : "inline-warning"}>{deleteMessage.text}</p> : null}
 
       <section className="model-import-panel-section">
+        {MODEL_IMPORT_ENABLED && (
         <form className="lora-import-panel models-import-panel" aria-label="Import model" onSubmit={importModel}>
           <div>
             <strong>Import model</strong>
@@ -895,6 +904,7 @@ export function ModelManagerScreen() {
           </div>
           {modelImportMessage.text ? <p className={modelImportMessage.tone === "success" ? "inline-success" : "inline-warning"}>{modelImportMessage.text}</p> : null}
         </form>
+        )}
         {pendingModelImportJobs.length ? (
           <div className="lora-import-progress">
             <strong>Model imports in progress</strong>


### PR DESCRIPTION
## Why

The Models-page model upload/import (`POST /api/v1/models/import` → the `Import model` form) produced a catalog entry that **can't generate**:

- Import does **no conversion** — it writes a `user.models.jsonc` entry with a torch/diffusers adapter + raw weights. MLX conversion is a separate `mlx.converter`-keyed job imported entries never get.
- **macOS is MLX-only** (sc-3492, no torch worker); native dispatch resolves models via the compile-time `MODEL_TABLE` (`engines.rs::mlx_model`) — a novel imported id isn't in the table → fail-loud.
- **Off-Mac** the diffusers adapters only `from_pretrained` (full repo); no `from_single_file`, so the single-file uploads the UI accepts won't load there either.

So the feature validated and listed a model the app couldn't run. Per Michael's call, hide **and** disable it on **both** platforms until a real compatibility + conversion pipeline exists. **LoRA import is unaffected** (LoRAs attach to the native engines and work).

## Changes

- **rust-api** — `model_import_enabled() -> false` kill-switch + a 403 guard at the top of `create_model_import_job` (covers JSON + multipart, before any staging) + `ApiError::forbidden`. The route stays mounted so direct API callers get an actionable message, not a 404. The underlying queue/family-detection logic is kept intact for reuse by the future pipeline.
- **web** — `MODEL_IMPORT_ENABLED = false` gates the `Import model` form in `ModelManagerScreen.jsx`; the in-progress-import display and model cards are kept.
- **tests** — collapsed to assert the disabled behavior (`model_import_route_is_disabled_on_every_platform`; web `hides the model import form…`). The prior route-success test + two web form tests were removed — restore/expand when the feature is re-enabled (epic 7080 P5).

Re-enable later by flipping `model_import_enabled()` + `MODEL_IMPORT_ENABLED` behind the compatibility gate.

## Test plan

- `cargo test -p sceneworks-rust-api` → 128 passed, 0 failed; 0 build warnings/errors.
- `npm --prefix apps/web test` → 627 passed (39 files), incl. the new hidden-form test (renders the real `ModelManagerScreen` and asserts the import form is absent while LoRA import + model cards remain).
- eslint on the two changed JS files → 0 errors.

## Tracking

- Story: [sc-7081](https://app.shortcut.com/trefry/story/7081)
- Epic (real conversion pipeline): [7080](https://app.shortcut.com/trefry/epic/7080) — P1–P5 = sc-7082..7086

🤖 Generated with [Claude Code](https://claude.com/claude-code)