### PR TITLE
feat(worker): N3 sampler/scheduler fallback + video plumb (sc-7127)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -766,6 +766,95 @@ pub(crate) fn emit_load_event(event: &str, job_id: &str, engine: &str, adapter_c
     );
 }
 
+/// N3 (epic 7114): a per-generation `sampler` / `scheduler` knob that names something the engine does
+/// NOT advertise must never hard-fail the generation. `gen_core::Capabilities::validate_request` (and
+/// each engine's own `validate`) rejects an unadvertised name with an `Err`, so the worker pre-filters
+/// the knob here against the linked descriptor's advertised surface (`Capabilities.samplers` /
+/// `.schedulers`): an advertised name passes through untouched; an unknown one — a stale recipe, a
+/// per-backend capability gap (candle advertises a narrower set than mlx until P4), or manifest drift —
+/// is dropped back to the engine default (`None`) and a `sampling_knob_unsupported` worker event is
+/// emitted for observability. `None` and the `"default"` sentinel are already stripped at the read site,
+/// so this only fires on a real, unsupported name. Shared by the MLX (`generate_stream`) + candle
+/// (`generate_candle_stream`) image lanes and the video lane (`run_loaded_video_generation`).
+pub(crate) fn normalize_sampling_knob(
+    requested: Option<String>,
+    advertised: &[&str],
+    knob: &str,
+    model_id: &str,
+    job_id: &str,
+    engine: &str,
+) -> Option<String> {
+    let name = requested?;
+    if advertised.contains(&name.as_str()) {
+        return Some(name);
+    }
+    tracing::warn!(
+        "{engine}: requested {knob} {name:?} is not advertised (supported: {advertised:?}); \
+         falling back to the engine default"
+    );
+    emit_event(
+        "sampling_knob_unsupported",
+        json!({
+            "jobId": job_id,
+            "engine": engine,
+            "model": model_id,
+            "knob": knob,
+            "requested": name,
+            "supported": advertised,
+        }),
+    );
+    None
+}
+
+#[cfg(test)]
+mod sampling_knob_tests {
+    use super::*;
+
+    #[test]
+    fn advertised_name_passes_through() {
+        let advertised = ["euler", "dpmpp_2m", "uni_pc"];
+        assert_eq!(
+            normalize_sampling_knob(
+                Some("dpmpp_2m".to_owned()),
+                &advertised,
+                "sampler",
+                "qwen_image",
+                "job-1",
+                "mlx",
+            ),
+            Some("dpmpp_2m".to_owned())
+        );
+    }
+
+    #[test]
+    fn unadvertised_name_falls_back_to_default() {
+        // N3: a name the engine doesn't advertise (a legacy `dpmpp`/`unipc` recipe, or a candle
+        // per-backend gap) is dropped to the engine default (`None`) instead of hard-failing the
+        // generation in `validate_request`.
+        let advertised = ["lightning"];
+        assert_eq!(
+            normalize_sampling_knob(
+                Some("dpmpp".to_owned()),
+                &advertised,
+                "sampler",
+                "qwen_image",
+                "job-1",
+                "mlx",
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn unset_knob_stays_unset() {
+        let advertised = ["euler"];
+        assert_eq!(
+            normalize_sampling_knob(None, &advertised, "scheduler", "m", "j", "mlx"),
+            None
+        );
+    }
+}
+
 /// Optional prompt-enhancement settings resolved from a job request's `advanced` block and threaded
 /// into a [`GenerationRequest`] (sc-6135). Mirrors the LTX-2.3 video path (`advanced.enhancePrompt` /
 /// `enhanceTemperature` / `enhanceMaxTokens`). Only FLUX.2-dev / FLUX.2-dev-edit act on it — the
@@ -1293,6 +1382,27 @@ async fn generate_stream(
                 .or_else(|| value.as_str()?.trim().parse().ok())
         })
         .map(|value| value as f32);
+    // N3 (epic 7114): drop a sampler/scheduler the linked engine descriptor doesn't advertise back to
+    // the engine default + emit an event, instead of letting `validate_request` hard-fail the whole
+    // generation over a sampling knob (a stale recipe, manifest drift, or a per-backend gap). The forced
+    // `realvisxl_lightning` sampler above is always in that family's advertised set, so it passes through.
+    let caps = &model.descriptor.capabilities;
+    let sampler = normalize_sampling_knob(
+        sampler,
+        &caps.samplers,
+        "sampler",
+        &request.model,
+        &job.id,
+        backend,
+    );
+    let scheduler = normalize_sampling_knob(
+        scheduler,
+        &caps.schedulers,
+        "scheduler",
+        &request.model,
+        &job.id,
+        backend,
+    );
     // True-CFG families (Chroma) carry the CFG scale in `true_cfg`, not `guidance` (which their
     // engine rejects); `None` for every other family. The recipe records the effective CFG knob.
     let model_true_cfg = resolve_true_cfg(request, &model);
@@ -1763,16 +1873,56 @@ async fn generate_candle_stream(
             (None, None)
         };
     let (width, height) = (request.width, request.height);
-    // RealVisXL Lightning (sc-7176, the candle sibling of the MLX forcing in `generate_stream`): the
-    // standalone distilled checkpoint must run on candle-gen-sdxl's few-step `lightning` (Euler-trailing,
-    // CFG-off) schedule, not the default 30-step DDIM, regardless of the UI payload. candle-gen-sdxl
-    // advertises `["ddim", "lightning"]`; every other candle txt2img family ignores the sampler (uses its
-    // single family default), so this is the only forced id. steps/guidance come from the manifest row.
-    let sampler: Option<&str> = if request.model == "realvisxl_lightning" {
-        Some("lightning")
+    // Per-payload sampler / scheduler / schedule-shift, mirroring the MLX `generate_stream` lane (the
+    // 1753 front-half advanced carrier — epic 7114 P5, sc-7127). RealVisXL Lightning (sc-7176) forces the
+    // few-step `lightning` id regardless of the payload: candle-gen-sdxl advertises `["ddim", "lightning"]`,
+    // so it survives the N3 guard below. Every value is then run through `normalize_sampling_knob` against
+    // this family's advertised surface — a name candle doesn't honor (candle adopts the unified framework in
+    // P4, so most families advertise only their family default today) is dropped back to the engine default
+    // + a `sampling_knob_unsupported` event, never a hard-fail. The curated knobs light up per-family with
+    // zero worker change as the candle engines are adopted.
+    let sampler = request
+        .advanced
+        .get("sampler")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty() && *value != "default")
+        .map(str::to_owned);
+    let sampler = if request.model == "realvisxl_lightning" {
+        Some("lightning".to_owned())
     } else {
-        None
+        sampler
     };
+    let scheduler = request
+        .advanced
+        .get("scheduler")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty() && *value != "default")
+        .map(str::to_owned);
+    let scheduler_shift = request
+        .advanced
+        .get("schedulerShift")
+        .or_else(|| request.advanced.get("timestepShift"))
+        .and_then(|value| value.as_f64().or_else(|| value.as_str()?.trim().parse().ok()))
+        .map(|value| value as f32);
+    let caps = &model.descriptor.capabilities;
+    let sampler = normalize_sampling_knob(
+        sampler,
+        &caps.samplers,
+        "sampler",
+        &request.model,
+        &job.id,
+        backend,
+    );
+    let scheduler = normalize_sampling_knob(
+        scheduler,
+        &caps.schedulers,
+        "scheduler",
+        &request.model,
+        &job.id,
+        backend,
+    );
     // sc-6135: caption upsampling is FLUX.2-dev-only and dev runs on the macOS path, so this is a
     // no-op here — resolved for uniformity (and so a future candle enhancer would be wired).
     let enhance = PromptEnhance::from_advanced(&request.advanced);
@@ -1802,13 +1952,13 @@ async fn generate_candle_stream(
                         ideogram_reference.as_ref(),
                         ideogram_mask.as_ref(),
                         true_cfg,
-                        // RealVisXL Lightning forces the few-step `lightning` sampler (sc-7176); every
-                        // other candle txt2img family advertises no sampler/scheduler selection (each uses
-                        // its family default), so `sampler` is `None` for them and scheduler/shift are
-                        // always unset on this lane.
-                        sampler,
-                        None,
-                        None,
+                        // Per-payload sampler / scheduler / schedule-shift (sc-7127), already N3-guarded
+                        // against this family's advertised surface above. RealVisXL Lightning forces
+                        // `lightning`; most candle families advertise only their default until P4, so an
+                        // unsupported request was dropped to `None` (the engine default) before reaching here.
+                        sampler.as_deref(),
+                        scheduler.as_deref(),
+                        scheduler_shift,
                         &enhance,
                         &cancel,
                         on_progress,

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -2392,6 +2392,13 @@ struct VideoGenInput {
     /// Flow-matching scheduler shift (`req.scheduler_shift`); `None` ⇒ the engine default. Set by the
     /// SCAIL-2 lightning recipe (shift 1.0, sc-5700); the other models leave it at the engine default.
     scheduler_shift: Option<f32>,
+    /// Per-generation sampler / scheduler (epic 7114 P5, sc-7127). Left `None` by the handlers; the
+    /// shared funnel [`generate_video`] reads them from the job's `advanced` block and N3-guards them
+    /// against the resolved engine descriptor's advertised surface before they reach `req`. A video
+    /// engine that does not advertise the curated sampler/scheduler axis (everything but the Wan
+    /// fold-in + the SVD/LTX sampler-only outliers, until candle adoption) leaves these `None`.
+    sampler: Option<String>,
+    scheduler: Option<String>,
     seed: u64,
     /// Per-request control-clip conditioning scale (Wan-VACE `conditioning_scale`, sc-3441 /
     /// sc-3521); `None` ⇒ the engine default (1.0). Unused by the non-control paths.
@@ -2433,6 +2440,8 @@ impl Default for VideoGenInput {
             steps: None,
             guidance: None,
             scheduler_shift: None,
+            sampler: None,
+            scheduler: None,
             seed: 0,
             control_scale: None,
             video_mode: None,
@@ -2489,6 +2498,11 @@ fn run_loaded_video_generation(
         steps: input.steps,
         guidance: input.guidance,
         scheduler_shift: input.scheduler_shift,
+        // Per-generation sampler / scheduler (sc-7127), already N3-guarded against the engine's
+        // advertised surface in `generate_video`, so an unsupported name was dropped to `None` (the
+        // engine default) before reaching here — `validate_request` only ever sees an advertised name.
+        sampler: input.sampler,
+        scheduler: input.scheduler,
         seed: Some(input.seed),
         conditioning: input.conditioning,
         control_scale: input.control_scale,
@@ -2637,6 +2651,28 @@ pub(crate) async fn begin_video_cancel(
     .await;
 }
 
+/// The `(samplers, schedulers)` a video engine advertises (epic 7114), read from its registered
+/// gen-core descriptor by engine id — the same `Capabilities` surface `validate_request` enforces, so
+/// the N3 guard in [`generate_video`] mirrors the image lane's `model.descriptor.capabilities` read.
+/// Empty (so every name N3-falls back to the engine default) when the id isn't registered on this
+/// backend — e.g. a candle video engine before it adopts the unified framework.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn video_engine_sampling_surface(engine_id: &str) -> (Vec<&'static str>, Vec<&'static str>) {
+    gen_core::registry::generators()
+        .map(|reg| (reg.descriptor)())
+        .find(|descriptor| descriptor.id == engine_id)
+        .map(|descriptor| {
+            (
+                descriptor.capabilities.samplers,
+                descriptor.capabilities.schedulers,
+            )
+        })
+        .unwrap_or_default()
+}
+
 /// Drive a `run_video_generation` on a blocking thread, forwarding its streamed denoise
 /// progress to the async worker (Generating stage ~0.25..0.58) + polling cancel ~every 2s.
 /// The shared blocking + mpsc + cancel plumbing for Wan and LTX. A forward-progress watchdog
@@ -2650,8 +2686,56 @@ async fn generate_video(
     settings: &Settings,
     job: &JobSnapshot,
     backend: &str,
-    input: VideoGenInput,
+    mut input: VideoGenInput,
 ) -> WorkerResult<DecodedVideo> {
+    // Per-generation sampler / scheduler axis for video (epic 7114 P5, sc-7127). The handlers leave
+    // `input.sampler`/`scheduler` `None`; read them from the job's `advanced` block here — the single
+    // funnel every Wan / LTX / SVD path passes through — and N3-guard each against the resolved engine
+    // descriptor's advertised surface. A name the engine does not advertise (every video engine but the
+    // Wan fold-in + the SVD/LTX sampler-only outliers, until candle adoption) is dropped to the engine
+    // default + a `sampling_knob_unsupported` event, never a `validate_request` hard-fail.
+    {
+        let advanced = VideoRequest::from_payload(&job.payload).advanced;
+        let read = |key: &str| {
+            advanced
+                .get(key)
+                .and_then(|value| value.as_str())
+                .map(str::trim)
+                .filter(|value| !value.is_empty() && *value != "default")
+                .map(str::to_owned)
+        };
+        let (samplers, schedulers) = video_engine_sampling_surface(input.engine_id);
+        input.sampler = crate::image_jobs::normalize_sampling_knob(
+            read("sampler"),
+            &samplers,
+            "sampler",
+            input.engine_id,
+            &job.id,
+            backend,
+        );
+        input.scheduler = crate::image_jobs::normalize_sampling_knob(
+            read("scheduler"),
+            &schedulers,
+            "scheduler",
+            input.engine_id,
+            &job.id,
+            backend,
+        );
+        // Schedule shift: only when the handler hasn't already forced it (the SCAIL-2 lightning recipe
+        // sets shift 1.0), so the user knob can't clobber a model's required recipe. Parity with the
+        // image lane's `advanced.schedulerShift` / `timestepShift` read.
+        if input.scheduler_shift.is_none() {
+            input.scheduler_shift = advanced
+                .get("schedulerShift")
+                .or_else(|| advanced.get("timestepShift"))
+                .and_then(|value| {
+                    value
+                        .as_f64()
+                        .or_else(|| value.as_str()?.trim().parse().ok())
+                })
+                .map(|value| value as f32);
+        }
+    }
     let cancel = CancelFlag::new();
     let stall_timeout = video_stall_timeout();
     let log_engine_id = input.engine_id;
@@ -3066,6 +3150,8 @@ async fn generate_candle_video(
     // resolved above.
     if engine_id == "svd_xt" {
         let input = VideoGenInput {
+            sampler: None,
+            scheduler: None,
             engine_id,
             model_dir,
             conditioning,
@@ -3117,6 +3203,8 @@ async fn generate_candle_video(
         wan_frame_count(request.raw_frame_count())
     };
     let input = VideoGenInput {
+        sampler: None,
+        scheduler: None,
         engine_id,
         model_dir,
         conditioning,
@@ -3504,6 +3592,8 @@ async fn generate_candle_scail2(
     let lightning = candle_scail2_adapters_have_lightning(&adapters);
     let (steps, guidance, scheduler_shift) = candle_scail2_sampling(request, lightning);
     let input = VideoGenInput {
+        sampler: None,
+        scheduler: None,
         engine_id,
         model_dir: resolve_candle_scail2_model_dir(settings)?,
         adapters,
@@ -3663,6 +3753,8 @@ async fn generate_candle_scail2_replace(
         resolve_candle_scail2_replace_conditioning(api, settings, job, request, project_path)
             .await?;
     let input = VideoGenInput {
+        sampler: None,
+        scheduler: None,
         engine_id,
         model_dir: resolve_candle_scail2_model_dir(settings)?,
         conditioning,
@@ -3748,6 +3840,8 @@ async fn generate_candle_wan_vace(
         (!trimmed.is_empty()).then(|| trimmed.to_owned())
     };
     let input = VideoGenInput {
+        sampler: None,
+        scheduler: None,
         engine_id: "wan_vace",
         model_dir,
         conditioning,
@@ -3852,6 +3946,8 @@ async fn generate_candle_wan_vace_extend_bridge(
         (!trimmed.is_empty()).then(|| trimmed.to_owned())
     };
     let input = VideoGenInput {
+        sampler: None,
+        scheduler: None,
         engine_id: "wan_vace",
         model_dir,
         conditioning,
@@ -3898,6 +3994,8 @@ async fn generate_wan(
         _ => resolve_wan_conditioning(settings, request, project_path, engine_id)?,
     };
     let input = VideoGenInput {
+        sampler: None,
+        scheduler: None,
         engine_id,
         model_dir: resolve_wan_model_dir(settings, &request.model, engine_id)?,
         quant: resolve_wan_quant(request),
@@ -4146,6 +4244,8 @@ async fn generate_bernini(
     let conditioning =
         resolve_bernini_conditioning(api, settings, job, request, project_path).await?;
     let input = VideoGenInput {
+        sampler: None,
+        scheduler: None,
         engine_id,
         model_dir: resolve_bernini_model_dir(settings)?,
         quant: resolve_bernini_quant(request),
@@ -4425,6 +4525,8 @@ async fn generate_scail2(
     let (steps, guidance, scheduler_shift) =
         scail2_sampling(request, scail2_adapters_have_lightning(&adapters));
     let input = VideoGenInput {
+        sampler: None,
+        scheduler: None,
         engine_id,
         model_dir: resolve_scail2_model_dir(settings)?,
         quant: resolve_scail2_quant(request),
@@ -4588,6 +4690,8 @@ async fn generate_scail2_replace(
     let (conditioning, status) =
         resolve_scail2_replace_conditioning(api, settings, job, request, project_path).await?;
     let input = VideoGenInput {
+        sampler: None,
+        scheduler: None,
         engine_id,
         model_dir: resolve_scail2_model_dir(settings)?,
         quant: resolve_scail2_quant(request),
@@ -5320,6 +5424,8 @@ async fn generate_ltx(
     // encoder — point the engine at it (sc-5608) before load. No-op for legacy/local conversions.
     ensure_bundled_ltx_gemma_dir(&model_dir);
     let input = VideoGenInput {
+        sampler: None,
+        scheduler: None,
         engine_id,
         model_dir,
         quant: None,
@@ -5598,6 +5704,8 @@ async fn generate_svd(
     backend: &str,
 ) -> WorkerResult<DecodedVideo> {
     let input = VideoGenInput {
+        sampler: None,
+        scheduler: None,
         engine_id,
         model_dir: resolve_svd_model_dir(settings)?,
         quant: None,
@@ -6236,6 +6344,8 @@ async fn generate_wan_vace_engine(
             .map(|value| value as f32)
     });
     let input = VideoGenInput {
+        sampler: None,
+        scheduler: None,
         engine_id,
         model_dir,
         quant,
@@ -6631,6 +6741,8 @@ async fn generate_wan_vace_extend_bridge(
             .map(|value| value as f32)
     });
     let input = VideoGenInput {
+        sampler: None,
+        scheduler: None,
         engine_id: "wan_vace",
         model_dir,
         quant: resolve_wan_quant(request),
@@ -7161,6 +7273,8 @@ mod tests {
             build_vace_conditioning(frames, masks, vec![gray()], 1.0, ReplacementMode::FaceOnly)
                 .expect("conditioning builds");
         let input = VideoGenInput {
+            sampler: None,
+            scheduler: None,
             engine_id: "wan_vace",
             model_dir,
             conditioning,
@@ -7260,6 +7374,8 @@ mod tests {
         let w = bernini_smoke_u32("SCENEWORKS_BERNINI_SMOKE_W", 832);
         let h = bernini_smoke_u32("SCENEWORKS_BERNINI_SMOKE_H", 480);
         let input = VideoGenInput {
+            sampler: None,
+            scheduler: None,
             engine_id: "bernini",
             model_dir,
             quant: bernini_smoke_quant(),
@@ -7542,6 +7658,8 @@ mod tests {
 
         for (task, conditioning) in cases {
             let input = VideoGenInput {
+                sampler: None,
+                scheduler: None,
                 engine_id: "bernini",
                 model_dir: model_dir.clone(),
                 quant: Some(Quant::Q4),
@@ -7876,6 +7994,8 @@ mod tests {
                 },
             ];
             let input = VideoGenInput {
+                sampler: None,
+                scheduler: None,
                 engine_id: "scail2_14b",
                 model_dir: model_dir.clone(),
                 quant: Some(Quant::Q4),
@@ -7947,6 +8067,8 @@ mod tests {
         )
         .expect("extend conditioning builds");
         let input = VideoGenInput {
+            sampler: None,
+            scheduler: None,
             engine_id: "wan_vace",
             model_dir,
             conditioning,
@@ -8234,6 +8356,8 @@ mod tests {
             return;
         };
         let input = VideoGenInput {
+            sampler: None,
+            scheduler: None,
             engine_id: "wan2_2_ti2v_5b",
             model_dir,
             prompt: "a calm ocean wave at sunset, cinematic".to_owned(),
@@ -8329,6 +8453,8 @@ mod tests {
             return;
         };
         let input = VideoGenInput {
+            sampler: None,
+            scheduler: None,
             engine_id: "wan2_2_ti2v_5b",
             model_dir,
             conditioning: vec![Conditioning::Reference {
@@ -8424,6 +8550,8 @@ mod tests {
         }
         mlx_rs::memory::reset_peak_memory();
         let input = VideoGenInput {
+            sampler: None,
+            scheduler: None,
             engine_id: "wan2_2_ti2v_5b",
             model_dir,
             prompt: "a calm ocean wave at sunset, cinematic".to_owned(),
@@ -8681,6 +8809,8 @@ mod tests {
             }
         }
         let input = VideoGenInput {
+            sampler: None,
+            scheduler: None,
             engine_id: "svd_xt",
             model_dir,
             width: 256,
@@ -8748,6 +8878,8 @@ mod tests {
             })
             .collect();
         let input = VideoGenInput {
+            sampler: None,
+            scheduler: None,
             engine_id: "seedvr2_3b",
             model_dir: PathBuf::from(dir),
             conditioning: vec![Conditioning::VideoClip {
@@ -9179,6 +9311,8 @@ mod tests {
         // path) so the smoke needs no separate mlx-community/gemma snapshot in the HF cache.
         ensure_bundled_ltx_gemma_dir(&model_dir);
         let input = VideoGenInput {
+            sampler: None,
+            scheduler: None,
             engine_id: "ltx_2_3",
             model_dir,
             prompt: "a calm ocean wave at sunset, gentle surf".to_owned(),


### PR DESCRIPTION
## Epic 7114 P5 — sc-7127

Plumb the per-generation **sampler / scheduler / schedulerShift** knobs to the gen-core `GenerationRequest` with an **N3 graceful-fallback** guard on BOTH the mlx-gen and candle-gen lanes, so an unsupported sampling name never hard-fails a generation.

### Why
`gen_core::Capabilities::validate_request` (and each engine's own `validate`) **rejects** an unadvertised sampler/scheduler with an `Err` — i.e. today a stale recipe / over-advertised manifest (e.g. the live `qwen_image` mismatch, sc-7126) hard-fails the whole job. N3 makes the worker the safety net.

### Changes
- **New shared `normalize_sampling_knob`** (`image_jobs/base.rs`): a requested name not in the linked descriptor's advertised `Capabilities.{samplers,schedulers}` is dropped to the engine default (`None`) + a `sampling_knob_unsupported` worker event. `None` / `"default"` are stripped upstream, so it only fires on a real unsupported name.
- **MLX image** (`generate_stream`): guard the advanced-read sampler/scheduler.
- **Candle image** (`generate_candle_stream`): now reads advanced sampler/scheduler/schedulerShift (was hardcoded to the RealVisXL `lightning` force + `None`s) + same N3 guard. Most candle families advertise only their default until P4, so unsupported requests fall back; curated knobs light up per-family with zero worker change as candle is adopted.
- **Video** (`VideoGenInput` + `generate_video`): new `sampler`/`scheduler` fields; the shared funnel reads them from the job advanced block, N3-guards against the engine descriptor (`video_engine_sampling_surface`), threads onto `req`. schedulerShift read only when the handler hasn't forced it (preserves the SCAIL-2 lightning recipe).

### Verification
- ✅ `cargo check`/`clippy -p sceneworks-worker --all-targets -D warnings` clean (worktree-local target).
- ✅ New `normalize_sampling_knob` unit tests pass (advertised passes through / unadvertised → default / unset stays unset).
- ✅ Full worker test binary links (the 26 `VideoGenInput` literal updates compile).
- Candle lane builds on the **desktop-windows** CI lane (cfg'd out on macOS).

### Scope notes
- **N1 holds**: an unset sampler is `None` → unchanged default output.
- Real-weight **N1/N2 engine-behavior** validation lands with the gen-core pin bump (**sc-7129**), where the curated samplers actually change engine output. This PR is the plumbing + fallback; it is inert-but-safe on the current `d8038beb` pin (engines advertise narrow sets → names fall back).

🤖 Generated with [Claude Code](https://claude.com/claude-code)