### PR TITLE
fix(remote-access): trust loopback so a LAN password never gates the local app (sc-7937)

### DIFF
--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -494,6 +494,12 @@ fn spawn_api(app: &AppHandle) -> Result<(), String> {
         // Loopback/dynamic by default; 0.0.0.0/fixed-port in LAN mode (epic 4484).
         .env("SCENEWORKS_API_HOST", bind.host)
         .env("SCENEWORKS_API_PORT", &bind.port)
+        // Epic 4484: in LAN mode the password becomes the API access token, but the
+        // embedded desktop UI and local GPU worker(s) reach the API over loopback with no
+        // password. Trust loopback peers so local use stays password-free while LAN
+        // callers stay gated. A no-op in loopback-only mode (no token is set). Never set
+        // by Docker/server, so a reverse-proxied deployment stays fail-closed.
+        .env("SCENEWORKS_TRUST_LOOPBACK", "true")
         .env("SCENEWORKS_RUN_UTILITY_INPROCESS", "true")
         // Parent-death watchdog: a force-quit/crash skips `begin_shutdown`, so
         // without this the API orphans to launchd (PPID=1), holding its

--- a/apps/rust-api/src/auth.rs
+++ b/apps/rust-api/src/auth.rs
@@ -1,12 +1,20 @@
 use super::*;
+use axum::extract::ConnectInfo;
+use std::net::SocketAddr;
 
 pub(crate) async fn access_control(
     State(state): State<AppState>,
+    // `Option<…>` so unit tests that drive the router via `oneshot` (no connect info)
+    // still resolve the extractor — absent peer ⇒ not loopback-trusted, falls through
+    // to the token check.
+    connect_info: Option<ConnectInfo<SocketAddr>>,
     request: Request<axum::body::Body>,
     next: Next,
 ) -> Response {
+    let peer = connect_info.map(|ConnectInfo(addr)| addr);
     if request.method() == Method::OPTIONS
         || !requires_token(request.uri().path())
+        || loopback_trusted(state.settings.trust_loopback, peer)
         || is_authorized(request.headers(), &state.settings)
     {
         return next.run(request).await;
@@ -63,6 +71,21 @@ pub(crate) fn cors_layer(settings: &Settings) -> CorsLayer {
 /// before it can attach the token header.
 pub(crate) fn requires_token(path: &str) -> bool {
     path.starts_with("/api/") && !PUBLIC_PATHS.contains(&path)
+}
+
+/// Whether a request should bypass the access token because it originates from this
+/// machine. When LAN remote access is on, the desktop launcher binds `0.0.0.0` and sets
+/// the password as the API's access token — but the embedded desktop UI and the local
+/// GPU worker(s) reach the API over loopback and have no password to send. Trusting
+/// loopback peers keeps local use password-free while still gating LAN callers (other
+/// source IPs).
+///
+/// Opt-in via `SCENEWORKS_TRUST_LOOPBACK` (the desktop sets it; Docker/server does NOT),
+/// so a server deployment fronted by a reverse proxy — where every request would appear
+/// to come from loopback — stays fail-closed. Pure so the decision is unit-tested without
+/// a live listener; mirrors `should_warn_open_bind`.
+pub(crate) fn loopback_trusted(trust_loopback: bool, peer: Option<SocketAddr>) -> bool {
+    trust_loopback && peer.is_some_and(|addr| addr.ip().is_loopback())
 }
 
 pub(crate) fn is_authorized(headers: &HeaderMap, settings: &Settings) -> bool {

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -195,6 +195,13 @@ pub struct Settings {
     /// job terminal with `candle_unsupported`. Read from `SCENEWORKS_CANDLE_UNSUPPORTED_MODE`
     /// (`enforce` vs anything else). Irrelevant unless `candle_required`.
     pub candle_enforce_unsupported: bool,
+    /// Epic 4484 — trust loopback peers to bypass the access token. When LAN remote
+    /// access binds `0.0.0.0` with the password as `access_token`, the embedded desktop
+    /// UI and the local GPU worker(s) still reach the API over loopback with no password;
+    /// trusting `127.0.0.1`/`::1` peers keeps local use password-free while LAN callers
+    /// (other source IPs) stay gated. The desktop sets `SCENEWORKS_TRUST_LOOPBACK`;
+    /// Docker/server never does, so a reverse-proxied deployment stays fail-closed.
+    pub trust_loopback: bool,
 }
 
 impl Settings {
@@ -244,6 +251,9 @@ impl Settings {
                 .unwrap_or(false),
             candle_enforce_unsupported: std::env::var("SCENEWORKS_CANDLE_UNSUPPORTED_MODE")
                 .map(|value| value.trim().eq_ignore_ascii_case("enforce"))
+                .unwrap_or(false),
+            trust_loopback: std::env::var("SCENEWORKS_TRUST_LOOPBACK")
+                .map(|value| matches!(value.trim(), "1" | "true" | "TRUE" | "True"))
                 .unwrap_or(false),
         }
     }
@@ -412,9 +422,15 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     let utility_worker = run_utility_inprocess.then(|| spawn_inprocess_utility_worker(port));
 
-    axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal())
-        .await?;
+    // `into_make_service_with_connect_info` exposes the peer `SocketAddr` to the auth
+    // middleware so loopback callers can be trusted (epic 4484: keep the local desktop UI
+    // and worker password-free while LAN clients stay gated).
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .with_graceful_shutdown(shutdown_signal())
+    .await?;
 
     if let Some(worker) = utility_worker {
         worker.shutdown().await;

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -1,4 +1,4 @@
-use super::auth::requires_token;
+use super::auth::{loopback_trusted, requires_token};
 use super::events::{EventHub, EventMessage};
 use super::training::{insufficient_disk_space, resolve_base_model_path};
 use super::workers::person_readiness_from_workers;
@@ -40,6 +40,23 @@ fn warns_only_on_open_bind_without_token() {
     assert!(!should_warn_open_bind("secret", v4("0.0.0.0")));
     assert!(!should_warn_open_bind("", v4("127.0.0.1")));
     assert!(!should_warn_open_bind("", "::1".parse().unwrap()));
+}
+
+#[test]
+fn loopback_trusted_only_when_enabled_and_peer_is_local() {
+    use std::net::SocketAddr;
+    let addr = |s: &str| s.parse::<SocketAddr>().unwrap();
+    // Epic 4484: only a loopback peer is trusted, and only when the opt-in is set — so the
+    // local desktop UI/worker bypass the password while LAN clients (other IPs) don't.
+    assert!(loopback_trusted(true, Some(addr("127.0.0.1:51234"))));
+    assert!(loopback_trusted(true, Some(addr("[::1]:51234"))));
+    // Enabled but the peer is on the LAN → still gated.
+    assert!(!loopback_trusted(true, Some(addr("192.168.1.5:51234"))));
+    assert!(!loopback_trusted(true, Some(addr("0.0.0.0:51234"))));
+    // A loopback peer alone never trusts without the opt-in (server/Docker default).
+    assert!(!loopback_trusted(false, Some(addr("127.0.0.1:51234"))));
+    // Unknown peer (e.g. the unit-test oneshot path with no connect info) → not trusted.
+    assert!(!loopback_trusted(true, None));
 }
 
 #[test]
@@ -234,6 +251,7 @@ fn test_settings(temp_dir: &tempfile::TempDir) -> Settings {
         mlx_enforce_unsupported: false,
         candle_required: false,
         candle_enforce_unsupported: false,
+        trust_loopback: false,
     }
 }
 

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -463,6 +463,11 @@ function FirstRunProjectGate({ onCreate, disabled }) {
 export function App() {
   const [health, setHealth] = useState(null);
   const [access, setAccess] = useState({ authRequired: false });
+  // Whether GET /api/v1/access has answered yet. Until it does we don't know if a
+  // password is required, so a remote browser must hold its protected data loads —
+  // otherwise they fire optimistically, 401, and bury the password prompt under a band
+  // of "access token required" errors (epic 4484).
+  const [accessResolved, setAccessResolved] = useState(false);
   const [token, setToken] = useState(() => window.localStorage.getItem("sceneworks-token") ?? "");
   // Wrong-password feedback for the remote-browser login gate (epic 4484 story 7).
   const [authError, setAuthError] = useState("");
@@ -739,7 +744,17 @@ export function App() {
     createVideoJob,
   });
 
-  const authenticated = useMemo(() => !access.authRequired || token.length > 0, [access, token]);
+  // The desktop shell reaches its own API over loopback, which the API trusts
+  // (SCENEWORKS_TRUST_LOOPBACK), so it's authenticated without a password — never prompt
+  // for one locally (epic 4484). A remote browser must wait for GET /api/v1/access before
+  // it knows whether a password is needed; until then it holds its protected loads rather
+  // than firing them unauthenticated.
+  const authenticated = useMemo(
+    () =>
+      isDesktopShell ||
+      (accessResolved && (!access.authRequired || token.length > 0)),
+    [accessResolved, access, token],
+  );
   const imageModels = useMemo(() => {
     const items = models.filter((model) => model.type === "image" && model.installState !== "missing");
     return items.length || models.length ? items : fallbackModels.filter((model) => model.type === "image");
@@ -944,7 +959,10 @@ export function App() {
 
     apiFetch("/api/v1/access", "")
       .then(setAccess)
-      .catch((err) => setError(err.message));
+      .catch((err) => setError(err.message))
+      // Either way the auth state is now as resolved as it'll get; release the gate so
+      // an authenticated client (or one not requiring auth) can load its data.
+      .finally(() => setAccessResolved(true));
   }, []);
 
   useEffect(() => {
@@ -2054,7 +2072,7 @@ export function App() {
           <p className="notice error" key={notice.kind}>{notice.message}</p>
         ))}
 
-        {access.authRequired && !window.localStorage.getItem("sceneworks-token") ? (
+        {access.authRequired && !isDesktopShell && !window.localStorage.getItem("sceneworks-token") ? (
           <section className="auth-band">
             <form onSubmit={saveToken}>
               <label htmlFor="token">Password</label>


### PR DESCRIPTION
Fixes [sc-7937](https://app.shortcut.com/trefry/story/7937) — found while user-testing epic [4484](https://app.shortcut.com/trefry/epic/4484) (LAN remote access).

## Symptom
After setting a LAN password, the user got `Projects: SceneWorks access token required; Jobs: …; Workers: …; Models: …; LoRAs: …; Training targets: …; Training presets: …` **inside the desktop app**, and a remote browser showed the same error band **instead of** a password prompt.

Expected: the local desktop app must never require/prompt for a password; a remote LAN browser should get the prompt (and nothing else) until it authenticates.

## Root cause
In LAN mode the desktop launcher injects the password as a **process-global** `SCENEWORKS_ACCESS_TOKEN` (`decide_api_bind_env`). The auth middleware (`is_authorized`) then demands that token from **every** protected `/api/*` caller — including the embedded desktop WebView and the local GPU worker, both on loopback. Epic 4484 (sc-7063) injected the token into the GPU *worker* but **overlooked the embedded UI**, which has no password to send, so its data fetches 401. The Windows validation (sc-7074) only checked the WebView loads the *public* `/health`, never its *protected* loads, so the gap shipped.

Secondary (remote browser): the SPA started with `authRequired: false`, so it fired all loads *before* `GET /api/v1/access` reported auth was required — the premature 401s buried the password form.

## Fix
1. **API trusts loopback peers (opt-in).** `Settings.trust_loopback` from `SCENEWORKS_TRUST_LOOPBACK`; pure `loopback_trusted(trust_loopback, peer)` helper; `access_control` bypasses the token when the opt-in is set **and** the peer IP `is_loopback()`. Server now uses `into_make_service_with_connect_info::<SocketAddr>()`; middleware reads `Option<ConnectInfo<SocketAddr>>` so unit-test `oneshot` (no connect info) ⇒ not trusted. `is_authorized` / `/auth/verify` left header-only so the real password is still validated. **Docker/server never set the env ⇒ a reverse-proxied deployment stays fail-closed** (the sc-7064 open-bind refusal is untouched).
2. **Desktop opts in.** `spawn_api` sets `SCENEWORKS_TRUST_LOOPBACK=true` (no-op in loopback-only mode).
3. **Web SPA.** `authenticated = isDesktopShell || (accessResolved && (!authRequired || token))` — the desktop shell is always authenticated (its loopback is trusted server-side) so it never prompts and never gates its own loads; a remote browser holds protected loads until `/api/v1/access` resolves (new `accessResolved` flag). Password band hidden in the desktop shell.

## Test plan
- [x] `cargo test -p sceneworks-rust-api` auth set — 6/6 incl. new `loopback_trusted_only_when_enabled_and_peer_is_local`; existing token-enforcement / health-withholding / requires-token tests still green.
- [x] `cargo check -p sceneworks-rust-api` and `cargo check -p sceneworks-desktop` clean.
- [ ] **Live LAN smoke (needs a real second device):** (a) local desktop app with a LAN password set works with NO prompt and NO token errors; (b) a remote browser shows ONLY the password prompt, then loads after entering the password.

## Security note
The loopback bypass is gated behind `SCENEWORKS_TRUST_LOOPBACK`, which only the desktop sets. Server/Docker deployments (where a reverse proxy can make every request appear to originate from loopback) do not set it and remain fully token-gated and fail-closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)