### PR TITLE
Krea 2 [P4 candle]: candle lane for krea_2_turbo (sc-7581)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,6 +585,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "candle-gen-krea"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
+dependencies = [
+ "candle-gen",
+ "candle-gen-qwen-image",
+ "candle-transformers",
+ "inventory",
+ "rand 0.9.4",
+ "rand_distr 0.5.1",
+ "serde_json",
+]
+
+[[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
 source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
@@ -5489,6 +5503,7 @@ dependencies = [
  "candle-gen-instantid",
  "candle-gen-joycaption",
  "candle-gen-kolors",
+ "candle-gen-krea",
  "candle-gen-lens",
  "candle-gen-ltx",
  "candle-gen-prompt-refine",
@@ -7744,7 +7759,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1320,7 +1320,10 @@
       "type": "image",
       "adapter": "mlx_krea",
       "capabilities": ["text_to_image"],
-      "macOnly": true,
+      // macOnly is now a no-op label (mirroring klein/flux2_dev): candle availability is driven by the
+      // routing tables (`CANDLE_ROUTED_MODELS` / `is_candle_engine`), not this flag. The candle
+      // (Windows/Linux) lane lights up off the bf16 download below (sc-7581).
+      "macOnly": false,
       "downloads": [
         {
           // Q8 `q8/` subdir of the SceneWorks/krea-2-turbo-mlx turnkey (sc-7573). Each quant subdir is a
@@ -1338,6 +1341,18 @@
           ],
           "platforms": ["macos"],
           "estimatedSizeBytes": 18000000000
+        },
+        {
+          // Candle (Windows/Linux CUDA) dense bf16 — the ungated public `krea/Krea-2-Turbo` diffusers tree
+          // (Krea 2 Community License). The native candle loader (`Weights::from_dir`) reads the diffusers
+          // subdirs from the snapshot ROOT (no quant subdir — the boogu pattern), so it does NOT use the
+          // MLX `q8/` turnkey above; `candle_krea_repo` reads this entry's `repo`. The repo also ships a
+          // redundant ~24 GB single-file `turbo.safetensors`; skip it (the loader reads only the subdirs).
+          "provider": "huggingface",
+          "repo": "krea/Krea-2-Turbo",
+          "files": ["model_index.json", "transformer/*", "text_encoder/*", "vae/*", "tokenizer/*"],
+          "platforms": ["windows", "linux"],
+          "estimatedSizeBytes": 33800000000
         }
       ],
       "paths": {

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3824,6 +3824,14 @@ const CANDLE_ROUTED_MODELS: &[&str] = &[
     "boogu_image",
     "boogu_image_turbo",
     "boogu_image_edit",
+    // Krea 2 Turbo (epic 7565 P4, sc-7581): the candle `candle-gen-krea` provider serves `krea_2_turbo`
+    // (12B single-stream rectified-flow DiT + Qwen3-VL-4B TE + Qwen-Image VAE, TDM-distilled CFG-free
+    // few-step). Pure **txt2img** — `image_request_candle_eligible` accepts the plain shape and rejects
+    // edit / reference / mask / quant / LoRA (the provider advertises none). The MODEL_TABLE row + manifest
+    // entry are the MLX twin (sc-7572); sc-7581 adds the candle lane (bf16 off the ungated public
+    // `krea/Krea-2-Turbo`, the boogu pattern). NOT yet in `MLX_ROUTED_MODELS` (the mac/MLX routing is a
+    // separate mlx-P2 follow-up), so off-Mac candle is the only native lane today.
+    "krea_2_turbo",
 ];
 
 /// The candle image families that advertise on-the-fly Q4/Q8 quant AND LoRA/LoKr adapters — Lens /

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -392,6 +392,10 @@ backend-candle = [
     # Apache-2.0 ungated. Its `MODEL_TABLE` rows already exist (the MLX twin), so
     # `engines::registry_capabilities` advertises them off-Mac with no further change.
     "dep:candle-gen-boogu",
+    # sc-7581 (epic 7565 P4): the candle Krea 2 image provider (`krea_2_turbo`). MODEL_TABLE row +
+    # manifest entry already exist (the MLX twin sc-7572); sc-7581 adds the candle force-link + the
+    # windows/linux bf16 download.
+    "dep:candle-gen-krea",
     # sc-5576 (epic 3692): the candle Kolors image provider (`kolors` — SDXL UNet + ChatGLM3-6B
     # encoder) and the candle SenseNova-U1 NEO-Unify image provider (`sensenova_u1_8b` +
     # `sensenova_u1_8b_fast`). Both pure T2I; their `MODEL_TABLE` rows already exist (MLX families), so
@@ -1110,6 +1114,14 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
 candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
+# Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
+# Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
+# rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
+# `image_jobs.rs` (`use candle_gen_krea as _;`). The MODEL_TABLE row + manifest entry already exist
+# (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
+# the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
+# as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -122,6 +122,11 @@ use candle_gen_chroma as _;
 // Windows/CUDA sibling of the `mlx_gen_boogu` anchor above.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_boogu as _;
+// Candle Krea 2 (sc-7581, epic 7565 P4): `krea_2_turbo` self-registers into the shared gen_core
+// inventory; `as _;` keeps the MSVC release linker from GC-ing the `ModelRegistration`. The
+// Windows/CUDA sibling of the `mlx_gen_krea` anchor above.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+use candle_gen_krea as _;
 // Candle Kolors (sc-5576, epic 3692): the `kolors` T2I id self-registers into the shared gen_core
 // inventory; `as _;` keeps the MSVC release linker from GC-ing the registration.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -1869,6 +1869,11 @@ fn is_candle_engine(model: &str) -> bool {
             | "boogu_image"
             | "boogu_image_turbo"
             | "boogu_image_edit"
+            // Krea 2 Turbo (sc-7581, epic 7565 P4): pure txt2img on the generic candle lane (CFG-free
+            // 8-step). Like Boogu, its MLX turnkey (`SceneWorks/krea-2-turbo-mlx`, q8/q4 packed) isn't
+            // candle-readable, so the candle lane loads bf16 from the ungated public `krea/Krea-2-Turbo`
+            // snapshot root (no subdir). No edit/reference/control shapes.
+            | "krea_2_turbo"
     )
 }
 
@@ -1892,6 +1897,7 @@ fn candle_adapter_label(model: &str) -> &'static str {
         "sensenova_u1_8b" | "sensenova_u1_8b_fast" => "candle_sensenova",
         "ideogram_4" | "ideogram_4_turbo" => "candle_ideogram",
         "boogu_image" | "boogu_image_turbo" | "boogu_image_edit" => "candle_boogu",
+        "krea_2_turbo" => "candle_krea",
         // sdxl / realvisxl share the candle "sdxl" engine.
         _ => CANDLE_ADAPTER,
     }
@@ -1997,6 +2003,47 @@ fn candle_boogu_repo(request: &ImageRequest) -> String {
         .unwrap_or_else(|| candle_boogu_default_repo(&request.model).to_owned())
 }
 
+/// The candle Krea 2 Turbo weights repo (bf16). The MLX turnkey (`SceneWorks/krea-2-turbo-mlx`, the
+/// `MODEL_TABLE` default + the macOS MLX repo) ships packed `q8/`/`q4/` subdirs, which the candle
+/// provider (dense bf16, `supported_quants: &[]`) can't load — but, like Boogu, Krea needs no re-hosted
+/// bf16 turnkey: the ORIGINAL public `krea/Krea-2-Turbo` (Krea 2 Community License, ungated) is already a
+/// complete bf16 `transformer/ text_encoder/ vae/ tokenizer/` diffusers snapshot at the repo root —
+/// exactly what the provider's `pipeline::load_components` reads. So the candle lane points straight at it
+/// (loaded from the snapshot root — no subdir). Mirrors `candle_boogu_repo` / `candle_ideogram_repo`.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+const CANDLE_KREA_REPO: &str = "krea/Krea-2-Turbo";
+
+/// Resolve the candle Krea weights repo: the off-Mac (`std::env::consts::OS`) download entry's `repo`
+/// from the manifest (the bf16 repo — the single source of truth, also driving the downloader) — else
+/// the [`CANDLE_KREA_REPO`] default. Deliberately NOT the entry-level `repo` / `model_repo`, which is the
+/// macOS MLX turnkey. Mirrors `candle_boogu_repo`.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn candle_krea_repo(request: &ImageRequest) -> String {
+    let os = std::env::consts::OS;
+    request
+        .model_manifest_entry
+        .get("downloads")
+        .and_then(Value::as_array)
+        .and_then(|downloads| {
+            downloads.iter().find_map(|entry| {
+                let matches_os = entry
+                    .get("platforms")
+                    .and_then(Value::as_array)
+                    .is_some_and(|platforms| platforms.iter().any(|p| p.as_str() == Some(os)));
+                if !matches_os {
+                    return None;
+                }
+                entry
+                    .get("repo")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|repo| !repo.is_empty())
+                    .map(str::to_owned)
+            })
+        })
+        .unwrap_or_else(|| CANDLE_KREA_REPO.to_owned())
+}
+
 /// Windows/CUDA candle execution path (sc-3675 SDXL, generalized in sc-5096). The macOS dispatch is
 /// MLX-bound; candle is a narrow **txt2img-only** lane, so this is a trimmed sibling of
 /// [`generate_stream`] that drives the SAME neutral streaming harness (`start_cached_gen_stream` →
@@ -2051,17 +2098,23 @@ async fn generate_candle_stream(
         request.model.as_str(),
         "boogu_image" | "boogu_image_turbo" | "boogu_image_edit"
     );
-    // Ideogram + Boogu are the candle image families whose `MODEL_TABLE` turnkey isn't candle-readable:
-    // the published `SceneWorks/ideogram-4-mlx` / `SceneWorks/boogu-image-mlx` (the macOS MLX repos) are
-    // MLX-quantized, so the candle lane loads bf16 from a different repo. Ideogram re-hosts a bf16 copy
-    // (`SceneWorks/ideogram-4`'s `bf16/` subdir, because the upstream is gated); Boogu points straight at
-    // its ungated public originals (`Boogu/Boogu-Image-0.1-*`, one repo per variant, loaded from the
-    // snapshot root). macOS keeps the MLX turnkeys. Every other candle family shares its upstream diffusers
-    // repo via `model_repo`.
+    // Krea 2 Turbo (sc-7581) is the third such family: its `SceneWorks/krea-2-turbo-mlx` turnkey is packed
+    // q8/q4, so the candle lane loads bf16 from the ungated public `krea/Krea-2-Turbo` (the boogu pattern —
+    // the diffusers snapshot root, no subdir).
+    let is_krea = request.model == "krea_2_turbo";
+    // Ideogram + Boogu + Krea are the candle image families whose `MODEL_TABLE` turnkey isn't
+    // candle-readable: the published `SceneWorks/ideogram-4-mlx` / `SceneWorks/boogu-image-mlx` /
+    // `SceneWorks/krea-2-turbo-mlx` (the macOS MLX repos) are MLX-quantized, so the candle lane loads bf16
+    // from a different repo. Ideogram re-hosts a bf16 copy (`SceneWorks/ideogram-4`'s `bf16/` subdir,
+    // because the upstream is gated); Boogu + Krea point straight at their ungated public originals
+    // (`Boogu/Boogu-Image-0.1-*` / `krea/Krea-2-Turbo`, loaded from the snapshot root). macOS keeps the MLX
+    // turnkeys. Every other candle family shares its upstream diffusers repo via `model_repo`.
     let repo = if is_ideogram {
         candle_ideogram_repo(request)
     } else if is_boogu {
         candle_boogu_repo(request)
+    } else if is_krea {
+        candle_krea_repo(request)
     } else {
         model_repo(request, &model)
     };
@@ -2547,6 +2600,8 @@ mod candle_label_tests {
         assert_eq!(candle_adapter_label("boogu_image"), "candle_boogu");
         assert_eq!(candle_adapter_label("boogu_image_turbo"), "candle_boogu");
         assert_eq!(candle_adapter_label("boogu_image_edit"), "candle_boogu");
+        // Krea 2 Turbo (sc-7581): the candle asset stamp.
+        assert_eq!(candle_adapter_label("krea_2_turbo"), "candle_krea");
         assert_eq!(candle_adapter_label("sdxl"), "candle_sdxl");
         assert_eq!(candle_adapter_label("realvisxl"), "candle_sdxl");
         // Every wired engine carries a `candle_`-prefixed label, distinct from the `mlx_` labels.
@@ -2608,6 +2663,8 @@ mod candle_label_tests {
             "boogu_image",
             "boogu_image_turbo",
             "boogu_image_edit",
+            // Krea 2 Turbo (sc-7581): pure txt2img on the generic candle lane.
+            "krea_2_turbo",
         ] {
             assert!(is_candle_engine(model), "{model} should be a candle engine");
         }


### PR DESCRIPTION
## Krea 2 — candle lane for `krea_2_turbo` (epic 7565 P4, sc-7581)

Adds the candle (Windows/Linux) lane for the Krea 2 Turbo engine ([candle-gen-krea](https://github.com/SceneWorks/candle-gen/pull/145), sc-7580). **Rebased onto the merged mlx P2** ([#880](https://github.com/SceneWorks/SceneWorks/pull/880), sc-7572), which already added the shared `krea_2_turbo` MODEL_TABLE row + manifest entry + `mlx-gen-krea` pin + force-link — so this is now the focused **candle delta**, following the **boogu candle pattern** (load the ungated public bf16 from the snapshot root).

### Changes
- **Cargo.toml** — add `candle-gen-krea` at the existing candle-gen rev `88a214fc` (gen-core `cf6f338c`, already aligned — **no re-pin**) + `dep:candle-gen-krea` in `backend-candle`.
- **image_jobs.rs** — force-link `candle_gen_krea` off-Mac (the sibling of the mlx anchor #880 added).
- **jobs_store.rs** — add `krea_2_turbo` to `CANDLE_ROUTED_MODELS` (pure txt2img; **not** yet in `MLX_ROUTED_MODELS` — the mac routing is a separate mlx-P2 follow-up).
- **base.rs** — `is_candle_engine` + `candle_adapter_label` (`candle_krea`) + a `candle_krea_repo`/`CANDLE_KREA_REPO` override + the `generate_candle_stream` repo dispatch. The MLX turnkey (`SceneWorks/krea-2-turbo-mlx`, packed q8/q4) **isn't candle-readable**, so candle loads bf16 from the ungated public `krea/Krea-2-Turbo` diffusers **root** (no subdir) — exactly Boogu's pattern. Plus the two candle-engine unit tests extended with krea.
- **builtin.models.jsonc** — add the windows/linux bf16 download block (repo `krea/Krea-2-Turbo`, diffusers globs) to the **existing** entry + flip `macOnly` to `false` (candle availability is driven by the routing tables, like flux2_dev).

### Validation
- **Skew gate green**: single `sceneworks-gen-core cf6f338c` + single candle-gen `88a214fc` across `--features backend-candle --target all`.
- Worker **compiles under `backend-candle`**; `manifest_menu_is_subset_of_descriptor` + `candle_backend_lights_up_with_zero_worker_changes` + `candle_image_adapter_labels_are_per_family` + `is_candle_engine_covers_only_the_wired_txt2img_families` all **pass** (krea registers, resolves to the candle engine, menu matches, candle stamp + engine gate correct).
- `sceneworks-core` `candle_routed_models_plain_txt2img_are_eligible` + manifest-seed tests pass.
- Engine real-weight **1024² GPU render validated upstream** (sc-7582): coherent, on-prompt, ~25 s.

### Notes
- No candle converter — the published `krea/Krea-2-Turbo` bf16 loads directly (`Weights::from_dir`), the boogu dense-bf16 precedent.
- The macOS/MLX **routing** (krea into `MLX_ROUTED_MODELS`) is an mlx-P2 follow-up. The entry stays `autoDownload:false` pending the Krea 2 Community License content-filter review (sc-7583).

🤖 Generated with [Claude Code](https://claude.com/claude-code)