### PR TITLE
chore(krea): refresh manifest estimatedSizeBytes to measured Q8 turnkey (sc-7573)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1328,7 +1328,8 @@
         {
           // Q8 `q8/` subdir of the SceneWorks/krea-2-turbo-mlx turnkey (sc-7573). Each quant subdir is a
           // complete `from_snapshot`-loadable root (transformer/ text_encoder/ vae/ tokenizer/ scheduler/
-          // model_index.json). `estimatedSizeBytes` is a pre-publish estimate refreshed by sc-7573.
+          // model_index.json). `estimatedSizeBytes` is the MEASURED q8 turnkey download (sc-7573:
+          // 20,554,619,613 B = transformer 14.57 + text_encoder 5.47 + vae 0.48 GB; rounded up).
           "provider": "huggingface",
           "repo": "SceneWorks/krea-2-turbo-mlx",
           "files": [
@@ -1340,7 +1341,7 @@
             "q8/model_index.json"
           ],
           "platforms": ["macos"],
-          "estimatedSizeBytes": 18000000000
+          "estimatedSizeBytes": 20600000000
         },
         {
           // Candle (Windows/Linux CUDA) dense bf16 — the ungated public `krea/Krea-2-Turbo` diffusers tree
@@ -1395,7 +1396,7 @@
       "licenseUrl": "https://www.krea.ai/krea-2-licensing",
       "ui": {
         "label": "Krea 2 Turbo",
-        "description": "Krea 2 Turbo — Krea AI's from-scratch foundation image model, distilled to a fast few-step (~8), CFG-free variant: a 28-block single-stream rectified-flow DiT with a Qwen3-VL-4B text encoder, native MLX (Apple Silicon). Strong photorealism up to 2048². Pre-quantized Q8 (~18 GB download, default). Krea 2 Community License (non-commercial). Needs a 48 GB-class Mac.",
+        "description": "Krea 2 Turbo — Krea AI's from-scratch foundation image model, distilled to a fast few-step (~8), CFG-free variant: a 28-block single-stream rectified-flow DiT with a Qwen3-VL-4B text encoder, native MLX (Apple Silicon). Strong photorealism up to 2048². Pre-quantized Q8 (~20.5 GB download, default). Krea 2 Community License (non-commercial). Needs a 48 GB-class Mac.",
         "recommendedFor": ["text_to_image"],
         "promptGuide": {
           "title": "Krea 2 Prompt Guide",


### PR DESCRIPTION
Epic 7565 P2, sc-7573 (re-host turnkey `SceneWorks/krea-2-turbo-mlx`).

The Krea 2 Turbo MLX turnkey has been published to `SceneWorks/krea-2-turbo-mlx` (q8 + q4 subdirs, license + attribution). This refreshes the manifest now that the real download size is known.

## Changes (`config/manifests/builtin.models.jsonc`, `krea_2_turbo`)
- MLX download `estimatedSizeBytes`: `18000000000` (pre-publish guess) → **`20600000000`** (measured q8 = 20,554,619,613 B: transformer 14.57 + text_encoder 5.47 + vae 0.48 GB, rounded up).
- UI description: `~18 GB` → `~20.5 GB`.
- Comment updated to record the measured breakdown.

The candle (Windows/Linux) download added in sc-7581 and `macOnly:false` are left untouched.

JSONC re-validated (44 models parse; both downloads intact: macos MLX 20.6 GB + win/linux candle 33.8 GB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)