### PR TITLE
chore(worker): re-pin candle-gen for the Boogu edit 1024² overflow fix (sc-7523)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -489,7 +489,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -506,7 +506,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -520,7 +520,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -548,7 +548,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -559,7 +559,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -586,7 +586,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -598,7 +598,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -609,7 +609,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -626,7 +626,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -641,7 +641,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -652,7 +652,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -667,7 +667,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -685,7 +685,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -696,7 +696,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -709,7 +709,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -720,7 +720,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -733,7 +733,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=33d50a3b4f4d57161923c72380ce7d6d31e0ad18#33d50a3b4f4d57161923c72380ce7d6d31e0ad18"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
 dependencies = [
  "candle-core",
  "candle-gen",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1050,25 +1050,34 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e8
 # can't carry both). `80451b3` pins gen-core 418f900d, matched by this worker's mlx pin (bumped 43aa2bf ->
 # 418f900d above) so `--features backend-candle --target all` resolves the SINGLE gen-core rev 418f900d.
 # Boogu is bf16-only on candle (the provider rejects on-the-fly quant), Apache-2.0 ungated (no gating UI).
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
+# (Intermediate `80451b3` -> `33d50a3`: #874/sc-7404 re-pinned candle-gen + this worker's gen-core to
+# 54e87e9 in lockstep — see the mlx-pin block; 33d50a3 = candle-gen #142 merge, gen-core 54e87e9.)
+# Rev 33d50a3 -> 30ce2c2 (sc-7523, epic 6831): candle-gen-ONLY re-pin to main HEAD to pick up the Boogu
+# Edit i32-attention-overflow FIX (candle-gen #146 — `sdpa` now query-row-chunks over a 1.0B-element budget
+# so the 1024² edit's ~8.4k-token joint attention no longer crosses the CUDA i32 index limit; GPU-validated
+# coherent). 30ce2c2 also carries #143/#144 (sc-7645 multi-reference edit, sc-7459 flux2 converter). #146 is
+# SOURCE-ONLY so 30ce2c2 STILL pins gen-core 54e87e9 == this worker's mlx pin (unchanged) — so `--features
+# backend-candle --target all` stays a SINGLE gen-core rev 54e87e9, no mlx bump (the mlx pin already moved
+# to 54e87e9 via #874). T2I (Base/Turbo) attention is byte-identical (chunking only triggers above budget).
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1078,21 +1087,21 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1101,11 +1110,11 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1114,19 +1123,19 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1135,12 +1144,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1148,7 +1157,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1157,7 +1166,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1165,7 +1174,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1174,7 +1183,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1201,7 +1210,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "33d50a3b4f4d57161923c72380ce7d6d31e0ad18", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with


### PR DESCRIPTION
Ships the Boogu **Edit** i32-attention-overflow fix off-Mac. The candle-gen fix is [candle-gen#146](https://github.com/SceneWorks/candle-gen/pull/146) (merged); this is the worker re-pin (the candle-gen treadmill).

## What
candle-gen-only re-pin `33d50a3 → 30ce2c2` (main HEAD). `30ce2c2` carries:
- **#146 (sc-7523)** — the Boogu Edit fix: `sdpa` query-row-chunks over a 1.0B-element budget so the 1024² edit's ~8.4k-token joint attention no longer crosses the CUDA `i32` index limit.
- #143/#144 — sc-7645 multi-reference edit + sc-7459 flux2 converter (additive; the worker links the boogu/flux2 crates).

#146 is **source-only**, so `30ce2c2` still pins gen-core `54e87e9` == this worker's mlx pin (already there via #874/sc-7158). So `--features backend-candle --target all` stays a **single gen-core rev `54e87e9`** — **no mlx bump**. T2I (Base/Turbo) attention is byte-identical (chunking only triggers above budget).

## Why it was needed
GPU validation of the candle Boogu lane on the RTX PRO 6000 found the 1024² Edit produced washed-out garbage (Base/Turbo T2I were fine). Root cause: the edit prepends the reference image tokens to the noise tokens, ~doubling the sequence, so the attention score tensor `[1,28,L,L]` ≈ 1.98B elements crossed `i32::MAX`. (Latest candle-gen main with sc-7645 multi-ref was *still* broken — multi-ref added the feature, not the chunking.)

## Verification
- `cargo check -p sceneworks-worker --features backend-candle` — clean, 0 warnings (candle-gen `30ce2c2`).
- `scripts/check-gen-core-skew.sh` — single gen-core rev `54e87e9`.
- `cargo test -p sceneworks-core --lib` — 237 passed.
- fmt clean.
- **GPU end-to-end (RTX PRO 6000): Base + Turbo T2I + the 1024² single-reference Edit all coherent** — the edit was the last gap for epic 6831.

🤖 Generated with [Claude Code](https://claude.com/claude-code)