### PR TITLE
sc-8002: catch-up worker dep bump to mlx-gen c45caec (PiD seam prerequisite)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -520,7 +520,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -586,7 +586,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -601,7 +601,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -614,7 +614,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -626,7 +626,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -643,7 +643,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -669,7 +669,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -684,7 +684,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -702,7 +702,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -713,7 +713,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -726,7 +726,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -737,7 +737,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -750,7 +750,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -774,7 +774,7 @@ dependencies = [
 [[package]]
 name = "candle-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/candle-llm?rev=8ab61c8dd2b5617cfc6dba1cda978c73bf9d34bf#8ab61c8dd2b5617cfc6dba1cda978c73bf9d34bf"
+source = "git+https://github.com/SceneWorks/candle-llm?rev=54ef5a1ed43b8918f01858fe431bfec0eb2a3f25#54ef5a1ed43b8918f01858fe431bfec0eb2a3f25"
 dependencies = [
  "candle-core",
  "candle-nn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=00d9aae807f629d1784affb75dfb6d0f84fb04b9#00d9aae807f629d1784affb75dfb6d0f84fb04b9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=00d9aae807f629d1784affb75dfb6d0f84fb04b9#00d9aae807f629d1784affb75dfb6d0f84fb04b9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=00d9aae807f629d1784affb75dfb6d0f84fb04b9#00d9aae807f629d1784affb75dfb6d0f84fb04b9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=00d9aae807f629d1784affb75dfb6d0f84fb04b9#00d9aae807f629d1784affb75dfb6d0f84fb04b9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=00d9aae807f629d1784affb75dfb6d0f84fb04b9#00d9aae807f629d1784affb75dfb6d0f84fb04b9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=00d9aae807f629d1784affb75dfb6d0f84fb04b9#00d9aae807f629d1784affb75dfb6d0f84fb04b9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -520,7 +520,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=00d9aae807f629d1784affb75dfb6d0f84fb04b9#00d9aae807f629d1784affb75dfb6d0f84fb04b9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=00d9aae807f629d1784affb75dfb6d0f84fb04b9#00d9aae807f629d1784affb75dfb6d0f84fb04b9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=00d9aae807f629d1784affb75dfb6d0f84fb04b9#00d9aae807f629d1784affb75dfb6d0f84fb04b9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=00d9aae807f629d1784affb75dfb6d0f84fb04b9#00d9aae807f629d1784affb75dfb6d0f84fb04b9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=00d9aae807f629d1784affb75dfb6d0f84fb04b9#00d9aae807f629d1784affb75dfb6d0f84fb04b9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -586,7 +586,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=00d9aae807f629d1784affb75dfb6d0f84fb04b9#00d9aae807f629d1784affb75dfb6d0f84fb04b9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -594,13 +594,14 @@ dependencies = [
  "inventory",
  "rand 0.9.4",
  "rand_distr 0.5.1",
+ "safetensors 0.7.0",
  "serde_json",
 ]
 
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=00d9aae807f629d1784affb75dfb6d0f84fb04b9#00d9aae807f629d1784affb75dfb6d0f84fb04b9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -613,7 +614,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=00d9aae807f629d1784affb75dfb6d0f84fb04b9#00d9aae807f629d1784affb75dfb6d0f84fb04b9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -625,7 +626,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=00d9aae807f629d1784affb75dfb6d0f84fb04b9#00d9aae807f629d1784affb75dfb6d0f84fb04b9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -642,7 +643,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=00d9aae807f629d1784affb75dfb6d0f84fb04b9#00d9aae807f629d1784affb75dfb6d0f84fb04b9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -657,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=00d9aae807f629d1784affb75dfb6d0f84fb04b9#00d9aae807f629d1784affb75dfb6d0f84fb04b9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -668,7 +669,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=00d9aae807f629d1784affb75dfb6d0f84fb04b9#00d9aae807f629d1784affb75dfb6d0f84fb04b9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -683,7 +684,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=00d9aae807f629d1784affb75dfb6d0f84fb04b9#00d9aae807f629d1784affb75dfb6d0f84fb04b9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -701,7 +702,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=00d9aae807f629d1784affb75dfb6d0f84fb04b9#00d9aae807f629d1784affb75dfb6d0f84fb04b9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -712,7 +713,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=00d9aae807f629d1784affb75dfb6d0f84fb04b9#00d9aae807f629d1784affb75dfb6d0f84fb04b9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -725,7 +726,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=00d9aae807f629d1784affb75dfb6d0f84fb04b9#00d9aae807f629d1784affb75dfb6d0f84fb04b9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -736,7 +737,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=00d9aae807f629d1784affb75dfb6d0f84fb04b9#00d9aae807f629d1784affb75dfb6d0f84fb04b9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -749,7 +750,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=00d9aae807f629d1784affb75dfb6d0f84fb04b9#00d9aae807f629d1784affb75dfb6d0f84fb04b9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4281c82b0e9461cae78d278cd740b67e2b69fcd5#4281c82b0e9461cae78d278cd740b67e2b69fcd5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1058,7 +1059,7 @@ dependencies = [
 [[package]]
 name = "core-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/core-llm?branch=main#58f2e64bb16a6cdf711ccaaf6ddc75c88ed8f625"
+source = "git+https://github.com/SceneWorks/core-llm?branch=main#a49ca6d9738d5e0786f29634d57c8d1bd1939c38"
 dependencies = [
  "inventory",
  "minijinja",
@@ -3408,8 +3409,10 @@ version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb3d648e68cea56d9858d535ee28f9538404e2dd8cb08ed0bd05dca379477f39"
 dependencies = [
+ "indexmap 2.14.0",
  "memo-map",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3452,7 +3455,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=9c740013a50f65778f1db3ef577a29828073448d#9c740013a50f65778f1db3ef577a29828073448d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3464,7 +3467,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=9c740013a50f65778f1db3ef577a29828073448d#9c740013a50f65778f1db3ef577a29828073448d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
 dependencies = [
  "image",
  "inventory",
@@ -3478,7 +3481,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=9c740013a50f65778f1db3ef577a29828073448d#9c740013a50f65778f1db3ef577a29828073448d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
 dependencies = [
  "image",
  "inventory",
@@ -3491,7 +3494,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=9c740013a50f65778f1db3ef577a29828073448d#9c740013a50f65778f1db3ef577a29828073448d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3503,7 +3506,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=9c740013a50f65778f1db3ef577a29828073448d#9c740013a50f65778f1db3ef577a29828073448d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3514,7 +3517,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=9c740013a50f65778f1db3ef577a29828073448d#9c740013a50f65778f1db3ef577a29828073448d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3523,7 +3526,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=9c740013a50f65778f1db3ef577a29828073448d#9c740013a50f65778f1db3ef577a29828073448d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3535,7 +3538,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=9c740013a50f65778f1db3ef577a29828073448d#9c740013a50f65778f1db3ef577a29828073448d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3547,7 +3550,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=9c740013a50f65778f1db3ef577a29828073448d#9c740013a50f65778f1db3ef577a29828073448d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3559,7 +3562,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=9c740013a50f65778f1db3ef577a29828073448d#9c740013a50f65778f1db3ef577a29828073448d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3570,7 +3573,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=9c740013a50f65778f1db3ef577a29828073448d#9c740013a50f65778f1db3ef577a29828073448d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3580,7 +3583,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=9c740013a50f65778f1db3ef577a29828073448d#9c740013a50f65778f1db3ef577a29828073448d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
 dependencies = [
  "image",
  "inventory",
@@ -3592,11 +3595,12 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=9c740013a50f65778f1db3ef577a29828073448d#9c740013a50f65778f1db3ef577a29828073448d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
 dependencies = [
  "image",
  "inventory",
  "mlx-gen",
+ "mlx-gen-pid",
  "mlx-gen-qwen-image",
  "pmetal-mlx-rs",
  "serde_json",
@@ -3605,7 +3609,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=9c740013a50f65778f1db3ef577a29828073448d#9c740013a50f65778f1db3ef577a29828073448d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
 dependencies = [
  "image",
  "inventory",
@@ -3618,7 +3622,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=9c740013a50f65778f1db3ef577a29828073448d#9c740013a50f65778f1db3ef577a29828073448d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
 dependencies = [
  "image",
  "inventory",
@@ -3628,9 +3632,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "mlx-gen-pid"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
+dependencies = [
+ "image",
+ "mlx-gen",
+ "pmetal-mlx-rs",
+ "serde_json",
+]
+
+[[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=9c740013a50f65778f1db3ef577a29828073448d#9c740013a50f65778f1db3ef577a29828073448d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3642,17 +3657,18 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=9c740013a50f65778f1db3ef577a29828073448d#9c740013a50f65778f1db3ef577a29828073448d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
 dependencies = [
  "inventory",
  "mlx-gen",
+ "mlx-gen-pid",
  "pmetal-mlx-rs",
 ]
 
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=9c740013a50f65778f1db3ef577a29828073448d#9c740013a50f65778f1db3ef577a29828073448d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3661,7 +3677,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=9c740013a50f65778f1db3ef577a29828073448d#9c740013a50f65778f1db3ef577a29828073448d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3670,7 +3686,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=9c740013a50f65778f1db3ef577a29828073448d#9c740013a50f65778f1db3ef577a29828073448d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3682,7 +3698,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=9c740013a50f65778f1db3ef577a29828073448d#9c740013a50f65778f1db3ef577a29828073448d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
 dependencies = [
  "image",
  "inventory",
@@ -3695,7 +3711,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=9c740013a50f65778f1db3ef577a29828073448d#9c740013a50f65778f1db3ef577a29828073448d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3706,7 +3722,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=9c740013a50f65778f1db3ef577a29828073448d#9c740013a50f65778f1db3ef577a29828073448d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3718,7 +3734,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=9c740013a50f65778f1db3ef577a29828073448d#9c740013a50f65778f1db3ef577a29828073448d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3729,7 +3745,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=9c740013a50f65778f1db3ef577a29828073448d#9c740013a50f65778f1db3ef577a29828073448d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
 dependencies = [
  "image",
  "inventory",
@@ -3743,7 +3759,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=9c740013a50f65778f1db3ef577a29828073448d#9c740013a50f65778f1db3ef577a29828073448d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
 dependencies = [
  "image",
  "inventory",
@@ -3754,7 +3770,7 @@ dependencies = [
 [[package]]
 name = "mlx-internal-macros"
 version = "0.25.3"
-source = "git+https://github.com/michaeltrefry/mlx-rs?rev=44929a001ab8a8837403a71c65cf064224de0cdc#44929a001ab8a8837403a71c65cf064224de0cdc"
+source = "git+https://github.com/michaeltrefry/mlx-rs?rev=38e1cc1730a11b1e40c2c8ecda01606763a12d51#38e1cc1730a11b1e40c2c8ecda01606763a12d51"
 dependencies = [
  "darling 0.21.3",
  "itertools 0.14.0",
@@ -3766,7 +3782,7 @@ dependencies = [
 [[package]]
 name = "mlx-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/mlx-llm?rev=29e382bd6a3800accf0bac5daf5d8eb61e1a2adf#29e382bd6a3800accf0bac5daf5d8eb61e1a2adf"
+source = "git+https://github.com/SceneWorks/mlx-llm?rev=6c052ba6bbb81be0b95bd5e4ba650d25edb62896#6c052ba6bbb81be0b95bd5e4ba650d25edb62896"
 dependencies = [
  "core-llm",
  "half",
@@ -3779,7 +3795,7 @@ dependencies = [
 [[package]]
 name = "mlx-macros"
 version = "0.25.3"
-source = "git+https://github.com/michaeltrefry/mlx-rs?rev=44929a001ab8a8837403a71c65cf064224de0cdc#44929a001ab8a8837403a71c65cf064224de0cdc"
+source = "git+https://github.com/michaeltrefry/mlx-rs?rev=38e1cc1730a11b1e40c2c8ecda01606763a12d51#38e1cc1730a11b1e40c2c8ecda01606763a12d51"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
@@ -4569,7 +4585,7 @@ dependencies = [
 [[package]]
 name = "pmetal-mlx-rs"
 version = "0.25.8"
-source = "git+https://github.com/michaeltrefry/mlx-rs?rev=44929a001ab8a8837403a71c65cf064224de0cdc#44929a001ab8a8837403a71c65cf064224de0cdc"
+source = "git+https://github.com/michaeltrefry/mlx-rs?rev=38e1cc1730a11b1e40c2c8ecda01606763a12d51#38e1cc1730a11b1e40c2c8ecda01606763a12d51"
 dependencies = [
  "dyn-clone",
  "half",
@@ -4592,7 +4608,7 @@ dependencies = [
 [[package]]
 name = "pmetal-mlx-sys"
 version = "0.2.4"
-source = "git+https://github.com/michaeltrefry/mlx-rs?rev=44929a001ab8a8837403a71c65cf064224de0cdc#44929a001ab8a8837403a71c65cf064224de0cdc"
+source = "git+https://github.com/michaeltrefry/mlx-rs?rev=38e1cc1730a11b1e40c2c8ecda01606763a12d51#38e1cc1730a11b1e40c2c8ecda01606763a12d51"
 dependencies = [
  "bindgen",
  "cc",
@@ -5433,7 +5449,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=9c740013a50f65778f1db3ef577a29828073448d#9c740013a50f65778f1db3ef577a29828073448d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
 dependencies = [
  "core-llm",
  "inventory",
@@ -5767,6 +5783,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -352,7 +352,20 @@ sceneworks-core = { path = "../sceneworks-core" }
 # same PR. The candle pin below moves `5967f05` -> `0e308af` (candle-gen #154 = its own gen-core re-pin
 # cf6f338 -> 7a4c437; candle-gen had already dropped the trait under sc-7404) so `--features
 # backend-candle --target all` resolves the SINGLE gen-core rev 7a4c437. mlx-rs unchanged (44929a0).
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c740013a50f65778f1db3ef577a29828073448d" }
+# Bumped `9c74001` -> `c45caec` (epic 7840, sc-8002 — catch-up): a 33-commit jump to mlx-gen main HEAD to
+# pick up the PiD pixel-diffusion decode seam (engine sc-7843/7844, qwen+krea wiring sc-7845 #574) so the
+# worker can wire per-generation `usePid` routing (sc-7849). The gen-core delta is purely additive
+# (`GenerationRequest.use_pid: bool`, `LoadSpec.pid: Option<PidWeights>` + `with_pid()`). The range ALSO
+# carries two non-PiD concerns that make this a real catch-up, not a doc bump:
+#   1) the sc-7898 metallib-resolver cascade — so `mlx-rs` (pmetal-mlx-rs) moves `44929a0` -> `38e1cc1`
+#      and `mlx-llm` moves `29e382bd` -> `6c052ba` IN LOCKSTEP below (mlx-gen #562 pins exactly these;
+#      a mismatched pmetal rev would compile pmetal-mlx-sys twice). This rebuilds MLX from source. Pulling
+#      mlx-llm `6c052ba` also brings Qwen3.6 `core_llm::Message.tool_calls`.
+#   2) the register-macro migration (sc-7779/7780/7970) — provider crates moved onto `register_*!`; the
+#      worker only force-links + `gen_core::load`s, so it is source-transparent (verified at build).
+# Candle moves in lockstep below (candle-gen #159 re-pins its gen-core 93ca0db -> c45caec) so
+# `--features backend-candle --target all` resolves the SINGLE gen-core rev c45caec.
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -694,7 +707,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c740013a50f65778f1db3ef577a29828073448d" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -705,76 +718,80 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c740013a50
 # unchanged by the 4db50b2 (sc-5105 Lens, epic 3164) bump above — kept in lockstep with mlx-gen's
 # internal pin (the Lens engine PRs #407–#414 did not move it; nor did the seedvr2 engine #416/#419/
 # #421 or the softness PR #422, so the 1a97909 bump above leaves mlx-rs at 44929a0).
-mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "44929a001ab8a8837403a71c65cf064224de0cdc" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c740013a50f65778f1db3ef577a29828073448d" }
+# Bumped `44929a0` -> `38e1cc1` (sc-8002 / sc-7898 cascade): the metallib-resolver fork fix (mlx-rs#11 —
+# prefer the build's own compiled-in metallib over a stale `~/.cache/pmetal` cache). mlx-gen #562 pins
+# exactly this rev, so the worker MUST match (a different rev would compile pmetal-mlx-sys twice). This
+# rebuilds MLX from source. Paired with mlx-llm `6c052ba` below (mlx-llm#45 carries the same fork pin).
+mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c740013a50f65778f1db3ef577a29828073448d" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c740013a50f65778f1db3ef577a29828073448d" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
 # Krea 2 Turbo (native MLX, Krea 2 Community License; epic 7565, sc-7572). Same git rev as mlx-gen.
 # Self-registers `krea_2_turbo` (Qwen3-VL-4B TE + 28-block single-stream DiT + Qwen-Image VAE; CFG-free
 # rectified-flow few-step) via inventory only when force-linked (`use mlx_gen_krea as _;` in
 # image_jobs.rs). Loads the packed Q8/Q4 turnkey subdir (krea_model_subdir; the loader auto-detects the
 # packed quant, so the resolved `spec.quantize` is a no-op on it). Depends on mlx-gen-qwen-image for the
 # shared `AutoencoderKLQwenImage` VAE.
-mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c740013a50f65778f1db3ef577a29828073448d" }
+mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c740013a50f65778f1db3ef577a29828073448d" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c740013a50f65778f1db3ef577a29828073448d" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c740013a50f65778f1db3ef577a29828073448d" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c740013a50f65778f1db3ef577a29828073448d" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
 # CLIP ViT-L/14 image embedder for the Dataset Doctor analysis job (epic 6529 P2, sc-6535).
 # Self-registers `clip_vit_l14` (gen_core::ImageEmbedder) via inventory only when force-linked
 # (`use mlx_gen_clip as _;` in dataset_analysis_jobs.rs). Reuses mlx-gen-sdxl's CLIP body → same rev.
-mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c740013a50f65778f1db3ef577a29828073448d" }
+mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c740013a50f65778f1db3ef577a29828073448d" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c740013a50f65778f1db3ef577a29828073448d" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c740013a50f65778f1db3ef577a29828073448d" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c740013a50f65778f1db3ef577a29828073448d" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c740013a50f65778f1db3ef577a29828073448d" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c740013a50f65778f1db3ef577a29828073448d" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c740013a50f65778f1db3ef577a29828073448d" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -783,12 +800,12 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c7400
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c740013a50f65778f1db3ef577a29828073448d" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c740013a50f65778f1db3ef577a29828073448d" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -797,7 +814,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c7400
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c740013a50f65778f1db3ef577a29828073448d" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -805,7 +822,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c740013a50f65778f1db3ef577a29828073448d" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -816,7 +833,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c74
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c740013a50f65778f1db3ef577a29828073448d" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -827,7 +844,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c740
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c740013a50f65778f1db3ef577a29828073448d" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -842,7 +859,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c7400
 # converted in-memory at load (no Python); the precomputed neg-prompt embedding is bundled in-crate. No
 # LoRA/guidance/CFG (one-step). 3B fp16 only here — 7B (sc-5197) + int8 (sc-5198) are engine-side and
 # unwired. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c740013a50f65778f1db3ef577a29828073448d" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -853,17 +870,21 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c7
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c740013a50f65778f1db3ef577a29828073448d" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
 # The unified LLM engine (epic 7153, sc-7158): the macOS `prompt_refine` job now runs through
 # mlx-llm's generic `mlx-llama` provider (a `core_llm::TextLlm`) resolved model-first via
 # `gen_core::core_llm::load_for_model`, RETIRING the bespoke `mlx-gen-prompt-refine` hand-rolled
 # Llama decoder. prompt_refine_jobs.rs force-links this crate (`use mlx_llm as _;`) so mlx-llm's
 # `inventory::submit!` of `mlx-llama` survives the release linker (the "no provider can serve" trap).
-# Same pmetal mlx-rs pin (44929a0) as the mlx-gen crates → one shared `Array` type + one MLX build;
+# Same pmetal mlx-rs pin (now 38e1cc1) as the mlx-gen crates → one shared `Array` type + one MLX build;
 # mlx-llm's core-llm dep unifies with gen-core's (both branch=main). Serves the same Anubis-Mini-8B
 # (sc-6550) for free-text refine + the JSON-constrained magic-prompt caption. The candle (Windows) lane
 # is the symmetric twin: candle-llm's `candle-llama` via the same seam (sc-7404), see `candle-llm` below.
-mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "29e382bd6a3800accf0bac5daf5d8eb61e1a2adf" }
+# Bumped `29e382bd` -> `6c052ba` (sc-8002 / sc-7898 cascade): mlx-llm#45 re-pins the fork to 38e1cc1 and
+# mlx-gen #562 pins mlx-llm at exactly 6c052ba, so the worker matches to keep ONE mlx-llm / ONE MLX build.
+# This rev also brings Qwen3.6 work incl. `core_llm::Message.tool_calls` (additive; worker builds no
+# `Message {…}` literal, so source-transparent — verified at build).
+mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "6c052ba6bbb81be0b95bd5e4ba650d25edb62896" }
 # SCAIL-2 (zai-org) end-to-end character-animation provider (epic 5439, sc-5448). An inventory-registered
 # `Generator` under id `scail2_14b` (`Modality::Video`): a Wan2.1-14B I2V DiT that animates a reference
 # character with a driving video's motion (`video_mode == "replacement"` flips the cross-identity
@@ -875,7 +896,7 @@ mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "29e382bd6a3800
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c740013a50f65778f1db3ef577a29828073448d" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -1122,25 +1143,30 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9c74
 # SOURCE-ONLY so 30ce2c2 STILL pins gen-core 54e87e9 == this worker's mlx pin (unchanged) — so `--features
 # backend-candle --target all` stays a SINGLE gen-core rev 54e87e9, no mlx bump (the mlx pin already moved
 # to 54e87e9 via #874). T2I (Base/Turbo) attention is byte-identical (chunking only triggers above budget).
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "00d9aae807f629d1784affb75dfb6d0f84fb04b9", features = ["cuda"], optional = true }
+# Bumped `00d9aae8` -> `4281c82` (sc-8002, candle-gen #159): lockstep with the worker's mlx pin moving to
+# c45caec (PiD seam, epic 7840). candle-gen #159 is a PURE gen-core re-pin `93ca0db` -> `c45caec` (no candle
+# source change — candle does NOT wire PiD; that is Phase 4 sc-7853 `candle-gen-pid`), so `--features
+# backend-candle --target all` resolves the SINGLE gen-core rev c45caec (== this worker's mlx pin). candle
+# builds nothing new. ALL candle-gen-* rev lines move together.
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "00d9aae807f629d1784affb75dfb6d0f84fb04b9", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "00d9aae807f629d1784affb75dfb6d0f84fb04b9", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "00d9aae807f629d1784affb75dfb6d0f84fb04b9", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "00d9aae807f629d1784affb75dfb6d0f84fb04b9", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "00d9aae807f629d1784affb75dfb6d0f84fb04b9", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "00d9aae807f629d1784affb75dfb6d0f84fb04b9", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1150,7 +1176,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "00d9aae807f629d1784affb75dfb6d0f84fb04b9", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1158,21 +1184,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "00d9aae807f629d1784affb75dfb6d0f84fb04b9", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "00d9aae807f629d1784affb75dfb6d0f84fb04b9", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "00d9aae807f629d1784affb75dfb6d0f84fb04b9", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "00d9aae807f629d1784affb75dfb6d0f84fb04b9", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1181,17 +1207,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "00d9aae807f629d1784affb75dfb6d0f84fb04b9", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "00d9aae807f629d1784affb75dfb6d0f84fb04b9", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "00d9aae807f629d1784affb75dfb6d0f84fb04b9", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1200,7 +1226,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "00d9aae807f629d1784affb75dfb6d0f84fb04b9", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1214,7 +1240,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "8ab61c8d
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "00d9aae807f629d1784affb75dfb6d0f84fb04b9", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1223,12 +1249,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "00d9aae807f629d1784affb75dfb6d0f84fb04b9", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "00d9aae807f629d1784affb75dfb6d0f84fb04b9", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1236,7 +1262,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "00d9a
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "00d9aae807f629d1784affb75dfb6d0f84fb04b9", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1245,7 +1271,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "00d9aae807f629d1784affb75dfb6d0f84fb04b9", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1253,7 +1279,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "00d9aae807f629d1784affb75dfb6d0f84fb04b9", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1262,7 +1288,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "00d9aae807f629d1784affb75dfb6d0f84fb04b9", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1289,7 +1315,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "00d9aae807f629d1784affb75dfb6d0f84fb04b9", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1148,25 +1148,30 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45c
 # source change — candle does NOT wire PiD; that is Phase 4 sc-7853 `candle-gen-pid`), so `--features
 # backend-candle --target all` resolves the SINGLE gen-core rev c45caec (== this worker's mlx pin). candle
 # builds nothing new. ALL candle-gen-* rev lines move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
+# Bumped `4281c82` -> `e4b80b77` (sc-8002, candle-gen #161): the mlx-llm bump moves `core-llm` to the
+# Qwen3.6 tool-calling API, which broke `candle-gen-joycaption`'s candle-llm pin (`8ab61c8`, pre-tool_calls)
+# on the #905 candle-worker CI. #161 bumps candle-gen-joycaption's candle-llm -> `54ef5a1` (== the worker's
+# candle-llm pin below) + adds `tool_calls: Vec::new()` to its `core_llm::Message` literals, so the worker
+# graph unifies ONE candle-llm. Still a single gen-core rev (c45caec) + now a single candle-llm (54ef5a1).
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1176,7 +1181,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1184,21 +1189,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1207,17 +1212,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1226,21 +1231,29 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
 # Force-linked in prompt_refine_jobs.rs (`use candle_llm as _;`) so the MSVC release linker keeps the
-# `inventory::submit!` registration. Pinned to the SAME rev `candle-gen-joycaption` pins (8ab61c8) so
-# cargo unifies ONE candle-llm — one `candle_core::Tensor`, one `core-llm` — across the graph (both
-# candle-llm and candle-gen pin the identical candle-core rev). Retires the bespoke
-# `candle-gen-prompt-refine` hand-rolled Llama decoder.
-candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "8ab61c8dd2b5617cfc6dba1cda978c73bf9d34bf", features = ["cuda"], optional = true }
+# `inventory::submit!` registration. cargo unifies ONE candle-llm — one `candle_core::Tensor`, one
+# `core-llm` — across the graph (both candle-llm and candle-gen pin the identical candle-core rev).
+# Retires the bespoke `candle-gen-prompt-refine` hand-rolled Llama decoder.
+# Bumped `8ab61c8` -> `54ef5a1` (sc-8002): REQUIRED by the mlx-llm `6c052ba` bump above. That bump moves
+# `core-llm` (branch=main, one rev for the whole graph) to `a49ca6d9`, which carries the Qwen3.6
+# tool-calling API (`TextLlmOutput.tool_calls`, `TextLlmCapabilities.supports_tools`, `RenderOptions
+# .tools`, `core_llm::ToolCallSegmenter`). The old candle-llm `8ab61c8` predates that API and constructs
+# those structs WITHOUT the new fields → E0063 (caught on the #905 candle-worker CI). `54ef5a1` is
+# candle-llm main HEAD, which adds the matching tool-calling wiring (candle-llm #35). Verified on macOS
+# (no-cuda): `candle-llm@54ef5a1` `cargo check` is green against `core-llm@a49ca6d9` (a49ca6d9 is 4
+# template/registry-only commits ahead of candle-llm's own validated `75873b48` — the tool-calling TYPES
+# are byte-identical between them, so a49ca6d9 is an API-superset for both mlx-llm and candle-llm).
+candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "54ef5a1ed43b8918f01858fe431bfec0eb2a3f25", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1249,12 +1262,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1262,7 +1275,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1271,7 +1284,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1279,7 +1292,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1288,7 +1301,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1315,7 +1328,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4281c82b0e9461cae78d278cd740b67e2b69fcd5", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -2472,6 +2472,9 @@ fn video_load_spec(input: &VideoGenInput) -> LoadSpec {
         extra_controls: Vec::new(),
         ip_adapter: None,
         adapters: input.adapters.clone(),
+        // PiD super-resolving decode (epic 7840) is an image-only latent-space swap; video
+        // providers have no PiD backbone, so never request it.
+        pid: None,
     }
 }
 
@@ -2556,6 +2559,9 @@ fn load_video_generation_for_tests(input: &VideoGenInput) -> WorkerResult<Box<dy
         extra_controls: Vec::new(),
         ip_adapter: None,
         adapters: input.adapters.clone(),
+        // PiD super-resolving decode (epic 7840) is an image-only latent-space swap; video
+        // providers have no PiD backbone, so never request it.
+        pid: None,
     };
     gen_core::load(input.engine_id, &spec)
         .map_err(|error| WorkerError::Engine(format!("video load failed: {error}")))


### PR DESCRIPTION
## What
Catch-up dependency bump moving the SceneWorks worker **33 mlx-gen commits forward** to main HEAD `c45caec`, so it can reference the PiD per-generation decode contract (`LoadSpec::with_pid` + `GenerationRequest.use_pid`, [mlx-gen#574](https://github.com/SceneWorks/mlx-gen/pull/574) / sc-7845). This **unblocks the `usePid` worker routing (sc-7849)**, epic 7840.

Pins-only catch-up — no worker behavior change beyond two additive `pid: None` fields.

## Pins
| dep | from | to | why |
|---|---|---|---|
| `mlx-gen-*` | `9c740013` | `c45caec` | PiD seam + engine wiring (sc-7843/7844/7845) |
| `pmetal-mlx-rs` | `44929a0` | `38e1cc1` | sc-7898 metallib-resolver fix; mlx-gen#562 pins exactly this (a mismatch compiles `pmetal-mlx-sys` twice) |
| `mlx-llm` | `29e382bd` | `6c052ba` | mlx-llm#45 (same fork pin); brings Qwen3.6 `core_llm::Message.tool_calls` (additive) |
| `candle-gen-*` | `00d9aae8` | `4281c82` | candle-gen#159 lockstep gen-core re-pin `93ca0db → c45caec` |
| `core-llm` (lock) | `58f2e64b` | `a49ca6d9` | the rev mlx-gen#562 validated `mlx-llm@6c052ba` against (see note) |

## Notes
- **core-llm floating-branch landmine (caught + fixed):** `mlx-llm@6c052ba` requires the Qwen3.6 tool-calling API (`ToolCallSegmenter`, `Message.tool_calls`, `TextLlmRequest.tools`…), but `core-llm = branch="main"` had floated to HEAD `58f2e64b`, which **lacks** those fields → 15 compile errors. Pinned the lockfile to `a49ca6d9` (mlx-gen#562's validated rev). _Latent org-wide hazard: a fresh `cargo update` of core-llm without re-pinning mlx-llm will reintroduce this — pre-existing, out of scope here._
- The range also carries the register-macro migration (sc-7779/7780/7970). The worker only force-links + `gen_core::load`s providers, so it's **source-transparent** (verified at build).
- `video_jobs.rs`: added `pid: None` to the two exhaustive `gen_core::LoadSpec` literals (video has no PiD backbone).

## Validation (macOS / MLX lane)
- `cargo check --all-targets` ✅ · `clippy --all-targets -D warnings` ✅ · `fmt --check` ✅
- `cargo test --lib` ✅ — **385 passed / 0 failed / 88 ignored**
- gen-core **skew gate single-rev (`c45caec`)** on default **and** `--features backend-candle` ✅
- candle-gen#159 **CUDA CI green on merge** ✅
- pmetal metallib change validated on-device upstream (sc-7898); weight-gated `*_real_weights` smokes run in the weighted env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)