### PR TITLE
feat(web): higher default LoRA apply weight for krea_2 on distilled Turbo (sc-7932)

### DIFF
--- a/apps/web/public/prompt-guides/krea-2.md
+++ b/apps/web/public/prompt-guides/krea-2.md
@@ -68,6 +68,18 @@ realistic subjects you don't need to say "photorealistic"; that's already the de
 - **Quantization:** Q8 is the default (near-lossless, ~27 GB peak — needs a 48 GB-class Mac); Q4 is a
   lighter option.
 
+## Using LoRAs
+
+Krea LoRAs train on the full **Krea 2 Raw** base and apply at inference on the distilled **Turbo**.
+Because Turbo is few-step and CFG-free it adheres tightly to the prompt, so a LoRA's effect reads
+softer here than it would on the Raw base. To compensate, Krea LoRAs start at a **higher default apply
+weight (1.5)** than other families — they stay coherent well above that, so:
+
+- If a LoRA's style or subject isn't coming through on a strongly-described scene, raise the weight
+  toward **2.0** and leave the prompt a little room rather than over-specifying every detail.
+- If a LoRA over-dominates, lower it. The weight slider is the main lever; the default is just a
+  starting point tuned for the distilled Turbo.
+
 ## Example Prompts
 
 `A weathered lighthouse on a rocky cliff at golden hour, waves breaking below, gulls in the distance.

--- a/apps/web/src/presetUtils.js
+++ b/apps/web/src/presetUtils.js
@@ -208,9 +208,17 @@ export function presetLoraId(presetLora) {
   return typeof presetLora === "string" ? presetLora : presetLora?.id ?? presetLora?.loraId;
 }
 
+// Krea 2's distilled, CFG-free Turbo attenuates Raw-trained LoRAs (sc-7579 / sc-7932): the generic
+// 0.8 default under-expresses on the few-step student, so a krea-2-family LoRA defaults to a higher
+// apply weight (real-weight-validated coherent through scale 4). This is still a DEFAULT — an explicit
+// preset weight, a stored `defaultWeight`, or the LoRA's own `weight` still wins. Family token is the
+// normalized form (`normalizeLoraFamily`: krea_2 → krea-2).
+const KREA_LORA_DEFAULT_WEIGHT = 1.5;
+
 export function loraWeight(lora, presetLora = {}) {
-  const value = Number(presetLora.weight ?? lora?.defaultWeight ?? lora?.weight ?? 0.8);
-  return Number.isFinite(value) ? value : 0.8;
+  const fallback = loraFamilies(lora).includes("krea-2") ? KREA_LORA_DEFAULT_WEIGHT : 0.8;
+  const value = Number(presetLora.weight ?? lora?.defaultWeight ?? lora?.weight ?? fallback);
+  return Number.isFinite(value) ? value : fallback;
 }
 
 export function serializePresetLora(lora, presetLora = {}) {

--- a/apps/web/src/presetUtils.test.jsx
+++ b/apps/web/src/presetUtils.test.jsx
@@ -6,6 +6,7 @@ import {
   clearPresetDefault,
   editModelForAsset,
   finiteNumberOrUndefined,
+  loraWeight,
   presetMatchesModel,
   presetNameTaken,
   slugifyPresetId,
@@ -109,6 +110,31 @@ describe("finiteNumberOrUndefined", () => {
     expect(finiteNumberOrUndefined(null)).toBeUndefined();
     expect(finiteNumberOrUndefined("abc")).toBeUndefined();
     expect(finiteNumberOrUndefined(undefined)).toBeUndefined();
+  });
+});
+
+describe("loraWeight", () => {
+  it("defaults a generic LoRA to 0.8", () => {
+    expect(loraWeight({ id: "sdxl_style", family: "sdxl" })).toBe(0.8);
+    expect(loraWeight(null)).toBe(0.8);
+  });
+
+  it("defaults a krea-2-family LoRA higher (1.5) for the distilled-Turbo attenuation (sc-7932)", () => {
+    // The family token is normalized (krea_2 -> krea-2), and the bump applies via any of the
+    // family-bearing shapes extractFamilies() reads.
+    expect(loraWeight({ id: "k", family: "krea_2" })).toBe(1.5);
+    expect(loraWeight({ id: "k", compatibility: { families: ["krea_2"] } })).toBe(1.5);
+  });
+
+  it("lets an explicit weight win over the krea-2 family default", () => {
+    expect(loraWeight({ id: "k", family: "krea_2", defaultWeight: 1.0 })).toBe(1.0);
+    expect(loraWeight({ id: "k", family: "krea_2", weight: 0.7 })).toBe(0.7);
+    expect(loraWeight({ id: "k", family: "krea_2" }, { weight: 2.0 })).toBe(2.0);
+  });
+
+  it("falls back to the family default when an explicit value is non-finite", () => {
+    expect(loraWeight({ id: "k", family: "krea_2", defaultWeight: "nope" })).toBe(1.5);
+    expect(loraWeight({ id: "g", family: "sdxl", defaultWeight: "nope" })).toBe(0.8);
   });
 });
 


### PR DESCRIPTION
## sc-7932 (epic 7565 Krea 2) — tune the default LoRA apply scale for distilled-Turbo transfer

Follow-up to the sc-7579 viability validation. Krea 2 Turbo is few-step + CFG-free, so it adheres tightly to the prompt and a Raw-trained LoRA's effect is **attenuated** at the generic `0.8` default — especially on strongly-described scenes (measured: magenta probe +0.7 @scale1 → +3.1 @scale4, coherent throughout). The path works; it just needs a higher *default* so user LoRAs express without manual scale tuning.

### Part 1 — higher default apply weight for `krea_2` LoRAs ✅ implemented
`krea-2`-family LoRAs now default to **1.5** (vs 0.8), real-weight-validated coherent through scale 4.

- Implemented at the **single chokepoint** `loraWeight()` ([presetUtils.js](apps/web/src/presetUtils.js)) — the live picker (`generationStudio` / `LoraPickerField`), presets, and recipes all route through it, so one change covers every entry point.
- It replaces **only** the bare `0.8` fallback: an explicit preset weight, a stored `defaultWeight`, or the LoRA's own `weight` still wins. It's a default — fully user-overridable via the weight slider.
- Family detection uses the normalized token (`normalizeLoraFamily`: `krea_2` → `krea-2`) via the existing `loraFamilies()` helper.
- The worker's `resolve_adapters` `0.8` fallback (a weight-less-payload safety net) stays generic **on purpose** — the default lives in one source of truth (the web serialization layer) rather than duplicating the tuning constant across the web/worker boundary; the web always serializes a computed weight, so all UI/preset/recipe flows already carry 1.5 to the worker.
- Adds a `loraWeight` test block + a "Using LoRAs" note to the Krea 2 prompt guide ([krea-2.md](apps/web/public/prompt-guides/krea-2.md)) explaining the higher default + how to tune toward 2.0.

### Part 2 — inference-time Raw-base preview: explicitly declined (per the AC)
The AC frames this as "implemented or explicitly declined with rationale." Declining, because:
1. The **in-training preview already renders on the resident Krea Raw base** (the target's `sampleSteps:28`/`sampleGuidanceScale:3.5`), so users already see Raw-strength previews during training — the verification need is largely met.
2. An inference-time Raw preview would mean loading the **12B non-distilled Raw model** (far heavier than Turbo) plus a new generation mode + UI, for a verification-only affordance.
3. Part 1 directly addresses the underlying "will my LoRA show?" concern on Turbo itself.

### Checks
- `npm test` (web): **721 passed / 43 files** (incl. 4 new `loraWeight` tests). `npm run lint`: **0 errors** (48 pre-existing `exhaustive-deps` warnings, none in changed files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)