### PR TITLE
feat(worker): route boogu_image_edit multi-reference (N∈[1,5]) edits (sc-7645)

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -4426,10 +4426,20 @@ fn boogu_edit_candle_eligible(payload: &Map<String, Value>) -> bool {
     if payload.get("mode").and_then(Value::as_str) != Some("edit_image") {
         return false;
     }
-    payload
+    // One source: the single `sourceAssetId`, or the plural `referenceAssetIds` multi-image picker
+    // (sc-7645 — the Boogu DiT packs up to 5 references). Either routes the edit to candle.
+    let single = payload
         .get("sourceAssetId")
         .and_then(Value::as_str)
-        .is_some_and(|value| !value.trim().is_empty())
+        .is_some_and(|value| !value.trim().is_empty());
+    let plural = payload
+        .get("referenceAssetIds")
+        .and_then(Value::as_array)
+        .is_some_and(|ids| {
+            ids.iter()
+                .any(|v| v.as_str().is_some_and(|s| !s.trim().is_empty()))
+        });
+    single || plural
 }
 
 /// SDXL IP-Adapter-Plus candle-routing conditions (sc-5488, epic 5480). The candle `IpAdapterSdxl`
@@ -5928,9 +5938,19 @@ mod candle_routing_tests {
         assert!(!image_job_is_candle_eligible(&image_edit_job(
             edit_payload("boogu_image_turbo")
         )));
+        // sc-7645: the multi-image picker sends plural `referenceAssetIds` (no `sourceAssetId`) — the
+        // bespoke branch still claims it for candle (the Boogu DiT packs up to 5 references).
+        assert!(boogu_edit_candle_eligible(&object(json!({
+            "model": "boogu_image_edit", "mode": "edit_image",
+            "referenceAssetIds": ["a", "b"]
+        }))));
         // `edit_image` WITHOUT a source → nothing to edit → not this lane.
         assert!(!boogu_edit_candle_eligible(&object(json!({
             "model": "boogu_image_edit", "mode": "edit_image"
+        }))));
+        // An empty plural list with no `sourceAssetId` is also nothing to edit.
+        assert!(!boogu_edit_candle_eligible(&object(json!({
+            "model": "boogu_image_edit", "mode": "edit_image", "referenceAssetIds": []
         }))));
         // bf16-only: a deliberate Q8/Q4 quant request defers (boogu is not in CANDLE_QUANT_LORA_MODELS).
         assert!(!image_request_candle_eligible(

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -1013,6 +1013,7 @@ fn generate_one(
     guidance: Option<f32>,
     negative_prompt: Option<String>,
     reference: Option<&(Image, f32)>,
+    multi_references: &[Image],
     edit_mask: Option<&Image>,
     true_cfg: Option<f32>,
     sampler: Option<&str>,
@@ -1022,12 +1023,19 @@ fn generate_one(
     cancel: &CancelFlag,
     on_progress: &mut dyn FnMut(Progress),
 ) -> WorkerResult<(u32, u32, Vec<u8>)> {
-    let mut conditioning = match reference {
-        Some((image, strength)) => vec![Conditioning::Reference {
-            image: image.clone(),
-            strength: Some(*strength),
-        }],
-        None => Vec::new(),
+    // `multi_references` (Boogu instruction edit, sc-7645) takes precedence when present: one image →
+    // `Reference` (byte-identical to the single-reference path); 2–5 → `MultiReference`. Every other
+    // family passes `&[]` and keeps the single `reference` (img2img init / IP-Adapter) path unchanged.
+    let mut conditioning = if !multi_references.is_empty() {
+        build_reference_conditioning(multi_references)
+    } else {
+        match reference {
+            Some((image, strength)) => vec![Conditioning::Reference {
+                image: image.clone(),
+                strength: Some(*strength),
+            }],
+            None => Vec::new(),
+        }
     };
     // Inpaint / outpaint mask (Ideogram 4 edit, sc-6303): a `Conditioning::Mask` (white = repaint)
     // alongside the source `Reference`. Only the Ideogram edit path supplies one today; every other
@@ -1142,15 +1150,75 @@ const IDEOGRAM_EDIT_STRENGTH: f32 = 0.6;
 ))]
 const IDEOGRAM_INPAINT_STRENGTH: f32 = 0.85;
 
-/// Resolve the Boogu instruction-edit source: the `sourceAssetId` image, fit to the output W×H (so
-/// it satisfies the engine's multiple-of-16 guard and aligns to the target aspect). Returns
-/// `(source, strength)`; `None` when not an edit / no source. The `strength` is inert for Boogu (the
-/// edit is structural — the engine ignores `Conditioning::Reference.strength`), so a full-strength
-/// 1.0 is returned for the contract. No mask / outpaint path (the descriptor accepts only `Reference`).
+/// Upper bound on reference images for a Boogu instruction edit (sc-7645). The DiT's
+/// `image_index_embedding` carries 5 per-image index slots (OmniGen2 lineage), so `N ∈ [1, 5]`
+/// references can be packed into one edit (e.g. subject-from-A composed into scene-from-B); a plural
+/// picker beyond that is capped here. Matches the `mlx-gen-boogu` / `candle-gen-boogu` `MAX_EDIT_REFS`.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+const BOOGU_MAX_EDIT_REFERENCES: usize = 5;
+
+/// One `Conditioning::Reference` (a single reference) or one `Conditioning::MultiReference` (2–5) from
+/// the resolved Boogu edit references (cloned per output). Empty references → empty (T2I fallback).
+/// The single case stays a `Reference` so it is byte-identical to the pre-sc-7645 single-reference
+/// path. Mirrors `flux2.rs::build_edit_conditioning`. The per-reference strength is inert for Boogu
+/// (the edit is structural), so `None` is used. Not cfg-gated — called from the un-gated [`generate_one`].
+fn build_reference_conditioning(references: &[Image]) -> Vec<Conditioning> {
+    match references {
+        [] => Vec::new(),
+        [single] => vec![Conditioning::Reference {
+            image: single.clone(),
+            strength: None,
+        }],
+        many => vec![Conditioning::MultiReference {
+            images: many.to_vec(),
+        }],
+    }
+}
+
+/// Reference asset ids for a Boogu instruction edit, in order. The multi-image picker sends the plural
+/// `referenceAssetIds` — take all of them, capped at [`BOOGU_MAX_EDIT_REFERENCES`]; with no plural list
+/// it falls back to the single Image-Edit `sourceAssetId` (`edit_image` mode). Mirrors
+/// `flux2_edit_reference_ids`.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn boogu_edit_reference_ids(request: &ImageRequest) -> Vec<String> {
+    if !request.reference_asset_ids.is_empty() {
+        // The parsed list is already trimmed + non-empty (sceneworks-core `string_list`).
+        return request
+            .reference_asset_ids
+            .iter()
+            .take(BOOGU_MAX_EDIT_REFERENCES)
+            .cloned()
+            .collect();
+    }
+    if let Some(id) = request
+        .source_asset_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+    {
+        return vec![id.to_owned()];
+    }
+    Vec::new()
+}
+
+/// Resolve the Boogu instruction-edit sources: the `N ∈ [1, 5]` reference images (plural
+/// `referenceAssetIds`, else the single `sourceAssetId` — [`boogu_edit_reference_ids`]), each fit to the
+/// output W×H (so it satisfies the engine's multiple-of-16 guard and aligns to the target aspect).
+/// Returns the references in order; **empty** when not an edit / no source. The engine treats one
+/// reference as `Conditioning::Reference` and 2–5 as `Conditioning::MultiReference` (each read by the
+/// Qwen3-VL vision tower + VAE-encoded into the DiT spatial sequence). The per-reference strength is
+/// inert for Boogu (the edit is structural — the engine ignores `Conditioning::Reference.strength`). No
+/// mask / outpaint path (the descriptor accepts only `Reference` / `MultiReference`).
 ///
 /// Shared by the macOS MLX `generate_stream` and the off-Mac candle `generate_candle_stream` (sc-7524):
 /// Boogu is the same engine family for T2I and edit on both backends (the registered `boogu_image_edit`
-/// resolves the source `Reference` in-lane, like Ideogram), so both lanes resolve the edit source the
+/// resolves the source `Reference`(s) in-lane, like Ideogram), so both lanes resolve the edit sources the
 /// same way. Its deps (`load_reference_image`, `fit_engine_image`) already compile off-Mac under
 /// `backend-candle` (the Ideogram edit path uses them too).
 #[cfg(any(
@@ -1161,26 +1229,18 @@ fn resolve_boogu_edit(
     request: &ImageRequest,
     settings: &Settings,
     project_path: &Path,
-) -> WorkerResult<Option<(Image, f32)>> {
+) -> WorkerResult<Vec<Image>> {
     if request.mode != "edit_image" {
-        return Ok(None);
+        return Ok(Vec::new());
     }
-    let Some(asset_id) = request
-        .source_asset_id
-        .as_deref()
-        .map(str::trim)
-        .filter(|id| !id.is_empty())
-    else {
-        return Ok(None);
-    };
-    let source = load_reference_image(
-        &settings.data_dir,
-        &request.project_id,
-        asset_id,
-        project_path,
-    )?;
-    let source = fit_engine_image(source, request.width, request.height, &request.fit_mode)?;
-    Ok(Some((source, 1.0)))
+    let ids = boogu_edit_reference_ids(request);
+    let mut references = Vec::with_capacity(ids.len());
+    for id in &ids {
+        let source = load_reference_image(&settings.data_dir, &request.project_id, id, project_path)?;
+        let source = fit_engine_image(source, request.width, request.height, &request.fit_mode)?;
+        references.push(source);
+    }
+    Ok(references)
 }
 
 /// Resolve the Ideogram 4 `edit_image` conditioning (sc-6303) into the base MLX path's
@@ -1595,16 +1655,19 @@ async fn generate_stream(
             }
             None => (None, None, None),
         }
-    } else if request.model == "boogu_image_edit" && request.mode == "edit_image" {
-        // Boogu instruction edit (epic 6387): `sourceAssetId` → the engine's `Reference` (the Qwen3-VL
-        // vision tower reads it + it VAE-encodes into the DiT spatial latent); the prompt is the edit
-        // instruction. No mask / IP-Adapter (the `boogu_image_edit` descriptor accepts only `Reference`).
-        match resolve_boogu_edit(request, settings, project_path)? {
-            Some((source, strength)) => (Some((source, strength)), None, None),
-            None => (None, None, None),
-        }
     } else {
+        // Boogu instruction edit resolves its (1..5) references separately into `boogu_refs` below —
+        // it uses the `MultiReference`-capable path, not the single `identity_init` reference.
         (None, None, None)
+    };
+    // Boogu instruction edit (epic 6387, multi-reference sc-7645): resolve the 1..5 source references
+    // (the Qwen3-VL vision tower reads each + they VAE-encode into the DiT spatial sequence); the prompt
+    // is the edit instruction. Threaded to `generate_one` as `Conditioning::Reference` (one reference) /
+    // `MultiReference` (2–5). No mask / IP-Adapter (the descriptor accepts only Reference/MultiReference).
+    let boogu_refs: Vec<Image> = if request.model == "boogu_image_edit" {
+        resolve_boogu_edit(request, settings, project_path)?
+    } else {
+        Vec::new()
     };
     // The CFG scale passed to the engine as `true_cfg`: the FLUX.1-dev reference path's scale if
     // present, otherwise the true-CFG family scale (Chroma). `None` for the guidance-scalar and
@@ -1649,6 +1712,7 @@ async fn generate_stream(
                         guidance,
                         negative_prompt.clone(),
                         identity_init.as_ref(),
+                        &boogu_refs,
                         ideogram_edit_mask.as_ref(),
                         true_cfg,
                         sampler.as_deref(),
@@ -2032,13 +2096,17 @@ async fn generate_candle_stream(
             Some((source, strength, mask)) => (Some((source, strength)), mask),
             None => (None, None),
         }
-    } else if request.model == "boogu_image_edit" {
-        match resolve_boogu_edit(request, settings, project_path)? {
-            Some((source, strength)) => (Some((source, strength)), None),
-            None => (None, None),
-        }
     } else {
         (None, None)
+    };
+    // Boogu instruction edit (sc-7524, multi-reference sc-7645): resolve the 1..5 references here (each
+    // read by the Qwen3-VL vision tower + VAE-encoded into the DiT spatial sequence) — the
+    // `MultiReference`-capable path, not the single `edit_reference`. Threaded to `generate_one` as
+    // `Conditioning::Reference` (one) / `MultiReference` (2–5). Empty for non-Boogu / non-edit jobs.
+    let boogu_refs: Vec<Image> = if request.model == "boogu_image_edit" {
+        resolve_boogu_edit(request, settings, project_path)?
+    } else {
+        Vec::new()
     };
     let (width, height) = (request.width, request.height);
     // Per-payload sampler / scheduler / schedule-shift, mirroring the MLX `generate_stream` lane (the
@@ -2104,6 +2172,7 @@ async fn generate_candle_stream(
                         guidance,
                         negative_prompt.clone(),
                         edit_reference.as_ref(),
+                        &boogu_refs,
                         edit_mask.as_ref(),
                         true_cfg,
                         // Per-payload sampler / scheduler / schedule-shift (sc-7127), already N3-guarded

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -992,6 +992,7 @@ fn smoke_generate_one(
         guidance,
         negative_prompt,
         None,
+        &[],
         None,
         None,
         None,
@@ -1167,6 +1168,7 @@ fn lens_turbo_real_weights_bucket_resolution() {
         Some(1.0),
         None,
         None,
+        &[],
         None,
         None,
         None,
@@ -1416,6 +1418,7 @@ fn kolors_real_weights_img2img_generates_one_image() {
         Some(5.0),
         Some("blurry, low quality".to_owned()),
         Some(&(source, 0.6)),
+        &[],
         None,
         None,
         None,
@@ -1467,6 +1470,7 @@ fn kolors_real_weights_ip_adapter_generates_one_image() {
         Some(5.0),
         Some("blurry, low quality".to_owned()),
         Some(&(reference, 0.6)),
+        &[],
         None,
         None,
         None,
@@ -1801,6 +1805,7 @@ fn smoke_generate_one_true_cfg(
         None,
         negative_prompt,
         None,
+        &[],
         None,
         true_cfg,
         None,
@@ -1993,6 +1998,7 @@ fn sc3031_ab_dump_txt2img() {
         guidance,
         negative,
         None,
+        &[],
         None,
         None,
         None,
@@ -2714,6 +2720,58 @@ fn build_edit_conditioning_single_vs_multi() {
     }
     match build_edit_conditioning(&[img(1), img(2)]).as_slice() {
         [gen_core::Conditioning::MultiReference { images }] => assert_eq!(images.len(), 2),
+        other => panic!("expected MultiReference, got {other:?}"),
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn boogu_edit_reference_ids_prefers_plural_then_source() {
+    // sc-7645: the multi-image picker's plural `referenceAssetIds` wins, in order (over `sourceAssetId`).
+    assert_eq!(
+        boogu_edit_reference_ids(&request(json!({
+            "projectId": "p", "mode": "edit_image",
+            "referenceAssetIds": ["a", "b", "c"], "sourceAssetId": "ignored"
+        }))),
+        vec!["a".to_owned(), "b".to_owned(), "c".to_owned()]
+    );
+    // With no plural list it falls back to the single Image-Edit `sourceAssetId`.
+    assert_eq!(
+        boogu_edit_reference_ids(&request(json!({
+            "projectId": "p", "mode": "edit_image", "sourceAssetId": "src_1"
+        }))),
+        vec!["src_1".to_owned()]
+    );
+    // Capped at BOOGU_MAX_EDIT_REFERENCES (5) — a 7-image pick keeps the first five.
+    assert_eq!(
+        boogu_edit_reference_ids(&request(json!({
+            "projectId": "p", "mode": "edit_image",
+            "referenceAssetIds": ["a", "b", "c", "d", "e", "f", "g"]
+        })))
+        .len(),
+        BOOGU_MAX_EDIT_REFERENCES
+    );
+    // Neither a plural list nor a source → empty (the generic lane runs plain txt2img).
+    assert!(boogu_edit_reference_ids(&request(json!({ "projectId": "p" }))).is_empty());
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn boogu_build_reference_conditioning_single_vs_multi() {
+    // sc-7645: one reference stays a `Reference` (byte-identical to the single-reference edit path);
+    // 2–5 become a single `MultiReference` (the DiT packs all of them). Empty → no conditioning.
+    let img = |seed| gen_core::Image {
+        width: 8,
+        height: 8,
+        pixels: stub_rgb8(8, 8, seed),
+    };
+    assert!(build_reference_conditioning(&[]).is_empty());
+    match build_reference_conditioning(std::slice::from_ref(&img(1))).as_slice() {
+        [gen_core::Conditioning::Reference { strength, .. }] => assert!(strength.is_none()),
+        other => panic!("expected one Reference, got {other:?}"),
+    }
+    match build_reference_conditioning(&[img(1), img(2), img(3)]).as_slice() {
+        [gen_core::Conditioning::MultiReference { images }] => assert_eq!(images.len(), 3),
         other => panic!("expected MultiReference, got {other:?}"),
     }
 }
@@ -4142,6 +4200,7 @@ fn ideogram_4_real_weights_generates_caption_and_plain_images() {
             guidance,
             None,
             None,
+            &[],
             None,
             None,
             None,
@@ -4314,6 +4373,7 @@ fn ideogram_4_headless_auto_caption_renders_real_image() {
             guidance,
             None,
             None,
+            &[],
             None,
             None,
             None,
@@ -4448,6 +4508,7 @@ fn ideogram_4_real_weights_edit_img2img_and_inpaint() {
             guidance,
             None,
             reference,
+            &[],
             edit_mask,
             None,
             None,
@@ -4643,6 +4704,7 @@ fn boogu_real_weights_generates_base_turbo_edit() {
             guidance,
             None,
             reference,
+            &[],
             None,
             true_cfg,
             None,


### PR DESCRIPTION
## What

Routes **`boogu_image_edit`** instruction edits with **1–5 reference images** through the worker, as `Conditioning::Reference` (single) / `Conditioning::MultiReference` (2–5) — matching the Boogu DiT's five `image_index_embedding` slots (OmniGen2 lineage). Closes the worker half of [sc-7645](https://app.shortcut.com/trefry/story/7645).

The backends were already uncapped: candle-gen [#143](https://github.com/SceneWorks/candle-gen/pull/143) (`562126c`), mlx-gen [#548](https://github.com/SceneWorks/mlx-gen/pull/548) (`879a959`). This wires the worker to resolve and route N references instead of a single `sourceAssetId`.

## Changes

- **`image_jobs/base.rs`**
  - `boogu_edit_reference_ids` — prefer the plural `referenceAssetIds` multi-image picker (capped at `BOOGU_MAX_EDIT_REFERENCES = 5`), else fall back to the single `sourceAssetId` (mirrors `flux2_edit_reference_ids`).
  - `resolve_boogu_edit` now returns `Vec<Image>` (was `Option<(Image, f32)>`), each fit to the output W×H.
  - `build_reference_conditioning` — `Reference` for N=1 (byte-identical to the pre-existing single-reference path) / one `MultiReference` for 2–5 (mirrors `flux2::build_edit_conditioning`).
  - `generate_one` gains a `multi_references: &[Image]` param; **both** the macOS `generate_stream` and the off-Mac candle `generate_candle_stream` lanes resolve `boogu_refs` and thread it. Every other family passes `&[]` (single-reference path unchanged).
- **`sceneworks-core/jobs_store.rs`** — `boogu_edit_candle_eligible` also accepts a plural `referenceAssetIds` (a pure-multi-ref request now routes to candle; the MLX gate already routes any `boogu_image_edit` edit).
- **tests** — reference-id precedence + cap, `Reference` vs `MultiReference` shape, and plural-`referenceAssetIds` candle routing.

## Verification

- `cargo clippy -D warnings` clean (worker + core), `cargo fmt --check` clean.
- **369 `sceneworks-worker` lib tests pass / 0 fail**; new boogu unit tests + the core candle-routing test green.
- The candle lane is `cfg(not(macos))`, so it builds on the Windows/CUDA CI runner — it is line-for-line symmetric to the verified macOS lane.

## ⚠️ Follow-up gate (NOT in this PR)

This is routing code. The linked providers only expose `MultiReference` once the worker bumps its backend pins — **mlx-gen `54e87e9` → ≥ `879a959` (#548)** and **candle-gen → ≥ `562126c` (#143)** onto a single gen-core rev (the lockstep treadmill). Deliberately **not** done here to avoid racing the in-flight sc-7158 pin churn; tracked on sc-7645 to fold into the next pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)