### PR TITLE
feat(krea): wire Krea 2 Turbo into the worker + Image Studio (sc-7572)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -520,7 +520,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -587,7 +587,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -600,7 +600,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -612,7 +612,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -623,7 +623,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -640,7 +640,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -655,7 +655,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -666,7 +666,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -681,7 +681,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -699,7 +699,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -710,7 +710,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -723,7 +723,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -734,7 +734,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -747,7 +747,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=30ce2c295043b468dce110f512fd40bd8bda66ab#30ce2c295043b468dce110f512fd40bd8bda66ab"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -3437,7 +3437,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf6f338c68fe6b6cf4b76f22c61a230010d35c51#cf6f338c68fe6b6cf4b76f22c61a230010d35c51"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3449,7 +3449,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf6f338c68fe6b6cf4b76f22c61a230010d35c51#cf6f338c68fe6b6cf4b76f22c61a230010d35c51"
 dependencies = [
  "image",
  "inventory",
@@ -3463,7 +3463,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf6f338c68fe6b6cf4b76f22c61a230010d35c51#cf6f338c68fe6b6cf4b76f22c61a230010d35c51"
 dependencies = [
  "image",
  "inventory",
@@ -3476,7 +3476,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf6f338c68fe6b6cf4b76f22c61a230010d35c51#cf6f338c68fe6b6cf4b76f22c61a230010d35c51"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3488,7 +3488,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf6f338c68fe6b6cf4b76f22c61a230010d35c51#cf6f338c68fe6b6cf4b76f22c61a230010d35c51"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3499,7 +3499,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf6f338c68fe6b6cf4b76f22c61a230010d35c51#cf6f338c68fe6b6cf4b76f22c61a230010d35c51"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3508,7 +3508,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf6f338c68fe6b6cf4b76f22c61a230010d35c51#cf6f338c68fe6b6cf4b76f22c61a230010d35c51"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3520,7 +3520,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf6f338c68fe6b6cf4b76f22c61a230010d35c51#cf6f338c68fe6b6cf4b76f22c61a230010d35c51"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3531,7 +3531,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf6f338c68fe6b6cf4b76f22c61a230010d35c51#cf6f338c68fe6b6cf4b76f22c61a230010d35c51"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3543,7 +3543,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf6f338c68fe6b6cf4b76f22c61a230010d35c51#cf6f338c68fe6b6cf4b76f22c61a230010d35c51"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3554,17 +3554,17 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf6f338c68fe6b6cf4b76f22c61a230010d35c51#cf6f338c68fe6b6cf4b76f22c61a230010d35c51"
 dependencies = [
  "inventory",
  "mlx-gen",
- "pmetal-mlx-rs",
+ "mlx-llm",
 ]
 
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf6f338c68fe6b6cf4b76f22c61a230010d35c51#cf6f338c68fe6b6cf4b76f22c61a230010d35c51"
 dependencies = [
  "image",
  "inventory",
@@ -3574,9 +3574,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "mlx-gen-krea"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf6f338c68fe6b6cf4b76f22c61a230010d35c51#cf6f338c68fe6b6cf4b76f22c61a230010d35c51"
+dependencies = [
+ "inventory",
+ "mlx-gen",
+ "mlx-gen-qwen-image",
+ "pmetal-mlx-rs",
+ "serde_json",
+]
+
+[[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf6f338c68fe6b6cf4b76f22c61a230010d35c51#cf6f338c68fe6b6cf4b76f22c61a230010d35c51"
 dependencies = [
  "image",
  "inventory",
@@ -3589,7 +3601,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf6f338c68fe6b6cf4b76f22c61a230010d35c51#cf6f338c68fe6b6cf4b76f22c61a230010d35c51"
 dependencies = [
  "image",
  "inventory",
@@ -3601,7 +3613,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf6f338c68fe6b6cf4b76f22c61a230010d35c51#cf6f338c68fe6b6cf4b76f22c61a230010d35c51"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3613,7 +3625,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf6f338c68fe6b6cf4b76f22c61a230010d35c51#cf6f338c68fe6b6cf4b76f22c61a230010d35c51"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3623,7 +3635,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf6f338c68fe6b6cf4b76f22c61a230010d35c51#cf6f338c68fe6b6cf4b76f22c61a230010d35c51"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3632,7 +3644,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf6f338c68fe6b6cf4b76f22c61a230010d35c51#cf6f338c68fe6b6cf4b76f22c61a230010d35c51"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3641,7 +3653,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf6f338c68fe6b6cf4b76f22c61a230010d35c51#cf6f338c68fe6b6cf4b76f22c61a230010d35c51"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3653,7 +3665,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf6f338c68fe6b6cf4b76f22c61a230010d35c51#cf6f338c68fe6b6cf4b76f22c61a230010d35c51"
 dependencies = [
  "image",
  "inventory",
@@ -3666,7 +3678,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf6f338c68fe6b6cf4b76f22c61a230010d35c51#cf6f338c68fe6b6cf4b76f22c61a230010d35c51"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3677,7 +3689,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf6f338c68fe6b6cf4b76f22c61a230010d35c51#cf6f338c68fe6b6cf4b76f22c61a230010d35c51"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3688,7 +3700,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf6f338c68fe6b6cf4b76f22c61a230010d35c51#cf6f338c68fe6b6cf4b76f22c61a230010d35c51"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3699,7 +3711,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf6f338c68fe6b6cf4b76f22c61a230010d35c51#cf6f338c68fe6b6cf4b76f22c61a230010d35c51"
 dependencies = [
  "image",
  "inventory",
@@ -3713,7 +3725,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf6f338c68fe6b6cf4b76f22c61a230010d35c51#cf6f338c68fe6b6cf4b76f22c61a230010d35c51"
 dependencies = [
  "image",
  "inventory",
@@ -5403,7 +5415,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=54e87e995f1477176bba815814648ded1f2a65a4#54e87e995f1477176bba815814648ded1f2a65a4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf6f338c68fe6b6cf4b76f22c61a230010d35c51#cf6f338c68fe6b6cf4b76f22c61a230010d35c51"
 dependencies = [
  "core-llm",
  "inventory",
@@ -5507,6 +5519,7 @@ dependencies = [
  "mlx-gen-instantid",
  "mlx-gen-joycaption",
  "mlx-gen-kolors",
+ "mlx-gen-krea",
  "mlx-gen-lens",
  "mlx-gen-ltx",
  "mlx-gen-pulid",

--- a/apps/web/public/prompt-guides/krea-2.md
+++ b/apps/web/public/prompt-guides/krea-2.md
@@ -1,0 +1,86 @@
+# Krea 2 Prompt Guide
+
+## Best For
+
+Photorealistic and aesthetically-strong **still images** from natural-language prompts. Krea 2 is Krea
+AI's from-scratch foundation image model — a single-stream rectified-flow DiT paired with a Qwen3-VL-4B
+text encoder, so it reads your prompt as plain language. Describe the image the way you'd describe it to
+a person; it is especially strong on **photographic realism, lighting, and coherent composition**.
+
+> **Krea 2 Turbo** is the fast, few-step (~8) distilled variant shipped here — the model is trajectory-
+> distilled (TDM) and runs classifier-free guidance internally, so it is **CFG-free** (no guidance
+> slider, no negative prompt). Best for quick, high-quality iteration up to 2048².
+
+## Prompt Shape
+
+`subject + scene + composition + camera/framing + aesthetic/style`
+
+Krea reads the whole prompt as intent, so natural descriptive language works better than a pile of
+disconnected tags.
+
+## How Krea Reads A Prompt (keep it faithful and concise)
+
+The goal is a clear prompt, not a long one:
+
+- **Already clear → barely change it.** A short, well-defined prompt ("a cup of coffee on a windowsill")
+  needs little more than maybe one style or lighting word. Don't invent scenes, props, or mood the
+  prompt didn't mention.
+- **Be concise.** Short sentences; don't repeat ideas, pile up synonyms ("realistic, photographic,
+  ultra-real"), or add empty praise ("stunning", "premium", "masterpiece"). Concrete quality words like
+  `cinematic` or `soft window light` are fine.
+- **Describe what you want, not what you don't.** Krea Turbo is CFG-free and takes **no negative
+  prompt**, so avoid negations ("no people", "without text") — state the positive scene instead; a thing
+  you don't name simply won't appear.
+
+## Build The Prompt
+
+### Subject
+
+Name the main subject and its visible traits (color, material, clothing, expression). One or two clear
+subjects render more coherently than a crowded frame.
+
+### Scene Details
+
+Describe background, foreground, lighting, weather, and time of day. Krea is particularly responsive to
+**lighting description** — "soft overcast light", "golden-hour backlight", "hard noon sun" — which
+drives much of its photorealism.
+
+### Composition & Framing
+
+Direct framing language works: `low angle`, `wide shot`, `medium close-up`, `centered subject`,
+`rule of thirds`, `shallow depth of field`.
+
+### Style
+
+Concise style labels work well: `photorealistic`, `cinematic`, `editorial photography`, `watercolor`,
+`flat illustration`, `studio portrait`, `film noir`. Name a known style by its name only (e.g.
+`Kodak Portra`, `ukiyo-e`, `cyberpunk`) — you don't need to describe what it looks like. For everyday
+realistic subjects you don't need to say "photorealistic"; that's already the default.
+
+## Quality & Speed Notes
+
+- **Resolution:** use a native bucket (1024² / 768×1024 / 1024×768 / 1280×720 / 720×1280 / 1536²); width
+  and height must be multiples of 16. 1024² is the default. The model supports up to 2048².
+- **Steps:** ~8 (few-step distilled — more steps rarely help and slow you down).
+- **Guidance:** none — Krea Turbo is CFG-free (the guidance slider is inert).
+- **Sampler / scheduler:** `default` is the native rectified-flow loop and the best starting point; the
+  curated samplers/schedulers are exposed for experimentation.
+- **Quantization:** Q8 is the default (near-lossless, ~27 GB peak — needs a 48 GB-class Mac); Q4 is a
+  lighter option.
+
+## Example Prompts
+
+`A weathered lighthouse on a rocky cliff at golden hour, waves breaking below, gulls in the distance.
+Wide shot, low angle, warm directional light. Photorealistic, cinematic.`
+
+`Portrait of an elderly fisherman, deep wrinkles, soft overcast window light, shallow depth of field.
+Editorial photography.`
+
+`A quiet Kyoto side street after rain at dusk, wet stone reflecting paper-lantern light, a lone cyclist.
+Medium shot, centered. Cinematic, photorealistic.`
+
+## Sources
+
+- [Krea 2 (Hugging Face)](https://huggingface.co/krea)
+- [Krea 2 Technical Report](https://www.krea.ai/blog/krea-2-technical-report)
+- [Krea 2 Community License](https://www.krea.ai/krea-2-licensing)

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1307,6 +1307,92 @@
       }
     },
     {
+      "id": "krea_2_turbo",
+      // Krea 2 Turbo (epic 7565) — Krea AI's from-scratch foundation image model, TDM-distilled to a
+      // few-step (~8), CFG-free rectified-flow student: a Qwen3-VL-4B text encoder (12-layer learned
+      // aggregator) + a 28-block single-stream DiT + the Qwen-Image VAE, native MLX (Apple Silicon).
+      // Same gen_core engine code (the `krea_2_turbo` descriptor / KreaPipeline::generate_turbo); loads
+      // the packed Q8 (default) / Q4 turnkey subdir. Krea 2 Community License (non-commercial OK; the
+      // re-host carries the license + "Krea" name prefix + attribution — sc-7573).
+      "autoDownload": false,
+      "name": "Krea 2 Turbo",
+      "family": "krea_2",
+      "type": "image",
+      "adapter": "mlx_krea",
+      "capabilities": ["text_to_image"],
+      "macOnly": true,
+      "downloads": [
+        {
+          // Q8 `q8/` subdir of the SceneWorks/krea-2-turbo-mlx turnkey (sc-7573). Each quant subdir is a
+          // complete `from_snapshot`-loadable root (transformer/ text_encoder/ vae/ tokenizer/ scheduler/
+          // model_index.json). `estimatedSizeBytes` is a pre-publish estimate refreshed by sc-7573.
+          "provider": "huggingface",
+          "repo": "SceneWorks/krea-2-turbo-mlx",
+          "files": [
+            "q8/transformer/*",
+            "q8/text_encoder/*",
+            "q8/vae/*",
+            "q8/tokenizer/*",
+            "q8/scheduler/*",
+            "q8/model_index.json"
+          ],
+          "platforms": ["macos"],
+          "estimatedSizeBytes": 18000000000
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/SceneWorks/krea-2-turbo-mlx"
+      },
+      "defaults": {
+        // Turbo: TDM-distilled few-step (8), CFG-free (guidanceScale inert — the engine never forwards a
+        // guidance value or negative prompt), fixed mu 1.15. Up to 2048² (the descriptor max_size).
+        "resolution": "1024x1024",
+        "steps": 8,
+        "guidanceScale": 0,
+        "count": 1,
+        "sampler": "default",
+        "scheduler": "default"
+      },
+      "limits": {
+        "resolutions": ["1024x1024", "768x1024", "1024x768", "1280x720", "720x1280", "1536x1536"],
+        "count": [1, 2, 4],
+        // Krea Turbo routes the per-generation sampler/scheduler knobs through the unified framework
+        // (run_flow_sampler / resolve_flow_schedule), exactly like z_image_turbo — so it advertises the
+        // full curated flow menu. "default" is the native exp-shifted rectified-flow Euler loop. The
+        // `krea_2_turbo` descriptor advertises curated_sampler_names()/curated_scheduler_names(); the
+        // engines.rs drift guard checks this manifest list is a subset of it.
+        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+        "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
+      },
+      "loraCompatibility": {
+        // Krea LoRAs train on Raw and apply at Turbo inference (family match, no base-model gating —
+        // the Lens / Z-Image precedent). The Raw trainer + this compatibility tier land in P3 (sc-7576+).
+        "families": ["krea_2"],
+        "types": []
+      },
+      "mlx": {
+        // Pre-quantized Q8 turnkey (`q8/` subdir). MEASURED @1024²/8-step: Q8 ~27 GB peak (near-lossless),
+        // bf16 ~43 GB. minMemoryGb 48 covers Q8 + the 1536² stretch with headroom.
+        "minMemoryGb": 48,
+        "quantize": 8,
+        "repo": "SceneWorks/krea-2-turbo-mlx"
+      },
+      "licenseUrl": "https://www.krea.ai/krea-2-licensing",
+      "ui": {
+        "label": "Krea 2 Turbo",
+        "description": "Krea 2 Turbo — Krea AI's from-scratch foundation image model, distilled to a fast few-step (~8), CFG-free variant: a 28-block single-stream rectified-flow DiT with a Qwen3-VL-4B text encoder, native MLX (Apple Silicon). Strong photorealism up to 2048². Pre-quantized Q8 (~18 GB download, default). Krea 2 Community License (non-commercial). Needs a 48 GB-class Mac.",
+        "recommendedFor": ["text_to_image"],
+        "promptGuide": {
+          "title": "Krea 2 Prompt Guide",
+          "path": "/prompt-guides/krea-2.md",
+          "sources": [
+            { "label": "Krea 2 (Hugging Face)", "url": "https://huggingface.co/krea" },
+            { "label": "Krea 2 Technical Report", "url": "https://www.krea.ai/blog/krea-2-technical-report" }
+          ]
+        }
+      }
+    },
+    {
       "id": "flux2_klein_9b",
       "name": "FLUX.2 [klein] 9B",
       "family": "flux2-klein",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -313,7 +313,15 @@ sceneworks-core = { path = "../sceneworks-core" }
 # to `33d50a3` — a SUPERSET of `80451b3` (keeps Boogu Base/Turbo/Edit + flux2_dev Q4) that also carries
 # gen-core 54e87e9 — so `--features backend-candle --target all` still resolves the SINGLE gen-core rev
 # 54e87e9. 418f900d..54e87e9 is additive (the core_llm re-export + krea); mlx-rs unchanged (44929a0).
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
+# Further bumped `54e87e9` -> `cf6f338` (epic 7565 sc-7572 + epic 7153 sc-7265): mlx-gen main HEAD — adds
+# the `mlx-gen-krea` provider (`krea_2_turbo`, Krea P1; krea dep below) and absorbs #551 (delete the
+# retired `mlx-gen-prompt-refine`, already off this worker — prompt_refine runs through mlx-llm) + #552
+# (joycaption via mlx-llm). `git diff 54e87e9..cf6f338 -- gen-core/` is EMPTY (byte-identical) and the
+# internal mlx-rs pin is unchanged (44929a0), so the worker import surface holds. The candle pin moves
+# `30ce2c2` -> `88a214f` (candle-gen #148 = its own gen-core re-pin to cf6f338; a descendant of 30ce2c2,
+# so it keeps the sc-7459 klein work) so `--features backend-candle --target all` resolves the SINGLE
+# gen-core rev cf6f338. Pin-aligned with the designated worker bump #882 (sc-7265).
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf6f338c68fe6b6cf4b76f22c61a230010d35c51" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -645,7 +653,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf6f338c68fe6b6cf4b76f22c61a230010d35c51" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -657,68 +665,75 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1
 # internal pin (the Lens engine PRs #407–#414 did not move it; nor did the seedvr2 engine #416/#419/
 # #421 or the softness PR #422, so the 1a97909 bump above leaves mlx-rs at 44929a0).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "44929a001ab8a8837403a71c65cf064224de0cdc" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf6f338c68fe6b6cf4b76f22c61a230010d35c51" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf6f338c68fe6b6cf4b76f22c61a230010d35c51" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf6f338c68fe6b6cf4b76f22c61a230010d35c51" }
+# Krea 2 Turbo (native MLX, Krea 2 Community License; epic 7565, sc-7572). Same git rev as mlx-gen.
+# Self-registers `krea_2_turbo` (Qwen3-VL-4B TE + 28-block single-stream DiT + Qwen-Image VAE; CFG-free
+# rectified-flow few-step) via inventory only when force-linked (`use mlx_gen_krea as _;` in
+# image_jobs.rs). Loads the packed Q8/Q4 turnkey subdir (krea_model_subdir; the loader auto-detects the
+# packed quant, so the resolved `spec.quantize` is a no-op on it). Depends on mlx-gen-qwen-image for the
+# shared `AutoencoderKLQwenImage` VAE.
+mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf6f338c68fe6b6cf4b76f22c61a230010d35c51" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf6f338c68fe6b6cf4b76f22c61a230010d35c51" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf6f338c68fe6b6cf4b76f22c61a230010d35c51" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf6f338c68fe6b6cf4b76f22c61a230010d35c51" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf6f338c68fe6b6cf4b76f22c61a230010d35c51" }
 # CLIP ViT-L/14 image embedder for the Dataset Doctor analysis job (epic 6529 P2, sc-6535).
 # Self-registers `clip_vit_l14` (gen_core::ImageEmbedder) via inventory only when force-linked
 # (`use mlx_gen_clip as _;` in dataset_analysis_jobs.rs). Reuses mlx-gen-sdxl's CLIP body → same rev.
-mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
+mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf6f338c68fe6b6cf4b76f22c61a230010d35c51" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf6f338c68fe6b6cf4b76f22c61a230010d35c51" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf6f338c68fe6b6cf4b76f22c61a230010d35c51" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf6f338c68fe6b6cf4b76f22c61a230010d35c51" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf6f338c68fe6b6cf4b76f22c61a230010d35c51" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf6f338c68fe6b6cf4b76f22c61a230010d35c51" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf6f338c68fe6b6cf4b76f22c61a230010d35c51" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf6f338c68fe6b6cf4b76f22c61a230010d35c51" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -727,12 +742,12 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf6f338c68fe6b6cf4b76f22c61a230010d35c51" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf6f338c68fe6b6cf4b76f22c61a230010d35c51" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -741,7 +756,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf6f338c68fe6b6cf4b76f22c61a230010d35c51" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -749,7 +764,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "5
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf6f338c68fe6b6cf4b76f22c61a230010d35c51" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -760,7 +775,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e8
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf6f338c68fe6b6cf4b76f22c61a230010d35c51" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -771,7 +786,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf6f338c68fe6b6cf4b76f22c61a230010d35c51" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -786,7 +801,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e
 # converted in-memory at load (no Python); the precomputed neg-prompt embedding is bundled in-crate. No
 # LoRA/guidance/CFG (one-step). 3B fp16 only here — 7B (sc-5197) + int8 (sc-5198) are engine-side and
 # unwired. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf6f338c68fe6b6cf4b76f22c61a230010d35c51" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -797,7 +812,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf6f338c68fe6b6cf4b76f22c61a230010d35c51" }
 # The unified LLM engine (epic 7153, sc-7158): the macOS `prompt_refine` job now runs through
 # mlx-llm's generic `mlx-llama` provider (a `core_llm::TextLlm`) resolved model-first via
 # `gen_core::core_llm::load_for_model`, RETIRING the bespoke `mlx-gen-prompt-refine` hand-rolled
@@ -819,7 +834,7 @@ mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "29e382bd6a3800
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e87e995f1477176bba815814648ded1f2a65a4" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf6f338c68fe6b6cf4b76f22c61a230010d35c51" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -1066,25 +1081,25 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "54e8
 # SOURCE-ONLY so 30ce2c2 STILL pins gen-core 54e87e9 == this worker's mlx pin (unchanged) — so `--features
 # backend-candle --target all` stays a SINGLE gen-core rev 54e87e9, no mlx bump (the mlx pin already moved
 # to 54e87e9 via #874). T2I (Base/Turbo) attention is byte-identical (chunking only triggers above budget).
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1094,21 +1109,21 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1117,15 +1132,15 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1134,19 +1149,19 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1155,12 +1170,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1168,7 +1183,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1177,7 +1192,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1185,7 +1200,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1194,7 +1209,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1221,7 +1236,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "30ce2c295043b468dce110f512fd40bd8bda66ab", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -407,6 +407,18 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
         default_guidance: 4.0,
         adapter_label: "mlx_boogu",
     },
+    // Krea 2 Turbo (epic 7565) — native MLX, CFG-free rectified-flow few-step T2I (Qwen3-VL-4B TE +
+    // 28-block single-stream DiT + Qwen-Image VAE). 8 steps; guidance is INERT (the `krea_2_turbo`
+    // descriptor advertises supports_guidance=false, so `resolve_guidance` returns None and never
+    // forwards a value). Loads the packed Q8 (default) / Q4 turnkey subdir (`krea_model_subdir`).
+    ModelRow {
+        sceneworks_id: "krea_2_turbo",
+        engine_id: "krea_2_turbo",
+        default_repo: "SceneWorks/krea-2-turbo-mlx",
+        default_steps: 8,
+        default_guidance: 0.0,
+        adapter_label: "mlx_krea",
+    },
 ];
 
 /// The mlx-gen registry ids of the video generators this worker serves (the engine ids

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -56,6 +56,10 @@ use mlx_gen_ideogram as _;
 use mlx_gen_boogu as _;
 #[cfg(target_os = "macos")]
 use mlx_gen_kolors as _;
+// Krea 2 Turbo (epic 7565) — force-link so `inventory::submit!` registers `krea_2_turbo` (else linker GC
+// drops its `ModelRegistration` and `gen_core::load("krea_2_turbo")` returns "no generator registered").
+#[cfg(target_os = "macos")]
+use mlx_gen_krea as _;
 // Lens / Lens-Turbo (epic 3164 engine / sc-5105) — an inventory-registered `Generator` under the ids
 // `lens` + `lens_turbo`, reached through the generic MODEL_TABLE / `generate_stream` path. Force-link
 // or the linker GCs its `ModelRegistration` and `gen_core::load("lens_turbo")` returns "no generator

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -225,6 +225,12 @@ pub(crate) fn resolve_weights_dir(
     ) {
         return Ok(snapshot.map(|root| boogu_model_subdir(&root, request)));
     }
+    // Krea 2 Turbo (epic 7565) ships a turnkey with packed `q8/` (default) + `q4/` self-contained subdirs;
+    // point the engine at the chosen quant's subdir rather than the repo root. The packed weights
+    // auto-detect their quant on load, so the resolved `spec.quantize` is a no-op on them.
+    if request.model == "krea_2_turbo" {
+        return Ok(snapshot.map(|root| krea_model_subdir(&root, request)));
+    }
     Ok(snapshot)
 }
 
@@ -289,6 +295,36 @@ fn boogu_model_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
     }
     present(variant)
         .or_else(|| present(&bf16))
+        .unwrap_or_else(|| root.to_path_buf())
+}
+
+/// Pick the engine-complete packed subdir of a Krea 2 Turbo turnkey `root`: `q4/` when the request opts
+/// into Q4 (`advanced.mlxQuantize <= 4`) AND it is downloaded, else the default `q8/` (the shipped
+/// default — the P1-validated near-lossless quant). Falls back to whichever subdir is present, then
+/// `root`, so a partially-downloaded bundle surfaces as a load error rather than a silent half-load. The
+/// turnkey (`SceneWorks/krea-2-turbo-mlx`, sc-7573) carries one `from_snapshot`-loadable subdir per quant
+/// (each with a packed `transformer/diffusion_pytorch_model.safetensors`); the loader auto-detects the
+/// packed quant, so the resolved `spec.quantize` is a no-op on it. Mirrors [`ideogram_model_subdir`]
+/// (q4/q8 subdirs) with Boogu's packed-transformer filename and a Q8-default selection.
+fn krea_model_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
+    let wants_q4 = request
+        .advanced
+        .get("mlxQuantize")
+        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()))
+        .is_some_and(|bits| bits <= 4);
+    let present = |name: &str| -> Option<PathBuf> {
+        let dir = root.join(name);
+        dir.join("transformer/diffusion_pytorch_model.safetensors")
+            .is_file()
+            .then_some(dir)
+    };
+    if wants_q4 {
+        if let Some(dir) = present("q4") {
+            return dir;
+        }
+    }
+    present("q8")
+        .or_else(|| present("q4"))
         .unwrap_or_else(|| root.to_path_buf())
 }
 

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -712,6 +712,10 @@ fn model_table_rows_resolve_and_flags_match_descriptor() {
         ("boogu_image", true, false),
         ("boogu_image_turbo", false, false),
         ("boogu_image_edit", true, false),
+        // Krea 2 Turbo (epic 7565 / sc-7572): TDM-distilled few-step, CFG-free
+        // (supports_guidance=false) with no user negative prompt (supports_negative_prompt=false) — the
+        // z_image_turbo / boogu_image_turbo distilled-turbo pattern.
+        ("krea_2_turbo", false, false),
     ];
     // Every row is covered by the expectation table (no row added without a flag pair here).
     assert_eq!(MODEL_TABLE.len(), expected.len());


### PR DESCRIPTION
Wires the native-MLX **Krea 2 Turbo** provider (`mlx-gen-krea`, epic 7565 P1) into the SceneWorks worker + web. Covers **sc-7572** and the code halves of **sc-7574** (web surface) and **sc-7575** (drift guard).

## Changes
- **Pin bump (lockstep):** `mlx-gen` `54e87e9 → 014f7c4` (Krea P1 final) across all 25 `mlx-gen-*` + `sceneworks-gen-core` deps + the new `mlx-gen-krea` dep + force-link. `git diff 54e87e9..014f7c4 -- gen-core/` is **EMPTY** (byte-identical contract) and `mlx-rs` is unchanged — pure additive provider code. Deliberately not main HEAD `a6b8922` (#551 deletes `mlx-gen-prompt-refine`, still a worker dep).
- **`MODEL_TABLE`** row `krea_2_turbo` + **`krea_model_subdir`** resolver (Q8 default / Q4 via `mlxQuantize<=4`; packed turnkey subdir, quant auto-detected so `spec.quantize` is a no-op).
- **Manifest** `krea_2_turbo` entry (type image / `text_to_image` / macOnly; Q8 default, minMemoryGb 48; curated sampler+scheduler vocab mirroring `z_image_turbo`) + **`krea-2.md`** prompt guide → auto-gates in Image Studio (sc-7574).
- **Drift-guard test** updated (`krea_2_turbo`: CFG-free, no negative prompt, backend mlx) (sc-7575).

## Companion (required, must merge first)
**SceneWorks/candle-gen#147** re-pins candle-gen's gen-core `54e87e9 → 014f7c4` (byte-identical) so the `desktop-windows.yml` `--features backend-candle` skew gate stays single-rev. This PR pins candle-gen at that branch's tip (`047d126`); **before merge I'll re-point it to candle-gen's merge commit** once #147 lands.

## Validation (local macOS)
`cargo build -p sceneworks-worker` ✓ · `fmt --check` ✓ · `clippy --all-targets -D warnings` ✓ · `cargo test -p sceneworks-worker` ✓ (**367 passed**) · `node scripts/check-scaffold.mjs` ✓ · skew gate default + `--features backend-candle` (worker & rust-api) ✓ (single gen-core rev `014f7c4`).

## Not in this PR
- **sc-7573** re-host publish `SceneWorks/krea-2-turbo-mlx` (q4+q8) to HF — the download target; until it lands the model is wired but not yet runnable. The real-weight worker smoke (sc-7575) is gated on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)