### PR TITLE
sc-7404: candle prompt_refine via candle-llm candle-llama (retire candle-gen-prompt-refine)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5967f055e9e19ff0a47819ecf11ac01ae88d4815#5967f055e9e19ff0a47819ecf11ac01ae88d4815"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5967f055e9e19ff0a47819ecf11ac01ae88d4815#5967f055e9e19ff0a47819ecf11ac01ae88d4815"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5967f055e9e19ff0a47819ecf11ac01ae88d4815#5967f055e9e19ff0a47819ecf11ac01ae88d4815"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5967f055e9e19ff0a47819ecf11ac01ae88d4815#5967f055e9e19ff0a47819ecf11ac01ae88d4815"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5967f055e9e19ff0a47819ecf11ac01ae88d4815#5967f055e9e19ff0a47819ecf11ac01ae88d4815"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5967f055e9e19ff0a47819ecf11ac01ae88d4815#5967f055e9e19ff0a47819ecf11ac01ae88d4815"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -520,7 +520,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5967f055e9e19ff0a47819ecf11ac01ae88d4815#5967f055e9e19ff0a47819ecf11ac01ae88d4815"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5967f055e9e19ff0a47819ecf11ac01ae88d4815#5967f055e9e19ff0a47819ecf11ac01ae88d4815"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5967f055e9e19ff0a47819ecf11ac01ae88d4815#5967f055e9e19ff0a47819ecf11ac01ae88d4815"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5967f055e9e19ff0a47819ecf11ac01ae88d4815#5967f055e9e19ff0a47819ecf11ac01ae88d4815"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5967f055e9e19ff0a47819ecf11ac01ae88d4815#5967f055e9e19ff0a47819ecf11ac01ae88d4815"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -586,7 +586,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5967f055e9e19ff0a47819ecf11ac01ae88d4815#5967f055e9e19ff0a47819ecf11ac01ae88d4815"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -600,7 +600,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5967f055e9e19ff0a47819ecf11ac01ae88d4815#5967f055e9e19ff0a47819ecf11ac01ae88d4815"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -613,7 +613,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5967f055e9e19ff0a47819ecf11ac01ae88d4815#5967f055e9e19ff0a47819ecf11ac01ae88d4815"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -623,20 +623,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "candle-gen-prompt-refine"
-version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
-dependencies = [
- "candle-gen",
- "candle-transformers",
- "inventory",
- "serde_json",
-]
-
-[[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5967f055e9e19ff0a47819ecf11ac01ae88d4815#5967f055e9e19ff0a47819ecf11ac01ae88d4815"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -653,7 +642,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5967f055e9e19ff0a47819ecf11ac01ae88d4815#5967f055e9e19ff0a47819ecf11ac01ae88d4815"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -668,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5967f055e9e19ff0a47819ecf11ac01ae88d4815#5967f055e9e19ff0a47819ecf11ac01ae88d4815"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -679,7 +668,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5967f055e9e19ff0a47819ecf11ac01ae88d4815#5967f055e9e19ff0a47819ecf11ac01ae88d4815"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -694,7 +683,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5967f055e9e19ff0a47819ecf11ac01ae88d4815#5967f055e9e19ff0a47819ecf11ac01ae88d4815"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -712,7 +701,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5967f055e9e19ff0a47819ecf11ac01ae88d4815#5967f055e9e19ff0a47819ecf11ac01ae88d4815"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -723,7 +712,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5967f055e9e19ff0a47819ecf11ac01ae88d4815#5967f055e9e19ff0a47819ecf11ac01ae88d4815"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -736,7 +725,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5967f055e9e19ff0a47819ecf11ac01ae88d4815#5967f055e9e19ff0a47819ecf11ac01ae88d4815"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -747,7 +736,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5967f055e9e19ff0a47819ecf11ac01ae88d4815#5967f055e9e19ff0a47819ecf11ac01ae88d4815"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -760,7 +749,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5#1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5967f055e9e19ff0a47819ecf11ac01ae88d4815#5967f055e9e19ff0a47819ecf11ac01ae88d4815"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -5518,7 +5507,6 @@ dependencies = [
  "candle-gen-krea",
  "candle-gen-lens",
  "candle-gen-ltx",
- "candle-gen-prompt-refine",
  "candle-gen-pulid",
  "candle-gen-qwen-image",
  "candle-gen-sam3",
@@ -5529,6 +5517,7 @@ dependencies = [
  "candle-gen-svd",
  "candle-gen-wan",
  "candle-gen-z-image",
+ "candle-llm",
  "futures-util",
  "glob",
  "image",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -432,9 +432,10 @@ backend-candle = [
     # sc-6537: the candle CLIP image + text embedders for the Dataset Doctor analysis job — wired via
     # the neutral `gen_core::load_image_embedder` / `load_text_embedder` seams (dataset_analysis_jobs.rs).
     "dep:candle-gen-clip",
-    # sc-5525 (epic 5095): the candle prompt-refine LLM (Llama-3.2-3B-Instruct), wired into the
-    # worker's prompt_refine job via the neutral `gen_core::load_textllm` seam (sc-5500 contract).
-    "dep:candle-gen-prompt-refine",
+    # sc-7404 (epic 7153): candle-llm's `candle-llama` `core_llm::TextLlm` provider serves the worker's
+    # prompt_refine job, resolved model-first via `gen_core::core_llm::load_for_model` (retiring the
+    # bespoke `candle-gen-prompt-refine` decoder — the twin of the macOS mlx-llm cutover, sc-7158).
+    "dep:candle-llm",
     # sc-5491 (epic 5480): the candle InstantID identity-preserving SDXL provider — the Windows/CUDA
     # sibling of `mlx-gen-instantid`, composing candle-gen-sdxl (IP-Adapter/ControlNet/euler/denoise)
     # + candle-gen-face (SCRFD/ArcFace). A bespoke provider referenced by name (`InstantId::load`),
@@ -832,8 +833,8 @@ mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf6
 # `inventory::submit!` of `mlx-llama` survives the release linker (the "no provider can serve" trap).
 # Same pmetal mlx-rs pin (44929a0) as the mlx-gen crates → one shared `Array` type + one MLX build;
 # mlx-llm's core-llm dep unifies with gen-core's (both branch=main). Serves the same Anubis-Mini-8B
-# (sc-6550) for free-text refine + the JSON-constrained magic-prompt caption. The candle (Windows)
-# lane keeps `candle-gen-prompt-refine` until its twin migration (sc-7404).
+# (sc-6550) for free-text refine + the JSON-constrained magic-prompt caption. The candle (Windows) lane
+# is the symmetric twin: candle-llm's `candle-llama` via the same seam (sc-7404), see `candle-llm` below.
 mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "29e382bd6a3800accf0bac5daf5d8eb61e1a2adf" }
 # SCAIL-2 (zai-org) end-to-end character-animation provider (epic 5439, sc-5448). An inventory-registered
 # `Generator` under id `scail2_14b` (`Modality::Video`): a Wan2.1-14B I2V DiT that animates a reference
@@ -1093,25 +1094,25 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf6f
 # SOURCE-ONLY so 30ce2c2 STILL pins gen-core 54e87e9 == this worker's mlx pin (unchanged) — so `--features
 # backend-candle --target all` stays a SINGLE gen-core rev 54e87e9, no mlx bump (the mlx pin already moved
 # to 54e87e9 via #874). T2I (Base/Turbo) attention is byte-identical (chunking only triggers above budget).
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5967f055e9e19ff0a47819ecf11ac01ae88d4815", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5967f055e9e19ff0a47819ecf11ac01ae88d4815", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5967f055e9e19ff0a47819ecf11ac01ae88d4815", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5967f055e9e19ff0a47819ecf11ac01ae88d4815", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5967f055e9e19ff0a47819ecf11ac01ae88d4815", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5967f055e9e19ff0a47819ecf11ac01ae88d4815", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5967f055e9e19ff0a47819ecf11ac01ae88d4815", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1121,7 +1122,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5967f055e9e19ff0a47819ecf11ac01ae88d4815", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1129,21 +1130,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5967f055e9e19ff0a47819ecf11ac01ae88d4815", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5967f055e9e19ff0a47819ecf11ac01ae88d4815", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5967f055e9e19ff0a47819ecf11ac01ae88d4815", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5967f055e9e19ff0a47819ecf11ac01ae88d4815", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1152,17 +1153,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5967f055e9e19ff0a47819ecf11ac01ae88d4815", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5967f055e9e19ff0a47819ecf11ac01ae88d4815", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5967f055e9e19ff0a47819ecf11ac01ae88d4815", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1171,19 +1172,21 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
-# Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
-# twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
-# `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
-# `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
-# (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
-# single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5967f055e9e19ff0a47819ecf11ac01ae88d4815", features = ["cuda"], optional = true }
+# Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
+# `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
+# `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
+# Force-linked in prompt_refine_jobs.rs (`use candle_llm as _;`) so the MSVC release linker keeps the
+# `inventory::submit!` registration. Pinned to the SAME rev `candle-gen-joycaption` pins (8ab61c8) so
+# cargo unifies ONE candle-llm — one `candle_core::Tensor`, one `core-llm` — across the graph (both
+# candle-llm and candle-gen pin the identical candle-core rev). Retires the bespoke
+# `candle-gen-prompt-refine` hand-rolled Llama decoder.
+candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "8ab61c8dd2b5617cfc6dba1cda978c73bf9d34bf", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5967f055e9e19ff0a47819ecf11ac01ae88d4815", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1192,12 +1195,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5967f055e9e19ff0a47819ecf11ac01ae88d4815", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5967f055e9e19ff0a47819ecf11ac01ae88d4815", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1205,7 +1208,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5967f055e9e19ff0a47819ecf11ac01ae88d4815", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1214,7 +1217,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5967f055e9e19ff0a47819ecf11ac01ae88d4815", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1222,7 +1225,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5967f055e9e19ff0a47819ecf11ac01ae88d4815", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1231,7 +1234,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5967f055e9e19ff0a47819ecf11ac01ae88d4815", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1258,7 +1261,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1b3dc9b56255fdb1e30f3828f639bacd8ddfcbf5", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5967f055e9e19ff0a47819ecf11ac01ae88d4815", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -634,26 +634,18 @@ pub(crate) fn registry_capabilities(
     if has_clip_image && has_clip_text {
         push(Cap::DatasetAnalysis, &mut caps);
     }
-    // Prompt-refinement (sc-5500 contract). Two provider paths advertise the `prompt_refine` cap:
-    //  - candle (Windows, sc-5525): `candle-gen-prompt-refine` registers a `gen_core::TextLlm` under id
-    //    `prompt_refine` — light it up when the `candle` backend is enabled.
-    //  - macOS (epic 7153, sc-7158): prompt_refine now runs through mlx-llm's `mlx-llama`
-    //    (`core_llm::TextLlm`, resolved model-first), which registers in core-llm's registry, NOT
-    //    gen_core's — so light it up when the `mlx` backend is enabled and a core-llm text (non-vision)
-    //    provider is linked. (Retired the old `mlx-gen-prompt-refine` gen_core registration.)
-    // The Python torch `PromptRefiner` stays the fallback on platforms with neither.
-    let candle_prompt_refine = gen_core::registry::textllms().any(|r| {
-        let d = (r.descriptor)();
-        backends.contains(&d.backend) && d.id == "prompt_refine"
-    });
-    #[cfg(target_os = "macos")]
+    // Prompt-refinement (epic 7153). Both native lanes now run through the unified LLM engine — a
+    // generic `core_llm::TextLlm` registered in core-llm's registry (NOT gen_core's), resolved
+    // model-first: mlx-llm's `mlx-llama` on macOS (sc-7158), candle-llm's `candle-llama` on the
+    // Windows/CUDA candle build (sc-7404). Light up `prompt_refine` when an enabled backend has a
+    // core-llm text (non-vision) provider linked — the vision providers (mlx-joycaption / candle-llava)
+    // set `supports_vision` and are excluded. The Python torch `PromptRefiner` stays the fallback on
+    // platforms with neither.
     let native_prompt_refine = gen_core::core_llm::textllms().any(|r| {
         let d = (r.descriptor)();
         backends.contains(&d.backend.as_str()) && !d.capabilities.supports_vision
     });
-    #[cfg(not(target_os = "macos"))]
-    let native_prompt_refine = false;
-    if candle_prompt_refine || native_prompt_refine {
+    if native_prompt_refine {
         push(Cap::PromptRefine, &mut caps);
     }
     caps
@@ -975,24 +967,32 @@ mod tests {
         gen_core::registry::ModelRegistration { descriptor: stub_unknown_descriptor, load: stub_unknown_load }
     }
 
-    // A candle-backed TextLlm stub under id `prompt_refine`: proves the prompt-refine TextLlm
-    // derivation lights up `prompt_refine` purely from a registered descriptor with `backend =
-    // "candle"` (sc-5525), exactly like the generator/captioner derivations above.
-    fn stub_textllm_descriptor() -> gen_core::TextLlmDescriptor {
-        gen_core::TextLlmDescriptor {
-            id: "prompt_refine",
-            family: "llama",
-            backend: "candle",
-            capabilities: gen_core::TextLlmCapabilities::default(),
+    // A candle-backed core-llm `TextLlm` stub (backend "candle", non-vision): proves the prompt-refine
+    // derivation lights up `prompt_refine` purely from a registered `core_llm::TextLlm` descriptor on an
+    // enabled backend (sc-7404), so the default (Linux) CI lane exercises it without linking a real
+    // provider crate. The real lanes register mlx-llama / candle-llama into this SAME core-llm registry.
+    fn stub_textllm_descriptor() -> gen_core::core_llm::TextLlmDescriptor {
+        gen_core::core_llm::TextLlmDescriptor {
+            id: "prompt_refine".to_string(),
+            family: "llama".to_string(),
+            backend: "candle".to_string(),
+            capabilities: gen_core::core_llm::TextLlmCapabilities::default(),
         }
     }
     fn stub_textllm_load(
-        _spec: &gen_core::LoadSpec,
-    ) -> gen_core::Result<Box<dyn gen_core::TextLlm>> {
+        _spec: &gen_core::core_llm::LoadSpec,
+    ) -> gen_core::core_llm::Result<Box<dyn gen_core::core_llm::TextLlm>> {
         unimplemented!("registry-derivation test stub never loads")
     }
+    fn stub_textllm_can_load(_spec: &gen_core::core_llm::LoadSpec) -> bool {
+        false
+    }
     inventory::submit! {
-        gen_core::registry::TextLlmRegistration { descriptor: stub_textllm_descriptor, load: stub_textllm_load }
+        gen_core::core_llm::TextLlmRegistration {
+            descriptor: stub_textllm_descriptor,
+            load: stub_textllm_load,
+            can_load: stub_textllm_can_load,
+        }
     }
 
     #[test]
@@ -1029,11 +1029,11 @@ mod tests {
 
     #[test]
     fn candle_textllm_lights_up_prompt_refine() {
-        // candle enabled ⇒ the candle `prompt_refine` TextLlm stub derives the PromptRefine cap.
+        // candle enabled ⇒ the candle core-llm `TextLlm` stub (non-vision) derives the PromptRefine cap.
         let on = registry_capabilities(&settings_with_backends(false, true));
         assert!(
             on.contains(&Cap::PromptRefine),
-            "an enabled candle backend should derive prompt_refine from its TextLlm descriptor"
+            "an enabled candle backend should derive prompt_refine from its core-llm TextLlm descriptor"
         );
         // both off ⇒ nothing (neither the candle stub nor — on macOS — the real mlx twin is enabled).
         let off = registry_capabilities(&settings_with_backends(false, false));

--- a/crates/sceneworks-worker/src/prompt_refine_jobs.rs
+++ b/crates/sceneworks-worker/src/prompt_refine_jobs.rs
@@ -835,9 +835,8 @@ mod tests {
                 let home = std::env::var("USERPROFILE")
                     .or_else(|_| std::env::var("HOME"))
                     .expect("USERPROFILE/HOME");
-                let snapshots = std::path::Path::new(&home).join(
-                    ".cache/huggingface/hub/models--TheDrummer--Anubis-Mini-8B-v1/snapshots",
-                );
+                let snapshots = std::path::Path::new(&home)
+                    .join(".cache/huggingface/hub/models--TheDrummer--Anubis-Mini-8B-v1/snapshots");
                 std::fs::read_dir(&snapshots)
                     .expect("prompt-refine model staged in the HF cache (or set PROMPT_REFINE_SNAPSHOT)")
                     .flatten()

--- a/crates/sceneworks-worker/src/prompt_refine_jobs.rs
+++ b/crates/sceneworks-worker/src/prompt_refine_jobs.rs
@@ -1,11 +1,11 @@
 //! Native prompt refinement (epic 5095): candle on Windows/CUDA (sc-5525) + MLX on macOS (sc-5552).
 //!
-//! Routes the `prompt_refine` job to a native LLM provider. On macOS (sc-7158, epic 7153) it runs
-//! through the unified mlx-llm engine — the generic `mlx-llama` `core_llm::TextLlm` provider resolved
-//! model-first via `gen_core::core_llm::load_for_model` (Anubis-Mini-8B, sc-6550) — retiring the
-//! bespoke `mlx-gen-prompt-refine` decoder. The Windows candle build still uses the
-//! `candle-gen-prompt-refine` `gen_core::TextLlm` (sc-5525) via `gen_core::load_textllm` until its
-//! twin migration (sc-7404). The Python torch `PromptRefiner`
+//! Routes the `prompt_refine` job to a native LLM provider through the unified LLM engine (epic 7153)
+//! — a generic `core_llm::TextLlm` resolved model-first via `gen_core::core_llm::load_for_model`
+//! (Anubis-Mini-8B, sc-6550), so the dispatch body is one backend-agnostic path: macOS (sc-7158) picks
+//! mlx-llm's `mlx-llama`, the Windows/CUDA candle build (sc-7404) picks candle-llm's `candle-llama`.
+//! Both retired their bespoke hand-rolled Llama decoders (`mlx-gen-prompt-refine` /
+//! `candle-gen-prompt-refine`). The Python torch `PromptRefiner`
 //! (`apps/worker/scene_worker/prompt_refine.py`) stays the fallback only on platforms with neither
 //! native provider (e.g. the candle-less Desktop installer).
 //!
@@ -20,20 +20,15 @@
 use super::*;
 
 // Prompt-refine provider force-link anchors: keep each backend's `inventory::submit!` provider
-// registration from being dropped by the release linker. macOS (sc-7158, epic 7153) force-links
-// `mlx_llm` so the unified `mlx-llama` `core_llm::TextLlm` provider — resolved model-first via
-// `gen_core::core_llm::load_for_model` — survives the linker; the Windows/CUDA candle build keeps
-// sc-5525's `candle_gen_prompt_refine` anchor (its `gen_core::TextLlm` migration is the sc-7404 twin).
+// registration from being dropped by the release linker, so model-first `core_llm::load_for_model`
+// resolution can discover it. macOS (sc-7158, epic 7153) force-links `mlx_llm` for `mlx-llama`; the
+// Windows/CUDA candle build (sc-7404) force-links `candle_llm` for `candle-llama` — both generic
+// `core_llm::TextLlm` providers (retiring the bespoke `mlx-gen-prompt-refine` / `candle-gen-prompt-refine`).
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-use candle_gen_prompt_refine as _;
+use candle_llm as _;
 #[cfg(target_os = "macos")]
 use mlx_llm as _;
 
-// The candle provider's registry id (`prompt::PROMPT_REFINE_ID`). Only the candle lane still routes by
-// id through `gen_core::load_textllm`; the macOS lane resolves mlx-llm model-first (no id), so this is
-// candle-only now (retired on macOS with sc-7158).
-#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-const PROMPT_REFINE_ENGINE_ID: &str = "prompt_refine";
 // The prompt-refinement / magic-prompt checkpoint — the coherent Anubis-8B (sc-6550 bake-off). It
 // serves BOTH the free-text "Refine my prompt" rewrite AND the Ideogram magic-prompt JSON caption:
 // the bake-off found the old 3B (and plain Llama-3.1-8B, stock + abliterated) stochastically emit
@@ -340,15 +335,11 @@ pub(crate) async fn run_prompt_refine_job(
     settings: &Settings,
     job: &JobSnapshot,
 ) -> WorkerResult<()> {
-    // The cooperative cancel handle is created here and threaded into the (backend-specific) request
-    // built inside the blocking task. macOS uses core-llm's CancelFlag (via the gen_core re-export),
-    // the candle lane gen-core's; both expose new()/clone()/cancel()/is_cancelled(), so the shared
-    // orchestration below is identical regardless. The request/load/stream types are backend-specific
-    // and are imported inside each arm of the blocking task.
-    #[cfg(target_os = "macos")]
+    // The cooperative cancel handle is created here and threaded into the request built inside the
+    // blocking task. Both lanes now run through the unified `core_llm` contract, so this is core-llm's
+    // CancelFlag (via the gen_core re-export) on both — new()/clone()/cancel()/is_cancelled() — and the
+    // dispatch body below is a single backend-agnostic path.
     use gen_core::core_llm::CancelFlag;
-    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-    use gen_core::CancelFlag;
 
     let payload = &job.payload;
     let original_prompt = payload
@@ -450,11 +441,11 @@ pub(crate) async fn run_prompt_refine_job(
             json!({ "jobId": job_id, "engine": engine_label }),
         );
 
-        // macOS (sc-7158): resolve mlx-llm's generic provider model-first (no provider id) — a JSON
-        // constraint steers resolution to the JSON-capable `mlx-llama` — and stream through the
-        // `core_llm::TextLlm` contract. The provider renders the model's own chat template, so the
-        // worker supplies only the system + user turns (the product policy stays caller-side).
-        #[cfg(target_os = "macos")]
+        // Resolve the native provider model-first (no provider id) — a JSON constraint steers
+        // resolution to a JSON-capable provider — and stream through the `core_llm::TextLlm` contract.
+        // One backend-agnostic path: the force-linked provider (mlx-llama on macOS, candle-llama on the
+        // Windows candle build) wins resolution. The provider renders the model's own chat template, so
+        // the worker supplies only the system + user turns (the product policy stays caller-side).
         let text = {
             use gen_core::core_llm::{
                 load_for_model_with, Constraint, LoadSpec, Message, ModelRequirements, Sampling,
@@ -467,7 +458,7 @@ pub(crate) async fn run_prompt_refine_job(
             messages.push(Message::user(prompt));
             let request = TextLlmRequest {
                 messages,
-                // The mlx-gen-prompt-refine sampler was plain temperature/top-p (no repetition
+                // The bespoke prompt-refine samplers were plain temperature/top-p (no repetition
                 // penalty / top-k); core-llm's defaults match (top_k 0, repetition_penalty 1.0).
                 sampling: Sampling {
                     temperature,
@@ -478,6 +469,8 @@ pub(crate) async fn run_prompt_refine_job(
                 seed: None,
                 // sc-6585: magic-prompt expansion must emit a structurally-valid JSON caption, so
                 // constrain its decode to the JSON grammar; the free-text rewrite is unconstrained.
+                // (On the candle lane this constraint now actually steers + masks the decode — the
+                // sc-7404 parity gain over the old `candle-gen-prompt-refine` path.)
                 constraint: is_magic.then_some(Constraint::Json),
                 cancel: blocking_cancel.clone(),
                 ..Default::default()
@@ -497,7 +490,7 @@ pub(crate) async fn run_prompt_refine_job(
             if blocking_cancel.is_cancelled() {
                 return Err(WorkerError::Canceled(CANCEL_MESSAGE.to_owned()));
             }
-            // Drive the same (current, total) progress channel the shared loop below reads, counting
+            // Drive the (current, total) progress channel the shared loop below reads, counting
             // generated tokens against the max-new-tokens budget.
             let mut on_event = |event: StreamEvent| {
                 if let StreamEvent::Token { index, .. } = event {
@@ -507,51 +500,6 @@ pub(crate) async fn run_prompt_refine_job(
             let output = refiner.generate(&request, &mut on_event).map_err(|error| {
                 WorkerError::Engine(format!("prompt-refine generation failed: {error}"))
             })?;
-            output.text
-        };
-
-        // candle (Windows/CUDA): unchanged legacy path — the `candle-gen-prompt-refine`
-        // `gen_core::TextLlm` resolved by id (migrates to candle-llm under sc-7404).
-        #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-        let text = {
-            use gen_core::{
-                LoadSpec, Progress, TextLlmConstraint, TextLlmRequest, TextLlmSampling,
-                WeightsSource,
-            };
-            let refiner = gen_core::load_textllm(
-                PROMPT_REFINE_ENGINE_ID,
-                &LoadSpec::new(WeightsSource::Dir(weights_dir)),
-            )
-            .map_err(|error| WorkerError::Engine(format!("prompt-refine load failed: {error}")))?;
-            emit_event(
-                "prompt_refine_load_complete",
-                json!({ "jobId": job_id, "engine": engine_label }),
-            );
-            if blocking_cancel.is_cancelled() {
-                return Err(WorkerError::Canceled(CANCEL_MESSAGE.to_owned()));
-            }
-            let request = TextLlmRequest {
-                system,
-                prompt,
-                sampling: TextLlmSampling {
-                    temperature,
-                    top_p: 0.9,
-                    max_new_tokens,
-                    seed: None,
-                },
-                constraint: is_magic.then_some(TextLlmConstraint::Json),
-                cancel: blocking_cancel.clone(),
-            };
-            let mut on_progress = |progress: Progress| {
-                if let Progress::Step { current, total } = progress {
-                    let _ = tx.blocking_send((current, total));
-                }
-            };
-            let output = refiner
-                .generate(&request, &mut on_progress)
-                .map_err(|error| {
-                    WorkerError::Engine(format!("prompt-refine generation failed: {error}"))
-                })?;
             output.text
         };
 
@@ -847,6 +795,87 @@ mod tests {
         let output = refiner.generate(&request, &mut sink).expect("generate");
         let json = clean_json_output(&output.text);
         eprintln!("magic-prompt JSON:\n{json}");
+
+        let parsed: Value = serde_json::from_str(&json).expect("a valid JSON object");
+        let cd = parsed
+            .get("compositional_deconstruction")
+            .expect("has compositional_deconstruction");
+        assert!(cd.get("background").is_some(), "has a background");
+        assert!(
+            cd.get("elements").map(Value::is_array).unwrap_or(false),
+            "elements is an array"
+        );
+    }
+
+    /// Real-weight magic-prompt smoke (sc-7404) — the Windows/CUDA twin of the macOS test above. Expands
+    /// a plain idea into a JSON caption through the unified candle engine: `gen_core::core_llm::load_for_model`
+    /// resolves candle-llm's `candle-llama` on the Anubis snapshot (the JSON constraint steers the
+    /// model-first pick + masks the decode), and the cleaned reply must parse with the caption's required
+    /// section. This is the candle parity gate for retiring `candle-gen-prompt-refine`. `#[ignore]` — the
+    /// weights live outside CI; run on the CUDA box with the model staged (point `PROMPT_REFINE_SNAPSHOT`
+    /// at the snapshot dir, else it resolves the standard HF cache under `%USERPROFILE%`):
+    ///   cargo test -p sceneworks-worker --lib --features backend-candle --release -- --ignored magic_prompt_expands_plain_text_to_caption_candle --nocapture
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    #[test]
+    #[ignore = "real-weight: needs the Anubis-Mini-8B prompt-refine model staged + a CUDA GPU"]
+    fn magic_prompt_expands_plain_text_to_caption_candle() {
+        use gen_core::core_llm::{
+            load_for_model_with, Constraint, LoadSpec, Message, ModelRequirements, Sampling,
+            StreamEvent, TextLlmRequest,
+        };
+
+        // Force-link `candle-llama` so model-first resolution can discover it in this test binary
+        // (the worker's force-link anchor is cfg'd to the job path, not the test module).
+        use candle_llm as _;
+
+        // An explicit snapshot override wins; otherwise resolve the HF cache under the Windows home.
+        let weights_dir = match std::env::var("PROMPT_REFINE_SNAPSHOT") {
+            Ok(dir) => std::path::PathBuf::from(dir),
+            Err(_) => {
+                let home = std::env::var("USERPROFILE")
+                    .or_else(|_| std::env::var("HOME"))
+                    .expect("USERPROFILE/HOME");
+                let snapshots = std::path::Path::new(&home).join(
+                    ".cache/huggingface/hub/models--TheDrummer--Anubis-Mini-8B-v1/snapshots",
+                );
+                std::fs::read_dir(&snapshots)
+                    .expect("prompt-refine model staged in the HF cache (or set PROMPT_REFINE_SNAPSHOT)")
+                    .flatten()
+                    .map(|entry| entry.path())
+                    .find(|path| path.is_dir())
+                    .expect("a snapshot dir")
+            }
+        };
+
+        let (system, user) = build_magic_prompt_messages(
+            "a red fox sitting in a snowy forest at golden hour",
+            "1:1",
+        );
+        let request = TextLlmRequest {
+            messages: vec![Message::system(system), Message::user(user)],
+            sampling: Sampling {
+                temperature: 0.4,
+                top_p: 0.9,
+                ..Sampling::default()
+            },
+            max_new_tokens: 2048,
+            seed: None,
+            constraint: Some(Constraint::Json), // sc-6585: exercise constrained decoding on candle
+            ..Default::default()
+        };
+        let refiner = load_for_model_with(
+            &LoadSpec {
+                source: weights_dir.to_string_lossy().into_owned(),
+                quantize: None,
+            },
+            &ModelRequirements::from_request(&request),
+        )
+        .expect("load prompt_refine via core-llm model-first resolution (candle-llama)");
+
+        let mut sink = |_event: StreamEvent| {};
+        let output = refiner.generate(&request, &mut sink).expect("generate");
+        let json = clean_json_output(&output.text);
+        eprintln!("magic-prompt JSON (candle):\n{json}");
 
         let parsed: Value = serde_json::from_str(&json).expect("a valid JSON object");
         let cd = parsed


### PR DESCRIPTION
**sc-7404** — the candle/Windows-CUDA twin of the now-DONE **sc-7158**, under epic 7153's LLM-serving unification. The Windows `prompt_refine` job now runs through the unified LLM engine — candle-llm's generic `candle-llama` (`core_llm::TextLlm`) resolved model-first via `gen_core::core_llm::load_for_model` — retiring the bespoke `candle-gen-prompt-refine` hand-rolled Llama decoder.

Paired with **candle-gen [#153](https://github.com/SceneWorks/candle-gen/pull/153)** (deletes the crate).

**Changes**
- **`prompt_refine_jobs.rs`** — collapse the candle dispatch arm onto the SAME `core_llm::load_for_model_with(&spec, &ModelRequirements::from_request(&req))` path the macOS lane already uses (one backend-agnostic body, no cfg-split); force-link `use candle_llm as _;` (was `candle_gen_prompt_refine`). The magic-prompt `Constraint::Json` now actually steers + masks the **candle** decode (the parity gain the story calls out). Product logic (rewrite rules / Ideogram magic-prompt / `<think>`/fence/quote cleanup) is already caller-side and unchanged. Added a candle-gated real-weight magic-prompt smoke (`magic_prompt_expands_plain_text_to_caption_candle`, `#[ignore]`).
- **`engines.rs`** — derive the `prompt_refine` capability from the **core-llm** registry (non-vision text provider on an enabled backend) for BOTH lanes, off the soon-retired `gen_core::registry::textllms()`; convert the unit-test stub from a `gen_core::TextLlm` to a `core_llm::TextLlm` so the default CI lane still exercises the derivation without a real provider crate.
- **`Cargo.toml`** — drop `candle-gen-prompt-refine` (+ its `dep:` feature entry); add direct `candle-llm` (rev `8ab61c8`, matching `candle-gen-joycaption`'s pin → cargo unifies ONE candle-llm); bump the 24 remaining `candle-gen*` pins `1b3dc9b` → `5967f05` (candle-gen #153's content commit).

**Skew gate (no gen-core bump):** `scripts/check-gen-core-skew.sh sceneworks-worker --features backend-candle` → **exactly one** `sceneworks-gen-core` (`cf6f338c`); worker mlx pin and candle pin resolve the same rev.

**Validation**
- ✅ `cargo clippy -p sceneworks-worker --features backend-candle -- -D warnings` — clean (vcvars 14.44 / `CUDA_COMPUTE_CAP=120`).
- ✅ gen-core skew gate single-rev.
- 🔄 Real-weight GPU smoke (magic-prompt JSON through `candle-llama`) in progress on the RTX PRO 6000 — result to follow in a comment.

**Coordination with sc-7189** (gen-core consumes core-llm, in flight Mac-side): this does NOT touch `gen_core::TextLlm` or bump gen-core. It's the last candle `gen_core::TextLlm` implementor, so it lands first on the current gen-core (`cf6f338c`, trait still present); 7189's Phase 3 then retires the trait + does the final lockstep rev bump. SHA-pinning enforces the order.

**Merge order:** candle-gen #153 first (so `5967f05` is on candle-gen `main`), then this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)