### PR TITLE
feat(worker): route flux2_dev T2I on candle off-Mac (sc-7458)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -523,7 +523,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -535,7 +535,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -585,7 +585,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -596,7 +596,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -613,7 +613,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -628,7 +628,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -639,7 +639,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -654,7 +654,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -672,7 +672,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -683,7 +683,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -696,7 +696,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -707,7 +707,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -720,7 +720,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ea4865119d7164b89ec39df516acbef2653cf1e#5ea4865119d7164b89ec39df516acbef2653cf1e"
 dependencies = [
  "candle-core",
  "candle-gen",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1579,12 +1579,18 @@
       "type": "image",
       // FLUX.2 [dev] (epic 5914) — the guidance-distilled 32B flagship, a SEPARATE
       // model from klein: a Mistral3 text encoder (vs klein's Qwen3) + a 48/48/15360
-      // DiT, ported natively to mlx-gen (sc-5915/5916/5917/2365). MLX-only (no torch
-      // backend), Mac-only. Shares the `mlx_flux2` adapter + the `flux2` engine.
+      // DiT, ported natively to mlx-gen (sc-5915/5916/5917/2365). No torch backend.
+      // Shares the `mlx_flux2` adapter + the `flux2` engine. On Apple Silicon it runs
+      // on MLX (the pre-quantized Q4 dir below); off-Mac the **candle** (Windows/Linux
+      // CUDA) lane now serves txt2img (epic 6564: `candle-gen-flux2` `flux2_dev`, sc-7457
+      // provider + sc-7458 worker wiring) — `macOnly` stays a no-op label mirroring klein,
+      // since candle availability is driven by the routing tables, not this flag. The
+      // candle lane loads the dense diffusers snapshot and Q4-quantizes it at load (the
+      // install-time convert + packed loader are MLX-only; off-Mac is download-and-go).
       // Image edit + reference (sc-5919/5922): reference image(s) condition via the
       // DiT token concat through the `flux2_dev_edit` variant — the same surface as
-      // klein. Pose library is best-effort (skeleton-as-edit-image, like klein); the
-      // real FLUX.2-dev pose ControlNet is sc-2292.
+      // klein (candle edit is epic 6564 story 4). Pose library is best-effort
+      // (skeleton-as-edit-image, like klein); the real FLUX.2-dev pose ControlNet is sc-2292.
       "adapter": "mlx_flux2",
       "capabilities": ["text_to_image", "edit_image", "character_image", "style_variations"],
       "macOnly": true,

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3745,6 +3745,15 @@ const CANDLE_ROUTED_MODELS: &[&str] = &[
     "flux_schnell",
     "flux_dev",
     "flux2_klein_9b",
+    // FLUX.2-dev (epic 6564 sc-7458): the guidance-distilled 32B flagship, a SEPARATE candle engine
+    // from klein (Mistral3 TE + 48/48/15360 DiT), registered by `candle-gen-flux2`'s `flux2_dev`
+    // generator (sc-7457). Off-Mac the candle lane loads the dense `black-forest-labs/FLUX.2-dev`
+    // diffusers snapshot and Q4-quantizes it at load (CPU-stage → quantize-onto-GPU; the 32B doesn't
+    // fit the GPU dense) — the manifest `mlx.quantize: 4` + the dev descriptor's `supported_quants`
+    // drive that through the shared `resolve_quant` gate, so it needs no per-payload quant request and
+    // stays a pure **txt2img** id here. Edit / multi-reference / strict-pose shapes are rejected below
+    // (`image_request_candle_eligible`) and fall back to the Python torch worker until story 4 lands.
+    "flux2_dev",
     "qwen_image",
     "lens",
     "lens_turbo",
@@ -5959,6 +5968,9 @@ mod candle_routing_tests {
             "realvisxl_lightning",
             "z_image_turbo",
             "flux_dev",
+            // sc-7458: FLUX.2-dev (the 32B flagship) routes to candle for plain txt2img off-Mac (loads
+            // the dense snapshot + Q4-quantizes at load). Edit/reference shapes still defer (story 4).
+            "flux2_dev",
             "qwen_image",
             "chroma1_hd",
             "kolors",
@@ -6061,6 +6073,18 @@ mod candle_routing_tests {
             "model": "flux2_klein_9b_kv",
             "mode": "edit_image",
             "sourceAssetId": "asset_1"
+        }))));
+        // sc-7458: FLUX.2-dev is txt2img-only on candle in this slice. Its edit / multi-reference shapes
+        // (the `flux2_dev_edit` surface) are NOT a candle lane yet (epic 6564 story 4), so the candle
+        // worker does NOT claim them — they stay off the candle lane until that port lands.
+        assert!(!image_job_is_candle_eligible(&image_generate_job(json!({
+            "model": "flux2_dev",
+            "mode": "edit_image",
+            "sourceAssetId": "asset_1"
+        }))));
+        assert!(!image_job_is_candle_eligible(&image_generate_job(json!({
+            "model": "flux2_dev",
+            "referenceAssetId": "asset_1"
         }))));
         // sc-5487: a Qwen-Image-Edit edit (`edit_image` + a source) is now the candle `QwenEdit` lane
         // (dual-latent reference editing). Off-Mac this was a torch fallback; the candle worker CLAIMS

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -286,6 +286,16 @@ sceneworks-core = { path = "../sceneworks-core" }
 # `671cb13` -> `2dc0306` IN LOCKSTEP — candle-gen #134 mirrors the `ms` thread + re-pins candle-gen's
 # gen-core to 43aa2bf, so `--features backend-candle --target all` resolves the SINGLE gen-core rev
 # 43aa2bf (the skew gate) rather than two.
+# Bumped the candle pin ALONE `2dc0306` -> `5ea4865` (epic 6564 sc-7458) — mlx-gen/gen-core stays 43aa2bf.
+# UNLIKE the lockstep bumps above (which move mlx-gen + candle-gen together), this moves ONLY the candle-gen
+# pin to pick up sc-7457's FLUX.2-dev Q4/Q8 dev-quant load path (candle-gen #136/#137: the CPU-stage ->
+# `quantize_onto`-GPU `flux2_dev` loader the worker's `generate_candle_stream` needs — the `2dc0306` pin had
+# only the DENSE dev port, which rejects `spec.quantize` and can't fit the 32B on the GPU). `5ea4865` is the
+# #137 merge, which lands BEFORE candle-gen's own gen-core bump to 418f900d (#138), so it STILL pins gen-core
+# 43aa2bf — IDENTICAL to the worker's mlx-gen pin, no mlx-gen bump needed. Only `candle-gen-flux2` differs
+# across `2dc0306..5ea4865` (candle-gen-boogu also changed, but the worker doesn't link it), so the bump is
+# surgical: `flux2_dev` gains its Q4 lane, every other candle family is byte-identical, and `--features
+# backend-candle --target all` still resolves the SINGLE gen-core rev 43aa2bf (the skew gate).
 sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -1007,39 +1017,39 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa
 # — AND #132's gen-core re-pin 903f295 -> 04aa4aa (BYTE-IDENTICAL; same `gen-core/` tree SHA 5450444), so
 # `--features backend-candle --target all` resolves the SINGLE gen-core rev 04aa4aa shared with the mlx
 # pin. candle-gen #132 CI (macos-15 + ubuntu-latest fmt/clippy/check/test) green against 04aa4aa.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1048,11 +1058,11 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1061,19 +1071,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1082,12 +1092,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1095,7 +1105,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc03
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1104,7 +1114,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1112,7 +1122,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1121,7 +1131,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1148,7 +1158,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ea4865119d7164b89ec39df516acbef2653cf1e", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -196,9 +196,13 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
     // model `flux2_dev` (Mistral3 TE + 48/48/15360 DiT), NOT a klein weight variant, so it
     // maps to its own engine id. Embedded distilled guidance (FLUX.1-dev pattern, NOT
     // true-CFG): the descriptor advertises `supports_guidance` but not negative prompt, so
-    // the engine takes the guidance scalar (default 4.0) over ~28 steps. Loaded from a
-    // pre-quantized Q4 dir assembled by the install-time `flux2_dev_quant` convert job
-    // (sc-5917 / sc-5921) — in-app Q4 load of the dense bf16 snapshot would peak ~105 GB.
+    // the engine takes the guidance scalar (default 4.0) over ~28 steps. On MLX it loads
+    // from a pre-quantized Q4 dir assembled by the install-time `flux2_dev_quant` convert
+    // job (sc-5917 / sc-5921). On the **candle** off-Mac lane (sc-7458) there is no packed
+    // convert: it loads the dense `black-forest-labs/FLUX.2-dev` diffusers snapshot and
+    // Q4-quantizes it at load — the 32B dense never lands on the GPU (CPU-staged in system
+    // RAM, then `quantize_onto` the GPU; candle-gen-flux2 sc-7457). `resolve_quant` reads
+    // the manifest `mlx.quantize: 4` so the candle descriptor's Q4 support drives it.
     ModelRow {
         sceneworks_id: "flux2_dev",
         engine_id: "flux2_dev",

--- a/crates/sceneworks-worker/src/flux2_dev_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/flux2_dev_gpu_smoke.rs
@@ -1,0 +1,154 @@
+//! Local real-weight GPU smoke for the candle FLUX.2-dev worker lane (epic 6564 sc-7458, the worker
+//! half of the sc-7457 provider). `#[ignore]`d — run by hand on the RTX PRO 6000. It drives the real
+//! candle FLUX.2-dev engine via `gen_core::load("flux2_dev")` with a **Q4** `LoadSpec` — the exact
+//! runtime seam `generate_candle_stream` uses (minus the API/job plumbing) once the router routes
+//! `flux2_dev` to candle off-Mac. The 32B doesn't fit the GPU dense, so the dev quant path stages the
+//! dense diffusers snapshot in system RAM and quantizes each projection onto the GPU at load
+//! (candle-gen-flux2 sc-7457) — this is the end-to-end worker-lane validation backing the routing wire.
+//!
+//! Build with `CUDA_COMPUTE_CAP=120` (native Blackwell sm_120): the cap=80 PTX baseline JIT-no-ops
+//! candle's CUDA quantized matmul on sm_120 (sc-7457 black-image root cause → sc-7544 packaging).
+//!
+//! Setup (PowerShell; point at the dense FLUX.2-dev diffusers snapshot — `transformer/ text_encoder/
+//! vae/ tokenizer/ model_index.json`):
+//! ```text
+//! $env:FLUX2_DEV_DIR="D:\models\FLUX.2-dev"
+//! $env:FLUX2_DEV_OUT_DIR="D:\sceneworks-sampler-validate\flux2-dev"
+//! # optional: FLUX2_DEV_STEPS=28 FLUX2_DEV_W=1024 FLUX2_DEV_H=1024 FLUX2_DEV_GUIDANCE=4.0
+//! #           FLUX2_DEV_QUANT=q4|q8  FLUX2_DEV_PROMPT="..."
+//! cargo test -p sceneworks-worker --features backend-candle --release flux2_dev_candle_gpu_smoke -- --ignored --nocapture
+//! ```
+
+use std::path::{Path, PathBuf};
+
+use gen_core::{GenerationOutput, GenerationRequest, Image, LoadSpec, Quant, WeightsSource};
+
+fn env_path(key: &str) -> PathBuf {
+    // Trim: a cmd `set VAR=value && ...` keeps the trailing space before `&&`.
+    PathBuf::from(
+        std::env::var(key)
+            .unwrap_or_else(|_| panic!("set ${key}"))
+            .trim(),
+    )
+}
+
+fn env_or(key: &str, default: &str) -> String {
+    std::env::var(key)
+        .map(|v| v.trim().to_string())
+        .unwrap_or_else(|_| default.to_string())
+}
+
+/// Mean per-pixel std-dev across the RGB channels — a cheap "is the image non-degenerate" check. The
+/// sc-7457 dev-quant bug (CUDA-Q4 matmul no-op at cap=80) produced an all-black decode whose std
+/// collapses toward 0; this guards that degenerate floor (the real quality call is the saved-PNG eyeball).
+fn image_std(img: &Image) -> f64 {
+    let n = img.pixels.len() as f64;
+    if n == 0.0 {
+        return 0.0;
+    }
+    let mean = img.pixels.iter().map(|&p| p as f64).sum::<f64>() / n;
+    let var = img
+        .pixels
+        .iter()
+        .map(|&p| (p as f64 - mean).powi(2))
+        .sum::<f64>()
+        / n;
+    var.sqrt()
+}
+
+fn save_png(img: &Image, path: &Path) {
+    image::RgbImage::from_raw(img.width, img.height, img.pixels.clone())
+        .expect("rgb buffer")
+        .save(path)
+        .unwrap_or_else(|e| panic!("save {}: {e}", path.display()));
+}
+
+#[test]
+#[ignore = "real-weight GPU smoke; needs the dense FLUX.2-dev diffusers snapshot + a CUDA device (cap=120)"]
+fn flux2_dev_candle_gpu_smoke() {
+    let weights_dir = env_path("FLUX2_DEV_DIR");
+    assert!(
+        weights_dir.join("model_index.json").is_file(),
+        "FLUX2_DEV_DIR must point at the dense FLUX.2-dev diffusers snapshot (model_index.json missing): {}",
+        weights_dir.display()
+    );
+    let out_dir = PathBuf::from(env_or("FLUX2_DEV_OUT_DIR", "flux2-dev-out"));
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+
+    let steps: u32 = env_or("FLUX2_DEV_STEPS", "28")
+        .parse()
+        .expect("FLUX2_DEV_STEPS");
+    let w: u32 = env_or("FLUX2_DEV_W", "1024").parse().expect("FLUX2_DEV_W");
+    let h: u32 = env_or("FLUX2_DEV_H", "1024").parse().expect("FLUX2_DEV_H");
+    let guidance: f32 = env_or("FLUX2_DEV_GUIDANCE", "4.0")
+        .parse()
+        .expect("FLUX2_DEV_GUIDANCE");
+    // The shipped worker forces Q4 (manifest `mlx.quantize: 4` → `resolve_quant`); allow Q8 for an
+    // optional contrast run. dev advertises only Q4/Q8 — dense doesn't fit the GPU.
+    let quant = match env_or("FLUX2_DEV_QUANT", "q4").as_str() {
+        "q8" | "Q8" => Quant::Q8,
+        _ => Quant::Q4,
+    };
+    let prompt = env_or(
+        "FLUX2_DEV_PROMPT",
+        "a rusty robot holding a lit candle in a dark workshop, cinematic, sharp focus",
+    );
+
+    // Same seam as `generate_candle_stream`: a registry load of the candle `flux2_dev` engine + a
+    // Q4 `LoadSpec` pointed at the dense diffusers snapshot. The dev quant path CPU-stages the dense
+    // weights and quantizes each projection onto the GPU — the 32B never lands on the GPU dense.
+    println!(
+        "[smoke] loading flux2_dev ({quant:?}) from {} ...",
+        weights_dir.display()
+    );
+    let spec = LoadSpec::new(WeightsSource::Dir(weights_dir.clone())).with_quant(quant);
+    let generator = gen_core::load("flux2_dev", &spec).expect("load candle flux2_dev provider");
+
+    let req = GenerationRequest {
+        prompt: prompt.clone(),
+        width: w,
+        height: h,
+        count: 1,
+        seed: Some(42),
+        steps: Some(steps),
+        // dev is guidance-distilled (embedded scalar, single forward — no negative pass).
+        guidance: Some(guidance),
+        ..Default::default()
+    };
+    println!("[smoke] rendering {w}x{h} @ {steps} steps, guidance {guidance} ...");
+    let mut last = String::new();
+    let output = generator
+        .generate(&req, &mut |p| {
+            let s = format!("{p:?}");
+            if s != last {
+                println!("[progress] {s}");
+                last = s;
+            }
+        })
+        .expect("flux2_dev generate");
+    let image = match output {
+        GenerationOutput::Images(mut images) => images.pop().expect("engine returned no image"),
+        other => panic!("expected Images output, got {other:?}"),
+    };
+
+    let std = image_std(&image);
+    let png = out_dir.join(format!(
+        "flux2_dev_{}_{steps}step.png",
+        env_or("FLUX2_DEV_QUANT", "q4")
+    ));
+    save_png(&image, &png);
+    println!(
+        "[smoke] flux2_dev {}x{} std {:.2} -> {}",
+        image.width,
+        image.height,
+        std,
+        png.display()
+    );
+    assert_eq!((image.width, image.height), (w, h));
+    assert!(
+        std > 5.0,
+        "flux2_dev render looks degenerate (std {std:.2}) — possible NaN / all-black decode \
+         (check CUDA_COMPUTE_CAP=120: cap=80 JIT-no-ops the quantized matmul on sm_120, sc-7457)"
+    );
+    println!("[smoke] DONE: flux2_dev {quant:?} render coherent at {steps} steps");
+}

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -1730,6 +1730,11 @@ fn is_candle_engine(model: &str) -> bool {
             | "flux_schnell"
             | "flux_dev"
             | "flux2_klein_9b"
+            // FLUX.2-dev (sc-7458): the 32B flagship rides the generic candle txt2img lane like klein.
+            // `generate_candle_stream` resolves Q4 (manifest `mlx.quantize: 4` + the dev descriptor's
+            // `supported_quants`) so the dense snapshot is staged in CPU RAM and quantized onto the GPU
+            // at load. Edit/control/reference shapes route to their bespoke lanes or torch (story 4).
+            | "flux2_dev"
             | "qwen_image"
             | "chroma1_hd"
             | "chroma1_base"
@@ -1753,7 +1758,7 @@ fn candle_adapter_label(model: &str) -> &'static str {
     match model {
         "z_image_turbo" => "candle_z_image",
         "flux_schnell" | "flux_dev" => "candle_flux",
-        "flux2_klein_9b" => "candle_flux2",
+        "flux2_klein_9b" | "flux2_dev" => "candle_flux2",
         "qwen_image" => "candle_qwen",
         "chroma1_hd" | "chroma1_base" | "chroma1_flash" => "candle_chroma",
         "lens" | "lens_turbo" => "candle_lens",
@@ -1982,8 +1987,13 @@ async fn generate_candle_stream(
         &job.id,
         backend,
     );
-    // sc-6135: caption upsampling is FLUX.2-dev-only and dev runs on the macOS path, so this is a
-    // no-op here — resolved for uniformity (and so a future candle enhancer would be wired).
+    // sc-6135 / sc-7458: caption upsampling is FLUX.2-dev-only. On candle (off-Mac) dev now runs here,
+    // but the Mistral3/Pixtral caption-upsampler vision tower is NOT ported (deferred to epic 6564
+    // story 4), so `enhance` degrades to **passthrough**: it is carried onto the `GenerationRequest`
+    // for uniformity, but the candle `Flux2Generator` ignores `enhance_prompt`, so the raw prompt is
+    // used verbatim. Critically this is a no-op, NOT a fall-back to the Python torch worker — the dev
+    // T2I job stays on candle (a future candle enhancer lights up here with no router change). Every
+    // other candle family ignores the fields too.
     let enhance = PromptEnhance::from_advanced(&request.advanced);
     // Record the effective CFG knob (guidance for guided families, else true_cfg) + quant bits in the
     // recipe, so a Lens asset's sidecar reflects the Q4/Q8 it ran at (parity with the MLX path).
@@ -2295,6 +2305,7 @@ mod candle_label_tests {
         assert_eq!(candle_adapter_label("flux_schnell"), "candle_flux");
         assert_eq!(candle_adapter_label("flux_dev"), "candle_flux");
         assert_eq!(candle_adapter_label("flux2_klein_9b"), "candle_flux2");
+        assert_eq!(candle_adapter_label("flux2_dev"), "candle_flux2");
         assert_eq!(candle_adapter_label("qwen_image"), "candle_qwen");
         assert_eq!(candle_adapter_label("chroma1_hd"), "candle_chroma");
         assert_eq!(candle_adapter_label("chroma1_base"), "candle_chroma");
@@ -2315,6 +2326,7 @@ mod candle_label_tests {
             "flux_schnell",
             "flux_dev",
             "flux2_klein_9b",
+            "flux2_dev",
             "qwen_image",
             "chroma1_hd",
             "chroma1_base",
@@ -2341,6 +2353,7 @@ mod candle_label_tests {
             "flux_schnell",
             "flux_dev",
             "flux2_klein_9b",
+            "flux2_dev",
             "qwen_image",
             "chroma1_hd",
             "chroma1_base",

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -118,6 +118,11 @@ mod scail2_gpu_smoke;
 // drives `gen_core::load("sdxl")` with the forced `lightning` sampler against the distilled checkpoint.
 #[cfg(all(test, not(target_os = "macos"), feature = "backend-candle"))]
 mod realvisxl_lightning_gpu_smoke;
+// Real-weight GPU smoke for the candle FLUX.2-dev lane (epic 6564 sc-7458). Test-only + candle-only;
+// drives `gen_core::load("flux2_dev")` with a Q4 LoadSpec (CPU-stage → quantize-onto-GPU) against the
+// dense diffusers snapshot — the worker-lane validation backing the off-Mac candle routing wire.
+#[cfg(all(test, not(target_os = "macos"), feature = "backend-candle"))]
+mod flux2_dev_gpu_smoke;
 // The DWPose skeleton rasterizer is consumed only by the macOS Z-Image strict-pose
 // control path; on Mac AND the off-Mac candle DWPose lane (sc-5496) it backs the
 // `pose_jobs` skeleton render; on a candle-disabled box off Mac it still builds +


### PR DESCRIPTION
## sc-7458 — SceneWorks worker: route `flux2_dev` T2I on candle

Epic [6564](https://app.shortcut.com/trefry/epic/6564), **story 2 of 4** — the worker half of the sc-7457 `candle-gen-flux2` `flux2_dev` provider (story 1, Done). Brings **FLUX.2-dev** (the 32B guidance-distilled flagship) txt2img to the candle (Windows/Linux CUDA) lane off-Mac; previously `flux2_dev` was `MLX_ROUTED_MODELS`-only and fell through to the Python torch lane off-Mac.

### What changed
- **Router** (`jobs_store.rs`): `flux2_dev` → `CANDLE_ROUTED_MODELS`. Rides the generic candle txt2img gate like klein; edit / multi-reference / strict-pose shapes are rejected and defer to torch until story 4.
- **Worker** (`base.rs` / `engines.rs`): `flux2_dev` → `is_candle_engine` + `candle_adapter_label` (`candle_flux2`). Q4-at-load falls out of the existing machinery — the candle `descriptor_dev` advertises Q4/Q8, so `resolve_quant` reads the manifest `mlx.quantize: 4` and the `LoadSpec` carries Q4; the provider CPU-stages the dense diffusers snapshot (the 32B won't fit the GPU dense) and `quantize_onto`s each projection to the GPU. No forcing needed.
- **`enhance_prompt`**: degrades to **passthrough** (the Mistral3/Pixtral caption upsampler isn't ported — story 4). Carried onto the `GenerationRequest` but the candle `Flux2Generator` ignores it; critically **not** routed to Python.
- **Manifest/comments**: corrected the stale "MLX-only / off-Mac→torch" notes (off-Mac is candle now; convert stays Mac-gated; `macOnly` is a functional no-op, mirroring how klein already serves off-Mac on candle).
- **gen-core pin lockstep**: bump the candle-gen pin **alone** `2dc0306 → 5ea4865`. The `2dc0306` pin had only the **dense** dev port (rejects `spec.quantize`, can't fit the 32B on the GPU); `5ea4865` (#137 merge) carries sc-7457's CPU-stage Q4 load path **and** still pins gen-core `43aa2bf` == the worker's mlx-gen pin → `--features backend-candle` resolves a **single gen-core rev**, no mlx-gen bump. Surgical: only `candle-gen-flux2` differs in the range (the worker doesn't link the other changed crate, `candle-gen-boogu`).

### Design note (vs the original task wording)
Task 2 said "assemble the pre-quantized dir at install." Story 1 actually shipped **load-time** quant (CPU-stage → `quantize_onto` GPU), not a disk-packed convert — the packed loader is explicitly deferred in `candle-gen-flux2`. So off-Mac is **download-the-dense-snapshot + quantize-at-load** (cached per worker process); a disk-packed install convert is a viable follow-up optimization. The convert job + catalog status stay Mac-gated, so off-Mac is cleanly download-and-go.

### Validation
- Routing + engine/label tests added. `sceneworks-core` lib suite **236 green**; candle label/engine tests green; clean build with `--features backend-candle` (single gen-core rev `43aa2bf`). NB: the candle lane is `workflow_dispatch`-only in CI, so this was built + validated locally.
- **GPU-validated on RTX PRO 6000** (`CUDA_COMPUTE_CAP=120`) via the new `flux2_dev_gpu_smoke.rs` (sibling of the realvisxl/scail2 candle smokes), driving the same `gen_core::load("flux2_dev")` + Q4 `LoadSpec` seam as `generate_candle_stream`: coherent 1024×1024 / 28-step Q4 render, **std 40.44, 299 s**; probes healthy (`prompt_embeds` ±151, `velocity@step0` ±7.7, `decoded` ∈ [−1.3, 1.05], all finite) — a rusty-robot-with-candle, matching story 1's eyeball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
