### PR TITLE
feat(worker): FLUX.2-klein kv + true_v2 candle variant parity (sc-7459)

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3747,15 +3747,18 @@ fn realvisxl_lightning_mlx_eligible(payload: &Map<String, Value>) -> bool {
 
 /// The models the candle (Windows/CUDA) lane can serve (epic 3672 sc-3678 for SDXL; epic 5095
 /// sc-5096 adds the four image families; sc-5126 adds Lens / Lens-Turbo; sc-5484 + sc-5576 add Chroma,
-/// Kolors, and SenseNova-U1). Mirrors the worker's
+/// Kolors, and SenseNova-U1; sc-7459 adds the two FLUX.2-klein weight variants). Mirrors the worker's
 /// `image_jobs::is_candle_engine`: SDXL/RealVisXL (`realvisxl` shares the candle `"sdxl"` engine via a
-/// weights swap), plus z-image-turbo, FLUX.1 schnell/dev, FLUX.2-klein-9B, Qwen-Image,
+/// weights swap), plus z-image-turbo, FLUX.1 schnell/dev, FLUX.2-klein-9B (+ the `_kv` / `_true_v2`
+/// weight variants, which share the candle `flux2_klein_9b` loader), Qwen-Image,
 /// `lens`/`lens_turbo`, `chroma1_hd`/`_base`/`_flash`, `kolors`, and `sensenova_u1_8b`/`_fast` —
-/// the base **txt2img** ids only. Deliberately narrow: candle is a gated
-/// txt2img-only lane, so every conditioning shape AND every non-base weight variant (e.g.
-/// `flux2_klein_9b_kv`, `qwen_image_edit`) falls back to the Python torch worker. Lens is pure T2I
-/// (no conditioning at all) but — unlike the others — DOES advertise quant + LoRA/LoKr, so it is also
-/// listed in [`CANDLE_QUANT_LORA_MODELS`] below to exempt it from the quant/LoRA → torch fallbacks.
+/// the base **txt2img** ids (plus the klein weight swaps). Deliberately narrow: candle is a gated
+/// txt2img-only lane, so every conditioning shape AND every still-unwired weight variant (e.g.
+/// `qwen_image_edit`) falls back to the Python torch worker — including the klein variants' OWN edit /
+/// KV-cache shapes (`flux2_klein_9b_kv`'s reference-edit accel is out of scope; sc-7459 is txt2img weight
+/// parity only). Lens is pure T2I (no conditioning at all) but — unlike the others — DOES advertise
+/// quant + LoRA/LoKr, so it is also listed in [`CANDLE_QUANT_LORA_MODELS`] below to exempt it from the
+/// quant/LoRA → torch fallbacks.
 const CANDLE_ROUTED_MODELS: &[&str] = &[
     "sdxl",
     "realvisxl",
@@ -3771,6 +3774,15 @@ const CANDLE_ROUTED_MODELS: &[&str] = &[
     "flux_schnell",
     "flux_dev",
     "flux2_klein_9b",
+    // FLUX.2-klein weight variants (sc-7459, epic 6564 story 3): same candle `flux2_klein_9b`
+    // loader/arch, a weights swap. `_kv` is a separately-distilled checkpoint with a full diffusers
+    // tree (4-step, guidance 1.0); `_true_v2` is the wikeeyang undistilled fine-tune (24-step,
+    // guidance 1.0) the convert-at-install lane assembles into a local diffusers dir (loaded via the
+    // `modelPath` seam — candle converter sc-7459). **txt2img only**: `_kv`'s reference-edit / KV-cache
+    // accel and every reference/edit shape are rejected below (`image_request_candle_eligible`) and
+    // fall back to the Python torch worker.
+    "flux2_klein_9b_kv",
+    "flux2_klein_9b_true_v2",
     // FLUX.2-dev (epic 6564 sc-7458): the guidance-distilled 32B flagship, a SEPARATE candle engine
     // from klein (Mistral3 TE + 48/48/15360 DiT), registered by `candle-gen-flux2`'s `flux2_dev`
     // generator (sc-7457). Off-Mac the candle lane loads the dense `black-forest-labs/FLUX.2-dev`
@@ -5824,18 +5836,38 @@ mod candle_routing_tests {
 
     #[test]
     fn non_candle_families_and_variants_are_never_candle_eligible() {
-        // A family with no candle provider at all (`bernini_image`) AND the non-base weight/shape
-        // variants of wired families (edit ids, the kv distill) all stay on the Python torch worker.
-        // (chroma / kolors / sensenova ARE candle-routed now — sc-5484 / sc-5576 — for txt2img.)
-        for model in [
-            "bernini_image",
-            "z_image_edit",
-            "qwen_image_edit",
-            "flux2_klein_9b_kv",
-        ] {
+        // A family with no candle provider at all (`bernini_image`) AND the still-unwired weight/shape
+        // variants of wired families (edit ids) all stay on the Python torch worker.
+        // (chroma / kolors / sensenova ARE candle-routed now — sc-5484 / sc-5576 — for txt2img; the
+        // FLUX.2-klein `_kv` / `_true_v2` weight variants are too — sc-7459 — see the dedicated test below.)
+        for model in ["bernini_image", "z_image_edit", "qwen_image_edit"] {
             assert!(
                 !image_request_candle_eligible(model, &object(json!({ "prompt": "p" }))),
                 "{model} must fall back to the Python worker"
+            );
+        }
+    }
+
+    #[test]
+    fn flux2_klein_weight_variants_route_txt2img_to_candle() {
+        // sc-7459 (epic 6564 story 3): both klein weight variants serve plain txt2img on the candle lane
+        // via the shared `flux2_klein_9b` loader — a weights swap, not a new arch.
+        for model in ["flux2_klein_9b_kv", "flux2_klein_9b_true_v2"] {
+            assert!(
+                image_request_candle_eligible(model, &object(json!({ "prompt": "a red fox" }))),
+                "{model} plain txt2img should be candle-eligible"
+            );
+        }
+        // ...but their reference/edit shapes are NOT in scope (txt2img weight parity only). The `_kv`
+        // checkpoint's whole point is the reference-edit KV-cache accel — that stays on the Python torch
+        // worker (the candle lane has no klein edit path), same as every other candle conditioning shape.
+        for payload in [
+            json!({ "referenceAssetId": "a" }),
+            json!({ "mode": "edit_image", "sourceAssetId": "a" }),
+        ] {
+            assert!(
+                !image_request_candle_eligible("flux2_klein_9b_kv", &object(payload.clone())),
+                "flux2_klein_9b_kv conditioning shape must fall back to torch: {payload}"
             );
         }
     }

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -1782,8 +1782,10 @@ async fn generate_stream(
 /// Whether `model` is served by the candle (Windows/CUDA) backend's generic lane (txt2img, plus the
 /// Ideogram 4 in-lane edit, below). SDXL/RealVisXL (sc-3675) plus the four image families wired in
 /// sc-5096 — z-image, flux schnell/dev, flux2-klein, qwen-image — plus Lens / Lens-Turbo (sc-5126, the
-/// first candle family with quant + LoRA/LoKr) plus Ideogram 4 + Turbo (sc-6597/sc-6598, epic 6561).
-/// `realvisxl` shares the candle `"sdxl"` engine via a weights swap; every other id maps 1:1 to its
+/// first candle family with quant + LoRA/LoKr) plus Ideogram 4 + Turbo (sc-6597/sc-6598, epic 6561) plus
+/// the two FLUX.2-klein weight variants (sc-7459: `_kv` / `_true_v2`, sharing the `flux2_klein_9b` loader).
+/// `realvisxl` (and the klein `_kv` / `_true_v2`) share an existing candle engine via a weights swap;
+/// every other id maps 1:1 to its
 /// `MODEL_TABLE` engine id. For the OTHER families, edit/control/reference shapes route to their bespoke
 /// candle lanes (checked before this gate in the dispatch) or to the Python torch worker; Ideogram is
 /// the exception — its img2img/mask edit is the SAME engine as its T2I, so `generate_candle_stream`
@@ -1803,6 +1805,12 @@ fn is_candle_engine(model: &str) -> bool {
             | "flux_schnell"
             | "flux_dev"
             | "flux2_klein_9b"
+            // FLUX.2-klein weight variants (sc-7459): same candle `flux2_klein_9b` loader/arch, a
+            // weights swap. `_kv` loads its own full diffusers tree; `_true_v2` loads the locally
+            // converted diffusers dir (`modelPath` seam). txt2img only — `_kv`'s reference-edit /
+            // KV-cache accel and every edit/reference shape defer to torch (`image_request_candle_eligible`).
+            | "flux2_klein_9b_kv"
+            | "flux2_klein_9b_true_v2"
             // FLUX.2-dev (sc-7458): the 32B flagship rides the generic candle txt2img lane like klein.
             // `generate_candle_stream` resolves Q4 (manifest `mlx.quantize: 4` + the dev descriptor's
             // `supported_quants`) so the dense snapshot is staged in CPU RAM and quantized onto the GPU
@@ -1837,7 +1845,10 @@ fn candle_adapter_label(model: &str) -> &'static str {
     match model {
         "z_image_turbo" => "candle_z_image",
         "flux_schnell" | "flux_dev" => "candle_flux",
-        "flux2_klein_9b" | "flux2_dev" => "candle_flux2",
+        // The base klein + its `_kv` / `_true_v2` weight variants (sc-7459) + dev all run candle FLUX.2.
+        "flux2_klein_9b" | "flux2_klein_9b_kv" | "flux2_klein_9b_true_v2" | "flux2_dev" => {
+            "candle_flux2"
+        }
         "qwen_image" => "candle_qwen",
         "chroma1_hd" | "chroma1_base" | "chroma1_flash" => "candle_chroma",
         "lens" | "lens_turbo" => "candle_lens",
@@ -2018,15 +2029,31 @@ async fn generate_candle_stream(
     } else {
         model_repo(request, &model)
     };
-    let snapshot = huggingface_snapshot_dir(&settings.data_dir, &repo).ok_or_else(|| {
-        WorkerError::InvalidPayload(format!("candle weights snapshot not found for {repo}"))
-    })?;
-    // Ideogram nests its weights under a `bf16/` subdir; Boogu's originals (and every other family) are a
-    // complete snapshot at the root, so `weights_dir` is the snapshot itself.
-    let weights_dir = if is_ideogram {
-        candle_ideogram_subdir(&snapshot)
+    // A convert-at-install model (FLUX.2-klein `_true_v2`, sc-7459) is a single-file fine-tune with no
+    // diffusers tree in its HF cache, so it loads from the locally-assembled converted dir via the
+    // `modelPath` seam (injected by the API's `inject_converted_model_path`), exactly like the MLX
+    // path's `resolve_weights_dir`. An explicit `modelPath` (advanced override or manifest) wins over
+    // the HF-cache snapshot; `resolve_app_managed_model_dir` constrains it to app-managed data.
+    let model_path = request
+        .advanced
+        .get("modelPath")
+        .or_else(|| request.model_manifest_entry.get("modelPath"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|path| !path.is_empty());
+    let weights_dir = if let Some(model_path) = model_path {
+        resolve_app_managed_model_dir(settings, model_path, "Image modelPath")?
     } else {
-        snapshot
+        let snapshot = huggingface_snapshot_dir(&settings.data_dir, &repo).ok_or_else(|| {
+            WorkerError::InvalidPayload(format!("candle weights snapshot not found for {repo}"))
+        })?;
+        // Ideogram nests its weights under a `bf16/` subdir; Boogu's originals (and every other family)
+        // are a complete snapshot at the root, so `weights_dir` is the snapshot itself.
+        if is_ideogram {
+            candle_ideogram_subdir(&snapshot)
+        } else {
+            snapshot
+        }
     };
 
     // Descriptor-derived denoise/guidance surface (distilled families → no guidance/negative; guided
@@ -2460,6 +2487,12 @@ mod candle_label_tests {
         assert_eq!(candle_adapter_label("flux_dev"), "candle_flux");
         assert_eq!(candle_adapter_label("flux2_klein_9b"), "candle_flux2");
         assert_eq!(candle_adapter_label("flux2_dev"), "candle_flux2");
+        // sc-7459: the klein weight variants share the FLUX.2 family label.
+        assert_eq!(candle_adapter_label("flux2_klein_9b_kv"), "candle_flux2");
+        assert_eq!(
+            candle_adapter_label("flux2_klein_9b_true_v2"),
+            "candle_flux2"
+        );
         assert_eq!(candle_adapter_label("qwen_image"), "candle_qwen");
         assert_eq!(candle_adapter_label("chroma1_hd"), "candle_chroma");
         assert_eq!(candle_adapter_label("chroma1_base"), "candle_chroma");
@@ -2519,6 +2552,9 @@ mod candle_label_tests {
             "flux_dev",
             "flux2_klein_9b",
             "flux2_dev",
+            // sc-7459: the two klein weight variants share the candle FLUX.2 engine.
+            "flux2_klein_9b_kv",
+            "flux2_klein_9b_true_v2",
             "qwen_image",
             "chroma1_hd",
             "chroma1_base",
@@ -2539,14 +2575,14 @@ mod candle_label_tests {
         ] {
             assert!(is_candle_engine(model), "{model} should be a candle engine");
         }
-        // Non-candle families + non-base variants (the bespoke-stream edit ids, the kv distill) are not
-        // in the generic lane. (kolors / sensenova ARE candle engines now — sc-5576 — for their base
-        // txt2img shape; `boogu_image_edit` IS — sc-7524 — because its edit is in-lane, not bespoke.)
+        // Non-candle families + still-unwired variants (bespoke-stream edit ids) are not in the generic
+        // lane. (kolors / sensenova ARE candle engines now — sc-5576 — for their base txt2img shape;
+        // `boogu_image_edit` IS — sc-7524 — because its edit is in-lane, not bespoke; the klein
+        // `_kv` / `_true_v2` weight variants are candle engines too — sc-7459 — for txt2img.)
         for model in [
             "bernini_image",
             "z_image_edit",
             "qwen_image_edit",
-            "flux2_klein_9b_kv",
             "wan_2_2",
         ] {
             assert!(!is_candle_engine(model), "{model} must not be a candle engine");

--- a/crates/sceneworks-worker/src/image_jobs/kolors_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/kolors_control.rs
@@ -298,8 +298,6 @@ async fn generate_candle_kolors_control_stream(
                     steps: steps as usize,
                     guidance,
                     control_scale,
-                    sampler: None,
-                    scheduler: None,
                     seed: seed as u64,
                     sampler: sampler.clone(),
                     scheduler: scheduler.clone(),

--- a/crates/sceneworks-worker/src/image_jobs/kolors_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/kolors_ipadapter.rs
@@ -312,8 +312,6 @@ async fn generate_candle_kolors_ipadapter_stream(
                     steps: steps as usize,
                     guidance,
                     ip_adapter_scale: ip_scale,
-                    sampler: None,
-                    scheduler: None,
                     seed: seed as u64,
                     sampler: sampler.clone(),
                     scheduler: scheduler.clone(),

--- a/crates/sceneworks-worker/src/image_jobs/pulid_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/pulid_candle.rs
@@ -343,8 +343,6 @@ async fn generate_candle_pulid_stream(
                     steps: steps as usize,
                     guidance,
                     id_weight,
-                    sampler: None,
-                    scheduler: None,
                     seed: seed as u64,
                     sampler: sampler.clone(),
                     scheduler: scheduler.clone(),

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
@@ -318,8 +318,6 @@ async fn generate_candle_sdxl_ipadapter_stream(
                     steps: steps as usize,
                     guidance,
                     ip_adapter_scale: ip_scale,
-                    sampler: None,
-                    scheduler: None,
                     seed: seed as u64,
                     sampler: sampler.clone(),
                     scheduler: scheduler.clone(),

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -433,8 +433,8 @@ pub(crate) async fn overlay_derived_tokenizer(
 /// transformer, remaps it to the diffusers layout (fused-qkv 1→3 split + the load-bearing
 /// `norm_out` scale/shift swap), validates against the base, and assembles a local diffusers
 /// dir whose borrowed vae/text-encoder/tokenizer are absolute symlinks (so they survive the
-/// worker's temp→final atomic rename). Runs MLX, so macOS-only — other targets can't reach
-/// it (FLUX.2-klein is `macOnly` in the manifest).
+/// worker's temp→final atomic rename). Runs MLX on macOS; the candle (Windows/CUDA) lane runs the
+/// byte-equivalent candle twin (sc-7459) so `flux2_klein_9b_true_v2` installs + converts off-Mac too.
 #[cfg(target_os = "macos")]
 fn convert_flux2_klein_diffusers(
     source_file: &Path,
@@ -447,14 +447,32 @@ fn convert_flux2_klein_diffusers(
         .map_err(|error| error.to_string())
 }
 
-#[cfg(not(target_os = "macos"))]
+/// Candle (Windows/CUDA) twin of the macOS converter (sc-7459): the same single-file → diffusers key
+/// remap (fused-qkv split + the `norm_out` scale/shift swap), implemented on candle CPU tensors, so the
+/// `flux2_klein_9b_true_v2` weight variant has a real install-time convert lane on the candle worker
+/// (the borrowed components are hardlinked, not symlinked — Windows symlinks fail to read; see the
+/// crate's `convert` module). Reached only on the `backend-candle` build.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn convert_flux2_klein_diffusers(
+    source_file: &Path,
+    base_dir: &Path,
+    out_dir: &Path,
+) -> Result<(), String> {
+    // CARVE-OUT(epic 3720 / sc-7459): backend-specific weight converter; not a registry contract.
+    candle_gen_flux2::convert_and_assemble(source_file, base_dir, out_dir)
+        .map(|_| ())
+        .map_err(|error| error.to_string())
+}
+
+#[cfg(all(not(target_os = "macos"), not(feature = "backend-candle")))]
 fn convert_flux2_klein_diffusers(
     _source_file: &Path,
     _base_dir: &Path,
     _out_dir: &Path,
 ) -> Result<(), String> {
     Err(
-        "FLUX.2-klein conversion requires macOS (mlx-gen-flux2); this model is macOS-only."
+        "FLUX.2-klein conversion requires the candle backend (Windows/CUDA, --features \
+         backend-candle) or macOS (mlx-gen-flux2)."
             .to_owned(),
     )
 }


### PR DESCRIPTION
Epic [6564](https://app.shortcut.com/trefry/epic/6564), story [sc-7459](https://app.shortcut.com/trefry/story/7459) — bring the two MLX-routed FLUX.2-klein weight variants (`flux2_klein_9b_kv`, `flux2_klein_9b_true_v2`) onto the candle (Windows/CUDA) **txt2img** lane. Companion to candle-gen #144 (the converter), **now merged**.

Both variants reuse the shared `flux2_klein_9b` candle loader/arch — a weights swap, not a new engine.

## Changes (commit 1 — sc-7459)
- **Routing:** add both ids to `CANDLE_ROUTED_MODELS` (`sceneworks-core/jobs_store.rs`) + `is_candle_engine` + `candle_adapter_label` (`sceneworks-worker/image_jobs/base.rs`). **txt2img only** — `kv`'s reference-edit / KV-cache accel and every edit/reference shape defer to the Python torch worker (out of scope: txt2img weight parity only). Routing tests updated.
- **true_v2 load:** `generate_candle_stream` consults the `modelPath` seam so the convert-at-install diffusers dir loads instead of the raw single-file repo.
- **true_v2 convert off-Mac:** non-macOS `convert_flux2_klein_diffusers` (`model_jobs.rs`) calls candle `candle_gen_flux2::convert_and_assemble` under `backend-candle`.
- **No Cargo pin change** (this PR was rebased onto main): candle-gen #144 is merged, and main's current pin (candle-gen `30ce2c29` / mlx `54e87e9`) already carries the converter — single gen-core rev, no lockstep bump needed.

## Drive-by fix (commit 2 — pre-existing backend-candle regression)
While validating, the `backend-candle` build failed on a **pre-existing main breakage**: the candle conditioned-lane request literals (KolorsControl / Kolors-IP-Adapter / PuLID-FLUX / SDXL-IP-Adapter) each set `sampler`/`scheduler` **twice** (a stale `None` + the real `.clone()` from the sc-7389 wiring) — `field specified more than once`. It slipped onto main because the candle CI lane is manual-only and the default PR gate doesn't compile `backend-candle`. Commit 2 drops the stale `None` inits. Unrelated to sc-7459 — fixed here to unblock the candle build; happy to split into its own PR if preferred.

## Validation (Windows/CUDA)
`cargo check` + `clippy -D warnings` (backend-candle) clean; candle worker tests (routing / labels / manifest-subset) + sceneworks-core routing green. End-to-end GPU renders (via candle-gen): base-klein + true_v2 (convert→load→24-step render) both coherent.

## Note
**`kv` weights are not yet renderable end-to-end:** `black-forest-labs/FLUX.2-klein-9b-kv` is a separately manual-approval-gated HF repo this account isn't approved for. Its code path is base-klein-identical (GPU-proven via the base-klein render); only its weights are inaccessible until access is granted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
