### PR TITLE
feat(worker): wire candle Boogu-Image-0.1 Base/Turbo/Edit (sc-7524)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=80451b306fbc589822c65fa25fbf007b99e4b8a3#80451b306fbc589822c65fa25fbf007b99e4b8a3"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -450,9 +450,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "candle-gen-boogu"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=80451b306fbc589822c65fa25fbf007b99e4b8a3#80451b306fbc589822c65fa25fbf007b99e4b8a3"
+dependencies = [
+ "candle-gen",
+ "candle-transformers",
+ "inventory",
+ "rand 0.9.4",
+ "rand_distr 0.5.1",
+ "serde_json",
+]
+
+[[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=80451b306fbc589822c65fa25fbf007b99e4b8a3#80451b306fbc589822c65fa25fbf007b99e4b8a3"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +479,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=80451b306fbc589822c65fa25fbf007b99e4b8a3#80451b306fbc589822c65fa25fbf007b99e4b8a3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +489,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=80451b306fbc589822c65fa25fbf007b99e4b8a3#80451b306fbc589822c65fa25fbf007b99e4b8a3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +506,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=80451b306fbc589822c65fa25fbf007b99e4b8a3#80451b306fbc589822c65fa25fbf007b99e4b8a3"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -507,7 +520,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=80451b306fbc589822c65fa25fbf007b99e4b8a3#80451b306fbc589822c65fa25fbf007b99e4b8a3"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -523,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=80451b306fbc589822c65fa25fbf007b99e4b8a3#80451b306fbc589822c65fa25fbf007b99e4b8a3"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -535,7 +548,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=80451b306fbc589822c65fa25fbf007b99e4b8a3#80451b306fbc589822c65fa25fbf007b99e4b8a3"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -546,7 +559,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=80451b306fbc589822c65fa25fbf007b99e4b8a3#80451b306fbc589822c65fa25fbf007b99e4b8a3"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -560,7 +573,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=80451b306fbc589822c65fa25fbf007b99e4b8a3#80451b306fbc589822c65fa25fbf007b99e4b8a3"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -573,7 +586,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=80451b306fbc589822c65fa25fbf007b99e4b8a3#80451b306fbc589822c65fa25fbf007b99e4b8a3"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -585,7 +598,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=80451b306fbc589822c65fa25fbf007b99e4b8a3#80451b306fbc589822c65fa25fbf007b99e4b8a3"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -596,7 +609,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=80451b306fbc589822c65fa25fbf007b99e4b8a3#80451b306fbc589822c65fa25fbf007b99e4b8a3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -613,7 +626,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=80451b306fbc589822c65fa25fbf007b99e4b8a3#80451b306fbc589822c65fa25fbf007b99e4b8a3"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -628,7 +641,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=80451b306fbc589822c65fa25fbf007b99e4b8a3#80451b306fbc589822c65fa25fbf007b99e4b8a3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -639,7 +652,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=80451b306fbc589822c65fa25fbf007b99e4b8a3#80451b306fbc589822c65fa25fbf007b99e4b8a3"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -654,7 +667,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=80451b306fbc589822c65fa25fbf007b99e4b8a3#80451b306fbc589822c65fa25fbf007b99e4b8a3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -672,7 +685,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=80451b306fbc589822c65fa25fbf007b99e4b8a3#80451b306fbc589822c65fa25fbf007b99e4b8a3"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -683,7 +696,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=80451b306fbc589822c65fa25fbf007b99e4b8a3#80451b306fbc589822c65fa25fbf007b99e4b8a3"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -696,7 +709,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=80451b306fbc589822c65fa25fbf007b99e4b8a3#80451b306fbc589822c65fa25fbf007b99e4b8a3"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -707,7 +720,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=80451b306fbc589822c65fa25fbf007b99e4b8a3#80451b306fbc589822c65fa25fbf007b99e4b8a3"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -720,7 +733,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=80451b306fbc589822c65fa25fbf007b99e4b8a3#80451b306fbc589822c65fa25fbf007b99e4b8a3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -3352,7 +3365,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=418f900d696703a82bbd8e19f56eb2ac9c71dc01#418f900d696703a82bbd8e19f56eb2ac9c71dc01"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3364,7 +3377,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=418f900d696703a82bbd8e19f56eb2ac9c71dc01#418f900d696703a82bbd8e19f56eb2ac9c71dc01"
 dependencies = [
  "image",
  "inventory",
@@ -3378,7 +3391,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=418f900d696703a82bbd8e19f56eb2ac9c71dc01#418f900d696703a82bbd8e19f56eb2ac9c71dc01"
 dependencies = [
  "image",
  "inventory",
@@ -3391,7 +3404,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=418f900d696703a82bbd8e19f56eb2ac9c71dc01#418f900d696703a82bbd8e19f56eb2ac9c71dc01"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3403,7 +3416,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=418f900d696703a82bbd8e19f56eb2ac9c71dc01#418f900d696703a82bbd8e19f56eb2ac9c71dc01"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3412,7 +3425,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=418f900d696703a82bbd8e19f56eb2ac9c71dc01#418f900d696703a82bbd8e19f56eb2ac9c71dc01"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3424,7 +3437,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=418f900d696703a82bbd8e19f56eb2ac9c71dc01#418f900d696703a82bbd8e19f56eb2ac9c71dc01"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3435,7 +3448,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=418f900d696703a82bbd8e19f56eb2ac9c71dc01#418f900d696703a82bbd8e19f56eb2ac9c71dc01"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3447,7 +3460,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=418f900d696703a82bbd8e19f56eb2ac9c71dc01#418f900d696703a82bbd8e19f56eb2ac9c71dc01"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3458,7 +3471,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=418f900d696703a82bbd8e19f56eb2ac9c71dc01#418f900d696703a82bbd8e19f56eb2ac9c71dc01"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3468,7 +3481,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=418f900d696703a82bbd8e19f56eb2ac9c71dc01#418f900d696703a82bbd8e19f56eb2ac9c71dc01"
 dependencies = [
  "image",
  "inventory",
@@ -3480,7 +3493,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=418f900d696703a82bbd8e19f56eb2ac9c71dc01#418f900d696703a82bbd8e19f56eb2ac9c71dc01"
 dependencies = [
  "image",
  "inventory",
@@ -3493,7 +3506,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=418f900d696703a82bbd8e19f56eb2ac9c71dc01#418f900d696703a82bbd8e19f56eb2ac9c71dc01"
 dependencies = [
  "image",
  "inventory",
@@ -3505,7 +3518,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=418f900d696703a82bbd8e19f56eb2ac9c71dc01#418f900d696703a82bbd8e19f56eb2ac9c71dc01"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3516,7 +3529,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=418f900d696703a82bbd8e19f56eb2ac9c71dc01#418f900d696703a82bbd8e19f56eb2ac9c71dc01"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3528,7 +3541,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=418f900d696703a82bbd8e19f56eb2ac9c71dc01#418f900d696703a82bbd8e19f56eb2ac9c71dc01"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3538,7 +3551,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=418f900d696703a82bbd8e19f56eb2ac9c71dc01#418f900d696703a82bbd8e19f56eb2ac9c71dc01"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3547,7 +3560,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=418f900d696703a82bbd8e19f56eb2ac9c71dc01#418f900d696703a82bbd8e19f56eb2ac9c71dc01"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3556,7 +3569,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=418f900d696703a82bbd8e19f56eb2ac9c71dc01#418f900d696703a82bbd8e19f56eb2ac9c71dc01"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3568,7 +3581,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=418f900d696703a82bbd8e19f56eb2ac9c71dc01#418f900d696703a82bbd8e19f56eb2ac9c71dc01"
 dependencies = [
  "image",
  "inventory",
@@ -3581,7 +3594,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=418f900d696703a82bbd8e19f56eb2ac9c71dc01#418f900d696703a82bbd8e19f56eb2ac9c71dc01"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3592,7 +3605,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=418f900d696703a82bbd8e19f56eb2ac9c71dc01#418f900d696703a82bbd8e19f56eb2ac9c71dc01"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3603,7 +3616,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=418f900d696703a82bbd8e19f56eb2ac9c71dc01#418f900d696703a82bbd8e19f56eb2ac9c71dc01"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3614,7 +3627,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=418f900d696703a82bbd8e19f56eb2ac9c71dc01#418f900d696703a82bbd8e19f56eb2ac9c71dc01"
 dependencies = [
  "image",
  "inventory",
@@ -3628,7 +3641,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=418f900d696703a82bbd8e19f56eb2ac9c71dc01#418f900d696703a82bbd8e19f56eb2ac9c71dc01"
 dependencies = [
  "image",
  "inventory",
@@ -5271,7 +5284,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=418f900d696703a82bbd8e19f56eb2ac9c71dc01#418f900d696703a82bbd8e19f56eb2ac9c71dc01"
 dependencies = [
  "inventory",
  "safetensors 0.4.5",
@@ -5321,6 +5334,7 @@ version = "0.2.0"
 dependencies = [
  "axum",
  "candle-gen",
+ "candle-gen-boogu",
  "candle-gen-chroma",
  "candle-gen-face",
  "candle-gen-flux",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1059,6 +1059,18 @@
           "files": ["base/transformer/*", "base/mllm/*", "base/vae/*"],
           "platforms": ["macos"],
           "estimatedSizeBytes": 23380234752
+        },
+        {
+          // Candle (Windows/Linux CUDA) bf16 snapshot (sc-7524, epic 6831): the candle provider can't
+          // read the MLX-quantized turnkey above, so off-Mac loads bf16 from the sibling repo
+          // `SceneWorks/boogu-image` (the worker's `candle_boogu_repo` / `candle_boogu_subdir`). Same
+          // per-variant `base/ transformer mllm vae/` layout (leaf-dir globs — the subfolder nests). bf16
+          // only (the candle provider rejects on-the-fly quant). Apache-2.0, ungated. Windows/Linux download.
+          "provider": "huggingface",
+          "repo": "SceneWorks/boogu-image",
+          "files": ["base/transformer/*", "base/mllm/*", "base/vae/*"],
+          "platforms": ["windows", "linux"],
+          "estimatedSizeBytes": 38500000000
         }
       ],
       "paths": {
@@ -1142,6 +1154,16 @@
           "files": ["turbo/transformer/*", "turbo/mllm/*", "turbo/vae/*"],
           "platforms": ["macos"],
           "estimatedSizeBytes": 23380234586
+        },
+        {
+          // Candle (Windows/Linux CUDA) bf16 snapshot (sc-7524): off-Mac loads bf16 from the `turbo/`
+          // subfolder of `SceneWorks/boogu-image` (same weights-arch as Base; the DMD few-step distill).
+          // bf16 only (the candle provider rejects on-the-fly quant). Apache-2.0, ungated.
+          "provider": "huggingface",
+          "repo": "SceneWorks/boogu-image",
+          "files": ["turbo/transformer/*", "turbo/mllm/*", "turbo/vae/*"],
+          "platforms": ["windows", "linux"],
+          "estimatedSizeBytes": 38500000000
         }
       ],
       "paths": {
@@ -1220,6 +1242,16 @@
           "files": ["edit/transformer/*", "edit/mllm/*", "edit/vae/*"],
           "platforms": ["macos"],
           "estimatedSizeBytes": 23380234314
+        },
+        {
+          // Candle (Windows/Linux CUDA) bf16 snapshot (sc-7524): off-Mac loads bf16 from the `edit/`
+          // subfolder of `SceneWorks/boogu-image` (the instruction-edit checkpoint — carries the Qwen3-VL
+          // vision tower). bf16 only (the candle provider rejects on-the-fly quant). Apache-2.0, ungated.
+          "provider": "huggingface",
+          "repo": "SceneWorks/boogu-image",
+          "files": ["edit/transformer/*", "edit/mllm/*", "edit/vae/*"],
+          "platforms": ["windows", "linux"],
+          "estimatedSizeBytes": 38500000000
         }
       ],
       "paths": {

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3774,6 +3774,18 @@ const CANDLE_ROUTED_MODELS: &[&str] = &[
     // lane lands (sc-6598). These ids are also in `MLX_ROUTED_MODELS` (the macOS native engine).
     "ideogram_4",
     "ideogram_4_turbo",
+    // Boogu-Image-0.1 (sc-7524, epic 6831): the candle `candle-gen-boogu` provider serves `boogu_image`
+    // (Base, true-CFG), `boogu_image_turbo` (DMD few-step, CFG-free), and `boogu_image_edit` (single-
+    // reference instruction TI2I). Base + Turbo are pure **txt2img** on candle; `boogu_image_edit`'s
+    // `edit_image` shape is handled by the bespoke `boogu_edit_candle_eligible` branch in
+    // `image_job_is_candle_eligible` (the source `Reference` is resolved in-lane by the worker's
+    // `generate_candle_stream`, like Ideogram — NOT a separate bespoke stream). bf16-only (the provider
+    // rejects on-the-fly quant), so a deliberate quant request defers below — boogu is intentionally NOT
+    // in `CANDLE_QUANT_LORA_MODELS`. Apache-2.0 ungated. These ids are also in `MLX_ROUTED_MODELS` (the
+    // macOS native engine); mirror `boogu_mlx_eligible`.
+    "boogu_image",
+    "boogu_image_turbo",
+    "boogu_image_edit",
 ];
 
 /// The candle image families that advertise on-the-fly Q4/Q8 quant AND LoRA/LoKr adapters — Lens /
@@ -3884,6 +3896,17 @@ fn image_job_is_candle_eligible(job: &JobSnapshot) -> bool {
     if matches!(model, "ideogram_4" | "ideogram_4_turbo")
         && ideogram_edit_candle_eligible(&job.payload)
     {
+        return true;
+    }
+    // Boogu instruction edit (sc-7524, epic 6831): a `boogu_image_edit` `edit_image` job with a source
+    // image runs the candle `candle-gen-boogu` edit path. Like Ideogram (and unlike the SDXL/FLUX.2/Qwen/
+    // Z-Image bespoke streams above), Boogu has no separate edit stream — the SAME registered
+    // `boogu_image_edit` engine resolves the source `Reference` in the worker's `generate_candle_stream`
+    // (the Qwen3-VL vision tower reads it + it VAE-encodes into the DiT reference latent), exactly as the
+    // MLX `generate_stream` handles Boogu edit in-lane. The `image_request_candle_eligible` gate below
+    // rejects the whole `edit_image` family, so branch it out here. Base/Turbo are pure T2I (the generic
+    // gate). Mirrors the worker's dispatch + the MLX `boogu_mlx_eligible`.
+    if model == "boogu_image_edit" && boogu_edit_candle_eligible(&job.payload) {
         return true;
     }
     // SDXL IP-Adapter-Plus reference conditioning (sc-5488, epic 5480): an sdxl-family model with a
@@ -4381,6 +4404,25 @@ fn zimage_edit_candle_eligible(payload: &Map<String, Value>) -> bool {
 /// gate to mirror — the worker's `is_candle_engine` + in-lane edit resolve cover both. Candle-only —
 /// macOS keeps the MLX `ideogram_4` registry generator's edit path (sc-6303).
 fn ideogram_edit_candle_eligible(payload: &Map<String, Value>) -> bool {
+    if payload.get("mode").and_then(Value::as_str) != Some("edit_image") {
+        return false;
+    }
+    payload
+        .get("sourceAssetId")
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.trim().is_empty())
+}
+
+/// Boogu instruction-edit candle-routing conditions (sc-7524, epic 6831). The candle `boogu_image_edit`
+/// engine serves `edit_image` mode with a `sourceAssetId` — a single-reference instruction TI2I (the
+/// source is VAE-encoded into the DiT reference latent AND read by the Qwen3-VL vision tower; no mask /
+/// inpaint / outpaint, the descriptor accepts only `Reference`). Same payload predicate as the other edit
+/// gates, gated to `boogu_image_edit` by the caller (only the Edit checkpoint edits — Base/Turbo are
+/// T2I-only). Like Ideogram, the candle lane reuses the generic `generate_candle_stream` (the source is
+/// resolved in-lane by `resolve_boogu_edit`), so there is no separate worker `*_available` gate to mirror
+/// — the worker's `is_candle_engine` + in-lane edit resolve cover it. Candle-only — macOS keeps the MLX
+/// `boogu_image_edit` registry generator's edit path.
+fn boogu_edit_candle_eligible(payload: &Map<String, Value>) -> bool {
     if payload.get("mode").and_then(Value::as_str) != Some("edit_image") {
         return false;
     }
@@ -5849,6 +5891,52 @@ mod candle_routing_tests {
                 &object(json!({ "referenceAssetId": "a" }))
             ));
         }
+    }
+
+    #[test]
+    fn boogu_text_to_image_and_edit_route_to_candle() {
+        // sc-7524 (epic 6831): the candle parity of `boogu_text_to_image_and_edit_route_to_mlx`. The
+        // three Boogu ids are in `CANDLE_ROUTED_MODELS`; Base + Turbo are pure txt2img (the generic gate),
+        // and `boogu_image_edit`'s `edit_image` shape routes via the bespoke `boogu_edit_candle_eligible`
+        // branch (the source `Reference` is resolved in-lane by `generate_candle_stream`, like Ideogram).
+        for model in ["boogu_image", "boogu_image_turbo", "boogu_image_edit"] {
+            // Plain txt2img → the generic gate (the edit checkpoint can also T2I, mirroring MLX).
+            assert!(
+                image_request_candle_eligible(model, &object(json!({ "prompt": "a red panda" }))),
+                "{model} plain txt2img must be candle-eligible"
+            );
+        }
+        // Edit (source instruction) is the Edit checkpoint's capability ONLY.
+        let edit_payload = |model: &str| json!({ "model": model, "mode": "edit_image", "sourceAssetId": "asset_1" });
+        // `boogu_image_edit` + edit_image + source → the bespoke branch claims it for candle.
+        assert!(boogu_edit_candle_eligible(&object(edit_payload(
+            "boogu_image_edit"
+        ))));
+        assert!(image_job_is_candle_eligible(&image_edit_job(edit_payload(
+            "boogu_image_edit"
+        ))));
+        // The generic txt2img gate still rejects the edit_image family (the bespoke lane handles it).
+        assert!(!image_request_candle_eligible(
+            "boogu_image_edit",
+            &object(edit_payload("boogu_image_edit"))
+        ));
+        // Base / Turbo do NOT edit — an edit_image job on them is not candle-eligible (no edit lane; the
+        // generic gate rejects edit_image and the boogu edit branch is gated to `boogu_image_edit`).
+        assert!(!image_job_is_candle_eligible(&image_edit_job(
+            edit_payload("boogu_image")
+        )));
+        assert!(!image_job_is_candle_eligible(&image_edit_job(
+            edit_payload("boogu_image_turbo")
+        )));
+        // `edit_image` WITHOUT a source → nothing to edit → not this lane.
+        assert!(!boogu_edit_candle_eligible(&object(json!({
+            "model": "boogu_image_edit", "mode": "edit_image"
+        }))));
+        // bf16-only: a deliberate Q8/Q4 quant request defers (boogu is not in CANDLE_QUANT_LORA_MODELS).
+        assert!(!image_request_candle_eligible(
+            "boogu_image",
+            &object(json!({ "prompt": "x", "advanced": { "mlxQuantize": 8 } }))
+        ));
     }
 
     #[test]

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -296,7 +296,19 @@ sceneworks-core = { path = "../sceneworks-core" }
 # across `2dc0306..5ea4865` (candle-gen-boogu also changed, but the worker doesn't link it), so the bump is
 # surgical: `flux2_dev` gains its Q4 lane, every other candle family is byte-identical, and `--features
 # backend-candle --target all` still resolves the SINGLE gen-core rev 43aa2bf (the skew gate).
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+# Bumped `43aa2bf` -> `418f900d` (sc-7524, epic 6831): the candle Boogu wiring needs the candle-gen rev
+# to carry the COMPLETE Boogu provider (Base+Turbo #136 + Edit #140) AND keep sc-7458's FLUX.2-dev Q4 lane
+# (#137). Those two landed on DIVERGENT candle-gen branches — #137 (`5ea4865`, gen-core 43aa2bf) does NOT
+# contain the Boogu Edit, and the Edit (#140) merged into candle-gen main TOGETHER with candle-gen's own
+# gen-core bump to 418f900d (the sc-6537 CLIP-text-embedder, mlx-gen #542). So NO single candle-gen rev
+# has {flux2_dev + Boogu Base+Turbo+Edit} on gen-core 43aa2bf — shipping Boogu Edit without regressing
+# sc-7458 REQUIRES advancing to candle-gen main HEAD `80451b3` (has #136+#137+#140+#141), which pins
+# gen-core 418f900d. So this worker syncs its mlx-gen pin 43aa2bf -> 418f900d IN LOCKSTEP (the candle pin
+# below moves `5ea4865` -> `80451b3`) → `--features backend-candle --target all` resolves the SINGLE
+# gen-core rev 418f900d. The mlx-gen delta 43aa2bf..418f900d is exactly ONE additive PR (#542: the new
+# `gen-core` CLIP-text-embedder contract, +197 lines in lib/registry/text_embed) — the worker's import
+# surface is unchanged, MLX core does not rebuild beyond gen-core, so N1/skew-gate hold at one rev.
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "418f900d696703a82bbd8e19f56eb2ac9c71dc01" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -362,6 +374,11 @@ backend-candle = [
     "dep:candle-gen-ideogram",
     # sc-5484 (epic 3692): the candle Chroma image provider (chroma1_hd / chroma1_base / chroma1_flash).
     "dep:candle-gen-chroma",
+    # sc-7524 (epic 6831): the candle Boogu-Image-0.1 provider (`boogu_image` / `boogu_image_turbo` /
+    # `boogu_image_edit`). Base/Turbo T2I + the single-reference instruction-edit lane; bf16-only,
+    # Apache-2.0 ungated. Its `MODEL_TABLE` rows already exist (the MLX twin), so
+    # `engines::registry_capabilities` advertises them off-Mac with no further change.
+    "dep:candle-gen-boogu",
     # sc-5576 (epic 3692): the candle Kolors image provider (`kolors` — SDXL UNet + ChatGLM3-6B
     # encoder) and the candle SenseNova-U1 NEO-Unify image provider (`sensenova_u1_8b` +
     # `sensenova_u1_8b_fast`). Both pure T2I; their `MODEL_TABLE` rows already exist (MLX families), so
@@ -620,7 +637,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "418f900d696703a82bbd8e19f56eb2ac9c71dc01" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -632,64 +649,64 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556
 # internal pin (the Lens engine PRs #407–#414 did not move it; nor did the seedvr2 engine #416/#419/
 # #421 or the softness PR #422, so the 1a97909 bump above leaves mlx-rs at 44929a0).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "44929a001ab8a8837403a71c65cf064224de0cdc" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "418f900d696703a82bbd8e19f56eb2ac9c71dc01" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "418f900d696703a82bbd8e19f56eb2ac9c71dc01" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "418f900d696703a82bbd8e19f56eb2ac9c71dc01" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "418f900d696703a82bbd8e19f56eb2ac9c71dc01" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "418f900d696703a82bbd8e19f56eb2ac9c71dc01" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "418f900d696703a82bbd8e19f56eb2ac9c71dc01" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "418f900d696703a82bbd8e19f56eb2ac9c71dc01" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "418f900d696703a82bbd8e19f56eb2ac9c71dc01" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "418f900d696703a82bbd8e19f56eb2ac9c71dc01" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "418f900d696703a82bbd8e19f56eb2ac9c71dc01" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "418f900d696703a82bbd8e19f56eb2ac9c71dc01" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "418f900d696703a82bbd8e19f56eb2ac9c71dc01" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "418f900d696703a82bbd8e19f56eb2ac9c71dc01" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "418f900d696703a82bbd8e19f56eb2ac9c71dc01" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -698,12 +715,12 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2b
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "418f900d696703a82bbd8e19f56eb2ac9c71dc01" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "418f900d696703a82bbd8e19f56eb2ac9c71dc01" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -712,7 +729,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2b
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "418f900d696703a82bbd8e19f56eb2ac9c71dc01" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -720,7 +737,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "418f900d696703a82bbd8e19f56eb2ac9c71dc01" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -731,7 +748,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "418f900d696703a82bbd8e19f56eb2ac9c71dc01" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -742,7 +759,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "418f900d696703a82bbd8e19f56eb2ac9c71dc01" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -757,7 +774,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2b
 # converted in-memory at load (no Python); the precomputed neg-prompt embedding is bundled in-crate. No
 # LoRA/guidance/CFG (one-step). 3B fp16 only here — 7B (sc-5197) + int8 (sc-5198) are engine-side and
 # unwired. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "418f900d696703a82bbd8e19f56eb2ac9c71dc01" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -768,7 +785,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43a
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "418f900d696703a82bbd8e19f56eb2ac9c71dc01" }
 # Prompt-refine provider (sc-5552, the MLX twin of candle-gen-prompt-refine / sc-5500). An
 # inventory-registered `TextLlm` under id `prompt_refine` (`backend="mlx"`, `mac_only`): a native MLX
 # Llama-3.2-3B-Instruct that rewrites a user's prompt, replacing the Python `prompt_refine.py`
@@ -778,7 +795,7 @@ mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43a
 # textllm registered" trap). Weights = a stock Llama-3.2-3B-Instruct HF snapshot (config.json +
 # tokenizer.json + model-*.safetensors; default `huihui-ai/Llama-3.2-3B-Instruct-abliterated`). Same
 # git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "418f900d696703a82bbd8e19f56eb2ac9c71dc01" }
 # SCAIL-2 (zai-org) end-to-end character-animation provider (epic 5439, sc-5448). An inventory-registered
 # `Generator` under id `scail2_14b` (`Modality::Video`): a Wan2.1-14B I2V DiT that animates a reference
 # character with a driving video's motion (`video_mode == "replacement"` flips the cross-identity
@@ -790,7 +807,7 @@ mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev 
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "418f900d696703a82bbd8e19f56eb2ac9c71dc01" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -1017,39 +1034,60 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa
 # — AND #132's gen-core re-pin 903f295 -> 04aa4aa (BYTE-IDENTICAL; same `gen-core/` tree SHA 5450444), so
 # `--features backend-candle --target all` resolves the SINGLE gen-core rev 04aa4aa shared with the mlx
 # pin. candle-gen #132 CI (macos-15 + ubuntu-latest fmt/clippy/check/test) green against 04aa4aa.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
+# Rev 671cb13 -> 2dc0306 (sc-7491): documented in the mlx-pin block above (candle-gen #134 mirrored the
+# `ms` thread + re-pinned its gen-core to 43aa2bf in lockstep with the worker's mlx pin).
+# Rev 5ea4865 -> 80451b3 (sc-7524, epic 6831): re-pin candle-gen to main HEAD to ADD the `candle-gen-boogu`
+# Boogu-Image-0.1 provider (Windows/CUDA sibling of mlx-gen-boogu; registers `boogu_image` /
+# `boogu_image_turbo` / `boogu_image_edit`) the worker now links + force-links (boogu dep below), WHILE
+# keeping sc-7458's FLUX.2-dev Q4 lane (#137 / `5ea4865`). main HEAD `80451b3` carries #136 (Boogu
+# Base+Turbo) + #137 (flux2_dev) + #140 (Boogu Edit) + #141 — the FIRST rev with both the Edit and
+# flux2_dev (they were on divergent branches; see the mlx-pin block above for why a single 43aa2bf rev
+# can't carry both). `80451b3` pins gen-core 418f900d, matched by this worker's mlx pin (bumped 43aa2bf ->
+# 418f900d above) so `--features backend-candle --target all` resolves the SINGLE gen-core rev 418f900d.
+# Boogu is bf16-only on candle (the provider rejects on-the-fly quant), Apache-2.0 ungated (no gating UI).
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "80451b306fbc589822c65fa25fbf007b99e4b8a3", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "80451b306fbc589822c65fa25fbf007b99e4b8a3", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "80451b306fbc589822c65fa25fbf007b99e4b8a3", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "80451b306fbc589822c65fa25fbf007b99e4b8a3", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "80451b306fbc589822c65fa25fbf007b99e4b8a3", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "80451b306fbc589822c65fa25fbf007b99e4b8a3", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "80451b306fbc589822c65fa25fbf007b99e4b8a3", features = ["cuda"], optional = true }
+# Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
+# Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
+# CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
+# DiT reference latent AND read by the Qwen3-VL vision tower). A ~10.3B Lumina-Image-2.0 / OmniGen2-lineage
+# hybrid MMDiT (8 double + 32 single + 2 refiner) + Qwen3-VL-8B condition encoder + the FLUX.1 16-ch VAE.
+# bf16-only on candle (the provider rejects on-the-fly Q4/Q8 — see `image_request_candle_eligible`'s quant
+# gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
+# Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
+# Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "80451b306fbc589822c65fa25fbf007b99e4b8a3", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "80451b306fbc589822c65fa25fbf007b99e4b8a3", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "80451b306fbc589822c65fa25fbf007b99e4b8a3", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "80451b306fbc589822c65fa25fbf007b99e4b8a3", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1058,11 +1096,11 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "80451b306fbc589822c65fa25fbf007b99e4b8a3", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "80451b306fbc589822c65fa25fbf007b99e4b8a3", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1071,19 +1109,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "80451b306fbc589822c65fa25fbf007b99e4b8a3", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "80451b306fbc589822c65fa25fbf007b99e4b8a3", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "80451b306fbc589822c65fa25fbf007b99e4b8a3", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1092,12 +1130,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "80451b306fbc589822c65fa25fbf007b99e4b8a3", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "80451b306fbc589822c65fa25fbf007b99e4b8a3", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1105,7 +1143,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea48
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "80451b306fbc589822c65fa25fbf007b99e4b8a3", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1114,7 +1152,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "80451b306fbc589822c65fa25fbf007b99e4b8a3", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1122,7 +1160,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "80451b306fbc589822c65fa25fbf007b99e4b8a3", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1131,7 +1169,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "80451b306fbc589822c65fa25fbf007b99e4b8a3", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1158,7 +1196,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "80451b306fbc589822c65fa25fbf007b99e4b8a3", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -112,6 +112,12 @@ use candle_gen_ideogram as _;
 // shared gen_core inventory; the `as _;` keeps the MSVC release linker from GC-ing the registrations.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_chroma as _;
+// Candle Boogu-Image-0.1 (sc-7524, epic 6831): `boogu_image` / `boogu_image_turbo` / `boogu_image_edit`
+// self-register into the shared gen_core inventory; the `as _;` keeps the MSVC release linker from GC-ing
+// the `ModelRegistration`s (else `gen_core::load("boogu_image")` returns "no generator registered"). The
+// Windows/CUDA sibling of the `mlx_gen_boogu` anchor above.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+use candle_gen_boogu as _;
 // Candle Kolors (sc-5576, epic 3692): the `kolors` T2I id self-registers into the shared gen_core
 // inventory; `as _;` keeps the MSVC release linker from GC-ing the registration.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -1147,7 +1147,16 @@ const IDEOGRAM_INPAINT_STRENGTH: f32 = 0.85;
 /// `(source, strength)`; `None` when not an edit / no source. The `strength` is inert for Boogu (the
 /// edit is structural — the engine ignores `Conditioning::Reference.strength`), so a full-strength
 /// 1.0 is returned for the contract. No mask / outpaint path (the descriptor accepts only `Reference`).
-#[cfg(target_os = "macos")]
+///
+/// Shared by the macOS MLX `generate_stream` and the off-Mac candle `generate_candle_stream` (sc-7524):
+/// Boogu is the same engine family for T2I and edit on both backends (the registered `boogu_image_edit`
+/// resolves the source `Reference` in-lane, like Ideogram), so both lanes resolve the edit source the
+/// same way. Its deps (`load_reference_image`, `fit_engine_image`) already compile off-Mac under
+/// `backend-candle` (the Ideogram edit path uses them too).
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 fn resolve_boogu_edit(
     request: &ImageRequest,
     settings: &Settings,
@@ -1746,6 +1755,12 @@ fn is_candle_engine(model: &str) -> bool {
             | "sensenova_u1_8b_fast"
             | "ideogram_4"
             | "ideogram_4_turbo"
+            // Boogu-Image-0.1 (sc-7524, epic 6831): Base + Turbo (txt2img) and the Edit checkpoint, all
+            // on the generic candle lane. Like Ideogram, `boogu_image_edit`'s instruction edit is in-lane
+            // (the engine resolves the source `Reference`), not a separate bespoke stream.
+            | "boogu_image"
+            | "boogu_image_turbo"
+            | "boogu_image_edit"
     )
 }
 
@@ -1765,6 +1780,7 @@ fn candle_adapter_label(model: &str) -> &'static str {
         "kolors" => "candle_kolors",
         "sensenova_u1_8b" | "sensenova_u1_8b_fast" => "candle_sensenova",
         "ideogram_4" | "ideogram_4_turbo" => "candle_ideogram",
+        "boogu_image" | "boogu_image_turbo" | "boogu_image_edit" => "candle_boogu",
         // sdxl / realvisxl share the candle "sdxl" engine.
         _ => CANDLE_ADAPTER,
     }
@@ -1823,6 +1839,65 @@ fn candle_ideogram_subdir(root: &Path) -> PathBuf {
     }
 }
 
+/// The candle Boogu-Image-0.1 weights repo (bf16). Like Ideogram, Boogu's published turnkey
+/// (`SceneWorks/boogu-image-mlx`, the `MODEL_TABLE` default + the macOS MLX repo) is MLX-quantized and
+/// not candle-readable, so off-Mac the candle lane loads bf16 from a separate sibling repo (sc-7524) with
+/// per-variant `base/ turbo/ edit/` subfolders (each a complete `transformer/ mllm/ vae/` snapshot the
+/// provider's `pipeline::load_components` reads). The image sibling of the video `CANDLE_WAN_5B_REPO`.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+const CANDLE_BOOGU_REPO: &str = "SceneWorks/boogu-image";
+
+/// Resolve the candle Boogu weights repo: the off-Mac (`std::env::consts::OS`) download entry's `repo`
+/// from the manifest (the bf16 repo) — the single source of truth, also driving the downloader — else the
+/// [`CANDLE_BOOGU_REPO`] default. Deliberately NOT the entry-level `repo`, which is the macOS MLX turnkey.
+/// Mirrors `candle_ideogram_repo`.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn candle_boogu_repo(request: &ImageRequest) -> String {
+    let os = std::env::consts::OS;
+    request
+        .model_manifest_entry
+        .get("downloads")
+        .and_then(Value::as_array)
+        .and_then(|downloads| {
+            downloads.iter().find_map(|entry| {
+                let matches_os = entry
+                    .get("platforms")
+                    .and_then(Value::as_array)
+                    .is_some_and(|platforms| platforms.iter().any(|p| p.as_str() == Some(os)));
+                if !matches_os {
+                    return None;
+                }
+                entry
+                    .get("repo")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|repo| !repo.is_empty())
+                    .map(str::to_owned)
+            })
+        })
+        .unwrap_or_else(|| CANDLE_BOOGU_REPO.to_owned())
+}
+
+/// Pick the engine-complete `base/ turbo/ edit/` subfolder of a candle Boogu snapshot `root` for the
+/// requested variant (`boogu_image`→`base`, `boogu_image_turbo`→`turbo`, `boogu_image_edit`→`edit`) —
+/// each a complete `transformer/ mllm/ vae/` snapshot. Candle is bf16-only (the provider rejects
+/// on-the-fly quant), so there is no quant subdir to choose. Falls back to the snapshot root so a flat
+/// (subdir-less) layout still loads. Mirrors the MLX `boogu_model_subdir` variant mapping.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn candle_boogu_subdir(root: &Path, model: &str) -> PathBuf {
+    let variant = match model {
+        "boogu_image_turbo" => "turbo",
+        "boogu_image_edit" => "edit",
+        _ => "base",
+    };
+    let dir = root.join(variant);
+    if dir.join("transformer").is_dir() {
+        dir
+    } else {
+        root.to_path_buf()
+    }
+}
+
 /// Windows/CUDA candle execution path (sc-3675 SDXL, generalized in sc-5096). The macOS dispatch is
 /// MLX-bound; candle is a narrow **txt2img-only** lane, so this is a trimmed sibling of
 /// [`generate_stream`] that drives the SAME neutral streaming harness (`start_cached_gen_stream` →
@@ -1869,13 +1944,23 @@ async fn generate_candle_stream(
         model.backend()
     };
     let is_ideogram = crate::ideogram_caption::is_ideogram_model(&request.model);
-    // Ideogram is the lone candle image family whose upstream isn't candle-readable: the published
-    // turnkey `SceneWorks/ideogram-4-mlx` (the MODEL_TABLE default + the macOS MLX repo) is
-    // MLX-quantized, so the candle lane loads bf16 from `SceneWorks/ideogram-4` (the `bf16/` subdir)
-    // instead — the image sibling of the candle video `candle_video_repo` override (sc-6859). macOS
-    // keeps the MLX turnkey. Every other candle family shares its upstream diffusers repo via `model_repo`.
+    // Boogu (sc-7524) is the second candle image family whose upstream turnkey isn't candle-readable: its
+    // `SceneWorks/boogu-image-mlx` turnkey is MLX-quantized, so the candle lane loads bf16 from the sibling
+    // `SceneWorks/boogu-image` (per-variant `base/ turbo/ edit/` subfolders), exactly as Ideogram below.
+    let is_boogu = matches!(
+        request.model.as_str(),
+        "boogu_image" | "boogu_image_turbo" | "boogu_image_edit"
+    );
+    // Ideogram + Boogu are the candle image families whose upstream isn't candle-readable: the published
+    // turnkeys (`SceneWorks/ideogram-4-mlx` / `SceneWorks/boogu-image-mlx`, the MODEL_TABLE defaults + the
+    // macOS MLX repos) are MLX-quantized, so the candle lane loads bf16 from a separate repo
+    // (`SceneWorks/ideogram-4`'s `bf16/` subdir / `SceneWorks/boogu-image`'s per-variant subfolder)
+    // instead — the image sibling of the candle video `candle_video_repo` override (sc-6859). macOS keeps
+    // the MLX turnkeys. Every other candle family shares its upstream diffusers repo via `model_repo`.
     let repo = if is_ideogram {
         candle_ideogram_repo(request)
+    } else if is_boogu {
+        candle_boogu_repo(request)
     } else {
         model_repo(request, &model)
     };
@@ -1884,6 +1969,8 @@ async fn generate_candle_stream(
     })?;
     let weights_dir = if is_ideogram {
         candle_ideogram_subdir(&snapshot)
+    } else if is_boogu {
+        candle_boogu_subdir(&snapshot, &request.model)
     } else {
         snapshot
     };
@@ -1941,20 +2028,28 @@ async fn generate_candle_stream(
     } else {
         request.prompt.clone()
     };
-    // Ideogram 4 img2img / Remix + mask inpaint / outpaint edit (sc-6598): resolve the source
-    // `Reference` (+ optional `Mask`) + strength once, seed-independent — the candle sibling of the MLX
-    // `generate_stream` edit path. `resolve_ideogram_edit` returns `None` for a non-edit (T2I) job, and
-    // it is gated to the ideogram family so a stray non-ideogram job reaching this generic lane is
-    // untouched. Other candle edit families have their own bespoke streams (checked before this dispatch).
-    let (ideogram_reference, ideogram_mask) =
-        if is_ideogram {
-            match resolve_ideogram_edit(request, settings, project_path)? {
-                Some((source, strength, mask)) => (Some((source, strength)), mask),
-                None => (None, None),
-            }
-        } else {
-            (None, None)
-        };
+    // In-lane edit conditioning (sc-6598 Ideogram / sc-7524 Boogu): resolve the source `Reference`
+    // (+ optional `Mask` for Ideogram) + strength once, seed-independent — the candle sibling of the MLX
+    // `generate_stream` edit path. Both families edit on the SAME engine as their T2I (no separate bespoke
+    // stream), so the generic lane resolves the source here. `resolve_ideogram_edit` / `resolve_boogu_edit`
+    // return `None` for a non-edit (T2I) job, and each is gated to its family so a stray job reaching this
+    // generic lane is untouched. Boogu has no mask (the `boogu_image_edit` descriptor accepts only
+    // `Reference` — the Qwen3-VL vision tower reads it + it VAE-encodes into the DiT reference latent).
+    // Other candle edit families (sdxl/flux2/qwen/z-image) have their own bespoke streams (checked before
+    // this dispatch).
+    let (edit_reference, edit_mask) = if is_ideogram {
+        match resolve_ideogram_edit(request, settings, project_path)? {
+            Some((source, strength, mask)) => (Some((source, strength)), mask),
+            None => (None, None),
+        }
+    } else if request.model == "boogu_image_edit" {
+        match resolve_boogu_edit(request, settings, project_path)? {
+            Some((source, strength)) => (Some((source, strength)), None),
+            None => (None, None),
+        }
+    } else {
+        (None, None)
+    };
     let (width, height) = (request.width, request.height);
     // Per-payload sampler / scheduler / schedule-shift, mirroring the MLX `generate_stream` lane (the
     // 1753 front-half advanced carrier — epic 7114 P5, sc-7127). RealVisXL Lightning (sc-7176) forces the
@@ -2018,8 +2113,8 @@ async fn generate_candle_stream(
                         steps,
                         guidance,
                         negative_prompt.clone(),
-                        ideogram_reference.as_ref(),
-                        ideogram_mask.as_ref(),
+                        edit_reference.as_ref(),
+                        edit_mask.as_ref(),
                         true_cfg,
                         // Per-payload sampler / scheduler / schedule-shift (sc-7127), already N3-guarded
                         // against this family's advertised surface above. RealVisXL Lightning forces
@@ -2318,6 +2413,12 @@ mod candle_label_tests {
             candle_adapter_label("sensenova_u1_8b_fast"),
             "candle_sensenova"
         );
+        assert_eq!(candle_adapter_label("ideogram_4"), "candle_ideogram");
+        assert_eq!(candle_adapter_label("ideogram_4_turbo"), "candle_ideogram");
+        // Boogu (sc-7524): all three variants share the `candle_boogu` asset stamp.
+        assert_eq!(candle_adapter_label("boogu_image"), "candle_boogu");
+        assert_eq!(candle_adapter_label("boogu_image_turbo"), "candle_boogu");
+        assert_eq!(candle_adapter_label("boogu_image_edit"), "candle_boogu");
         assert_eq!(candle_adapter_label("sdxl"), "candle_sdxl");
         assert_eq!(candle_adapter_label("realvisxl"), "candle_sdxl");
         // Every wired engine carries a `candle_`-prefixed label, distinct from the `mlx_` labels.
@@ -2336,6 +2437,11 @@ mod candle_label_tests {
             "kolors",
             "sensenova_u1_8b",
             "sensenova_u1_8b_fast",
+            "ideogram_4",
+            "ideogram_4_turbo",
+            "boogu_image",
+            "boogu_image_turbo",
+            "boogu_image_edit",
             "sdxl",
             "realvisxl",
         ] {
@@ -2363,11 +2469,20 @@ mod candle_label_tests {
             "kolors",
             "sensenova_u1_8b",
             "sensenova_u1_8b_fast",
+            "ideogram_4",
+            "ideogram_4_turbo",
+            // Boogu (sc-7524): Base + Turbo (txt2img) AND `boogu_image_edit` — unlike z_image_edit /
+            // qwen_image_edit (bespoke streams), Boogu's instruction edit is in-lane on the generic
+            // candle stream (like Ideogram), so `boogu_image_edit` IS a candle engine.
+            "boogu_image",
+            "boogu_image_turbo",
+            "boogu_image_edit",
         ] {
             assert!(is_candle_engine(model), "{model} should be a candle engine");
         }
-        // Non-candle families + non-base variants (edit ids, the kv distill) are not in the lane.
-        // (kolors / sensenova ARE candle engines now — sc-5576 — for their base txt2img shape.)
+        // Non-candle families + non-base variants (the bespoke-stream edit ids, the kv distill) are not
+        // in the generic lane. (kolors / sensenova ARE candle engines now — sc-5576 — for their base
+        // txt2img shape; `boogu_image_edit` IS — sc-7524 — because its edit is in-lane, not bespoke.)
         for model in [
             "bernini_image",
             "z_image_edit",


### PR DESCRIPTION
Story 4 of epic [6831](https://app.shortcut.com/trefry/epic/6831) (candle/CUDA Boogu-Image-0.1, the sibling of the done MLX epic 6387). Worker wiring for the `candle-gen-boogu` provider — Base+Turbo ([candle-gen#136](https://github.com/SceneWorks/candle-gen/pull/136), sc-7521/7522) + Edit (candle-gen #140, sc-7523), both on candle-gen `main`.

## What this does
- **Cargo.toml**: add the `candle-gen-boogu` optional dep + `dep:candle-gen-boogu` in the `backend-candle` feature.
- **`image_jobs.rs`**: force-link `use candle_gen_boogu as _;` (keeps the `boogu_image` / `boogu_image_turbo` / `boogu_image_edit` inventory registrations).
- **`jobs_store.rs`** (router): the three ids → `CANDLE_ROUTED_MODELS`; bespoke `boogu_edit_candle_eligible` branch for the Edit lane (mirrors Ideogram + the MLX `boogu_mlx_eligible`). **Q8/Q4 gating**: Boogu stays OUT of `CANDLE_QUANT_LORA_MODELS`, so a deliberate quant request defers (the provider is bf16-only — rejects on-the-fly quant). + candle routing test (parity with the MLX route).
- **`base.rs`** (executor): Boogu in `is_candle_engine` + `candle_adapter_label` (`candle_boogu`); `candle_boogu_repo`/`candle_boogu_subdir` (bf16 turnkey, `base/turbo/edit` subfolders); `resolve_boogu_edit` now compiles off-Mac; the Edit `Reference` is resolved **in-lane** by `generate_candle_stream` (like Ideogram — not a separate bespoke stream). + Boogu coverage in `candle_label_tests`.
- **`builtin.models.jsonc`**: windows/linux candle bf16 download entries (`SceneWorks/boogu-image`) for the three models. `macOnly` stays `true` (candle-only off-Mac, gated by `backend_candle_enabled` — mirrors Ideogram). Apache-2.0 ungated, no gating UI.

## gen-core lockstep (single rev — the candle-gen treadmill)
**Rebased onto main after [#873](https://github.com/SceneWorks/SceneWorks/pull/873) (sc-7458, flux2_dev candle) landed.** That re-pinned candle-gen to `5ea4865` (flux2_dev #137, gen-core `43aa2bf`). The Boogu **Edit** (#140) and flux2_dev (#137) sit on **divergent** candle-gen branches — and #140 merged into candle-gen main *together with* candle-gen's own gen-core bump to `418f900d` (the unrelated sc-6537 CLIP-text-embedder). So **no single candle-gen rev carries both flux2_dev and Boogu-Edit on gen-core `43aa2bf`**. Shipping Boogu Edit without regressing sc-7458 therefore requires candle-gen **main HEAD `80451b3`** (has #136+#137+#140+#141, pins gen-core `418f900d`) + a lockstep worker mlx bump **`43aa2bf → 418f900d`**. The mlx delta is exactly one additive PR (mlx-gen #542: the new `gen-core` CLIP-text-embedder contract, +197 lines) — import surface unchanged. `--features backend-candle --target all` resolves a **single gen-core rev `418f900d`**.

## Verification (post-rebase)
- `cargo check -p sceneworks-worker --features backend-candle` — clean, 0 warnings (MSVC 14.44 + CUDA sm_120; candle-gen `80451b3`).
- `scripts/check-gen-core-skew.sh` — exactly one `sceneworks-gen-core` (`418f900d`) across `--target all`.
- `cargo test -p sceneworks-core --lib` — 237 passed (incl. `boogu_text_to_image_and_edit_route_to_candle`; flux2_dev + Boogu coexist in the routed lists).
- `cargo test -p sceneworks-worker --lib --features backend-candle candle_label_tests` — 2 passed.
- `cargo fmt --check` — clean.

## Follow-up (GPU validation)
Base/Turbo/Edit GPU renders + quality eyeball vs MLX are blocked on **publishing the bf16 turnkey `SceneWorks/boogu-image`** with the `mllm/ transformer/ vae/` per-variant layout the candle provider reads (the original `Boogu/Boogu-Image-0.1-*` repos are public but diffusers-layout, not the `mllm/` snapshot). Same pattern as Ideogram's candle lane (`SceneWorks/ideogram-4`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)