### PR TITLE
feat(worker): expose curated video sampler menus + extend drift guard to video (sc-7296)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2464,7 +2464,10 @@
         // the square option at 640x640 even though normalized_dimensions would
         // accept larger.
         "resolutions": ["768x512", "512x768", "640x640", "1280x720", "720x1280"],
-        "requiresDimensionsMultipleOf": 32
+        "requiresDimensionsMultipleOf": 32,
+        // Epic 7114 curated sampler menu (sc-7296): both backends' LTX engine advertises the full
+        // curated set (candle also keeps the legacy `rectified-flow` alias). No scheduler axis.
+        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"]
       },
       "loraCompatibility": {
         "families": ["ltx-video"],
@@ -2569,7 +2572,10 @@
         // See LTX-2.3 note above: squares above 640x640 are out-of-distribution
         // and render black.
         "resolutions": ["768x512", "512x768", "640x640", "1280x720", "720x1280"],
-        "requiresDimensionsMultipleOf": 32
+        "requiresDimensionsMultipleOf": 32,
+        // Epic 7114 curated sampler menu (sc-7296): shares LTX's curated set (same engine id as
+        // base LTX-2.3 per backend). No scheduler axis.
+        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"]
       },
       "loraCompatibility": {
         "families": ["ltx-video"],
@@ -2650,7 +2656,10 @@
         "recommendedMaxDuration": 4,
         "hardMaxDuration": 4,
         "fps": [6, 7, 8, 10, 12, 25],
-        "resolutions": ["1024x576", "576x1024"]
+        "resolutions": ["1024x576", "576x1024"],
+        // Epic 7114 curated sampler menu (sc-7296): both backends' SVD engine advertises the
+        // full curated set. No scheduler axis. Same menu both backends (no per-backend override).
+        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"]
       },
       "loraCompatibility": {
         // No SVD LoRA ecosystem (generation-only); declare the family so the
@@ -2717,9 +2726,11 @@
         "hardMaxDuration": 8,
         "fps": [16, 24],
         "resolutions": ["832x480", "1280x720", "720x1280"],
-        // Diffusers WanPipeline (torch backend) supports flow-matching swaps
-        // via apply_sampler. Per-backend MLX override below pins default-only.
-        "samplers": ["default"],
+        // Epic 7114 curated sampler menu (sc-7296). Base = the candle (Windows) Wan engine's
+        // curated set, run over Wan's native flow σ schedule; the macOS mlx override below adds
+        // `dpmpp_2m` (mlx Wan's native FLOW-SNR DPM++2M). No scheduler axis — the flow shift is
+        // the separate `scheduler_shift` knob. The drift guard keeps each ⊆ its engine descriptor.
+        "samplers": ["default", "uni_pc", "euler", "euler_ancestral", "heun", "dpmpp_sde", "ddim"],
         "schedulers": ["default"]
       },
       "loraCompatibility": {
@@ -2755,10 +2766,11 @@
         // converter "wan_ti2v_5b" emits bf16 (Q4/Q8 applied at load, not baked in).
         "minMemoryGb": 45,
         "repo": "SceneWorks/wan2.2-ti2v-5b-mlx",
-        // MLX path is sealed (own ODE solver, no diffusers scheduler) — override
-        // the top-level sampler/scheduler menu to default-only (epic 1753 §14).
+        // macOS curated menu (sc-7296): mlx Wan adopts the unified framework over its native
+        // flow σ schedule, adding `dpmpp_2m` (native FLOW-SNR DPM++2M) on top of the base set.
+        // No scheduler axis (the flow shift is `scheduler_shift`).
         "limits": {
-          "samplers": ["default"],
+          "samplers": ["default", "uni_pc", "euler", "dpmpp_2m", "euler_ancestral", "heun", "dpmpp_sde", "ddim"],
           "schedulers": ["default"]
         }
       },
@@ -2824,9 +2836,10 @@
         "hardMaxDuration": 5,
         "fps": [16],
         "resolutions": ["832x480", "480x832", "1280x720", "720x1280"],
-        // Diffusers WanPipeline (torch backend) supports flow-matching swaps
-        // via apply_sampler. MLX path is default-only — declared on mlx.limits.
-        "samplers": ["default"],
+        // Epic 7114 curated menu (sc-7296). Base = the candle (Windows) A14B engine's curated
+        // set (native `uni_pc`/`euler`); the macOS mlx override below exposes the full curated
+        // fold-in. No scheduler axis (flow shift = `scheduler_shift`).
+        "samplers": ["default", "uni_pc", "euler"],
         "schedulers": ["default"]
       },
       "loraCompatibility": {
@@ -2867,8 +2880,10 @@
         // Lightning LoRA is downloaded on demand by MlxVideoAdapter at generation time.
         "minMemoryGb": 133,
         "repo": "SceneWorks/wan2.2-t2v-a14b-mlx",
+        // macOS curated menu (sc-7296): the full curated fold-in over the A14B native flow σ
+        // schedule. No scheduler axis (flow shift = `scheduler_shift`).
         "limits": {
-          "samplers": ["default"],
+          "samplers": ["default", "uni_pc", "euler", "dpmpp_2m", "euler_ancestral", "heun", "dpmpp_sde", "ddim"],
           "schedulers": ["default"]
         }
       },
@@ -2931,9 +2946,10 @@
         "hardMaxDuration": 5,
         "fps": [16],
         "resolutions": ["832x480", "480x832", "1280x720", "720x1280"],
-        // Diffusers WanPipeline (torch backend) supports flow-matching swaps
-        // via apply_sampler. MLX path is default-only — declared on mlx.limits.
-        "samplers": ["default"],
+        // Epic 7114 curated menu (sc-7296). Base = the candle (Windows) A14B engine's curated
+        // set (native `uni_pc`/`euler`); the macOS mlx override below exposes the full curated
+        // fold-in. No scheduler axis (flow shift = `scheduler_shift`).
+        "samplers": ["default", "uni_pc", "euler"],
         "schedulers": ["default"]
       },
       "loraCompatibility": {
@@ -2972,8 +2988,10 @@
         // (Q4/Q8 at load). Its distill LoRA is applied at run time.
         "minMemoryGb": 133,
         "repo": "SceneWorks/wan2.2-i2v-a14b-mlx",
+        // macOS curated menu (sc-7296): the full curated fold-in over the A14B native flow σ
+        // schedule. No scheduler axis (flow shift = `scheduler_shift`).
         "limits": {
-          "samplers": ["default"],
+          "samplers": ["default", "uni_pc", "euler", "dpmpp_2m", "euler_ancestral", "heun", "dpmpp_sde", "ddim"],
           "schedulers": ["default"]
         }
       },
@@ -3050,9 +3068,10 @@
         "hardMaxDuration": 5,
         "fps": [16],
         "resolutions": ["832x480", "480x832", "1280x720", "720x1280"],
-        // Native engines are default-sampler only (no flow-match swaps wired) — declared on
-        // mlx.limits too; there is no Torch backend for this model.
-        "samplers": ["default"],
+        // Epic 7114 curated menu (sc-7296). mlx-only model (no candle/Torch backend) — the native
+        // dual-expert VACE-Fun engine over Wan's flow σ schedule exposes the native curated set.
+        // No scheduler axis (flow shift = `scheduler_shift`).
+        "samplers": ["default", "uni_pc", "euler", "dpmpp_2m"],
         "schedulers": ["default"]
       },
       "loraCompatibility": {
@@ -3068,11 +3087,7 @@
         // transformers; the validated real-weight smoke ran at Q4, ~38 GB RSS on a 128 GB Mac).
         // 64 GB floor keeps a 128 GB Mac eligible while staying honest about the dual-expert load.
         "minMemoryGb": 64,
-        "repo": "linoyts/Wan2.2-VACE-Fun-14B-diffusers",
-        "limits": {
-          "samplers": ["default"],
-          "schedulers": ["default"]
-        }
+        "repo": "linoyts/Wan2.2-VACE-Fun-14B-diffusers"
       },
       "ui": {
         "label": "Wan2.2 VACE-Fun (A14B)",

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -638,8 +638,9 @@ mod tests {
     // The builtin manifest's advertised sampler/scheduler menu for a model MUST be a subset of what
     // the linked engine descriptor actually advertises on the ACTIVE backend, or the worker N3-falls
     // the name back to the default (sc-7127) — i.e. the UI offers a knob the engine silently ignores.
-    // This test parses the embedded manifest and, for every image model with a linked descriptor,
-    // asserts the per-backend-effective menu (base `limits` overridden by `<backend>.limits`) is
+    // This test parses the embedded manifest and, for every image model (via `mlx_model` / MODEL_TABLE)
+    // AND every video model (via `video_descriptor`, sc-7296) with a linked descriptor on the active
+    // backend, asserts the per-backend-effective menu (base `limits` overridden by `<backend>.limits`) is
     // honoured by the descriptor. It checks `mlx` on macOS (where the MLX provider crates are linked)
     // and `candle` on the `backend-candle` build — whichever registry is active — so each backend's
     // truthfulness is enforced on its own lane. `"default"` is the engine-default sentinel, always allowed.
@@ -678,6 +679,46 @@ mod tests {
         model.get(backend).and_then(pick).or_else(|| pick(model))
     }
 
+    /// The engine registry id(s) a video manifest model resolves to, across backends — the union of
+    /// the mlx maps (`wan_engine_id` / `ltx_engine_id` / `svd_engine_id` + the native VACE-Fun
+    /// dispatch) and the candle map (`candle_video_engine_id`) in `video_jobs`. LTX is backend-split
+    /// (`ltx_2_3` on mlx, `ltx_2_3_distilled` on candle) and `ltx_2_3_eros` shares the base engine id
+    /// per backend; the resolver lists both and picks whichever the active registry actually holds.
+    /// `wan_2_2_vace_fun_14b` is mlx-only (candle has no VACE engine), so it resolves to `None` on the
+    /// candle lane and is skipped there.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    fn video_engine_ids(sceneworks_id: &str) -> &'static [&'static str] {
+        match sceneworks_id {
+            "wan_2_2" => &["wan2_2_ti2v_5b"],
+            "wan_2_2_t2v_14b" => &["wan2_2_t2v_14b"],
+            "wan_2_2_i2v_14b" => &["wan2_2_i2v_14b"],
+            "wan_2_2_vace_fun_14b" => &["wan2_2_vace_fun_14b"],
+            "svd" => &["svd_xt"],
+            "ltx_2_3" | "ltx_2_3_eros" => &["ltx_2_3", "ltx_2_3_distilled"],
+            _ => &[],
+        }
+    }
+
+    /// The linked gen-core descriptor for a video manifest model on the ACTIVE backend, or `None`
+    /// when no provider crate registered its engine id here. Mirrors [`mlx_model`]'s registry join
+    /// for the video ids that live outside [`MODEL_TABLE`] (the image path).
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    fn video_descriptor(sceneworks_id: &str) -> Option<gen_core::ModelDescriptor> {
+        let ids = video_engine_ids(sceneworks_id);
+        if ids.is_empty() {
+            return None;
+        }
+        gen_core::registry::generators()
+            .map(|reg| (reg.descriptor)())
+            .find(|d| ids.contains(&d.id))
+    }
+
     #[cfg(any(
         target_os = "macos",
         all(not(target_os = "macos"), feature = "backend-candle")
@@ -697,12 +738,16 @@ mod tests {
             let Some(id) = model["id"].as_str() else {
                 continue;
             };
-            // Only image models with a linked descriptor (MODEL_TABLE). Video / unlinked models are out
-            // of this guard's scope (their descriptors aren't reached via `mlx_model`).
-            let Some(resolved) = mlx_model(id) else {
+            // Image models resolve via MODEL_TABLE (`mlx_model`); video models via their engine-id
+            // map (`video_descriptor`). A model with no linked descriptor on the active backend is
+            // skipped (e.g. the mlx-only `wan_2_2_vace_fun_14b` on the candle lane).
+            let Some(descriptor) = mlx_model(id)
+                .map(|resolved| resolved.descriptor)
+                .or_else(|| video_descriptor(id))
+            else {
                 continue;
             };
-            let caps = &resolved.descriptor.capabilities;
+            let caps = &descriptor.capabilities;
             for (axis, advertised) in [
                 ("samplers", &caps.samplers),
                 ("schedulers", &caps.schedulers),
@@ -715,7 +760,7 @@ mod tests {
                         if !advertised.contains(&name.as_str()) {
                             violations.push(format!(
                                 "{id}: {backend} {axis} {name:?} not advertised by descriptor {:?} (advertised: {advertised:?})",
-                                resolved.descriptor.id
+                                descriptor.id
                             ));
                         }
                     }


### PR DESCRIPTION
## What

Epic 7114, **sc-7296 parts 2 & 3** — expose the curated video sampler menus in the UI and keep them honest. Part 1 (the Wan engine-name reconcile) already landed in [mlx-gen#536](https://github.com/SceneWorks/mlx-gen/pull/536) + [candle-gen#127](https://github.com/SceneWorks/candle-gen/pull/127); this is the SceneWorks-side close-out, riding on the `903f295`/`f647aeb` pins from [#862](https://github.com/SceneWorks/SceneWorks/pull/862).

### Manifest (`config/manifests/builtin.models.jsonc`)
Widen the seven video entries' `limits.samplers` from `["default"]` to the curated menu each engine actually advertises — **per model, per backend** (`base` = the candle/Windows menu, `mlx` override = the wider macOS menu where they differ):

| model | mlx menu | candle menu |
|---|---|---|
| `wan_2_2` (TI2V-5B) | uni_pc, euler, **dpmpp_2m**, euler_ancestral, heun, dpmpp_sde, ddim | uni_pc, euler, euler_ancestral, heun, dpmpp_sde, ddim |
| `wan_2_2_t2v_14b` / `_i2v_14b` | full curated fold-in | uni_pc, euler |
| `wan_2_2_vace_fun_14b` | uni_pc, euler, dpmpp_2m | *(mlx-only)* |
| `svd` | 8 curated | 8 curated |
| `ltx_2_3` / `ltx_2_3_eros` | 8 curated | 8 curated |

- The `dpmpp_2m` gap on candle Wan is **intentional** (part 1 decision: candle Wan's `Sampler` enum has no native DPM++2M; not implementing a net-new solver for a name reconcile) — so it stays mlx-only by capability, expressed truthfully by the per-backend menus.
- Every video descriptor has an **empty scheduler axis**, so scheduler menus stay `["default"]`. Stale "MLX path is sealed / default-only" comments rewritten.
- `wan_2_2_vace_fun_14b` is mlx-only, so its base menu = the mlx menu and the now-redundant `mlx.limits` override is dropped.

### Drift guard (`crates/sceneworks-worker/src/engines.rs`)
`manifest_menu_is_subset_of_descriptor` previously skipped video models (resolved only `MODEL_TABLE` via `mlx_model`). It now also resolves video manifest ids to their engine descriptor via a new `video_descriptor` / `video_engine_ids` helper (mirrors `mlx_model`'s registry join for ids outside `MODEL_TABLE`), so each per-backend video menu is enforced ⊆ its engine's advertised surface — same truthfulness contract as image models. LTX is backend-split (`ltx_2_3` mlx / `ltx_2_3_distilled` candle); the mlx-only VACE-Fun resolves to `None` on the candle lane and is skipped.

### Video Studio UI
No change — the sampler/scheduler pickers already light up once the manifest advertises a menu of length > 1.

## Verification
- `cargo test -p sceneworks-worker --lib` ✓ (incl. the extended `manifest_menu_is_subset_of_descriptor` + the N1 sampling-knob regression)
- **Guard actually bites:** planted a bogus video sampler name and confirmed the guard fails naming that entry, then reverted.
- macOS lane verified locally (mlx registry); the candle lane runs the same guard in CI under `--features backend-candle`.

Closes sc-7296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
