### PR TITLE
sc-7849: worker per-generation usePid PiD decode routing

### DIFF
--- a/crates/sceneworks-worker/src/generator_cache.rs
+++ b/crates/sceneworks-worker/src/generator_cache.rs
@@ -36,6 +36,11 @@ pub(crate) struct GeneratorCacheKey {
     extra_controls: Vec<CacheWeightsSource>,
     ip_adapter: Option<CacheWeightsSource>,
     adapters: Vec<CacheAdapterSpec>,
+    // Per-generation PiD decoder aux-weights (epic 7840, sc-7849): `(checkpoint, gemma)` when the
+    // generator was loaded with `LoadSpec::with_pid`, else `None`. Keyed so a PiD-equipped load is a
+    // distinct cache entry from the plain VAE load — toggling `usePid` reloads rather than reusing a
+    // generator with the wrong decoder.
+    pid: Option<(CacheWeightsSource, CacheWeightsSource)>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -68,6 +73,12 @@ impl GeneratorCacheKey {
                 .collect(),
             ip_adapter: spec.ip_adapter.as_ref().map(CacheWeightsSource::from),
             adapters: spec.adapters.iter().map(CacheAdapterSpec::from).collect(),
+            pid: spec.pid.as_ref().map(|pid| {
+                (
+                    CacheWeightsSource::from(&pid.checkpoint),
+                    CacheWeightsSource::from(&pid.gemma),
+                )
+            }),
         }
     }
 }

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -1233,6 +1233,9 @@ include!("image_jobs/stream.rs");
 // base image routing (MLX) + neutral txt2img generation harness + the candle execution path.
 include!("image_jobs/base.rs");
 #[cfg(target_os = "macos")]
+// Per-generation PiD (pixel-diffusion) super-resolving decoder routing (epic 7840, sc-7849).
+include!("image_jobs/pid.rs");
+#[cfg(target_os = "macos")]
 // Z-Image strict-pose and prompt augmentation helpers.
 include!("image_jobs/zimage.rs");
 #[cfg(target_os = "macos")]

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -1055,6 +1055,10 @@ fn generate_one(
     sampler: Option<&str>,
     scheduler: Option<&str>,
     scheduler_shift: Option<f32>,
+    // Per-generation PiD super-resolving decode (epic 7840, sc-7849). Must be `true` only when the
+    // generator was loaded with `LoadSpec::with_pid` (the engine rejects a mismatch); the caller keeps
+    // the two in lockstep. The candle path passes `false` (candle PiD is Phase 4, sc-7853).
+    use_pid: bool,
     enhance: &PromptEnhance,
     cancel: &CancelFlag,
     on_progress: &mut dyn FnMut(Progress),
@@ -1094,6 +1098,7 @@ fn generate_one(
         sampler: sampler.map(str::to_owned),
         scheduler: scheduler.map(str::to_owned),
         scheduler_shift,
+        use_pid,
         conditioning,
         cancel: cancel.clone(),
         ..Default::default()
@@ -1728,7 +1733,15 @@ async fn generate_stream(
     // sc-6135: caption upsampling (FLUX.2-dev only; every other engine ignores it). Resolved from
     // the request's advanced `enhancePrompt` toggle, gated to dev by the manifest `ui.promptEnhance`.
     let enhance = PromptEnhance::from_advanced(&request.advanced);
-    let spec = load_spec(weights_dir, quant, adapters, flux_ip_dir);
+    // Per-generation PiD decode (epic 7840, sc-7849): resolve the PiD checkpoint + Gemma for this
+    // model's latent space when `advanced.usePid` is set and the snapshots are cached; otherwise keep
+    // the native VAE. `use_pid` and `spec.pid` stay in lockstep (the engine rejects a mismatch).
+    let pid_weights = resolve_pid_weights(request, &settings.data_dir, &request.model);
+    let use_pid = pid_weights.is_some();
+    let mut spec = load_spec(weights_dir, quant, adapters, flux_ip_dir);
+    if let Some(pid) = pid_weights {
+        spec = spec.with_pid(pid.checkpoint, pid.gemma);
+    }
     let (cancel, rx, blocking) = start_cached_gen_stream(
         job.id.clone(),
         engine_id,
@@ -1754,6 +1767,7 @@ async fn generate_stream(
                         sampler.as_deref(),
                         scheduler.as_deref(),
                         scheduler_shift,
+                        use_pid,
                         &enhance,
                         &cancel,
                         on_progress,
@@ -2298,6 +2312,8 @@ async fn generate_candle_stream(
                         sampler.as_deref(),
                         scheduler.as_deref(),
                         scheduler_shift,
+                        // candle PiD is Phase 4 (sc-7853); the off-Mac lane never requests it.
+                        false,
                         &enhance,
                         &cancel,
                         on_progress,

--- a/crates/sceneworks-worker/src/image_jobs/pid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/pid.rs
@@ -1,0 +1,174 @@
+// Per-generation PiD (pixel-diffusion) super-resolving decoder routing (epic 7840, sc-7849).
+//
+// PiD is an OPTIONAL, per-generation replacement for a model's VAE decoder: when the request opts in
+// (`advanced.usePid`) and a PiD checkpoint for the model's latent space is available, the engine swaps
+// `vae.decode(latent)` for a PiD `decode + 4x super-resolve` pass (mlx-gen `PidEngine`, sc-7843/7845).
+// PiD is tied to a LATENT SPACE, not a model, so eligibility keys on the model's backbone.
+//
+// This file is `include!`d on macOS only (the MLX lane); the candle PiD duplicate is Phase 4 (sc-7853).
+// It threads the toggle into the load-time `LoadSpec::with_pid` aux-weights + the per-gen
+// `GenerationRequest.use_pid` flag; the engine errors loudly if `use_pid` is set without `spec.pid`, so
+// the caller resolves the two together (both set, or neither → native VAE).
+
+// Default PiD checkpoint + Gemma-2 caption-encoder provisioning. These are the turnkey re-host
+// convention that the Phase-3 provisioning story (sc-7852) finalizes + makes downloadable; until then
+// the snapshots are simply absent, so `resolve_pid_weights` returns `None` and decode stays on the
+// native VAE (behavior-preserving). Both are overridable per-request via `advanced.pidCheckpoint`
+// (`{repo, filename}`) and `advanced.pidGemma` (repo string), mirroring `advanced.controlWeights`.
+const PID_QWENIMAGE_REPO: &str = "SceneWorks/pid-qwenimage";
+const PID_QWENIMAGE_FILE: &str = "pid_qwenimage_2kto4k.safetensors";
+// gemma-2-2b-it is the PiD caption encoder. sc-7852 finalizes the concrete source (likely a SceneWorks
+// mirror to avoid the upstream gated repo); the default points at the canonical id for now.
+const PID_GEMMA_REPO: &str = "google/gemma-2-2b-it";
+
+/// Map a SceneWorks image model id to its PiD latent-space backbone, or `None` when the model has no
+/// PiD backbone (so `usePid` is silently ignored — the guard for SenseNova et al.). Today only the
+/// `qwenimage` latent space is wired (sc-7845): Qwen-Image (incl. its strict-pose control variant,
+/// which shares the `qwen_image` model id), Qwen-Image-Edit, and Krea 2 Turbo (reuses `QwenVae`). The
+/// flux / flux2 / sdxl backbones light up in sc-7846 / 7847 / 7848.
+fn pid_backbone_for(model: &str) -> Option<&'static str> {
+    match model {
+        // Qwen-Image T2I + its strict-pose control variant (both the `qwen_image` model id), every
+        // Qwen-Image-Edit variant (all → the one `qwen_image_edit` engine), and Krea 2 Turbo.
+        "qwen_image"
+        | "qwen_image_edit"
+        | "qwen_image_edit_2509"
+        | "qwen_image_edit_2511"
+        | "qwen_image_edit_2511_lightning"
+        | "krea_2_turbo" => Some("qwenimage"),
+        _ => None,
+    }
+}
+
+/// True when the request opted into the PiD decoder via `advanced.usePid` (an opaque pass-through bool,
+/// like `mlxQuantize` / `schedulerShift` — no top-level `ImageRequest` field, so zero contract-snapshot
+/// drift). Accepts a JSON bool or the string `"true"`.
+fn pid_requested(request: &ImageRequest) -> bool {
+    request
+        .advanced
+        .get("usePid")
+        .map(|value| {
+            value.as_bool().unwrap_or_else(|| {
+                value
+                    .as_str()
+                    .is_some_and(|s| s.trim().eq_ignore_ascii_case("true"))
+            })
+        })
+        .unwrap_or(false)
+}
+
+/// Resolve the per-generation PiD decoder weights for `model`, or `None` to keep the native VAE decode.
+///
+/// Returns `None` whenever ANY of: the request did not opt in (`advanced.usePid` unset/false); the
+/// model has no PiD backbone (non-eligible → silently ignore the toggle); or the PiD checkpoint / Gemma
+/// snapshot is not cached under `data_dir` yet (provisioning is sc-7852). The checkpoint repo+filename
+/// and the Gemma repo default to the turnkey convention and may be overridden via
+/// `advanced.pidCheckpoint` (`{repo, filename}`) / `advanced.pidGemma` (repo string).
+///
+/// The caller sets BOTH `LoadSpec::with_pid(checkpoint, gemma)` and `GenerationRequest.use_pid = true`
+/// exactly when this returns `Some` — never one without the other (the engine rejects that).
+fn resolve_pid_weights(
+    request: &ImageRequest,
+    data_dir: &Path,
+    model: &str,
+) -> Option<gen_core::PidWeights> {
+    if !pid_requested(request) {
+        return None;
+    }
+    let backbone = pid_backbone_for(model)?;
+    let (default_repo, default_file) = match backbone {
+        "qwenimage" => (PID_QWENIMAGE_REPO, PID_QWENIMAGE_FILE),
+        // flux / flux2 / sdxl backbones (sc-7846/47/48) register their defaults here as they land.
+        _ => return None,
+    };
+
+    let ckpt_cfg = request
+        .advanced
+        .get("pidCheckpoint")
+        .and_then(Value::as_object);
+    let repo = ckpt_cfg
+        .and_then(|c| c.get("repo"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or(default_repo);
+    let filename = ckpt_cfg
+        .and_then(|c| c.get("filename"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or(default_file);
+    let gemma_repo = request
+        .advanced
+        .get("pidGemma")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or(PID_GEMMA_REPO);
+
+    // Both snapshots must be cached, or fall through to the native VAE (no partial/half-loaded PiD).
+    let checkpoint = huggingface_snapshot_dir(data_dir, repo)?.join(filename);
+    if !checkpoint.exists() {
+        return None;
+    }
+    let gemma = huggingface_snapshot_dir(data_dir, gemma_repo)?;
+    Some(gen_core::PidWeights {
+        checkpoint: WeightsSource::File(checkpoint),
+        gemma: WeightsSource::Dir(gemma),
+    })
+}
+
+#[cfg(all(target_os = "macos", test))]
+mod pid_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn request(model: &str, advanced: Value) -> ImageRequest {
+        ImageRequest::from_payload(
+            json!({ "model": model, "advanced": advanced })
+                .as_object()
+                .unwrap(),
+        )
+    }
+
+    #[test]
+    fn backbone_map_covers_qwenimage_family_only() {
+        assert_eq!(pid_backbone_for("qwen_image"), Some("qwenimage"));
+        assert_eq!(pid_backbone_for("qwen_image_edit"), Some("qwenimage"));
+        assert_eq!(pid_backbone_for("krea_2_turbo"), Some("qwenimage"));
+        // Not yet wired / no PiD backbone → silently ignored.
+        assert_eq!(pid_backbone_for("flux_dev"), None);
+        assert_eq!(pid_backbone_for("sdxl"), None);
+        assert_eq!(pid_backbone_for("sensenova_u1_8b"), None);
+    }
+
+    #[test]
+    fn pid_requested_reads_bool_and_string() {
+        assert!(pid_requested(&request("qwen_image", json!({ "usePid": true }))));
+        assert!(pid_requested(&request("qwen_image", json!({ "usePid": "true" }))));
+        assert!(!pid_requested(&request("qwen_image", json!({ "usePid": false }))));
+        assert!(!pid_requested(&request("qwen_image", json!({}))));
+    }
+
+    #[test]
+    fn resolve_returns_none_without_opt_in() {
+        let dir = tempfile::tempdir().unwrap();
+        let req = request("qwen_image", json!({}));
+        assert!(resolve_pid_weights(&req, dir.path(), &req.model).is_none());
+    }
+
+    #[test]
+    fn resolve_returns_none_for_non_eligible_model_even_when_requested() {
+        let dir = tempfile::tempdir().unwrap();
+        let req = request("sdxl", json!({ "usePid": true }));
+        assert!(resolve_pid_weights(&req, dir.path(), &req.model).is_none());
+    }
+
+    #[test]
+    fn resolve_returns_none_when_checkpoint_not_cached() {
+        // Opted-in + eligible, but the PiD checkpoint repo is not in the (empty) HF cache → native VAE.
+        let dir = tempfile::tempdir().unwrap();
+        let req = request("qwen_image", json!({ "usePid": true }));
+        assert!(resolve_pid_weights(&req, dir.path(), &req.model).is_none());
+    }
+}

--- a/crates/sceneworks-worker/src/image_jobs/qwen.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen.rs
@@ -64,6 +64,7 @@ fn qwen_control_generate_one(
     guidance: f32,
     control: Image,
     control_scale: f32,
+    use_pid: bool,
     cancel: &CancelFlag,
     on_progress: &mut dyn FnMut(Progress),
 ) -> WorkerResult<(u32, u32, Vec<u8>)> {
@@ -76,6 +77,7 @@ fn qwen_control_generate_one(
         seed: Some(seed as u64),
         steps: Some(steps),
         guidance: Some(guidance),
+        use_pid,
         conditioning: vec![Conditioning::Control {
             image: control,
             kind: ControlKind::Pose,
@@ -173,7 +175,15 @@ async fn generate_qwen_control_stream(
     let (width, height) = (request.width, request.height);
     let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
     let adapter_count = adapters.len();
-    let spec = qwen_control_spec(weights_dir, control_weights, quant, adapters);
+    // Per-generation PiD decode (epic 7840, sc-7849): the strict-pose control engine shares the
+    // `qwenimage` latent space, so route its decode through PiD when `advanced.usePid` is set and the
+    // snapshots are cached; otherwise native VAE. `use_pid` and `spec.pid` stay in lockstep.
+    let pid_weights = resolve_pid_weights(request, &settings.data_dir, &request.model);
+    let use_pid = pid_weights.is_some();
+    let mut spec = qwen_control_spec(weights_dir, control_weights, quant, adapters);
+    if let Some(pid) = pid_weights {
+        spec = spec.with_pid(pid.checkpoint, pid.gemma);
+    }
     let (cancel, rx, blocking) = start_cached_gen_stream(
         job.id.clone(),
         QWEN_CONTROL_ENGINE_ID,
@@ -206,6 +216,7 @@ async fn generate_qwen_control_stream(
                     guidance,
                     control,
                     control_scale,
+                    use_pid,
                     &cancel,
                     on_progress,
                 )?;
@@ -460,6 +471,7 @@ fn qwen_edit_generate_one(
     guidance: f32,
     sampler: Option<&str>,
     conditioning: Vec<Conditioning>,
+    use_pid: bool,
     cancel: &CancelFlag,
     on_progress: &mut dyn FnMut(Progress),
 ) -> WorkerResult<(u32, u32, Vec<u8>)> {
@@ -473,6 +485,7 @@ fn qwen_edit_generate_one(
         steps: Some(steps),
         guidance: Some(guidance),
         sampler: sampler.map(str::to_owned),
+        use_pid,
         conditioning,
         cancel: cancel.clone(),
         ..Default::default()
@@ -639,7 +652,15 @@ async fn generate_qwen_edit_stream(
     let (width, height) = (request.width, request.height);
     let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
     let adapter_count = adapters.len();
-    let spec = load_spec(weights_dir, quant, adapters, None);
+    // Per-generation PiD decode (epic 7840, sc-7849): Qwen-Image-Edit shares the `qwenimage` latent
+    // space, so route its decode through PiD when `advanced.usePid` is set and the snapshots are
+    // cached; otherwise native VAE. `use_pid` and `spec.pid` stay in lockstep.
+    let pid_weights = resolve_pid_weights(request, &settings.data_dir, &request.model);
+    let use_pid = pid_weights.is_some();
+    let mut spec = load_spec(weights_dir, quant, adapters, None);
+    if let Some(pid) = pid_weights {
+        spec = spec.with_pid(pid.checkpoint, pid.gemma);
+    }
     let (cancel, rx, blocking) = start_cached_gen_stream(
         job.id.clone(),
         engine_id,
@@ -693,6 +714,7 @@ async fn generate_qwen_edit_stream(
                         guidance,
                         sampler,
                         conditioning,
+                        use_pid,
                         &cancel,
                         on_progress,
                     )?;

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -998,6 +998,7 @@ fn smoke_generate_one(
         None,
         None,
         None,
+        false,
         &PromptEnhance::default(),
         &cancel,
         &mut |p| {
@@ -1174,6 +1175,7 @@ fn lens_turbo_real_weights_bucket_resolution() {
         None,
         None,
         None,
+        false,
         &PromptEnhance::default(),
         &cancel,
         &mut |_p| {},
@@ -1424,6 +1426,7 @@ fn kolors_real_weights_img2img_generates_one_image() {
         None,
         None,
         None,
+        false,
         &PromptEnhance::default(),
         &cancel,
         &mut |p| {
@@ -1476,6 +1479,7 @@ fn kolors_real_weights_ip_adapter_generates_one_image() {
         None,
         None,
         None,
+        false,
         &PromptEnhance::default(),
         &cancel,
         &mut |p| {
@@ -1811,6 +1815,7 @@ fn smoke_generate_one_true_cfg(
         None,
         None,
         None,
+        false,
         &PromptEnhance::default(),
         &cancel,
         &mut |p| {
@@ -2004,6 +2009,7 @@ fn sc3031_ab_dump_txt2img() {
         None,
         None,
         None,
+        false,
         &PromptEnhance::default(),
         &cancel,
         &mut |_| {},
@@ -2335,6 +2341,7 @@ fn qwen_control_real_weights_generates_one_pose() {
         4.0,
         control,
         0.9,
+        false,
         &cancel,
         &mut |p| {
             if let gen_core::Progress::Step { current, .. } = p {
@@ -3351,6 +3358,7 @@ fn qwen_edit_real_weights_generates_one_image() {
         4.0,
         None,
         build_edit_conditioning(std::slice::from_ref(&reference)),
+        false,
         &cancel,
         &mut |p| {
             if let gen_core::Progress::Step { current, .. } = p {
@@ -3416,6 +3424,7 @@ fn qwen_edit_lightning_real_weights_generates_one_image() {
         1.0,
         Some("lightning"),
         build_edit_conditioning(std::slice::from_ref(&reference)),
+        false,
         &cancel,
         &mut |p| {
             if let gen_core::Progress::Step { current, .. } = p {
@@ -4206,6 +4215,7 @@ fn ideogram_4_real_weights_generates_caption_and_plain_images() {
             None,
             None,
             None,
+            false,
             &enhance,
             &cancel,
             &mut |p| {
@@ -4395,6 +4405,7 @@ fn ideogram_4_headless_auto_caption_renders_real_image() {
             None,
             None,
             None,
+            false,
             &enhance,
             &cancel,
             &mut |_| {},
@@ -4530,6 +4541,7 @@ fn ideogram_4_real_weights_edit_img2img_and_inpaint() {
             None,
             None,
             None,
+            false,
             &enhance,
             &cancel,
             &mut |p| {
@@ -4726,6 +4738,7 @@ fn boogu_real_weights_generates_base_turbo_edit() {
             None,
             None,
             None,
+            false,
             &enhance,
             &cancel,
             &mut |p| {


### PR DESCRIPTION
## What
Phase 3 of the PiD epic (7840): carry the optional per-generation PiD (pixel-diffusion) decoder from the job request through the worker into the engine decode dispatch. Builds on the gen-core seam from sc-7845 ([mlx-gen#574](https://github.com/SceneWorks/mlx-gen/pull/574)) — `LoadSpec::with_pid` + `GenerationRequest.use_pid` — now reachable after the sc-8002 dep bump.

> **Stacked on [#905](https://github.com/SceneWorks/SceneWorks/pull/905) (sc-8002).** Base is the sc-8002 branch; retarget to `main` once #905 merges. Only the 6 routing files below are this PR's diff.

## Change
**New `image_jobs/pid.rs`** (macOS-only include):
- `pid_backbone_for(model)` — the `qwenimage` latent space today: Qwen-Image T2I + its strict-pose control variant, every Qwen-Image-Edit variant, and Krea 2 Turbo. `None` for non-eligible models → `usePid` silently ignored (the SenseNova guard). flux/flux2/sdxl land in sc-7846/47/48.
- `resolve_pid_weights(request, data_dir, model)` — reads `advanced.usePid`; returns the PiD checkpoint + Gemma-2 `WeightsSource` **only** when opted in, eligible, AND both snapshots are cached — else `None` → native VAE (behavior-preserving). Repo/filename default to the turnkey convention (provisioning is **sc-7852**) and are overridable via `advanced.pidCheckpoint` / `advanced.pidGemma` (mirrors `advanced.controlWeights`). **Zero contract-snapshot drift** (`advanced` is an opaque pass-through map).

**Routing (macOS MLX lane):** all four PiD-eligible paths resolve PiD once, wrap the `LoadSpec` with `.with_pid`, and pass `use_pid` into the `GenerationRequest` **in lockstep** (the engine rejects `use_pid` without `spec.pid`) — `generate_stream` (qwen_image T2I + krea_2_turbo), qwen control, qwen edit. `generate_one` + `qwen_{control,edit}_generate_one` gain a `use_pid` param; the candle path passes `false` (candle PiD is Phase 4, sc-7853).

**Cache key:** `GeneratorCacheKey` keys on `pid` (checkpoint, gemma) so toggling `usePid` loads a distinct generator rather than reusing the wrong decoder; PiD weights load lazily (only when requested) — no bloat on plain generations.

## Validation (macOS / MLX)
- `cargo check --all-targets`, `clippy --all-targets -D warnings`, `fmt --check` — green.
- `cargo test --lib` — **390 passed / 0 failed / 88 ignored** (5 new `pid_tests`: backbone map, usePid parse, resolve None cases).

## Scope boundary (per the epic decomposition)
End-to-end PiD *firing* is gated on **sc-7852** (checkpoint re-host + download wiring). Until then `usePid` is a safe no-op (native VAE) — exactly the "when the checkpoint is available" condition in this story's scope. The web toggle is **sc-7851**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)