### PR TITLE
feat(desktop): LAN server mode — remote browser access to the desktop host (epic 4484)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2792,6 +2792,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4263,7 +4273,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5243,6 +5253,7 @@ dependencies = [
 name = "sceneworks-desktop"
 version = "0.2.0"
 dependencies = [
+ "if-addrs",
  "keyring",
  "nix",
  "reqwest 0.12.28",
@@ -7555,7 +7566,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -14,6 +14,10 @@ publish = false
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
+# Cross-platform network-interface enumeration for the LAN remote-access URL
+# (epic 4484, story 5): lists adapters with their IPs on macOS AND Windows, so the
+# desktop can offer a likely private LAN address. Small, std-only deps under the hood.
+if-addrs = "0.13"
 keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
 # In-app session log buffer (sc-3451): shared LogEntry/SessionLog types.
 sceneworks-core = { path = "../../crates/sceneworks-core" }

--- a/apps/desktop/build.rs
+++ b/apps/desktop/build.rs
@@ -17,6 +17,12 @@ fn main() {
             "delete_credential",
             "restart_worker",
             "get_gpu_info",
+            // LAN remote access (epic 4484, stories 4/5).
+            "get_remote_access",
+            "set_remote_access",
+            "set_remote_access_password",
+            "clear_remote_access_password",
+            "get_lan_address",
         ]),
     ))
     .expect("failed to run Tauri build script");

--- a/apps/desktop/capabilities/default.json
+++ b/apps/desktop/capabilities/default.json
@@ -22,6 +22,11 @@
     "allow-set-credential",
     "allow-delete-credential",
     "allow-restart-worker",
-    "allow-get-gpu-info"
+    "allow-get-gpu-info",
+    "allow-get-remote-access",
+    "allow-set-remote-access",
+    "allow-set-remote-access-password",
+    "allow-clear-remote-access-password",
+    "allow-get-lan-address"
   ]
 }

--- a/apps/desktop/permissions/autogenerated/clear_remote_access_password.toml
+++ b/apps/desktop/permissions/autogenerated/clear_remote_access_password.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-clear-remote-access-password"
+description = "Enables the clear_remote_access_password command without any pre-configured scope."
+commands.allow = ["clear_remote_access_password"]
+
+[[permission]]
+identifier = "deny-clear-remote-access-password"
+description = "Denies the clear_remote_access_password command without any pre-configured scope."
+commands.deny = ["clear_remote_access_password"]

--- a/apps/desktop/permissions/autogenerated/get_lan_address.toml
+++ b/apps/desktop/permissions/autogenerated/get_lan_address.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-get-lan-address"
+description = "Enables the get_lan_address command without any pre-configured scope."
+commands.allow = ["get_lan_address"]
+
+[[permission]]
+identifier = "deny-get-lan-address"
+description = "Denies the get_lan_address command without any pre-configured scope."
+commands.deny = ["get_lan_address"]

--- a/apps/desktop/permissions/autogenerated/get_remote_access.toml
+++ b/apps/desktop/permissions/autogenerated/get_remote_access.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-get-remote-access"
+description = "Enables the get_remote_access command without any pre-configured scope."
+commands.allow = ["get_remote_access"]
+
+[[permission]]
+identifier = "deny-get-remote-access"
+description = "Denies the get_remote_access command without any pre-configured scope."
+commands.deny = ["get_remote_access"]

--- a/apps/desktop/permissions/autogenerated/set_remote_access.toml
+++ b/apps/desktop/permissions/autogenerated/set_remote_access.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-set-remote-access"
+description = "Enables the set_remote_access command without any pre-configured scope."
+commands.allow = ["set_remote_access"]
+
+[[permission]]
+identifier = "deny-set-remote-access"
+description = "Denies the set_remote_access command without any pre-configured scope."
+commands.deny = ["set_remote_access"]

--- a/apps/desktop/permissions/autogenerated/set_remote_access_password.toml
+++ b/apps/desktop/permissions/autogenerated/set_remote_access_password.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-set-remote-access-password"
+description = "Enables the set_remote_access_password command without any pre-configured scope."
+commands.allow = ["set_remote_access_password"]
+
+[[permission]]
+identifier = "deny-set-remote-access-password"
+description = "Denies the set_remote_access_password command without any pre-configured scope."
+commands.deny = ["set_remote_access_password"]

--- a/apps/desktop/src/main.rs
+++ b/apps/desktop/src/main.rs
@@ -10,6 +10,8 @@ mod cred_ipc;
 // run into %APPDATA%\SceneWorks\gpu-runtime and resolved from there.
 #[cfg(target_os = "windows")]
 mod cuda_provision;
+// Likely-LAN-address discovery for the remote-access URL (epic 4484, story 5).
+mod net;
 mod settings;
 mod setup;
 
@@ -46,6 +48,12 @@ fn main() {
             settings::delete_credential,
             settings::restart_worker,
             settings::get_gpu_info,
+            // LAN remote access (epic 4484, stories 4/5).
+            settings::get_remote_access,
+            settings::set_remote_access,
+            settings::set_remote_access_password,
+            settings::clear_remote_access_password,
+            net::get_lan_address,
         ])
         .build(tauri::generate_context!())
         .expect("error while building the SceneWorks desktop shell");

--- a/apps/desktop/src/net.rs
+++ b/apps/desktop/src/net.rs
@@ -1,0 +1,133 @@
+//! Likely-LAN-address discovery for the remote-access URL (epic 4484, story 5).
+//!
+//! When the user enables LAN remote access the Settings UI shows the host URL
+//! (`http://<ip>:<port>`) so another device can reach it. This module enumerates the
+//! host's network interfaces and picks a best-guess private IPv4 to put in that URL,
+//! returning the full candidate list too so the UI can offer a picker if the guess is
+//! wrong. Cross-platform via `if-addrs` (lists adapters with their IPs on macOS AND
+//! Windows); the private-IPv4 heuristic is name-agnostic, so it doesn't assume macOS
+//! `en0`-style naming.
+
+use std::net::{IpAddr, Ipv4Addr};
+
+use serde::Serialize;
+
+/// Best-guess LAN IPv4 plus all private candidates for the remote-access URL.
+#[derive(Serialize, Default, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct LanAddresses {
+    /// Best-guess private LAN IPv4 to show in the remote URL, or `None` if the host
+    /// has no private IPv4 (e.g. offline / loopback-only). `candidates.first()`.
+    pub primary: Option<String>,
+    /// Every private LAN IPv4 found, best-first, so the UI can offer a picker when the
+    /// primary guess is wrong (multi-homed: Wi-Fi + Ethernet + VPN).
+    pub candidates: Vec<String>,
+}
+
+/// Whether an address is a usable private LAN IPv4. `Ipv4Addr::is_private` already
+/// excludes loopback (127/8) and link-local (169.254/16) — they aren't in the
+/// 10/8, 172.16/12, 192.168/16 private ranges — but the extra guards make the intent
+/// explicit and survive any future loosening of `is_private`.
+fn is_private_lan_ipv4(ip: &Ipv4Addr) -> bool {
+    ip.is_private() && !ip.is_loopback() && !ip.is_link_local() && !ip.is_unspecified()
+}
+
+/// Preference rank for a private IPv4 (lower = more likely the real LAN address on a
+/// typical home/office Wi-Fi/Ethernet setup): 192.168/16 first, then 10/8, then
+/// 172.16-31/12 (often Docker/VM bridges), then anything else.
+fn rank(ip: &Ipv4Addr) -> u8 {
+    match ip.octets() {
+        [192, 168, ..] => 0,
+        [10, ..] => 1,
+        [172, b, ..] if (16..=31).contains(&b) => 2,
+        _ => 3,
+    }
+}
+
+/// Order + de-duplicate discovered private IPv4s into a [`LanAddresses`]. Pure so the
+/// ranking is unit-tested without touching real interfaces.
+fn rank_addresses(mut found: Vec<Ipv4Addr>) -> LanAddresses {
+    found.sort_by_key(|ip| (rank(ip), ip.octets()));
+    found.dedup();
+    let candidates: Vec<String> = found.iter().map(Ipv4Addr::to_string).collect();
+    LanAddresses {
+        primary: candidates.first().cloned(),
+        candidates,
+    }
+}
+
+/// Enumerate the host's private LAN IPv4 addresses, best guess first. Skips
+/// loopback/link-local/down interfaces (a down interface exposes no address, so
+/// `if-addrs` omits it). Returns an empty [`LanAddresses`] (the UI shows "unknown")
+/// when none is found rather than erroring.
+pub fn lan_addresses() -> LanAddresses {
+    let mut found: Vec<Ipv4Addr> = Vec::new();
+    if let Ok(interfaces) = if_addrs::get_if_addrs() {
+        for interface in interfaces {
+            if interface.is_loopback() {
+                continue;
+            }
+            if let IpAddr::V4(v4) = interface.ip() {
+                if is_private_lan_ipv4(&v4) {
+                    found.push(v4);
+                }
+            }
+        }
+    }
+    rank_addresses(found)
+}
+
+/// Tauri command: the likely LAN address(es) for the remote-access URL (story 4
+/// combines `primary` with the configured port).
+#[tauri::command]
+pub fn get_lan_address() -> LanAddresses {
+    lan_addresses()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_non_private_and_loopback_and_link_local() {
+        assert!(!is_private_lan_ipv4(&Ipv4Addr::new(127, 0, 0, 1))); // loopback
+        assert!(!is_private_lan_ipv4(&Ipv4Addr::new(169, 254, 1, 1))); // link-local
+        assert!(!is_private_lan_ipv4(&Ipv4Addr::new(8, 8, 8, 8))); // public
+        assert!(!is_private_lan_ipv4(&Ipv4Addr::new(0, 0, 0, 0))); // unspecified
+        assert!(is_private_lan_ipv4(&Ipv4Addr::new(192, 168, 1, 50)));
+        assert!(is_private_lan_ipv4(&Ipv4Addr::new(10, 0, 0, 4)));
+        assert!(is_private_lan_ipv4(&Ipv4Addr::new(172, 16, 5, 9)));
+        // 172.32 is outside the private 172.16-31 block.
+        assert!(!is_private_lan_ipv4(&Ipv4Addr::new(172, 32, 0, 1)));
+    }
+
+    #[test]
+    fn ranks_192_168_first_then_10_then_172() {
+        let result = rank_addresses(vec![
+            Ipv4Addr::new(172, 17, 0, 1),
+            Ipv4Addr::new(10, 1, 2, 3),
+            Ipv4Addr::new(192, 168, 0, 42),
+        ]);
+        assert_eq!(result.primary.as_deref(), Some("192.168.0.42"));
+        assert_eq!(
+            result.candidates,
+            vec!["192.168.0.42", "10.1.2.3", "172.17.0.1"]
+        );
+    }
+
+    #[test]
+    fn empty_when_no_private_address() {
+        let result = rank_addresses(Vec::new());
+        assert_eq!(result.primary, None);
+        assert!(result.candidates.is_empty());
+    }
+
+    #[test]
+    fn dedupes_repeated_addresses() {
+        let result = rank_addresses(vec![
+            Ipv4Addr::new(192, 168, 1, 5),
+            Ipv4Addr::new(192, 168, 1, 5),
+        ]);
+        assert_eq!(result.candidates, vec!["192.168.1.5"]);
+    }
+}

--- a/apps/desktop/src/settings.rs
+++ b/apps/desktop/src/settings.rs
@@ -6,10 +6,10 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use serde::{Deserialize, Serialize};
-use tauri::{AppHandle, Manager};
+use tauri::AppHandle;
 use tauri_plugin_dialog::DialogExt;
 
-use crate::setup::{app_support_dir, default_data_dir, shared_huggingface_home, Managed};
+use crate::setup::{app_support_dir, default_data_dir, shared_huggingface_home};
 
 const KEYRING_SERVICE: &str = "SceneWorks";
 /// Pre-migration account that held the single Hugging Face token. Retained only so
@@ -20,6 +20,16 @@ const KEYRING_SERVICE: &str = "SceneWorks";
 const HF_TOKEN_ACCOUNT: &str = "huggingface_token";
 /// Host of the migrated Hugging Face credential.
 const HF_HOST: &str = "huggingface.co";
+/// Keychain account for the LAN remote-access password (epic 4484, story 1). The
+/// password the user sets to gate LAN access is stored as a secret here — never in
+/// `settings.json`, which holds only the `remote_password_set` boolean. Resolves to
+/// macOS Keychain / Windows Credential Manager via the same `keyring::Entry` path as
+/// the download credentials above. Read only when the user opts into LAN mode, so a
+/// default (LAN-off) install never touches the keychain for it.
+const REMOTE_PASSWORD_ACCOUNT: &str = "remote-access-password";
+/// Suggested default LAN port the Settings UI pre-fills the first time remote access
+/// is enabled (story 4). Kept here so the launcher and UI agree on the suggestion.
+pub const DEFAULT_REMOTE_PORT: u16 = 8787;
 
 /// How a stored credential is attached to a download request for its host.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -153,6 +163,23 @@ pub struct AppSettings {
     /// host/label/scheme so the UI can enumerate them.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub credentials: Vec<CredentialMeta>,
+    /// LAN remote-access master switch (epic 4484). OFF by default: the API sidecar
+    /// binds loopback-only on a dynamic port exactly as before. When ON *and* a
+    /// password is set, the launcher binds `0.0.0.0:<remote_port>` with the password
+    /// as the API access token so other devices on the LAN can reach the host.
+    #[serde(default)]
+    pub remote_access_enabled: bool,
+    /// Fixed port for LAN remote access. `None` until the user picks one; the UI
+    /// pre-fills [`DEFAULT_REMOTE_PORT`] (8787) the first time remote access is
+    /// enabled. Only consulted when `remote_access_enabled`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_port: Option<u16>,
+    /// Whether a LAN password secret is recorded in the OS keychain. Non-secret
+    /// metadata (the password itself never lands in `settings.json`); gates the
+    /// keychain read so a no-password install never touches it (mirrors the HF
+    /// `credentials` gate, sc-5891). LAN cannot be enabled while this is false.
+    #[serde(default)]
+    pub remote_password_set: bool,
 }
 
 fn settings_path() -> PathBuf {
@@ -251,6 +278,186 @@ pub fn credentials_env_json() -> Option<String> {
     } else {
         serde_json::to_string(&serde_json::Value::Object(map)).ok()
     }
+}
+
+// ---------------------------------------------------------------------------
+// LAN remote-access (epic 4484, story 1)
+// ---------------------------------------------------------------------------
+
+/// Whether a LAN password is recorded, from the non-secret `settings.json`
+/// metadata. The keychain gate for [`read_remote_password`]: a no-password install
+/// must short-circuit here so it never constructs a `keyring::Entry` / prompts —
+/// the same pattern as `hf_credential_recorded` (sc-5891).
+fn remote_password_recorded(settings: &AppSettings) -> bool {
+    settings.remote_password_set
+}
+
+/// Apply a password set/clear to the non-secret metadata. Pure (no keychain/disk)
+/// so the metadata transitions — including the fail-closed disable on clear — are
+/// unit-tested; the keychain write/delete is done by the set/clear wrappers around
+/// this. Clearing the password also disables LAN remote access: with no password the
+/// launcher must never bind non-loopback (epic 4484 security constraint, story 3).
+fn mark_remote_password(settings: &mut AppSettings, present: bool) {
+    settings.remote_password_set = present;
+    if !present {
+        settings.remote_access_enabled = false;
+    }
+}
+
+/// The LAN remote-access password from the OS keychain, used as the API access token
+/// when the launcher binds non-loopback (story 2). Gated on the non-secret
+/// `settings.json` metadata first: if no password is recorded, returns `None`
+/// *without constructing a `keyring::Entry` or calling `get_password()`*, so a
+/// LAN-off install never touches the OS keychain at launch (mirrors `read_hf_token`,
+/// sc-5891). Empty/whitespace secrets are treated as absent.
+pub fn read_remote_password() -> Option<String> {
+    if !remote_password_recorded(&load_settings()) {
+        return None;
+    }
+    keyring::Entry::new(KEYRING_SERVICE, REMOTE_PASSWORD_ACCOUNT)
+        .ok()
+        .and_then(|entry| entry.get_password().ok())
+        .map(|secret| secret.trim().to_owned())
+        .filter(|secret| !secret.is_empty())
+}
+
+/// Store (or overwrite) the LAN password secret in the OS keychain and record the
+/// `remote_password_set` metadata. The password is write-only — it is never read back
+/// to the UI (only used as the sidecar access token). Rejects an empty password so a
+/// LAN bind can never end up with an empty token (story 3 backstop).
+pub fn set_remote_password(password: &str) -> Result<(), String> {
+    let password = password.trim();
+    if password.is_empty() {
+        return Err("A password is required.".to_owned());
+    }
+    keyring::Entry::new(KEYRING_SERVICE, REMOTE_PASSWORD_ACCOUNT)
+        .map_err(|error| error.to_string())?
+        .set_password(password)
+        .map_err(|error| error.to_string())?;
+    let mut settings = load_settings();
+    mark_remote_password(&mut settings, true);
+    save_settings(&settings)
+}
+
+/// Remove the LAN password from the keychain and clear its metadata, which also
+/// disables remote access (fail-closed: no password ⇒ no non-loopback bind). Safe to
+/// call when no password is stored.
+pub fn clear_remote_password() -> Result<(), String> {
+    if let Ok(entry) = keyring::Entry::new(KEYRING_SERVICE, REMOTE_PASSWORD_ACCOUNT) {
+        match entry.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry) => {}
+            Err(error) => return Err(error.to_string()),
+        }
+    }
+    let mut settings = load_settings();
+    mark_remote_password(&mut settings, false);
+    save_settings(&settings)
+}
+
+/// Host OS the desktop shell is running on, so the Settings UI can show the
+/// platform-correct firewall guidance (story 11): macOS firewall prompt vs Windows
+/// Defender alert.
+fn host_platform() -> &'static str {
+    #[cfg(target_os = "macos")]
+    {
+        "macos"
+    }
+    #[cfg(target_os = "windows")]
+    {
+        "windows"
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        "linux"
+    }
+}
+
+/// Snapshot of the LAN remote-access state for the Settings UI (story 4). Carries no
+/// secret — only whether a password is set, plus the computed URL/candidates.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteAccessStatus {
+    /// Whether LAN remote access is enabled (takes effect on next launch).
+    enabled: bool,
+    /// Configured port, or the [`DEFAULT_REMOTE_PORT`] suggestion when unset, so the
+    /// UI can pre-fill the input.
+    port: u16,
+    /// Whether a password secret is recorded (gates enabling; never the value).
+    password_set: bool,
+    /// Best-guess LAN IPv4 for the URL, or `None` if none could be determined.
+    lan_address: Option<String>,
+    /// All private LAN candidates (so the UI could offer a picker if the guess is off).
+    lan_candidates: Vec<String>,
+    /// `http://<lan_address>:<port>` when an address is known; `None` otherwise.
+    url: Option<String>,
+    /// The suggested default port, for the UI's initial value / reset.
+    default_port: u16,
+    /// Host OS (`macos`/`windows`/`linux`) for platform-conditional firewall copy.
+    platform: &'static str,
+}
+
+/// Build the current remote-access snapshot from persisted settings + a fresh LAN
+/// address probe. Never reads the password secret (only its `*_set` metadata).
+fn remote_access_status() -> RemoteAccessStatus {
+    let settings = load_settings();
+    let port = settings.remote_port.unwrap_or(DEFAULT_REMOTE_PORT);
+    let lan = crate::net::lan_addresses();
+    let url = lan.primary.as_ref().map(|ip| format!("http://{ip}:{port}"));
+    RemoteAccessStatus {
+        enabled: settings.remote_access_enabled,
+        port,
+        password_set: settings.remote_password_set,
+        lan_address: lan.primary,
+        lan_candidates: lan.candidates,
+        url,
+        default_port: DEFAULT_REMOTE_PORT,
+        platform: host_platform(),
+    }
+}
+
+/// Current LAN remote-access status for the Settings screen (story 4).
+#[tauri::command]
+pub fn get_remote_access() -> RemoteAccessStatus {
+    remote_access_status()
+}
+
+/// Enable/disable LAN remote access and set the port (story 4). Fail-closed: enabling
+/// is rejected unless a password is already set (mirrors the launcher guard, story 3),
+/// and a privileged/low port the app can't bind is rejected up front rather than
+/// bricking startup. The change takes effect on the next launch (sidecar relaunch).
+#[tauri::command]
+pub fn set_remote_access(enabled: bool, port: u16) -> Result<RemoteAccessStatus, String> {
+    let mut settings = load_settings();
+    if enabled && !settings.remote_password_set {
+        return Err("Set a password before enabling remote access.".to_owned());
+    }
+    if enabled && port < 1024 {
+        return Err(
+            "Choose a port between 1024 and 65535 — lower ports need administrator privileges."
+                .to_owned(),
+        );
+    }
+    settings.remote_access_enabled = enabled;
+    // Persist a valid port choice even while disabled, so it's remembered for next time.
+    if port >= 1024 {
+        settings.remote_port = Some(port);
+    }
+    save_settings(&settings)?;
+    Ok(remote_access_status())
+}
+
+/// Set/change the LAN password (story 4). Stored in the OS keychain; never echoed back.
+#[tauri::command]
+pub fn set_remote_access_password(password: String) -> Result<RemoteAccessStatus, String> {
+    set_remote_password(&password)?;
+    Ok(remote_access_status())
+}
+
+/// Clear the LAN password, which also disables remote access (fail-closed, story 3).
+#[tauri::command]
+pub fn clear_remote_access_password() -> Result<RemoteAccessStatus, String> {
+    clear_remote_password()?;
+    Ok(remote_access_status())
 }
 
 #[derive(Serialize)]
@@ -523,27 +730,9 @@ pub fn delete_credential(app: AppHandle, host: String) -> Result<Vec<CredentialS
 #[tauri::command]
 pub fn restart_worker(app: AppHandle) {
     // Kill the current GPU worker child; its supervisor respawns it. macOS runs the MLX
-    // worker; Windows runs the candle worker (the Python worker was retired off-Mac, sc-5563).
-    #[cfg(target_os = "macos")]
-    let child = app
-        .state::<Managed>()
-        .mlx_worker
-        .lock()
-        .expect("mlx worker lock")
-        .take();
-    #[cfg(target_os = "windows")]
-    let child = app
-        .state::<Managed>()
-        .candle_worker
-        .lock()
-        .expect("candle worker lock")
-        .take();
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
-    if let Some(child) = child {
-        let _ = child.kill();
-    }
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-    let _ = app;
+    // worker; Windows runs the candle worker (the Python worker was retired off-Mac,
+    // sc-5563). Shared with the remote REST restart (epic 4484 story 12).
+    crate::setup::restart_gpu_worker(&app);
 }
 
 #[tauri::command]
@@ -683,5 +872,66 @@ mod tests {
         let settings = AppSettings::default();
         assert!(!hf_credential_recorded(&settings));
         assert!(settings.credentials.is_empty());
+    }
+
+    /// epic 4484 story 1: LAN remote access is OFF by default with no port and no
+    /// recorded password, and a default `settings.json` carries none of the new keys
+    /// it doesn't need (so an untouched install reads exactly as before).
+    #[test]
+    fn remote_access_defaults_off() {
+        let settings = AppSettings::default();
+        assert!(!settings.remote_access_enabled);
+        assert_eq!(settings.remote_port, None);
+        assert!(!settings.remote_password_set);
+        // The keychain gate short-circuits with no password recorded.
+        assert!(!remote_password_recorded(&settings));
+        // remote_port is Option → skipped when None; the bools default to false so
+        // they round-trip but add no behavior.
+        let json = serde_json::to_string(&settings).unwrap();
+        assert!(!json.contains("remotePort"));
+    }
+
+    /// The new fields round-trip through serde with the expected camelCase keys.
+    #[test]
+    fn remote_access_settings_round_trip() {
+        let settings = AppSettings {
+            remote_access_enabled: true,
+            remote_port: Some(DEFAULT_REMOTE_PORT),
+            remote_password_set: true,
+            ..AppSettings::default()
+        };
+        let json = serde_json::to_string(&settings).unwrap();
+        assert!(json.contains("remoteAccessEnabled"));
+        assert!(json.contains("remotePort"));
+        assert!(json.contains("remotePasswordSet"));
+        let back: AppSettings = serde_json::from_str(&json).unwrap();
+        assert!(back.remote_access_enabled);
+        assert_eq!(back.remote_port, Some(DEFAULT_REMOTE_PORT));
+        assert!(back.remote_password_set);
+    }
+
+    /// Setting a password records the metadata; clearing it both drops the metadata
+    /// AND disables remote access (fail-closed: no password ⇒ no LAN bind). This is
+    /// the pure metadata half of `set_remote_password`/`clear_remote_password` — the
+    /// keychain write/delete is exercised on real hardware (story 13).
+    #[test]
+    fn mark_remote_password_sets_then_clears_and_disables() {
+        let mut settings = AppSettings {
+            remote_access_enabled: true,
+            remote_port: Some(DEFAULT_REMOTE_PORT),
+            ..AppSettings::default()
+        };
+        mark_remote_password(&mut settings, true);
+        assert!(settings.remote_password_set);
+        assert!(remote_password_recorded(&settings));
+        // Still enabled — setting a password doesn't toggle the switch.
+        assert!(settings.remote_access_enabled);
+        // Clearing the password forces remote access off.
+        mark_remote_password(&mut settings, false);
+        assert!(!settings.remote_password_set);
+        assert!(!remote_password_recorded(&settings));
+        assert!(!settings.remote_access_enabled);
+        // Port choice is preserved across a clear (the user's preference persists).
+        assert_eq!(settings.remote_port, Some(DEFAULT_REMOTE_PORT));
     }
 }

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -268,16 +268,25 @@ fn append_log(path: &Path, line: &str) {
     session_log().push_line(source, line);
 }
 
-/// Extract the port from the API's `listening on http://127.0.0.1:PORT` line.
+/// Extract the port from the API's bound-address startup line. In loopback mode the
+/// API logs `…address=127.0.0.1:PORT`; in LAN mode (epic 4484) it binds 0.0.0.0 and
+/// logs `…address=0.0.0.0:PORT`, so both markers are tried. (LAN mode also pre-sets
+/// the known fixed port, so this is the fallback for the dynamic loopback case.)
 fn parse_listening_port(line: &str) -> Option<u16> {
-    const MARKER: &str = "127.0.0.1:";
-    let start = line.find(MARKER)? + MARKER.len();
-    line[start..]
-        .chars()
-        .take_while(char::is_ascii_digit)
-        .collect::<String>()
-        .parse()
-        .ok()
+    for marker in ["127.0.0.1:", "0.0.0.0:"] {
+        if let Some(index) = line.find(marker) {
+            let start = index + marker.len();
+            if let Ok(port) = line[start..]
+                .chars()
+                .take_while(char::is_ascii_digit)
+                .collect::<String>()
+                .parse()
+            {
+                return Some(port);
+            }
+        }
+    }
+    None
 }
 
 /// Health check that also confirms the responder is genuinely the SceneWorks API
@@ -381,16 +390,110 @@ fn resolve_bundled_cuda_dir(_app: &AppHandle) -> Option<std::path::PathBuf> {
     crate::cuda_provision::cuda_dir_if_present()
 }
 
+/// The resolved bind/auth environment for the API sidecar for one launch (epic 4484
+/// stories 2/3). Pure output of [`decide_api_bind_env`] so the loopback-vs-LAN choice
+/// is unit-tested without spawning anything.
+#[derive(Debug, PartialEq)]
+struct ApiBindEnv {
+    /// `SCENEWORKS_API_HOST`: `127.0.0.1` (loopback) or `0.0.0.0` (LAN, all interfaces).
+    host: &'static str,
+    /// `SCENEWORKS_API_PORT`: `"0"` (OS-assigned dynamic) in loopback mode, or the
+    /// configured fixed port (as a string) in LAN mode.
+    port: String,
+    /// `SCENEWORKS_ACCESS_TOKEN`: the user's password in LAN mode, `None` otherwise.
+    /// When set it is also injected into the GPU worker(s) so they can still reach the
+    /// now-authenticated API.
+    access_token: Option<String>,
+    /// The fixed bound port when known up-front (LAN mode), so window-gating doesn't
+    /// depend on parsing the API's stdout marker. `None` ⇒ discover from the log.
+    fixed_port: Option<u16>,
+    /// A non-fatal warning to log when remote access is requested but can't be honored
+    /// safely (enabled without a password) — the bind falls back to loopback rather
+    /// than exposing the host unauthenticated (fail-closed, story 3).
+    warning: Option<String>,
+}
+
+/// Choose the API sidecar's bind/auth env from the persisted remote-access settings.
+///
+/// Fail-closed security invariant (epic 4484 story 3): a non-loopback bind happens
+/// ONLY when remote access is explicitly enabled AND a non-empty password is present.
+/// Disabled → today's loopback/dynamic/no-token behavior, byte-for-byte. Enabled but
+/// no password → loopback with a warning (NEVER an open unauthenticated bind). The
+/// desktop never sets `SCENEWORKS_ALLOW_OPEN_BIND`, so even a hand-edited settings.json
+/// can't get past the server's own open-bind refusal.
+fn decide_api_bind_env(enabled: bool, port: Option<u16>, password: Option<String>) -> ApiBindEnv {
+    let loopback = || ApiBindEnv {
+        host: "127.0.0.1",
+        // OS-assigned free port (no reserve/release TOCTOU); discovered from the log.
+        port: "0".to_owned(),
+        access_token: None,
+        fixed_port: None,
+        warning: None,
+    };
+    if !enabled {
+        return loopback();
+    }
+    let password = password
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty());
+    let Some(password) = password else {
+        return ApiBindEnv {
+            warning: Some(
+                "remote access is enabled but no password is set — binding loopback-only. \
+                 Set a password in Settings → Remote Access to allow LAN connections."
+                    .to_owned(),
+            ),
+            ..loopback()
+        };
+    };
+    let port = port.unwrap_or(crate::settings::DEFAULT_REMOTE_PORT);
+    ApiBindEnv {
+        host: "0.0.0.0",
+        port: port.to_string(),
+        access_token: Some(password),
+        fixed_port: Some(port),
+        warning: None,
+    }
+}
+
+/// The API access token for this launch when LAN remote access is on (the user's
+/// password), or `None` for the default loopback mode. Used to authenticate the GPU
+/// worker(s) to the now-protected API; mirrors the fail-closed rule in
+/// [`decide_api_bind_env`] (enabled AND a non-empty password). Returns `None` without
+/// touching the keychain when remote access is disabled (the password read self-gates
+/// on the `remote_password_set` metadata).
+fn lan_access_token() -> Option<String> {
+    if !crate::settings::load_settings().remote_access_enabled {
+        return None;
+    }
+    crate::settings::read_remote_password()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+}
+
 /// Spawn the API sidecar, pipe its output to api.log, and return the chosen port.
 fn spawn_api(app: &AppHandle) -> Result<(), String> {
+    // epic 4484 stories 2/3: pick loopback/dynamic (default) vs 0.0.0.0/fixed-port +
+    // password-as-access-token (LAN) from the persisted settings, fail-closed.
+    let settings = crate::settings::load_settings();
+    let bind = decide_api_bind_env(
+        settings.remote_access_enabled,
+        settings.remote_port,
+        crate::settings::read_remote_password(),
+    );
+    if let Some(warning) = &bind.warning {
+        append_log(
+            &logs_dir().join("api.log"),
+            &format!("[desktop] {warning}\n"),
+        );
+    }
     let mut command = app
         .shell()
         .sidecar("sceneworks-api")
         .map_err(|error| format!("locate api: {error}"))?
-        .env("SCENEWORKS_API_HOST", "127.0.0.1")
-        // Let the OS assign a free port (no reserve/release TOCTOU); the actual
-        // port is discovered from the API's startup line below.
-        .env("SCENEWORKS_API_PORT", "0")
+        // Loopback/dynamic by default; 0.0.0.0/fixed-port in LAN mode (epic 4484).
+        .env("SCENEWORKS_API_HOST", bind.host)
+        .env("SCENEWORKS_API_PORT", &bind.port)
         .env("SCENEWORKS_RUN_UTILITY_INPROCESS", "true")
         // Parent-death watchdog: a force-quit/crash skips `begin_shutdown`, so
         // without this the API orphans to launchd (PPID=1), holding its
@@ -459,6 +562,15 @@ fn spawn_api(app: &AppHandle) -> Result<(), String> {
             command = command.env("PATH", joined);
         }
     }
+    // LAN mode (epic 4484): hand the API the user's password as the access token so it
+    // requires auth on the now-network-reachable bind. The server ALSO refuses any
+    // non-loopback bind without a token (API-001 gate), so this is what unlocks the
+    // 0.0.0.0 bind — and we deliberately never set SCENEWORKS_ALLOW_OPEN_BIND, leaving
+    // that server gate as the backstop. The in-process utility worker inherits this
+    // env; the separately-spawned GPU worker(s) get it via `lan_access_token()` below.
+    if let Some(token) = &bind.access_token {
+        command = command.env("SCENEWORKS_ACCESS_TOKEN", token);
+    }
     // FLUX.2-klein true_v2 single-file conversion is now in-process Rust/MLX
     // (mlx_gen_flux2::convert_and_assemble, sc-3136) — no sidecar venv / converter
     // script, so no SCENEWORKS_MLX_FLUX_* env wiring.
@@ -471,6 +583,16 @@ fn spawn_api(app: &AppHandle) -> Result<(), String> {
         .lock()
         .expect("api lock")
         .replace(child);
+    // In LAN mode the bound port is known up-front (fixed), and the API logs it as
+    // `0.0.0.0:<port>` rather than the `127.0.0.1:` marker the stdout parser keys on —
+    // so seed it directly. Window-gating + the loopback health check then proceed
+    // without depending on the marker (0.0.0.0 includes 127.0.0.1).
+    if let Some(fixed_port) = bind.fixed_port {
+        *app.state::<Managed>()
+            .api_port
+            .lock()
+            .expect("api port lock") = Some(fixed_port);
+    }
 
     let log_path = logs_dir().join("api.log");
     let _ = std::fs::create_dir_all(logs_dir());
@@ -486,12 +608,21 @@ fn spawn_api(app: &AppHandle) -> Result<(), String> {
                 CommandEvent::Stdout(bytes) | CommandEvent::Stderr(bytes) => {
                     let text = String::from_utf8_lossy(&bytes).into_owned();
                     // Discover the OS-assigned port from the API's startup line.
-                    let state = app_handle.state::<Managed>();
-                    let mut port = state.api_port.lock().expect("api port lock");
-                    if port.is_none() {
-                        if let Some(found) = parse_listening_port(&text) {
-                            *port = Some(found);
+                    {
+                        let state = app_handle.state::<Managed>();
+                        let mut port = state.api_port.lock().expect("api port lock");
+                        if port.is_none() {
+                            if let Some(found) = parse_listening_port(&text) {
+                                *port = Some(found);
+                            }
                         }
+                    }
+                    // Remote worker-restart sentinel (epic 4484 story 12): the API
+                    // prints this when an authenticated remote admin POSTs
+                    // /api/v1/worker/restart. Do the same kill-and-respawn as the local
+                    // "Restart worker" command.
+                    if text.contains(sceneworks_core::WORKER_RESTART_SENTINEL) {
+                        restart_gpu_worker(&app_handle);
                     }
                     text
                 }
@@ -625,6 +756,34 @@ pub fn invalidate_credential_cache(app: &AppHandle, host: &str) {
     }
 }
 
+/// Kill the current GPU worker child so its supervisor respawns it — the shared core of
+/// the local "Restart worker" Tauri command and the remote REST restart (epic 4484
+/// story 12, triggered when the API prints `WORKER_RESTART_SENTINEL` to stdout). macOS
+/// runs the MLX worker; Windows runs the candle worker; elsewhere there is no GPU
+/// worker to restart.
+pub fn restart_gpu_worker(app: &AppHandle) {
+    #[cfg(target_os = "macos")]
+    let child = app
+        .state::<Managed>()
+        .mlx_worker
+        .lock()
+        .expect("mlx worker lock")
+        .take();
+    #[cfg(target_os = "windows")]
+    let child = app
+        .state::<Managed>()
+        .candle_worker
+        .lock()
+        .expect("candle worker lock")
+        .take();
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    if let Some(child) = child {
+        let _ = child.kill();
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    let _ = app;
+}
+
 /// Spawn and supervise the Apple-Silicon MLX GPU worker (sc-3289): the same
 /// `sceneworks-api` sidecar binary re-launched in worker mode
 /// (`SCENEWORKS_WORKER_ONLY=1`) with `SCENEWORKS_GPU_ID=mlx`, so MLX-eligible
@@ -719,6 +878,13 @@ fn supervise_mlx_worker(app: AppHandle, api_port: u16) {
                         command = command.env("SCENEWORKS_CREDENTIAL_HOSTS", hosts);
                     }
                 }
+            }
+            // LAN mode (epic 4484): the API now requires the password as an access
+            // token, so the MLX worker must send it on every API call (register/claim/
+            // heartbeat) or it'd be 401'd. `None` in the default loopback mode, so this
+            // is a no-op unless the user opted into LAN remote access.
+            if let Some(token) = lan_access_token() {
+                command = command.env("SCENEWORKS_ACCESS_TOKEN", token);
             }
             let spawned = command.spawn();
             let (mut events, child) = match spawned {
@@ -905,6 +1071,12 @@ fn supervise_candle_worker(app: AppHandle, api_port: u16) {
             }
             if let Some(credentials) = crate::settings::credentials_env_json() {
                 command = command.env("SCENEWORKS_CREDENTIALS", credentials);
+            }
+            // LAN mode (epic 4484): the API now requires the password as an access
+            // token, so the candle worker must send it on every API call or it'd be
+            // 401'd. `None` in the default loopback mode (no-op unless LAN is on).
+            if let Some(token) = lan_access_token() {
+                command = command.env("SCENEWORKS_ACCESS_TOKEN", token);
             }
             let spawned = command.spawn();
             let (mut events, child) = match spawned {
@@ -1345,5 +1517,110 @@ mod preflight_tests {
     fn unparseable_driver_does_not_block_a_present_gpu() {
         // The GPU is present; an odd version string shouldn't hard-block startup.
         assert!(evaluate_nvidia_preflight(Some("NVIDIA RTX, not-a-version")).is_ok());
+    }
+}
+
+#[cfg(test)]
+mod bind_tests {
+    use super::{decide_api_bind_env, parse_listening_port, ApiBindEnv};
+    use crate::settings::DEFAULT_REMOTE_PORT;
+
+    // epic 4484 stories 2/3/10: the API sidecar launch-env selector.
+
+    #[test]
+    fn disabled_binds_loopback_dynamic_no_token() {
+        // Default (remote access off): byte-for-byte today's behavior.
+        let env = decide_api_bind_env(false, Some(9000), Some("hunter2".to_owned()));
+        assert_eq!(
+            env,
+            ApiBindEnv {
+                host: "127.0.0.1",
+                port: "0".to_owned(),
+                access_token: None,
+                fixed_port: None,
+                warning: None,
+            }
+        );
+    }
+
+    #[test]
+    fn enabled_with_password_binds_open_fixed_port_with_token() {
+        let env = decide_api_bind_env(true, Some(8910), Some("  swordfish  ".to_owned()));
+        assert_eq!(env.host, "0.0.0.0");
+        assert_eq!(env.port, "8910");
+        // Token is the trimmed password; it is also handed to the GPU worker(s).
+        assert_eq!(env.access_token.as_deref(), Some("swordfish"));
+        assert_eq!(env.fixed_port, Some(8910));
+        assert!(env.warning.is_none());
+    }
+
+    #[test]
+    fn enabled_without_port_uses_the_default_suggestion() {
+        let env = decide_api_bind_env(true, None, Some("pw".to_owned()));
+        assert_eq!(env.host, "0.0.0.0");
+        assert_eq!(env.port, DEFAULT_REMOTE_PORT.to_string());
+        assert_eq!(env.fixed_port, Some(DEFAULT_REMOTE_PORT));
+    }
+
+    #[test]
+    fn enabled_without_password_fails_closed_to_loopback() {
+        // Security invariant: never bind non-loopback without a password (story 3).
+        let env = decide_api_bind_env(true, Some(8787), None);
+        assert_eq!(env.host, "127.0.0.1");
+        assert_eq!(env.port, "0");
+        assert!(env.access_token.is_none());
+        assert!(env.fixed_port.is_none());
+        assert!(
+            env.warning.is_some(),
+            "missing-password must surface a warning"
+        );
+    }
+
+    #[test]
+    fn enabled_with_blank_password_fails_closed() {
+        // A whitespace-only password is treated as absent → loopback, never an empty
+        // token on an open bind.
+        let env = decide_api_bind_env(true, Some(8787), Some("   ".to_owned()));
+        assert_eq!(env.host, "127.0.0.1");
+        assert!(env.access_token.is_none());
+        assert!(env.warning.is_some());
+    }
+
+    /// Story 3: the desktop must NEVER set `SCENEWORKS_ALLOW_OPEN_BIND` (the server's
+    /// open-bind refusal must remain the backstop). Assert the var never appears as a
+    /// double-quoted string literal anywhere in the desktop crate — i.e. it is never
+    /// passed to `.env("…")` / `set_var("…")`. (Explanatory comments referencing the
+    /// var in prose or `backticks` are allowed and don't match.) The needle is
+    /// assembled from parts so this test's own source doesn't trip the `include_str!`
+    /// scan of this very file.
+    #[test]
+    fn desktop_never_sets_allow_open_bind() {
+        let needle = concat!("\"SCENEWORKS_", "ALLOW_OPEN_BIND\"");
+        for source in [
+            include_str!("setup.rs"),
+            include_str!("settings.rs"),
+            include_str!("main.rs"),
+            include_str!("net.rs"),
+        ] {
+            assert!(
+                !source.contains(needle),
+                "desktop crate must never set the open-bind override env var"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_listening_port_handles_both_markers() {
+        // Loopback (dynamic) startup line.
+        assert_eq!(
+            parse_listening_port("api_listening address=127.0.0.1:54321 ..."),
+            Some(54321)
+        );
+        // LAN (0.0.0.0/fixed) startup line.
+        assert_eq!(
+            parse_listening_port("api_listening address=0.0.0.0:8787 ..."),
+            Some(8787)
+        );
+        assert_eq!(parse_listening_port("nothing to see here"), None);
     }
 }

--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -106,6 +106,27 @@ pub(crate) struct AccessResponse {
     pub(crate) token_header: &'static str,
 }
 
+/// Host memory for remote-browser model gating (epic 4484 story 9). A remote browser
+/// can't call the desktop-only Tauri `get_gpu_info`, so it reads the host's memory
+/// from here — derived from the registered GPU worker's reported utilization. Carries
+/// only aggregate memory totals + the platform string (no paths/secrets), and is
+/// auth-protected (not a public path).
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct HostCapabilitiesResponse {
+    /// API host OS (`macos`/`windows`/`linux`) so the client gates with the right
+    /// memory concept (unified vs VRAM).
+    pub(crate) platform: &'static str,
+    /// Unified system memory (GB) — the macOS MLX worker reports `sysctl hw.memsize`.
+    /// `None` when no MLX worker is registered.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) unified_memory_gb: Option<f64>,
+    /// Largest discrete GPU VRAM (GB) across registered GPU workers (Windows candle /
+    /// CUDA). `None` when no such worker is registered.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) gpu_memory_gb: Option<f64>,
+}
+
 #[derive(Debug, Serialize)]
 pub(crate) struct VerifyResponse {
     pub(crate) ok: bool,

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -913,6 +913,10 @@ pub(crate) fn create_app_with_state(
             get(person_capability_readiness),
         )
         .route("/api/v1/capabilities/mac", get(mac_capability_support))
+        // Host memory for remote-browser model gating (epic 4484 story 9).
+        .route("/api/v1/host-capabilities", get(host_capabilities))
+        // Remote-admin GPU worker restart (epic 4484 story 12).
+        .route("/api/v1/worker/restart", post(request_worker_restart))
         .route("/api/v1/workers/register", post(register_worker))
         .route(
             "/api/v1/workers/:worker_id/heartbeat",

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -7980,6 +7980,87 @@ async fn public_health_withholds_host_paths_when_a_token_is_configured() {
     assert!(health.get("directories").is_none());
 }
 
+#[tokio::test]
+async fn host_capabilities_requires_token_and_reports_host_memory() {
+    // epic 4484 story 9: the remote-browser host-memory signal is auth-protected and
+    // derives the platform-correct memory from the registered GPU worker's utilization.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let mut settings = test_settings(&temp_dir);
+    settings.access_token = "secret-token".to_owned();
+    let app = create_app(settings).expect("app creates");
+
+    // Protected: no token → 401 (not a public path).
+    let (status, _) = request(app.clone(), "GET", "/api/v1/host-capabilities", Value::Null).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+
+    // With the token but no workers registered: 200, platform present, memory omitted.
+    let (status, caps) = request_with_headers(
+        app.clone(),
+        "GET",
+        "/api/v1/host-capabilities",
+        Value::Null,
+        &[("x-sceneworks-token", "secret-token")],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(caps.get("platform").is_some());
+    assert!(caps.get("unifiedMemoryGb").is_none());
+
+    // Register an MLX worker reporting unified memory (sysctl hw.memsize as total MB);
+    // the endpoint surfaces it as GB.
+    let (status, _) = request_with_headers(
+        app.clone(),
+        "POST",
+        "/api/v1/workers/register",
+        json!({
+            "workerId": "mlx-test",
+            "gpuId": "mlx",
+            "capabilities": [],
+            "loadedModels": [],
+            "utilization": { "memoryTotalMb": 131072 }
+        }),
+        &[("x-sceneworks-token", "secret-token")],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, caps) = request_with_headers(
+        app,
+        "GET",
+        "/api/v1/host-capabilities",
+        Value::Null,
+        &[("x-sceneworks-token", "secret-token")],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(caps["unifiedMemoryGb"], 128.0);
+    // No host paths or secrets leak through this endpoint.
+    assert!(caps.get("directories").is_none());
+}
+
+#[tokio::test]
+async fn worker_restart_requires_token() {
+    // epic 4484 story 12: the remote-admin worker-restart endpoint is auth-protected.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let mut settings = test_settings(&temp_dir);
+    settings.access_token = "secret-token".to_owned();
+    let app = create_app(settings).expect("app creates");
+
+    let (status, _) = request(app.clone(), "POST", "/api/v1/worker/restart", Value::Null).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+
+    let (status, body) = request_with_headers(
+        app,
+        "POST",
+        "/api/v1/worker/restart",
+        Value::Null,
+        &[("x-sceneworks-token", "secret-token")],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["ok"], true);
+}
+
 #[test]
 fn requires_token_only_gates_api_paths() {
     // Non-API paths (embedded UI / SPA fallback) must never require a token,

--- a/apps/rust-api/src/workers.rs
+++ b/apps/rust-api/src/workers.rs
@@ -74,6 +74,64 @@ pub(crate) async fn mac_capability_support(State(state): State<AppState>) -> Jso
     ))
 }
 
+/// Host memory for remote-browser model gating (epic 4484 story 9). A remote browser
+/// can't call the desktop-only Tauri `get_gpu_info`, so it reads the host's memory
+/// here, derived from the registered GPU worker's reported utilization: the macOS MLX
+/// worker reports unified memory (`sysctl hw.memsize`) as its total, and the Windows
+/// candle worker reports discrete GPU VRAM. Auth-protected (not in `PUBLIC_PATHS`) and
+/// leaks no paths/secrets — only aggregate memory totals + the platform string. The
+/// desktop keeps using the richer Tauri probe; this serves the remote browser.
+pub(crate) async fn host_capabilities(
+    State(state): State<AppState>,
+) -> Result<Json<HostCapabilitiesResponse>, ApiError> {
+    let workers = store_call(state, move |store, _timeout| store.list_workers()).await?;
+    let mb_to_gb = |mb: u64| (mb as f64) / 1024.0;
+    // Unified memory: the macOS MLX worker reports sysctl hw.memsize as its total.
+    let unified_memory_gb = workers
+        .iter()
+        .find(|worker| worker.gpu_id == "mlx")
+        .and_then(|worker| worker.utilization.as_ref())
+        .and_then(|util| util.memory_total_mb)
+        .map(mb_to_gb);
+    // GPU VRAM: largest total across the discrete GPU workers (Windows candle / CUDA).
+    let gpu_memory_gb = workers
+        .iter()
+        .filter(|worker| worker.gpu_id != "mlx" && worker.gpu_id != "cpu")
+        .filter_map(|worker| {
+            worker
+                .utilization
+                .as_ref()
+                .and_then(|util| util.memory_total_mb)
+        })
+        .max()
+        .map(mb_to_gb);
+    Ok(Json(HostCapabilitiesResponse {
+        platform: std::env::consts::OS,
+        unified_memory_gb,
+        gpu_memory_gb,
+    }))
+}
+
+/// Remote-admin GPU worker restart (epic 4484 story 12). The API process does NOT
+/// supervise the GPU worker — the desktop shell does — so it can't kill it directly.
+/// Instead it prints a unique sentinel to stdout that the desktop's existing
+/// sidecar-output reader matches, then the desktop performs the same kill-and-respawn
+/// as its local "Restart worker" button. In a server/Docker deployment (no desktop
+/// supervisor reading stdout) the sentinel is just a log line and nothing restarts —
+/// container workers are managed by their own supervisors. Auth-protected (not a public
+/// path), so only an authenticated remote admin can trigger it.
+pub(crate) async fn request_worker_restart() -> Json<Value> {
+    // A plain stdout line (Rust stdout is line-buffered, so the trailing newline
+    // flushes it) — not structured tracing — so the desktop reader matches it
+    // unambiguously regardless of the active log format.
+    println!("{}", sceneworks_core::WORKER_RESTART_SENTINEL);
+    tracing::info!(
+        event = "worker_restart_requested",
+        "remote worker restart requested over REST"
+    );
+    Json(json!({ "ok": true }))
+}
+
 pub(crate) async fn register_worker(
     State(state): State<AppState>,
     ApiJson(payload): ApiJson<WorkerRegisterRequest>,

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -39,13 +39,13 @@ import {
   restrictFoldedToScope,
 } from "./assetVariants.js";
 import { buildWorkersById } from "./workers.js";
+import { isDesktop as isDesktopShell, tauriInvoke } from "./runtime.js";
 
-// Desktop (Tauri) shell detection. The first-run setup wizard is desktop-only;
-// web/Docker keep the existing first-run project gate. Tauri commands persist the
-// wizard state (the API binds a random port each launch, so localStorage — keyed
-// to the origin — can't be relied on across launches).
-const isDesktopShell = typeof window !== "undefined" && !!window.__TAURI__;
-const tauriInvoke = (command, args) => window.__TAURI__.core.invoke(command, args);
+// Desktop (Tauri) shell detection (unified helper, epic 4484 story 6). The first-run
+// setup wizard is desktop-only; web/Docker (and a remote LAN browser) keep the
+// existing first-run project gate. Tauri commands persist the wizard state (the API
+// binds a random port each launch, so localStorage — keyed to the origin — can't be
+// relied on across launches).
 
 function isActiveWorker(worker) {
   return worker.status !== "offline";
@@ -464,6 +464,8 @@ export function App() {
   const [health, setHealth] = useState(null);
   const [access, setAccess] = useState({ authRequired: false });
   const [token, setToken] = useState(() => window.localStorage.getItem("sceneworks-token") ?? "");
+  // Wrong-password feedback for the remote-browser login gate (epic 4484 story 7).
+  const [authError, setAuthError] = useState("");
   const [projects, setProjects] = useState([]);
   const [projectsLoaded, setProjectsLoaded] = useState(false);
   // Desktop first-run wizard gate: null = unknown (still reading on desktop),
@@ -1229,11 +1231,42 @@ export function App() {
   refreshDataWithLoraOverlayRef.current = refreshDataWithLoraOverlay;
 
 
-  function saveToken(event) {
+  // Remote-browser login (epic 4484 story 7): the password IS the API access token.
+  // Verify it against the public /api/v1/auth/verify endpoint BEFORE persisting, so a
+  // wrong password keeps the gate up (instead of saving a bad token and silently
+  // failing every subsequent request). A correct password is stored to localStorage
+  // and unlocks the app; it persists across reloads.
+  async function saveToken(event) {
     event.preventDefault();
-    window.localStorage.setItem("sceneworks-token", token);
+    const candidate = token.trim();
+    if (!candidate) {
+      setAuthError("Enter the password.");
+      return;
+    }
+    try {
+      const result = await apiFetch("/api/v1/auth/verify", candidate, { method: "POST" });
+      if (!result?.ok) {
+        setAuthError("Incorrect password. Try again.");
+        return;
+      }
+    } catch {
+      setAuthError("Couldn't reach the host to verify the password.");
+      return;
+    }
+    window.localStorage.setItem("sceneworks-token", candidate);
+    setToken(candidate);
+    setAuthError("");
     setError("");
     refreshData();
+  }
+
+  // Clear the stored password and re-show the login gate ("lock"/forget affordance,
+  // epic 4484 story 7). Setting the token state to "" forces a re-render so the gate
+  // (which keys off the stored token) reappears.
+  function lockRemote() {
+    window.localStorage.removeItem("sceneworks-token");
+    setToken("");
+    setAuthError("");
   }
 
   async function completeSetupWizard() {
@@ -1993,6 +2026,18 @@ export function App() {
           >
             {theme === "light" ? <Icon.Moon /> : <Icon.Sun />}
           </button>
+          {/* Lock/forget the saved password (epic 4484 story 7) — only meaningful in a
+              remote browser where a password was entered to unlock the host. */}
+          {access.authRequired && !isDesktopShell && token ? (
+            <button
+              className="icon-btn"
+              onClick={lockRemote}
+              title="Lock — forget the saved password"
+              type="button"
+            >
+              Lock
+            </button>
+          ) : null}
         </header>
 
         {notices.map((notice) => (
@@ -2002,17 +2047,18 @@ export function App() {
         {access.authRequired && !window.localStorage.getItem("sceneworks-token") ? (
           <section className="auth-band">
             <form onSubmit={saveToken}>
-              <label htmlFor="token">Pairing token</label>
+              <label htmlFor="token">Password</label>
               <div className="form-row">
                 <input
                   id="token"
                   onChange={(event) => setToken(event.target.value)}
-                  placeholder="Enter local token"
+                  placeholder="Enter the access password"
                   type="password"
                   value={token}
                 />
                 <button type="submit">Unlock</button>
               </div>
+              {authError ? <p className="notice error">{authError}</p> : null}
             </form>
           </section>
         ) : null}

--- a/apps/web/src/credentials.js
+++ b/apps/web/src/credentials.js
@@ -1,14 +1,16 @@
 import { apiFetch } from "./api.js";
+import { isDesktop, tauriInvoke } from "./runtime.js";
 
 // Service-credential transport shared by the Settings screen (where users manage
 // tokens) and the Models screen (which checks token presence for gated models).
 // The desktop build stores credentials in the OS keychain via Tauri (sc-1891);
 // the server/Docker build manages them over the authed REST API (sc-1893). These
 // helpers hide that split so both screens use one transport + presence check.
-export const credentialsIsDesktop =
-  typeof window !== "undefined" && !!window.__TAURI__;
+// `credentialsIsDesktop` is a thin re-export of the unified `isDesktop` (epic 4484
+// story 6) kept for existing importers.
+export const credentialsIsDesktop = isDesktop;
 
-const invoke = (command, args) => window.__TAURI__.core.invoke(command, args);
+const invoke = tauriInvoke;
 
 export const SCHEME_LABELS = {
   bearer: "Bearer header",

--- a/apps/web/src/runtime.js
+++ b/apps/web/src/runtime.js
@@ -1,0 +1,18 @@
+// Single source of truth for "are we running inside the Tauri desktop shell?"
+// (epic 4484, story 6).
+//
+// Previously credentials.js, App.jsx, LogsScreen.jsx, ModelManagerScreen.jsx, and
+// SettingsScreen.jsx each re-derived this from `window.__TAURI__` with subtly
+// different expressions (one used `Boolean(...)`, the rest `!!...`). This unifies them
+// so desktop-vs-remote-browser gating is consistent everywhere.
+//
+// A remote browser reaching the desktop host over the LAN (the whole point of
+// epic 4484) has no `window.__TAURI__`, so `isDesktop` is false there and every
+// desktop-only affordance falls back to its REST/web code path.
+export const isDesktop = typeof window !== "undefined" && !!window.__TAURI__;
+
+// Invoke a Tauri command. Only valid when `isDesktop` is true — callers MUST gate on
+// it, since `window.__TAURI__` is undefined in a remote browser.
+export function tauriInvoke(command, args) {
+  return window.__TAURI__.core.invoke(command, args);
+}

--- a/apps/web/src/screens/LogsScreen.jsx
+++ b/apps/web/src/screens/LogsScreen.jsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 
 import { apiFetch } from "../api.js";
 import { useAppContext } from "../context/AppContext.js";
+import { isDesktop, tauriInvoke } from "../runtime.js";
 
 // In-app Logs viewer (sc-3452). Shows the current session's activity — most
 // importantly the GPU routing decisions (`gpu_route_decision`) and claim
@@ -10,9 +11,9 @@ import { useAppContext } from "../context/AppContext.js";
 //
 // Data source: on the desktop the rich multi-source buffer (api + worker +
 // mlx-worker) is read via the `get_session_logs` Tauri command (sc-3451); on
-// web/Docker the API-side buffer is read over HTTP (`GET /api/v1/logs`, sc-3453).
-const isDesktop = typeof window !== "undefined" && !!window.__TAURI__;
-const tauriInvoke = (command, args) => window.__TAURI__.core.invoke(command, args);
+// web/Docker (and a remote LAN browser) the API-side buffer is read over HTTP
+// (`GET /api/v1/logs`, sc-3453). `isDesktop`/`tauriInvoke` come from the unified
+// runtime helper (epic 4484 story 6).
 
 const SOURCES = ["api", "worker", "mlx-worker"];
 const LEVELS = ["info", "warn", "error"];

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useState } from "react";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
 import { terminalStatuses } from "../constants.js";
-import { hasPresentCredential, loadCredentials } from "../credentials.js";
+import { hasPresentCredential, loadCredentials, serverToken } from "../credentials.js";
 import { extractFamilies, modelLoraFamilies, presetLoraId, presetLoras } from "../presetUtils.js";
 import { useAppContext } from "../context/AppContext.js";
 import { DEFAULT_MAC_CAPABILITIES, macModelBlock } from "../macGating.js";
+import { apiFetch } from "../api.js";
+import { isDesktop, tauriInvoke } from "../runtime.js";
 
 // Wan A14B is a two-expert mixture; its LoRAs come as a high/low-noise pair. These
 // base models accept the optional low-noise expert upload (sc-1991). The 5B model
@@ -280,9 +282,10 @@ export function ModelManagerScreen() {
   const [modelFileInputKey, setModelFileInputKey] = useState(0);
   const [deletingItem, setDeletingItem] = useState("");
   const [deleteMessage, setDeleteMessage] = useState({ tone: "neutral", text: "" });
-  // Desktop only: read the host's unified memory so MLX models can be gated against
-  // their memory tier. Browser/Docker builds have no Tauri bridge and skip this.
-  const isDesktop = typeof window !== "undefined" && Boolean(window.__TAURI__);
+  // Read the host's memory so MLX models can be gated against their memory tier.
+  // Desktop reads it from the Tauri GPU probe; a remote LAN browser reads the
+  // auth-protected REST signal (epic 4484 story 9). `isDesktop`/`tauriInvoke` come
+  // from the unified runtime helper (story 6).
   const [unifiedMemoryGb, setUnifiedMemoryGb] = useState(null);
   // Gated-model credential presence (sc-1898): only fetched when the catalog has a
   // gated model, so non-gated deployments make no extra credential request.
@@ -319,22 +322,37 @@ export function ModelManagerScreen() {
   }, [importForm.family]);
 
   useEffect(() => {
-    if (!isDesktop) {
-      return undefined;
-    }
     let cancelled = false;
-    window.__TAURI__.core
-      .invoke("get_gpu_info")
-      .then((info) => {
-        if (!cancelled && info && typeof info.unifiedMemoryMb === "number") {
-          setUnifiedMemoryGb(info.unifiedMemoryMb / 1024);
-        }
-      })
-      .catch(() => {});
+    if (isDesktop) {
+      // Desktop: read unified memory straight from the Tauri GPU probe.
+      tauriInvoke("get_gpu_info")
+        .then((info) => {
+          if (!cancelled && info && typeof info.unifiedMemoryMb === "number") {
+            setUnifiedMemoryGb(info.unifiedMemoryMb / 1024);
+          }
+        })
+        .catch(() => {});
+    } else {
+      // Remote LAN browser (epic 4484 story 9): the Tauri probe is unavailable, so
+      // read the host's memory from the auth-protected REST signal derived from the
+      // registered GPU worker (unified memory on macOS / GPU VRAM on Windows). Without
+      // this, memory gating would silently no-op for remote users.
+      apiFetch("/api/v1/host-capabilities", serverToken())
+        .then((caps) => {
+          if (cancelled || !caps) {
+            return;
+          }
+          const gb = caps.unifiedMemoryGb ?? caps.gpuMemoryGb;
+          if (typeof gb === "number") {
+            setUnifiedMemoryGb(gb);
+          }
+        })
+        .catch(() => {});
+    }
     return () => {
       cancelled = true;
     };
-  }, [isDesktop]);
+  }, []);
 
   useEffect(() => {
     if (!hasGatedModel) {

--- a/apps/web/src/screens/ModelManagerScreen.test.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.test.jsx
@@ -643,3 +643,94 @@ describe("ModelManagerScreen type-grouped layout", () => {
     expect(downloadButton).toBeUndefined();
   });
 });
+
+// epic 4484 stories 9/10: a remote browser (no Tauri) can't call get_gpu_info, so it
+// reads the host's memory from GET /api/v1/host-capabilities and gates MLX models with
+// it exactly as the desktop does with the Tauri probe.
+describe("ModelManagerScreen remote memory gating (REST)", () => {
+  let container;
+  let root;
+  let apiFetch;
+  let ModelManagerScreen;
+  let AppContext;
+
+  const HEAVY_MLX_MODEL = {
+    id: "big_mlx",
+    name: "Big MLX",
+    type: "image",
+    family: "flux",
+    installState: "installed",
+    mlxConversionState: "needs_conversion",
+    mlx: { minMemoryGb: 64 },
+    ui: { description: "Heavy MLX model." },
+  };
+
+  beforeEach(async () => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    delete window.__TAURI__;
+    apiFetch = vi.fn(async (path) => {
+      if (path === "/api/v1/host-capabilities") {
+        return { platform: "macos", unifiedMemoryGb: 16 };
+      }
+      return [];
+    });
+    vi.resetModules();
+    vi.doMock("../api.js", () => ({
+      apiFetch,
+      isAbortError: () => false,
+      API_BASE_URL: "",
+      eventUrl: () => "",
+    }));
+    ({ AppContext } = await import("../context/AppContext.js"));
+    ({ ModelManagerScreen } = await import("./ModelManagerScreen.jsx"));
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    vi.doUnmock("../api.js");
+    vi.restoreAllMocks();
+  });
+
+  async function render(models) {
+    const value = {
+      activeProject: null,
+      jobs: [],
+      loras: [],
+      models,
+      presets: [],
+      jobAction: () => {},
+      setActiveView: () => {},
+      deleteLora: () => {},
+      deleteModel: () => {},
+      createModelDownloadJob: () => {},
+      createModelConvertJob: () => {},
+      createLoraImportJob: () => {},
+      createModelImportJob: () => {},
+    };
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={value}>
+          <ModelManagerScreen />
+        </AppContext.Provider>,
+      );
+    });
+    // Flush the host-capabilities effect promise.
+    await act(async () => {});
+  }
+
+  it("reads host memory over REST and warns when the model needs more than the host has", async () => {
+    await render([HEAVY_MLX_MODEL]);
+    expect(apiFetch).toHaveBeenCalledWith("/api/v1/host-capabilities", expect.anything());
+    // 64 GB required vs 16 GB host → the insufficient-memory warning is shown, proving
+    // the REST signal drives gating just like the desktop Tauri probe.
+    expect(container.textContent).toContain("needs ≥ 64 GB");
+    expect(container.textContent).toContain("Needs ≥ 64 GB unified memory");
+    expect(container.textContent).toContain("~16 GB");
+  });
+});

--- a/apps/web/src/screens/SettingsScreen.jsx
+++ b/apps/web/src/screens/SettingsScreen.jsx
@@ -1,17 +1,21 @@
 import React, { useCallback, useEffect, useState } from "react";
 import {
   SCHEME_LABELS,
-  credentialsIsDesktop as isDesktop,
   loadCredentials,
   removeCredentialRequest,
   saveCredential,
+  serverToken,
 } from "../credentials.js";
+import { apiFetch } from "../api.js";
+import { isDesktop, tauriInvoke as invoke } from "../runtime.js";
 
-// The data-dir / GPU / worker / wizard controls are desktop-only (backed by Tauri
-// commands in the shell). Service credentials work in both deployments and route
-// through the shared ../credentials.js transport (keychain on desktop, authed REST
-// on the server). The remaining commands here are desktop-only Tauri invokes.
-const invoke = (command, args) => window.__TAURI__.core.invoke(command, args);
+// The data-dir / GPU / worker / wizard / remote-access controls are desktop-only
+// (backed by Tauri commands in the shell) and are gated behind `isDesktop` so a
+// remote LAN browser (epic 4484) doesn't render buttons that would call a missing
+// Tauri bridge. Service credentials work in both deployments and route through the
+// shared ../credentials.js transport (keychain on desktop, authed REST on the
+// server / remote browser). `isDesktop`/`invoke` come from the unified runtime
+// helper (story 6).
 
 export function SettingsScreen() {
   const [settings, setSettings] = useState(null);
@@ -22,18 +26,28 @@ export function SettingsScreen() {
   const [newScheme, setNewScheme] = useState("bearer");
   const [newToken, setNewToken] = useState("");
   const [status, setStatus] = useState("");
+  // LAN remote access (epic 4484 stories 4/11). `remote` is the RemoteAccessStatus
+  // snapshot from the shell; only fetched/rendered on desktop.
+  const [remote, setRemote] = useState(null);
+  const [remotePort, setRemotePort] = useState("");
+  const [remotePassword, setRemotePassword] = useState("");
 
   const refresh = useCallback(async () => {
     try {
       if (isDesktop) {
-        const [loadedSettings, gpuInfo, storedCredentials] = await Promise.all([
+        const [loadedSettings, gpuInfo, storedCredentials, remoteAccess] = await Promise.all([
           invoke("get_app_settings"),
           invoke("get_gpu_info"),
           invoke("list_credentials"),
+          invoke("get_remote_access"),
         ]);
         setSettings(loadedSettings);
         setGpu(gpuInfo);
         setCredentials(storedCredentials ?? []);
+        if (remoteAccess) {
+          setRemote(remoteAccess);
+          setRemotePort(String(remoteAccess.port));
+        }
       } else {
         setCredentials(await loadCredentials());
       }
@@ -102,7 +116,13 @@ export function SettingsScreen() {
 
   async function restartWorker() {
     try {
-      await invoke("restart_worker");
+      // Desktop kills the worker child directly via Tauri; a remote admin restarts it
+      // over REST (epic 4484 story 12), which signals the desktop supervisor to respawn.
+      if (isDesktop) {
+        await invoke("restart_worker");
+      } else {
+        await apiFetch("/api/v1/worker/restart", serverToken(), { method: "POST" });
+      }
       setStatus("Restarting the inference worker…");
     } catch (error) {
       setStatus(String(error));
@@ -115,6 +135,60 @@ export function SettingsScreen() {
       window.location.reload();
     } catch (error) {
       setStatus(String(error));
+    }
+  }
+
+  // --- Remote access (LAN) handlers (epic 4484 story 4) ---
+  async function saveRemotePassword() {
+    try {
+      const updated = await invoke("set_remote_access_password", { password: remotePassword });
+      setRemote(updated);
+      setRemotePassword("");
+      setStatus("Remote access password saved.");
+    } catch (error) {
+      setStatus(String(error));
+    }
+  }
+
+  async function clearRemotePassword() {
+    try {
+      const updated = await invoke("clear_remote_access_password");
+      setRemote(updated);
+      setStatus("Password cleared — remote access disabled.");
+    } catch (error) {
+      setStatus(String(error));
+    }
+  }
+
+  async function applyRemoteAccess(enabled) {
+    const port = Number.parseInt(remotePort, 10);
+    if (!Number.isInteger(port) || port < 1024 || port > 65535) {
+      setStatus("Choose a port between 1024 and 65535.");
+      return;
+    }
+    try {
+      const updated = await invoke("set_remote_access", { enabled, port });
+      setRemote(updated);
+      setRemotePort(String(updated.port));
+      setStatus(
+        enabled
+          ? "Remote access enabled — restart SceneWorks to apply."
+          : "Remote access disabled — restart SceneWorks to apply.",
+      );
+    } catch (error) {
+      setStatus(String(error));
+    }
+  }
+
+  async function copyRemoteUrl() {
+    if (!remote?.url) {
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(remote.url);
+      setStatus(`Copied ${remote.url}`);
+    } catch {
+      setStatus("Couldn't copy to clipboard.");
     }
   }
 
@@ -136,6 +210,121 @@ export function SettingsScreen() {
               Reveal in {gpu?.platform === "windows" ? "Explorer" : "Finder"}
             </button>
           </div>
+        </section>
+      ) : null}
+
+      {isDesktop && remote ? (
+        <section className="settings-card">
+          <h3>Remote access (LAN)</h3>
+          <p className="settings-muted">
+            Let another device on your local network use SceneWorks in a browser, with
+            generation running on this computer. Off by default; protected by a password
+            you set.
+          </p>
+          <p className="settings-value">
+            {remote.enabled ? "Enabled" : "Disabled"}
+            {remote.enabled && remote.url ? ` · ${remote.url}` : ""}
+          </p>
+
+          <div className="settings-actions settings-credential-form">
+            <input
+              type="password"
+              placeholder={remote.passwordSet ? "Change password" : "Set a password"}
+              value={remotePassword}
+              onChange={(event) => setRemotePassword(event.target.value)}
+              aria-label="Remote access password"
+            />
+            <button
+              type="button"
+              onClick={saveRemotePassword}
+              disabled={!remotePassword.trim()}
+            >
+              {remote.passwordSet ? "Change password" : "Set password"}
+            </button>
+            {remote.passwordSet ? (
+              <button type="button" onClick={clearRemotePassword}>
+                Clear password
+              </button>
+            ) : null}
+          </div>
+          <p className="settings-muted">
+            {remote.passwordSet
+              ? "A password is set. Remote browsers must enter it to connect."
+              : "Set a password before enabling remote access."}
+          </p>
+
+          <div className="settings-actions">
+            <label htmlFor="remote-port">Port</label>
+            <input
+              id="remote-port"
+              type="number"
+              min="1024"
+              max="65535"
+              value={remotePort}
+              onChange={(event) => setRemotePort(event.target.value)}
+              aria-label="Remote access port"
+            />
+            {remote.enabled ? (
+              <button type="button" onClick={() => applyRemoteAccess(false)}>
+                Disable remote access
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() => applyRemoteAccess(true)}
+                disabled={!remote.passwordSet}
+              >
+                Enable remote access
+              </button>
+            )}
+            {remote.url ? (
+              <button type="button" onClick={copyRemoteUrl}>
+                Copy URL
+              </button>
+            ) : null}
+          </div>
+
+          {remote.url ? (
+            <p className="settings-muted">
+              Open <code>{remote.url}</code> on another device on this network.
+              {remote.lanCandidates && remote.lanCandidates.length > 1
+                ? ` Other addresses: ${remote.lanCandidates.slice(1).join(", ")}.`
+                : ""}
+            </p>
+          ) : (
+            <p className="settings-muted">
+              Couldn’t determine this computer’s LAN address — check your network
+              connection.
+            </p>
+          )}
+
+          {/* Security note + platform firewall guidance (story 11). */}
+          <p className="settings-help">
+            Trusted local networks only. Traffic uses plain HTTP, so the password and
+            your content travel unencrypted on the LAN — do not port-forward this or
+            expose it to the public internet. The URL only works for devices on the same
+            network.
+          </p>
+          {remote.enabled ? (
+            remote.platform === "windows" ? (
+              <p className="settings-help">
+                The first time SceneWorks binds the network port, Windows shows a
+                “Windows Security Alert”. Allow SceneWorks on <strong>Private</strong>{" "}
+                networks (not Public), or remote devices can’t connect. To change it
+                later: Windows Security → Firewall &amp; network protection → Allow an
+                app through firewall.
+              </p>
+            ) : (
+              <p className="settings-help">
+                The first time SceneWorks binds the network port, macOS may ask to
+                “allow incoming connections” — click Allow. To change it later: System
+                Settings → Network → Firewall.
+              </p>
+            )
+          ) : null}
+          <p className="settings-muted">
+            Changing these settings takes effect after you restart SceneWorks.
+          </p>
         </section>
       ) : null}
 
@@ -238,16 +427,16 @@ export function SettingsScreen() {
         </section>
       ) : null}
 
-      {isDesktop ? (
-        <section className="settings-card">
-          <h3>Inference worker</h3>
-          <div className="settings-actions">
-            <button type="button" onClick={restartWorker}>
-              Restart worker
-            </button>
-          </div>
-        </section>
-      ) : null}
+      {/* Available in both modes: desktop restarts via Tauri, a remote admin via REST
+          (epic 4484 story 12). */}
+      <section className="settings-card">
+        <h3>Inference worker</h3>
+        <div className="settings-actions">
+          <button type="button" onClick={restartWorker}>
+            Restart worker
+          </button>
+        </div>
+      </section>
 
       {isDesktop ? (
         <section className="settings-card">

--- a/apps/web/src/screens/SettingsScreen.test.jsx
+++ b/apps/web/src/screens/SettingsScreen.test.jsx
@@ -186,4 +186,117 @@ describe("SettingsScreen server (REST) mode", () => {
       expect.objectContaining({ method: "PUT" }),
     );
   });
+
+  // epic 4484 stories 10/12: a remote browser hides the Tauri-only cards (including
+  // the desktop-only Remote Access controls) but keeps the inference-worker restart,
+  // which routes over REST instead of the Tauri command.
+  it("hides desktop-only cards and restarts the worker over REST", async () => {
+    await render();
+    expect(container.textContent).not.toContain("Remote access (LAN)");
+    expect(container.textContent).not.toContain("Data directory");
+    expect(container.textContent).not.toContain("Detected GPU");
+    expect(container.textContent).not.toContain("Setup wizard");
+    expect(container.textContent).toContain("Inference worker");
+    const restartButton = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent.trim() === "Restart worker",
+    );
+    expect(restartButton).toBeTruthy();
+    await click(restartButton);
+    expect(apiFetch).toHaveBeenCalledWith(
+      "/api/v1/worker/restart",
+      expect.anything(),
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+});
+
+describe("SettingsScreen remote access (desktop)", () => {
+  let container;
+  let root;
+  let invoke;
+  let remote;
+  let SettingsScreen;
+
+  beforeEach(async () => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    remote = {
+      enabled: false,
+      port: 8787,
+      passwordSet: false,
+      lanAddress: "192.168.1.50",
+      lanCandidates: ["192.168.1.50"],
+      url: "http://192.168.1.50:8787",
+      defaultPort: 8787,
+      platform: "macos",
+    };
+    invoke = vi.fn(async (command, args) => {
+      switch (command) {
+        case "get_app_settings":
+          return {};
+        case "get_gpu_info":
+          return { platform: "macos", devices: [] };
+        case "list_credentials":
+          return [];
+        case "get_remote_access":
+          return remote;
+        case "set_remote_access_password":
+          remote = { ...remote, passwordSet: true };
+          return remote;
+        case "clear_remote_access_password":
+          remote = { ...remote, passwordSet: false, enabled: false };
+          return remote;
+        case "set_remote_access":
+          remote = { ...remote, enabled: args.enabled, port: args.port };
+          return remote;
+        default:
+          return null;
+      }
+    });
+    window.__TAURI__ = { core: { invoke } };
+    vi.resetModules();
+    ({ SettingsScreen } = await import("./SettingsScreen.jsx"));
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    delete window.__TAURI__;
+    vi.restoreAllMocks();
+  });
+
+  async function render() {
+    await act(async () => {
+      root.render(<SettingsScreen />);
+    });
+    await act(async () => {});
+  }
+
+  const button = (label) =>
+    [...container.querySelectorAll("button")].find((b) => b.textContent.trim() === label);
+
+  it("shows the section, the LAN URL, and blocks enabling without a password", async () => {
+    await render();
+    expect(container.textContent).toContain("Remote access (LAN)");
+    expect(container.textContent).toContain("http://192.168.1.50:8787");
+    expect(button("Enable remote access").disabled).toBe(true);
+  });
+
+  it("sets a password, then can enable remote access on the chosen port", async () => {
+    await render();
+    await changeField(
+      container.querySelector('[aria-label="Remote access password"]'),
+      "lan-pass",
+    );
+    await click(button("Set password"));
+    expect(invoke).toHaveBeenCalledWith("set_remote_access_password", { password: "lan-pass" });
+    // Re-rendered with passwordSet → the enable button is now allowed.
+    expect(button("Enable remote access").disabled).toBe(false);
+    await click(button("Enable remote access"));
+    expect(invoke).toHaveBeenCalledWith("set_remote_access", { enabled: true, port: 8787 });
+  });
 });

--- a/crates/sceneworks-core/src/lib.rs
+++ b/crates/sceneworks-core/src/lib.rs
@@ -26,6 +26,14 @@ pub mod video_request;
 pub const API_PREFIX: &str = "/api/v1";
 pub const HEALTH_ROUTE: &str = "/health";
 
+/// Stdout sentinel for remote worker-restart (epic 4484 story 12). The API process
+/// doesn't supervise the desktop's GPU worker, so `POST /api/v1/worker/restart` prints
+/// this exact line to stdout; the desktop shell — which already reads the API sidecar's
+/// stdout — matches it and performs the same kill-and-respawn as its local "Restart
+/// worker" button. Shared here so the emitter (rust-api) and matcher (desktop) can
+/// never drift. Deliberately unique/unlikely to appear in ordinary log output.
+pub const WORKER_RESTART_SENTINEL: &str = "__SCENEWORKS_WORKER_RESTART_REQUESTED__";
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct HealthContract {
     route: &'static str,


### PR DESCRIPTION
## Summary
Implements **[epic 4484 — Desktop LAN Server Mode](https://app.shortcut.com/trefry/epic/4484)**: an opt-in setting that exposes the existing desktop-hosted Rust API + React UI over the local network, gated by a user-set password, so another device can open SceneWorks in a browser and submit work to the GPU host. **Off by default; macOS + Windows.**

Closes 12 of the 13 stories; story 13 is Windows real-hardware validation (needs a Windows/CUDA box — see below).

## What changed
**Desktop (sc-7062 / 7063 / 7064 / 7066)**
- `AppSettings` + keyring password helpers (OS Keychain / Windows Credential Manager); read only when LAN is opted into, so a default install never touches the keychain.
- `spawn_api()` picks the bind/auth env: loopback/dynamic (default) vs `0.0.0.0`/fixed-port + `SCENEWORKS_ACCESS_TOKEN=password` (LAN). **Fail-closed** — enabled-without-password binds loopback only, and `SCENEWORKS_ALLOW_OPEN_BIND` is *never* set (the server's open-bind refusal stays the backstop). GPU worker(s) receive the token so they keep reaching the now-authenticated API.
- `net.rs` computes the likely private LAN IPv4 (`if-addrs`, cross-platform) for the URL.

**Web (sc-7065 / 7067 / 7068 / 7069 / 7072)**
- `runtime.js`: a single `isDesktop`/`tauriInvoke` helper replacing 5 ad-hoc `window.__TAURI__` checks.
- Settings → **Remote Access (LAN)**: toggle, port, password set/change, status, computed URL + copy-to-clipboard, security note + platform-conditional firewall guidance (macOS prompt vs Windows Defender alert).
- Auth gate relabeled **"Pairing token" → "Password"**, verified via `/api/v1/auth/verify` *before* persisting (wrong password keeps the gate up), plus a **Lock** affordance.

**API + Web (sc-7070 / 7073)**
- `GET /api/v1/host-capabilities` surfaces host memory (unified on macOS / GPU VRAM on Windows) from the registered GPU worker so model gating works in a remote browser.
- `POST /api/v1/worker/restart` for remote admins: the API prints a shared stdout sentinel the desktop already reads, then reuses its kill-and-respawn. Both endpoints auth-protected.

## Tests (sc-7071)
- **Desktop** (18 pass): launch-env selection both modes, fail-closed, `ALLOW_OPEN_BIND` never set, port-marker parsing, LAN-address ranking, settings round-trip.
- **API**: new endpoints' auth protection + memory derivation; existing 401 / health-withholds-paths / access negatives cover the security story.
- **Web** (632 pass): remote-mode hides Tauri-only cards, restarts worker over REST, gates models from the REST memory signal; SettingsScreen remote-access section.

## Verification
`cargo test -p sceneworks-desktop` ✅ · `cargo test -p sceneworks-rust-api` ✅ · `cargo clippy --workspace --all-targets` ✅ clean · `npm run lint && npm test && npm run build` ✅ (632 tests).

## Not in this PR
- **Story 13 (sc-7074)** — end-to-end validation on real Windows/CUDA hardware. All Windows code paths are implemented (Credential Manager via keyring, Windows adapter enumeration, candle-worker token injection, `platform:"windows"` + VRAM in host-capabilities, Defender-firewall copy, candle-worker restart) but a manual pass on a Windows box is still required.
- QR-code URL affordance — the epic scopes this as an *optional* acceptance item beyond the copy-to-clipboard MVP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)