### PR TITLE
fix(worker): refresh stale candle video eros engine-map test (sc-7475)

### DIFF
--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -9399,14 +9399,19 @@ mod candle_video_label_tests {
         assert_eq!(candle_video_engine_id("ltx_2_3"), Some("ltx_2_3_distilled"));
         // SVD maps to the candle `svd_xt` engine (sc-5493).
         assert_eq!(candle_video_engine_id("svd"), Some("svd_xt"));
-        // The eros LTX still has no candle provider.
-        assert_eq!(candle_video_engine_id("ltx_2_3_eros"), None);
-        assert!(!is_candle_video_engine("ltx_2_3_eros"));
+        // eros now shares the one candle LTX-2.3 engine with the base (sc-5495 wired the eros
+        // dense checkpoint through `ltx_2_3_distilled`; they differ only in `candle_video_repo`).
+        assert_eq!(
+            candle_video_engine_id("ltx_2_3_eros"),
+            Some("ltx_2_3_distilled")
+        );
+        assert!(is_candle_video_engine("ltx_2_3_eros"));
         for model in [
             "wan_2_2",
             "wan_2_2_t2v_14b",
             "wan_2_2_i2v_14b",
             "ltx_2_3",
+            "ltx_2_3_eros",
             "svd",
         ] {
             assert!(is_candle_video_engine(model), "{model}");


### PR DESCRIPTION
## What

Fixes a **pre-existing, candle-lane-only test failure** surfaced while verifying sc-7432 on the candle (Windows/CUDA) lane for **[sc-7475](https://app.shortcut.com/trefry/story/7475)**.

The candle-gated `video_jobs::candle_video_label_tests::candle_video_engine_ids_map_5b_ltx_and_14b` still asserted:

```rust
// The eros LTX still has no candle provider.
assert_eq!(candle_video_engine_id("ltx_2_3_eros"), None);
assert!(!is_candle_video_engine("ltx_2_3_eros"));
```

But **sc-5495** (commit `062590ca`, 2026-06-16) wired `ltx_2_3_eros` onto the shared `ltx_2_3_distilled` candle engine (`candle_video_engine_id` maps `"ltx_2_3" | "ltx_2_3_eros" => Some("ltx_2_3_distilled")`; they differ only in `candle_video_repo`). The test (written 2026-06-15 under sc-5493) was never updated, so it has been **red on `main` ever since** — invisible because CI only runs the worker suite on the **mlx** lane (`nax-worker`/`parity`), never `--features backend-candle` (`build-windows` is a release installer build, no tests).

## Fix

Update the assertion + the `is_candle_video_engine` loop to match the actual (correct) routing. Pure test change — the production routing was already correct and is unchanged.

## Verification

`cargo test -p sceneworks-worker --lib --features backend-candle` on the RTX PRO 6000 box (MSVC 14.44, `CUDA_COMPUTE_CAP=120`):

- before: `231 passed; 1 failed; 9 ignored`
- after: **`232 passed; 0 failed; 9 ignored`**

`cargo fmt -p sceneworks-worker -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)