### PR TITLE
chore(worker): re-pin mlx-gen 903f295 + candle-gen f647aeb; widen Lens manifest (sc-7305)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -523,7 +523,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -535,7 +535,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -585,7 +585,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -596,7 +596,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -613,7 +613,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -628,7 +628,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -639,7 +639,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -654,7 +654,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -672,7 +672,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -683,7 +683,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -696,7 +696,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -707,7 +707,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -720,7 +720,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2#7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -3352,7 +3352,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3364,7 +3364,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
 dependencies = [
  "image",
  "inventory",
@@ -3378,7 +3378,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
 dependencies = [
  "image",
  "inventory",
@@ -3391,7 +3391,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3403,7 +3403,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3412,7 +3412,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3424,7 +3424,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3435,7 +3435,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3447,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3458,7 +3458,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3468,7 +3468,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
 dependencies = [
  "image",
  "inventory",
@@ -3480,7 +3480,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
 dependencies = [
  "image",
  "inventory",
@@ -3493,7 +3493,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
 dependencies = [
  "image",
  "inventory",
@@ -3505,7 +3505,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3516,7 +3516,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3528,7 +3528,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3538,7 +3538,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3547,7 +3547,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3556,7 +3556,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3568,7 +3568,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
 dependencies = [
  "image",
  "inventory",
@@ -3581,7 +3581,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3592,7 +3592,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3603,7 +3603,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3614,7 +3614,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
 dependencies = [
  "image",
  "inventory",
@@ -3628,7 +3628,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
 dependencies = [
  "image",
  "inventory",
@@ -5271,7 +5271,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c59f73cba7cce4e0c03e859955e300f8562ee3d8#c59f73cba7cce4e0c03e859955e300f8562ee3d8"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
 dependencies = [
  "inventory",
  "safetensors 0.4.5",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -432,16 +432,10 @@
       "limits": {
         "resolutions": ["1024x1024", "1440x1440", "1152x864", "864x1152", "1376x768", "768x1376"],
         "count": [1, 2, 4],
-        // Vendored flow-matching loop — sampler/scheduler threaded through
-        // sc-1764. Full flow menu surfaced once the vendored loop swap lands.
-        "samplers": ["default"],
-        "schedulers": ["default"]
-      },
-      "candle": {
-        "limits": {
-          "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
-          "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
-        }
+        // sc-7305: mlx + candle Lens both adopt the unified curated sampler framework, so the curated
+        // menu now applies to BOTH backends — the candle-only override is dropped (last asymmetry gone).
+        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+        "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
       },
       "loraCompatibility": {
         // Same `lens` family as Lens-Turbo; a LoRA trained here applies to both.
@@ -493,16 +487,10 @@
         // these map to 1:1 (1024 & 1440), 4:3, 3:4, 16:9, and 9:16 base-1024 buckets.
         "resolutions": ["1024x1024", "1440x1440", "1152x864", "864x1152", "1376x768", "768x1376"],
         "count": [1, 2, 4],
-        // Vendored flow-matching loop — sampler/scheduler threaded through
-        // sc-1764. Full flow menu surfaced once the vendored loop swap lands.
-        "samplers": ["default"],
-        "schedulers": ["default"]
-      },
-      "candle": {
-        "limits": {
-          "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
-          "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
-        }
+        // sc-7305: mlx + candle Lens both adopt the unified curated sampler framework, so the curated
+        // menu now applies to BOTH backends — the candle-only override is dropped (last asymmetry gone).
+        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+        "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
       },
       "loraCompatibility": {
         // Lens LoRA training (sc-1583) trains on the non-distilled microsoft/Lens

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -257,7 +257,15 @@ sceneworks-core = { path = "../sceneworks-core" }
 # its gen-core (workspace + all 17 testkit dev-deps) to c59f73cb (candle-gen #124) and carries the candle
 # flow-match adoption (sc-7123, #124) — so `--features backend-candle --target all` resolves the SINGLE
 # gen-core rev c59f73cb again (the skew gate the default PR lane is blind to).
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
+# Bumped `c59f73cb` -> `903f295` (epic 7114 sc-7305/sc-7296): mlx-gen main now carries the lens
+# curated-sampler adoption (mlx-gen #535, sc-7305) + the Wan engine-name reconcile `unipc`/`dpmpp2m` ->
+# `uni_pc`/`dpmpp_2m` (mlx-gen #536, sc-7296). gen-core is BYTE-IDENTICAL `c59f73cb..903f295` (both PRs
+# are additive in their own provider crates `mlx-gen-lens`/`mlx-gen-wan`, NOT gen-core), so the worker's
+# import surface is unchanged and N1 (default sampler = today's output) holds. Bumps EVERY mlx-gen crate
+# + gen-core in lockstep. The candle pin below moves `7b12e8c` -> `f647aeb` IN LOCKSTEP — candle-gen #129
+# re-pinned its gen-core (workspace + per-crate testkit dev-deps) to 903f295, so `--features
+# backend-candle --target all` resolves the SINGLE gen-core rev 903f295 again (the skew gate).
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -581,7 +589,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -593,64 +601,64 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7c
 # internal pin (the Lens engine PRs #407–#414 did not move it; nor did the seedvr2 engine #416/#419/
 # #421 or the softness PR #422, so the 1a97909 bump above leaves mlx-rs at 44929a0).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "44929a001ab8a8837403a71c65cf064224de0cdc" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -659,12 +667,12 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -673,7 +681,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -681,7 +689,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -692,7 +700,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -703,7 +711,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f7
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -718,7 +726,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73
 # converted in-memory at load (no Python); the precomputed neg-prompt embedding is bundled in-crate. No
 # LoRA/guidance/CFG (one-step). 3B fp16 only here — 7B (sc-5197) + int8 (sc-5198) are engine-side and
 # unwired. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -729,7 +737,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
 # Prompt-refine provider (sc-5552, the MLX twin of candle-gen-prompt-refine / sc-5500). An
 # inventory-registered `TextLlm` under id `prompt_refine` (`backend="mlx"`, `mac_only`): a native MLX
 # Llama-3.2-3B-Instruct that rewrites a user's prompt, replacing the Python `prompt_refine.py`
@@ -739,7 +747,7 @@ mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59
 # textllm registered" trap). Weights = a stock Llama-3.2-3B-Instruct HF snapshot (config.json +
 # tokenizer.json + model-*.safetensors; default `huihui-ai/Llama-3.2-3B-Instruct-abliterated`). Same
 # git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
+mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
 # SCAIL-2 (zai-org) end-to-end character-animation provider (epic 5439, sc-5448). An inventory-registered
 # `Generator` under id `scail2_14b` (`Modality::Video`): a Wan2.1-14B I2V DiT that animates a reference
 # character with a driving video's motion (`video_mode == "replacement"` flips the cross-identity
@@ -751,7 +759,7 @@ mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev 
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f73cba7cce4e0c03e859955e300f8562ee3d8" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -970,39 +978,39 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c59f
 # the curated sampler axis. This is a candle-gen-only advancement: 7b12e8c STILL pins gen-core c59f73cb
 # (same as the mlx pin), so `--features backend-candle --target all` stays a SINGLE gen-core rev — NOT a
 # gen-core lockstep, just the candle crates moving forward within the same contract rev.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1011,11 +1019,11 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1024,19 +1032,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1045,12 +1053,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1058,7 +1066,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1067,7 +1075,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1075,7 +1083,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1084,7 +1092,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1111,7 +1119,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b12e8cb1c50d422ae7272d2fb4dbcdb93d807d2", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with


### PR DESCRIPTION
## What

The epic-7114 pin-bump lockstep (step 2) + the sc-7305 SceneWorks close-out.

**Pins** (`crates/sceneworks-worker/Cargo.toml`):
- mlx-gen + `sceneworks-gen-core`: `c59f73cb → 903f295` (26 deps) — carries lens adoption ([mlx-gen#535](https://github.com/SceneWorks/mlx-gen/pull/535), sc-7305) + Wan reconcile ([mlx-gen#536](https://github.com/SceneWorks/mlx-gen/pull/536), sc-7296).
- candle-gen: `7b12e8c → f647aeb` (22 deps) — [candle-gen#129](https://github.com/SceneWorks/candle-gen/pull/129) re-pinned its gen-core to `903f295`.
- **Skew gate green:** exactly one `sceneworks-gen-core` (`903f295`) across the graph, `--target all`.

**sc-7305 manifest** (`builtin.models.jsonc`): the mlx Lens engine now adopts the unified curated sampler framework (matching candle), so `lens`/`lens_turbo` `limits` widen to the full curated menu for **both** backends and the candle-only `limits` override is **dropped** — the last per-backend Lens asymmetry. The drift guard validates the widened menu against the new mlx descriptor.

## Why N1 holds
gen-core is **byte-identical** across `c59f73cb..903f295` (both engine PRs are additive in their own provider crates, not gen-core), so the default sampler reproduces today's output.

## Scope note
The **video** manifest (Wan/SVD/LTX per-backend menus + extending the drift guard to `VIDEO_ENGINE_IDS`) — sc-7296 parts 2 & 3 — is a follow-up PR on top of these pins; the video entries stay `["default"]` here (a valid subset, guard stays green). Splitting keeps this pin bump clean and the intricate video work focused.

## Verification
- `scripts/check-gen-core-skew.sh` ✓ (single gen-core rev `903f295`)
- `cargo test -p sceneworks-worker --lib` ✓ (incl. `manifest_menu_is_subset_of_descriptor` + the N1 sampling-knob regression)

Closes sc-7305 (SceneWorks half). sc-7296 parts 2 & 3 follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
