### PR TITLE
chore(worker): gen-core lockstep c59f73cb + N1 regression suite (sc-7129)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f8481639c7543f929a5c76e9e8ad12858d3a3c65#f8481639c7543f929a5c76e9e8ad12858d3a3c65"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f8481639c7543f929a5c76e9e8ad12858d3a3c65#f8481639c7543f929a5c76e9e8ad12858d3a3c65"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f8481639c7543f929a5c76e9e8ad12858d3a3c65#f8481639c7543f929a5c76e9e8ad12858d3a3c65"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f8481639c7543f929a5c76e9e8ad12858d3a3c65#f8481639c7543f929a5c76e9e8ad12858d3a3c65"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f8481639c7543f929a5c76e9e8ad12858d3a3c65#f8481639c7543f929a5c76e9e8ad12858d3a3c65"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f8481639c7543f929a5c76e9e8ad12858d3a3c65#f8481639c7543f929a5c76e9e8ad12858d3a3c65"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -523,7 +523,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f8481639c7543f929a5c76e9e8ad12858d3a3c65#f8481639c7543f929a5c76e9e8ad12858d3a3c65"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -535,7 +535,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f8481639c7543f929a5c76e9e8ad12858d3a3c65#f8481639c7543f929a5c76e9e8ad12858d3a3c65"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f8481639c7543f929a5c76e9e8ad12858d3a3c65#f8481639c7543f929a5c76e9e8ad12858d3a3c65"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f8481639c7543f929a5c76e9e8ad12858d3a3c65#f8481639c7543f929a5c76e9e8ad12858d3a3c65"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f8481639c7543f929a5c76e9e8ad12858d3a3c65#f8481639c7543f929a5c76e9e8ad12858d3a3c65"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -585,7 +585,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f8481639c7543f929a5c76e9e8ad12858d3a3c65#f8481639c7543f929a5c76e9e8ad12858d3a3c65"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -596,7 +596,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f8481639c7543f929a5c76e9e8ad12858d3a3c65#f8481639c7543f929a5c76e9e8ad12858d3a3c65"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -613,7 +613,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f8481639c7543f929a5c76e9e8ad12858d3a3c65#f8481639c7543f929a5c76e9e8ad12858d3a3c65"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -628,7 +628,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f8481639c7543f929a5c76e9e8ad12858d3a3c65#f8481639c7543f929a5c76e9e8ad12858d3a3c65"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -639,7 +639,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f8481639c7543f929a5c76e9e8ad12858d3a3c65#f8481639c7543f929a5c76e9e8ad12858d3a3c65"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -654,7 +654,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f8481639c7543f929a5c76e9e8ad12858d3a3c65#f8481639c7543f929a5c76e9e8ad12858d3a3c65"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -672,7 +672,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f8481639c7543f929a5c76e9e8ad12858d3a3c65#f8481639c7543f929a5c76e9e8ad12858d3a3c65"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -683,7 +683,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f8481639c7543f929a5c76e9e8ad12858d3a3c65#f8481639c7543f929a5c76e9e8ad12858d3a3c65"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -696,7 +696,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f8481639c7543f929a5c76e9e8ad12858d3a3c65#f8481639c7543f929a5c76e9e8ad12858d3a3c65"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -707,7 +707,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f8481639c7543f929a5c76e9e8ad12858d3a3c65#f8481639c7543f929a5c76e9e8ad12858d3a3c65"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -720,7 +720,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f8481639c7543f929a5c76e9e8ad12858d3a3c65#f8481639c7543f929a5c76e9e8ad12858d3a3c65"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -3352,7 +3352,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d8038beb3d81b8edce3e084078e2fc6d356a0081#d8038beb3d81b8edce3e084078e2fc6d356a0081"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3364,7 +3364,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d8038beb3d81b8edce3e084078e2fc6d356a0081#d8038beb3d81b8edce3e084078e2fc6d356a0081"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
 dependencies = [
  "image",
  "inventory",
@@ -3378,7 +3378,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d8038beb3d81b8edce3e084078e2fc6d356a0081#d8038beb3d81b8edce3e084078e2fc6d356a0081"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
 dependencies = [
  "image",
  "inventory",
@@ -3391,7 +3391,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d8038beb3d81b8edce3e084078e2fc6d356a0081#d8038beb3d81b8edce3e084078e2fc6d356a0081"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3403,7 +3403,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d8038beb3d81b8edce3e084078e2fc6d356a0081#d8038beb3d81b8edce3e084078e2fc6d356a0081"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3412,7 +3412,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d8038beb3d81b8edce3e084078e2fc6d356a0081#d8038beb3d81b8edce3e084078e2fc6d356a0081"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3424,7 +3424,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d8038beb3d81b8edce3e084078e2fc6d356a0081#d8038beb3d81b8edce3e084078e2fc6d356a0081"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3435,7 +3435,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d8038beb3d81b8edce3e084078e2fc6d356a0081#d8038beb3d81b8edce3e084078e2fc6d356a0081"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3447,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d8038beb3d81b8edce3e084078e2fc6d356a0081#d8038beb3d81b8edce3e084078e2fc6d356a0081"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3458,7 +3458,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d8038beb3d81b8edce3e084078e2fc6d356a0081#d8038beb3d81b8edce3e084078e2fc6d356a0081"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3468,7 +3468,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d8038beb3d81b8edce3e084078e2fc6d356a0081#d8038beb3d81b8edce3e084078e2fc6d356a0081"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
 dependencies = [
  "image",
  "inventory",
@@ -3480,7 +3480,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d8038beb3d81b8edce3e084078e2fc6d356a0081#d8038beb3d81b8edce3e084078e2fc6d356a0081"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
 dependencies = [
  "image",
  "inventory",
@@ -3493,7 +3493,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d8038beb3d81b8edce3e084078e2fc6d356a0081#d8038beb3d81b8edce3e084078e2fc6d356a0081"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
 dependencies = [
  "image",
  "inventory",
@@ -3505,7 +3505,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d8038beb3d81b8edce3e084078e2fc6d356a0081#d8038beb3d81b8edce3e084078e2fc6d356a0081"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3516,7 +3516,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d8038beb3d81b8edce3e084078e2fc6d356a0081#d8038beb3d81b8edce3e084078e2fc6d356a0081"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3528,7 +3528,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d8038beb3d81b8edce3e084078e2fc6d356a0081#d8038beb3d81b8edce3e084078e2fc6d356a0081"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3538,7 +3538,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d8038beb3d81b8edce3e084078e2fc6d356a0081#d8038beb3d81b8edce3e084078e2fc6d356a0081"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3547,7 +3547,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d8038beb3d81b8edce3e084078e2fc6d356a0081#d8038beb3d81b8edce3e084078e2fc6d356a0081"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3556,7 +3556,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d8038beb3d81b8edce3e084078e2fc6d356a0081#d8038beb3d81b8edce3e084078e2fc6d356a0081"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3568,7 +3568,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d8038beb3d81b8edce3e084078e2fc6d356a0081#d8038beb3d81b8edce3e084078e2fc6d356a0081"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
 dependencies = [
  "image",
  "inventory",
@@ -3581,7 +3581,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d8038beb3d81b8edce3e084078e2fc6d356a0081#d8038beb3d81b8edce3e084078e2fc6d356a0081"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3592,7 +3592,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d8038beb3d81b8edce3e084078e2fc6d356a0081#d8038beb3d81b8edce3e084078e2fc6d356a0081"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3603,7 +3603,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d8038beb3d81b8edce3e084078e2fc6d356a0081#d8038beb3d81b8edce3e084078e2fc6d356a0081"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3614,7 +3614,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d8038beb3d81b8edce3e084078e2fc6d356a0081#d8038beb3d81b8edce3e084078e2fc6d356a0081"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
 dependencies = [
  "image",
  "inventory",
@@ -3628,7 +3628,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d8038beb3d81b8edce3e084078e2fc6d356a0081#d8038beb3d81b8edce3e084078e2fc6d356a0081"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
 dependencies = [
  "image",
  "inventory",
@@ -3944,7 +3944,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5271,7 +5271,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d8038beb3d81b8edce3e084078e2fc6d356a0081#d8038beb3d81b8edce3e084078e2fc6d356a0081"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
 dependencies = [
  "inventory",
  "safetensors 0.4.5",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -245,7 +245,19 @@ sceneworks-core = { path = "../sceneworks-core" }
 # is sampling/* + registry/caption/imageops/tiling + testkit) and 6 behind mlx-gen main HEAD. mlx-rs is
 # unchanged (44929a0 at both revs), so MLX core does not rebuild beyond the changed mlx-gen layers.
 # Bumps EVERY mlx-gen crate + gen-core in lockstep (the macOS block below).
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d8038beb3d81b8edce3e084078e2fc6d356a0081" }
+# Rev d8038beb -> c59f73cb (epic 7114 P5 / sc-7129): bring the worker onto the unified sampler/scheduler
+# framework (epic 7114). c59f73cb (mlx-gen main, PRs #528/#530/#531/#532/#533/#534) is the P3 mlx-gen
+# adoption — the flow-match cohort (Chroma/FLUX.1/Qwen-Image/Z-Image/FLUX.2 + Boogu Base/Edit) now routes
+# its denoise through the curated `gen_core::sampling::Sampler<MlxLatentOps>` + `FlowModelSampling` and
+# advertises the curated sampler/scheduler menu in its `Capabilities`; the DDPM cohort (SDXL/Kolors) +
+# outliers (SVD/LTX) too (sc-7121/7122). The gen-core delta d8038beb..c59f73cb is PURELY ADDITIVE
+# (`FlowModelSampling::with_shift`; `new(conv)` stays mu=0 byte-exact), so the worker's import surface is
+# unchanged and N1 (default sampler = today's output) holds. Bumps EVERY mlx-gen crate + gen-core in
+# lockstep. The candle pin below moves f8481639 -> ed77abdc IN LOCKSTEP — candle-gen main already re-pins
+# its gen-core (workspace + all 17 testkit dev-deps) to c59f73cb (candle-gen #124) and carries the candle
+# flow-match adoption (sc-7123, #124) — so `--features backend-candle --target all` resolves the SINGLE
+# gen-core rev c59f73cb again (the skew gate the default PR lane is blind to).
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -569,7 +581,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d8038beb3d81b8edce3e084078e2fc6d356a0081" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -581,64 +593,64 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d8038beb3d8
 # internal pin (the Lens engine PRs #407–#414 did not move it; nor did the seedvr2 engine #416/#419/
 # #421 or the softness PR #422, so the 1a97909 bump above leaves mlx-rs at 44929a0).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "44929a001ab8a8837403a71c65cf064224de0cdc" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d8038beb3d81b8edce3e084078e2fc6d356a0081" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d8038beb3d81b8edce3e084078e2fc6d356a0081" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d8038beb3d81b8edce3e084078e2fc6d356a0081" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d8038beb3d81b8edce3e084078e2fc6d356a0081" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d8038beb3d81b8edce3e084078e2fc6d356a0081" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d8038beb3d81b8edce3e084078e2fc6d356a0081" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d8038beb3d81b8edce3e084078e2fc6d356a0081" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d8038beb3d81b8edce3e084078e2fc6d356a0081" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d8038beb3d81b8edce3e084078e2fc6d356a0081" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d8038beb3d81b8edce3e084078e2fc6d356a0081" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d8038beb3d81b8edce3e084078e2fc6d356a0081" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d8038beb3d81b8edce3e084078e2fc6d356a0081" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d8038beb3d81b8edce3e084078e2fc6d356a0081" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d8038beb3d81b8edce3e084078e2fc6d356a0081" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -647,12 +659,12 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d8038b
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d8038beb3d81b8edce3e084078e2fc6d356a0081" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d8038beb3d81b8edce3e084078e2fc6d356a0081" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -661,7 +673,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d8038b
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d8038beb3d81b8edce3e084078e2fc6d356a0081" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -669,7 +681,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d8038beb3d81b8edce3e084078e2fc6d356a0081" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -680,7 +692,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d803
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d8038beb3d81b8edce3e084078e2fc6d356a0081" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -691,7 +703,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d8038
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d8038beb3d81b8edce3e084078e2fc6d356a0081" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -706,7 +718,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d8038b
 # converted in-memory at load (no Python); the precomputed neg-prompt embedding is bundled in-crate. No
 # LoRA/guidance/CFG (one-step). 3B fp16 only here — 7B (sc-5197) + int8 (sc-5198) are engine-side and
 # unwired. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d8038beb3d81b8edce3e084078e2fc6d356a0081" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -717,7 +729,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d80
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d8038beb3d81b8edce3e084078e2fc6d356a0081" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
 # Prompt-refine provider (sc-5552, the MLX twin of candle-gen-prompt-refine / sc-5500). An
 # inventory-registered `TextLlm` under id `prompt_refine` (`backend="mlx"`, `mac_only`): a native MLX
 # Llama-3.2-3B-Instruct that rewrites a user's prompt, replacing the Python `prompt_refine.py`
@@ -727,7 +739,7 @@ mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d80
 # textllm registered" trap). Weights = a stock Llama-3.2-3B-Instruct HF snapshot (config.json +
 # tokenizer.json + model-*.safetensors; default `huihui-ai/Llama-3.2-3B-Instruct-abliterated`). Same
 # git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d8038beb3d81b8edce3e084078e2fc6d356a0081" }
+mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
 # SCAIL-2 (zai-org) end-to-end character-animation provider (epic 5439, sc-5448). An inventory-registered
 # `Generator` under id `scail2_14b` (`Modality::Video`): a Wan2.1-14B I2V DiT that animates a reference
 # character with a driving video's motion (`video_mode == "replacement"` flips the cross-identity
@@ -739,7 +751,7 @@ mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev 
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d8038beb3d81b8edce3e084078e2fc6d356a0081" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -944,39 +956,46 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d803
 # fix). Its gen-core pin is d8038beb, so the worker's mlx pin was bumped 4d3aa49 -> d8038beb in lockstep
 # (above) to keep `--features backend-candle --target all` at a SINGLE gen-core rev. (Prior pin 13405ce
 # = candle-gen #118 / sc-6838.)
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f8481639c7543f929a5c76e9e8ad12858d3a3c65", features = ["cuda"], optional = true }
+# Rev f8481639 -> ed77abdc (epic 7114 P5 / sc-7129): re-pin candle-gen to main HEAD in LOCKSTEP with the
+# mlx pin bump d8038beb -> c59f73cb (above). ed77abdc = candle-gen main HEAD (#124) which re-pins its
+# gen-core (workspace + all 17 testkit dev-deps) d8038beb -> c59f73cb AND carries the candle flow-match
+# unified-sampler adoption (sc-7123): the candle flow-match cohort now advertises the curated
+# sampler/scheduler menu too. So `--features backend-candle --target all` resolves the SINGLE gen-core rev
+# c59f73cb shared with the mlx pin. gen-core delta d8038beb..c59f73cb is purely additive
+# (`FlowModelSampling::with_shift`), so the worker's candle import surface is unchanged.
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f8481639c7543f929a5c76e9e8ad12858d3a3c65", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f8481639c7543f929a5c76e9e8ad12858d3a3c65", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f8481639c7543f929a5c76e9e8ad12858d3a3c65", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f8481639c7543f929a5c76e9e8ad12858d3a3c65", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f8481639c7543f929a5c76e9e8ad12858d3a3c65", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f8481639c7543f929a5c76e9e8ad12858d3a3c65", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f8481639c7543f929a5c76e9e8ad12858d3a3c65", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f8481639c7543f929a5c76e9e8ad12858d3a3c65", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f8481639c7543f929a5c76e9e8ad12858d3a3c65", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -985,11 +1004,11 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f8481639c7543f929a5c76e9e8ad12858d3a3c65", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f8481639c7543f929a5c76e9e8ad12858d3a3c65", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -998,19 +1017,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f8481639c7543f929a5c76e9e8ad12858d3a3c65", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f8481639c7543f929a5c76e9e8ad12858d3a3c65", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f8481639c7543f929a5c76e9e8ad12858d3a3c65", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1019,12 +1038,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f8481639c7543f929a5c76e9e8ad12858d3a3c65", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f8481639c7543f929a5c76e9e8ad12858d3a3c65", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1032,7 +1051,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f8481
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f8481639c7543f929a5c76e9e8ad12858d3a3c65", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1041,7 +1060,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f8481639c7543f929a5c76e9e8ad12858d3a3c65", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1049,7 +1068,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f8481639c7543f929a5c76e9e8ad12858d3a3c65", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1058,7 +1077,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f8481639c7543f929a5c76e9e8ad12858d3a3c65", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1085,7 +1104,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f8481639c7543f929a5c76e9e8ad12858d3a3c65", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -806,6 +806,32 @@ pub(crate) fn normalize_sampling_knob(
     None
 }
 
+/// Read the raw per-generation sampler / scheduler / schedule-shift knobs from a job's `advanced`
+/// block (the 1753 front-half carrier). `sampler` / `scheduler` strip the `"default"` sentinel + blanks
+/// to `None`, so the engine default — N1's guaranteed no-op — is the ABSENCE of a name, not a magic
+/// string; `scheduler_shift` accepts the `schedulerShift` (or legacy `timestepShift`) key as a number or
+/// numeric string. Shared by the MLX (`generate_stream`) + candle (`generate_candle_stream`) image lanes
+/// — the result is then realvisxl-forced (the lightning checkpoint) and N3-guarded via
+/// [`normalize_sampling_knob`]. Returns `(sampler, scheduler, scheduler_shift)`.
+pub(crate) fn read_advanced_sampling_knobs(
+    advanced: &JsonObject,
+) -> (Option<String>, Option<String>, Option<f32>) {
+    let name = |key: &str| {
+        advanced
+            .get(key)
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty() && *value != "default")
+            .map(str::to_owned)
+    };
+    let scheduler_shift = advanced
+        .get("schedulerShift")
+        .or_else(|| advanced.get("timestepShift"))
+        .and_then(|value| value.as_f64().or_else(|| value.as_str()?.trim().parse().ok()))
+        .map(|value| value as f32);
+    (name("sampler"), name("scheduler"), scheduler_shift)
+}
+
 #[cfg(test)]
 mod sampling_knob_tests {
     use super::*;
@@ -852,6 +878,56 @@ mod sampling_knob_tests {
             normalize_sampling_knob(None, &advertised, "scheduler", "m", "j", "mlx"),
             None
         );
+    }
+
+    fn advanced(value: serde_json::Value) -> JsonObject {
+        value.as_object().expect("object").clone()
+    }
+
+    // N1 (epic 7114): the guaranteed no-op default. A job with no sampling knobs — or the explicit
+    // `"default"` sentinel the UI sends for "Model default" — must resolve to ALL `None`, i.e. the engine
+    // runs its existing native path byte-for-byte. This guards the worker read against a future change
+    // that silently injects a non-default sampler onto the default path.
+    #[test]
+    fn n1_default_advanced_is_a_no_op() {
+        assert_eq!(
+            read_advanced_sampling_knobs(&advanced(serde_json::json!({}))),
+            (None, None, None)
+        );
+        assert_eq!(
+            read_advanced_sampling_knobs(&advanced(serde_json::json!({
+                "sampler": "default",
+                "scheduler": "default",
+                "steps": 30
+            }))),
+            (None, None, None)
+        );
+        // Blank / whitespace-only names are also treated as the default (no name).
+        assert_eq!(
+            read_advanced_sampling_knobs(&advanced(serde_json::json!({"sampler": "  ", "scheduler": ""}))),
+            (None, None, None)
+        );
+    }
+
+    #[test]
+    fn read_passes_real_names_and_shift_through() {
+        assert_eq!(
+            read_advanced_sampling_knobs(&advanced(serde_json::json!({
+                "sampler": "dpmpp_2m",
+                "scheduler": "sgm_uniform",
+                "schedulerShift": 2.5
+            }))),
+            (
+                Some("dpmpp_2m".to_owned()),
+                Some("sgm_uniform".to_owned()),
+                Some(2.5)
+            )
+        );
+        // schedulerShift accepts a numeric string and the legacy `timestepShift` key.
+        let (_, _, shift) = read_advanced_sampling_knobs(&advanced(serde_json::json!({
+            "timestepShift": "1.5"
+        })));
+        assert_eq!(shift, Some(1.5));
     }
 }
 
@@ -1347,13 +1423,7 @@ async fn generate_stream(
     let (quant, quant_bits) = resolve_quant(request);
     let steps = resolve_steps(request, &model);
     let guidance = resolve_guidance(request, &model);
-    let sampler = request
-        .advanced
-        .get("sampler")
-        .and_then(|value| value.as_str())
-        .map(str::trim)
-        .filter(|value| !value.is_empty() && *value != "default")
-        .map(str::to_owned);
+    let (sampler, scheduler, scheduler_shift) = read_advanced_sampling_knobs(&request.advanced);
     // RealVisXL Lightning (sc-6075): a standalone few-step *distilled checkpoint* (the
     // SDXL-Lightning distillation is baked into the weights — no acceleration LoRA). It must run
     // on the engine's `lightning` (Euler-trailing) few-step schedule, not the 30-step
@@ -1365,23 +1435,6 @@ async fn generate_stream(
     } else {
         sampler
     };
-    let scheduler = request
-        .advanced
-        .get("scheduler")
-        .and_then(|value| value.as_str())
-        .map(str::trim)
-        .filter(|value| !value.is_empty() && *value != "default")
-        .map(str::to_owned);
-    let scheduler_shift = request
-        .advanced
-        .get("schedulerShift")
-        .or_else(|| request.advanced.get("timestepShift"))
-        .and_then(|value| {
-            value
-                .as_f64()
-                .or_else(|| value.as_str()?.trim().parse().ok())
-        })
-        .map(|value| value as f32);
     // N3 (epic 7114): drop a sampler/scheduler the linked engine descriptor doesn't advertise back to
     // the engine default + emit an event, instead of letting `validate_request` hard-fail the whole
     // generation over a sampling knob (a stale recipe, manifest drift, or a per-backend gap). The forced
@@ -1881,31 +1934,12 @@ async fn generate_candle_stream(
     // P4, so most families advertise only their family default today) is dropped back to the engine default
     // + a `sampling_knob_unsupported` event, never a hard-fail. The curated knobs light up per-family with
     // zero worker change as the candle engines are adopted.
-    let sampler = request
-        .advanced
-        .get("sampler")
-        .and_then(|value| value.as_str())
-        .map(str::trim)
-        .filter(|value| !value.is_empty() && *value != "default")
-        .map(str::to_owned);
+    let (sampler, scheduler, scheduler_shift) = read_advanced_sampling_knobs(&request.advanced);
     let sampler = if request.model == "realvisxl_lightning" {
         Some("lightning".to_owned())
     } else {
         sampler
     };
-    let scheduler = request
-        .advanced
-        .get("scheduler")
-        .and_then(|value| value.as_str())
-        .map(str::trim)
-        .filter(|value| !value.is_empty() && *value != "default")
-        .map(str::to_owned);
-    let scheduler_shift = request
-        .advanced
-        .get("schedulerShift")
-        .or_else(|| request.advanced.get("timestepShift"))
-        .and_then(|value| value.as_f64().or_else(|| value.as_str()?.trim().parse().ok()))
-        .map(|value| value as f32);
     let caps = &model.descriptor.capabilities;
     let sampler = normalize_sampling_knob(
         sampler,

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -2696,17 +2696,11 @@ async fn generate_video(
     // default + a `sampling_knob_unsupported` event, never a `validate_request` hard-fail.
     {
         let advanced = VideoRequest::from_payload(&job.payload).advanced;
-        let read = |key: &str| {
-            advanced
-                .get(key)
-                .and_then(|value| value.as_str())
-                .map(str::trim)
-                .filter(|value| !value.is_empty() && *value != "default")
-                .map(str::to_owned)
-        };
+        let (raw_sampler, raw_scheduler, raw_shift) =
+            crate::image_jobs::read_advanced_sampling_knobs(&advanced);
         let (samplers, schedulers) = video_engine_sampling_surface(input.engine_id);
         input.sampler = crate::image_jobs::normalize_sampling_knob(
-            read("sampler"),
+            raw_sampler,
             &samplers,
             "sampler",
             input.engine_id,
@@ -2714,7 +2708,7 @@ async fn generate_video(
             backend,
         );
         input.scheduler = crate::image_jobs::normalize_sampling_knob(
-            read("scheduler"),
+            raw_scheduler,
             &schedulers,
             "scheduler",
             input.engine_id,
@@ -2725,15 +2719,7 @@ async fn generate_video(
         // sets shift 1.0), so the user knob can't clobber a model's required recipe. Parity with the
         // image lane's `advanced.schedulerShift` / `timestepShift` read.
         if input.scheduler_shift.is_none() {
-            input.scheduler_shift = advanced
-                .get("schedulerShift")
-                .or_else(|| advanced.get("timestepShift"))
-                .and_then(|value| {
-                    value
-                        .as_f64()
-                        .or_else(|| value.as_str()?.trim().parse().ok())
-                })
-                .map(|value| value as f32);
+            input.scheduler_shift = raw_shift;
         }
     }
     let cancel = CancelFlag::new();


### PR DESCRIPTION
## Epic 7114 P5 — sc-7129

Lands the **N4 single-rev invariant** so the SceneWorks worker runs on the unified sampler/scheduler framework, plus an **N1 default-no-op regression suite** and the **recipe round-trip** confirmation.

### Pin lockstep (N4)
- **mlx-gen + sceneworks-gen-core: `d8038beb → c59f73cb`** (26 dep lines). `c59f73cb` is the P3 mlx-gen adoption — flow-match cohort + Boogu Base/Edit route denoise through the curated `Sampler<MlxLatentOps>` + `FlowModelSampling` and advertise the curated menu; DDPM (SDXL/Kolors) + outliers (SVD/LTX) too.
- **candle-gen: `f8481639 → ed77abdc`** (22 dep lines), in lockstep. candle-gen `main` already re-pins its gen-core (workspace + all 17 testkit dev-deps) to `c59f73cb` (candle-gen #124) and carries the candle **flow-match adoption (sc-7123)**, so `--features backend-candle --target all` resolves the **single** gen-core rev `c59f73cb`.
- gen-core delta `d8038beb..c59f73cb` is **purely additive** (`FlowModelSampling::with_shift`; `new(conv)` stays `mu=0` byte-exact) → worker import surface unchanged, **N1 holds**.

### N1 regression suite + DRY
- Extracted the duplicated advanced-sampling read (mlx + candle image lanes, introduced in sc-7127) into a shared `read_advanced_sampling_knobs`; the video lane reuses it.
- New N1 tests: a default / empty / `"default"`-sentinel advanced block resolves to **all `None`** (the guaranteed no-op default), so a future change can't silently inject a non-default sampler onto the default path; real names + `schedulerShift` (incl. legacy `timestepShift`) pass through.

### Verification
- ✅ Both skew gates green — single rev `c59f73cb` across `sceneworks-worker` + `sceneworks-rust-api` (`--target all`, the candle lane the default PR gate is blind to).
- ✅ `cargo clippy -D warnings` clean.
- ✅ Full worker suite **365 passed / 0 failed** against the new pin (no regression from the engine-code bump).
- ✅ Recipe round-trip confirmed already-wired in ImageStudio + VideoStudio (state init from `saved.*`, restore from `rawSettings.*`, preset snapshots, job payload).
- Engine **N1/N2 real-weight** validated upstream in mlx-gen at the pinned commits (sc-7120/7121/7122 smokes); the curated samplers are now live end-to-end on the worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)