### PR TITLE
feat(training): wire Krea 2 Raw LoRA training surface (sc-7578)

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -5089,12 +5089,15 @@ fn video_mode_is_mlx_eligible(model: &str, mode: &str) -> bool {
 /// kernel and base model onto an engine trainer id). `kolors_lora` (SDXL U-Net plus
 /// ChatGLM3) gained a native trainer in sc-4568, cut over here in sc-4732. `lens_lora`
 /// gained a native mlx-gen-lens trainer in sc-5148, cut over here in sc-5180 (off-Mac
-/// keeps the Python sidecar trainer). A kernel absent here is never routed to the mlx worker.
+/// keeps the Python sidecar trainer). `krea_lora` is the native `mlx-gen-krea` trainer
+/// (sc-7577); it has no torch path, so it is also listed in `MLX_ONLY_TRAINING_KERNELS`
+/// (sc-7578). A kernel absent here is never routed to the mlx worker.
 const MLX_ROUTED_TRAINING_KERNELS: &[&str] = &[
     "z_image_lora",
     "sdxl_lora",
     "kolors_lora",
     "lens_lora",
+    "krea_lora",
     "wan_lora",
     "wan_moe_lora",
     "ltx_mlx_lora",
@@ -5227,8 +5230,9 @@ fn video_upscale_job_is_candle_eligible(job: &JobSnapshot) -> bool {
 /// so a non-mlx worker must refuse the job (leaving it queued for the mlx worker)
 /// rather than claim it and fail with "no training kernel". The torch families
 /// (z-image/sdxl/wan) keep their Python trainer as the Windows path + Mac fallback, so
-/// they are deliberately NOT listed here.
-const MLX_ONLY_TRAINING_KERNELS: &[&str] = &["ltx_mlx_lora"];
+/// they are deliberately NOT listed here. `krea_lora` (epic 7565 P3) is MLX-native with
+/// no torch trainer — like LTX — so it is listed here (the candle Krea trainer is sc P4).
+const MLX_ONLY_TRAINING_KERNELS: &[&str] = &["ltx_mlx_lora", "krea_lora"];
 
 /// Whether this `lora_train` job targets a kernel with no non-Rust fallback (see
 /// [`MLX_ONLY_TRAINING_KERNELS`]). Such a job can only run on the mlx worker.

--- a/crates/sceneworks-core/src/lora_family.rs
+++ b/crates/sceneworks-core/src/lora_family.rs
@@ -1971,4 +1971,29 @@ mod tests {
         )
         .is_ok());
     }
+
+    #[test]
+    fn validate_lora_compatibility_accepts_krea_raw_lora_on_turbo() {
+        // epic 7565 P3 (sc-7578): a Krea LoRA trained on Krea 2 Raw records
+        // `family: krea_2` / `baseModel: krea_2_raw` and applies at Krea 2 Turbo inference
+        // by family match. `krea_2` is NOT base-model-gated (only wan-video is), so the Raw
+        // base model differing from the served Turbo model id does NOT reject — the Lens /
+        // Z-Image train-on-base → infer-on-Turbo precedent.
+        assert!(validate_lora_compatibility(
+            &[json!({ "id": "k", "family": "krea_2", "baseModel": "krea_2_raw" })],
+            Some("krea_2"),
+            "mlx_krea",
+            Some("krea_2_turbo"),
+        )
+        .is_ok());
+        // A foreign-family LoRA is still rejected on the Krea Turbo model.
+        let err = validate_lora_compatibility(
+            &[json!({ "id": "sdxllora", "family": "sdxl" })],
+            Some("krea_2"),
+            "mlx_krea",
+            Some("krea_2_turbo"),
+        )
+        .unwrap_err();
+        assert!(err.contains("sdxllora"), "got: {err}");
+    }
 }

--- a/crates/sceneworks-core/src/training.rs
+++ b/crates/sceneworks-core/src/training.rs
@@ -421,6 +421,7 @@ pub fn builtin_training_targets() -> TrainingTargetRegistry {
             sdxl_lora_target(),
             kolors_lora_target(),
             lens_turbo_lora_target(),
+            krea_raw_lora_target(),
             ltx_video_lora_target(),
             wan_lora_target(),
             wan_t2v_14b_lora_target(),
@@ -435,6 +436,7 @@ pub fn builtin_training_presets() -> TrainingPresetRegistry {
     let target = z_image_turbo_lora_target();
     let sdxl_target = sdxl_lora_target();
     let kolors_target = kolors_lora_target();
+    let krea_target = krea_raw_lora_target();
     let wan_target = wan_lora_target();
     let wan_t2v_14b_target = wan_t2v_14b_lora_target();
     let wan_i2v_14b_target = wan_i2v_14b_lora_target();
@@ -686,6 +688,52 @@ pub fn builtin_training_presets() -> TrainingPresetRegistry {
                 object(json!({
                     "description": "768px preset for tighter-VRAM Kolors training.",
                     "order": 40
+                })),
+            ),
+            krea_preset(
+                &krea_target,
+                "krea_2_raw_lora.character.adamw8bit.balanced",
+                "Character balanced",
+                &["character"],
+                ("adamw8bit", "balanced"),
+                |config| config,
+                object(json!({
+                    "description": "Balanced first run for 12-25 clean character images on Krea 2 (trains on Raw, applies to Turbo).",
+                    "default": true,
+                    "order": 10
+                })),
+            ),
+            krea_preset(
+                &krea_target,
+                "krea_2_raw_lora.character.adamw8bit.conservative",
+                "Character conservative",
+                &["character"],
+                ("adamw8bit", "conservative"),
+                |mut config| {
+                    config.rank = 8;
+                    config.alpha = 8;
+                    config.learning_rate = number(0.00005);
+                    config
+                },
+                object(json!({
+                    "description": "Lower-rank, lower-LR character preset for tight identity datasets.",
+                    "order": 20
+                })),
+            ),
+            krea_preset(
+                &krea_target,
+                "krea_2_raw_lora.style.adamw8bit.balanced",
+                "Style balanced",
+                &["style"],
+                ("adamw8bit", "balanced"),
+                |mut config| {
+                    config.rank = 32;
+                    config.alpha = 16;
+                    config
+                },
+                object(json!({
+                    "description": "Higher-capacity style LoRA defaults for texture and look transfer.",
+                    "order": 30
                 })),
             ),
             wan_preset(
@@ -947,6 +995,44 @@ where
     }
 }
 
+/// Build a Krea 2 LoRA preset. The flow-matching knobs (timestep sampling, Raw-base preview
+/// settings, gradient checkpointing, target modules) live on the target defaults, so the preset only
+/// overrides the optimizer + quality label and whatever the `mutate` closure tweaks (rank/alpha/LR).
+fn krea_preset<F>(
+    target: &TrainingTarget,
+    id: &str,
+    name: &str,
+    recommended_for: &[&str],
+    optimizer_quality: (&str, &str),
+    mutate: F,
+    ui: JsonObject,
+) -> TrainingPreset
+where
+    F: FnOnce(TrainingConfig) -> TrainingConfig,
+{
+    let (optimizer, quality_preset) = optimizer_quality;
+    let mut config = mutate(target.defaults.clone());
+    config.optimizer = optimizer.to_owned();
+    config
+        .advanced
+        .insert("qualityPreset".to_owned(), json!(quality_preset));
+    TrainingPreset {
+        id: id.to_owned(),
+        version: 1,
+        target_id: target.id.clone(),
+        name: name.to_owned(),
+        recommended_for: recommended_for
+            .iter()
+            .map(|value| (*value).to_owned())
+            .collect(),
+        optimizer: optimizer.to_owned(),
+        quality_preset: quality_preset.to_owned(),
+        config,
+        ui,
+        extra: ExtraFields::new(),
+    }
+}
+
 fn z_image_turbo_lora_target() -> TrainingTarget {
     TrainingTarget {
         id: "z_image_turbo_lora".to_owned(),
@@ -1115,6 +1201,111 @@ fn lens_turbo_lora_target() -> TrainingTarget {
             "label": "Lens LoRA",
             "description": "Train an image LoRA for Microsoft Lens (gpt-oss text encoder + FLUX.2 VAE). Trains on the non-distilled base and applies to Lens-Turbo.",
             "recommendedFor": ["character", "style"]
+        })),
+        extra: ExtraFields::new(),
+    }
+}
+
+/// Krea 2 LoRA training, trained on the undistilled `krea/Krea-2-Raw` 12B DiT and applied at
+/// inference to Krea 2 Turbo (epic 7565 P3). Same train-on-base → infer-on-Turbo pattern as Lens
+/// and Z-Image: the output registers as a `krea_2` family LoRA the Turbo adapter loads at generation
+/// time by **family match, no base-model gating** (`lora_family.rs` gates only `wan-video`). The
+/// Turbo manifest declares `loraCompatibility.families: [krea_2]`.
+///
+/// Native MLX, **Apple-Silicon only**: the `krea_lora` kernel runs the in-process `mlx-gen-krea`
+/// Rust trainer (a functional-autograd flow-match velocity loop on the single-stream DiT). There is
+/// no torch Krea trainer, so — like the LTX MLX video target — the job has no non-Rust fallback
+/// (`MLX_ONLY_TRAINING_KERNELS` keeps it queued for the mlx worker) and the target is Mac-gated in
+/// the UI via `MacTrainingSupport::supported_kernels`.
+///
+/// `base_model_repo` points the plan's `baseModelPath` at the ungated public `krea/Krea-2-Raw`
+/// diffusers tree (Krea 2 Community License), independent of the served `krea_2_turbo` model. The
+/// single-stream DiT uses separate `to_q`/`to_k`/`to_v` attention projections plus the joint-attention
+/// output projection (`to_out` is an `nn.ModuleList([Linear, Identity])`, so the trainable Linear is
+/// `to_out.0`), matching the engine trainer's `DEFAULT_TARGET_MODULES`.
+fn krea_raw_lora_target() -> TrainingTarget {
+    TrainingTarget {
+        id: "krea_2_raw_lora".to_owned(),
+        name: "Krea 2 LoRA".to_owned(),
+        modality: TrainingModality::Image,
+        output_kind: TrainingOutputKind::Lora,
+        family: "krea_2".to_owned(),
+        base_model: "krea_2_raw".to_owned(),
+        base_model_repo: Some("krea/Krea-2-Raw".to_owned()),
+        kernel: "krea_lora".to_owned(),
+        defaults: TrainingConfig {
+            rank: 16,
+            alpha: 16,
+            learning_rate: ContractNumber::from_f64(0.0001).expect("0.0001 is finite"),
+            steps: 3000,
+            batch_size: 1,
+            gradient_accumulation: 1,
+            resolution: 1024,
+            save_every: 250,
+            seed: 42,
+            // MLX training aliases `adamw8bit` → AdamW (bitsandbytes 8-bit is CUDA-only); the label
+            // stays consistent with the other image targets (the engine normalizes it).
+            optimizer: "adamw8bit".to_owned(),
+            trigger_word: None,
+            advanced: object(json!({
+                "mixedPrecision": "bf16",
+                "cacheLatents": true,
+                "cacheTextEmbeddings": true,
+                "gradientCheckpointing": true,
+                "networkType": "lora",
+                // Flow-matching noise sampling (see the Z-Image target); the high-noise bias
+                // emphasizes the region the few-step distilled Turbo relies on at inference, the
+                // same reasoning the Lens base→Turbo target uses.
+                "timestepType": "sigmoid",
+                "timestepBias": "high_noise",
+                "lossType": "mse",
+                "weightDecay": 0.0001,
+                // Learning-rate scheduler (see the Z-Image target); the worker honors
+                // `constant`/`linear`/`cosine` with an optional warmup.
+                "lrScheduler": "constant",
+                // Krea's single-stream DiT uses separate q/k/v projections plus the joint-attention
+                // output projection. `to_out` is a ModuleList, so its trainable Linear is `to_out.0`
+                // — the engine trainer's default target set (`mlx-gen-krea` DEFAULT_TARGET_MODULES).
+                "loraTargetModules": ["to_q", "to_k", "to_v", "to_out.0"],
+                // In-training previews render on the loaded undistilled Raw base (not the distilled
+                // CFG-free Turbo), so they use Raw's real-CFG settings — a few-step / CFG-0 preview
+                // on the non-distilled base is garbage. Heavier than Turbo previews, so a wider
+                // cadence by default (the Lens base-preview precedent).
+                "sampleEvery": 500,
+                "sampleSteps": 28,
+                "sampleGuidanceScale": 3.5,
+                "qualityPreset": "balanced",
+                "outputScope": "project",
+                "requestedGpu": "auto",
+                // Native MLX trainer (surfaced for the UI; Apple-Silicon only).
+                "backend": "mlx"
+            })),
+            extra: ExtraFields::new(),
+        },
+        limits: object(json!({
+            "rank": [4, 128],
+            "alpha": [1, 128],
+            "steps": [200, 6000],
+            "resolutions": [768, 1024, 1536],
+            "batchSize": [1, 4],
+            "optimizers": ["adamw8bit", "adamw", "adam", "prodigyopt", "rose"],
+            // Both LoRA and LoKr round-trip the engine's `apply_adapters_strict` seam at Turbo
+            // inference (the `mlx-gen-krea` trainer builds both; the apply path handles both).
+            "networkTypes": ["lora", "lokr"],
+            "lrSchedulers": ["constant", "linear", "cosine"],
+            "qualityPresets": ["speed", "balanced", "quality"],
+            "outputScopes": ["project", "global"],
+            // Native MLX trainer — no torch Krea path (mirrors the LTX MLX target).
+            "requiresBackend": "mlx",
+            "appleSiliconOnly": true
+        })),
+        ui: object(json!({
+            "label": "Krea 2 LoRA",
+            "description": "Train an image LoRA for Krea 2 (Qwen3-VL-4B text encoder + Qwen-Image VAE). Trains on the undistilled Krea 2 Raw base and applies to Krea 2 Turbo. Apple Silicon only (native MLX).",
+            "recommendedFor": ["character", "style"],
+            "appleSiliconOnly": true,
+            "backend": "mlx",
+            "datasetModality": "image"
         })),
         extra: ExtraFields::new(),
     }

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -3707,6 +3707,67 @@ fn ltx_training_is_mlx_worker_only_with_no_torch_fallback() {
     assert_eq!(claimed.assigned_gpu.as_deref(), Some("mlx"));
 }
 
+#[test]
+fn krea_training_is_mlx_worker_only_with_no_torch_fallback() {
+    let store = store("mlx-training-krea-only");
+    // Krea 2 (epic 7565 P3, sc-7578) trains on the native `mlx-gen-krea` trainer and has no
+    // torch path, so — like LTX — a torch worker must NOT claim a `krea_lora` job; it stays
+    // queued for the mlx worker (the candle Krea trainer is the separate P4 path).
+    register_gpu_worker(&store, "worker-torch", "mps", training_caps());
+    let job = store
+        .create_job(mlx_training_job(
+            "krea_lora",
+            "krea_2_raw",
+            "lora",
+            false,
+            "auto",
+        ))
+        .expect("job creates");
+
+    assert!(store
+        .claim_next_job("worker-torch")
+        .expect("torch claim ok")
+        .is_none());
+
+    // The mlx worker is the only home for it.
+    register_gpu_worker(&store, "worker-mlx", "mlx", training_caps());
+    let claimed = store
+        .claim_next_job("worker-mlx")
+        .expect("mlx claim ok")
+        .expect("mlx claims the Krea training job");
+    assert_eq!(claimed.id, job.id);
+    assert_eq!(claimed.assigned_gpu.as_deref(), Some("mlx"));
+}
+
+#[test]
+fn lokr_krea_training_stays_mlx_eligible() {
+    let store = store("mlx-training-krea-lokr");
+    // Unlike Wan (no MLX Kronecker merge), Krea's native trainer + Turbo inference seam both
+    // handle LoKr, so a LoKr `krea_lora` job stays MLX-eligible and is NOT shed to torch.
+    register_gpu_worker(&store, "worker-torch", "mps", training_caps());
+    register_gpu_worker(&store, "worker-mlx", "mlx", training_caps());
+    let job = store
+        .create_job(mlx_training_job(
+            "krea_lora",
+            "krea_2_raw",
+            "lokr",
+            false,
+            "auto",
+        ))
+        .expect("job creates");
+
+    // Torch defers (Krea is MLX-only); the mlx worker claims the LoKr job.
+    assert!(store
+        .claim_next_job("worker-torch")
+        .expect("torch claim ok")
+        .is_none());
+    let claimed = store
+        .claim_next_job("worker-mlx")
+        .expect("mlx claim ok")
+        .expect("mlx claims the Krea LoKr training job");
+    assert_eq!(claimed.id, job.id);
+}
+
 // --- Video routing (epic 3018, sc-3036) ---
 
 fn video_caps() -> Vec<WorkerCapability> {

--- a/crates/sceneworks-core/tests/training_contracts.rs
+++ b/crates/sceneworks-core/tests/training_contracts.rs
@@ -105,11 +105,13 @@ fn builtin_targets_gate_network_types() {
             .is_some_and(|types| types.iter().any(|entry| entry.as_str() == Some(value)))
     };
 
-    // Every target advertises `lora`; only the validated torch/PEFT backends
-    // (epic 2193) advertise `lokr`: the Z-Image/SDXL image backends (v1), the
-    // Kolors image backend (SDXL-architecture, epic 1929 / sc-2217), the Lens
-    // sidecar backend (sc-2218), and the Wan2.2 5B video backend (sc-2211).
-    // MLX-only and MoE targets stay lora-only.
+    // Every target advertises `lora`; the validated torch/PEFT backends (epic 2193)
+    // advertise `lokr`: the Z-Image/SDXL image backends (v1), the Kolors image backend
+    // (SDXL-architecture, epic 1929 / sc-2217), the Lens sidecar backend (sc-2218), and
+    // the Wan2.2 5B video backend (sc-2211). Krea 2 (epic 7565) is the first *native-MLX*
+    // LoKr target: its `mlx-gen-krea` trainer reports `supports_lokr` and builds LoKr targets
+    // natively, and the Turbo inference loader applies LoKr through the shared adapter seam
+    // (sc-7911). The older MLX-only LTX and the Wan MoE targets stay lora-only.
     let lokr_targets: Vec<&str> = registry
         .targets
         .iter()
@@ -131,6 +133,7 @@ fn builtin_targets_gate_network_types() {
             "sdxl_lora",
             "kolors_lora",
             "lens_turbo_lora",
+            "krea_2_raw_lora",
             "wan_lora"
         ]
     );
@@ -287,6 +290,43 @@ fn builtin_registry_exposes_kolors_target() {
     assert_eq!(
         target.limits.get("networkTypes"),
         Some(&serde_json::json!(["lora", "lokr"]))
+    );
+}
+
+#[test]
+fn builtin_registry_exposes_krea_target() {
+    // Krea 2 (epic 7565 P3) trains on the undistilled `krea/Krea-2-Raw` 12B single-stream
+    // DiT via the native `mlx-gen-krea` `krea_lora` kernel and applies at Krea 2 Turbo
+    // inference (family `krea_2`, no base-model gating). Native MLX, Apple-Silicon only.
+    let registry = builtin_training_targets();
+    let target = registry
+        .targets
+        .iter()
+        .find(|target| target.id == "krea_2_raw_lora")
+        .expect("krea_2_raw_lora target present");
+
+    assert_eq!(target.modality, TrainingModality::Image);
+    assert_eq!(target.output_kind, TrainingOutputKind::Lora);
+    assert_eq!(target.family, "krea_2");
+    assert_eq!(target.base_model, "krea_2_raw");
+    assert_eq!(target.kernel, "krea_lora");
+    assert_eq!(target.base_model_repo.as_deref(), Some("krea/Krea-2-Raw"));
+    // Single-stream DiT attention modules (separate q/k/v + the joint-attention output
+    // projection `to_out.0`), matching the engine trainer's default target set.
+    assert_eq!(
+        target.defaults.advanced.get("loraTargetModules"),
+        Some(&serde_json::json!(["to_q", "to_k", "to_v", "to_out.0"]))
+    );
+    // First native-MLX LoKr target (the `mlx-gen-krea` trainer + the Turbo inference seam
+    // both handle LoKr).
+    assert_eq!(
+        target.limits.get("networkTypes"),
+        Some(&serde_json::json!(["lora", "lokr"]))
+    );
+    // No torch Krea trainer — Apple-Silicon/MLX-only, like the LTX video target.
+    assert_eq!(
+        target.limits.get("appleSiliconOnly"),
+        Some(&serde_json::Value::Bool(true))
     );
 }
 

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -34,6 +34,8 @@ use gen_core::{
     TrainingOutput, TrainingProgress, TrainingRequest, WeightsSource,
 };
 #[cfg(target_os = "macos")]
+use mlx_gen_krea as _;
+#[cfg(target_os = "macos")]
 use mlx_gen_kolors as _;
 #[cfg(target_os = "macos")]
 use mlx_gen_lens as _;
@@ -272,6 +274,9 @@ fn engine_trainer_id(plan: &TrainingPlan) -> Option<&'static str> {
         // Lens trains the base `microsoft/Lens` DiT; the engine registers its LoRA/LoKr trainer
         // under the base generator id `"lens"` (arch-identical to lens_turbo), sc-5148.
         "lens_lora" => Some("lens"),
+        // Krea trains the undistilled `krea/Krea-2-Raw` DiT; the engine registers its LoRA/LoKr
+        // trainer under the base id `"krea_2_raw"` (arch-identical to krea_2_turbo), sc-7577/7578.
+        "krea_lora" => Some("krea_2_raw"),
         "ltx_mlx_lora" => Some("ltx_2_3"),
         // Dense Wan2.2-TI2V-5B.
         "wan_lora" => Some("wan2_2_ti2v_5b"),
@@ -1484,6 +1489,9 @@ mod tests {
             // Lens gained a native mlx-gen trainer (sc-5148) and now routes here (sc-5180); the
             // trainer registers under the base generator id `"lens"`.
             ("lens_lora", "lens", Some("lens")),
+            // Krea trains the undistilled Raw DiT; the engine trainer registers under the base id
+            // `"krea_2_raw"` (sc-7577/7578).
+            ("krea_lora", "krea_2_raw", Some("krea_2_raw")),
             // Unknown A14B base model variant.
             ("wan_moe_lora", "wan_2_2_mystery", None),
         ];

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -34,9 +34,9 @@ use gen_core::{
     TrainingOutput, TrainingProgress, TrainingRequest, WeightsSource,
 };
 #[cfg(target_os = "macos")]
-use mlx_gen_krea as _;
-#[cfg(target_os = "macos")]
 use mlx_gen_kolors as _;
+#[cfg(target_os = "macos")]
+use mlx_gen_krea as _;
 #[cfg(target_os = "macos")]
 use mlx_gen_lens as _;
 #[cfg(target_os = "macos")]

--- a/tests/fixtures/rust_migration_contracts/training/preset-registry.json
+++ b/tests/fixtures/rust_migration_contracts/training/preset-registry.json
@@ -681,6 +681,163 @@
       }
     },
     {
+      "id": "krea_2_raw_lora.character.adamw8bit.balanced",
+      "version": 1,
+      "targetId": "krea_2_raw_lora",
+      "name": "Character balanced",
+      "recommendedFor": [
+        "character"
+      ],
+      "optimizer": "adamw8bit",
+      "qualityPreset": "balanced",
+      "config": {
+        "rank": 16,
+        "alpha": 16,
+        "learningRate": 0.0001,
+        "steps": 3000,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 1024,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "backend": "mlx",
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": true,
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
+          "lossType": "mse",
+          "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
+          "outputScope": "project",
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 500,
+          "sampleGuidanceScale": 3.5,
+          "sampleSteps": 28,
+          "timestepBias": "high_noise",
+          "timestepType": "sigmoid",
+          "weightDecay": 0.0001
+        }
+      },
+      "ui": {
+        "default": true,
+        "description": "Balanced first run for 12-25 clean character images on Krea 2 (trains on Raw, applies to Turbo).",
+        "order": 10
+      }
+    },
+    {
+      "id": "krea_2_raw_lora.character.adamw8bit.conservative",
+      "version": 1,
+      "targetId": "krea_2_raw_lora",
+      "name": "Character conservative",
+      "recommendedFor": [
+        "character"
+      ],
+      "optimizer": "adamw8bit",
+      "qualityPreset": "conservative",
+      "config": {
+        "rank": 8,
+        "alpha": 8,
+        "learningRate": 0.00005,
+        "steps": 3000,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 1024,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "backend": "mlx",
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": true,
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
+          "lossType": "mse",
+          "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
+          "outputScope": "project",
+          "qualityPreset": "conservative",
+          "requestedGpu": "auto",
+          "sampleEvery": 500,
+          "sampleGuidanceScale": 3.5,
+          "sampleSteps": 28,
+          "timestepBias": "high_noise",
+          "timestepType": "sigmoid",
+          "weightDecay": 0.0001
+        }
+      },
+      "ui": {
+        "description": "Lower-rank, lower-LR character preset for tight identity datasets.",
+        "order": 20
+      }
+    },
+    {
+      "id": "krea_2_raw_lora.style.adamw8bit.balanced",
+      "version": 1,
+      "targetId": "krea_2_raw_lora",
+      "name": "Style balanced",
+      "recommendedFor": [
+        "style"
+      ],
+      "optimizer": "adamw8bit",
+      "qualityPreset": "balanced",
+      "config": {
+        "rank": 32,
+        "alpha": 16,
+        "learningRate": 0.0001,
+        "steps": 3000,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 1024,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "backend": "mlx",
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": true,
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
+          "lossType": "mse",
+          "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
+          "outputScope": "project",
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 500,
+          "sampleGuidanceScale": 3.5,
+          "sampleSteps": 28,
+          "timestepBias": "high_noise",
+          "timestepType": "sigmoid",
+          "weightDecay": 0.0001
+        }
+      },
+      "ui": {
+        "description": "Higher-capacity style LoRA defaults for texture and look transfer.",
+        "order": 30
+      }
+    },
+    {
       "id": "wan_lora.character.adamw.balanced",
       "version": 1,
       "targetId": "wan_lora",

--- a/tests/fixtures/rust_migration_contracts/training/target-registry.json
+++ b/tests/fixtures/rust_migration_contracts/training/target-registry.json
@@ -399,6 +399,114 @@
       }
     },
     {
+      "id": "krea_2_raw_lora",
+      "name": "Krea 2 LoRA",
+      "modality": "image",
+      "outputKind": "lora",
+      "family": "krea_2",
+      "baseModel": "krea_2_raw",
+      "baseModelRepo": "krea/Krea-2-Raw",
+      "kernel": "krea_lora",
+      "defaults": {
+        "rank": 16,
+        "alpha": 16,
+        "learningRate": 0.0001,
+        "steps": 3000,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 1024,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "backend": "mlx",
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": true,
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
+          "lossType": "mse",
+          "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
+          "outputScope": "project",
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 500,
+          "sampleGuidanceScale": 3.5,
+          "sampleSteps": 28,
+          "timestepBias": "high_noise",
+          "timestepType": "sigmoid",
+          "weightDecay": 0.0001
+        }
+      },
+      "limits": {
+        "alpha": [
+          1,
+          128
+        ],
+        "appleSiliconOnly": true,
+        "batchSize": [
+          1,
+          4
+        ],
+        "lrSchedulers": [
+          "constant",
+          "linear",
+          "cosine"
+        ],
+        "networkTypes": [
+          "lora",
+          "lokr"
+        ],
+        "optimizers": [
+          "adamw8bit",
+          "adamw",
+          "adam",
+          "prodigyopt",
+          "rose"
+        ],
+        "outputScopes": [
+          "project",
+          "global"
+        ],
+        "qualityPresets": [
+          "speed",
+          "balanced",
+          "quality"
+        ],
+        "rank": [
+          4,
+          128
+        ],
+        "requiresBackend": "mlx",
+        "resolutions": [
+          768,
+          1024,
+          1536
+        ],
+        "steps": [
+          200,
+          6000
+        ]
+      },
+      "ui": {
+        "appleSiliconOnly": true,
+        "backend": "mlx",
+        "datasetModality": "image",
+        "description": "Train an image LoRA for Krea 2 (Qwen3-VL-4B text encoder + Qwen-Image VAE). Trains on the undistilled Krea 2 Raw base and applies to Krea 2 Turbo. Apple Silicon only (native MLX).",
+        "label": "Krea 2 LoRA",
+        "recommendedFor": [
+          "character",
+          "style"
+        ]
+      }
+    },
+    {
       "id": "ltx_video_lora",
       "name": "LTX-2.3 Video LoRA",
       "modality": "video",


### PR DESCRIPTION
## What

Wires the **Krea 2 Raw LoRA training surface** end-to-end (epic 7565 P3). Train on the undistilled **Krea 2 Raw** 12B DiT → apply at **Krea 2 Turbo** inference — the Lens / Z-Image base→Turbo precedent (family match, **no base-model gating**). The native `mlx-gen-krea` trainer landed in [sc-7577](https://app.shortcut.com/trefry/story/7577); this is the SceneWorks-side wiring ([sc-7578](https://app.shortcut.com/trefry/story/7578)).

## Changes

- **`crates/sceneworks-core/src/training.rs`** — `krea_2_raw_lora` target (family `krea_2`, base `krea_2_raw`, repo `krea/Krea-2-Raw`, kernel `krea_lora`, image modality, single-stream block attention `to_q/to_k/to_v/to_out.0`). Native MLX, **Apple-Silicon only** (no torch Krea trainer, like the LTX MLX target). Advertises **`lora` + `lokr`** — the first native-MLX LoKr target. Adds 3 presets (character balanced default, character conservative, style balanced).
- **`crates/sceneworks-core/src/jobs_store.rs`** — route `krea_lora` to the in-process MLX worker (`MLX_ROUTED_TRAINING_KERNELS`) and mark it no-torch-fallback (`MLX_ONLY_TRAINING_KERNELS`), so a non-mlx worker never claims it. The Mac capability advertisement + web Training-Studio gating pick it up automatically.
- **`crates/sceneworks-worker/src/training_jobs.rs`** — map kernel `krea_lora` → engine trainer id `krea_2_raw`; force-link `mlx-gen-krea`.
- The `krea_2_turbo` manifest already declares `loraCompatibility.families: [krea_2]` (P1), so Raw-trained LoRAs validate against Turbo unchanged. Web `ConfigureJobPanel` is registry-driven → the target auto-surfaces.

## Tests

- Krea target contract (`base_model krea_2_raw` / `family krea_2` / `kernel krea_lora` / `lora`+`lokr` / `appleSiliconOnly`).
- **AC**: a Krea Raw-trained LoRA (`family: krea_2`, `baseModel: krea_2_raw`) passes `validate_lora_compatibility` against `krea_2_turbo` by family match, no base-model gating; a foreign family is still rejected.
- Kernel→trainer mapping; MLX-only routing (torch worker refuses, mlx worker claims); LoKr stays MLX-eligible.
- Regenerated the training target/preset registry snapshots.

`cargo test -p sceneworks-core` (contracts + lora_family + jobs_store routing) and the worker `engine_trainer_id` test pass; `clippy -p sceneworks-core --tests` clean.

## Follow-up (separate, tracked)

The **Turbo inference-side apply** is [mlx-gen#559](https://github.com/SceneWorks/mlx-gen/pull/559) / [sc-7911](https://app.shortcut.com/trefry/story/7911) (the engine previously rejected adapters at load). After that merges, this worker bumps its `mlx-gen-krea` pin to light up the in-app apply, unblocking [sc-7579](https://app.shortcut.com/trefry/story/7579) (train→infer numeric validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)