### PR TITLE
chore(worker): repoint candle JoyCaption onto candle-llm — candle-gen 88a214f → 1b3dc9b (sc-7692)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -520,7 +520,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -562,18 +562,17 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
 dependencies = [
  "candle-gen",
+ "candle-llm",
  "inventory",
- "rand 0.9.4",
- "tokenizers 0.22.2",
 ]
 
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -587,7 +586,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -601,7 +600,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -614,7 +613,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -626,7 +625,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -637,7 +636,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -654,7 +653,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -669,7 +668,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -680,7 +679,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -695,7 +694,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -713,7 +712,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -724,7 +723,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -737,7 +736,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -748,7 +747,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -761,7 +760,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88a214fcb8501d54dc6bc67593573f9758d9b651#88a214fcb8501d54dc6bc67593573f9758d9b651"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -780,6 +779,19 @@ version = "0.10.2"
 source = "git+https://github.com/huggingface/candle?rev=65ecb58c11d2244a7e60c71bdcdb19b15b0a4343#65ecb58c11d2244a7e60c71bdcdb19b15b0a4343"
 dependencies = [
  "cudaforge",
+]
+
+[[package]]
+name = "candle-llm"
+version = "0.0.0"
+source = "git+https://github.com/SceneWorks/candle-llm?rev=8ab61c8dd2b5617cfc6dba1cda978c73bf9d34bf#8ab61c8dd2b5617cfc6dba1cda978c73bf9d34bf"
+dependencies = [
+ "candle-core",
+ "candle-nn",
+ "core-llm",
+ "inventory",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -321,6 +321,14 @@ sceneworks-core = { path = "../sceneworks-core" }
 # `30ce2c2` -> `88a214f` (candle-gen #148 = its own gen-core re-pin to cf6f338; a descendant of 30ce2c2,
 # so it keeps the sc-7459 klein work) so `--features backend-candle --target all` resolves the SINGLE
 # gen-core rev cf6f338. Pin-aligned with the designated worker bump #882 (sc-7265).
+# The candle pin moves further `88a214f` -> `1b3dc9b` (epic 7153 sc-7692, candle-gen #150): the candle
+# twin of #552 — candle-gen-joycaption deletes its in-core JoyCaption model and consumes candle-llm's
+# `candle-llava` VLM provider through the `core_llm` contract. 88a214f..1b3dc9b is additive (the
+# joycaption repoint + the sc-7702 Lens Q8 quant fix); 1b3dc9b still pins gen-core cf6f338c, so the
+# skew gate stays single-rev. This bump brings `candle-llm` (8ab61c8) into the backend-candle graph
+# via candle-gen-joycaption — its `candle-core` rev (65ecb58c) matches candle-gen (one `Tensor`) and
+# its `core-llm` is `branch = "main"` like gen-core's (one rev). The `Captioner` contract +
+# `load_captioner` dispatch + the `use candle_gen_joycaption as _;` force-link are unchanged.
 sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf6f338c68fe6b6cf4b76f22c61a230010d35c51" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -1085,25 +1093,25 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf6f
 # SOURCE-ONLY so 30ce2c2 STILL pins gen-core 54e87e9 == this worker's mlx pin (unchanged) — so `--features
 # backend-candle --target all` stays a SINGLE gen-core rev 54e87e9, no mlx bump (the mlx pin already moved
 # to 54e87e9 via #874). T2I (Base/Turbo) attention is byte-identical (chunking only triggers above budget).
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1113,7 +1121,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1121,21 +1129,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1144,15 +1152,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
-# Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
-# captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
+# Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
+# mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
+# (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
+# provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1161,19 +1171,19 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1182,12 +1192,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1195,7 +1205,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a21
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1204,7 +1214,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1212,7 +1222,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1221,7 +1231,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1248,7 +1258,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88a214fcb8501d54dc6bc67593573f9758d9b651", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with


### PR DESCRIPTION
The candle-side worker pin for **sc-7692** (the candle twin of #882/sc-7265). Bumps all 25 `candle-gen*` pins `88a214f → 1b3dc9b` ([candle-gen #150](https://github.com/SceneWorks/candle-gen/pull/150)) so the worker picks up `candle-gen-joycaption`'s repoint onto candle-llm's `candle-llava` VLM provider.

### What changed
- All 25 `candle-gen*` provider pins move `88a214f → 1b3dc9b` in lockstep (single candle-gen rev for the skew gate). `88a214f..1b3dc9b` is additive: the JoyCaption→candle-llm repoint + the sc-7702 Lens Q8 quant fix.
- **gen-core stays `cf6f338c`** (1b3dc9b pins the same gen-core as 88a214f), so `--features backend-candle --target all` resolves a **single** `sceneworks-gen-core`.
- Brings **`candle-llm` (8ab61c8)** into the backend-candle graph via `candle-gen-joycaption`: its `candle-core` rev (`65ecb58c`) matches candle-gen (one `Tensor`); its `core-llm` is `branch = "main"` like gen-core's (one rev — `58f2e64`, unchanged).
- **No worker code change**: the `Captioner` contract, `gen_core::load_captioner` dispatch, and the `use candle_gen_joycaption as _;` force-link are unchanged.

### Validation
- `scripts/check-gen-core-skew.sh sceneworks-worker --features backend-candle` → **one** gen-core (`cf6f338c`).
- `cargo clippy -p sceneworks-worker --features backend-candle -- -D warnings` → **clean** (the candle lane compiles with candle-llm pulled in). This matters because the backend-candle build is `workflow_dispatch`-only, not a PR gate.
- candle-gen #150 itself was GPU-validated on RTX PRO 6000 (real-weight captioner-contract conformance via the candle-llm engine).

Depends on [candle-gen #150](https://github.com/SceneWorks/candle-gen/pull/150) (merged) and #882/sc-7265-worker-pins (merged — moved the worker to gen-core `cf6f338c`).

Story: https://app.shortcut.com/trefry/story/7692

🤖 Generated with [Claude Code](https://claude.com/claude-code)