### PR TITLE
feat(worker): route LoRA/LoKr training to the candle trainers off-Mac (sc-7817)

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -2049,12 +2049,13 @@ fn job_is_any_mlx_eligible(job: &JobSnapshot) -> bool {
 }
 
 /// True when *any* candle-routing predicate (image, video, image/video upscale, caption,
-/// understanding) claims this job — the union a candle (Windows/CUDA) worker would want, the
-/// off-Mac twin of [`job_is_any_mlx_eligible`] (sc-5502, epic 5483). Used to identify the jobs
+/// understanding, training) claims this job — the union a candle (Windows/CUDA) worker would want,
+/// the off-Mac twin of [`job_is_any_mlx_eligible`] (sc-5502, epic 5483). Used to identify the jobs
 /// the Phase-7 candle grace sweep must fail when no live candle worker is alive
 /// ([`JobsStore::fail_stranded_candle_jobs`]). Deliberately excludes the unsupported-pose shapes
 /// the candle worker only *owns to reject* ([`image_job_candle_pose_reject`]) — those are gaps,
-/// not served, so they must strand/enforce-fail rather than wait for a candle worker.
+/// not served, so they must strand/enforce-fail rather than wait for a candle worker. Training
+/// (sc-7817) is included only for the candle-trainable kernels; the rest stay on the torch worker.
 fn job_is_any_candle_eligible(job: &JobSnapshot) -> bool {
     image_job_is_candle_eligible(job)
         || video_job_is_candle_eligible(job)
@@ -2062,6 +2063,7 @@ fn job_is_any_candle_eligible(job: &JobSnapshot) -> bool {
         || video_upscale_job_is_candle_eligible(job)
         || caption_job_is_mlx_eligible(job)
         || understanding_job_is_mlx_eligible(job)
+        || training_job_is_candle_eligible(job)
 }
 
 /// Actionable terminal error for an MLX-eligible job stranded on macOS with no live `mlx`
@@ -5134,6 +5136,52 @@ fn training_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
     true
 }
 
+/// SceneWorks training kernels with a native candle trainer that needs no base-model disambiguation
+/// (sc-7817, epic 5164) — the off-Mac twin of [`MLX_ROUTED_TRAINING_KERNELS`]. The candle registry
+/// holds trainers for `sdxl`, `z_image_turbo`, `lens`, and the Wan **A14B T2V** MoE
+/// (`wan2_2_t2v_14b`); the first three map straight from kernel, while `wan_moe_lora` is base-model
+/// gated (handled in [`training_job_is_candle_eligible`]). The dense Wan 5B + the I2V A14B have no
+/// candle trainer yet (sc-5167 follow-ups) and Kolors/LTX none at all — those kernels stay on the
+/// Python torch worker off-Mac.
+const CANDLE_ROUTED_TRAINING_KERNELS: &[&str] = &["z_image_lora", "sdxl_lora", "lens_lora"];
+
+/// Epic 5164 / sc-7817 routing — does this `lora_train` job belong on the candle (Windows/CUDA +
+/// Linux/NVIDIA) worker (vs the Python torch worker)? The training sibling of
+/// [`image_job_is_candle_eligible`]/[`video_job_is_candle_eligible`]: the candle engine has a native
+/// trainer for the family. Both dry-run and real runs are eligible (the dry-run validates the same
+/// resolved plan). `wan_moe_lora` is candle-eligible ONLY for the **T2V** A14B base model
+/// (`wan_2_2_t2v_14b`) — the candle Wan trainer is registered under `wan2_2_t2v_14b` only; the I2V
+/// A14B and the dense `wan_lora` 5B have no candle trainer, so they stay on torch. UNLIKE the mlx Wan
+/// path, the candle Wan trainer DOES support LoKr (its `build_lokr_targets` merge), so there is no
+/// LoKr-on-Wan exclusion here. The resolved plan is stamped into the payload at submit (apps/rust-api
+/// training.rs), so the kernel + base model are readable without touching the dataset or weights.
+fn training_job_is_candle_eligible(job: &JobSnapshot) -> bool {
+    if !matches!(job.job_type, JobType::LoraTrain) {
+        return false;
+    }
+    let Some(plan) = job.payload.get("plan").and_then(Value::as_object) else {
+        return false;
+    };
+    let target = plan.get("target").and_then(Value::as_object);
+    let kernel = target
+        .and_then(|target| target.get("kernel"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if CANDLE_ROUTED_TRAINING_KERNELS.contains(&kernel) {
+        return true;
+    }
+    // The A14B MoE: candle registers only the T2V trainer (`wan2_2_t2v_14b`). The I2V A14B base
+    // model has no candle trainer, so it stays on torch.
+    if kernel == "wan_moe_lora" {
+        let base_model = target
+            .and_then(|target| target.get("baseModel"))
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        return base_model == "wan_2_2_t2v_14b";
+    }
+    false
+}
+
 /// sc-3556 routing: SceneWorks training caption jobs keep their public
 /// `captioner=joy_caption` contract while the macOS mlx worker serves them through
 /// mlx-gen's JoyCaption provider. Other/unknown captioners stay off the mlx worker.
@@ -5385,6 +5433,16 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
                 | JobType::PersonReplace
         ) && !video_job_is_candle_eligible(job)
         {
+            return false;
+        }
+        // Training (sc-7817, epic 5164): the candle worker trains only the candle-native families
+        // (sdxl / z_image / lens / the Wan A14B T2V MoE) via `gen_core::load_trainer`. Everything
+        // else — Kolors, LTX, the dense Wan 5B, the Wan I2V A14B — has no candle trainer and stays on
+        // the co-resident Python torch worker. WITHOUT this gate the candle worker would claim a real
+        // training job it can't execute (the `lora_train_execute` advertisement is coarse — it lights
+        // up whenever ANY candle trainer is registered) and fail it terminally instead of leaving it
+        // for torch. Applies to both dry-run and real runs; mirrors the mlx training gate above.
+        if matches!(job.job_type, JobType::LoraTrain) && !training_job_is_candle_eligible(job) {
             return false;
         }
         // Dataset captioning (sc-5098): the candle worker serves only JoyCaption (the candle

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -3676,6 +3676,113 @@ fn mlx_eligible_training_falls_back_to_torch_when_no_mlx_worker() {
     assert_eq!(claimed.assigned_gpu.as_deref(), Some("cuda:0"));
 }
 
+// ── sc-7817: off-Mac candle training routing (epic 5164) ───────────────────────────────────────
+// A candle (Windows/CUDA) worker — a real CUDA gpu_id + the `candle` marker + training caps.
+fn candle_training_caps() -> Vec<WorkerCapability> {
+    vec![
+        WorkerCapability::Gpu,
+        WorkerCapability::LoraTrain,
+        WorkerCapability::LoraTrainExecute,
+        WorkerCapability::Unknown("candle".to_owned()),
+    ]
+}
+
+#[test]
+fn candle_worker_claims_candle_native_training_kernels() {
+    // The four families with a candle trainer (sdxl / z_image / lens / Wan A14B T2V) route to the
+    // candle worker off-Mac. Each in its own store so the claim is unambiguous.
+    let cases: &[(&str, &str, &str)] = &[
+        ("sdxl_lora", "sdxl", "lora"),
+        ("z_image_lora", "z_image_turbo", "lokr"),
+        ("lens_lora", "lens", "lora"),
+        ("wan_moe_lora", "wan_2_2_t2v_14b", "lora"),
+    ];
+    for (kernel, base_model, network_type) in cases {
+        let store = store(&format!("candle-training-{kernel}-{base_model}"));
+        register_gpu_worker(&store, "worker-candle", "0", candle_training_caps());
+        let job = store
+            .create_job(mlx_training_job(
+                kernel,
+                base_model,
+                network_type,
+                false,
+                "auto",
+            ))
+            .expect("job creates");
+        let claimed = store
+            .claim_next_job("worker-candle")
+            .unwrap_or_else(|error| panic!("candle claim ok ({kernel}): {error:?}"))
+            .unwrap_or_else(|| panic!("candle should claim {kernel}/{base_model}"));
+        assert_eq!(claimed.id, job.id, "kernel={kernel} base={base_model}");
+    }
+}
+
+#[test]
+fn candle_worker_refuses_torch_served_training_kernels() {
+    // Kernels with no candle trainer but a torch fallback: the candle worker must REFUSE them (the
+    // `lora_train_execute` advertisement is coarse), leaving them for the co-resident torch worker —
+    // otherwise the candle worker would claim and fail terminally. Covers Kolors, the dense Wan 5B,
+    // and the I2V A14B (candle has only the T2V A14B trainer).
+    let cases: &[(&str, &str)] = &[
+        ("kolors_lora", "kolors"),
+        ("wan_lora", "wan_2_2"),
+        ("wan_moe_lora", "wan_2_2_i2v_14b"),
+    ];
+    for (kernel, base_model) in cases {
+        let store = store(&format!("candle-refuse-{kernel}-{base_model}"));
+        register_gpu_worker(&store, "worker-candle", "0", candle_training_caps());
+        let job = store
+            .create_job(mlx_training_job(kernel, base_model, "lora", false, "auto"))
+            .expect("job creates");
+        assert!(
+            store
+                .claim_next_job("worker-candle")
+                .unwrap_or_else(|error| panic!("candle claim ok ({kernel}): {error:?}"))
+                .is_none(),
+            "candle must refuse {kernel}/{base_model} (no candle trainer)"
+        );
+        // The co-resident torch worker serves it.
+        register_gpu_worker(&store, "worker-torch", "cuda:0", training_caps());
+        let claimed = store
+            .claim_next_job("worker-torch")
+            .expect("torch claim ok")
+            .unwrap_or_else(|| panic!("torch should claim {kernel}/{base_model}"));
+        assert_eq!(claimed.id, job.id, "kernel={kernel} base={base_model}");
+    }
+}
+
+#[test]
+fn candle_worker_refuses_ltx_mlx_only_training() {
+    // ltx_mlx_lora has no torch fallback (MLX_ONLY_TRAINING_KERNELS) AND no candle trainer, so off-Mac
+    // neither the candle worker nor a torch worker may claim it — it stays queued for an mlx worker.
+    let store = store("candle-refuse-ltx");
+    register_gpu_worker(&store, "worker-candle", "0", candle_training_caps());
+    register_gpu_worker(&store, "worker-torch", "cuda:0", training_caps());
+    store
+        .create_job(mlx_training_job(
+            "ltx_mlx_lora",
+            "ltx_2_3",
+            "lora",
+            false,
+            "auto",
+        ))
+        .expect("job creates");
+    assert!(
+        store
+            .claim_next_job("worker-candle")
+            .expect("candle claim ok")
+            .is_none(),
+        "candle must refuse ltx_mlx_lora (no candle trainer)"
+    );
+    assert!(
+        store
+            .claim_next_job("worker-torch")
+            .expect("torch claim ok")
+            .is_none(),
+        "torch must refuse ltx_mlx_lora (mlx-only, no torch trainer)"
+    );
+}
+
 #[test]
 fn ltx_training_is_mlx_worker_only_with_no_torch_fallback() {
     let store = store("mlx-training-ltx-only");

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -437,14 +437,20 @@ pub(crate) const VIDEO_ENGINE_IDS: &[&str] = &[
     "svd_xt",
 ];
 
-/// The mlx-gen trainer registry ids this worker can train (the ids `engine_trainer_id`
-/// maps TO). Trainer descriptors carry no `backend` field at this gen_core rev (a Phase-0
-/// limitation), so the derivation gates the training capabilities on "any backend enabled"
-/// + a registered trainer whose id is one of these, rather than on a per-trainer backend.
+/// The trainer registry ids this worker serves (the ids `engine_trainer_id` maps TO). Used by
+/// [`registry_capabilities`] as the "is this a trainer the worker actually serves" filter: the
+/// training capabilities light up when an enabled backend has a registered trainer whose id is one
+/// of these. Trainer descriptors DO carry `backend` (sc-4906), so the derivation gates per-backend
+/// — a candle trainer lights training up only under `backend_candle_enabled`, an mlx one only under
+/// `backend_mlx_enabled` (see the gate in `registry_capabilities`). `lens` is the mlx (sc-5148) +
+/// candle (sc-7817) Lens trainer. The mlx backend registers all of these; the candle backend only
+/// the subset {`sdxl`, `z_image_turbo`, `lens`, `wan2_2_t2v_14b`} (the Wan 5B / I2V A14B + Kolors /
+/// LTX have no candle trainer — `jobs_store::training_job_is_candle_eligible` keeps them off candle).
 pub(crate) const TRAINER_IDS: &[&str] = &[
     "z_image_turbo",
     "sdxl",
     "kolors",
+    "lens",
     "ltx_2_3",
     "wan2_2_ti2v_5b",
     "wan2_2_t2v_14b",
@@ -995,6 +1001,40 @@ mod tests {
         }
     }
 
+    // A candle-backed stub `Trainer` (backend "candle") registered under an id that IS in TRAINER_IDS
+    // (`sdxl`): proves a Windows/candle backend lights up `lora_train` + `lora_train_execute` from a
+    // registered `backend = "candle"` trainer descriptor alone (sc-7817), so the default (Linux) CI
+    // lane exercises the per-backend training gate without linking a real provider crate. The real
+    // lanes register the candle-gen-{sdxl,z-image,lens,wan} trainers into this SAME registry.
+    //
+    // Compiled out of the `backend-candle` build: there the REAL `candle-gen-sdxl` trainer registers
+    // `sdxl` already (so the capability test still lights up off it), and a stub `sdxl` would be a
+    // DUPLICATE — `load_trainer("sdxl")` is first-wins, so in --release (where the candle GPU smokes
+    // run, debug_assert off) the smoke could resolve THIS `unimplemented!()` stub instead of the real
+    // trainer. On macOS the real trainers are `backend = "mlx"`, so the candle stub is still needed
+    // there to exercise the candle branch, and no macOS smoke loads `sdxl`, so no collision.
+    #[cfg(any(target_os = "macos", not(feature = "backend-candle")))]
+    fn stub_candle_trainer_descriptor() -> gen_core::TrainerDescriptor {
+        gen_core::TrainerDescriptor {
+            id: "sdxl",
+            family: "test",
+            backend: "candle",
+            modality: gen_core::Modality::Image,
+            supports_lora: true,
+            supports_lokr: true,
+        }
+    }
+    #[cfg(any(target_os = "macos", not(feature = "backend-candle")))]
+    fn stub_candle_trainer_load(
+        _spec: &gen_core::LoadSpec,
+    ) -> gen_core::Result<Box<dyn gen_core::Trainer>> {
+        unimplemented!("registry-derivation test stub never loads")
+    }
+    #[cfg(any(target_os = "macos", not(feature = "backend-candle")))]
+    inventory::submit! {
+        gen_core::registry::TrainerRegistration { descriptor: stub_candle_trainer_descriptor, load: stub_candle_trainer_load }
+    }
+
     #[test]
     fn mlx_enabled_advertises_image_generate_from_registry() {
         let caps = registry_capabilities(&settings_with_backends(true, false));
@@ -1038,6 +1078,43 @@ mod tests {
         // both off ⇒ nothing (neither the candle stub nor — on macOS — the real mlx twin is enabled).
         let off = registry_capabilities(&settings_with_backends(false, false));
         assert!(!off.contains(&Cap::PromptRefine));
+    }
+
+    #[test]
+    fn candle_backend_lights_up_lora_train_execute() {
+        // candle enabled ⇒ the candle `sdxl` trainer stub (backend "candle", id in TRAINER_IDS)
+        // derives BOTH the dry-run `lora_train` and the real-run `lora_train_execute` caps — the
+        // off-Mac training cutover (sc-7817). They light up together (same in-process trainer registry).
+        let on = registry_capabilities(&settings_with_backends(false, true));
+        assert!(
+            on.contains(&Cap::LoraTrain),
+            "an enabled candle backend with a registered trainer should derive lora_train"
+        );
+        assert!(
+            on.contains(&Cap::LoraTrainExecute),
+            "an enabled candle backend with a registered trainer should derive lora_train_execute"
+        );
+        // both off ⇒ no training caps from the candle trainer (and on macOS the real mlx trainers are
+        // filtered out too, since neither backend is enabled).
+        let off = registry_capabilities(&settings_with_backends(false, false));
+        assert!(!off.contains(&Cap::LoraTrain));
+        assert!(!off.contains(&Cap::LoraTrainExecute));
+    }
+
+    // Off-macOS the ONLY trainer linked is the candle stub above (backend "candle"); no real mlx
+    // trainer crate is linked. So an mlx-only worker must NOT advertise training off a candle trainer
+    // — proving the per-backend gate (sc-4906) actually keys on `descriptor.backend`. On macOS the
+    // real mlx trainers ARE linked, so an mlx-only worker legitimately advertises training and this
+    // isolation no longer holds (hence the cfg gate).
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn mlx_only_does_not_advertise_training_from_a_candle_trainer() {
+        let mlx_only = registry_capabilities(&settings_with_backends(true, false));
+        assert!(
+            !mlx_only.contains(&Cap::LoraTrainExecute),
+            "off-macOS the only trainer is candle-backed, so an mlx-only worker must not advertise \
+             lora_train_execute"
+        );
     }
 
     // Off-macOS no real mlx prompt_refine provider is linked (only the candle stub above), so an

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -34,11 +34,13 @@ pub(crate) async fn discover_gpu(settings: &Settings) -> DiscoveredGpu {
 
 /// Light up the Windows/CUDA candle SDXL lane on the discovered nvidia GPU (epic 3672, sc-3678).
 /// When the candle backend is enabled, extend the GPU's advertised capabilities with the
-/// registry-DERIVED core (`engines::registry_capabilities` → `image_generate`, from the linked
-/// candle SDXL descriptor) plus a `candle` marker capability. The marker lets the API routing gate
-/// (`jobs_store::worker_supports_job`) recognize this worker and confine it to the SDXL/RealVisXL
-/// txt2img lane — every other shape falls back to the Python torch worker. Mirrors the macOS
-/// `mlx_gpu` derivation, but bolted onto the real nvidia GPU descriptor rather than a sentinel id.
+/// registry-DERIVED core (`engines::registry_capabilities` → `image_generate` / `video_generate`
+/// from the linked candle generator descriptors, plus `lora_train` + `lora_train_execute` from the
+/// linked candle trainers — sc-7817) plus a `candle` marker capability. The marker lets the API
+/// routing gate (`jobs_store::worker_supports_job`) recognize this worker and confine each lane to
+/// the candle-served shapes (txt2img/txt2video, the candle-trainable kernels, …) — every other shape
+/// falls back to the Python torch worker. Mirrors the macOS `mlx_gpu` derivation, but bolted onto
+/// the real nvidia GPU descriptor rather than a sentinel id.
 ///
 /// All-targets signature so `discover_gpu` is uniform; a no-op everywhere except the Windows candle
 /// build with `backend_candle_enabled`, so production routing is unchanged until the lane is on.

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -2965,8 +2965,12 @@ async fn begin_video_cancel_trips_flag_and_stays_non_terminal() {
 
 /// sc-5516 — the training sibling of the above: `begin_training_cancel` trips the
 /// flag and acknowledges with a NON-terminal `running` update; the terminal
-/// `Canceled` is posted by `consume_training_events` after training stops.
-#[cfg(target_os = "macos")]
+/// `Canceled` is posted by `consume_training_events` after training stops. Compiled on the macOS MLX
+/// path AND the off-Mac candle training lane (sc-7817), where `begin_training_cancel` is also linked.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 #[tokio::test]
 async fn begin_training_cancel_trips_flag_and_stays_non_terminal() {
     let (base_url, posts) = spawn_progress_capture_stub().await;

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -9,30 +9,37 @@
 //! it from the staged `manifestEntry` + the files on disk (apps/rust-api jobs.rs
 //! `register_trained_lora`), so the streamed `result` here is informational/UI only.
 //!
-//! Routing (sc-3049): the API only sends MLX-native families
-//! (`z_image_lora`/`sdxl_lora`/`kolors_lora`/`wan_lora`/`wan_moe_lora`/`ltx_mlx_lora`)
-//! here (`jobs_store::training_job_is_mlx_eligible`). `kolors_lora` joined the native
-//! trainers in sc-4732 (engine trainer sc-4568). `lens` and LoKr-on-Wan stay on the
-//! Python torch worker, which also remains the Windows/Linux path + the Mac fallback
-//! (the torch Kolors trainer is kept for those paths too). The dry-run validator is
-//! cross-platform; the real run is macOS-only
-//! (mlx-gen builds Apple MLX) and unreachable elsewhere (the capability is never
-//! advertised off macOS).
+//! Routing (sc-3049, sc-7817): the API sends native-trainable families
+//! (`z_image_lora`/`sdxl_lora`/`kolors_lora`/`lens_lora`/`wan_lora`/`wan_moe_lora`/`ltx_mlx_lora`)
+//! here (`jobs_store::training_job_is_mlx_eligible` on Mac, `…_is_candle_eligible` off-Mac).
+//! `kolors_lora` joined the native trainers in sc-4732 (engine trainer sc-4568); `lens_lora` in
+//! sc-5180. The dry-run validator is cross-platform. The real run executes in-process on the macOS
+//! MLX engine OR — the off-Mac cutover (sc-7817, epic 5164) — on the candle Windows/CUDA + Linux
+//! engine, for the four families with a candle trainer (`sdxl`/`z_image_turbo`/`lens`/the Wan A14B
+//! **T2V** `wan2_2_t2v_14b`). The Python torch trainer stays the fallback for everything off-Mac
+//! with no candle trainer (Kolors, LTX, the dense Wan 5B, the Wan I2V A14B) and the cross-platform
+//! default until candle is the default off-Mac worker.
 
 use super::*;
 use sceneworks_core::training::{TrainingPlan, TRAINING_PLAN_VERSION};
 
-// epic 3720 (sc-3724): the backend-neutral training contract types come from `gen_core`.
-// Force each trainer-provider crate to link so its `inventory::submit!` trainer
-// registration survives linker GC and `load_trainer` can find it. The same crates
-// are referenced by image_jobs/video_jobs for generation; re-stating the training
-// dependency here keeps it explicit and independent of those modules. `cfg(target_os)`
-// decides which backend crates register, not which contract types this module names.
-#[cfg(target_os = "macos")]
+// epic 3720 (sc-3724): the backend-neutral training contract types come from `gen_core`, which is
+// tensor-free and links on every target. The import is gated to the backends that actually run a
+// trainer — macOS (mlx-gen) OR the candle Windows/CUDA + Linux/NVIDIA lane (sc-7817) — only so the
+// non-training default build doesn't carry an unused-import warning.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 use gen_core::{
     CancelFlag, LoadSpec, LrSchedule, NetworkType, Precision, TrainingConfig, TrainingItem,
     TrainingOutput, TrainingProgress, TrainingRequest, WeightsSource,
 };
+// Force each trainer-provider crate to link so its `inventory::submit!` trainer registration
+// survives linker GC and `load_trainer` can find it. The same crates are referenced by
+// image_jobs/video_jobs for generation; re-stating the training dependency here keeps it explicit
+// and independent of those modules. `cfg(target_os)` / `feature` decides which backend's crates
+// register, not which contract types this module names — macOS links the mlx-gen trainers.
 #[cfg(target_os = "macos")]
 use mlx_gen_kolors as _;
 #[cfg(target_os = "macos")]
@@ -45,6 +52,24 @@ use mlx_gen_sdxl as _;
 use mlx_gen_wan as _;
 #[cfg(target_os = "macos")]
 use mlx_gen_z_image as _;
+// The candle (Windows/CUDA + Linux/NVIDIA) trainer-provider crates, force-linked for the off-Mac
+// training cutover (sc-7817, epic 5164). Each self-registers a `backend = "candle"` `Trainer` into
+// the SAME gen_core registry the mlx crates use, so `gen_core::load_trainer(id, …)` resolves the
+// candle trainer by id with no candle-specific dispatch (exactly like the inference path). These
+// four crates are already linked for inference under `backend-candle`; the trainer `inventory::
+// submit!` is NOT behind a separate feature, so re-stating the dependency here is purely explicit.
+// Only the four families with a candle trainer are anchored: `sdxl`, `z_image_turbo`, `lens`, and
+// the Wan **A14B T2V** MoE (`wan2_2_t2v_14b`). The dense Wan 5B + the I2V A14B have no candle
+// trainer yet (sc-5167 follow-ups) and Kolors/LTX none at all — those kernels stay on the Python
+// torch worker off-Mac (`jobs_store::training_job_is_candle_eligible` keeps them from routing here).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+use candle_gen_lens as _;
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+use candle_gen_sdxl as _;
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+use candle_gen_wan as _;
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+use candle_gen_z_image as _;
 
 /// Run a `lora_train` job: parse the resolved plan, then either validate it
 /// (dry run, the default) or execute real training. Mirrors the Python
@@ -252,16 +277,27 @@ fn training_progress(
 }
 
 // --------------------------------------------------------------------------- #
-// Real training — macOS / Apple-Silicon only (mlx-gen builds Apple MLX). The
-// capability is never advertised off macOS, so the non-macOS arm is unreachable.
+// Real training — the in-process native engine: macOS / Apple-Silicon (mlx-gen) OR the candle
+// Windows/CUDA + Linux/NVIDIA lane (sc-7817). The whole section is backend-neutral (it drives the
+// `gen_core::Trainer` contract via `load_trainer`), so it compiles on whichever backend is linked;
+// the registry resolves the trainer by id. The capability is advertised only when a backend with a
+// registered trainer is enabled, so on a build with neither this section is cfg'd out and the stub
+// at the bottom fails loudly.
 // --------------------------------------------------------------------------- #
 
-/// Map a resolved plan's `(kernel, baseModel)` onto the mlx-gen trainer registry id
-/// (the trainer id matches the generator id of the same base model). Wan splits by
-/// the base model variant: the dense TI2V-5B (`wan_lora`) vs the two A14B MoE
-/// variants (`wan_moe_lora` + the T2V/I2V base model). `None` for a family with no
-/// mlx-gen trainer — those never route here, but the mapping fails loudly if one does.
-#[cfg(target_os = "macos")]
+/// Map a resolved plan's `(kernel, baseModel)` onto the trainer registry id (the trainer id matches
+/// the generator id of the same base model). Backend-neutral: the registry resolves it to the mlx
+/// trainer on macOS or the candle trainer off-Mac. Wan splits by the base model variant: the dense
+/// TI2V-5B (`wan_lora`) vs the two A14B MoE variants (`wan_moe_lora` + the T2V/I2V base model).
+/// `None` for a family with no native trainer at all — those never route here, but the mapping fails
+/// loudly if one does. NB the candle registry only holds a subset of these ids (`sdxl`,
+/// `z_image_turbo`, `lens`, `wan2_2_t2v_14b`); the API's `training_job_is_candle_eligible` gate keeps
+/// the candle-untrained ids (Kolors/LTX/Wan-5B/Wan-I2V) off the candle worker, and `load_trainer`
+/// fails loudly as the backstop if one ever slips through.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 fn engine_trainer_id(plan: &TrainingPlan) -> Option<&'static str> {
     match plan.target.kernel.as_str() {
         "z_image_lora" => Some("z_image_turbo"),
@@ -286,7 +322,10 @@ fn engine_trainer_id(plan: &TrainingPlan) -> Option<&'static str> {
 }
 
 /// Read an `advanced` field as a string, trimmed and non-empty, else `default`.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 fn advanced_str(advanced: &JsonObject, key: &str, default: &str) -> String {
     advanced
         .get(key)
@@ -298,7 +337,10 @@ fn advanced_str(advanced: &JsonObject, key: &str, default: &str) -> String {
 }
 
 /// Read an `advanced` field as an f32, else `default`.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 fn advanced_f32(advanced: &JsonObject, key: &str, default: f32) -> f32 {
     advanced
         .get(key)
@@ -312,7 +354,10 @@ fn advanced_f32(advanced: &JsonObject, key: &str, default: f32) -> f32 {
 }
 
 /// Read an `advanced` field as a u32, else `default`.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 fn advanced_u32(advanced: &JsonObject, key: &str, default: u32) -> u32 {
     advanced
         .get(key)
@@ -327,7 +372,10 @@ fn advanced_u32(advanced: &JsonObject, key: &str, default: u32) -> u32 {
 
 /// Read an `advanced` field as a bool (accepting a JSON bool or a `"true"`/`"false"`
 /// string), else `default`.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 fn advanced_bool(advanced: &JsonObject, key: &str, default: bool) -> bool {
     advanced
         .get(key)
@@ -345,7 +393,10 @@ fn advanced_bool(advanced: &JsonObject, key: &str, default: bool) -> bool {
 /// anything unrecognized — falls back to full-precision `"f32"`, matching the
 /// engine's own "unrecognized ⇒ f32" rule. The *absent*-key default is applied by
 /// the caller (`"bf16"`), so a plan that omits the key keeps the OOM fix on.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 fn normalize_train_dtype(value: &str) -> String {
     match value.trim().to_ascii_lowercase().as_str() {
         "bf16" => "bf16".to_owned(),
@@ -358,7 +409,10 @@ fn normalize_train_dtype(value: &str) -> String {
 /// passed verbatim — the engine normalizes aliases (`adamw8bit`→`adamw`,
 /// `prodigyopt`→`prodigy`). An empty `loraTargetModules` lets the family trainer use
 /// its default target set.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 fn map_training_config(config: &sceneworks_core::training::TrainingConfig) -> TrainingConfig {
     let advanced = &config.advanced;
     let lora_target_modules = advanced
@@ -431,19 +485,26 @@ fn map_training_config(config: &sceneworks_core::training::TrainingConfig) -> Tr
 }
 
 /// One progress event streamed from the blocking training thread to the async side.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 enum TrainEvent {
     Progress(TrainingProgress),
     Done(TrainingOutput),
 }
 
-/// Execute a real training run on the in-process mlx-gen engine. Loads the (frozen)
-/// base model via a [`LoadSpec`] (exactly as inference's `load_engine`), runs the
-/// family trainer on a blocking thread, streams staged progress, honors cancellation
-/// via the engine's [`CancelFlag`], and reports the produced adapter. The adapter is
-/// written by the engine into the plan's `output.outputDir`; the API registers it
-/// from the staged manifest entry.
-#[cfg(target_os = "macos")]
+/// Execute a real training run on the in-process native engine (mlx-gen on macOS, candle-gen
+/// off-Mac via `backend-candle`, sc-7817). Loads the (frozen) base model via a [`LoadSpec`] (exactly
+/// as inference's `load_engine`), runs the family trainer on a blocking thread, streams staged
+/// progress, honors cancellation via the engine's [`CancelFlag`], and reports the produced adapter.
+/// The adapter is written by the engine into the plan's `output.outputDir`; the API registers it
+/// from the staged manifest entry. Backend-neutral: `load_trainer(engine_id, …)` resolves whichever
+/// backend's trainer is registered under `engine_id`.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 async fn run_training_execution(
     api: &ApiClient,
     settings: &Settings,
@@ -515,10 +576,12 @@ async fn run_training_execution(
         let cancel = cancel.clone();
         tokio::task::spawn_blocking(move || -> WorkerResult<()> {
             // Load precision tracks the requested `train_dtype` (advanced `mixedPrecision`, default
-            // bf16). The Lens trainer loads its DiT at this precision and enforces `train_dtype`
-            // against it (sc-5148), so f32 training must load at Fp32; the cast-based trainers
+            // bf16). The MLX Lens trainer loads its DiT at this precision and enforces `train_dtype`
+            // against it (sc-5148), so f32 training must load at Fp32; the cast-based MLX trainers
             // (z-image/kolors/sdxl/wan/ltx) load dense and ignore `precision`, so this is inert for
-            // them — the default bf16 path is byte-identical to before.
+            // them — the default bf16 path is byte-identical to before. The candle trainers are lazy
+            // (sc-7817): they build the frozen base inside `train()` at the request's `train_dtype`,
+            // so `LoadSpec.precision` is likewise inert for them and this mapping stays harmless.
             let load_precision = if config.train_dtype.trim().eq_ignore_ascii_case("f32") {
                 Precision::Fp32
             } else {
@@ -580,7 +643,10 @@ async fn run_training_execution(
 /// until the GPU is genuinely idle, and the UI honestly shows "Cancelling…" until completion.
 /// Best-effort: a failed status update here is non-fatal because the post-run terminal write is
 /// what ultimately frees the worker. Mirrors the image path's `begin_image_cancel` (sc-5515).
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 pub(crate) async fn begin_training_cancel(
     api: &ApiClient,
     job_id: &str,
@@ -607,7 +673,10 @@ pub(crate) async fn begin_training_cancel(
 /// cancel ~every 2s (draining after a cancel so the blocking sender never blocks),
 /// and on the final `Done` event report completion with the result the UI shows.
 /// Mirrors `image_jobs::consume_gen_events`.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 #[allow(clippy::too_many_arguments)]
 async fn consume_training_events(
     api: &ApiClient,
@@ -800,7 +869,10 @@ async fn consume_training_events(
 /// message)`. The fractions follow the kernel's bands (prepare 0–.08, load .08–.18,
 /// cache .18–.32, train/checkpoint .32–.92, save .92–1.0) so the UI's existing
 /// `caching_latents`/`training`/`checkpointing`/`saving` stages light up unchanged.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 fn map_training_progress(
     progress: TrainingProgress,
     total_steps: u32,
@@ -859,7 +931,10 @@ fn map_training_progress(
 }
 
 /// Scale a training micro-step into the 0.32–0.92 training band.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 fn train_fraction(step: u32, total: u32) -> f64 {
     if total == 0 {
         return 0.32;
@@ -876,7 +951,10 @@ fn train_fraction(step: u32, total: u32) -> f64 {
 /// Studio reads: `trainingSamples` (cumulative), `latestTrainingSamples` (this cadence),
 /// `samplePrompts` (for labels), and `sampleSettings` (steps + guidance + source). Mirrors the
 /// Python trainer's `_result` sample keys.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 fn training_samples_result(
     all_samples: &[Value],
     latest_samples: &[Value],
@@ -905,7 +983,10 @@ fn training_samples_result(
 /// relative (the UI resolves it as `/api/v1/projects/<id>/files/<relativePath>`); it is omitted when
 /// the project root is unknown (the absolute `path` is still recorded for debugging). PNG encoding +
 /// the atomic temp-then-rename mirror `image_jobs::write_image_asset`.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 #[allow(clippy::too_many_arguments)]
 fn write_training_sample(
     output_dir: Option<&Path>,
@@ -953,7 +1034,10 @@ fn write_training_sample(
     Ok(record)
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 #[allow(clippy::too_many_arguments)]
 fn training_result(
     plan: &TrainingPlan,
@@ -1011,9 +1095,11 @@ fn training_result(
     result
 }
 
-/// Off macOS the mlx-gen engine is not linked; the `lora_train_execute` capability is
-/// never advertised, so a real run can never be claimed here. Fail loudly if one is.
-#[cfg(not(target_os = "macos"))]
+/// With no native trainer backend linked (not macOS/mlx-gen, and `backend-candle` off) the
+/// `lora_train_execute` capability is never advertised, so a real run can never be claimed here.
+/// Fail loudly if one is. Off-Mac with `backend-candle` the real `run_training_execution` above is
+/// compiled instead (sc-7817).
+#[cfg(all(not(target_os = "macos"), not(feature = "backend-candle")))]
 async fn run_training_execution(
     _api: &ApiClient,
     _settings: &Settings,
@@ -1021,7 +1107,8 @@ async fn run_training_execution(
     _plan: &TrainingPlan,
 ) -> WorkerResult<()> {
     Err(WorkerError::InvalidPayload(
-        "Native MLX LoRA training requires macOS (mlx-gen); this worker cannot execute it."
+        "Native LoRA training requires the macOS MLX engine or a `backend-candle` build; this \
+         worker has neither linked and cannot execute it."
             .to_owned(),
     ))
 }
@@ -1145,7 +1232,10 @@ mod tests {
 
     /// sc-4887: only an explicit bf16 selects bf16; every other value (incl. the
     /// engine-unsupported fp16, "no", empty) falls back to full-precision f32.
-    #[cfg(target_os = "macos")]
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
     #[test]
     fn normalize_train_dtype_only_bf16_selects_bf16() {
         assert_eq!(normalize_train_dtype("bf16"), "bf16");
@@ -1159,7 +1249,10 @@ mod tests {
     /// sc-4881 / sc-4887: the two OOM-fix levers must reach the engine config. The
     /// mapping builds it field-by-field (no `..Default::default()`), so a dropped
     /// field silently reverts to the wrong value — exactly the bug this story fixes.
-    #[cfg(target_os = "macos")]
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
     #[test]
     fn map_training_config_wires_train_dtype_and_gradient_checkpointing() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -1468,7 +1561,10 @@ mod tests {
         assert_eq!(summary.get("baseModelInstalled").unwrap(), false);
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
     #[test]
     fn engine_trainer_id_maps_mlx_native_families_and_rejects_the_rest() {
         let cases: &[(&str, &str, Option<&str>)] = &[
@@ -1505,7 +1601,10 @@ mod tests {
         }
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
     #[test]
     fn map_training_config_reads_advanced_and_passes_optimizer_verbatim() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -1539,7 +1638,10 @@ mod tests {
         assert_eq!(cfg.trigger_word, None);
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
     #[test]
     fn map_training_config_defaults_when_advanced_is_empty() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -1571,7 +1673,10 @@ mod tests {
     /// field-by-field (no `..Default`), so a dropped sample field silently disables previews — exactly
     /// the gap this story fixes. Asserts `sampleEvery`/`sampleSteps`/`sampleGuidanceScale`/`samplePrompts`
     /// flow through from the plan's `advanced` bag.
-    #[cfg(target_os = "macos")]
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
     #[test]
     fn map_training_config_wires_sample_fields() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -1607,7 +1712,10 @@ mod tests {
     /// `guidanceScale`/`sampleSource`), with `relativePath` resolved against the project root. Validates
     /// the worker persistence deterministically (no model weights), so the chain engine→worker→UI shape
     /// is covered without a real-weight run.
-    #[cfg(target_os = "macos")]
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
     #[test]
     fn write_training_sample_writes_png_and_project_relative_record() {
         let project_root = tempfile::tempdir().expect("project root tempdir");
@@ -1976,6 +2084,172 @@ mod tests {
         assert!(
             output_dir.join("z_image_1024_smoke.safetensors").exists(),
             "trained adapter was written"
+        );
+    }
+
+    // ── sc-7817: candle (Windows/CUDA + Linux/NVIDIA) real-weight training smokes ──────────────────
+    // The off-Mac twins of the macOS real-weight smokes above. They prove the worker links each
+    // candle trainer's `backend = "candle"` `inventory::submit!` registration (the dead-strip trap),
+    // resolves it via `gen_core::load_trainer(id, …)`, and runs a real step on the CUDA GPU through
+    // the full worker path. Release build only (the GPU smokes hit the debug_assert dup-id panic in
+    // debug, per the candle CI-gap note).
+
+    /// Resolve a snapshot directory for an HF repo from the local Hugging Face hub cache, the way
+    /// `resolve_base_model_path` hands the worker a base model dir. Honors `HF_HUB_CACHE`, then
+    /// `HF_HOME/hub`, then `%USERPROFILE%\.cache\huggingface\hub` (the Windows default). `repo_dir`
+    /// is the hub's `models--<org>--<name>` directory; `require` (when non-empty) filters snapshots
+    /// to one containing that child, so a partial download is skipped.
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    fn candle_hf_snapshot(repo_dir: &str, require: &str) -> std::path::PathBuf {
+        let hub = std::env::var_os("HF_HUB_CACHE")
+            .map(std::path::PathBuf::from)
+            .or_else(|| {
+                std::env::var_os("HF_HOME").map(|h| std::path::PathBuf::from(h).join("hub"))
+            })
+            .or_else(|| {
+                std::env::var_os("USERPROFILE").map(|p| {
+                    std::path::PathBuf::from(p)
+                        .join(".cache")
+                        .join("huggingface")
+                        .join("hub")
+                })
+            })
+            .expect("an HF hub cache (HF_HUB_CACHE / HF_HOME / %USERPROFILE%) must be resolvable");
+        let snapshots = hub.join(repo_dir).join("snapshots");
+        std::fs::read_dir(&snapshots)
+            .unwrap_or_else(|error| panic!("read {}: {error}", snapshots.display()))
+            .flatten()
+            .map(|entry| entry.path())
+            .find(|path| path.is_dir() && (require.is_empty() || path.join(require).exists()))
+            .unwrap_or_else(|| {
+                panic!(
+                    "no snapshot under {} containing {require:?}",
+                    snapshots.display()
+                )
+            })
+    }
+
+    /// Shared body for the candle real-weight training smokes: two LoRA micro-steps on a one-image
+    /// swatch dataset, asserting a finite loss and a written adapter — the candle twin of the macOS
+    /// `z_image_1024_bf16_trains_past_the_first_step` / `kolors_real_weights_*` smokes.
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    fn candle_real_weights_smoke(
+        engine_id: &str,
+        snapshot: &std::path::Path,
+        resolution: u32,
+        file_name: &str,
+    ) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let image_path = tmp.path().join("swatch.png");
+        image::RgbImage::from_fn(resolution, resolution, |x, y| {
+            image::Rgb([(x % 256) as u8, (y % 256) as u8, 128])
+        })
+        .save(&image_path)
+        .expect("write test image");
+        let output_dir = tmp.path().join("out");
+        std::fs::create_dir_all(&output_dir).unwrap();
+
+        let config = TrainingConfig {
+            rank: 4,
+            alpha: 4.0,
+            learning_rate: 1e-4,
+            steps: 2,
+            batch_size: 1,
+            gradient_accumulation: 1,
+            gradient_checkpointing: false,
+            train_dtype: "bf16".to_owned(),
+            resolution,
+            save_every: 0,
+            seed: 42,
+            optimizer: "adamw".to_owned(),
+            weight_decay: 0.0,
+            lr_scheduler: LrSchedule::parse("constant"),
+            lr_warmup_steps: 0,
+            network_type: NetworkType::parse("lora"),
+            decompose_factor: -1,
+            lora_target_modules: Vec::new(),
+            timestep_type: "sigmoid".to_owned(),
+            timestep_bias: "balanced".to_owned(),
+            loss_type: "mse".to_owned(),
+            trigger_word: None,
+            sample_every: 0,
+            sample_prompts: Vec::new(),
+            sample_steps: 20,
+            sample_guidance_scale: 1.0,
+        };
+        let request = TrainingRequest {
+            items: vec![TrainingItem {
+                image_path,
+                caption: "a colorful test swatch".to_owned(),
+            }],
+            config,
+            output_dir: output_dir.clone(),
+            file_name: file_name.to_owned(),
+            trigger_words: Vec::new(),
+            cancel: CancelFlag::new(),
+        };
+
+        let mut trainer = gen_core::load_trainer(
+            engine_id,
+            &LoadSpec::new(WeightsSource::Dir(snapshot.to_path_buf())),
+        )
+        .unwrap_or_else(|error| {
+            panic!("candle {engine_id} trainer loads + is registered (force-link survived GC): {error}")
+        });
+        trainer
+            .validate(&request)
+            .expect("trainer accepts the plan");
+        let mut last_loss = f32::NAN;
+        let output = trainer
+            .train(&request, &mut |progress| {
+                if let TrainingProgress::Training { loss, .. } = progress {
+                    last_loss = loss;
+                }
+            })
+            .expect("training runs a step");
+
+        eprintln!(
+            "[candle-train-smoke {engine_id}] steps={} final_loss={} last_step_loss={} adapter={}",
+            output.steps,
+            output.final_loss,
+            last_loss,
+            output.adapter_path.display()
+        );
+        assert!(output.steps >= 1, "expected at least one micro-step");
+        assert!(output.final_loss.is_finite(), "final loss must be finite");
+        assert!(last_loss.is_finite(), "a training-step loss was observed");
+        assert!(
+            output_dir.join(file_name).exists(),
+            "trained adapter was written"
+        );
+    }
+
+    /// sc-7817 — the candle SDXL training smoke. Loads `load_trainer("sdxl", …)` from the installed
+    /// `stabilityai/stable-diffusion-xl-base-1.0` diffusers snapshot (`text_encoder/ text_encoder_2/
+    /// unet/`) and trains two LoRA micro-steps. Run on demand on the RTX box:
+    /// `cargo test -p sceneworks-worker --lib --release --features backend-candle -- --ignored candle_sdxl_real_weights --nocapture`.
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    #[test]
+    #[ignore = "needs real SDXL weights + a CUDA device; release build (debug_assert dup-id panic)"]
+    fn candle_sdxl_real_weights_trains_a_lora_step() {
+        let snapshot =
+            candle_hf_snapshot("models--stabilityai--stable-diffusion-xl-base-1.0", "unet");
+        candle_real_weights_smoke("sdxl", &snapshot, 512, "candle_sdxl_smoke.safetensors");
+    }
+
+    /// sc-7817 — the candle Z-Image training smoke. Loads `load_trainer("z_image_turbo", …)` from the
+    /// installed `Tongyi-MAI/Z-Image-Turbo` snapshot and trains two LoRA micro-steps. Run on demand:
+    /// `cargo test -p sceneworks-worker --lib --release --features backend-candle -- --ignored candle_z_image_real_weights --nocapture`.
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    #[test]
+    #[ignore = "needs real Z-Image-Turbo weights + a CUDA device; release build (debug_assert dup-id panic)"]
+    fn candle_z_image_real_weights_trains_a_lora_step() {
+        let snapshot = candle_hf_snapshot("models--Tongyi-MAI--Z-Image-Turbo", "");
+        candle_real_weights_smoke(
+            "z_image_turbo",
+            &snapshot,
+            512,
+            "candle_z_image_smoke.safetensors",
         );
     }
 }


### PR DESCRIPTION
## Why

The candle LoRA/LoKr **training kernels already exist** (epic [5164](https://app.shortcut.com/trefry/epic/5164), GPU-verified: SDXL / Z-Image / Wan A14B-T2V / Lens) but the SceneWorks worker **never cut over to them off-Mac**. Off-Mac `run_training_execution` was a deliberate hard stub (`training_jobs.rs`), so **through the product, LoRA training was MLX/macOS-only** — no off-Mac (candle/Windows/Linux) training path for any model. Story [sc-7817](https://app.shortcut.com/trefry/story/7817).

This was also a **live latent bug**: the candle trainers self-register (`backend="candle"`) whenever their crates are linked for inference, so a candle worker with `backend_candle_enabled` **already advertised `lora_train_execute`**, and the candle claim block in `worker_supports_job` had **no `LoraTrain` gate** — so it would claim a real training job, hit the stub, and **fail it terminally** instead of leaving it for the co-resident torch worker.

## What

- **`training_jobs.rs`** — widen the real-training section from `cfg(macos)` → `cfg(any(macos, all(not(macos), backend-candle)))`; force-link the candle trainer crates (`candle-gen-{sdxl,z-image,wan,lens}`, already linked for inference; the trainer `inventory::submit!` is **not** behind a separate cargo feature, so **no Cargo.toml dep change is needed**). The dispatch via `gen_core::load_trainer` is already backend-neutral. The hard stub now compiles only when *neither* backend is linked.
- **`engines.rs`** — reconcile the stale `TRAINER_IDS` comment (trainer descriptors carry `backend` since sc-4906; the per-backend gating was already correct) and add `lens`.
- **`jobs_store.rs`** — add `training_job_is_candle_eligible` + a candle claim gate so the candle worker claims **only** the candle-trainable kernels and leaves the rest on torch; include it in the candle grace-sweep union.
- **`gpu.rs`** — doc-only: the candle worker's training caps already flow through `registry_capabilities` ("lights up with zero worker changes").

## Scope correction vs the story

The candle Wan trainer (sc-5167) registers **only `wan2_2_t2v_14b`** — the dense Wan 5B (`wan2_2_ti2v_5b`) and the I2V A14B (`wan2_2_i2v_14b`) have **no candle trainer yet** (5B blocked on a z48 VAE-encoder port), and Kolors/LTX none at all. So the candle-eligible kernels are **`sdxl_lora` / `z_image_lora` / `lens_lora` / `wan_moe_lora`(T2V-14B only)**; everything else stays on the Python torch worker (retained as the documented off-Mac fallback). Unlike the mlx Wan path, the candle Wan trainer **supports LoKr**, so there's no LoKr-on-Wan exclusion for candle.

## Tests / validation

- **Default lane** (the parity gate): `cargo fmt --check` ✓, `cargo clippy -D warnings` ✓, `sceneworks-core` routing tests (candle claim/refuse for sdxl/z-image/lens/wan-T2V; refuse kolors/wan-5B/wan-I2V→torch; refuse ltx mlx-only) ✓, worker capability tests ✓.
- **`--features backend-candle` lane**: compiles clean on RTX PRO 6000 toolchain (MSVC 14.44 + CUDA 12.x, `CUDA_COMPUTE_CAP=120`); `cargo test --lib --features backend-candle` → **23 training tests pass** incl. the capability test asserting `lora_train_execute` lights up on the candle backend (via the real candle trainers). The widened backend-neutral mapping unit tests now run on the candle lane too.
- Added `#[ignore]` candle real-weight GPU smokes for **SDXL** and **Z-Image** (`load_trainer → train` two micro-steps, finite loss, adapter written), the candle twins of the macOS smokes — to run on the GPU box (release).

## Follow-ups (out of scope here)

- Real-weight GPU validation of the candle Wan-T2V-14B + Lens trainers through the worker path (the SDXL/Z-Image smokes are added; Wan/Lens can be split per the story's acceptance criteria).
- Eventual candle trainers for Wan 5B / Wan I2V / Kolors / LTX, and a candle Krea trainer (epic 7565 P3), would extend `training_job_is_candle_eligible`.
- Staged retirement of the off-Mac Python torch trainers (kept as the default fallback until candle is the default off-Mac worker, mirroring sc-5525).

🤖 Generated with [Claude Code](https://claude.com/claude-code)