### PR TITLE
feat(worker): wire candle SCAIL-2 inference LoRA + lightning/DPO toggles (sc-6838)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=13405ce0539b792b9e34a2ffc0161fbd36f3b6ea#13405ce0539b792b9e34a2ffc0161fbd36f3b6ea"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=13405ce0539b792b9e34a2ffc0161fbd36f3b6ea#13405ce0539b792b9e34a2ffc0161fbd36f3b6ea"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=13405ce0539b792b9e34a2ffc0161fbd36f3b6ea#13405ce0539b792b9e34a2ffc0161fbd36f3b6ea"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=13405ce0539b792b9e34a2ffc0161fbd36f3b6ea#13405ce0539b792b9e34a2ffc0161fbd36f3b6ea"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=13405ce0539b792b9e34a2ffc0161fbd36f3b6ea#13405ce0539b792b9e34a2ffc0161fbd36f3b6ea"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=13405ce0539b792b9e34a2ffc0161fbd36f3b6ea#13405ce0539b792b9e34a2ffc0161fbd36f3b6ea"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -523,7 +523,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=13405ce0539b792b9e34a2ffc0161fbd36f3b6ea#13405ce0539b792b9e34a2ffc0161fbd36f3b6ea"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -535,7 +535,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=13405ce0539b792b9e34a2ffc0161fbd36f3b6ea#13405ce0539b792b9e34a2ffc0161fbd36f3b6ea"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=13405ce0539b792b9e34a2ffc0161fbd36f3b6ea#13405ce0539b792b9e34a2ffc0161fbd36f3b6ea"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=13405ce0539b792b9e34a2ffc0161fbd36f3b6ea#13405ce0539b792b9e34a2ffc0161fbd36f3b6ea"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=13405ce0539b792b9e34a2ffc0161fbd36f3b6ea#13405ce0539b792b9e34a2ffc0161fbd36f3b6ea"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -585,7 +585,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=13405ce0539b792b9e34a2ffc0161fbd36f3b6ea#13405ce0539b792b9e34a2ffc0161fbd36f3b6ea"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -596,7 +596,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=13405ce0539b792b9e34a2ffc0161fbd36f3b6ea#13405ce0539b792b9e34a2ffc0161fbd36f3b6ea"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -613,7 +613,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=13405ce0539b792b9e34a2ffc0161fbd36f3b6ea#13405ce0539b792b9e34a2ffc0161fbd36f3b6ea"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -628,7 +628,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=13405ce0539b792b9e34a2ffc0161fbd36f3b6ea#13405ce0539b792b9e34a2ffc0161fbd36f3b6ea"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -639,7 +639,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=13405ce0539b792b9e34a2ffc0161fbd36f3b6ea#13405ce0539b792b9e34a2ffc0161fbd36f3b6ea"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -654,7 +654,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=13405ce0539b792b9e34a2ffc0161fbd36f3b6ea#13405ce0539b792b9e34a2ffc0161fbd36f3b6ea"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -672,7 +672,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=13405ce0539b792b9e34a2ffc0161fbd36f3b6ea#13405ce0539b792b9e34a2ffc0161fbd36f3b6ea"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -683,7 +683,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=13405ce0539b792b9e34a2ffc0161fbd36f3b6ea#13405ce0539b792b9e34a2ffc0161fbd36f3b6ea"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -696,7 +696,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=13405ce0539b792b9e34a2ffc0161fbd36f3b6ea#13405ce0539b792b9e34a2ffc0161fbd36f3b6ea"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -707,7 +707,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=13405ce0539b792b9e34a2ffc0161fbd36f3b6ea#13405ce0539b792b9e34a2ffc0161fbd36f3b6ea"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -720,7 +720,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=774fb317de56ba03ad532705e733e6572cbdf9fe#774fb317de56ba03ad532705e733e6572cbdf9fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=13405ce0539b792b9e34a2ffc0161fbd36f3b6ea#13405ce0539b792b9e34a2ffc0161fbd36f3b6ea"
 dependencies = [
  "candle-core",
  "candle-gen",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -4180,10 +4180,11 @@ fn video_request_candle_vace_eligible(
 /// engine (NOT Wan-VACE), so it has its own gate rather than membership in [`CANDLE_VIDEO_VACE_MODELS`]:
 /// the `scail2_14b` model + the `animate_character` mode + a reference character image
 /// (`referenceAssetId` / `referenceAssetIds` / `sourceAssetId`) + a driving clip (`sourceClipAssetId`).
-/// LoRA / on-the-fly quant are not on the candle path (the provider rejects them; inference LoRA is the
-/// follow-up sc-6838). Mirrors the MLX `video_mode_is_mlx_eligible(scail2_14b, animate_character)` shape,
-/// expressed as a candle-claim gate. Factored out so the routing tests can probe it with synthetic
-/// payloads (parity with [`video_request_candle_eligible`]).
+/// Inference LoRA / LoKr / LoHa + the Bias-Aware DPO LoRA + the lightx2v lightning diff-patch ARE on the
+/// candle path now (sc-6838 — the provider merges them into the dense DiT), so a LoRA-bearing animate job
+/// stays on candle. On-the-fly quantization is still torch (the candle provider is dense). Mirrors the
+/// MLX `video_mode_is_mlx_eligible(scail2_14b, animate_character)` shape, expressed as a candle-claim
+/// gate. Factored out so the routing tests can probe it (parity with [`video_request_candle_eligible`]).
 fn scail2_animate_candle_eligible(model: &str, payload: &Map<String, Value>) -> bool {
     if model != "scail2_14b" {
         return false;
@@ -4212,13 +4213,8 @@ fn scail2_animate_candle_eligible(model: &str, payload: &Map<String, Value>) -> 
     if !has_nonempty_id("sourceClipAssetId") {
         return false;
     }
-    if payload
-        .get("loras")
-        .and_then(Value::as_array)
-        .is_some_and(|loras| !loras.is_empty())
-    {
-        return false;
-    }
+    // Inference LoRA (DPO / lightning / user adapter) merges into the candle DiT (sc-6838), so a
+    // LoRA-bearing animate job is candle-eligible — only on-the-fly quant still falls back to torch.
     if candle_request_wants_quant(payload) {
         return false;
     }
@@ -6410,6 +6406,20 @@ mod candle_routing_tests {
                 "scail2 animate_character must be candle-eligible: {payload:?}"
             );
         }
+        // An animate job carrying an inference LoRA (DPO / lightning / user adapter) stays on candle —
+        // the provider merges it into the dense DiT (sc-6838); only on-the-fly quant defers to torch.
+        assert!(
+            scail2_animate_candle_eligible(
+                "scail2_14b",
+                &object(json!({
+                    "mode": "animate_character",
+                    "referenceAssetIds": ["ref_1"],
+                    "sourceClipAssetId": "clip_1",
+                    "loras": [{ "name": "scail2-dpo" }]
+                }))
+            ),
+            "scail2 animate with a LoRA must stay candle-eligible (sc-6838)"
+        );
         // Cross-identity replacement: scail2_14b PersonReplace with the clip + track + character.
         assert!(scail2_replace_candle_eligible(
             "scail2_14b",
@@ -6462,22 +6472,17 @@ mod candle_routing_tests {
                 "sourceClipAssetId": "c"
             }))
         ));
-        // LoRA / on-the-fly quant defer to torch (the candle SCAIL-2 path has no LoRA yet — sc-6838).
-        for extra in [
-            json!({ "loras": [{ "name": "x" }] }),
-            json!({ "advanced": { "mlxQuantize": 8 } }),
-        ] {
+        // On-the-fly quant still defers to torch (the candle SCAIL-2 provider is dense).
+        {
             let mut payload = object(json!({
                 "mode": "animate_character",
                 "sourceAssetId": "i",
                 "sourceClipAssetId": "c"
             }));
-            for (k, v) in object(extra) {
-                payload.insert(k, v);
-            }
+            payload.insert("advanced".into(), json!({ "mlxQuantize": 8 }));
             assert!(
                 !scail2_animate_candle_eligible("scail2_14b", &payload),
-                "scail2 animate with LoRA/quant must defer to torch: {payload:?}"
+                "scail2 animate with on-the-fly quant must defer to torch: {payload:?}"
             );
         }
         // replace_person needs the clip + track + character; missing any → torch.

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -928,39 +928,39 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4d3a
 # byte-identical (gen-core adds the constrained-decoding contract the twin consumes), but the worker's
 # `--features backend-candle` skew gate still resolves the SINGLE gen-core rev 4d3aa49 shared with the
 # mlx pin. (Pre-merge branch SHA; flip to the merged candle-gen `main` rev once #113 lands.)
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "13405ce0539b792b9e34a2ffc0161fbd36f3b6ea", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "13405ce0539b792b9e34a2ffc0161fbd36f3b6ea", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "13405ce0539b792b9e34a2ffc0161fbd36f3b6ea", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "13405ce0539b792b9e34a2ffc0161fbd36f3b6ea", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "13405ce0539b792b9e34a2ffc0161fbd36f3b6ea", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "13405ce0539b792b9e34a2ffc0161fbd36f3b6ea", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "13405ce0539b792b9e34a2ffc0161fbd36f3b6ea", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "13405ce0539b792b9e34a2ffc0161fbd36f3b6ea", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "13405ce0539b792b9e34a2ffc0161fbd36f3b6ea", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "13405ce0539b792b9e34a2ffc0161fbd36f3b6ea", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -969,11 +969,11 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "13405ce0539b792b9e34a2ffc0161fbd36f3b6ea", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "13405ce0539b792b9e34a2ffc0161fbd36f3b6ea", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -982,19 +982,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "13405ce0539b792b9e34a2ffc0161fbd36f3b6ea", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "13405ce0539b792b9e34a2ffc0161fbd36f3b6ea", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "13405ce0539b792b9e34a2ffc0161fbd36f3b6ea", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1003,12 +1003,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "13405ce0539b792b9e34a2ffc0161fbd36f3b6ea", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "13405ce0539b792b9e34a2ffc0161fbd36f3b6ea", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1016,7 +1016,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "13405ce0539b792b9e34a2ffc0161fbd36f3b6ea", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1025,7 +1025,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "13405ce0539b792b9e34a2ffc0161fbd36f3b6ea", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1033,7 +1033,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "13405ce0539b792b9e34a2ffc0161fbd36f3b6ea", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1042,7 +1042,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "13405ce0539b792b9e34a2ffc0161fbd36f3b6ea", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1069,7 +1069,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "774fb317de56ba03ad532705e733e6572cbdf9fe", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "13405ce0539b792b9e34a2ffc0161fbd36f3b6ea", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/scail2_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/scail2_gpu_smoke.rs
@@ -19,8 +19,8 @@
 use std::path::{Path, PathBuf};
 
 use gen_core::{
-    Conditioning, GenerationOutput, GenerationRequest, Image, LoadSpec, ReplacementMode,
-    WeightsSource,
+    AdapterKind, AdapterSpec, Conditioning, GenerationOutput, GenerationRequest, Image, LoadSpec,
+    ReplacementMode, WeightsSource,
 };
 
 fn env_path(key: &str) -> PathBuf {
@@ -195,7 +195,32 @@ fn scail2_candle_gpu_smoke() {
         video_mode: Some(mode.clone()),
         ..Default::default()
     };
-    let spec = LoadSpec::new(WeightsSource::Dir(snapshot));
+    // Optional inference LoRA (sc-6838): SCAIL2_LORA=<.safetensors> merges into the dense DiT before
+    // build. SCAIL2_LORA_SCALE (default 1.0) + SCAIL2_LORA_KIND (lora|lokr, default lora). A lightx2v
+    // lightning diff-patch file carries `.diff`/`.diff_b` deltas + the cross-arch `patch_embedding`
+    // skip; pair it with SCAIL2_STEPS=8 / SCAIL2_GUIDANCE=1.0 for the step-distill recipe. Unset →
+    // the byte-identical no-adapter (regression) path.
+    let spec = match std::env::var("SCAIL2_LORA")
+        .ok()
+        .map(|v| v.trim().to_string())
+    {
+        Some(p) if !p.is_empty() => {
+            let scale: f32 = env_or("SCAIL2_LORA_SCALE", "1.0")
+                .parse()
+                .expect("SCAIL2_LORA_SCALE");
+            let kind = match env_or("SCAIL2_LORA_KIND", "lora").as_str() {
+                "lokr" => AdapterKind::Lokr,
+                _ => AdapterKind::Lora,
+            };
+            println!("[smoke] merging adapter {p} (scale {scale}, {kind:?})");
+            LoadSpec::new(WeightsSource::Dir(snapshot)).with_adapters(vec![AdapterSpec::new(
+                PathBuf::from(p),
+                scale,
+                kind,
+            )])
+        }
+        _ => LoadSpec::new(WeightsSource::Dir(snapshot)),
+    };
     let generator = gen_core::load("scail2_14b", &spec).expect("load scail2_14b candle provider");
 
     let mut last = String::new();

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -468,7 +468,8 @@ pub(crate) async fn run_video_generate_job(
                 (
                     decoded,
                     CANDLE_SCAIL2_ADAPTER,
-                    candle_scail2_raw_settings(&request),
+                    // The replace_person path doesn't resolve user LoRAs (sc-5452), so no lightning recipe.
+                    candle_scail2_raw_settings(&request, false),
                     Some(status),
                 )
             } else {
@@ -3197,10 +3198,11 @@ fn resolve_candle_scail2_model_dir(settings: &Settings) -> WorkerResult<PathBuf>
     )))
 }
 
-/// Raw-settings recorded on a candle SCAIL-2 asset (mirrors `candle_video_raw_settings` + the macOS
-/// `scail2_raw_settings`, trimmed to the no-LoRA candle surface — inference LoRA is sc-6838).
+/// Raw-settings recorded on a candle SCAIL-2 asset (mirrors the macOS `scail2_raw_settings`). When a
+/// lightx2v lightning LoRA is applied (`lightning`, sc-6838), records the effective step-distill recipe
+/// the worker dispatched so the chosen steps/CFG/shift is inspectable on the asset, not silent.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-fn candle_scail2_raw_settings(request: &VideoRequest) -> Value {
+fn candle_scail2_raw_settings(request: &VideoRequest, lightning: bool) -> Value {
     let mut raw = request.advanced.clone();
     raw.insert("realModelInference".to_owned(), Value::Bool(true));
     raw.insert("model".to_owned(), Value::String(request.model.clone()));
@@ -3210,7 +3212,142 @@ fn candle_scail2_raw_settings(request: &VideoRequest) -> Value {
         "scail2Task".to_owned(),
         Value::String(candle_scail2_engine_video_mode(&request.mode).to_owned()),
     );
+    if lightning {
+        let (steps, guidance, shift) = candle_scail2_sampling(request, true);
+        raw.insert("scail2Lightning".to_owned(), Value::Bool(true));
+        if let Some(steps) = steps {
+            raw.insert("effectiveSteps".to_owned(), json!(steps));
+        }
+        if let Some(guidance) = guidance {
+            raw.insert("effectiveGuidanceScale".to_owned(), json!(guidance));
+        }
+        if let Some(shift) = shift {
+            raw.insert("effectiveSchedulerShift".to_owned(), json!(shift));
+        }
+    }
     Value::Object(raw)
+}
+
+/// Max LoRAs per candle SCAIL-2 job (matches the macOS `MAX_JOB_LORAS`).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+const CANDLE_SCAIL2_MAX_LORAS: usize = 3;
+
+/// The lightx2v lightning step-distill recipe (sc-6838, the candle sibling of the MLX sc-5684/5700
+/// recipe): 8 steps, CFG off, scheduler shift 1.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+const CANDLE_SCAIL2_LIGHTNING_STEPS: u32 = 8;
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+const CANDLE_SCAIL2_LIGHTNING_GUIDANCE: f32 = 1.0;
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+const CANDLE_SCAIL2_LIGHTNING_SHIFT: f32 = 1.0;
+
+/// A LoRA spec's strength (`weight`, default 0.8 — matches the macОS `lora_scale`).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn candle_scail2_lora_scale(lora: &Value) -> f32 {
+    lora.get("weight")
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .unwrap_or(0.8) as f32
+}
+
+/// Resolve a LoRA spec's file (a directory → its first `.safetensors`), confined to an app-managed root
+/// (sc-5723 / WKA-002) before any on-disk use — the candle sibling of the macOS `resolve_lora_file`.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn candle_resolve_lora_file(settings: &Settings, path: PathBuf) -> WorkerResult<PathBuf> {
+    let path = crate::normalize_app_managed_lora_path(settings, &path)?;
+    let file = if path.is_dir() {
+        let mut entries: Vec<PathBuf> = std::fs::read_dir(&path)
+            .map_err(|e| WorkerError::InvalidPayload(format!("LoRA dir {}: {e}", path.display())))?
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter(|p| p.extension().is_some_and(|x| x == "safetensors"))
+            .collect();
+        entries.sort();
+        entries.into_iter().next().ok_or_else(|| {
+            WorkerError::InvalidPayload(format!(
+                "LoRA has no .safetensors under {}",
+                path.display()
+            ))
+        })?
+    } else {
+        path
+    };
+    if !file.exists() {
+        return Err(WorkerError::InvalidPayload(format!(
+            "LoRA file is missing: {}",
+            file.display()
+        )));
+    }
+    Ok(file)
+}
+
+/// Build the candle SCAIL-2 adapter specs from `request.loras` — the candle sibling of the macOS
+/// `resolve_scail2_adapters` (sc-5451). SCAIL-2 is a single dense Wan2.1-14B-I2V transformer (no MoE
+/// high/low), so every adapter is shared (`moe_expert: None`); the engine merges LoRA / LoKr / LoHa and
+/// the lightx2v lightning diff-patch into the dense DiT before build ([`candle_gen_scail2::merge_adapters`]).
+/// Carries both a user-selected SCAIL-2 LoRA and the bundled Bias-Aware DPO quality LoRA (both surface
+/// through `request.loras`); selecting a lightning diff-patch LoRA makes the worker apply the
+/// step-distill recipe ([`candle_scail2_sampling`]).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn candle_resolve_scail2_adapters(
+    settings: &Settings,
+    request: &VideoRequest,
+) -> WorkerResult<Vec<AdapterSpec>> {
+    if request.loras.len() > CANDLE_SCAIL2_MAX_LORAS {
+        return Err(WorkerError::InvalidPayload(format!(
+            "Generation supports at most {CANDLE_SCAIL2_MAX_LORAS} LoRAs per job."
+        )));
+    }
+    let mut specs: Vec<AdapterSpec> = Vec::new();
+    for lora in &request.loras {
+        let path = crate::image_jobs::lora_path(lora).ok_or_else(|| {
+            WorkerError::InvalidPayload("LoRA is missing a usable path.".to_owned())
+        })?;
+        let file = candle_resolve_lora_file(settings, path)?;
+        let kind = crate::image_jobs::classify_adapter(&file)?;
+        specs.push(AdapterSpec {
+            path: file,
+            scale: candle_scail2_lora_scale(lora),
+            kind,
+            pass_scales: None,
+            moe_expert: None,
+        });
+    }
+    Ok(specs)
+}
+
+/// `true` if any resolved adapter is a lightx2v diff-patch ("lightning") LoRA — the engine's own
+/// detector (a file carrying full-rank `.diff`/`.diff_b` tensors), so the recipe keys off the actual
+/// format, not a catalog id or filename. A file that can't be read is treated as non-lightning (the
+/// engine surfaces the real load error downstream). The candle sibling of the macOS
+/// `scail2_adapters_have_lightning`.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn candle_scail2_adapters_have_lightning(adapters: &[AdapterSpec]) -> bool {
+    adapters
+        .iter()
+        .any(|a| candle_gen_scail2::has_diff_patch_keys(&a.path).unwrap_or(false))
+}
+
+/// SCAIL-2 sampling recipe `(steps, guidance, scheduler_shift)`. When a lightx2v diff-patch "lightning"
+/// LoRA is selected (`lightning`), apply the step-distill recipe (CFG off → the engine short-circuits to
+/// a single DiT forward per step, scheduler shift 1.0; step count defaults to 8 but honors an explicit
+/// `advanced.steps`). Without it, all-`None` so the engine's quality defaults stand. The candle sibling
+/// of the macOS `scail2_sampling`.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn candle_scail2_sampling(
+    request: &VideoRequest,
+    lightning: bool,
+) -> (Option<u32>, Option<f32>, Option<f32>) {
+    if !lightning {
+        return (None, None, None);
+    }
+    (
+        advanced_opt_u32(request, "steps").or(Some(CANDLE_SCAIL2_LIGHTNING_STEPS)),
+        Some(CANDLE_SCAIL2_LIGHTNING_GUIDANCE),
+        Some(CANDLE_SCAIL2_LIGHTNING_SHIFT),
+    )
 }
 
 /// Resolve a candle SCAIL-2 `animate_character` request into the engine conditioning — the candle
@@ -3340,11 +3477,12 @@ async fn resolve_candle_scail2_conditioning(
     ])
 }
 
-/// Real candle SCAIL-2 character animation (sc-6837): build the `VideoGenInput` and run the shared
-/// `generate_video` path. `animate_character` → engine task `animation`; the source media becomes the
-/// SAM3-painted conditioning. No LoRA / quant on the candle path (the provider rejects them — inference
-/// LoRA is sc-6838); steps/guidance stay at the engine defaults. Frame count uses the Wan 1-mod-4
-/// stride (the renderer is Wan2.1); the engine stitches > 81-frame clips into overlapping segments.
+/// Real candle SCAIL-2 character animation (sc-6837 + sc-6838): build the `VideoGenInput` and run the
+/// shared `generate_video` path. `animate_character` → engine task `animation`; the source media becomes
+/// the SAM3-painted conditioning. Inference LoRA / LoKr / LoHa + the Bias-Aware DPO LoRA + the lightx2v
+/// lightning diff-patch resolve from `request.loras` and merge into the dense DiT (sc-6838); a lightning
+/// LoRA also applies the step-distill recipe (8 steps / CFG-off / shift 1). Frame count uses the Wan
+/// 1-mod-4 stride (the renderer is Wan2.1); the engine stitches > 81-frame clips into overlapping segments.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 async fn generate_candle_scail2(
     api: &ApiClient,
@@ -3361,9 +3499,14 @@ async fn generate_candle_scail2(
     };
     let conditioning =
         resolve_candle_scail2_conditioning(api, settings, job, request, project_path).await?;
+    // Inference adapters (DPO / lightning / user LoRA) + the lightning step-distill recipe.
+    let adapters = candle_resolve_scail2_adapters(settings, request)?;
+    let lightning = candle_scail2_adapters_have_lightning(&adapters);
+    let (steps, guidance, scheduler_shift) = candle_scail2_sampling(request, lightning);
     let input = VideoGenInput {
         engine_id,
         model_dir: resolve_candle_scail2_model_dir(settings)?,
+        adapters,
         conditioning,
         prompt: request.prompt.clone(),
         negative_prompt,
@@ -3371,6 +3514,9 @@ async fn generate_candle_scail2(
         height: request.height,
         frames: wan_frame_count(request.raw_frame_count()),
         fps: request.fps,
+        steps,
+        guidance,
+        scheduler_shift,
         seed: resolve_video_seed(request) as u64,
         video_mode: Some(candle_scail2_engine_video_mode(&request.mode).to_owned()),
         ..VideoGenInput::default()
@@ -3379,7 +3525,7 @@ async fn generate_candle_scail2(
     Ok((
         decoded,
         CANDLE_SCAIL2_ADAPTER,
-        candle_scail2_raw_settings(request),
+        candle_scail2_raw_settings(request, lightning),
     ))
 }
 


### PR DESCRIPTION
**Story:** [sc-6838](https://app.shortcut.com/trefry/story/6838) (epic 6563 — candle/CUDA SCAIL-2, the LAST story). The off-Mac worker sibling of the MLX SCAIL-2 LoRA wiring (sc-5451 + sc-5684/5700). Pairs with provider PR **[candle-gen#118](https://github.com/SceneWorks/candle-gen/pull/118)**.

## What
Routes inference LoRA / LoKr / LoHa + the **Bias-Aware DPO** quality LoRA + the **lightx2v lightning** diff-patch through the candle SCAIL-2 lane (the provider merges them into the dense DiT before build).

`video_jobs.rs` (candle lane, all inside the `not(macos)+backend-candle` cfg — zero churn to the macOS build):
- `candle_resolve_scail2_adapters` — `AdapterSpec`s from `request.loras` (app-managed path confinement + `classify_adapter`).
- `candle_scail2_adapters_have_lightning` → `candle_gen_scail2::has_diff_patch_keys` (keys off the actual diff-patch format, not a catalog id/filename).
- `candle_scail2_sampling` — lightning step-distill recipe (8 steps / CFG-off / shift 1; honors an explicit `advanced.steps`), else the engine quality defaults.
- `generate_candle_scail2` threads the adapters + recipe into `VideoGenInput`; `candle_scail2_raw_settings` records the effective recipe (`scail2Lightning` / `effectiveSteps` / `effectiveGuidanceScale` / `effectiveSchedulerShift`) so what ran is inspectable on the asset.

`jobs_store.rs` (sceneworks-core): `scail2_14b` `animate_character` is now candle-eligible **with** a LoRA (only on-the-fly quant still defers to torch); `replace_person` unchanged (doesn't resolve user LoRAs — MLX parity). Routing tests flipped + a positive LoRA-eligible case added.

## Cargo / skew
Re-pin all 22 candle-gen-* deps `774fb31` → `0ec4163` (the candle-gen#118 **content commit**, a durable ancestor of its merge). `0ec4163` pins gen-core `4d3aa49` == the worker's mlx pin → **single gen-core rev, no skew** (`scripts/check-gen-core-skew.sh` OK).

## Gates
- `cargo clippy -p sceneworks-worker --features backend-candle --all-targets` **clean** (VS2022 14.44, `CUDA_COMPUTE_CAP=120`).
- `sceneworks-core` scail2 candle routing tests green.
- gen-core skew check: exactly one rev (`4d3aa49`).

## Merge order / follow-up
- Merge **candle-gen#118 first** (the worker pins its content commit `0ec4163`).
- GPU validation on the RTX PRO 6000 (lightx2v lightning 8-step merged animation + empty-adapter regression) is the merge-gate follow-up — the lightx2v LoRA is downloaded on the box; running via the extended `scail2_gpu_smoke`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)