### PR TITLE
feat(worker): plumb curated samplers into bespoke image paths — InstantID/Kolors/PuLID (sc-7432)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=671cb133173297e406b3ae66acce6bd5e6d95a22#671cb133173297e406b3ae66acce6bd5e6d95a22"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=671cb133173297e406b3ae66acce6bd5e6d95a22#671cb133173297e406b3ae66acce6bd5e6d95a22"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=671cb133173297e406b3ae66acce6bd5e6d95a22#671cb133173297e406b3ae66acce6bd5e6d95a22"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=671cb133173297e406b3ae66acce6bd5e6d95a22#671cb133173297e406b3ae66acce6bd5e6d95a22"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=671cb133173297e406b3ae66acce6bd5e6d95a22#671cb133173297e406b3ae66acce6bd5e6d95a22"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=671cb133173297e406b3ae66acce6bd5e6d95a22#671cb133173297e406b3ae66acce6bd5e6d95a22"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -523,7 +523,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=671cb133173297e406b3ae66acce6bd5e6d95a22#671cb133173297e406b3ae66acce6bd5e6d95a22"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -535,7 +535,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=671cb133173297e406b3ae66acce6bd5e6d95a22#671cb133173297e406b3ae66acce6bd5e6d95a22"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=671cb133173297e406b3ae66acce6bd5e6d95a22#671cb133173297e406b3ae66acce6bd5e6d95a22"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=671cb133173297e406b3ae66acce6bd5e6d95a22#671cb133173297e406b3ae66acce6bd5e6d95a22"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=671cb133173297e406b3ae66acce6bd5e6d95a22#671cb133173297e406b3ae66acce6bd5e6d95a22"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -585,7 +585,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=671cb133173297e406b3ae66acce6bd5e6d95a22#671cb133173297e406b3ae66acce6bd5e6d95a22"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -596,7 +596,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=671cb133173297e406b3ae66acce6bd5e6d95a22#671cb133173297e406b3ae66acce6bd5e6d95a22"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -613,7 +613,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=671cb133173297e406b3ae66acce6bd5e6d95a22#671cb133173297e406b3ae66acce6bd5e6d95a22"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -628,7 +628,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=671cb133173297e406b3ae66acce6bd5e6d95a22#671cb133173297e406b3ae66acce6bd5e6d95a22"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -639,7 +639,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=671cb133173297e406b3ae66acce6bd5e6d95a22#671cb133173297e406b3ae66acce6bd5e6d95a22"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -654,7 +654,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=671cb133173297e406b3ae66acce6bd5e6d95a22#671cb133173297e406b3ae66acce6bd5e6d95a22"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -672,7 +672,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=671cb133173297e406b3ae66acce6bd5e6d95a22#671cb133173297e406b3ae66acce6bd5e6d95a22"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -683,7 +683,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=671cb133173297e406b3ae66acce6bd5e6d95a22#671cb133173297e406b3ae66acce6bd5e6d95a22"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -696,7 +696,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=671cb133173297e406b3ae66acce6bd5e6d95a22#671cb133173297e406b3ae66acce6bd5e6d95a22"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -707,7 +707,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=671cb133173297e406b3ae66acce6bd5e6d95a22#671cb133173297e406b3ae66acce6bd5e6d95a22"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -720,7 +720,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f647aeb7b5e271ba369b5c7d3adcb542b7300f68#f647aeb7b5e271ba369b5c7d3adcb542b7300f68"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=671cb133173297e406b3ae66acce6bd5e6d95a22#671cb133173297e406b3ae66acce6bd5e6d95a22"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -3352,7 +3352,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=04aa4aa1f498f00a854f6a34ae5978f929fc163a#04aa4aa1f498f00a854f6a34ae5978f929fc163a"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3364,7 +3364,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=04aa4aa1f498f00a854f6a34ae5978f929fc163a#04aa4aa1f498f00a854f6a34ae5978f929fc163a"
 dependencies = [
  "image",
  "inventory",
@@ -3378,7 +3378,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=04aa4aa1f498f00a854f6a34ae5978f929fc163a#04aa4aa1f498f00a854f6a34ae5978f929fc163a"
 dependencies = [
  "image",
  "inventory",
@@ -3391,7 +3391,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=04aa4aa1f498f00a854f6a34ae5978f929fc163a#04aa4aa1f498f00a854f6a34ae5978f929fc163a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3403,7 +3403,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=04aa4aa1f498f00a854f6a34ae5978f929fc163a#04aa4aa1f498f00a854f6a34ae5978f929fc163a"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3412,7 +3412,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=04aa4aa1f498f00a854f6a34ae5978f929fc163a#04aa4aa1f498f00a854f6a34ae5978f929fc163a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3424,7 +3424,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=04aa4aa1f498f00a854f6a34ae5978f929fc163a#04aa4aa1f498f00a854f6a34ae5978f929fc163a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3435,7 +3435,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=04aa4aa1f498f00a854f6a34ae5978f929fc163a#04aa4aa1f498f00a854f6a34ae5978f929fc163a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3447,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=04aa4aa1f498f00a854f6a34ae5978f929fc163a#04aa4aa1f498f00a854f6a34ae5978f929fc163a"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3458,7 +3458,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=04aa4aa1f498f00a854f6a34ae5978f929fc163a#04aa4aa1f498f00a854f6a34ae5978f929fc163a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3468,7 +3468,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=04aa4aa1f498f00a854f6a34ae5978f929fc163a#04aa4aa1f498f00a854f6a34ae5978f929fc163a"
 dependencies = [
  "image",
  "inventory",
@@ -3480,7 +3480,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=04aa4aa1f498f00a854f6a34ae5978f929fc163a#04aa4aa1f498f00a854f6a34ae5978f929fc163a"
 dependencies = [
  "image",
  "inventory",
@@ -3493,7 +3493,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=04aa4aa1f498f00a854f6a34ae5978f929fc163a#04aa4aa1f498f00a854f6a34ae5978f929fc163a"
 dependencies = [
  "image",
  "inventory",
@@ -3505,7 +3505,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=04aa4aa1f498f00a854f6a34ae5978f929fc163a#04aa4aa1f498f00a854f6a34ae5978f929fc163a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3516,7 +3516,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=04aa4aa1f498f00a854f6a34ae5978f929fc163a#04aa4aa1f498f00a854f6a34ae5978f929fc163a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3528,7 +3528,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=04aa4aa1f498f00a854f6a34ae5978f929fc163a#04aa4aa1f498f00a854f6a34ae5978f929fc163a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3538,7 +3538,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=04aa4aa1f498f00a854f6a34ae5978f929fc163a#04aa4aa1f498f00a854f6a34ae5978f929fc163a"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3547,7 +3547,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=04aa4aa1f498f00a854f6a34ae5978f929fc163a#04aa4aa1f498f00a854f6a34ae5978f929fc163a"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3556,7 +3556,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=04aa4aa1f498f00a854f6a34ae5978f929fc163a#04aa4aa1f498f00a854f6a34ae5978f929fc163a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3568,7 +3568,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=04aa4aa1f498f00a854f6a34ae5978f929fc163a#04aa4aa1f498f00a854f6a34ae5978f929fc163a"
 dependencies = [
  "image",
  "inventory",
@@ -3581,7 +3581,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=04aa4aa1f498f00a854f6a34ae5978f929fc163a#04aa4aa1f498f00a854f6a34ae5978f929fc163a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3592,7 +3592,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=04aa4aa1f498f00a854f6a34ae5978f929fc163a#04aa4aa1f498f00a854f6a34ae5978f929fc163a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3603,7 +3603,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=04aa4aa1f498f00a854f6a34ae5978f929fc163a#04aa4aa1f498f00a854f6a34ae5978f929fc163a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3614,7 +3614,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=04aa4aa1f498f00a854f6a34ae5978f929fc163a#04aa4aa1f498f00a854f6a34ae5978f929fc163a"
 dependencies = [
  "image",
  "inventory",
@@ -3628,7 +3628,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=04aa4aa1f498f00a854f6a34ae5978f929fc163a#04aa4aa1f498f00a854f6a34ae5978f929fc163a"
 dependencies = [
  "image",
  "inventory",
@@ -5271,7 +5271,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=903f295134dd48b539c28786bc4b28d8dc37f628#903f295134dd48b539c28786bc4b28d8dc37f628"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=04aa4aa1f498f00a854f6a34ae5978f929fc163a#04aa4aa1f498f00a854f6a34ae5978f929fc163a"
 dependencies = [
  "inventory",
  "safetensors 0.4.5",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2217,11 +2217,15 @@
         // bucket is safe (no face stretching — the sc-2009 kps-aspect fix).
         "resolutions": ["1024x1024", "1152x896", "896x1152", "1216x832", "832x1216", "1344x768", "768x1344"],
         "count": [1, 2, 4],
-        // Sampler/scheduler selection is default-only: the dedicated InstantID worker
-        // path (`generate_instantid_stream`) builds its request without reading
-        // `advanced.sampler`, so a curated menu here would be a silent no-op until that
-        // bespoke path is plumbed through the unified framework (tracked follow-up, epic 7114).
-        "samplers": ["default"],
+        // Curated sampler selection (epic 7114, sc-7432): the bespoke InstantID worker path
+        // (`generate_instantid_stream`) now reads `advanced.sampler` and threads a curated solver
+        // through the engine's additive `denoise_curated` path. Advertise only the real-weight-validated
+        // solvers (mlx #538 / candle #130 identity smokes): euler + heun preserve identity as well as the
+        // bespoke ancestral default (ArcFace cosine ~0.79 mlx / ~0.72 candle); dpmpp_2m renders a
+        // recognizable identity but is the weakest under InstantID's strong conditioning (~0.63 mlx /
+        // ~0.70 candle), so it trails the menu. Scheduler stays default-only (the smokes held it at the
+        // native schedule). "default" = the native ancestral loop (N1 byte-exact when left unset).
+        "samplers": ["default", "euler", "heun", "dpmpp_2m"],
         "schedulers": ["default"]
       },
       "loraCompatibility": {
@@ -2329,7 +2333,13 @@
         // principle (FLUX DiT is bucket-agnostic) but were not run in the spike;
         // limit until follow-up A/B widens it.
         "resolutions": ["1024x1024"],
-        "count": [1, 2, 4]
+        "count": [1, 2, 4],
+        // Curated sampler selection (epic 7114, sc-7432): the bespoke PuLID-FLUX worker path now reads
+        // `advanced.sampler`/`scheduler` and threads it onto the FLUX backbone — mlx delegates to the
+        // FLUX flow loop which honors it (#537); the candle `PulidFlux` was made sampler-pluggable (#130).
+        // The FLUX flow curated menu, mirroring the base flux_dev entry. "default" = native flow-match (N1).
+        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+        "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
       },
       // Native MLX path (sc-3344): PuLID-FLUX runs on the Rust `mlx-gen-pulid` engine — the
       // FLUX.1-dev backbone + the f32 EVA/IDFormer/CA conditioning — retiring the torch MPS path

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -265,7 +265,17 @@ sceneworks-core = { path = "../sceneworks-core" }
 # + gen-core in lockstep. The candle pin below moves `7b12e8c` -> `f647aeb` IN LOCKSTEP — candle-gen #129
 # re-pinned its gen-core (workspace + per-crate testkit dev-deps) to 903f295, so `--features
 # backend-candle --target all` resolves the SINGLE gen-core rev 903f295 again (the skew gate).
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
+# Bumped `903f295` -> `04aa4aa` (epic 7114 sc-7432 / sc-7297): mlx-gen main now carries the conditioned
+# curated-sampler adoption for the bespoke families — PuLID (mlx-gen #537), InstantID (mlx-gen #538,
+# which adds the `InstantIdRequest.sampler`/`scheduler` fields the worker now sets), and Kolors-conditioned
+# (mlx-gen #539). gen-core is BYTE-IDENTICAL `903f295..04aa4aa` (same `gen-core/` tree SHA; all three PRs
+# are additive in their own provider crates `mlx-gen-{pulid,instantid,kolors}`, NOT gen-core), so the
+# worker's import surface is unchanged and N1 (default sampler = today's output) holds. Bumps EVERY
+# mlx-gen crate + gen-core in lockstep. The candle pin below moves `f647aeb` -> `671cb13` IN LOCKSTEP:
+# candle-gen #130 (sc-7389) adds the candle `sampler`/`scheduler` fields, and candle-gen #132 re-pins
+# candle-gen's own gen-core 903f295 -> 04aa4aa (a byte-identical rev-alignment) so `--features
+# backend-candle` resolves the SINGLE gen-core rev 04aa4aa (the skew gate) rather than two.
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "04aa4aa1f498f00a854f6a34ae5978f929fc163a" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -589,7 +599,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "04aa4aa1f498f00a854f6a34ae5978f929fc163a" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -601,64 +611,64 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134d
 # internal pin (the Lens engine PRs #407–#414 did not move it; nor did the seedvr2 engine #416/#419/
 # #421 or the softness PR #422, so the 1a97909 bump above leaves mlx-rs at 44929a0).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "44929a001ab8a8837403a71c65cf064224de0cdc" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "04aa4aa1f498f00a854f6a34ae5978f929fc163a" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "04aa4aa1f498f00a854f6a34ae5978f929fc163a" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "04aa4aa1f498f00a854f6a34ae5978f929fc163a" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "04aa4aa1f498f00a854f6a34ae5978f929fc163a" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "04aa4aa1f498f00a854f6a34ae5978f929fc163a" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "04aa4aa1f498f00a854f6a34ae5978f929fc163a" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "04aa4aa1f498f00a854f6a34ae5978f929fc163a" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "04aa4aa1f498f00a854f6a34ae5978f929fc163a" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "04aa4aa1f498f00a854f6a34ae5978f929fc163a" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "04aa4aa1f498f00a854f6a34ae5978f929fc163a" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "04aa4aa1f498f00a854f6a34ae5978f929fc163a" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "04aa4aa1f498f00a854f6a34ae5978f929fc163a" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "04aa4aa1f498f00a854f6a34ae5978f929fc163a" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "04aa4aa1f498f00a854f6a34ae5978f929fc163a" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -667,12 +677,12 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f29
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "04aa4aa1f498f00a854f6a34ae5978f929fc163a" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "04aa4aa1f498f00a854f6a34ae5978f929fc163a" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -681,7 +691,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f29
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "04aa4aa1f498f00a854f6a34ae5978f929fc163a" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -689,7 +699,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "04aa4aa1f498f00a854f6a34ae5978f929fc163a" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -700,7 +710,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "04aa4aa1f498f00a854f6a34ae5978f929fc163a" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -711,7 +721,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f2
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "04aa4aa1f498f00a854f6a34ae5978f929fc163a" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -726,7 +736,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f29
 # converted in-memory at load (no Python); the precomputed neg-prompt embedding is bundled in-crate. No
 # LoRA/guidance/CFG (one-step). 3B fp16 only here — 7B (sc-5197) + int8 (sc-5198) are engine-side and
 # unwired. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "04aa4aa1f498f00a854f6a34ae5978f929fc163a" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -737,7 +747,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "04aa4aa1f498f00a854f6a34ae5978f929fc163a" }
 # Prompt-refine provider (sc-5552, the MLX twin of candle-gen-prompt-refine / sc-5500). An
 # inventory-registered `TextLlm` under id `prompt_refine` (`backend="mlx"`, `mac_only`): a native MLX
 # Llama-3.2-3B-Instruct that rewrites a user's prompt, replacing the Python `prompt_refine.py`
@@ -747,7 +757,7 @@ mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903
 # textllm registered" trap). Weights = a stock Llama-3.2-3B-Instruct HF snapshot (config.json +
 # tokenizer.json + model-*.safetensors; default `huihui-ai/Llama-3.2-3B-Instruct-abliterated`). Same
 # git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
+mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "04aa4aa1f498f00a854f6a34ae5978f929fc163a" }
 # SCAIL-2 (zai-org) end-to-end character-animation provider (epic 5439, sc-5448). An inventory-registered
 # `Generator` under id `scail2_14b` (`Modality::Video`): a Wan2.1-14B I2V DiT that animates a reference
 # character with a driving video's motion (`video_mode == "replacement"` flips the cross-identity
@@ -759,7 +769,7 @@ mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev 
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f295134dd48b539c28786bc4b28d8dc37f628" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "04aa4aa1f498f00a854f6a34ae5978f929fc163a" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -978,39 +988,47 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "903f
 # the curated sampler axis. This is a candle-gen-only advancement: 7b12e8c STILL pins gen-core c59f73cb
 # (same as the mlx pin), so `--features backend-candle --target all` stays a SINGLE gen-core rev — NOT a
 # gen-core lockstep, just the candle crates moving forward within the same contract rev.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
+# Rev 7b12e8c -> f647aeb (sc-7296/sc-7305): candle-gen #129 re-pinned its gen-core c59f73cb -> 903f295 in
+# lockstep with the mlx pin (documented in the mlx-pin block above); pure rev-alignment, byte-identical.
+# Rev f647aeb -> 671cb13 (epic 7114 sc-7432 / sc-7389): candle-gen main HEAD (merge of #132). Carries
+# candle-gen #130 (sc-7389) — the candle `sampler`/`scheduler` fields on `KolorsControlRequest` /
+# `IpAdapterKolorsRequest` / `PulidFluxRequest` / `InstantIdRequest` the conditioned worker paths now set
+# — AND #132's gen-core re-pin 903f295 -> 04aa4aa (BYTE-IDENTICAL; same `gen-core/` tree SHA 5450444), so
+# `--features backend-candle --target all` resolves the SINGLE gen-core rev 04aa4aa shared with the mlx
+# pin. candle-gen #132 CI (macos-15 + ubuntu-latest fmt/clippy/check/test) green against 04aa4aa.
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "671cb133173297e406b3ae66acce6bd5e6d95a22", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "671cb133173297e406b3ae66acce6bd5e6d95a22", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "671cb133173297e406b3ae66acce6bd5e6d95a22", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "671cb133173297e406b3ae66acce6bd5e6d95a22", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "671cb133173297e406b3ae66acce6bd5e6d95a22", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "671cb133173297e406b3ae66acce6bd5e6d95a22", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "671cb133173297e406b3ae66acce6bd5e6d95a22", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "671cb133173297e406b3ae66acce6bd5e6d95a22", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "671cb133173297e406b3ae66acce6bd5e6d95a22", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "671cb133173297e406b3ae66acce6bd5e6d95a22", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1019,11 +1037,11 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "671cb133173297e406b3ae66acce6bd5e6d95a22", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "671cb133173297e406b3ae66acce6bd5e6d95a22", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1032,19 +1050,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "671cb133173297e406b3ae66acce6bd5e6d95a22", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "671cb133173297e406b3ae66acce6bd5e6d95a22", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "671cb133173297e406b3ae66acce6bd5e6d95a22", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1053,12 +1071,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "671cb133173297e406b3ae66acce6bd5e6d95a22", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "671cb133173297e406b3ae66acce6bd5e6d95a22", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1066,7 +1084,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647a
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "671cb133173297e406b3ae66acce6bd5e6d95a22", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1075,7 +1093,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "671cb133173297e406b3ae66acce6bd5e6d95a22", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1083,7 +1101,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "671cb133173297e406b3ae66acce6bd5e6d95a22", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1092,7 +1110,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "671cb133173297e406b3ae66acce6bd5e6d95a22", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1119,7 +1137,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f647aeb7b5e271ba369b5c7d3adcb542b7300f68", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "671cb133173297e406b3ae66acce6bd5e6d95a22", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -822,10 +822,8 @@ mod tests {
             else {
                 continue;
             };
-            for (axis, advertised) in [
-                ("samplers", &adv_samplers),
-                ("schedulers", &adv_schedulers),
-            ] {
+            for (axis, advertised) in [("samplers", &adv_samplers), ("schedulers", &adv_schedulers)]
+            {
                 if let Some(list) = effective_list(model, backend, axis) {
                     for name in list {
                         if name == "default" {
@@ -862,7 +860,10 @@ mod tests {
             let (samplers, schedulers) = bespoke_advertised(id)
                 .unwrap_or_else(|| panic!("{id}: bespoke_advertised must resolve an engine menu"));
             assert!(!samplers.is_empty(), "{id}: sampler menu must be non-empty");
-            assert!(!schedulers.is_empty(), "{id}: scheduler menu must be non-empty");
+            assert!(
+                !schedulers.is_empty(),
+                "{id}: scheduler menu must be non-empty"
+            );
             // The manifest advertises euler + heun for both; the engine must honor them.
             for solver in ["euler", "heun"] {
                 assert!(

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -634,16 +634,17 @@ mod tests {
         s
     }
 
-    // ── epic 7114 P5 / sc-7126: manifest ⊆ descriptor drift guard ────────────────────────────────
+    // ── epic 7114 P5 / sc-7126 (+ sc-7432 bespoke coverage): manifest ⊆ engine drift guard ─────────
     // The builtin manifest's advertised sampler/scheduler menu for a model MUST be a subset of what
-    // the linked engine descriptor actually advertises on the ACTIVE backend, or the worker N3-falls
-    // the name back to the default (sc-7127) — i.e. the UI offers a knob the engine silently ignores.
-    // This test parses the embedded manifest and, for every image model (via `mlx_model` / MODEL_TABLE)
-    // AND every video model (via `video_descriptor`, sc-7296) with a linked descriptor on the active
-    // backend, asserts the per-backend-effective menu (base `limits` overridden by `<backend>.limits`) is
-    // honoured by the descriptor. It checks `mlx` on macOS (where the MLX provider crates are linked)
-    // and `candle` on the `backend-candle` build — whichever registry is active — so each backend's
-    // truthfulness is enforced on its own lane. `"default"` is the engine-default sentinel, always allowed.
+    // the linked engine actually honors on the ACTIVE backend, or the worker N3-falls the name back to
+    // the default (sc-7127) — i.e. the UI offers a knob the engine silently ignores. This test parses
+    // the embedded manifest and, for every image model (via `mlx_model` / MODEL_TABLE), every video
+    // model (via `video_descriptor`, sc-7296), AND every bespoke out-of-MODEL_TABLE image model
+    // (InstantID / PuLID via `bespoke_advertised`, sc-7432) with a source on the active backend, asserts
+    // the per-backend-effective menu (base `limits` overridden by `<backend>.limits`) is honored. It
+    // checks `mlx` on macOS (where the MLX provider crates are linked) and `candle` on the
+    // `backend-candle` build — whichever registry is active — so each backend's truthfulness is enforced
+    // on its own lane. `"default"` is the engine-default sentinel, always allowed.
     #[cfg(any(
         target_os = "macos",
         all(not(target_os = "macos"), feature = "backend-candle")
@@ -719,6 +720,61 @@ mod tests {
             .find(|d| ids.contains(&d.id))
     }
 
+    /// The `(samplers, schedulers)` menu the engine actually honors for a **bespoke** image model that
+    /// lives OUTSIDE [`MODEL_TABLE`] (no `mlx_model` row, no video engine id) — sc-7432. These build
+    /// CUSTOM request structs the worker N3-normalizes against [`crate::image_jobs::curated_image_menu`]
+    /// (`instantid.rs` / `kolors_*` / `pulid*`), so the guard checks the manifest against the SAME source
+    /// of truth and the two never disagree:
+    ///   • `instantid_realvisxl` is a bespoke provider (`InstantId::load`) with NO `ModelDescriptor`;
+    ///     both engines (mlx #538 / candle #130) honor the curated solver vocab via `Solver::from_name` /
+    ///     the additive `denoise_curated` path, so the honored menu IS the curated vocab.
+    ///   • `pulid_flux_dev` is the inventory-registered `pulid_flux` Generator on mlx (a real descriptor
+    ///     advertising curated + flow_match/linear); on the candle lane it is the bespoke `PulidFlux`
+    ///     provider (no descriptor), so fall back to the curated vocab + FLUX's native flow names. Either
+    ///     way a superset of the manifest's `default`+curated menu.
+    /// Kolors-conditioned is NOT here: `kolors` IS a `MODEL_TABLE` row, so the loop already resolves it
+    /// via `mlx_model` and the existing descriptor check covers its (shared) menu.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    fn bespoke_advertised(sceneworks_id: &str) -> Option<(Vec<String>, Vec<String>)> {
+        let curated = || {
+            let (samplers, schedulers) = crate::image_jobs::curated_image_menu();
+            (
+                samplers.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+                schedulers.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+            )
+        };
+        match sceneworks_id {
+            "instantid_realvisxl" => Some(curated()),
+            "pulid_flux_dev" => gen_core::registry::generators()
+                .map(|reg| (reg.descriptor)())
+                .find(|d| d.id == "pulid_flux")
+                .map(|d| {
+                    (
+                        d.capabilities
+                            .samplers
+                            .iter()
+                            .map(|s| s.to_string())
+                            .collect::<Vec<_>>(),
+                        d.capabilities
+                            .schedulers
+                            .iter()
+                            .map(|s| s.to_string())
+                            .collect::<Vec<_>>(),
+                    )
+                })
+                .or_else(|| {
+                    let (mut samplers, mut schedulers) = curated();
+                    samplers.push("flow_match".to_string());
+                    schedulers.push("linear".to_string());
+                    Some((samplers, schedulers))
+                }),
+            _ => None,
+        }
+    }
+
     #[cfg(any(
         target_os = "macos",
         all(not(target_os = "macos"), feature = "backend-candle")
@@ -738,29 +794,46 @@ mod tests {
             let Some(id) = model["id"].as_str() else {
                 continue;
             };
-            // Image models resolve via MODEL_TABLE (`mlx_model`); video models via their engine-id
-            // map (`video_descriptor`). A model with no linked descriptor on the active backend is
-            // skipped (e.g. the mlx-only `wan_2_2_vace_fun_14b` on the candle lane).
-            let Some(descriptor) = mlx_model(id)
+            // The advertised sampler/scheduler menu the engine honors, from whichever source applies:
+            // image models via MODEL_TABLE (`mlx_model`); video models via their engine-id map
+            // (`video_descriptor`); the bespoke out-of-MODEL_TABLE image models (InstantID / PuLID,
+            // sc-7432) via `bespoke_advertised`. A model with no source on the active backend is skipped
+            // (e.g. the mlx-only `wan_2_2_vace_fun_14b` on the candle lane).
+            let Some((adv_samplers, adv_schedulers)) = mlx_model(id)
                 .map(|resolved| resolved.descriptor)
                 .or_else(|| video_descriptor(id))
+                .map(|descriptor| {
+                    (
+                        descriptor
+                            .capabilities
+                            .samplers
+                            .iter()
+                            .map(|s| s.to_string())
+                            .collect::<Vec<_>>(),
+                        descriptor
+                            .capabilities
+                            .schedulers
+                            .iter()
+                            .map(|s| s.to_string())
+                            .collect::<Vec<_>>(),
+                    )
+                })
+                .or_else(|| bespoke_advertised(id))
             else {
                 continue;
             };
-            let caps = &descriptor.capabilities;
             for (axis, advertised) in [
-                ("samplers", &caps.samplers),
-                ("schedulers", &caps.schedulers),
+                ("samplers", &adv_samplers),
+                ("schedulers", &adv_schedulers),
             ] {
                 if let Some(list) = effective_list(model, backend, axis) {
                     for name in list {
                         if name == "default" {
                             continue;
                         }
-                        if !advertised.contains(&name.as_str()) {
+                        if !advertised.iter().any(|advertised| advertised == &name) {
                             violations.push(format!(
-                                "{id}: {backend} {axis} {name:?} not advertised by descriptor {:?} (advertised: {advertised:?})",
-                                descriptor.id
+                                "{id}: {backend} {axis} {name:?} not honored by the engine (advertised: {advertised:?})"
                             ));
                         }
                     }
@@ -773,6 +846,31 @@ mod tests {
             violations.len(),
             violations.join("\n  ")
         );
+    }
+
+    // sc-7432: the subset guard above only EXERCISES the bespoke out-of-MODEL_TABLE models if
+    // `bespoke_advertised` resolves a menu for them — a `None` would silently skip them and leave the
+    // guard vacuously green. Pin that down: both bespoke ids must resolve a non-empty menu that includes
+    // the solvers their manifest entries advertise (euler/heun), on whichever backend is active.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    #[test]
+    fn bespoke_models_resolve_a_curated_menu() {
+        for id in ["instantid_realvisxl", "pulid_flux_dev"] {
+            let (samplers, schedulers) = bespoke_advertised(id)
+                .unwrap_or_else(|| panic!("{id}: bespoke_advertised must resolve an engine menu"));
+            assert!(!samplers.is_empty(), "{id}: sampler menu must be non-empty");
+            assert!(!schedulers.is_empty(), "{id}: scheduler menu must be non-empty");
+            // The manifest advertises euler + heun for both; the engine must honor them.
+            for solver in ["euler", "heun"] {
+                assert!(
+                    samplers.iter().any(|advertised| advertised == solver),
+                    "{id}: engine must honor {solver:?} (advertised: {samplers:?})"
+                );
+            }
+        }
     }
 
     // An MLX-backed stub generator registered into the same `inventory` registry the real

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -832,6 +832,31 @@ pub(crate) fn read_advanced_sampling_knobs(
     (name("sampler"), name("scheduler"), scheduler_shift)
 }
 
+/// The curated sampler/scheduler menu (epic 7114 decision 2) the **bespoke** conditioned image paths
+/// honor — the shared `gen_core` solver/scheduler vocabulary the unified-sampler engines gate on
+/// (`Solver::from_name` / the additive `denoise_curated` path; mlx #537/#538/#539, candle #130). The
+/// bespoke per-family paths (InstantID, Kolors-conditioned, PuLID — sc-7432) build CUSTOM request
+/// structs OUTSIDE `generate_stream`'s generic plumbing, so they N3-normalize the per-request knob
+/// against THIS menu instead of a `Capabilities` list: every engine's advertised set is a superset of
+/// it (their native default is the only extra, and `"default"`/`None` already strip to the engine
+/// default), so a name that survives [`normalize_sampling_knob`] here also passes the engine's own
+/// `validate_request`. This is also the single source of truth the manifest⊆engine drift guard
+/// (`engines.rs`) checks these out-of-`MODEL_TABLE` models against, so the runtime and the guard never
+/// disagree. Derived from `gen_core` (the engines' own vocab), so it tracks the framework on BOTH
+/// backends rather than hard-coding names. Returns `(samplers, schedulers)`.
+pub(crate) fn curated_image_menu() -> (Vec<&'static str>, Vec<&'static str>) {
+    (
+        gen_core::sampling::Solver::ALL
+            .iter()
+            .map(|solver| solver.name())
+            .collect(),
+        gen_core::sampling::Scheduler::ALL
+            .iter()
+            .map(|scheduler| scheduler.name())
+            .collect(),
+    )
+}
+
 #[cfg(test)]
 mod sampling_knob_tests {
     use super::*;

--- a/crates/sceneworks-worker/src/image_jobs/instantid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/instantid.rs
@@ -671,6 +671,31 @@ async fn generate_instantid_stream(
     };
     let total = work.len();
 
+    // Curated unified-sampler selection (epic 7114, sc-7432). InstantID builds its bespoke request
+    // OUTSIDE base.rs's generic plumbing, so read the per-generation knob here and N3-normalize it
+    // against the shared curated menu both engines honor — mlx #538 / candle #130 route a curated
+    // solver/scheduler through the additive `denoise_curated` path; an unknown name drops back to the
+    // engine default + emits an event rather than hard-failing `validate_request`. N1: with neither set
+    // the request carries `None` ⇒ the bespoke ancestral default loop runs byte-for-byte unchanged.
+    let (curated_samplers, curated_schedulers) = curated_image_menu();
+    let (sampler, scheduler, _shift) = read_advanced_sampling_knobs(&request.advanced);
+    let sampler = normalize_sampling_knob(
+        sampler,
+        &curated_samplers,
+        "sampler",
+        &request.model,
+        &job.id,
+        backend,
+    );
+    let scheduler = normalize_sampling_knob(
+        scheduler,
+        &curated_schedulers,
+        "scheduler",
+        &request.model,
+        &job.id,
+        backend,
+    );
+
     let negative_prompt = request.negative_prompt.clone();
     let (cancel, rx, blocking) = start_gen_stream(
         job.id.clone(),
@@ -796,6 +821,8 @@ async fn generate_instantid_stream(
                         controlnet_scale,
                         openpose_scale,
                         seed: seed as u64,
+                        sampler: sampler.clone(),
+                        scheduler: scheduler.clone(),
                         cancel: cancel.clone(),
                     };
                     let result = match &action {
@@ -834,6 +861,8 @@ async fn generate_instantid_stream(
                             controlnet_scale,
                             openpose_scale,
                             seed: seed as u64,
+                            sampler: sampler.clone(),
+                            scheduler: scheduler.clone(),
                             cancel: cancel.clone(),
                         };
                         out = match model.restore_face(

--- a/crates/sceneworks-worker/src/image_jobs/kolors.rs
+++ b/crates/sceneworks-worker/src/image_jobs/kolors.rs
@@ -216,6 +216,9 @@ fn kolors_control_generate_one(
     reference: &Image,
     ip_scale: f32,
     img2img_strength: f32,
+    sampler: Option<&str>,
+    scheduler: Option<&str>,
+    scheduler_shift: Option<f32>,
     cancel: &CancelFlag,
     on_progress: &mut dyn FnMut(Progress),
 ) -> WorkerResult<(u32, u32, Vec<u8>)> {
@@ -240,6 +243,12 @@ fn kolors_control_generate_one(
         steps: Some(steps),
         guidance,
         strength: Some(img2img_strength),
+        // Curated unified-sampler selection (epic 7114, sc-7432): the combined-pose tier honors a
+        // curated solver/scheduler via the kolors engine's `denoise_curated` path (#539). `None` ⇒ the
+        // native leading-Euler default, byte-exact (N1).
+        sampler: sampler.map(str::to_owned),
+        scheduler: scheduler.map(str::to_owned),
+        scheduler_shift,
         conditioning,
         cancel: cancel.clone(),
         ..Default::default()
@@ -324,6 +333,26 @@ async fn generate_kolors_control_stream(
     let control_scale = kolors_pose_control_scale(request);
     let ip_scale =
         advanced::f32_clamped(&request.advanced, "ipAdapterScale", KOLORS_IP_SCALE, 0.0..=1.0);
+    // Curated unified-sampler selection (epic 7114, sc-7432): the combined-pose tier builds its own
+    // `GenerationRequest`, so read + N3-normalize the knob against the linked kolors descriptor (the
+    // same advertised set base.rs uses for the generic kolors path). N1: unset ⇒ `None` ⇒ native default.
+    let (sampler, scheduler, scheduler_shift) = read_advanced_sampling_knobs(&request.advanced);
+    let sampler = normalize_sampling_knob(
+        sampler,
+        &kolors.descriptor.capabilities.samplers,
+        "sampler",
+        &request.model,
+        &job.id,
+        backend,
+    );
+    let scheduler = normalize_sampling_knob(
+        scheduler,
+        &kolors.descriptor.capabilities.schedulers,
+        "scheduler",
+        &request.model,
+        &job.id,
+        backend,
+    );
     let adapters = resolve_adapters(request, settings)?;
     let repo = model_repo(request, &kolors);
     let poses = parse_poses(request);
@@ -384,6 +413,9 @@ async fn generate_kolors_control_stream(
                     reference,
                     ip_scale,
                     KOLORS_POSE_IMG2IMG_STRENGTH,
+                    sampler.as_deref(),
+                    scheduler.as_deref(),
+                    scheduler_shift,
                     &cancel,
                     on_progress,
                 )?;

--- a/crates/sceneworks-worker/src/image_jobs/kolors_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/kolors_control.rs
@@ -215,6 +215,28 @@ async fn generate_candle_kolors_control_stream(
         KOLORS_CONTROL_DEFAULT_SCALE,
         0.0..=2.0,
     );
+    // Curated unified-sampler selection (epic 7114, sc-7432): the candle `KolorsControl` provider honors
+    // a curated solver/scheduler via the shared `denoise_curated` primitive (#130). Read + N3-normalize
+    // against the shared curated menu (an unknown name drops to the engine default + emits an event).
+    // N1: unset ⇒ `None` ⇒ the native leading-Euler default loop runs byte-exact.
+    let (curated_samplers, curated_schedulers) = curated_image_menu();
+    let (sampler, scheduler, _shift) = read_advanced_sampling_knobs(&request.advanced);
+    let sampler = normalize_sampling_knob(
+        sampler,
+        &curated_samplers,
+        "sampler",
+        &request.model,
+        &job.id,
+        backend,
+    );
+    let scheduler = normalize_sampling_knob(
+        scheduler,
+        &curated_schedulers,
+        "scheduler",
+        &request.model,
+        &job.id,
+        backend,
+    );
     let repo = request
         .model_manifest_entry
         .get("repo")
@@ -277,6 +299,8 @@ async fn generate_candle_kolors_control_stream(
                     guidance,
                     control_scale,
                     seed: seed as u64,
+                    sampler: sampler.clone(),
+                    scheduler: scheduler.clone(),
                     cancel: cancel.clone(),
                 };
                 let out = match model.generate(&req, &control, &mut *on_progress) {

--- a/crates/sceneworks-worker/src/image_jobs/kolors_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/kolors_ipadapter.rs
@@ -243,6 +243,27 @@ async fn generate_candle_kolors_ipadapter_stream(
         KOLORS_IPADAPTER_IP_SCALE,
         0.0..=1.0,
     );
+    // Curated unified-sampler selection (epic 7114, sc-7432): the candle `IpAdapterKolors` provider
+    // honors a curated solver/scheduler via the shared `denoise_curated` primitive (#130). Read +
+    // N3-normalize against the shared curated menu. N1: unset ⇒ `None` ⇒ the native default, byte-exact.
+    let (curated_samplers, curated_schedulers) = curated_image_menu();
+    let (sampler, scheduler, _shift) = read_advanced_sampling_knobs(&request.advanced);
+    let sampler = normalize_sampling_knob(
+        sampler,
+        &curated_samplers,
+        "sampler",
+        &request.model,
+        &job.id,
+        backend,
+    );
+    let scheduler = normalize_sampling_knob(
+        scheduler,
+        &curated_schedulers,
+        "scheduler",
+        &request.model,
+        &job.id,
+        backend,
+    );
     let repo = request
         .model_manifest_entry
         .get("repo")
@@ -292,6 +313,8 @@ async fn generate_candle_kolors_ipadapter_stream(
                     guidance,
                     ip_adapter_scale: ip_scale,
                     seed: seed as u64,
+                    sampler: sampler.clone(),
+                    scheduler: scheduler.clone(),
                     cancel: cancel.clone(),
                 };
                 let out = match model.generate(&req, &reference, &mut *on_progress) {

--- a/crates/sceneworks-worker/src/image_jobs/pulid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/pulid.rs
@@ -357,6 +357,28 @@ async fn generate_pulid_flux_stream(
     let id_weight = pulid_id_weight(request);
     let start_cfg = pulid_timestep_to_start_cfg(request);
     let (quant, recipe_bits) = pulid_quant(request);
+    // Curated unified-sampler selection (epic 7114, sc-7432): PuLID-FLUX delegates its denoise to the
+    // FLUX backbone, which honors a curated solver/scheduler on the `GenerationRequest` (#537). Read +
+    // N3-normalize against the shared curated menu (an unknown name drops to the engine default + emits
+    // an event). N1: unset ⇒ `None` ⇒ the native flow-match default loop runs byte-exact.
+    let (curated_samplers, curated_schedulers) = curated_image_menu();
+    let (sampler, scheduler, scheduler_shift) = read_advanced_sampling_knobs(&request.advanced);
+    let sampler = normalize_sampling_knob(
+        sampler,
+        &curated_samplers,
+        "sampler",
+        &request.model,
+        &job.id,
+        backend,
+    );
+    let scheduler = normalize_sampling_knob(
+        scheduler,
+        &curated_schedulers,
+        "scheduler",
+        &request.model,
+        &job.id,
+        backend,
+    );
     let repo = request
         .model_manifest_entry
         .get("repo")
@@ -406,6 +428,9 @@ async fn generate_pulid_flux_stream(
                     guidance: Some(guidance),
                     true_cfg: None,
                     timestep_to_start_cfg: Some(start_cfg),
+                    sampler: sampler.clone(),
+                    scheduler: scheduler.clone(),
+                    scheduler_shift,
                     conditioning: vec![Conditioning::Reference {
                         image: reference.clone(),
                         strength: Some(id_weight),

--- a/crates/sceneworks-worker/src/image_jobs/pulid_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/pulid_candle.rs
@@ -276,6 +276,28 @@ async fn generate_candle_pulid_stream(
     let steps = pulid_candle_steps(request);
     let guidance = pulid_candle_guidance(request);
     let id_weight = pulid_candle_id_weight(request);
+    // Curated unified-sampler selection (epic 7114, sc-7432): the candle `PulidFlux` provider was made
+    // sampler-pluggable in #130 (the `scheduler` axis re-strides FLUX's native schedule over the dev
+    // time-shift `mu`). Read + N3-normalize against the shared curated menu. N1: unset ⇒ `None` ⇒ the
+    // native euler-over-native-schedule default runs byte-exact.
+    let (curated_samplers, curated_schedulers) = curated_image_menu();
+    let (sampler, scheduler, _shift) = read_advanced_sampling_knobs(&request.advanced);
+    let sampler = normalize_sampling_knob(
+        sampler,
+        &curated_samplers,
+        "sampler",
+        &request.model,
+        &job.id,
+        backend,
+    );
+    let scheduler = normalize_sampling_knob(
+        scheduler,
+        &curated_schedulers,
+        "scheduler",
+        &request.model,
+        &job.id,
+        backend,
+    );
     let repo = request
         .model_manifest_entry
         .get("repo")
@@ -322,6 +344,8 @@ async fn generate_candle_pulid_stream(
                     guidance,
                     id_weight,
                     seed: seed as u64,
+                    sampler: sampler.clone(),
+                    scheduler: scheduler.clone(),
                     cancel: cancel.clone(),
                 };
                 let out = match model.generate(&req, &reference, &mut *on_progress) {

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
@@ -246,6 +246,29 @@ async fn generate_candle_sdxl_ipadapter_stream(
         SDXL_IPADAPTER_IP_SCALE,
         0.0..=1.0,
     );
+    // Curated unified-sampler selection (epic 7114, sc-7432): the candle `IpAdapterSdxl` provider honors
+    // a curated solver/scheduler via the shared `denoise_curated` primitive (#130). Read + N3-normalize
+    // against the shared curated menu (an unknown name drops to the engine default + emits an event). N1:
+    // unset ⇒ `None` ⇒ the native ancestral default loop runs byte-exact. (`sdxl`/`realvisxl` are
+    // MODEL_TABLE rows already advertising the curated menu — guarded by the existing drift guard.)
+    let (curated_samplers, curated_schedulers) = curated_image_menu();
+    let (sampler, scheduler, _shift) = read_advanced_sampling_knobs(&request.advanced);
+    let sampler = normalize_sampling_knob(
+        sampler,
+        &curated_samplers,
+        "sampler",
+        &request.model,
+        &job.id,
+        backend,
+    );
+    let scheduler = normalize_sampling_knob(
+        scheduler,
+        &curated_schedulers,
+        "scheduler",
+        &request.model,
+        &job.id,
+        backend,
+    );
     let repo = request
         .model_manifest_entry
         .get("repo")
@@ -296,6 +319,8 @@ async fn generate_candle_sdxl_ipadapter_stream(
                     guidance,
                     ip_adapter_scale: ip_scale,
                     seed: seed as u64,
+                    sampler: sampler.clone(),
+                    scheduler: scheduler.clone(),
                     cancel: cancel.clone(),
                 };
                 let out = match model.generate(&req, &reference, &mut *on_progress) {


### PR DESCRIPTION
S4 of epic 7114 / sc-7297: thread the unified curated sampler/scheduler path into the **bespoke** per-family image dispatch paths (the ones that build CUSTOM request structs outside `base.rs generate_stream`'s generic `read_advanced_sampling_knobs` + `normalize_sampling_knob` plumbing), widen the manifest, and extend the drift guard. Curated stays strictly **opt-in** (N1: knob unset ⇒ engine's historical default loop, byte-exact).

## Worker wiring
| Path | File | Carrier |
|---|---|---|
| InstantID (mlx + candle) | `image_jobs/instantid.rs` | `InstantIdRequest.sampler/scheduler` (main + face-restore) |
| Kolors strict-pose (macOS) | `image_jobs/kolors.rs` | `GenerationRequest` via `kolors_control_generate_one` |
| Kolors ControlNet (candle) | `image_jobs/kolors_control.rs` | `KolorsControlRequest` |
| Kolors IP-Adapter (candle) | `image_jobs/kolors_ipadapter.rs` | `IpAdapterKolorsRequest` |
| PuLID-FLUX (macOS) | `image_jobs/pulid.rs` | `GenerationRequest` (FLUX backbone) |
| PuLID-FLUX (candle) | `image_jobs/pulid_candle.rs` | `PulidFluxRequest` |

New shared `image_jobs::base::curated_image_menu()` derives the menu from `gen_core::sampling::{Solver,Scheduler}::ALL` (the engines' own vocab, available on both backends) — used by the bespoke N3 normalize **and** the drift guard so they share one source of truth.

## Manifest (`config/manifests/builtin.models.jsonc`)
- `instantid_realvisxl`: samplers `["default"]` → `["default","euler","heun","dpmpp_2m"]` (schedulers stay default-only; `dpmpp_2m` trails per the #538/#130 identity smokes).
- `pulid_flux_dev`: gains the full FLUX flow curated menu (mirrors `flux_dev`).
- Kolors already advertised the curated menu (MODEL_TABLE-guarded since P3) — only the worker conditioned paths needed threading.

## Drift guard (`engines.rs`)
`bespoke_advertised(id)` extends `manifest_menu_is_subset_of_descriptor` to the out-of-`MODEL_TABLE` bespoke models (InstantID → curated vocab; PuLID → real `pulid_flux` registry descriptor on mlx, curated+flow_match/linear fallback on candle), plus a new `bespoke_models_resolve_a_curated_menu` test so the bespoke ids can't be silently skipped.

## Lockstep pin bump
- mlx-gen `903f295` → `04aa4aa` (PuLID [#537](https://github.com/SceneWorks/mlx-gen/pull/537) / InstantID [#538](https://github.com/SceneWorks/mlx-gen/pull/538) / Kolors [#539](https://github.com/SceneWorks/mlx-gen/pull/539)).
- candle-gen `f647aeb` → `671cb13` (candle [#130](https://github.com/SceneWorks/candle-gen/pull/130) sampler/scheduler fields + [#132](https://github.com/SceneWorks/candle-gen/pull/132) gen-core re-pin `903f295`→`04aa4aa`).
- gen-core is byte-identical across the range; the worker lockfile resolves the **single** gen-core rev `04aa4aa`, so `--features backend-candle` stays single-rev (skew gate satisfied).

## Verification
- **mlx lane (macOS):** `cargo check --tests` ✅, `cargo clippy --tests` ✅, **367 lib tests pass / 0 fail** — incl. `manifest_menu_is_subset_of_descriptor`, `bespoke_models_resolve_a_curated_menu`, and the 5 sampling-knob/N1 tests.
- **candle lane:** CUDA-only (not compilable on macOS) — candle wiring cross-checked against the candle #130 struct diff + mirrors existing capture patterns; compile-verifies on the candle/Windows CI.
- **Real-weight e2e** (euler/heun actually changes the InstantID/Kolors-conditioned sampler; default byte-exact) is a runtime check for a GPU host.

Story: [sc-7432](https://app.shortcut.com/trefry/story/7432)

🤖 Generated with [Claude Code](https://claude.com/claude-code)