### PR TITLE
feat(gpu): live-apply GPU memory target + Settings telemetry; candle verdict (sc-7824/7825/7826)

### DIFF
--- a/apps/desktop/src/main.rs
+++ b/apps/desktop/src/main.rs
@@ -50,6 +50,8 @@ fn main() {
             settings::get_gpu_info,
             // GPU memory cap (epic 7819).
             settings::set_gpu_memory_limit,
+            // Live MLX memory telemetry for the Settings readout (epic 7819, sc-7825).
+            settings::get_gpu_telemetry,
             // LAN remote access (epic 4484, stories 4/5).
             settings::get_remote_access,
             settings::set_remote_access,

--- a/apps/desktop/src/settings.rs
+++ b/apps/desktop/src/settings.rs
@@ -497,9 +497,10 @@ const MIN_GPU_MEMORY_FRACTION: f32 = 0.1;
 
 /// Persist the user's GPU memory cap as a fraction of total unified memory, or clear it. `None`
 /// (and a non-finite or ≥ 1.0 value — 100% is "use everything" = no constraint) clears the cap;
-/// otherwise the value is clamped to `[MIN_GPU_MEMORY_FRACTION, 0.99]`. Mirrors `set_remote_access`:
-/// **persist only** — the worker reads the derived byte ceiling at spawn, so the change takes effect
-/// on the next "Restart worker" (the UI drives that), not mid-job. Returns the updated settings.
+/// otherwise the value is clamped to `[MIN_GPU_MEMORY_FRACTION, 0.99]`. Persists the fraction AND
+/// (macOS, sc-7824) writes the derived byte ceiling to the live-handoff file the running MLX worker
+/// re-reads between jobs, so the change applies within a couple of seconds with no worker restart.
+/// Returns the updated settings.
 #[tauri::command]
 pub fn set_gpu_memory_limit(fraction: Option<f32>) -> Result<AppSettings, String> {
     let mut settings = load_settings();
@@ -510,7 +511,30 @@ pub fn set_gpu_memory_limit(fraction: Option<f32>) -> Result<AppSettings, String
         _ => None,
     };
     save_settings(&settings)?;
+    #[cfg(target_os = "macos")]
+    write_gpu_memory_limit_file();
     Ok(settings)
+}
+
+/// Write the resolved byte ceiling (or `0` for "no limit") to the live-handoff file the running MLX
+/// worker re-reads between jobs (epic 7819, sc-7824), so a slider change applies without a worker
+/// restart. Best-effort: a write failure just means the change waits for the next worker restart
+/// (which re-reads `SCENEWORKS_GPU_MEMORY_LIMIT_BYTES` from the persisted fraction anyway).
+#[cfg(target_os = "macos")]
+fn write_gpu_memory_limit_file() {
+    let bytes = gpu_memory_limit_bytes().unwrap_or(0);
+    let path = sceneworks_core::app_paths::gpu_memory_limit_file(&crate::setup::config_dir());
+    let _ = std::fs::write(&path, bytes.to_string());
+}
+
+/// Read the MLX worker's latest GPU memory telemetry for the Settings readout (epic 7819, sc-7825).
+/// `None` when the worker hasn't published any yet, or on platforms/workers without MLX telemetry
+/// (candle/CPU never write the file). Best-effort: a missing or unparseable file yields `None`.
+#[tauri::command]
+pub fn get_gpu_telemetry() -> Option<sceneworks_core::app_paths::GpuMemoryTelemetry> {
+    let path = sceneworks_core::app_paths::gpu_telemetry_file(&crate::setup::config_dir());
+    let raw = std::fs::read_to_string(&path).ok()?;
+    serde_json::from_str(&raw).ok()
 }
 
 /// The configured GPU memory ceiling in BYTES for the MLX worker, or `None` for no limit:

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -178,7 +178,7 @@ pub fn default_data_dir() -> PathBuf {
     app_support_dir().join("data")
 }
 
-fn config_dir() -> PathBuf {
+pub(crate) fn config_dir() -> PathBuf {
     app_support_dir().join("config")
 }
 

--- a/apps/web/src/screens/SettingsScreen.jsx
+++ b/apps/web/src/screens/SettingsScreen.jsx
@@ -25,6 +25,12 @@ function fractionToPercent(fraction) {
   return Math.min(100, Math.max(GPU_LIMIT_MIN_PERCENT, Math.round(fraction * 100)));
 }
 
+// GPU memory telemetry (epic 7819, sc-7825). The worker publishes byte counts; the readout is in GB.
+function bytesToGb(bytes) {
+  if (typeof bytes !== "number" || !Number.isFinite(bytes) || bytes <= 0) return 0;
+  return bytes / (1024 * 1024 * 1024);
+}
+
 export function SettingsScreen() {
   const [settings, setSettings] = useState(null);
   const [gpu, setGpu] = useState(null);
@@ -42,6 +48,9 @@ export function SettingsScreen() {
   // GPU memory cap (epic 7819). Local slider percent for smooth dragging; committed to the shell
   // on release. 100 = Off (no limit). Synced from persisted settings once they load.
   const [gpuLimitPercent, setGpuLimitPercent] = useState(100);
+  // Live MLX memory telemetry (epic 7819, sc-7825). The worker's latest snapshot, polled while the
+  // GPU card is visible; null until the first sample arrives (or on platforms without it).
+  const [gpuTelemetry, setGpuTelemetry] = useState(null);
 
   const refresh = useCallback(async () => {
     try {
@@ -75,6 +84,28 @@ export function SettingsScreen() {
   useEffect(() => {
     if (settings) setGpuLimitPercent(fractionToPercent(settings.gpuMemoryLimitFraction));
   }, [settings]);
+
+  // Poll live MLX memory telemetry while the GPU card is visible (epic 7819, sc-7825). macOS-only —
+  // the worker only publishes the snapshot on the MLX path; elsewhere the command returns null.
+  // Lightweight: a small file read in the shell every 2s, cleaned up on unmount / platform change.
+  useEffect(() => {
+    if (!isDesktop || gpu?.platform !== "macos" || !gpu?.unifiedMemoryMb) return undefined;
+    let cancelled = false;
+    const poll = async () => {
+      try {
+        const telemetry = await invoke("get_gpu_telemetry");
+        if (!cancelled) setGpuTelemetry(telemetry ?? null);
+      } catch {
+        if (!cancelled) setGpuTelemetry(null);
+      }
+    };
+    poll();
+    const id = setInterval(poll, 2000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [gpu]);
 
   const secretStore = gpu?.platform === "windows" ? "Credential Manager" : "Keychain";
   const credentialLocation = isDesktop
@@ -151,13 +182,12 @@ export function SettingsScreen() {
       const fraction = percent >= 100 ? null : percent / 100;
       const updated = await invoke("set_gpu_memory_limit", { fraction });
       setSettings(updated);
-      // The worker only reads the target at spawn, so restart it now to actually apply the
-      // change — otherwise moving the slider silently does nothing until the next restart.
-      await invoke("restart_worker");
+      // sc-7824: the shell writes the new ceiling to a live-handoff file the running worker re-reads
+      // between jobs, so no restart is needed — it applies within a couple of seconds.
       setStatus(
         fraction == null
-          ? "GPU memory target turned off. Restarting the worker to apply…"
-          : `GPU memory target set to ${percent}%. Restarting the worker to apply…`,
+          ? "GPU memory target turned off — applies within a couple of seconds."
+          : `GPU memory target set to ${percent}% — applies within a couple of seconds.`,
       );
     } catch (error) {
       setStatus(String(error));
@@ -473,8 +503,17 @@ export function SettingsScreen() {
               <p className="settings-help">
                 A soft target for how much unified memory SceneWorks holds, so more stays free for the
                 rest of your system. It is not a hard limit — large models can still use more when they
-                need it. Changing this restarts the inference worker.
+                need it. Changes apply within a couple of seconds — no restart needed.
               </p>
+              {gpuTelemetry ? (
+                <p className="settings-muted">
+                  MLX memory — Active: {bytesToGb(gpuTelemetry.activeBytes).toFixed(1)} GB · Peak:{" "}
+                  {bytesToGb(gpuTelemetry.peakBytes).toFixed(1)} GB
+                  {gpuTelemetry.limitBytes
+                    ? ` · Limit: ${Math.round(bytesToGb(gpuTelemetry.limitBytes))} GB`
+                    : ""}
+                </p>
+              ) : null}
             </div>
           ) : null}
           {gpu?.platform === "macos" ? (
@@ -483,9 +522,11 @@ export function SettingsScreen() {
               <code>sudo sysctl iogpu.wired_limit_mb=&lt;bytes&gt;</code>
             </p>
           ) : null}
-          {gpu?.platform === "windows" ? (
+          {gpu?.platform === "windows" || gpu?.platform === "linux" ? (
             <p className="settings-help">
-              Requires current NVIDIA drivers with CUDA support.
+              Requires current NVIDIA drivers with CUDA support. The GPU memory target is
+              macOS-only — a discrete GPU has no per-process memory cap, so generations use
+              whatever VRAM they need.
             </p>
           ) : null}
         </section>

--- a/apps/web/src/screens/SettingsScreen.test.jsx
+++ b/apps/web/src/screens/SettingsScreen.test.jsx
@@ -300,3 +300,84 @@ describe("SettingsScreen remote access (desktop)", () => {
     expect(invoke).toHaveBeenCalledWith("set_remote_access", { enabled: true, port: 8787 });
   });
 });
+
+// epic 7819 Phase 2: live-apply the GPU memory target (sc-7824, no worker restart) and show live
+// MLX memory telemetry (sc-7825) on macOS with a known unified-memory total.
+describe("SettingsScreen GPU memory (desktop macOS)", () => {
+  let container;
+  let root;
+  let invoke;
+  let SettingsScreen;
+  const GIB = 1024 * 1024 * 1024;
+
+  beforeEach(async () => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    invoke = vi.fn(async (command) => {
+      switch (command) {
+        case "get_app_settings":
+          return {}; // no cap → slider starts at 100% (Off)
+        case "get_gpu_info":
+          return { platform: "macos", devices: ["Apple M3 Max"], unifiedMemoryMb: 131072 };
+        case "list_credentials":
+          return [];
+        case "get_remote_access":
+          return null;
+        case "get_gpu_telemetry":
+          return { activeBytes: 20 * GIB, peakBytes: 40 * GIB, cacheBytes: 2 * GIB, limitBytes: 64 * GIB };
+        case "set_gpu_memory_limit":
+          return { gpuMemoryLimitFraction: 0.5 };
+        default:
+          return null;
+      }
+    });
+    window.__TAURI__ = { core: { invoke } };
+    vi.resetModules();
+    ({ SettingsScreen } = await import("./SettingsScreen.jsx"));
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    delete window.__TAURI__;
+    vi.restoreAllMocks();
+  });
+
+  async function render() {
+    await act(async () => {
+      root.render(<SettingsScreen />);
+    });
+    await act(async () => {});
+  }
+
+  const slider = () =>
+    container.querySelector(
+      '[aria-label="GPU memory target for SceneWorks (percent of unified memory)"]',
+    );
+
+  it("shows live MLX memory telemetry from the worker", async () => {
+    await render();
+    expect(invoke).toHaveBeenCalledWith("get_gpu_telemetry", undefined);
+    expect(container.textContent).toContain("MLX memory");
+    expect(container.textContent).toContain("Active: 20.0 GB");
+    expect(container.textContent).toContain("Peak: 40.0 GB");
+    expect(container.textContent).toContain("Limit: 64 GB");
+  });
+
+  it("applies the GPU memory target live, without restarting the worker", async () => {
+    await render();
+    const input = slider();
+    expect(input).toBeTruthy();
+    await changeField(input, "50");
+    await act(async () => {
+      input.dispatchEvent(new window.MouseEvent("mouseup", { bubbles: true }));
+    });
+    expect(invoke).toHaveBeenCalledWith("set_gpu_memory_limit", { fraction: 0.5 });
+    expect(invoke).not.toHaveBeenCalledWith("restart_worker");
+    expect(container.textContent).toContain("applies within a couple of seconds");
+  });
+});

--- a/crates/sceneworks-core/src/app_paths.rs
+++ b/crates/sceneworks-core/src/app_paths.rs
@@ -1,4 +1,6 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
 
 /// OS-appropriate default locations for SceneWorks user data, configuration, and
 /// cache. Environment overrides (`SCENEWORKS_DATA_DIR`, `SCENEWORKS_CONFIG_DIR`,
@@ -36,6 +38,37 @@ impl AppPaths {
         std::fs::create_dir_all(&self.cache_dir)?;
         Ok(())
     }
+}
+
+/// Filename (under [`AppPaths::config_dir`]) of the live GPU-memory-limit handoff the desktop
+/// shell writes whenever the Settings slider changes, and the running MLX worker re-reads between
+/// jobs (epic 7819, sc-7824). A bare decimal byte count; `0` means "no limit". Keeping it in the
+/// shared config dir — which the desktop injects into the worker as `SCENEWORKS_CONFIG_DIR` — lets
+/// the cap change live without a worker restart. An absent file leaves the worker on whatever it
+/// applied at spawn from `SCENEWORKS_GPU_MEMORY_LIMIT_BYTES`.
+pub fn gpu_memory_limit_file(config_dir: &Path) -> PathBuf {
+    config_dir.join("gpu_memory_limit")
+}
+
+/// Filename (under [`AppPaths::config_dir`]) where the MLX worker publishes live GPU-memory
+/// telemetry for the Settings readout (epic 7819, sc-7825). JSON-encoded [`GpuMemoryTelemetry`],
+/// rewritten on a short interval. macOS/MLX only — candle/CPU workers never write it, so the
+/// desktop telemetry command returns `None` there.
+pub fn gpu_telemetry_file(config_dir: &Path) -> PathBuf {
+    config_dir.join("gpu_telemetry.json")
+}
+
+/// A snapshot of the MLX runtime's process-global memory counters (epic 7819, sc-7825), written by
+/// the worker to [`gpu_telemetry_file`] and read back by the desktop shell for the Settings
+/// display. All values are bytes. `limit_bytes` is the currently-applied soft ceiling (`0` = no
+/// limit), tracked from what the worker actually applied rather than MLX's internal default budget.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GpuMemoryTelemetry {
+    pub active_bytes: u64,
+    pub peak_bytes: u64,
+    pub cache_bytes: u64,
+    pub limit_bytes: u64,
 }
 
 fn repo_relative_paths() -> AppPaths {

--- a/crates/sceneworks-worker/src/generator_cache.rs
+++ b/crates/sceneworks-worker/src/generator_cache.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{mpsc, OnceLock};
 use std::thread;
 use std::time::Duration;
@@ -245,25 +245,103 @@ fn release_backend_cache_after_evict() {}
 /// The MLX limit is **process-global**, so calling this once at worker startup (before any model
 /// load) covers generations, upscales, AND LoRA training — even though training takes a separate
 /// path from the generator cache.
+/// The GPU memory ceiling (bytes) currently applied to this process's MLX runtime, so the live
+/// sync (sc-7824) only re-applies on an actual change. `u64::MAX` is the "nothing applied yet"
+/// sentinel — distinct from `0` ("no limit"), so the first real value (including a deliberate `0`
+/// that clears a prior cap) always takes effect.
 #[cfg(all(target_os = "macos", not(test)))]
-pub(crate) fn apply_gpu_memory_limit(bytes: u64) {
-    if bytes == 0 {
-        return;
-    }
-    let bytes = bytes as usize;
-    let previous_limit = mlx_rs::memory::set_memory_limit(bytes);
-    let previous_wired = mlx_rs::memory::set_wired_limit(bytes);
+static APPLIED_GPU_MEMORY_LIMIT: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(u64::MAX);
+
+#[cfg(all(target_os = "macos", not(test)))]
+fn set_gpu_memory_limit_inner(bytes: u64) {
+    use std::sync::atomic::Ordering;
+    let limit = bytes as usize;
+    let previous_limit = mlx_rs::memory::set_memory_limit(limit);
+    let previous_wired = mlx_rs::memory::set_wired_limit(limit);
+    APPLIED_GPU_MEMORY_LIMIT.store(bytes, Ordering::SeqCst);
     tracing::info!(
         event = "gpu_memory_limit_applied",
-        limitBytes = bytes,
+        limitBytes = limit,
         previousLimitBytes = previous_limit,
         previousWiredLimitBytes = previous_wired,
         "applied user-configured GPU memory ceiling to the MLX runtime"
     );
 }
 
+#[cfg(all(target_os = "macos", not(test)))]
+pub(crate) fn apply_gpu_memory_limit(bytes: u64) {
+    if bytes == 0 {
+        // Unset at startup: leave MLX on its own default budget — byte-identical to prior behavior.
+        // (The live sync below still applies a deliberate `0` to *clear* a previously-set cap.)
+        return;
+    }
+    set_gpu_memory_limit_inner(bytes);
+}
+
+/// Re-read the live GPU-memory-limit handoff file and apply it if it changed since the last applied
+/// value (epic 7819, sc-7824). Called from the worker poll loop *between jobs*, so moving the
+/// Settings slider takes effect on the next job without a worker restart. An absent file is a
+/// no-op (the spawn-time `SCENEWORKS_GPU_MEMORY_LIMIT_BYTES` value stays in force); a written `0`
+/// actively clears a previously-applied cap (MLX treats `0` as "no limit").
+#[cfg(all(target_os = "macos", not(test)))]
+pub(crate) fn sync_gpu_memory_limit(config_dir: &Path) {
+    use std::sync::atomic::Ordering;
+    let path = sceneworks_core::app_paths::gpu_memory_limit_file(config_dir);
+    let Some(bytes) = std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+    else {
+        return;
+    };
+    if APPLIED_GPU_MEMORY_LIMIT.load(Ordering::SeqCst) != bytes {
+        set_gpu_memory_limit_inner(bytes);
+    }
+}
+
+/// Publish a snapshot of the MLX runtime's process-global memory counters to the telemetry file for
+/// the desktop Settings readout (epic 7819, sc-7825). `limit_bytes` reports the cap this worker has
+/// actually applied (`0` = none), not MLX's internal default budget, so the UI can show "peak vs
+/// limit" honestly. Best-effort: a write failure is ignored (the readout just goes stale).
+#[cfg(all(target_os = "macos", not(test)))]
+pub(crate) fn write_gpu_telemetry(config_dir: &Path) {
+    use std::sync::atomic::Ordering;
+    let applied = APPLIED_GPU_MEMORY_LIMIT.load(Ordering::SeqCst);
+    let telemetry = sceneworks_core::app_paths::GpuMemoryTelemetry {
+        active_bytes: mlx_rs::memory::get_active_memory() as u64,
+        peak_bytes: mlx_rs::memory::get_peak_memory() as u64,
+        cache_bytes: mlx_rs::memory::get_cache_memory() as u64,
+        limit_bytes: if applied == u64::MAX { 0 } else { applied },
+    };
+    if let Ok(json) = serde_json::to_string(&telemetry) {
+        let path = sceneworks_core::app_paths::gpu_telemetry_file(config_dir);
+        let _ = std::fs::write(&path, json);
+    }
+}
+
+/// Spawn a background task that republishes MLX memory telemetry on a short interval (epic 7819,
+/// sc-7825). Runs independently of the job poll loop so the readout reflects usage *during* a
+/// generation, not only between jobs. The first tick fires immediately. The task lives for the
+/// worker's lifetime (aborted when the process exits).
+#[cfg(all(target_os = "macos", not(test)))]
+pub(crate) fn spawn_gpu_telemetry(config_dir: PathBuf) {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(Duration::from_secs(2));
+        loop {
+            ticker.tick().await;
+            write_gpu_telemetry(&config_dir);
+        }
+    });
+}
+
 #[cfg(any(not(target_os = "macos"), test))]
 pub(crate) fn apply_gpu_memory_limit(_bytes: u64) {}
+
+#[cfg(any(not(target_os = "macos"), test))]
+pub(crate) fn sync_gpu_memory_limit(_config_dir: &Path) {}
+
+#[cfg(any(not(target_os = "macos"), test))]
+pub(crate) fn spawn_gpu_telemetry(_config_dir: PathBuf) {}
 
 /// Best-effort human-readable text from a caught panic payload — the `&str`/`String` a `panic!`
 /// produces. mlx-rs `.unwrap()`/`.expect()` panics carry their formatted message as a `String`

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -372,6 +372,12 @@ pub async fn run_worker_loop(settings: Settings) -> WorkerResult<()> {
     // before any model load. The MLX limit is process-global, so this single call covers
     // generations, upscales, AND LoRA training. No-op when unset (0) and on non-macOS/candle builds.
     generator_cache::apply_gpu_memory_limit(settings.gpu_memory_limit_bytes);
+    // sc-7825 (epic 7819): on the MLX GPU worker only, publish live MLX memory telemetry to the
+    // shared config dir for the Settings readout. Gated to `mlx` so the CPU utility workers (which
+    // do no MLX work) don't clobber the file with zeros.
+    if settings.gpu_id == "mlx" {
+        generator_cache::spawn_gpu_telemetry(settings.config_dir.clone());
+    }
     let gpu = discover_gpu(&settings).await;
     let api = ApiClient::new(&settings);
     let http_client = reqwest::Client::new();
@@ -468,6 +474,12 @@ async fn poll_once(
     http_client: &reqwest::Client,
     idle_heartbeat: &mut IdleHeartbeat,
 ) -> WorkerResult<()> {
+    // sc-7824 (epic 7819): pick up a live GPU-memory-limit change here, before claiming the next
+    // job, so a Settings slider move applies between jobs (not mid-flight) with no worker restart.
+    // No-op unless this is the MLX worker and the desktop has written the live-handoff file.
+    if settings.gpu_id == "mlx" {
+        generator_cache::sync_gpu_memory_limit(&settings.config_dir);
+    }
     if idle_heartbeat.should_send() {
         heartbeat(api, settings, WorkerStatus::Idle, None).await?;
         idle_heartbeat.mark_sent();


### PR DESCRIPTION
Phase 2 of epic 7819 (user-set GPU memory limit). Builds on the merged Phase 1 (#894) and the soft-target rescope (#899).

## Design
The MLX worker is a **separate process** that polls the REST API for jobs — config was spawn-time env only with no live channel, and the MLX telemetry getters/setters only mean anything *inside* the worker process. Instead of extending the heartbeat/job contract (worker↔API skew + DB churn), this reuses the **`config_dir` the desktop already shares with the worker** (`SCENEWORKS_CONFIG_DIR`) as a small bidirectional file channel. **No REST API / job-contract / DB changes.** Shared path helpers + the `GpuMemoryTelemetry` struct live in `sceneworks_core::app_paths` so the worker (writer) and desktop (reader) share one type.

## sc-7824 — live-apply (no worker restart)
- Desktop `set_gpu_memory_limit` writes the resolved byte ceiling (or `0` = off) to `<config_dir>/gpu_memory_limit`.
- Worker `generator_cache::sync_gpu_memory_limit` re-reads it at the **top of `poll_once`** — between jobs, before the next claim, so it never applies mid-flight — and calls `set_memory_limit`/`set_wired_limit` only when the value changed. Tracked via an `AtomicU64` whose `u64::MAX` sentinel ≠ a deliberate `0`, so turning the cap back **off** actually clears a prior limit. (Startup still skips `0` to stay byte-identical-when-unset.)
- Web drops the `restart_worker` call; copy is now "applies within a couple of seconds."

## sc-7825 — live MLX memory telemetry in Settings
- Worker spawns a 2s **background task** (not the poll loop, which is blocked for the duration of a job — that would freeze the readout during a generation) writing `{active,peak,cache,limit}Bytes` JSON to `<config_dir>/gpu_telemetry.json`. `limitBytes` reports the cap the worker actually applied (`0` = none), not MLX's internal default budget.
- New `get_gpu_telemetry` desktop command reads it (`None` when absent → candle/CPU never write it).
- `SettingsScreen` polls every 2s and renders "MLX memory — Active: X · Peak: Y · Limit: Z GB" under the slider.

Both new paths are gated to `gpu_id == "mlx"` so the CPU utility workers (which also run `run_worker_loop` on macOS) don't act on the limit or clobber the telemetry file.

## sc-7826 — candle/CUDA feasibility spike
**Verdict: not feasible without upstream work (HIGH confidence, ~90%).** candle-core's `CudaDevice` allocates straight through cudarc's stream allocator (no pool/limit field); `candle-gen::default_device()` has no knobs; cudarc (0.17.8/0.19.7) exposes no `cudaMemPool*` bindings; and a discrete GPU's VRAM is already separate from system RAM, so the macOS "leave memory for the rest of the system" model doesn't map. Would need a 3-tier upstream chain (cudarc mempool → candle-core pooled allocator → candle-gen plumb a limit), after which the Phase-1 env seam is reusable as-is. Shipped here: honest Windows/Linux Settings copy explaining the absence (the slider was already gated to macOS + unified memory).

## Validation
- `cargo check` + `clippy --all-targets -- -D warnings` clean on **sceneworks-core, sceneworks-worker** (real macOS/MLX path — `mlx-rs` is an unconditional macOS dep) **and sceneworks-desktop**.
- **719 web tests pass** (717 + 2 new: live-apply does not call `restart_worker`; telemetry renders).
- Not browser-preview-verifiable: the control only renders under the Tauri bridge on macOS, so the vitest harness simulating Tauri is the meaningful check.

## Not in this PR
On-device validation is tracked in **sc-7823** (now also: peak drops on the next job after a *live* slider change; telemetry tracks a real generation) — needs a Mac + weights + a build with the bundled frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)