### PR TITLE
feat(web): curated sampler/scheduler vocabulary + per-backend gating (sc-7128)

### DIFF
--- a/apps/web/src/samplerOptions.js
+++ b/apps/web/src/samplerOptions.js
@@ -1,30 +1,55 @@
-// Shared labels + helpers for the configurable sampler/scheduler controls
-// (epic 1753). The worker's flow-compatible registry lives in
-// apps/worker/scene_worker/sampler_registry.py; the studios source their
-// dropdown contents from each model's manifest `limits.samplers` /
-// `limits.schedulers` arrays so invalid combos are never selectable.
+// Shared labels + helpers for the configurable sampler/scheduler controls. The
+// curated vocabulary (epic 7114) matches the native mlx-gen / candle-gen gen-core
+// Solver / Scheduler registries exactly — the names sent in the job's `advanced`
+// block ARE the engine's sampler/scheduler ids. The studios source their dropdown
+// contents from each model's per-backend manifest `limits.samplers` /
+// `limits.schedulers` arrays (base `limits` overridden by `mlx.limits` /
+// `candle.limits` for the active backend) so invalid combos are never selectable.
 
 export const SAMPLER_LABELS = {
   default: "Model default",
   euler: "Euler",
-  euler_a: "Euler ancestral",
+  euler_ancestral: "Euler ancestral",
   heun: "Heun (2nd-order)",
-  dpmpp: "DPM++ (2M)",
+  dpmpp_2m: "DPM++ (2M)",
   dpmpp_sde: "DPM++ SDE",
-  unipc: "UniPC",
+  uni_pc: "UniPC",
+  lcm: "LCM",
+  ddim: "DDIM",
 };
 
 export const SCHEDULER_LABELS = {
   default: "Model default",
+  normal: "Normal",
   simple: "Simple (uniform)",
-  shift: "Shift (timestep)",
   karras: "Karras",
   exponential: "Exponential",
+  sgm_uniform: "SGM uniform",
   beta: "Beta",
+  ddim_uniform: "DDIM uniform",
 };
 
-const SAMPLER_ORDER = ["default", "euler", "euler_a", "heun", "dpmpp", "dpmpp_sde", "unipc"];
-const SCHEDULER_ORDER = ["default", "simple", "shift", "karras", "exponential", "beta"];
+const SAMPLER_ORDER = [
+  "default",
+  "euler",
+  "euler_ancestral",
+  "heun",
+  "dpmpp_2m",
+  "dpmpp_sde",
+  "uni_pc",
+  "lcm",
+  "ddim",
+];
+const SCHEDULER_ORDER = [
+  "default",
+  "normal",
+  "simple",
+  "karras",
+  "exponential",
+  "sgm_uniform",
+  "beta",
+  "ddim_uniform",
+];
 
 function uniqueOrdered(values, order) {
   const seen = new Set();
@@ -45,16 +70,27 @@ function uniqueOrdered(values, order) {
   return result;
 }
 
+// The effective `limits` for the active backend: the per-backend `mlx.limits` /
+// `candle.limits` override when present, else the base `limits` (epic 7114 P5
+// per-model-per-backend gating). `backend` is the active worker's backend
+// ("mlx" | "candle"); a null/unknown backend falls back to the base menu.
+function effectiveLimits(model, backend) {
+  const override = backend ? model?.[backend]?.limits : null;
+  return override ?? model?.limits;
+}
+
 // Pull the menu out of a model manifest entry, falling back to default-only.
 // When the menu has fewer than 2 entries, the studio hides the dropdown — the
 // caller can use `samplerMenu.length > 1` to gate rendering.
-export function samplerOptionsFromModel(model) {
-  const values = Array.isArray(model?.limits?.samplers) ? model.limits.samplers : ["default"];
+export function samplerOptionsFromModel(model, backend) {
+  const limits = effectiveLimits(model, backend);
+  const values = Array.isArray(limits?.samplers) ? limits.samplers : ["default"];
   return uniqueOrdered(values, SAMPLER_ORDER);
 }
 
-export function schedulerOptionsFromModel(model) {
-  const values = Array.isArray(model?.limits?.schedulers) ? model.limits.schedulers : ["default"];
+export function schedulerOptionsFromModel(model, backend) {
+  const limits = effectiveLimits(model, backend);
+  const values = Array.isArray(limits?.schedulers) ? limits.schedulers : ["default"];
   return uniqueOrdered(values, SCHEDULER_ORDER);
 }
 

--- a/apps/web/src/samplerOptions.test.js
+++ b/apps/web/src/samplerOptions.test.js
@@ -19,8 +19,8 @@ describe("samplerOptions", () => {
   });
 
   it("returns options in canonical order regardless of manifest ordering", () => {
-    const model = { limits: { samplers: ["unipc", "default", "euler"] } };
-    expect(samplerOptionsFromModel(model)).toEqual(["default", "euler", "unipc"]);
+    const model = { limits: { samplers: ["uni_pc", "default", "euler"] } };
+    expect(samplerOptionsFromModel(model)).toEqual(["default", "euler", "uni_pc"]);
   });
 
   it("preserves unknown sampler keys (forward-compat)", () => {
@@ -31,23 +31,47 @@ describe("samplerOptions", () => {
   it("scheduler options are ordered canonically", () => {
     const model = {
       limits: {
-        schedulers: ["beta", "default", "karras", "shift"],
+        schedulers: ["beta", "default", "karras", "sgm_uniform"],
       },
     };
-    expect(schedulerOptionsFromModel(model)).toEqual(["default", "shift", "karras", "beta"]);
+    expect(schedulerOptionsFromModel(model)).toEqual([
+      "default",
+      "karras",
+      "sgm_uniform",
+      "beta",
+    ]);
+  });
+
+  it("resolves the per-backend limits override (epic 7114)", () => {
+    // SDXL-shaped asymmetry: full curated on MLX (base), narrow on candle.
+    const model = {
+      limits: { samplers: ["default", "euler", "dpmpp_2m"] },
+      candle: { limits: { samplers: ["default", "ddim"] } },
+    };
+    expect(samplerOptionsFromModel(model, "mlx")).toEqual(["default", "euler", "dpmpp_2m"]);
+    expect(samplerOptionsFromModel(model, "candle")).toEqual(["default", "ddim"]);
+    // No / unknown backend falls back to the base menu.
+    expect(samplerOptionsFromModel(model)).toEqual(["default", "euler", "dpmpp_2m"]);
+    // Lens-shaped asymmetry: default-only on MLX (base), curated on candle.
+    const lens = {
+      limits: { samplers: ["default"] },
+      candle: { limits: { samplers: ["default", "euler", "heun"] } },
+    };
+    expect(samplerOptionsFromModel(lens, "mlx")).toEqual(["default"]);
+    expect(samplerOptionsFromModel(lens, "candle")).toEqual(["default", "euler", "heun"]);
   });
 
   it("default helpers read defaults block with sensible fallbacks", () => {
     const model = {
       defaults: {
-        sampler: "dpmpp",
+        sampler: "dpmpp_2m",
         scheduler: "karras",
         schedulerShift: 4.5,
         steps: 20,
         guidanceScale: 3.5,
       },
     };
-    expect(samplerDefaultFromModel(model)).toBe("dpmpp");
+    expect(samplerDefaultFromModel(model)).toBe("dpmpp_2m");
     expect(schedulerDefaultFromModel(model)).toBe("karras");
     expect(schedulerShiftDefaultFromModel(model)).toBe(4.5);
     expect(stepsDefaultFromModel(model)).toBe(20);
@@ -61,11 +85,30 @@ describe("samplerOptions", () => {
     expect(guidanceDefaultFromModel({ defaults: { guidanceScale: "n/a" } })).toBeNull();
   });
 
-  it("labels cover the full menu", () => {
-    for (const key of ["default", "euler", "heun", "dpmpp", "unipc"]) {
+  it("labels cover the full curated menu (epic 7114)", () => {
+    for (const key of [
+      "default",
+      "euler",
+      "euler_ancestral",
+      "heun",
+      "dpmpp_2m",
+      "dpmpp_sde",
+      "uni_pc",
+      "lcm",
+      "ddim",
+    ]) {
       expect(SAMPLER_LABELS[key]).toBeTruthy();
     }
-    for (const key of ["default", "simple", "shift", "karras", "exponential", "beta"]) {
+    for (const key of [
+      "default",
+      "normal",
+      "simple",
+      "karras",
+      "exponential",
+      "sgm_uniform",
+      "beta",
+      "ddim_uniform",
+    ]) {
       expect(SCHEDULER_LABELS[key]).toBeTruthy();
     }
   });

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -710,10 +710,21 @@ export function ImageStudio() {
         : DEFAULT_RESOLUTION_OPTIONS,
     [selectedModel],
   );
-  // Sampler / scheduler menus declared by the model. The advanced panel hides
-  // the dropdowns when the menu has fewer than 2 options (epic 1753 §7.4).
-  const samplerOptions = useMemo(() => samplerOptionsFromModel(selectedModel), [selectedModel]);
-  const schedulerOptions = useMemo(() => schedulerOptionsFromModel(selectedModel), [selectedModel]);
+  // Sampler / scheduler menus declared by the model, gated to the ACTIVE backend
+  // (epic 7114 P5): `macGatingActive` is the worker `mlx_required` master switch, so
+  // it picks the manifest's `mlx.limits` override on Mac/MLX and the `candle.limits`
+  // override on the Windows/Linux candle build (e.g. Lens exposes the curated menu
+  // only on candle; SDXL only on MLX). The advanced panel hides the dropdowns when
+  // the menu has fewer than 2 options (epic 1753 §7.4).
+  const activeBackend = macCapabilities?.macGatingActive ? "mlx" : "candle";
+  const samplerOptions = useMemo(
+    () => samplerOptionsFromModel(selectedModel, activeBackend),
+    [selectedModel, activeBackend],
+  );
+  const schedulerOptions = useMemo(
+    () => schedulerOptionsFromModel(selectedModel, activeBackend),
+    [selectedModel, activeBackend],
+  );
   const showSamplerPicker = samplerOptions.length > 1;
   const showSchedulerPicker = schedulerOptions.length > 1;
   const advancedDefaultsModel = useRef(model);
@@ -1218,7 +1229,13 @@ export function ImageStudio() {
           // values unconditionally is safe — invalid values are ignored.
           ...(sampler && sampler !== "default" ? { sampler } : {}),
           ...(scheduler && scheduler !== "default" ? { scheduler } : {}),
-          ...(scheduler === "shift" && Number.isFinite(Number(schedulerShift))
+          // The schedule shift (time-shift mu) is only honored when a curated
+          // (non-default) scheduler is active — it shapes that curated schedule;
+          // the default scheduler keeps the engine's resolution-native shift, so
+          // emitting it there would override the no-op default (epic 7114).
+          ...(scheduler &&
+          scheduler !== "default" &&
+          Number.isFinite(Number(schedulerShift))
             ? { schedulerShift: Number(schedulerShift) }
             : {}),
           // Step / guidance overrides — empty string means "use the model
@@ -1772,7 +1789,7 @@ export function ImageStudio() {
                     </select>
                   </label>
                 ) : null}
-                {scheduler === "shift" ? (
+                {showSchedulerPicker && scheduler !== "default" ? (
                   <label>
                     Schedule shift
                     <input

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -367,9 +367,18 @@ export function VideoStudio() {
   });
   // Sampler / scheduler menus declared by the model. Video Wan torch
   // declares the full menu; sealed paths (LTX native, MLX) drop to
-  // default-only and the picker hides.
-  const samplerOptions = useMemo(() => samplerOptionsFromModel(selectedModel), [selectedModel]);
-  const schedulerOptions = useMemo(() => schedulerOptionsFromModel(selectedModel), [selectedModel]);
+  // default-only and the picker hides. Gated to the ACTIVE backend (epic 7114 P5):
+  // `macGating` is the worker `mlx_required` master switch, so the menu reflects the
+  // manifest's `mlx.limits` override on Mac/MLX and `candle.limits` on the candle build.
+  const activeBackend = macGating ? "mlx" : "candle";
+  const samplerOptions = useMemo(
+    () => samplerOptionsFromModel(selectedModel, activeBackend),
+    [selectedModel, activeBackend],
+  );
+  const schedulerOptions = useMemo(
+    () => schedulerOptionsFromModel(selectedModel, activeBackend),
+    [selectedModel, activeBackend],
+  );
   const showSamplerPicker = samplerOptions.length > 1;
   const showSchedulerPicker = schedulerOptions.length > 1;
   useEffect(() => {
@@ -831,7 +840,12 @@ export function VideoStudio() {
           // diffusers (torch) path actually applies these.
           ...(sampler && sampler !== "default" ? { sampler } : {}),
           ...(scheduler && scheduler !== "default" ? { scheduler } : {}),
-          ...(scheduler === "shift" && Number.isFinite(Number(schedulerShift))
+          // Schedule shift (time-shift mu) only pairs with a curated (non-default)
+          // scheduler — it shapes that schedule; the default scheduler keeps the
+          // engine's resolution-native shift (epic 7114).
+          ...(scheduler &&
+          scheduler !== "default" &&
+          Number.isFinite(Number(schedulerShift))
             ? { schedulerShift: Number(schedulerShift) }
             : {}),
           ...(stepsOverride !== "" && Number.isFinite(Number(stepsOverride))
@@ -1590,7 +1604,7 @@ export function VideoStudio() {
                       </select>
                     </label>
                   ) : null}
-                  {scheduler === "shift" ? (
+                  {showSchedulerPicker && scheduler !== "default" ? (
                     <label>
                       Schedule shift
                       <input


### PR DESCRIPTION
## Epic 7114 P5 — sc-7128 (final P5 story)

Bring the Image + Video Studio sampler/scheduler controls onto the unified **curated vocabulary** and gate them **per active backend**.

### Changes
- **`samplerOptions.js`** — `SAMPLER_LABELS` / `SCHEDULER_LABELS` / `*_ORDER` updated to the curated gen-core registry names (`dpmpp_2m`, `uni_pc`, `euler_ancestral`, `dpmpp_sde`, `lcm`, `ddim`; `normal`, `sgm_uniform`, `ddim_uniform`). The names the studios send in `advanced` **are** the engine ids. Legacy `euler_a`/`dpmpp`/`unipc`/`shift` are gone.
- **Per-backend gating** — `samplerOptionsFromModel`/`schedulerOptionsFromModel` take an optional `backend` and resolve `<backend>.limits` over base `limits`. Both studios derive the active backend from `macGatingActive` (the worker `mlx_required` master switch), so the menu reflects the manifest's `mlx.limits` on Mac/MLX and `candle.limits` on the candle build (e.g. Lens exposes the curated menu only on candle).
- **Schedule shift** — the 1753 `"shift"` pseudo-scheduler is gone, so the `schedulerShift` input now pairs with any curated (non-default) scheduler — it shapes that curated schedule, while the default scheduler keeps the engine's native shift (preserving the **N1** no-op default). Applied to both studios.

### Verification
- ✅ `samplerOptions.test.js` updated to the curated vocabulary + a **new per-backend-override resolution test** (SDXL-shaped mlx-full/candle-narrow + Lens-shaped mlx-narrow/candle-full).
- ✅ Web suite **632 tests pass**; lint 0 errors; production build green.

Completes the P5 vertical (sc-7126/7127/7128/7129). Follow-ups tracked: sc-7296 (video samplers), sc-7297 (InstantID/bespoke paths), sc-7305 (mlx Lens adoption).

🤖 Generated with [Claude Code](https://claude.com/claude-code)