### PR TITLE
fix(manifest): per-backend truthful sampler/scheduler menus + drift guard (sc-7126)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -523,7 +523,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -535,7 +535,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -585,7 +585,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -596,7 +596,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -613,7 +613,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -628,7 +628,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -639,7 +639,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -654,7 +654,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -672,7 +672,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -683,7 +683,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -696,7 +696,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -707,7 +707,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -720,7 +720,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ed77abdc3b0982bf31864fae3923444821d9b7f6#ed77abdc3b0982bf31864fae3923444821d9b7f6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -4273,7 +4273,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -7566,7 +7566,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1916,12 +1916,6 @@
         "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
         "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
       },
-      "candle": {
-        "limits": {
-          "samplers": ["default"],
-          "schedulers": ["default"]
-        }
-      },
       "loraCompatibility": {
         // Kolors uses an SDXL-style UNet. Advertise only the kolors family so the
         // picker never offers cross-architecture LoRAs (e.g. z-image): an empty
@@ -1992,12 +1986,6 @@
         "count": [1, 2, 4],
         "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
         "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
-      },
-      "candle": {
-        "limits": {
-          "samplers": ["default", "ddim"],
-          "schedulers": ["default"]
-        }
       },
       "loraCompatibility": {
         // Declare the real family so the picker only offers sdxl-family LoRAs
@@ -2084,12 +2072,6 @@
         "count": [1, 2, 4],
         "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
         "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
-      },
-      "candle": {
-        "limits": {
-          "samplers": ["default", "ddim"],
-          "schedulers": ["default"]
-        }
       },
       "loraCompatibility": {
         // SDXL UNet, so sdxl-family LoRAs apply (per sc-1927 declare the real

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -45,8 +45,8 @@
         "resolutions": ["768x768", "1024x1024", "1280x720", "720x1280"],
         "count": [1, 2, 4, 8],
         // Flow-matching DiT — full diffusers flow menu (epic 1753).
-        "samplers": ["default", "euler", "heun", "dpmpp", "unipc"],
-        "schedulers": ["default", "simple", "shift", "karras", "exponential", "beta"]
+        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+        "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
       },
       "loraCompatibility": {
         "families": ["z-image"],
@@ -66,8 +66,8 @@
         "minMemoryGb": 40,
         "quantize": 8,
         "limits": {
-          "samplers": ["default"],
-          "schedulers": ["default"]
+          "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+          "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
         }
       },
       "ui": {
@@ -125,8 +125,8 @@
       "limits": {
         "resolutions": ["768x768", "1024x1024", "1280x720", "720x1280"],
         "count": [1, 2, 4, 8],
-        "samplers": ["default", "euler", "heun", "dpmpp", "unipc"],
-        "schedulers": ["default", "simple", "shift", "karras", "exponential", "beta"]
+        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+        "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
       },
       "loraCompatibility": {
         "families": ["z-image"],
@@ -176,8 +176,8 @@
         "resolutions": ["768x768", "1024x1024", "1280x720", "720x1280"],
         "count": [1, 2, 4],
         // Flow-matching DiT — full diffusers flow menu (epic 1753).
-        "samplers": ["default", "euler", "heun", "dpmpp", "unipc"],
-        "schedulers": ["default", "simple", "shift", "karras", "exponential", "beta"]
+        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+        "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
       },
       "loraCompatibility": {
         "families": ["qwen-image"],
@@ -197,8 +197,8 @@
         "minMemoryGb": 50,
         "quantize": 8,
         "limits": {
-          "samplers": ["default"],
-          "schedulers": ["default"]
+          "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+          "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
         }
       },
       "ui": {
@@ -263,8 +263,8 @@
       "limits": {
         "resolutions": ["768x768", "1024x1024", "1280x720", "720x1280"],
         "count": [1, 2, 4],
-        "samplers": ["default", "euler", "heun", "dpmpp", "unipc"],
-        "schedulers": ["default", "simple", "shift", "karras", "exponential", "beta"]
+        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+        "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
       },
       "loraCompatibility": {
         "families": ["qwen-image"],
@@ -336,8 +336,8 @@
       "limits": {
         "resolutions": ["768x768", "1024x1024", "1280x720", "720x1280"],
         "count": [1, 2, 4],
-        "samplers": ["default", "euler", "heun", "dpmpp", "unipc"],
-        "schedulers": ["default", "simple", "shift", "karras", "exponential", "beta"]
+        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+        "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
       },
       "loraCompatibility": {
         "families": ["qwen-image"],
@@ -434,8 +434,14 @@
         "count": [1, 2, 4],
         // Vendored flow-matching loop — sampler/scheduler threaded through
         // sc-1764. Full flow menu surfaced once the vendored loop swap lands.
-        "samplers": ["default", "euler", "heun", "dpmpp", "unipc"],
-        "schedulers": ["default", "simple", "shift", "karras", "exponential", "beta"]
+        "samplers": ["default"],
+        "schedulers": ["default"]
+      },
+      "candle": {
+        "limits": {
+          "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+          "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
+        }
       },
       "loraCompatibility": {
         // Same `lens` family as Lens-Turbo; a LoRA trained here applies to both.
@@ -489,8 +495,14 @@
         "count": [1, 2, 4],
         // Vendored flow-matching loop — sampler/scheduler threaded through
         // sc-1764. Full flow menu surfaced once the vendored loop swap lands.
-        "samplers": ["default", "euler", "heun", "dpmpp", "unipc"],
-        "schedulers": ["default", "simple", "shift", "karras", "exponential", "beta"]
+        "samplers": ["default"],
+        "schedulers": ["default"]
+      },
+      "candle": {
+        "limits": {
+          "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+          "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
+        }
       },
       "loraCompatibility": {
         // Lens LoRA training (sc-1583) trains on the non-distilled microsoft/Lens
@@ -561,7 +573,7 @@
         "resolutions": ["2048x2048", "2720x1536", "2496x1664", "2368x1760", "1536x2720", "1664x2496", "1760x2368"],
         "count": [1, 2, 4],
         "samplers": ["default"],
-        "schedulers": ["shift"]
+        "schedulers": ["default"]
       },
       "loraCompatibility": {
         // SenseNova-U1 is an 8B MoT autoregressive image model with no diffusion-LoRA merge path,
@@ -636,7 +648,7 @@
         "resolutions": ["2048x2048", "2720x1536", "2496x1664", "2368x1760", "1536x2720", "1664x2496", "1760x2368"],
         "count": [1, 2, 4],
         "samplers": ["default"],
-        "schedulers": ["shift"]
+        "schedulers": ["default"]
       },
       "loraCompatibility": {
         // No user-LoRA path (MoT autoregressive; the distill LoRA is baked into this variant).
@@ -709,7 +721,9 @@
       },
       "limits": {
         "resolutions": ["768x768", "1024x1024", "1280x720", "720x1280"],
-        "count": [1, 2, 4]
+        "count": [1, 2, 4],
+        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+        "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
       },
       "loraCompatibility": {
         "families": ["flux"],
@@ -772,7 +786,9 @@
       },
       "limits": {
         "resolutions": ["768x768", "1024x1024", "1280x720", "720x1280"],
-        "count": [1, 2, 4]
+        "count": [1, 2, 4],
+        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+        "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
       },
       "loraCompatibility": {
         "families": ["flux"],
@@ -1075,8 +1091,8 @@
         // sampler / scheduler.
         "resolutions": ["1024x1024", "768x1024", "1024x768", "1280x720", "720x1280"],
         "count": [1, 2, 4],
-        "samplers": ["default"],
-        "schedulers": ["default"]
+        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+        "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
       },
       "loraCompatibility": {
         // No Boogu LoRA wired yet (the engine descriptor reports supports_lora: false). Family
@@ -1228,8 +1244,8 @@
       "limits": {
         "resolutions": ["1024x1024", "768x1024", "1024x768", "1280x720", "720x1280"],
         "count": [1, 2, 4],
-        "samplers": ["default"],
-        "schedulers": ["default"]
+        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+        "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
       },
       "loraCompatibility": {
         "families": ["boogu"],
@@ -1299,7 +1315,9 @@
       },
       "limits": {
         "resolutions": ["768x768", "1024x1024", "1280x720", "720x1280"],
-        "count": [1, 2, 4]
+        "count": [1, 2, 4],
+        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+        "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
       },
       "loraCompatibility": {
         "families": ["flux2"],
@@ -1405,7 +1423,9 @@
       },
       "limits": {
         "resolutions": ["768x768", "1024x1024", "1280x720", "720x1280"],
-        "count": [1, 2, 4]
+        "count": [1, 2, 4],
+        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+        "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
       },
       "loraCompatibility": {
         "families": ["flux2"],
@@ -1495,7 +1515,9 @@
       },
       "limits": {
         "resolutions": ["768x768", "1024x1024", "1280x720", "720x1280"],
-        "count": [1, 2, 4]
+        "count": [1, 2, 4],
+        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+        "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
       },
       "loraCompatibility": {
         "families": ["flux2"],
@@ -1595,7 +1617,9 @@
       },
       "limits": {
         "resolutions": ["768x768", "1024x1024", "1280x720", "720x1280"],
-        "count": [1, 2]
+        "count": [1, 2],
+        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+        "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
       },
       // 32B DiT + ~24B Mistral TE. In-app Q4 *load* of the dense bf16 snapshot peaks
       // ~105 GB (> the 128 GB ceiling), so the snapshot is pre-quantized to Q4 ON DISK
@@ -1722,7 +1746,9 @@
       },
       "limits": {
         "resolutions": ["768x768", "1024x1024", "1280x720", "720x1280"],
-        "count": [1, 2, 4]
+        "count": [1, 2, 4],
+        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+        "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
       },
       "loraCompatibility": {
         // Chroma is FLUX.1-schnell-derived and shares Flux's transformer layout,
@@ -1774,7 +1800,9 @@
       },
       "limits": {
         "resolutions": ["768x768", "1024x1024", "1280x720", "720x1280"],
-        "count": [1, 2, 4]
+        "count": [1, 2, 4],
+        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+        "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
       },
       "loraCompatibility": {
         // Chroma is FLUX.1-schnell-derived and shares Flux's transformer layout,
@@ -1829,8 +1857,8 @@
       },
       "limits": {
         "resolutions": ["768x768", "1024x1024", "1280x720", "720x1280"],
-        "samplers": ["default", "euler", "heun"],
-        "schedulers": ["default"],
+        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+        "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"],
         "count": [1, 2, 4]
       },
       "loraCompatibility": {
@@ -1884,7 +1912,15 @@
       },
       "limits": {
         "resolutions": ["768x768", "1024x1024", "1280x720", "720x1280"],
-        "count": [1, 2, 4]
+        "count": [1, 2, 4],
+        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+        "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
+      },
+      "candle": {
+        "limits": {
+          "samplers": ["default"],
+          "schedulers": ["default"]
+        }
       },
       "loraCompatibility": {
         // Kolors uses an SDXL-style UNet. Advertise only the kolors family so the
@@ -1953,7 +1989,15 @@
       "limits": {
         // Native 1024x1024 plus the canonical SDXL aspect-ratio buckets.
         "resolutions": ["1024x1024", "1152x896", "896x1152", "1216x832", "832x1216", "1344x768", "768x1344"],
-        "count": [1, 2, 4]
+        "count": [1, 2, 4],
+        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+        "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
+      },
+      "candle": {
+        "limits": {
+          "samplers": ["default", "ddim"],
+          "schedulers": ["default"]
+        }
       },
       "loraCompatibility": {
         // Declare the real family so the picker only offers sdxl-family LoRAs
@@ -2037,7 +2081,15 @@
       "limits": {
         // Native 1024x1024 plus the canonical SDXL aspect-ratio buckets.
         "resolutions": ["1024x1024", "1152x896", "896x1152", "1216x832", "832x1216", "1344x768", "768x1344"],
-        "count": [1, 2, 4]
+        "count": [1, 2, 4],
+        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+        "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
+      },
+      "candle": {
+        "limits": {
+          "samplers": ["default", "ddim"],
+          "schedulers": ["default"]
+        }
       },
       "loraCompatibility": {
         // SDXL UNet, so sdxl-family LoRAs apply (per sc-1927 declare the real
@@ -2195,11 +2247,12 @@
         // bucket is safe (no face stretching — the sc-2009 kps-aspect fix).
         "resolutions": ["1024x1024", "1152x896", "896x1152", "1216x832", "832x1216", "1344x768", "768x1344"],
         "count": [1, 2, 4],
-        // sc-3857: SDXL/epsilon sampler menu. The worker registry routes this
-        // epsilon pipe to standard solvers; dpmpp_sde + karras == "DPM++ SDE
-        // Karras" (the RealVisXL-recommended, sharper/less-saturated combo).
-        "samplers": ["default", "euler", "euler_a", "dpmpp", "dpmpp_sde", "unipc"],
-        "schedulers": ["default", "karras", "exponential"]
+        // Sampler/scheduler selection is default-only: the dedicated InstantID worker
+        // path (`generate_instantid_stream`) builds its request without reading
+        // `advanced.sampler`, so a curated menu here would be a silent no-op until that
+        // bespoke path is plumbed through the unified framework (tracked follow-up, epic 7114).
+        "samplers": ["default"],
+        "schedulers": ["default"]
       },
       "loraCompatibility": {
         // SDXL UNet, so sdxl-family LoRAs apply (per sc-1927 declare the real
@@ -2696,8 +2749,8 @@
         "resolutions": ["832x480", "1280x720", "720x1280"],
         // Diffusers WanPipeline (torch backend) supports flow-matching swaps
         // via apply_sampler. Per-backend MLX override below pins default-only.
-        "samplers": ["default", "euler", "heun", "dpmpp", "unipc"],
-        "schedulers": ["default", "simple", "shift", "karras", "exponential", "beta"]
+        "samplers": ["default"],
+        "schedulers": ["default"]
       },
       "loraCompatibility": {
         "families": ["wan-video"],
@@ -2803,8 +2856,8 @@
         "resolutions": ["832x480", "480x832", "1280x720", "720x1280"],
         // Diffusers WanPipeline (torch backend) supports flow-matching swaps
         // via apply_sampler. MLX path is default-only — declared on mlx.limits.
-        "samplers": ["default", "euler", "heun", "dpmpp", "unipc"],
-        "schedulers": ["default", "simple", "shift", "karras", "exponential", "beta"]
+        "samplers": ["default"],
+        "schedulers": ["default"]
       },
       "loraCompatibility": {
         "families": ["wan-video"],
@@ -2910,8 +2963,8 @@
         "resolutions": ["832x480", "480x832", "1280x720", "720x1280"],
         // Diffusers WanPipeline (torch backend) supports flow-matching swaps
         // via apply_sampler. MLX path is default-only — declared on mlx.limits.
-        "samplers": ["default", "euler", "heun", "dpmpp", "unipc"],
-        "schedulers": ["default", "simple", "shift", "karras", "exponential", "beta"]
+        "samplers": ["default"],
+        "schedulers": ["default"]
       },
       "loraCompatibility": {
         "families": ["wan-video"],

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -963,39 +963,46 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f
 # sampler/scheduler menu too. So `--features backend-candle --target all` resolves the SINGLE gen-core rev
 # c59f73cb shared with the mlx pin. gen-core delta d8038beb..c59f73cb is purely additive
 # (`FlowModelSampling::with_shift`), so the worker's candle import surface is unchanged.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
+# Rev ed77abdc -> 7b12e8c (epic 7114 P5 / sc-7126): advance candle-gen to pick up the REST of P4 — the
+# DDPM cohort + Wan fold-in (candle-gen #125 / sc-7124) and the SVD/LTX outliers (candle-gen #126 /
+# sc-7125). candle SDXL/Kolors now advertise the curated `menu_with_aliases` menu (so the manifest drops
+# their narrow `candle.limits` overrides — base curated applies to both backends), and SVD/LTX advertise
+# the curated sampler axis. This is a candle-gen-only advancement: 7b12e8c STILL pins gen-core c59f73cb
+# (same as the mlx pin), so `--features backend-candle --target all` stays a SINGLE gen-core rev — NOT a
+# gen-core lockstep, just the candle crates moving forward within the same contract rev.
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1004,11 +1011,11 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1017,19 +1024,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1038,12 +1045,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1051,7 +1058,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77a
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1060,7 +1067,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1068,7 +1075,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1077,7 +1084,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1104,7 +1111,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ed77abdc3b0982bf31864fae3923444821d9b7f6", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -634,6 +634,102 @@ mod tests {
         s
     }
 
+    // ── epic 7114 P5 / sc-7126: manifest ⊆ descriptor drift guard ────────────────────────────────
+    // The builtin manifest's advertised sampler/scheduler menu for a model MUST be a subset of what
+    // the linked engine descriptor actually advertises on the ACTIVE backend, or the worker N3-falls
+    // the name back to the default (sc-7127) — i.e. the UI offers a knob the engine silently ignores.
+    // This test parses the embedded manifest and, for every image model with a linked descriptor,
+    // asserts the per-backend-effective menu (base `limits` overridden by `<backend>.limits`) is
+    // honoured by the descriptor. It checks `mlx` on macOS (where the MLX provider crates are linked)
+    // and `candle` on the `backend-candle` build — whichever registry is active — so each backend's
+    // truthfulness is enforced on its own lane. `"default"` is the engine-default sentinel, always allowed.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    fn parse_builtin_models() -> serde_json::Value {
+        let text = sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS
+            .iter()
+            .find(|(name, _)| *name == "builtin.models.jsonc")
+            .expect("builtin.models.jsonc embedded")
+            .1;
+        let stripped = sceneworks_core::jsonc::strip_jsonc_comments(text);
+        serde_json::from_str(&stripped).expect("parse builtin.models.jsonc")
+    }
+
+    // The effective `limits[key]` list for `backend`: the per-backend `<backend>.limits[key]` override
+    // if present, else the base `limits[key]`. `None` => the model advertises no list for that axis.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    fn effective_list(model: &serde_json::Value, backend: &str, key: &str) -> Option<Vec<String>> {
+        let pick = |scope: &serde_json::Value| {
+            scope
+                .get("limits")
+                .and_then(|l| l.get(key))
+                .and_then(|a| a.as_array())
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|x| x.as_str().map(str::to_owned))
+                        .collect::<Vec<_>>()
+                })
+        };
+        model.get(backend).and_then(pick).or_else(|| pick(model))
+    }
+
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    #[test]
+    fn manifest_menu_is_subset_of_descriptor() {
+        // The active backend's registry: MLX on macOS, candle on the `backend-candle` build.
+        let backend = if cfg!(target_os = "macos") {
+            "mlx"
+        } else {
+            "candle"
+        };
+        let manifest = parse_builtin_models();
+        let models = manifest["models"].as_array().expect("models array");
+        let mut violations: Vec<String> = Vec::new();
+        for model in models {
+            let Some(id) = model["id"].as_str() else {
+                continue;
+            };
+            // Only image models with a linked descriptor (MODEL_TABLE). Video / unlinked models are out
+            // of this guard's scope (their descriptors aren't reached via `mlx_model`).
+            let Some(resolved) = mlx_model(id) else {
+                continue;
+            };
+            let caps = &resolved.descriptor.capabilities;
+            for (axis, advertised) in [
+                ("samplers", &caps.samplers),
+                ("schedulers", &caps.schedulers),
+            ] {
+                if let Some(list) = effective_list(model, backend, axis) {
+                    for name in list {
+                        if name == "default" {
+                            continue;
+                        }
+                        if !advertised.contains(&name.as_str()) {
+                            violations.push(format!(
+                                "{id}: {backend} {axis} {name:?} not advertised by descriptor {:?} (advertised: {advertised:?})",
+                                resolved.descriptor.id
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+        assert!(
+            violations.is_empty(),
+            "manifest advertises {} sampler/scheduler name(s) the {backend} engine does not honor:\n  {}",
+            violations.len(),
+            violations.join("\n  ")
+        );
+    }
+
     // An MLX-backed stub generator registered into the same `inventory` registry the real
     // provider crates use, with an id that IS in MODEL_TABLE (`z_image_turbo`). On Linux/Windows
     // no real provider crate is linked, so this is the only generator the derivation sees — which

--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -7,13 +7,32 @@
   "$defs": {
     "samplerKey": {
       "type": "string",
-      "enum": ["default", "euler", "heun", "dpmpp", "unipc"],
-      "description": "Integration method offered by a diffusers flow-matching adapter (epic 1753). \"default\" = whatever the loaded pipeline ships with (no swap)."
+      "enum": [
+        "default",
+        "euler",
+        "euler_ancestral",
+        "heun",
+        "dpmpp_2m",
+        "dpmpp_sde",
+        "uni_pc",
+        "lcm",
+        "ddim"
+      ],
+      "description": "Sampler (integration method) from the unified curated framework (epic 7114, decision 2), honored by the native mlx-gen / candle-gen engines. Names match gen-core's Solver registry exactly. \"default\" = the engine's native sampler (no swap). Supersedes the epic-1753 diffusers vocabulary (dpmpp -> dpmpp_2m, unipc -> uni_pc, + euler_ancestral / dpmpp_sde / lcm / ddim)."
     },
     "schedulerKey": {
       "type": "string",
-      "enum": ["default", "simple", "shift", "karras", "exponential", "beta"],
-      "description": "Sigma / timestep schedule axis (epic 1753). \"shift\" pairs with defaults.schedulerShift / advanced.schedulerShift. \"default\" preserves the trained schedule."
+      "enum": [
+        "default",
+        "normal",
+        "simple",
+        "karras",
+        "exponential",
+        "sgm_uniform",
+        "beta",
+        "ddim_uniform"
+      ],
+      "description": "Sigma schedule from the unified curated framework (epic 7114, decision 2). Names match gen-core's Scheduler registry exactly. \"default\" preserves the engine's native schedule. The epic-1753 \"shift\" pseudo-scheduler is gone — the per-generation time shift is the orthogonal defaults.schedulerShift / advanced.schedulerShift knob, not a scheduler choice."
     },
     "samplerLimits": {
       "type": "object",

--- a/tests/test_worker_image_adapters.py
+++ b/tests/test_worker_image_adapters.py
@@ -972,12 +972,14 @@ def test_qwen_image_manifest_has_mlx_block():
     assert mem_match and int(mem_match.group(1)) > 0, (
         "qwen_image mlx.minMemoryGb must be a positive int (sc-1972)"
     )
-    # MLX sampler/scheduler menu override
-    assert '"samplers": ["default"]' in mlx_block, (
-        "qwen_image mlx must restrict samplers to default (mflux loop is linear-only)"
+    # MLX sampler/scheduler menu (epic 7114 P5, sc-7126): the native MLX engine now
+    # routes through the unified curated sampler/scheduler framework (the old mflux
+    # linear-only loop is gone), so the mlx block advertises the curated menu.
+    assert '"dpmpp_2m"' in mlx_block and '"uni_pc"' in mlx_block, (
+        "qwen_image mlx must advertise the curated sampler menu (epic 7114)"
     )
-    assert '"schedulers": ["default"]' in mlx_block, (
-        "qwen_image mlx must restrict schedulers to default (mflux loop is linear-only)"
+    assert '"sgm_uniform"' in mlx_block, (
+        "qwen_image mlx must advertise the curated scheduler menu (epic 7114)"
     )
 
 def test_create_image_adapter_routes_qwen_image():
@@ -1087,11 +1089,13 @@ def test_z_image_turbo_manifest_has_mlx_block():
     assert mem_match and int(mem_match.group(1)) > 0, (
         "z_image_turbo mlx.minMemoryGb must be a positive int (sc-2145)"
     )
-    assert '"samplers": ["default"]' in mlx_block, (
-        "z_image_turbo mlx must restrict samplers to default (mflux loop is linear-only)"
+    # epic 7114 P5 (sc-7126): the native MLX engine adopted the unified curated
+    # sampler/scheduler framework, so the mflux linear-only restriction is gone.
+    assert '"dpmpp_2m"' in mlx_block and '"uni_pc"' in mlx_block, (
+        "z_image_turbo mlx must advertise the curated sampler menu (epic 7114)"
     )
-    assert '"schedulers": ["default"]' in mlx_block, (
-        "z_image_turbo mlx must restrict schedulers to default (mflux loop is linear-only)"
+    assert '"sgm_uniform"' in mlx_block, (
+        "z_image_turbo mlx must advertise the curated scheduler menu (epic 7114)"
     )
 
 def test_create_image_adapter_routes_z_image_turbo():


### PR DESCRIPTION
## Epic 7114 P5 — sc-7126

Reconcile the builtin manifest's advertised sampler/scheduler menus to be **per-model-per-backend** and truthful to each engine's gen-core `Capabilities`, fixing the live epic-1753-vocabulary mismatch (the manifest advertised diffusers names the native engines never honor — e.g. `qwen_image` `euler/heun/dpmpp/unipc`, which the engine rejects / N3-falls back).

### Curated vocabulary
gen-core Solver/Scheduler registry names: `dpmpp → dpmpp_2m`, `unipc → uni_pc`, `+ euler_ancestral / dpmpp_sde / lcm / ddim`; schedulers gain `normal / sgm_uniform / ddim_uniform`; the 1753 `shift` pseudo-scheduler is gone (the shift is the orthogonal `schedulerShift` knob).

### Expose the curated picker where the descriptor supports it
- **boogu_image / boogu_image_edit** gain the full menu (the originating "Boogu has no picker" request).
- **flux / flux2 / chroma / sdxl / kolors** (which had no picker at all) gain it.
- The stale `mlx.limits: ["default"]` overrides on `qwen_image` / `z_image_turbo` (mflux-era "sealed on linear") are lifted.

### Per-backend overrides for the real asymmetries
- candle `sdxl` = `["default","ddim"]` (mlx full); candle `kolors` = `["default"]` (DDPM cohort not yet adopted on candle).
- `lens`/`lens_turbo` base = `["default"]` (mlx advertises only `flow_match_euler`) **but** candle override = full curated (candle adopted lens via sc-7123).

### Default-only (bespoke / unverified paths)
`ideogram`, `sensenova`, `boogu_turbo`, `instantid_realvisxl` = `["default"]` (their engines / dedicated worker paths don't honor the curated framework). Video models collapsed to `["default"]` (removed the broken legacy menu). Both deferrals filed: **sc-7296** (video sampler exposure — needs a Wan engine-name reconcile) + **sc-7297** (InstantID/bespoke path plumbing).

### Schema + drift guard
- Extend `samplerKey`/`schedulerKey` enums to the curated vocabulary.
- New `engines.rs::manifest_menu_is_subset_of_descriptor`: asserts every image model's per-backend-effective menu (`base limits` overridden by `<backend>.limits`) is a subset of the linked descriptor's advertised set — so the manifest can never again drift from the engine. Checks **mlx on macOS, candle on the backend-candle build**.

### Verification
- ✅ Guard passes (caught **29** real violations before the fix).
- ✅ `clippy -D warnings` clean; manifest parses; **0 residual legacy names**.
- ✅ Web `samplerOptions` tests unaffected (it tests the JS functions with inline fixtures; the curated UI labels land in **sc-7128**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)