### PR TITLE
feat(gpu): user-set shared GPU memory cap (epic 7819)

### DIFF
--- a/apps/desktop/src/main.rs
+++ b/apps/desktop/src/main.rs
@@ -48,6 +48,8 @@ fn main() {
             settings::delete_credential,
             settings::restart_worker,
             settings::get_gpu_info,
+            // GPU memory cap (epic 7819).
+            settings::set_gpu_memory_limit,
             // LAN remote access (epic 4484, stories 4/5).
             settings::get_remote_access,
             settings::set_remote_access,

--- a/apps/desktop/src/settings.rs
+++ b/apps/desktop/src/settings.rs
@@ -180,6 +180,13 @@ pub struct AppSettings {
     /// `credentials` gate, sc-5891). LAN cannot be enabled while this is false.
     #[serde(default)]
     pub remote_password_set: bool,
+    /// User-set GPU memory cap as a fraction (0.1–1.0) of total unified memory (epic 7819).
+    /// `None` = no limit (MLX keeps its own default budget). Stored as a fraction so it's portable
+    /// across machines; the MLX worker spawn derives `fraction × hw.memsize` bytes and applies it to
+    /// the MLX runtime process-globally, covering generations, upscales, AND LoRA training. macOS/MLX
+    /// only today — the candle/Windows path is tracked separately (sc-7826).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gpu_memory_limit_fraction: Option<f32>,
 }
 
 fn settings_path() -> PathBuf {
@@ -482,6 +489,44 @@ fn run_capture(program: &str, args: &[&str]) -> Option<String> {
 #[tauri::command]
 pub fn get_app_settings() -> AppSettings {
     load_settings()
+}
+
+/// Floor for the user's GPU memory fraction — below this even small models can't load and the
+/// worker would just OOM on every job, so the slider clamps here (epic 7819).
+const MIN_GPU_MEMORY_FRACTION: f32 = 0.1;
+
+/// Persist the user's GPU memory cap as a fraction of total unified memory, or clear it. `None`
+/// (and a non-finite or ≥ 1.0 value — 100% is "use everything" = no constraint) clears the cap;
+/// otherwise the value is clamped to `[MIN_GPU_MEMORY_FRACTION, 0.99]`. Mirrors `set_remote_access`:
+/// **persist only** — the worker reads the derived byte ceiling at spawn, so the change takes effect
+/// on the next "Restart worker" (the UI drives that), not mid-job. Returns the updated settings.
+#[tauri::command]
+pub fn set_gpu_memory_limit(fraction: Option<f32>) -> Result<AppSettings, String> {
+    let mut settings = load_settings();
+    settings.gpu_memory_limit_fraction = match fraction {
+        Some(value) if value.is_finite() && value < 1.0 => {
+            Some(value.clamp(MIN_GPU_MEMORY_FRACTION, 0.99))
+        }
+        _ => None,
+    };
+    save_settings(&settings)?;
+    Ok(settings)
+}
+
+/// The configured GPU memory ceiling in BYTES for the MLX worker, or `None` for no limit:
+/// `fraction × hw.memsize` (total unified memory). Read at worker spawn (`supervise_mlx_worker`)
+/// and passed as `SCENEWORKS_GPU_MEMORY_LIMIT_BYTES`, which `run_worker_loop` applies process-
+/// globally. macOS only — the fraction is meaningless without a unified-memory total; the
+/// candle/Windows path is tracked separately (sc-7826).
+#[cfg(target_os = "macos")]
+pub fn gpu_memory_limit_bytes() -> Option<u64> {
+    let fraction = load_settings().gpu_memory_limit_fraction?;
+    if !(fraction.is_finite() && (MIN_GPU_MEMORY_FRACTION..1.0).contains(&fraction)) {
+        return None;
+    }
+    let total =
+        run_capture("sysctl", &["-n", "hw.memsize"]).and_then(|value| value.parse::<u64>().ok())?;
+    Some((total as f64 * fraction as f64).round() as u64)
 }
 
 /// First-run storage state for the splash Step 1 + the in-app wizard gate. The

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -847,6 +847,13 @@ fn supervise_mlx_worker(app: AppHandle, api_port: u16) {
                     "SCENEWORKS_CONFIG_DIR",
                     config_dir().to_string_lossy().to_string(),
                 );
+            // sc-7821 (epic 7819): the user's GPU memory ceiling, as fraction × total unified
+            // memory. run_worker_loop applies it to the MLX runtime process-globally (covers
+            // generations, upscales, AND LoRA training). Absent ⇒ no env ⇒ MLX default budget.
+            // Read here at spawn, so a slider change takes effect on the next worker restart.
+            if let Some(bytes) = crate::settings::gpu_memory_limit_bytes() {
+                command = command.env("SCENEWORKS_GPU_MEMORY_LIMIT_BYTES", bytes.to_string());
+            }
             // The worker muxes generated video with ffmpeg; the desktop ships no
             // system ffmpeg, so point it at the bundled binary (as spawn_api does).
             if let Some(ffmpeg) = resolve_bundled_ffmpeg(&app) {

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -295,6 +295,9 @@ export function ModelManagerScreen() {
   // auth-protected REST signal (epic 4484 story 9). `isDesktop`/`tauriInvoke` come
   // from the unified runtime helper (story 6).
   const [unifiedMemoryGb, setUnifiedMemoryGb] = useState(null);
+  // GPU memory cap (epic 7819): when the user caps GPU memory, per-model fit must be judged
+  // against the *effective* ceiling, not physical RAM. Desktop reads the persisted fraction.
+  const [gpuLimitFraction, setGpuLimitFraction] = useState(null);
   // Gated-model credential presence (sc-1898): only fetched when the catalog has a
   // gated model, so non-gated deployments make no extra credential request.
   const [credentials, setCredentials] = useState([]);
@@ -308,6 +311,15 @@ export function ModelManagerScreen() {
   const isMoeBaseModel = WAN_MOE_BASE_MODELS.has(importForm.baseModel);
   const showSecondaryFileSlot = isMoeBaseModel && importForm.mode === "file";
   const moeMissingSecondary = showSecondaryFileSlot && Boolean(importForm.file) && !importForm.secondaryFile;
+  // Effective GPU memory available to generations under the user's cap (epic 7819). A capped app
+  // can run fewer models than the Mac's physical memory implies, so gate per-model fit on this.
+  const memoryIsCapped =
+    unifiedMemoryGb != null &&
+    typeof gpuLimitFraction === "number" &&
+    Number.isFinite(gpuLimitFraction) &&
+    gpuLimitFraction > 0 &&
+    gpuLimitFraction < 1;
+  const effectiveMemoryGb = memoryIsCapped ? unifiedMemoryGb * gpuLimitFraction : unifiedMemoryGb;
 
   useEffect(() => {
     if (familyFilter !== "all" && !families.includes(familyFilter)) {
@@ -337,6 +349,16 @@ export function ModelManagerScreen() {
         .then((info) => {
           if (!cancelled && info && typeof info.unifiedMemoryMb === "number") {
             setUnifiedMemoryGb(info.unifiedMemoryMb / 1024);
+          }
+        })
+        .catch(() => {});
+      // GPU memory cap (epic 7819): the persisted fraction lowers the effective ceiling used for
+      // per-model fit, so a capped app flags the models it can no longer hold.
+      tauriInvoke("get_app_settings")
+        .then((appSettings) => {
+          if (!cancelled && appSettings) {
+            const fraction = appSettings.gpuMemoryLimitFraction;
+            setGpuLimitFraction(typeof fraction === "number" ? fraction : null);
           }
         })
         .catch(() => {});
@@ -588,7 +610,7 @@ export function ModelManagerScreen() {
     // MLX (macOS) variant: only present when the catalog computed mlxConversionState.
     const mlxState = model.mlxConversionState;
     const mlxMinGb = model.mlx?.minMemoryGb ?? null;
-    const mlxEnoughMemory = unifiedMemoryGb == null || mlxMinGb == null || unifiedMemoryGb >= mlxMinGb;
+    const mlxEnoughMemory = effectiveMemoryGb == null || mlxMinGb == null || effectiveMemoryGb >= mlxMinGb;
     const convertJobs = convertJobsFor(model);
     const convertJob = convertJobs.find((job) => !terminalStatuses.has(job.status));
     const failedConvert = convertJobs.find((job) => terminalStatuses.has(job.status) && job.status !== "completed");
@@ -669,7 +691,11 @@ export function ModelManagerScreen() {
             <p>{mlxStatusText(model)}</p>
             {!mlxEnoughMemory ? (
               <p className="inline-warning">
-                Needs ≥ {mlxMinGb} GB unified memory; this Mac has ~{Math.round(unifiedMemoryGb)} GB. It may run out of memory.
+                Needs ≥ {mlxMinGb} GB unified memory;{" "}
+                {memoryIsCapped
+                  ? `the app is limited to ~${Math.round(effectiveMemoryGb)} GB by your GPU memory cap`
+                  : `this Mac has ~${Math.round(effectiveMemoryGb)} GB`}
+                . It may run out of memory.
               </p>
             ) : null}
             {convertJob ? <WorkerProgressCard job={convertJob} onCancel={onCancelJob} onOpenQueue={onOpenQueue} /> : null}

--- a/apps/web/src/screens/SettingsScreen.jsx
+++ b/apps/web/src/screens/SettingsScreen.jsx
@@ -17,6 +17,14 @@ import { isDesktop, tauriInvoke as invoke } from "../runtime.js";
 // server / remote browser). `isDesktop`/`invoke` come from the unified runtime
 // helper (story 6).
 
+// GPU memory cap (epic 7819). The persisted value is a fraction (0.1–0.99) of total unified
+// memory, or null/absent for "no limit". The slider works in whole percent; 100% means Off.
+const GPU_LIMIT_MIN_PERCENT = 10;
+function fractionToPercent(fraction) {
+  if (typeof fraction !== "number" || !Number.isFinite(fraction) || fraction >= 1) return 100;
+  return Math.min(100, Math.max(GPU_LIMIT_MIN_PERCENT, Math.round(fraction * 100)));
+}
+
 export function SettingsScreen() {
   const [settings, setSettings] = useState(null);
   const [gpu, setGpu] = useState(null);
@@ -31,6 +39,9 @@ export function SettingsScreen() {
   const [remote, setRemote] = useState(null);
   const [remotePort, setRemotePort] = useState("");
   const [remotePassword, setRemotePassword] = useState("");
+  // GPU memory cap (epic 7819). Local slider percent for smooth dragging; committed to the shell
+  // on release. 100 = Off (no limit). Synced from persisted settings once they load.
+  const [gpuLimitPercent, setGpuLimitPercent] = useState(100);
 
   const refresh = useCallback(async () => {
     try {
@@ -59,6 +70,11 @@ export function SettingsScreen() {
   useEffect(() => {
     refresh();
   }, [refresh]);
+
+  // Keep the slider in sync with the persisted cap (also after a commit echoes settings back).
+  useEffect(() => {
+    if (settings) setGpuLimitPercent(fractionToPercent(settings.gpuMemoryLimitFraction));
+  }, [settings]);
 
   const secretStore = gpu?.platform === "windows" ? "Credential Manager" : "Keychain";
   const credentialLocation = isDesktop
@@ -124,6 +140,22 @@ export function SettingsScreen() {
         await apiFetch("/api/v1/worker/restart", serverToken(), { method: "POST" });
       }
       setStatus("Restarting the inference worker…");
+    } catch (error) {
+      setStatus(String(error));
+    }
+  }
+
+  async function commitGpuMemoryLimit(percent) {
+    try {
+      // 100% = no limit → send null so the shell clears the cap; otherwise a fraction (0.1–0.99).
+      const fraction = percent >= 100 ? null : percent / 100;
+      const updated = await invoke("set_gpu_memory_limit", { fraction });
+      setSettings(updated);
+      setStatus(
+        fraction == null
+          ? "GPU memory limit removed. Restart the worker to apply."
+          : `GPU memory limit set to ${percent}%. Restart the worker to apply.`,
+      );
     } catch (error) {
       setStatus(String(error));
     }
@@ -412,6 +444,35 @@ export function SettingsScreen() {
                 ? ` · GPU cap: ${Math.round(gpu.wiredLimitMb / 1024)} GB`
                 : ""}
             </p>
+          ) : null}
+          {gpu?.platform === "macos" && gpu?.unifiedMemoryMb ? (
+            <div className="settings-gpu-cap">
+              <label htmlFor="gpu-memory-cap">
+                GPU memory limit:{" "}
+                {gpuLimitPercent >= 100
+                  ? "Off — no limit"
+                  : `${Math.round((gpu.unifiedMemoryMb / 1024) * (gpuLimitPercent / 100))} GB of ` +
+                    `${Math.round(gpu.unifiedMemoryMb / 1024)} GB (${gpuLimitPercent}%)`}
+              </label>
+              <input
+                id="gpu-memory-cap"
+                type="range"
+                min={GPU_LIMIT_MIN_PERCENT}
+                max={100}
+                step={5}
+                value={gpuLimitPercent}
+                aria-label="GPU memory limit (percent of unified memory)"
+                onChange={(event) => setGpuLimitPercent(Number(event.target.value))}
+                onMouseUp={(event) => commitGpuMemoryLimit(Number(event.target.value))}
+                onKeyUp={(event) => commitGpuMemoryLimit(Number(event.target.value))}
+                onTouchEnd={(event) => commitGpuMemoryLimit(Number(event.target.value))}
+              />
+              <p className="settings-help">
+                Caps the shared memory generations and LoRA training may use, leaving the rest for
+                the system. This is a soft target, not a hard limit — set it too low and large models
+                may slow down or fail. Takes effect when you restart the worker.
+              </p>
+            </div>
           ) : null}
           {gpu?.platform === "macos" ? (
             <p className="settings-help">

--- a/crates/sceneworks-worker/src/caption_jobs.rs
+++ b/crates/sceneworks-worker/src/caption_jobs.rs
@@ -644,6 +644,7 @@ mod tests {
             utility_workers: 1,
             backend_mlx_enabled: true,
             backend_candle_enabled: false,
+            gpu_memory_limit_bytes: 0,
         }
     }
 

--- a/crates/sceneworks-worker/src/dataset_analysis_jobs.rs
+++ b/crates/sceneworks-worker/src/dataset_analysis_jobs.rs
@@ -494,6 +494,7 @@ mod tests {
             utility_workers: 1,
             backend_mlx_enabled: true,
             backend_candle_enabled: false,
+            gpu_memory_limit_bytes: 0,
         }
     }
 

--- a/crates/sceneworks-worker/src/downloads.rs
+++ b/crates/sceneworks-worker/src/downloads.rs
@@ -1179,6 +1179,7 @@ mod ensure_cached_file_tests {
             utility_workers: 1,
             backend_mlx_enabled: true,
             backend_candle_enabled: false,
+            gpu_memory_limit_bytes: 0,
         };
         let api = ApiClient::new(&settings);
         let context = DownloadContext {

--- a/crates/sceneworks-worker/src/generator_cache.rs
+++ b/crates/sceneworks-worker/src/generator_cache.rs
@@ -227,6 +227,44 @@ fn release_backend_cache_after_evict() {
 #[cfg(any(not(target_os = "macos"), test))]
 fn release_backend_cache_after_evict() {}
 
+/// Apply the user-configured GPU memory ceiling to the MLX runtime (epic 7819, sc-7820).
+///
+/// `bytes == 0` is a no-op — MLX keeps its own default budget (1.5× the device recommended working
+/// set), so an unset limit is byte-identical to prior behavior. When non-zero we set two MLX knobs:
+/// - `set_memory_limit` — soft backpressure: when active memory exceeds the limit MLX blocks and
+///   waits for in-flight GPU work to drain rather than hard-failing. It is a target, not a hard
+///   sandbox; a single oversized allocation can still exceed it (and on a too-low cap a model whose
+///   working set genuinely needs more will thrash/swap or hit a Metal OOM — already contained by the
+///   `catch_unwind` guard above).
+/// - `set_wired_limit` — caps pinned (non-pageable) residency so the OS can reclaim the rest of
+///   unified memory for other apps. macOS 15+.
+///
+/// We deliberately leave `set_cache_limit` at its default: forcing it low causes reallocation storms
+/// between steps (the fork's own doc warns about this).
+///
+/// The MLX limit is **process-global**, so calling this once at worker startup (before any model
+/// load) covers generations, upscales, AND LoRA training — even though training takes a separate
+/// path from the generator cache.
+#[cfg(all(target_os = "macos", not(test)))]
+pub(crate) fn apply_gpu_memory_limit(bytes: u64) {
+    if bytes == 0 {
+        return;
+    }
+    let bytes = bytes as usize;
+    let previous_limit = mlx_rs::memory::set_memory_limit(bytes);
+    let previous_wired = mlx_rs::memory::set_wired_limit(bytes);
+    tracing::info!(
+        event = "gpu_memory_limit_applied",
+        limitBytes = bytes,
+        previousLimitBytes = previous_limit,
+        previousWiredLimitBytes = previous_wired,
+        "applied user-configured GPU memory ceiling to the MLX runtime"
+    );
+}
+
+#[cfg(any(not(target_os = "macos"), test))]
+pub(crate) fn apply_gpu_memory_limit(_bytes: u64) {}
+
 /// Best-effort human-readable text from a caught panic payload — the `&str`/`String` a `panic!`
 /// produces. mlx-rs `.unwrap()`/`.expect()` panics carry their formatted message as a `String`
 /// (e.g. the `[metal::malloc] Attempting to allocate …` Metal OOM), so this surfaces the real cause.

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -360,6 +360,10 @@ pub async fn run_worker_loop(settings: Settings) -> WorkerResult<()> {
         gpuId = %settings.gpu_id,
         "rust_worker gen-core contract version"
     );
+    // sc-7820 (epic 7819): apply the user's GPU memory ceiling to the MLX runtime once at startup,
+    // before any model load. The MLX limit is process-global, so this single call covers
+    // generations, upscales, AND LoRA training. No-op when unset (0) and on non-macOS/candle builds.
+    generator_cache::apply_gpu_memory_limit(settings.gpu_memory_limit_bytes);
     let gpu = discover_gpu(&settings).await;
     let api = ApiClient::new(&settings);
     let http_client = reqwest::Client::new();

--- a/crates/sceneworks-worker/src/settings.rs
+++ b/crates/sceneworks-worker/src/settings.rs
@@ -39,6 +39,13 @@ pub struct Settings {
     /// env var still overrides either way (set `0` to force a candle build back onto the Python
     /// torch fallback during a staged rollout).
     pub backend_candle_enabled: bool,
+    /// Soft ceiling, in bytes, on the shared/unified GPU memory the MLX runtime may use, from
+    /// `SCENEWORKS_GPU_MEMORY_LIMIT_BYTES` (epic 7819, sc-7820). `0` (the default / unset) leaves
+    /// MLX at its own budget — byte-identical to prior behavior. When non-zero it is applied
+    /// **process-globally** at worker startup via `generator_cache::apply_gpu_memory_limit`, so a
+    /// single value covers generations, upscales, AND LoRA training in this process. macOS/MLX only;
+    /// inert on candle/CPU builds (the cross-platform path is tracked separately as sc-7826).
+    pub gpu_memory_limit_bytes: u64,
 }
 
 impl Settings {
@@ -99,6 +106,7 @@ impl Settings {
                 "SCENEWORKS_BACKEND_CANDLE_ENABLED",
                 cfg!(feature = "backend-candle"),
             ),
+            gpu_memory_limit_bytes: env_u64_any(&["SCENEWORKS_GPU_MEMORY_LIMIT_BYTES"], 0),
         }
     }
 }

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -2735,6 +2735,7 @@ fn test_settings(huggingface_base_url: String, huggingface_token: Option<&str>) 
         utility_workers: 1,
         backend_mlx_enabled: true,
         backend_candle_enabled: false,
+        gpu_memory_limit_bytes: 0,
     }
 }
 

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -1059,6 +1059,7 @@ mod tests {
             utility_workers: 1,
             backend_mlx_enabled: true,
             backend_candle_enabled: false,
+            gpu_memory_limit_bytes: 0,
         }
     }
 


### PR DESCRIPTION
## What

Adds a **Settings slider that caps how much shared/unified GPU memory** SceneWorks may use for generations, upscales, and LoRA training. On a 128 GB Mac, 50% targets ~64 GB and leaves the rest for the OS/other apps. Surfaces an MLX capability the pinned `pmetal-mlx-rs` fork already exposes — **no fork bump**.

Epic [sc-7819](https://app.shortcut.com/trefry/epic/7819). This PR is the macOS/MLX MVP vertical (sc-7820/7821/7822).

## How

- **Worker ([sc-7820](https://app.shortcut.com/trefry/story/7820))** — `Settings.gpu_memory_limit_bytes` from `SCENEWORKS_GPU_MEMORY_LIMIT_BYTES`; `generator_cache::apply_gpu_memory_limit` calls `set_memory_limit` + `set_wired_limit` (macOS/`not(test)`; no-op elsewhere). Applied **at `run_worker_loop` startup**, not in the generator-cache thread, because LoRA training bypasses that cache and the MLX limit is **process-global** — one call covers generation, upscale, and training. `set_cache_limit` left at default (forcing it low causes realloc storms).
- **Desktop ([sc-7821](https://app.shortcut.com/trefry/story/7821))** — `gpuMemoryLimitFraction` persisted in `AppSettings` (portable fraction); `set_gpu_memory_limit` Tauri command is **persist-only** (mirrors `set_remote_access`; the UI drives the existing "Restart worker" affordance, so a slider nudge never kills an in-flight job); `supervise_mlx_worker` injects `fraction × hw.memsize` as the byte ceiling at spawn.
- **Web ([sc-7822](https://app.shortcut.com/trefry/story/7822))** — slider (10–100%, 100% = Off, live "64 GB of 128 GB" readout, soft-cap copy), commit-on-release. Per-model fit reflects the cap by lowering `effectiveGb = min(unifiedMemoryGb, capGb)` into the existing `mlxEnoughMemory` check in `ModelManagerScreen`. No per-model warning baked into the slider — the cap is a model-agnostic global ceiling.

## Honest caveats

- The cap is a **soft target** (MLX backpressure), not a hard sandbox. A cap below a model's working set degrades gracefully via the existing `catch_unwind` OOM recovery.
- **macOS/MLX only.** candle/Windows has no clean budget knob today — tracked as a surfaced spike ([sc-7826](https://app.shortcut.com/trefry/story/7826)), not silently dropped. The worker no-op variant compiles there.

## Verification

- `cargo check -p sceneworks-worker --lib --tests` — clean (this caught a `Settings {}` literal in `tests.rs` that needed the new field).
- `cargo check -p sceneworks-desktop` — clean (main checkout; the worktree can't run `build.rs` without bundled sidecar/onnxruntime resources).
- `eslint` — 0 errors; `vitest run` — 717 tests / 43 files pass.
- **Not done here:** real-device validation (peak memory actually drops @50% across a generation *and* a training run; graceful below-requirement) — [sc-7823](https://app.shortcut.com/trefry/story/7823), needs a real Mac run with weights.

## Follow-ups (tracked)

[sc-7823](https://app.shortcut.com/trefry/story/7823) real-device validation · [sc-7824](https://app.shortcut.com/trefry/story/7824) live-apply without restart · [sc-7825](https://app.shortcut.com/trefry/story/7825) live/peak telemetry · [sc-7826](https://app.shortcut.com/trefry/story/7826) candle/Windows spike

🤖 Generated with [Claude Code](https://claude.com/claude-code)