### PR TITLE
fix(gpu): honest soft-target framing + auto-apply for GPU memory setting (sc-7915)

### DIFF
--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -295,9 +295,6 @@ export function ModelManagerScreen() {
   // auth-protected REST signal (epic 4484 story 9). `isDesktop`/`tauriInvoke` come
   // from the unified runtime helper (story 6).
   const [unifiedMemoryGb, setUnifiedMemoryGb] = useState(null);
-  // GPU memory cap (epic 7819): when the user caps GPU memory, per-model fit must be judged
-  // against the *effective* ceiling, not physical RAM. Desktop reads the persisted fraction.
-  const [gpuLimitFraction, setGpuLimitFraction] = useState(null);
   // Gated-model credential presence (sc-1898): only fetched when the catalog has a
   // gated model, so non-gated deployments make no extra credential request.
   const [credentials, setCredentials] = useState([]);
@@ -311,15 +308,6 @@ export function ModelManagerScreen() {
   const isMoeBaseModel = WAN_MOE_BASE_MODELS.has(importForm.baseModel);
   const showSecondaryFileSlot = isMoeBaseModel && importForm.mode === "file";
   const moeMissingSecondary = showSecondaryFileSlot && Boolean(importForm.file) && !importForm.secondaryFile;
-  // Effective GPU memory available to generations under the user's cap (epic 7819). A capped app
-  // can run fewer models than the Mac's physical memory implies, so gate per-model fit on this.
-  const memoryIsCapped =
-    unifiedMemoryGb != null &&
-    typeof gpuLimitFraction === "number" &&
-    Number.isFinite(gpuLimitFraction) &&
-    gpuLimitFraction > 0 &&
-    gpuLimitFraction < 1;
-  const effectiveMemoryGb = memoryIsCapped ? unifiedMemoryGb * gpuLimitFraction : unifiedMemoryGb;
 
   useEffect(() => {
     if (familyFilter !== "all" && !families.includes(familyFilter)) {
@@ -349,16 +337,6 @@ export function ModelManagerScreen() {
         .then((info) => {
           if (!cancelled && info && typeof info.unifiedMemoryMb === "number") {
             setUnifiedMemoryGb(info.unifiedMemoryMb / 1024);
-          }
-        })
-        .catch(() => {});
-      // GPU memory cap (epic 7819): the persisted fraction lowers the effective ceiling used for
-      // per-model fit, so a capped app flags the models it can no longer hold.
-      tauriInvoke("get_app_settings")
-        .then((appSettings) => {
-          if (!cancelled && appSettings) {
-            const fraction = appSettings.gpuMemoryLimitFraction;
-            setGpuLimitFraction(typeof fraction === "number" ? fraction : null);
           }
         })
         .catch(() => {});
@@ -610,7 +588,7 @@ export function ModelManagerScreen() {
     // MLX (macOS) variant: only present when the catalog computed mlxConversionState.
     const mlxState = model.mlxConversionState;
     const mlxMinGb = model.mlx?.minMemoryGb ?? null;
-    const mlxEnoughMemory = effectiveMemoryGb == null || mlxMinGb == null || effectiveMemoryGb >= mlxMinGb;
+    const mlxEnoughMemory = unifiedMemoryGb == null || mlxMinGb == null || unifiedMemoryGb >= mlxMinGb;
     const convertJobs = convertJobsFor(model);
     const convertJob = convertJobs.find((job) => !terminalStatuses.has(job.status));
     const failedConvert = convertJobs.find((job) => terminalStatuses.has(job.status) && job.status !== "completed");
@@ -691,11 +669,7 @@ export function ModelManagerScreen() {
             <p>{mlxStatusText(model)}</p>
             {!mlxEnoughMemory ? (
               <p className="inline-warning">
-                Needs ≥ {mlxMinGb} GB unified memory;{" "}
-                {memoryIsCapped
-                  ? `the app is limited to ~${Math.round(effectiveMemoryGb)} GB by your GPU memory cap`
-                  : `this Mac has ~${Math.round(effectiveMemoryGb)} GB`}
-                . It may run out of memory.
+                Needs ≥ {mlxMinGb} GB unified memory; this Mac has ~{Math.round(unifiedMemoryGb)} GB. It may run out of memory.
               </p>
             ) : null}
             {convertJob ? <WorkerProgressCard job={convertJob} onCancel={onCancelJob} onOpenQueue={onOpenQueue} /> : null}

--- a/apps/web/src/screens/SettingsScreen.jsx
+++ b/apps/web/src/screens/SettingsScreen.jsx
@@ -147,14 +147,17 @@ export function SettingsScreen() {
 
   async function commitGpuMemoryLimit(percent) {
     try {
-      // 100% = no limit → send null so the shell clears the cap; otherwise a fraction (0.1–0.99).
+      // 100% = Off → send null so the shell clears it; otherwise a fraction (0.1–0.99).
       const fraction = percent >= 100 ? null : percent / 100;
       const updated = await invoke("set_gpu_memory_limit", { fraction });
       setSettings(updated);
+      // The worker only reads the target at spawn, so restart it now to actually apply the
+      // change — otherwise moving the slider silently does nothing until the next restart.
+      await invoke("restart_worker");
       setStatus(
         fraction == null
-          ? "GPU memory limit removed. Restart the worker to apply."
-          : `GPU memory limit set to ${percent}%. Restart the worker to apply.`,
+          ? "GPU memory target turned off. Restarting the worker to apply…"
+          : `GPU memory target set to ${percent}%. Restarting the worker to apply…`,
       );
     } catch (error) {
       setStatus(String(error));
@@ -448,10 +451,10 @@ export function SettingsScreen() {
           {gpu?.platform === "macos" && gpu?.unifiedMemoryMb ? (
             <div className="settings-gpu-cap">
               <label htmlFor="gpu-memory-cap">
-                GPU memory limit:{" "}
+                GPU memory for SceneWorks:{" "}
                 {gpuLimitPercent >= 100
-                  ? "Off — no limit"
-                  : `${Math.round((gpu.unifiedMemoryMb / 1024) * (gpuLimitPercent / 100))} GB of ` +
+                  ? "Use all available"
+                  : `~${Math.round((gpu.unifiedMemoryMb / 1024) * (gpuLimitPercent / 100))} GB of ` +
                     `${Math.round(gpu.unifiedMemoryMb / 1024)} GB (${gpuLimitPercent}%)`}
               </label>
               <input
@@ -461,16 +464,16 @@ export function SettingsScreen() {
                 max={100}
                 step={5}
                 value={gpuLimitPercent}
-                aria-label="GPU memory limit (percent of unified memory)"
+                aria-label="GPU memory target for SceneWorks (percent of unified memory)"
                 onChange={(event) => setGpuLimitPercent(Number(event.target.value))}
                 onMouseUp={(event) => commitGpuMemoryLimit(Number(event.target.value))}
                 onKeyUp={(event) => commitGpuMemoryLimit(Number(event.target.value))}
                 onTouchEnd={(event) => commitGpuMemoryLimit(Number(event.target.value))}
               />
               <p className="settings-help">
-                Caps the shared memory generations and LoRA training may use, leaving the rest for
-                the system. This is a soft target, not a hard limit — set it too low and large models
-                may slow down or fail. Takes effect when you restart the worker.
+                A soft target for how much unified memory SceneWorks holds, so more stays free for the
+                rest of your system. It is not a hard limit — large models can still use more when they
+                need it. Changing this restarts the inference worker.
               </p>
             </div>
           ) : null}


### PR DESCRIPTION
## Why

Fixes [sc-7915](https://app.shortcut.com/trefry/story/7915). The merged GPU memory cap (epic [sc-7819](https://app.shortcut.com/trefry/epic/7819), #894) didn't do what it implied:

1. **It implied a hard limit it can't deliver.** `mlx_rs::set_memory_limit`/`set_wired_limit` are *soft* (backpressure + residency) — a large model still uses what it needs. Reported live: a 24 GB setting ran an LTX 2.3 video with no effect.
2. **It also never took effect.** The worker reads the value only at spawn, and the slider was persist-only — moving it silently did nothing until a manual "Restart worker". (Forensics confirmed: no `gpuMemoryLimitFraction` in settings.json, no `gpu_memory_limit_applied` in the worker log.)

Per the chosen direction (Option B): keep the soft MLX behavior, but make the UI honest and make changes actually apply. (Option A — a true hard cap via the privileged, system-wide `iogpu.wired_limit_mb` sysctl — was declined.)

## Changes (web only)

- **`SettingsScreen.jsx`** — reword the control from "GPU memory limit" → **"GPU memory for SceneWorks"**, a soft target. Copy now states plainly it's *not* a hard limit and large models can still use more. The handler **auto-restarts the worker on change** (`restart_worker` after persisting), so the setting actually applies instead of silently waiting.
- **`ModelManagerScreen.jsx`** — **revert** the `effectiveGb`/cap wiring. A soft target doesn't change what models can run, so per-model fit is judged on physical unified memory again; the cap-based "may not fit / limited by your GPU memory cap" warning was misleading and is removed.

No worker/desktop changes: `set_memory_limit` + `set_wired_limit` remain the correct soft knobs for returning memory to the OS between/within runs.

## Not in this PR
- The original report also surfaced a **stale-frontend build** (the installed app bundled an old web dist, so the slider wasn't even present). That's a build/release concern, not a code fix — a clean rebuild includes the (now honest) control. Noted on sc-7915.
- Live-apply-without-restart remains the nicer future option ([sc-7824](https://app.shortcut.com/trefry/story/7824)); auto-restart is the minimal reliable fix here.

## Verification
- `eslint` — 0 errors (2 pre-existing `families` warnings, unrelated).
- `vitest run` — 717 tests / 43 files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)