### PR TITLE
feat(worker): route macOS prompt_refine through the mlx-llm engine (sc-7158)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_distr 0.5.1",
  "safetensors 0.7.0",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365)",
  "serde_json",
  "thiserror 2.0.18",
 ]
@@ -1011,6 +1011,19 @@ dependencies = [
  "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "libc",
+]
+
+[[package]]
+name = "core-llm"
+version = "0.0.0"
+source = "git+https://github.com/SceneWorks/core-llm?branch=main#0b5315ba7794908c3571342eeb06343e2f7a848f"
+dependencies = [
+ "inventory",
+ "minijinja",
+ "minijinja-contrib",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokenizers 0.21.4",
 ]
 
 [[package]]
@@ -3298,6 +3311,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "memo-map"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3320,6 +3339,26 @@ checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
+]
+
+[[package]]
+name = "minijinja"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3d648e68cea56d9858d535ee28f9538404e2dd8cb08ed0bd05dca379477f39"
+dependencies = [
+ "memo-map",
+ "serde",
+]
+
+[[package]]
+name = "minijinja-contrib"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85342f6fac0be8ccd5bd00d9066be538f34f393f577b75d81b17c8398a6b43bb"
+dependencies = [
+ "minijinja",
+ "serde",
 ]
 
 [[package]]
@@ -3352,11 +3391,11 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4)",
  "thiserror 2.0.18",
  "tokenizers 0.21.4",
 ]
@@ -3364,7 +3403,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
 dependencies = [
  "image",
  "inventory",
@@ -3378,7 +3417,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
 dependencies = [
  "image",
  "inventory",
@@ -3391,7 +3430,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3403,7 +3442,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3412,7 +3451,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3424,7 +3463,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3435,7 +3474,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3447,7 +3486,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3458,7 +3497,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3468,7 +3507,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
 dependencies = [
  "image",
  "inventory",
@@ -3480,7 +3519,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
 dependencies = [
  "image",
  "inventory",
@@ -3493,7 +3532,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
 dependencies = [
  "image",
  "inventory",
@@ -3503,20 +3542,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "mlx-gen-prompt-refine"
-version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
-dependencies = [
- "inventory",
- "mlx-gen",
- "pmetal-mlx-rs",
- "serde_json",
-]
-
-[[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3528,7 +3556,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3538,7 +3566,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3547,7 +3575,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3556,7 +3584,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3568,7 +3596,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
 dependencies = [
  "image",
  "inventory",
@@ -3581,7 +3609,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3592,7 +3620,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3603,7 +3631,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3614,7 +3642,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
 dependencies = [
  "image",
  "inventory",
@@ -3628,7 +3656,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
 dependencies = [
  "image",
  "inventory",
@@ -3646,6 +3674,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "mlx-llm"
+version = "0.0.0"
+source = "git+https://github.com/SceneWorks/mlx-llm?rev=29e382bd6a3800accf0bac5daf5d8eb61e1a2adf#29e382bd6a3800accf0bac5daf5d8eb61e1a2adf"
+dependencies = [
+ "core-llm",
+ "half",
+ "inventory",
+ "pmetal-mlx-rs",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5281,6 +5322,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sceneworks-gen-core"
+version = "0.1.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
+dependencies = [
+ "core-llm",
+ "inventory",
+ "safetensors 0.4.5",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokenizers 0.21.4",
+]
+
+[[package]]
 name = "sceneworks-rust-api"
 version = "0.2.0"
 dependencies = [
@@ -5360,7 +5414,6 @@ dependencies = [
  "mlx-gen-kolors",
  "mlx-gen-lens",
  "mlx-gen-ltx",
- "mlx-gen-prompt-refine",
  "mlx-gen-pulid",
  "mlx-gen-qwen-image",
  "mlx-gen-sam2",
@@ -5372,12 +5425,13 @@ dependencies = [
  "mlx-gen-svd",
  "mlx-gen-wan",
  "mlx-gen-z-image",
+ "mlx-llm",
  "nix",
  "ort",
  "pmetal-mlx-rs",
  "reqwest 0.12.28",
  "sceneworks-core",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4)",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -444,7 +444,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_distr 0.5.1",
  "safetensors 0.7.0",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365)",
+ "sceneworks-gen-core",
  "serde_json",
  "thiserror 2.0.18",
 ]
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -523,7 +523,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -535,7 +535,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -585,7 +585,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -596,7 +596,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -613,7 +613,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -628,7 +628,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -639,7 +639,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -654,7 +654,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -672,7 +672,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -683,7 +683,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -696,7 +696,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -707,7 +707,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -720,7 +720,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2dc030688c27737bdd79b9ed5b668eaa1f9e3b39#2dc030688c27737bdd79b9ed5b668eaa1f9e3b39"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -3395,7 +3395,7 @@ source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba8
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4)",
+ "sceneworks-gen-core",
  "thiserror 2.0.18",
  "tokenizers 0.21.4",
 ]
@@ -5312,18 +5312,6 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=43aa2bf8556b2beab50b7008e168496bc77df365#43aa2bf8556b2beab50b7008e168496bc77df365"
-dependencies = [
- "inventory",
- "safetensors 0.4.5",
- "serde_json",
- "thiserror 2.0.18",
- "tokenizers 0.21.4",
-]
-
-[[package]]
-name = "sceneworks-gen-core"
-version = "0.1.0"
 source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
 dependencies = [
  "core-llm",
@@ -5431,7 +5419,7 @@ dependencies = [
  "pmetal-mlx-rs",
  "reqwest 0.12.28",
  "sceneworks-core",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4)",
+ "sceneworks-gen-core",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1014,39 +1014,39 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e8
 # — AND #132's gen-core re-pin 903f295 -> 04aa4aa (BYTE-IDENTICAL; same `gen-core/` tree SHA 5450444), so
 # `--features backend-candle --target all` resolves the SINGLE gen-core rev 04aa4aa shared with the mlx
 # pin. candle-gen #132 CI (macos-15 + ubuntu-latest fmt/clippy/check/test) green against 04aa4aa.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1055,11 +1055,11 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1068,19 +1068,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1089,12 +1089,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1102,7 +1102,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc03
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1111,7 +1111,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1119,7 +1119,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1128,7 +1128,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1155,7 +1155,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2dc030688c27737bdd79b9ed5b668eaa1f9e3b39", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -286,7 +286,14 @@ sceneworks-core = { path = "../sceneworks-core" }
 # `671cb13` -> `2dc0306` IN LOCKSTEP — candle-gen #134 mirrors the `ms` thread + re-pins candle-gen's
 # gen-core to 43aa2bf, so `--features backend-candle --target all` resolves the SINGLE gen-core rev
 # 43aa2bf (the skew gate) rather than two.
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+# Rev 54e87e9 (mlx-gen #545, sc-7189 + the #542/#544 catch-up): bumps EVERY mlx-gen crate + gen-core
+# 43aa2bf -> 54e87e9. The gen-core delta over the range is PURELY ADDITIVE — the `core_llm` re-export
+# (`gen_core::core_llm`, sc-7189) the macOS prompt_refine path now consumes, plus the additive
+# `TextEmbedder` CLIP contract (sc-6537); no existing TextLlm/registry/runtime/sampling surface moved,
+# so the worker's import surface is unchanged. SKEW GATE: the candle pin below must re-pin candle-gen's
+# gen-core to 54e87e9 IN LOCKSTEP (candle-gen dep bump, sc-7404) so `--features backend-candle --target
+# all` resolves the single gen-core rev 54e87e9. mlx-rs unchanged (44929a0).
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -610,7 +617,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -622,64 +629,64 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556
 # internal pin (the Lens engine PRs #407–#414 did not move it; nor did the seedvr2 engine #416/#419/
 # #421 or the softness PR #422, so the 1a97909 bump above leaves mlx-rs at 44929a0).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "44929a001ab8a8837403a71c65cf064224de0cdc" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -688,12 +695,12 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2b
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -702,7 +709,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2b
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -710,7 +717,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -721,7 +728,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -732,7 +739,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -747,7 +754,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2b
 # converted in-memory at load (no Python); the precomputed neg-prompt embedding is bundled in-crate. No
 # LoRA/guidance/CFG (one-step). 3B fp16 only here — 7B (sc-5197) + int8 (sc-5198) are engine-side and
 # unwired. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -758,17 +765,17 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43a
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
-# Prompt-refine provider (sc-5552, the MLX twin of candle-gen-prompt-refine / sc-5500). An
-# inventory-registered `TextLlm` under id `prompt_refine` (`backend="mlx"`, `mac_only`): a native MLX
-# Llama-3.2-3B-Instruct that rewrites a user's prompt, replacing the Python `prompt_refine.py`
-# (`AutoModelForCausalLM` + `model.generate`) on Mac. The worker reaches it through the registry
-# (`gen_core::load_textllm("prompt_refine")` → `.generate`), so prompt_refine_jobs.rs must force-link
-# the crate (`use mlx_gen_prompt_refine as _;`) or the linker drops the `TextLlmRegistration` (the "no
-# textllm registered" trap). Weights = a stock Llama-3.2-3B-Instruct HF snapshot (config.json +
-# tokenizer.json + model-*.safetensors; default `huihui-ai/Llama-3.2-3B-Instruct-abliterated`). Same
-# git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
+# The unified LLM engine (epic 7153, sc-7158): the macOS `prompt_refine` job now runs through
+# mlx-llm's generic `mlx-llama` provider (a `core_llm::TextLlm`) resolved model-first via
+# `gen_core::core_llm::load_for_model`, RETIRING the bespoke `mlx-gen-prompt-refine` hand-rolled
+# Llama decoder. prompt_refine_jobs.rs force-links this crate (`use mlx_llm as _;`) so mlx-llm's
+# `inventory::submit!` of `mlx-llama` survives the release linker (the "no provider can serve" trap).
+# Same pmetal mlx-rs pin (44929a0) as the mlx-gen crates → one shared `Array` type + one MLX build;
+# mlx-llm's core-llm dep unifies with gen-core's (both branch=main). Serves the same Anubis-Mini-8B
+# (sc-6550) for free-text refine + the JSON-constrained magic-prompt caption. The candle (Windows)
+# lane keeps `candle-gen-prompt-refine` until its twin migration (sc-7404).
+mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "29e382bd6a3800accf0bac5daf5d8eb61e1a2adf" }
 # SCAIL-2 (zai-org) end-to-end character-animation provider (epic 5439, sc-5448). An inventory-registered
 # `Generator` under id `scail2_14b` (`Modality::Video`): a Wan2.1-14B I2V DiT that animates a reference
 # character with a driving video's motion (`video_mode == "replacement"` flips the cross-identity
@@ -780,7 +787,7 @@ mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev 
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "43aa2bf8556b2beab50b7008e168496bc77df365" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -607,17 +607,26 @@ pub(crate) fn registry_capabilities(
     }) {
         push(Cap::TrainingCaption, &mut caps);
     }
-    // Prompt-refinement TextLlm (sc-5500 contract / sc-5525 candle cutover / sc-5552 mlx twin): a
-    // prompt-refine provider registers a `TextLlm` under id `prompt_refine`. Advertise `prompt_refine`
-    // when its backend is enabled — the native MLX Llama-3.2-3B path on macOS (sc-5552) and the candle
-    // Llama-3.2-3B path on the Windows candle build (sc-5525). The Python torch `PromptRefiner` stays
-    // the fallback on platforms with neither (e.g. the candle-less Desktop installer). The derivation
-    // is backend-agnostic, so no change here was needed to light up the mlx twin — only force-linking
-    // `mlx_gen_prompt_refine` in prompt_refine_jobs.rs.
-    if gen_core::registry::textllms().any(|r| {
+    // Prompt-refinement (sc-5500 contract). Two provider paths advertise the `prompt_refine` cap:
+    //  - candle (Windows, sc-5525): `candle-gen-prompt-refine` registers a `gen_core::TextLlm` under id
+    //    `prompt_refine` — light it up when the `candle` backend is enabled.
+    //  - macOS (epic 7153, sc-7158): prompt_refine now runs through mlx-llm's `mlx-llama`
+    //    (`core_llm::TextLlm`, resolved model-first), which registers in core-llm's registry, NOT
+    //    gen_core's — so light it up when the `mlx` backend is enabled and a core-llm text (non-vision)
+    //    provider is linked. (Retired the old `mlx-gen-prompt-refine` gen_core registration.)
+    // The Python torch `PromptRefiner` stays the fallback on platforms with neither.
+    let candle_prompt_refine = gen_core::registry::textllms().any(|r| {
         let d = (r.descriptor)();
         backends.contains(&d.backend) && d.id == "prompt_refine"
-    }) {
+    });
+    #[cfg(target_os = "macos")]
+    let native_prompt_refine = gen_core::core_llm::textllms().any(|r| {
+        let d = (r.descriptor)();
+        backends.contains(&d.backend.as_str()) && !d.capabilities.supports_vision
+    });
+    #[cfg(not(target_os = "macos"))]
+    let native_prompt_refine = false;
+    if candle_prompt_refine || native_prompt_refine {
         push(Cap::PromptRefine, &mut caps);
     }
     caps

--- a/crates/sceneworks-worker/src/prompt_refine_jobs.rs
+++ b/crates/sceneworks-worker/src/prompt_refine_jobs.rs
@@ -1,12 +1,13 @@
 //! Native prompt refinement (epic 5095): candle on Windows/CUDA (sc-5525) + MLX on macOS (sc-5552).
 //!
-//! Routes the `prompt_refine` job to a native `TextLlm` provider (Llama-3.2-3B-Instruct) through the
-//! backend-neutral `gen_core::load_textllm` seam (the sc-5500 contract): the candle provider
-//! (`backend="candle"`, `candle-gen-prompt-refine`) on the Windows candle build, and the MLX twin
-//! (`backend="mlx"`, `mlx-gen-prompt-refine`) on macOS. The Python torch `PromptRefiner`
+//! Routes the `prompt_refine` job to a native LLM provider. On macOS (sc-7158, epic 7153) it runs
+//! through the unified mlx-llm engine — the generic `mlx-llama` `core_llm::TextLlm` provider resolved
+//! model-first via `gen_core::core_llm::load_for_model` (Anubis-Mini-8B, sc-6550) — retiring the
+//! bespoke `mlx-gen-prompt-refine` decoder. The Windows candle build still uses the
+//! `candle-gen-prompt-refine` `gen_core::TextLlm` (sc-5525) via `gen_core::load_textllm` until its
+//! twin migration (sc-7404). The Python torch `PromptRefiner`
 //! (`apps/worker/scene_worker/prompt_refine.py`) stays the fallback only on platforms with neither
-//! native provider (e.g. the candle-less Desktop installer); its physical deletion waits on the candle
-//! provider being the default everywhere off-Mac (see sc-5525).
+//! native provider (e.g. the candle-less Desktop installer).
 //!
 //! The `TextLlm` contract is generic (`system` + `prompt` + sampling → text), so the
 //! prompt-refinement PRODUCT logic that lived in `prompt_refine.py` moves here caller-side: the
@@ -18,22 +19,20 @@
 
 use super::*;
 
-// Prompt-refine provider force-link anchors: keep each backend's `inventory::submit!` `TextLlm`
-// registration (id `prompt_refine`) from being dropped by the release linker. sc-5552 adds the native
-// MLX twin (`mlx_gen_prompt_refine`, backend `mlx`) alongside sc-5525's candle anchor; mirrors the
-// dual JoyCaption anchors in caption_jobs.rs.
+// Prompt-refine provider force-link anchors: keep each backend's `inventory::submit!` provider
+// registration from being dropped by the release linker. macOS (sc-7158, epic 7153) force-links
+// `mlx_llm` so the unified `mlx-llama` `core_llm::TextLlm` provider — resolved model-first via
+// `gen_core::core_llm::load_for_model` — survives the linker; the Windows/CUDA candle build keeps
+// sc-5525's `candle_gen_prompt_refine` anchor (its `gen_core::TextLlm` migration is the sc-7404 twin).
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_prompt_refine as _;
 #[cfg(target_os = "macos")]
-use mlx_gen_prompt_refine as _;
+use mlx_llm as _;
 
-// The registry id both providers register under (`prompt::PROMPT_REFINE_ID`); kept as a local literal
-// so the shared dispatch names no backend-specific symbol. `gen_core::load_textllm` resolves the MLX
-// twin on macOS and the candle provider on the Windows candle build.
-#[cfg(any(
-    target_os = "macos",
-    all(not(target_os = "macos"), feature = "backend-candle")
-))]
+// The candle provider's registry id (`prompt::PROMPT_REFINE_ID`). Only the candle lane still routes by
+// id through `gen_core::load_textllm`; the macOS lane resolves mlx-llm model-first (no id), so this is
+// candle-only now (retired on macOS with sc-7158).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 const PROMPT_REFINE_ENGINE_ID: &str = "prompt_refine";
 // The prompt-refinement / magic-prompt checkpoint — the coherent Anubis-8B (sc-6550 bake-off). It
 // serves BOTH the free-text "Refine my prompt" rewrite AND the Ideogram magic-prompt JSON caption:
@@ -341,10 +340,15 @@ pub(crate) async fn run_prompt_refine_job(
     settings: &Settings,
     job: &JobSnapshot,
 ) -> WorkerResult<()> {
-    use gen_core::{
-        CancelFlag, LoadSpec, Progress, TextLlmConstraint, TextLlmRequest, TextLlmSampling,
-        WeightsSource,
-    };
+    // The cooperative cancel handle is created here and threaded into the (backend-specific) request
+    // built inside the blocking task. macOS uses core-llm's CancelFlag (via the gen_core re-export),
+    // the candle lane gen-core's; both expose new()/clone()/cancel()/is_cancelled(), so the shared
+    // orchestration below is identical regardless. The request/load/stream types are backend-specific
+    // and are imported inside each arm of the blocking task.
+    #[cfg(target_os = "macos")]
+    use gen_core::core_llm::CancelFlag;
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    use gen_core::CancelFlag;
 
     let payload = &job.payload;
     let original_prompt = payload
@@ -445,44 +449,110 @@ pub(crate) async fn run_prompt_refine_job(
             "prompt_refine_load_start",
             json!({ "jobId": job_id, "engine": engine_label }),
         );
-        let refiner = gen_core::load_textllm(
-            PROMPT_REFINE_ENGINE_ID,
-            &LoadSpec::new(WeightsSource::Dir(weights_dir)),
-        )
-        .map_err(|error| WorkerError::Engine(format!("prompt-refine load failed: {error}")))?;
-        emit_event(
-            "prompt_refine_load_complete",
-            json!({ "jobId": job_id, "engine": engine_label }),
-        );
-        if blocking_cancel.is_cancelled() {
-            return Err(WorkerError::Canceled(CANCEL_MESSAGE.to_owned()));
-        }
-        let request = TextLlmRequest {
-            system,
-            prompt,
-            sampling: TextLlmSampling {
-                temperature,
-                top_p: 0.9,
+
+        // macOS (sc-7158): resolve mlx-llm's generic provider model-first (no provider id) — a JSON
+        // constraint steers resolution to the JSON-capable `mlx-llama` — and stream through the
+        // `core_llm::TextLlm` contract. The provider renders the model's own chat template, so the
+        // worker supplies only the system + user turns (the product policy stays caller-side).
+        #[cfg(target_os = "macos")]
+        let text = {
+            use gen_core::core_llm::{
+                load_for_model_with, Constraint, LoadSpec, Message, ModelRequirements, Sampling,
+                StreamEvent, TextLlmRequest,
+            };
+            let mut messages = Vec::with_capacity(2);
+            if !system.trim().is_empty() {
+                messages.push(Message::system(system));
+            }
+            messages.push(Message::user(prompt));
+            let request = TextLlmRequest {
+                messages,
+                // The mlx-gen-prompt-refine sampler was plain temperature/top-p (no repetition
+                // penalty / top-k); core-llm's defaults match (top_k 0, repetition_penalty 1.0).
+                sampling: Sampling {
+                    temperature,
+                    top_p: 0.9,
+                    ..Sampling::default()
+                },
                 max_new_tokens,
                 seed: None,
-            },
-            // sc-6585: magic-prompt expansion must emit a structurally-valid JSON caption, so
-            // constrain its decode to the JSON grammar; the free-text "Refine my prompt" rewrite is
-            // unconstrained prose.
-            constraint: is_magic.then_some(TextLlmConstraint::Json),
-            cancel: blocking_cancel.clone(),
-        };
-        let mut on_progress = |progress: Progress| {
-            if let Progress::Step { current, total } = progress {
-                let _ = tx.blocking_send((current, total));
+                // sc-6585: magic-prompt expansion must emit a structurally-valid JSON caption, so
+                // constrain its decode to the JSON grammar; the free-text rewrite is unconstrained.
+                constraint: is_magic.then_some(Constraint::Json),
+                cancel: blocking_cancel.clone(),
+                ..Default::default()
+            };
+            let refiner = load_for_model_with(
+                &LoadSpec {
+                    source: weights_dir.to_string_lossy().into_owned(),
+                    quantize: None,
+                },
+                &ModelRequirements::from_request(&request),
+            )
+            .map_err(|error| WorkerError::Engine(format!("prompt-refine load failed: {error}")))?;
+            emit_event(
+                "prompt_refine_load_complete",
+                json!({ "jobId": job_id, "engine": engine_label }),
+            );
+            if blocking_cancel.is_cancelled() {
+                return Err(WorkerError::Canceled(CANCEL_MESSAGE.to_owned()));
             }
-        };
-        let output = refiner
-            .generate(&request, &mut on_progress)
-            .map_err(|error| {
+            // Drive the same (current, total) progress channel the shared loop below reads, counting
+            // generated tokens against the max-new-tokens budget.
+            let mut on_event = |event: StreamEvent| {
+                if let StreamEvent::Token { index, .. } = event {
+                    let _ = tx.blocking_send((index as u32 + 1, max_new_tokens));
+                }
+            };
+            let output = refiner.generate(&request, &mut on_event).map_err(|error| {
                 WorkerError::Engine(format!("prompt-refine generation failed: {error}"))
             })?;
-        Ok(output.text)
+            output.text
+        };
+
+        // candle (Windows/CUDA): unchanged legacy path — the `candle-gen-prompt-refine`
+        // `gen_core::TextLlm` resolved by id (migrates to candle-llm under sc-7404).
+        #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+        let text = {
+            use gen_core::{
+                LoadSpec, Progress, TextLlmConstraint, TextLlmRequest, TextLlmSampling, WeightsSource,
+            };
+            let refiner = gen_core::load_textllm(
+                PROMPT_REFINE_ENGINE_ID,
+                &LoadSpec::new(WeightsSource::Dir(weights_dir)),
+            )
+            .map_err(|error| WorkerError::Engine(format!("prompt-refine load failed: {error}")))?;
+            emit_event(
+                "prompt_refine_load_complete",
+                json!({ "jobId": job_id, "engine": engine_label }),
+            );
+            if blocking_cancel.is_cancelled() {
+                return Err(WorkerError::Canceled(CANCEL_MESSAGE.to_owned()));
+            }
+            let request = TextLlmRequest {
+                system,
+                prompt,
+                sampling: TextLlmSampling {
+                    temperature,
+                    top_p: 0.9,
+                    max_new_tokens,
+                    seed: None,
+                },
+                constraint: is_magic.then_some(TextLlmConstraint::Json),
+                cancel: blocking_cancel.clone(),
+            };
+            let mut on_progress = |progress: Progress| {
+                if let Progress::Step { current, total } = progress {
+                    let _ = tx.blocking_send((current, total));
+                }
+            };
+            let output = refiner.generate(&request, &mut on_progress).map_err(|error| {
+                WorkerError::Engine(format!("prompt-refine generation failed: {error}"))
+            })?;
+            output.text
+        };
+
+        Ok(text)
     });
 
     let mut interval = tokio::time::interval(progress_report_interval(settings));
@@ -720,24 +790,24 @@ mod tests {
         assert_eq!(clean_json_output("{\"a\": [1, 2]}"), "{\"a\": [1, 2]}");
     }
 
-    /// Real-weight magic-prompt smoke (sc-5997): expands a plain idea into a JSON caption through the
-    /// actual `prompt_refine` Llama-3.2-3B and asserts the cleaned reply parses with the caption's
-    /// required section. `#[ignore]` — the weights live outside CI; run on a Mac with the model
-    /// staged in the HF cache:
+    /// Real-weight magic-prompt smoke (sc-7158): expands a plain idea into a JSON caption through the
+    /// unified mlx-llm engine — `gen_core::core_llm::load_for_model` resolves `mlx-llama` on the Anubis
+    /// snapshot (the JSON constraint steers the model-first pick) — and asserts the cleaned reply parses
+    /// with the caption's required section. `#[ignore]` — the weights live outside CI; run on a Mac with
+    /// the model staged in the HF cache:
     ///   cargo test -p sceneworks-worker --lib -- --ignored magic_prompt_expands
     #[cfg(target_os = "macos")]
     #[test]
-    #[ignore = "real-weight: needs the Llama-3.2-3B prompt-refine model in the HF cache"]
+    #[ignore = "real-weight: needs the Anubis-Mini-8B prompt-refine model in the HF cache"]
     fn magic_prompt_expands_plain_text_to_caption() {
-        use gen_core::{
-            CancelFlag, LoadSpec, Progress, TextLlmConstraint, TextLlmRequest, TextLlmSampling,
-            WeightsSource,
+        use gen_core::core_llm::{
+            load_for_model_with, Constraint, LoadSpec, Message, ModelRequirements, Sampling,
+            StreamEvent, TextLlmRequest,
         };
 
         let home = std::env::var("HOME").expect("HOME");
-        let snapshots = std::path::Path::new(&home).join(
-            ".cache/huggingface/hub/models--huihui-ai--Llama-3.2-3B-Instruct-abliterated/snapshots",
-        );
+        let snapshots = std::path::Path::new(&home)
+            .join(".cache/huggingface/hub/models--TheDrummer--Anubis-Mini-8B-v1/snapshots");
         let weights_dir = std::fs::read_dir(&snapshots)
             .expect("prompt-refine model staged in the HF cache")
             .flatten()
@@ -745,30 +815,33 @@ mod tests {
             .find(|path| path.is_dir())
             .expect("a snapshot dir");
 
-        let refiner = gen_core::load_textllm(
-            PROMPT_REFINE_ENGINE_ID,
-            &LoadSpec::new(WeightsSource::Dir(weights_dir)),
-        )
-        .expect("load prompt_refine");
-
         let (system, user) = build_magic_prompt_messages(
             "a red fox sitting in a snowy forest at golden hour",
             "1:1",
         );
         let request = TextLlmRequest {
-            system,
-            prompt: user,
-            sampling: TextLlmSampling {
+            messages: vec![Message::system(system), Message::user(user)],
+            sampling: Sampling {
                 temperature: 0.4,
                 top_p: 0.9,
-                max_new_tokens: 2048,
-                seed: None,
+                ..Sampling::default()
             },
-            constraint: Some(TextLlmConstraint::Json), // sc-6585: exercise constrained decoding
-            cancel: CancelFlag::new(),
+            max_new_tokens: 2048,
+            seed: None,
+            constraint: Some(Constraint::Json), // sc-6585: exercise constrained decoding
+            ..Default::default()
         };
-        let mut noop = |_progress: Progress| {};
-        let output = refiner.generate(&request, &mut noop).expect("generate");
+        let refiner = load_for_model_with(
+            &LoadSpec {
+                source: weights_dir.to_string_lossy().into_owned(),
+                quantize: None,
+            },
+            &ModelRequirements::from_request(&request),
+        )
+        .expect("load prompt_refine via core-llm model-first resolution");
+
+        let mut sink = |_event: StreamEvent| {};
+        let output = refiner.generate(&request, &mut sink).expect("generate");
         let json = clean_json_output(&output.text);
         eprintln!("magic-prompt JSON:\n{json}");
 
@@ -972,21 +1045,21 @@ mod tests {
         assert!(!ok_text.text_when_unwanted && !ok_text.degenerate());
     }
 
-    /// Real-weight magic-prompt bake-off (sc-6550). Runs the shipping magic-prompt system prompt over
-    /// `BAKEOFF_PROMPTS` × N seeds through the REAL `prompt_refine` provider and prints per-run +
-    /// aggregate degeneracy metrics. `#[ignore]` — the weights live outside CI. Point it at any
-    /// snapshot dir (the 3B baseline, a Llama-3.1-8B, an Anubis-8B …); the provider is config-driven
-    /// Llama, so any Llama-3.x-Instruct shape loads as-is. Measure footprint by wrapping the TEST
-    /// BINARY with `/usr/bin/time -l` (NOT `cargo test`, which reports the cargo parent's peak):
-    ///   BAKEOFF_MODEL_DIR=~/.cache/huggingface/hub/models--huihui-ai--Meta-Llama-3.1-8B-Instruct-abliterated/snapshots/<rev> \
+    /// Real-weight magic-prompt bake-off (sc-6550, ported to the unified engine in sc-7158). Runs the
+    /// shipping magic-prompt system prompt over `BAKEOFF_PROMPTS` × N seeds through mlx-llm's `mlx-llama`
+    /// (resolved model-first by `gen_core::core_llm::load_for_model`) and prints per-run + aggregate
+    /// degeneracy metrics. `#[ignore]` — the weights live outside CI. Point it at any Llama-3.x-Instruct
+    /// snapshot dir (the 3B baseline, a Llama-3.1-8B, an Anubis-8B …). Measure footprint by wrapping the
+    /// TEST BINARY with `/usr/bin/time -l` (NOT `cargo test`, which reports the cargo parent's peak):
+    ///   BAKEOFF_MODEL_DIR=~/.cache/huggingface/hub/models--TheDrummer--Anubis-Mini-8B-v1/snapshots/<rev> \
     ///   BAKEOFF_SEEDS=3 cargo test -p sceneworks-worker --lib -- --ignored --nocapture magic_prompt_bakeoff
     #[cfg(target_os = "macos")]
     #[test]
     #[ignore = "real-weight: set BAKEOFF_MODEL_DIR to a Llama-3.x-Instruct snapshot dir"]
     fn magic_prompt_bakeoff() {
-        use gen_core::{
-            CancelFlag, LoadSpec, Progress, TextLlmConstraint, TextLlmRequest, TextLlmSampling,
-            WeightsSource,
+        use gen_core::core_llm::{
+            load_for_model_with, Constraint, LoadSpec, Message, ModelRequirements, Sampling,
+            StreamEvent, TextLlmRequest,
         };
         use std::time::Instant;
 
@@ -997,13 +1070,23 @@ mod tests {
             .ok()
             .and_then(|s| s.parse().ok())
             .unwrap_or(3);
+        // sc-6585: set BAKEOFF_CONSTRAIN=1 to measure caption_valid under grammar-constrained decoding
+        // (expect ~100%) vs the unconstrained baseline. Steers the model-first pick to a JSON provider.
+        let constrain = std::env::var("BAKEOFF_CONSTRAIN").is_ok();
         eprintln!("BAKEOFF model_dir={}", weights_dir.display());
 
-        let refiner = gen_core::load_textllm(
-            PROMPT_REFINE_ENGINE_ID,
-            &LoadSpec::new(WeightsSource::Dir(weights_dir)),
+        let mut reqs = ModelRequirements::default();
+        if constrain {
+            reqs = reqs.with_constraint(Constraint::Json);
+        }
+        let refiner = load_for_model_with(
+            &LoadSpec {
+                source: weights_dir.to_string_lossy().into_owned(),
+                quantize: None,
+            },
+            &reqs,
         )
-        .expect("load prompt_refine");
+        .expect("load prompt_refine via core-llm model-first resolution");
 
         let (mut runs, mut parse_ok, mut caption_valid, mut degenerate) = (0u32, 0u32, 0u32, 0u32);
         let (mut text_bad, mut transp_bad, mut no_obj) = (0u32, 0u32, 0u32);
@@ -1015,24 +1098,23 @@ mod tests {
             let (system, user) = build_magic_prompt_messages(prompt.text, "1:1");
             for seed in 0..seeds {
                 let request = TextLlmRequest {
-                    system: system.clone(),
-                    prompt: user.clone(),
-                    sampling: TextLlmSampling {
+                    messages: vec![
+                        Message::system(system.clone()),
+                        Message::user(user.clone()),
+                    ],
+                    sampling: Sampling {
                         temperature: 0.4, // matches the worker's magic-prompt sampling
                         top_p: 0.9,
-                        max_new_tokens: 2048,
-                        seed: Some(seed),
+                        ..Sampling::default()
                     },
-                    // sc-6585: set BAKEOFF_CONSTRAIN=1 to measure caption_valid under grammar-
-                    // constrained decoding (expect ~100%) vs the unconstrained baseline.
-                    constraint: std::env::var("BAKEOFF_CONSTRAIN")
-                        .is_ok()
-                        .then_some(TextLlmConstraint::Json),
-                    cancel: CancelFlag::new(),
+                    max_new_tokens: 2048,
+                    seed: Some(seed),
+                    constraint: constrain.then_some(Constraint::Json),
+                    ..Default::default()
                 };
-                let mut noop = |_p: Progress| {};
+                let mut sink = |_event: StreamEvent| {};
                 let start = Instant::now();
-                let output = refiner.generate(&request, &mut noop).expect("generate");
+                let output = refiner.generate(&request, &mut sink).expect("generate");
                 let ms = start.elapsed().as_millis();
                 total_ms += ms;
 

--- a/crates/sceneworks-worker/src/prompt_refine_jobs.rs
+++ b/crates/sceneworks-worker/src/prompt_refine_jobs.rs
@@ -515,7 +515,8 @@ pub(crate) async fn run_prompt_refine_job(
         #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
         let text = {
             use gen_core::{
-                LoadSpec, Progress, TextLlmConstraint, TextLlmRequest, TextLlmSampling, WeightsSource,
+                LoadSpec, Progress, TextLlmConstraint, TextLlmRequest, TextLlmSampling,
+                WeightsSource,
             };
             let refiner = gen_core::load_textllm(
                 PROMPT_REFINE_ENGINE_ID,
@@ -546,9 +547,11 @@ pub(crate) async fn run_prompt_refine_job(
                     let _ = tx.blocking_send((current, total));
                 }
             };
-            let output = refiner.generate(&request, &mut on_progress).map_err(|error| {
-                WorkerError::Engine(format!("prompt-refine generation failed: {error}"))
-            })?;
+            let output = refiner
+                .generate(&request, &mut on_progress)
+                .map_err(|error| {
+                    WorkerError::Engine(format!("prompt-refine generation failed: {error}"))
+                })?;
             output.text
         };
 
@@ -1098,10 +1101,7 @@ mod tests {
             let (system, user) = build_magic_prompt_messages(prompt.text, "1:1");
             for seed in 0..seeds {
                 let request = TextLlmRequest {
-                    messages: vec![
-                        Message::system(system.clone()),
-                        Message::user(user.clone()),
-                    ],
+                    messages: vec![Message::system(system.clone()), Message::user(user.clone())],
                     sampling: Sampling {
                         temperature: 0.4, // matches the worker's magic-prompt sampling
                         top_p: 0.9,


### PR DESCRIPTION
## Summary
Migrate the macOS `prompt_refine` job off the bespoke `mlx-gen-prompt-refine` hand-rolled Llama decoder onto the unified **mlx-llm engine** (epic 7153, [sc-7158](https://app.shortcut.com/trefry/story/7158)). The job now resolves mlx-llm's generic `mlx-llama` provider **model-first** via `gen_core::core_llm::load_for_model_with` and streams through the `core_llm::TextLlm` contract.

This is the first SceneWorks-side consumer of the inverted dependency (gen-core → core-llm) landed by the keystone (mlx-gen #545, sc-7189).

## Changes
- **cfg-split dispatch** (`prompt_refine_jobs.rs`): macOS takes the new core-llm path (`TextLlmRequest` with `Message::system/user`, `StreamEvent` streaming, `ModelRequirements::from_request` so the JSON magic-prompt steers resolution to the JSON-capable provider). The **candle lane is left byte-identical** on its current `candle-gen-prompt-refine` path — its twin migration is [sc-7404](https://app.shortcut.com/trefry/story/7404) (verifiable only on Windows/CUDA). The cancel handle is cfg-aliased (core-llm vs gen-core `CancelFlag`, identical method surface).
- Force-link `mlx_llm` (was `mlx_gen_prompt_refine`); the product policy (rewrite rules, magic-prompt system prompt, reply cleanup) stays caller-side, untouched.
- **Cargo**: drop `mlx-gen-prompt-refine`, add `mlx-llm` (same pmetal mlx-rs pin → one `Array` / one MLX build); bump every mlx-gen pin `43aa2bf -> 54e87e9` (catch-up delta is purely additive: the `core_llm` re-export + the CLIP `TextEmbedder` contract).
- Both macOS-gated real-weight tests ported to the core-llm path, repointed at the cached Anubis-8B.

## Verification (this Mac, 128 GB)
- `cargo check -p sceneworks-worker` — green.
- `cargo clippy -p sceneworks-worker --all-targets -- -D warnings` — clean (incl. ported tests).
- `cargo test -p sceneworks-worker --lib prompt_refine_jobs` — 8 passed, 2 real-weight ignored.
- **Real-weight gate** — `magic_prompt_expands_plain_text_to_caption` on Anubis-8B through `mlx-llama`: loaded via `load_for_model`, JSON-constrained decode produced a structurally-valid, **non-degenerate** caption (`compositional_deconstruction` → background + an `obj` element for the subject; quality preserved), 29s. Chat-template parity confirmed (coherent on-spec output).

## ⚠️ Draft — merge order (skew gate)
This bumps the worker's mlx-gen gen-core pin to `54e87e9`, so the `--all-features` skew gate needs candle-gen at the same gen-core rev first:
1. Merge candle-gen [#142](https://github.com/SceneWorks/candle-gen/pull/142) (gen-core re-pin → `54e87e9`).
2. I bump this PR's candle-gen pins `2dc0306 -> <#142 merge rev>` (one commit), then mark ready.

Until step 1+2, the skew gate is red by construction; the macOS code + engine path above are fully verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)