### PR TITLE
chore(worker): re-pin candle-gen to SCAIL-2 engine fixes + land GPU smoke (sc-7078)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -523,7 +523,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -535,7 +535,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -585,7 +585,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -596,7 +596,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -613,7 +613,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -628,7 +628,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -639,7 +639,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -654,7 +654,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -672,7 +672,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -683,7 +683,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -696,7 +696,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -707,7 +707,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -720,7 +720,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=fad25396ea0d45d8ddb280005c77a0ca37472fa5#fad25396ea0d45d8ddb280005c77a0ca37472fa5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
 dependencies = [
  "candle-core",
  "candle-gen",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -928,39 +928,39 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4d3a
 # byte-identical (gen-core adds the constrained-decoding contract the twin consumes), but the worker's
 # `--features backend-candle` skew gate still resolves the SINGLE gen-core rev 4d3aa49 shared with the
 # mlx pin. (Pre-merge branch SHA; flip to the merged candle-gen `main` rev once #113 lands.)
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -969,11 +969,11 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -982,19 +982,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1003,12 +1003,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1016,7 +1016,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1025,7 +1025,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1033,7 +1033,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1042,7 +1042,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1069,7 +1069,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fad25396ea0d45d8ddb280005c77a0ca37472fa5", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -110,6 +110,10 @@ use caption_jobs::*;
 mod prompt_refine_jobs;
 use prompt_refine_jobs::*;
 mod downloads;
+// Real-weight GPU smoke for the candle SCAIL-2 lane (sc-7078). Test-only + candle-only; never built
+// in normal compiles. Drives the shipped worker conditioning + `gen_core::load("scail2_14b")`.
+#[cfg(all(test, not(target_os = "macos"), feature = "backend-candle"))]
+mod scail2_gpu_smoke;
 // The DWPose skeleton rasterizer is consumed only by the macOS Z-Image strict-pose
 // control path; on Mac AND the off-Mac candle DWPose lane (sc-5496) it backs the
 // `pose_jobs` skeleton render; on a candle-disabled box off Mac it still builds +

--- a/crates/sceneworks-worker/src/scail2_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/scail2_gpu_smoke.rs
@@ -1,0 +1,236 @@
+//! Local real-weight GPU smoke for the candle SCAIL-2 worker lane (sc-6837 / sc-6836). `#[ignore]`d —
+//! run by hand on the RTX PRO 6000. It drives the **shipped** worker conditioning code
+//! ([`crate::person_segment_sam3_candle::segment_all_persons_in_memory`] + the [`crate::scail2_masks`]
+//! painters) and then the real candle SCAIL-2 engine via `gen_core::load("scail2_14b")` — the same
+//! runtime seam the worker uses, minus the API/job plumbing. This is the engine + worker-conditioning
+//! validation that backs both stories' GPU merge gate.
+//!
+//! Setup (PowerShell, after extracting driving frames + converting the reference to PNG):
+//! ```text
+//! $env:SCENEWORKS_CANDLE_SCAIL2_DIR="D:\sceneworks-scail2-validate\snapshot"
+//! $env:SCAIL2_SAM3_DIR="D:\sam3-weights"
+//! $env:SCAIL2_REF="D:\sceneworks-scail2-validate\joel.png"
+//! $env:SCAIL2_DRIVING_DIR="D:\sceneworks-scail2-validate\driving"
+//! $env:SCAIL2_OUT_DIR="D:\sceneworks-scail2-validate\out"
+//! # optional: SCAIL2_FRAMES=21 SCAIL2_STEPS=8 SCAIL2_W=640 SCAIL2_H=352 SCAIL2_MODE=animation|replacement
+//! cargo test -p sceneworks-worker --features backend-candle --release scail2_candle_gpu_smoke -- --ignored --nocapture
+//! ```
+
+use std::path::{Path, PathBuf};
+
+use gen_core::{
+    Conditioning, GenerationOutput, GenerationRequest, Image, LoadSpec, ReplacementMode,
+    WeightsSource,
+};
+
+fn env_path(key: &str) -> PathBuf {
+    // Trim: a cmd `set VAR=value && ...` keeps the trailing space before `&&`.
+    PathBuf::from(
+        std::env::var(key)
+            .unwrap_or_else(|_| panic!("set ${key}"))
+            .trim(),
+    )
+}
+
+fn env_or(key: &str, default: &str) -> String {
+    std::env::var(key)
+        .map(|v| v.trim().to_string())
+        .unwrap_or_else(|_| default.to_string())
+}
+
+fn load_rgb(path: &Path) -> Image {
+    let img = image::open(path)
+        .unwrap_or_else(|e| panic!("open {}: {e}", path.display()))
+        .to_rgb8();
+    Image {
+        width: img.width(),
+        height: img.height(),
+        pixels: img.into_raw(),
+    }
+}
+
+fn to_rgb_image(img: &Image) -> image::RgbImage {
+    image::RgbImage::from_raw(img.width, img.height, img.pixels.clone()).expect("rgb buffer")
+}
+
+/// Per-frame pixel std-dev, averaged — a cheap "is the clip non-degenerate" check (a NaN-clamped /
+/// all-black engine output collapses toward 0).
+fn avg_frame_std(frames: &[Image]) -> f64 {
+    let mut total = 0f64;
+    for f in frames {
+        let n = f.pixels.len() as f64;
+        let mean = f.pixels.iter().map(|&v| v as f64).sum::<f64>() / n;
+        let var = f
+            .pixels
+            .iter()
+            .map(|&v| {
+                let d = v as f64 - mean;
+                d * d
+            })
+            .sum::<f64>()
+            / n;
+        total += var.sqrt();
+    }
+    total / frames.len().max(1) as f64
+}
+
+#[test]
+#[ignore = "real-weight GPU smoke; needs the candle SCAIL-2 snapshot + SAM3 weights + driving assets"]
+fn scail2_candle_gpu_smoke() {
+    // Anchor the provider's inventory registration into the test binary (mirrors video_jobs.rs).
+    use candle_gen_scail2 as _;
+
+    let snapshot = env_path("SCENEWORKS_CANDLE_SCAIL2_DIR");
+    let sam3_dir = env_path("SCAIL2_SAM3_DIR");
+    let sam3_model = sam3_dir.join("model.safetensors");
+    let sam3_tok = sam3_dir.join("tokenizer.json");
+    let ref_path = env_path("SCAIL2_REF");
+    let driving_dir = env_path("SCAIL2_DRIVING_DIR");
+    let out_dir = env_path("SCAIL2_OUT_DIR");
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+
+    let frames_n: usize = env_or("SCAIL2_FRAMES", "21")
+        .parse()
+        .expect("SCAIL2_FRAMES");
+    let steps: u32 = env_or("SCAIL2_STEPS", "8").parse().expect("SCAIL2_STEPS");
+    let width: u32 = env_or("SCAIL2_W", "640").parse().expect("SCAIL2_W");
+    let height: u32 = env_or("SCAIL2_H", "352").parse().expect("SCAIL2_H");
+    let mode = env_or("SCAIL2_MODE", "animation"); // "animation" | "replacement"
+    let replacement = mode == "replacement";
+    // Optional CFG override: unset → engine DEFAULT_GUIDANCE; "1.0" disables CFG (pure conditional).
+    let guidance: Option<f32> = std::env::var("SCAIL2_GUIDANCE")
+        .ok()
+        .and_then(|v| v.trim().parse().ok());
+    // Optional explicit prompt / negative prompt (defaults below).
+    let prompt = env_or("SCAIL2_PROMPT", "a person performing the driving motion");
+    let neg = std::env::var("SCAIL2_NEG")
+        .ok()
+        .map(|v| v.trim().to_string());
+
+    // --- reference character + its color-coded mask (SAM3 -> the primary person painted blue) ---
+    // Animation keeps the reference's world (white bg); replacement discards it (black bg).
+    let reference = load_rgb(&ref_path);
+    let ref_rgb = to_rgb_image(&reference);
+    let ref_masks = crate::person_segment_sam3_candle::segment_all_persons_in_memory(
+        &sam3_model,
+        &sam3_tok,
+        std::slice::from_ref(&ref_rgb),
+    )
+    .expect("sam3 reference segmentation");
+    let ref_bg = if replacement {
+        crate::scail2_masks::BG_BLACK
+    } else {
+        crate::scail2_masks::BG_WHITE
+    };
+    let ref_mask = crate::scail2_masks::paint_reference_mask(&ref_masks, ref_bg).expect("ref mask");
+
+    // --- driving frames + per-frame color masks (SAM3 -> every person painted its palette color) ---
+    let mut paths: Vec<PathBuf> = std::fs::read_dir(&driving_dir)
+        .expect("read driving dir")
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.extension().map(|x| x == "png").unwrap_or(false))
+        .collect();
+    paths.sort();
+    paths.truncate(frames_n);
+    assert!(
+        !paths.is_empty(),
+        "no driving .png frames in {}",
+        driving_dir.display()
+    );
+    let driving: Vec<Image> = paths.iter().map(|p| load_rgb(p)).collect();
+    let driving_rgb: Vec<image::RgbImage> = driving.iter().map(to_rgb_image).collect();
+    let drive_masks = crate::person_segment_sam3_candle::segment_all_persons_in_memory(
+        &sam3_model,
+        &sam3_tok,
+        &driving_rgb,
+    )
+    .expect("sam3 driving segmentation");
+    let drive_bg = if replacement {
+        crate::scail2_masks::BG_WHITE
+    } else {
+        crate::scail2_masks::BG_BLACK
+    };
+    let driving_masks = crate::scail2_masks::paint_driving_masks(&drive_masks, drive_bg);
+    assert_eq!(
+        driving_masks.len(),
+        driving.len(),
+        "one mask per driving frame"
+    );
+
+    println!(
+        "[smoke] ref {}x{} | {} driving frames @ {}x{} | mode={mode} steps={steps}",
+        reference.width,
+        reference.height,
+        driving.len(),
+        width,
+        height
+    );
+
+    // --- build the request + run the engine via the worker's runtime seam (gen_core::load) ---
+    let conditioning = vec![
+        Conditioning::Reference {
+            image: reference,
+            strength: None,
+        },
+        Conditioning::Mask { image: ref_mask },
+        Conditioning::ControlClip {
+            frames: driving,
+            mask: driving_masks,
+            masking_strength: 1.0,
+            start_frame: 0,
+            mode: ReplacementMode::default(),
+        },
+    ];
+    let req = GenerationRequest {
+        prompt,
+        negative_prompt: neg,
+        width,
+        height,
+        frames: Some(frames_n as u32),
+        fps: Some(16),
+        steps: Some(steps),
+        guidance,
+        seed: Some(42),
+        conditioning,
+        video_mode: Some(mode.clone()),
+        ..Default::default()
+    };
+    let spec = LoadSpec::new(WeightsSource::Dir(snapshot));
+    let generator = gen_core::load("scail2_14b", &spec).expect("load scail2_14b candle provider");
+
+    let mut last = String::new();
+    let output = generator
+        .generate(&req, &mut |p| {
+            let s = format!("{p:?}");
+            if s != last {
+                println!("[progress] {s}");
+                last = s;
+            }
+        })
+        .expect("scail2 generate");
+
+    let out_frames = match output {
+        GenerationOutput::Video { frames, .. } => frames,
+        other => panic!("expected Video output, got {other:?}"),
+    };
+    assert!(!out_frames.is_empty(), "engine returned no frames");
+
+    for (i, f) in out_frames.iter().enumerate() {
+        let p = out_dir.join(format!("out_{i:05}.png"));
+        image::RgbImage::from_raw(f.width, f.height, f.pixels.clone())
+            .expect("out frame buffer")
+            .save(&p)
+            .unwrap_or_else(|e| panic!("save {}: {e}", p.display()));
+    }
+    let avg_std = avg_frame_std(&out_frames);
+    println!(
+        "[smoke] DONE: wrote {} frames to {} (avg per-frame std {:.2})",
+        out_frames.len(),
+        out_dir.display(),
+        avg_std
+    );
+    assert!(
+        avg_std > 5.0,
+        "output frames look degenerate (avg std {avg_std:.2}) — possible NaN / all-black decode"
+    );
+}


### PR DESCRIPTION
## What

Re-pins all 22 `candle-gen-*` worker deps `fad2539 → 774fb31`, linking the candle **SCAIL-2** engine (`scail2_14b`) with the three GPU-bring-up fixes that make it produce coherent output for the first time:

- candle-gen **#114** — `candle-gen-scail2` provider
- candle-gen **#115** — img_emb MLPProj dims (load crash)
- candle-gen **#116** — unpatchify channel order (noise output) + empty-prompt embedding gather (the "UMT5 CUBLAS" crash)

`774fb31` is #116's content commit (a **durable ancestor** of the #116 merge) and pins **gen-core `4d3aa49` == this worker's mlx pin**, so `--features backend-candle` resolves a **single gen-core rev** — no skew. (The #116 *merge* pins gen-core `7b97542`, advanced by #117/sc-7076, which is why this re-pins to the content commit, not the merge.)

Also lands **`scail2_gpu_smoke.rs`** — an `#[ignore]`'d real-weight GPU smoke (test-only, candle-only) that drives the shipped worker conditioning (`person_segment_sam3_candle` + `scail2_masks`) + `gen_core::load("scail2_14b")`, the same runtime seam the worker uses.

## Validation

- **backend-candle** `cargo clippy -p sceneworks-worker --features backend-candle --tests` green; the smoke test compiles into the candle test binary; gen-core single rev.
- **GPU (RTX PRO 6000)** via the smoke harness: **animation** (reference identity preserved, follows the driving motion — arms-down → arms-raised) and **cross-identity replacement** both produce coherent video. Denoise converges (final-latent std → 0.79 at 40 steps).

## Scope

Closes the GPU gate for **sc-6836** (provider), completes **sc-6837**'s animate+replace validation (worker routing already merged in #851), and **sc-7078** (engine bring-up). No gen-core / mlx pin change. The default PR gate is unaffected (candle deps are optional / cfg-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)