### PR TITLE
sc-7852: PiD re-host download wiring — qwenimage + flux + flux2 + sdxl (NVIDIA License / NC)

### DIFF
--- a/apps/web/public/prompt-guides/pid.md
+++ b/apps/web/public/prompt-guides/pid.md
@@ -6,8 +6,10 @@ VAE decoder. Instead of decoding the latent at native resolution, PiD denoises
 pass** — so turning it on is effectively a "decode straight to high-res, with
 detail synthesis" mode rather than a transparent decoder swap.
 
-It applies to the **Qwen-Image latent space**: Qwen-Image, Qwen-Image-Edit, and
-Krea 2 Turbo.
+It's offered per latent space, so the eligible models depend on which PiD decoder
+is downloaded: **Qwen-Image** (Qwen-Image, Qwen-Image-Edit, Krea 2 Turbo),
+**FLUX.1** (FLUX.1, Boogu-Image, Chroma, Z-Image), and **FLUX.2** (FLUX.2-dev,
+FLUX.2-klein, Lens, Ideogram 4).
 
 ## ⚠️ Non-commercial — research / evaluation only
 

--- a/apps/web/public/prompt-guides/pid.md
+++ b/apps/web/public/prompt-guides/pid.md
@@ -1,0 +1,52 @@
+# PiD Decoder (Qwen-Image)
+
+**PiD** (Pixel Diffusion) is an optional, per-generation replacement for a model's
+VAE decoder. Instead of decoding the latent at native resolution, PiD denoises
+**directly in pixel space** and **decodes + 4× super-resolves in a single 4-step
+pass** — so turning it on is effectively a "decode straight to high-res, with
+detail synthesis" mode rather than a transparent decoder swap.
+
+It applies to the **Qwen-Image latent space**: Qwen-Image, Qwen-Image-Edit, and
+Krea 2 Turbo.
+
+## ⚠️ Non-commercial — research / evaluation only
+
+The PiD checkpoint is licensed under the **NVIDIA License** (HuggingFace tag
+`NSCLv1`). Under **§3.3**, the model and any derivative works may be used
+**non-commercially — for research or evaluation purposes only**.
+
+**This restriction applies to the images you decode with PiD.** PiD output is for
+research/evaluation use only and is distinct in that respect from images produced
+by the rest of the SceneWorks pipeline. When you enable PiD, SceneWorks marks the
+output accordingly.
+
+## What changes when you enable it
+
+- **Resolution jumps to 2K/4K.** PiD decodes to roughly **4× the native pixel
+  size** in one pass. Plan for larger gallery thumbnails, downloads, and dimensions.
+- **It is slower than the VAE.** The 4-step pixel-diffusion decode at 4K is a
+  premium path — expect noticeably longer decode time than the instant VAE decode.
+- **More memory.** The PiD backbone (~1.4 B params) plus its Gemma-2-2B caption
+  encoder load alongside the base model.
+
+## When to use it
+
+- You want a **high-resolution, detail-rich** result in one step (no separate
+  upscaler pass), **and** your use is research or evaluation.
+
+Leave PiD **off** for fast iteration, for native-resolution output, or for any use
+that is not strictly research/evaluation.
+
+## Availability
+
+PiD is shown only for eligible models and only once its checkpoint has been
+downloaded (Model Manager → "PiD Decoder (Qwen-Image)"). The PiD caption encoder
+(`gemma-2-2b-it`) is a gated Google repository, so its download requires a
+Hugging Face token that has accepted the Gemma terms.
+
+## Sources
+
+- Project: <https://research.nvidia.com/labs/sil/projects/pid/>
+- Model card: <https://huggingface.co/nvidia/PiD>
+- Code: <https://github.com/nv-tlabs/pid>
+- Paper: arXiv:2605.23902

--- a/apps/web/public/prompt-guides/pid.md
+++ b/apps/web/public/prompt-guides/pid.md
@@ -8,8 +8,9 @@ detail synthesis" mode rather than a transparent decoder swap.
 
 It's offered per latent space, so the eligible models depend on which PiD decoder
 is downloaded: **Qwen-Image** (Qwen-Image, Qwen-Image-Edit, Krea 2 Turbo),
-**FLUX.1** (FLUX.1, Boogu-Image, Chroma, Z-Image), and **FLUX.2** (FLUX.2-dev,
-FLUX.2-klein, Lens, Ideogram 4).
+**FLUX.1** (FLUX.1, Boogu-Image, Chroma, Z-Image), **FLUX.2** (FLUX.2-dev,
+FLUX.2-klein, Lens, Ideogram 4), and **SDXL** (SDXL, RealVisXL, RealVisXL
+Lightning, Kolors).
 
 ## ⚠️ Non-commercial — research / evaluation only
 

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -4036,6 +4036,75 @@
           ]
         }
       }
+    },
+    {
+      // PiD pixel-diffusion decoder — `sdxl` latent space (epic 7840, sc-7852). Serves the SDXL VAE
+      // latent space (4-ch affine 0.13025/0.0 — the largest latent→pixel ratio): SDXL base, RealVisXL
+      // (incl. RealVisXL Lightning), and Kolors (reuses the SDXL VAE). Engine wiring: sc-7848 (gate GO
+      // 4/4, #585). The `sdxl` student is variance-preserving (VP-frame); the shipped clean sigma=0
+      // decode path is frame-agnostic. 2kto4k-only (no 2k release).
+      //
+      // Worker routing = sc-8035 (qwenimage-only today). LICENSE (sc-7842): NVIDIA License (NSCLv1),
+      // non-commercial (research/evaluation) only, flows to output; SceneWorks/pid-sdxl ships the
+      // verbatim LICENSE + NOTICE + README.
+      "id": "pid_sdxl_decoder",
+      "autoDownload": false,
+      "nonCommercial": true,
+      "name": "PiD Decoder (SDXL / RealVisXL / Kolors)",
+      "family": "pid",
+      "type": "utility",
+      "adapter": "pid",
+      "capabilities": [],
+      "downloads": [
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/pid-sdxl",
+          "files": [],
+          "estimatedSizeBytes": 2724634940
+        },
+        {
+          "provider": "huggingface",
+          "repo": "google/gemma-2-2b-it",
+          "files": [],
+          "estimatedSizeBytes": 5228717488
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/SceneWorks/pid-sdxl"
+      },
+      "resources": {
+        "pidDecoders": {
+          "sdxl": {
+            "repo": "SceneWorks/pid-sdxl",
+            "file": "pid_sdxl_2kto4k.safetensors",
+            "gemmaRepo": "google/gemma-2-2b-it",
+            "nonCommercial": true,
+            "license": "NVIDIA License (NSCLv1)",
+            "licenseUrl": "https://huggingface.co/nvidia/PixelDiT-1300M-1024px/blob/main/LICENSE",
+            "originalUrl": "https://huggingface.co/nvidia/PiD"
+          }
+        }
+      },
+      "defaults": {},
+      "limits": {},
+      "loraCompatibility": {
+        "families": [],
+        "types": []
+      },
+      "ui": {
+        "label": "PiD Decoder (SDXL / RealVisXL / Kolors)",
+        "description": "Optional pixel-diffusion decoder that replaces the VAE for the SDXL latent space (SDXL, RealVisXL, RealVisXL Lightning, Kolors), decoding straight to 4x-larger (2K/4K) pixels with detail synthesis. NON-COMMERCIAL: research/evaluation use only — the restriction applies to images decoded with PiD.",
+        "recommendedFor": ["image_generate"],
+        "promptGuide": {
+          "title": "PiD Decoder Guide",
+          "path": "/prompt-guides/pid.md",
+          "sources": [
+            { "label": "PiD project page", "url": "https://research.nvidia.com/labs/sil/projects/pid/" },
+            { "label": "PiD model card (nvidia/PiD)", "url": "https://huggingface.co/nvidia/PiD" },
+            { "label": "PiD GitHub (nv-tlabs/pid)", "url": "https://github.com/nv-tlabs/pid" }
+          ]
+        }
+      }
     }
   ]
 }

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -3897,6 +3897,145 @@
           ]
         }
       }
+    },
+    {
+      // PiD pixel-diffusion decoder — `flux` latent space (epic 7840, sc-7852). Same opt-in
+      // per-generation VAE replacement as the qwenimage entry above; this `flux` student (FLUX.1-dev
+      // VAE, 16-ch affine 0.3611/0.1159) serves every model in that latent space: FLUX.1 (dev/schnell),
+      // Boogu-Image (base/turbo/edit), Chroma (hd/base/flash), and Z-Image (turbo/edit) — Z-Image shares
+      // the FLUX.1 VAE (PiD's zimage tags alias the flux checkpoint). Engine wiring: sc-7846.
+      //
+      // Worker routing for the flux/flux2/sdxl families is sc-8035 (the worker map is qwenimage-only
+      // today); until that lands a usePid request on these models falls through to native VAE.
+      // LICENSE (sc-7842): NVIDIA License (NSCLv1) — non-commercial (research/evaluation) only, flows to
+      // output; the SceneWorks/pid-flux repo ships the verbatim LICENSE + NOTICE + README.
+      "id": "pid_flux_decoder",
+      "autoDownload": false,
+      "nonCommercial": true,
+      "name": "PiD Decoder (FLUX.1 / Boogu / Chroma / Z-Image)",
+      "family": "pid",
+      "type": "utility",
+      "adapter": "pid",
+      "capabilities": [],
+      "downloads": [
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/pid-flux",
+          "files": [],
+          "estimatedSizeBytes": 2724745532
+        },
+        {
+          "provider": "huggingface",
+          "repo": "google/gemma-2-2b-it",
+          "files": [],
+          "estimatedSizeBytes": 5228717488
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/SceneWorks/pid-flux"
+      },
+      "resources": {
+        "pidDecoders": {
+          "flux": {
+            "repo": "SceneWorks/pid-flux",
+            "file": "pid_flux_2kto4k.safetensors",
+            "gemmaRepo": "google/gemma-2-2b-it",
+            "nonCommercial": true,
+            "license": "NVIDIA License (NSCLv1)",
+            "licenseUrl": "https://huggingface.co/nvidia/PixelDiT-1300M-1024px/blob/main/LICENSE",
+            "originalUrl": "https://huggingface.co/nvidia/PiD"
+          }
+        }
+      },
+      "defaults": {},
+      "limits": {},
+      "loraCompatibility": {
+        "families": [],
+        "types": []
+      },
+      "ui": {
+        "label": "PiD Decoder (FLUX.1 / Boogu / Chroma / Z-Image)",
+        "description": "Optional pixel-diffusion decoder that replaces the VAE for the FLUX.1 latent space (FLUX.1, Boogu-Image, Chroma, Z-Image), decoding straight to 4x-larger (2K/4K) pixels with detail synthesis. NON-COMMERCIAL: research/evaluation use only — the restriction applies to images decoded with PiD.",
+        "recommendedFor": ["image_generate"],
+        "promptGuide": {
+          "title": "PiD Decoder Guide",
+          "path": "/prompt-guides/pid.md",
+          "sources": [
+            { "label": "PiD project page", "url": "https://research.nvidia.com/labs/sil/projects/pid/" },
+            { "label": "PiD model card (nvidia/PiD)", "url": "https://huggingface.co/nvidia/PiD" },
+            { "label": "PiD GitHub (nv-tlabs/pid)", "url": "https://github.com/nv-tlabs/pid" }
+          ]
+        }
+      }
+    },
+    {
+      // PiD pixel-diffusion decoder — `flux2` latent space (epic 7840, sc-7852). Serves the FLUX.2 VAE
+      // latent space: FLUX.2-dev, FLUX.2-klein-9b, Lens (lens/lens_turbo), Ideogram 4 (ideogram_4/_turbo).
+      // The flux2 student consumes the packed 128-ch BN-normalized latent (sc-7847). Engine wiring:
+      // sc-7847 (merged). NOTE: the re-hosted checkpoint is the `_2606` revision of the 2kto4k flux2
+      // student — the un-suffixed 2kto4k flux2 checkpoint has a color-drift bug and is not used.
+      //
+      // Worker routing = sc-8035 (qwenimage-only today). LICENSE (sc-7842): NVIDIA License (NSCLv1),
+      // non-commercial (research/evaluation) only, flows to output; SceneWorks/pid-flux2 ships the
+      // verbatim LICENSE + NOTICE + README.
+      "id": "pid_flux2_decoder",
+      "autoDownload": false,
+      "nonCommercial": true,
+      "name": "PiD Decoder (FLUX.2 / Lens / Ideogram 4)",
+      "family": "pid",
+      "type": "utility",
+      "adapter": "pid",
+      "capabilities": [],
+      "downloads": [
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/pid-flux2",
+          "files": [],
+          "estimatedSizeBytes": 2725777732
+        },
+        {
+          "provider": "huggingface",
+          "repo": "google/gemma-2-2b-it",
+          "files": [],
+          "estimatedSizeBytes": 5228717488
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/SceneWorks/pid-flux2"
+      },
+      "resources": {
+        "pidDecoders": {
+          "flux2": {
+            "repo": "SceneWorks/pid-flux2",
+            "file": "pid_flux2_2kto4k.safetensors",
+            "gemmaRepo": "google/gemma-2-2b-it",
+            "nonCommercial": true,
+            "license": "NVIDIA License (NSCLv1)",
+            "licenseUrl": "https://huggingface.co/nvidia/PixelDiT-1300M-1024px/blob/main/LICENSE",
+            "originalUrl": "https://huggingface.co/nvidia/PiD"
+          }
+        }
+      },
+      "defaults": {},
+      "limits": {},
+      "loraCompatibility": {
+        "families": [],
+        "types": []
+      },
+      "ui": {
+        "label": "PiD Decoder (FLUX.2 / Lens / Ideogram 4)",
+        "description": "Optional pixel-diffusion decoder that replaces the VAE for the FLUX.2 latent space (FLUX.2-dev, FLUX.2-klein, Lens, Ideogram 4), decoding straight to 4x-larger (2K/4K) pixels with detail synthesis. NON-COMMERCIAL: research/evaluation use only — the restriction applies to images decoded with PiD.",
+        "recommendedFor": ["image_generate"],
+        "promptGuide": {
+          "title": "PiD Decoder Guide",
+          "path": "/prompt-guides/pid.md",
+          "sources": [
+            { "label": "PiD project page", "url": "https://research.nvidia.com/labs/sil/projects/pid/" },
+            { "label": "PiD model card (nvidia/PiD)", "url": "https://huggingface.co/nvidia/PiD" },
+            { "label": "PiD GitHub (nv-tlabs/pid)", "url": "https://github.com/nv-tlabs/pid" }
+          ]
+        }
+      }
     }
   ]
 }

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -3808,6 +3808,95 @@
           ]
         }
       }
+    },
+    {
+      // PiD pixel-diffusion super-resolving decoder — qwenimage latent space (epic 7840, sc-7852).
+      // OPTIONAL per-generation replacement for the VAE decoder (request `advanced.usePid`): PiD
+      // denoises directly in pixel space and decodes + 4x super-resolves in one 4-step pass. It is tied
+      // to a LATENT SPACE, not a model, so this one qwenimage checkpoint serves every Qwen-Image-family
+      // model that reuses QwenVae — Qwen-Image, Qwen-Image-Edit (all variants), and Krea 2 Turbo.
+      //
+      // The native worker (`image_jobs/pid.rs`, sc-7849) resolves the weights by REPO STRING
+      // (`SceneWorks/pid-qwenimage` checkpoint + `google/gemma-2-2b-it` caption encoder), not by this
+      // catalog id — cataloging it lets Model Manager download both into the HF cache the worker reads.
+      // `resolve_pid_weights` returns `None` (→ native VAE, behavior-preserving) until BOTH snapshots are
+      // cached, so this is a safe, opt-in, on-demand asset (autoDownload:false) with no auto-pull.
+      //
+      // LICENSE (sc-7842): the PiD checkpoint is under the NVIDIA License (HuggingFace tag "NSCLv1") —
+      // NON-COMMERCIAL (research/evaluation) use ONLY, and the restriction FLOWS TO DECODED OUTPUT
+      // (distinct from the rest of the pipeline; the web toggle surfaces an NC label per sc-7851). The
+      // re-host repo `SceneWorks/pid-qwenimage` ships the verbatim NVIDIA License + a NOTICE (NVIDIA
+      // attribution + provenance + the exact lossless conversion) + a model-card README; `files: []`
+      // pulls those alongside the weights so the obligation travels with the bytes (§3.1).
+      //
+      // gemma-2-2b-it is the PiD caption encoder. It is a GATED upstream Google repo today (the download
+      // needs a user HF token that has accepted the Gemma terms); a turnkey non-gated SceneWorks mirror
+      // is tracked as a follow-up so this entry stays focused on the PiD checkpoint re-host.
+      "id": "pid_qwenimage_decoder",
+      "autoDownload": false,
+      "nonCommercial": true,
+      "name": "PiD Decoder (Qwen-Image)",
+      "family": "pid",
+      "type": "utility",
+      "adapter": "pid",
+      "capabilities": [],
+      "downloads": [
+        {
+          // Converted qwenimage `2kto4k` 4-step student (456 tensors, bf16, ~2.7 GB) + the full NVIDIA
+          // License + NOTICE + model card. `files: []` pulls the whole repo so the license travels with
+          // the weights. Converted losslessly from nvidia/PiD's model_ema_bf16.pth (sc-7843 converter).
+          "provider": "huggingface",
+          "repo": "SceneWorks/pid-qwenimage",
+          "files": [],
+          "estimatedSizeBytes": 2724745532
+        },
+        {
+          // PiD caption encoder (Gemma-2-2B-IT). GATED upstream repo — download needs an HF token that
+          // has accepted the Gemma terms. Pulled as-is (no conversion); the mlx-gen-pid / candle-gen-pid
+          // Gemma-2 port reads the stock config/safetensors/tokenizer directly. `files: []` pulls the
+          // repo's own license/policy files alongside the weights.
+          "provider": "huggingface",
+          "repo": "google/gemma-2-2b-it",
+          "files": [],
+          "estimatedSizeBytes": 5228717488
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/SceneWorks/pid-qwenimage"
+      },
+      "resources": {
+        "pidDecoders": {
+          "qwenimage": {
+            "repo": "SceneWorks/pid-qwenimage",
+            "file": "pid_qwenimage_2kto4k.safetensors",
+            "gemmaRepo": "google/gemma-2-2b-it",
+            "nonCommercial": true,
+            "license": "NVIDIA License (NSCLv1)",
+            "licenseUrl": "https://huggingface.co/nvidia/PixelDiT-1300M-1024px/blob/main/LICENSE",
+            "originalUrl": "https://huggingface.co/nvidia/PiD"
+          }
+        }
+      },
+      "defaults": {},
+      "limits": {},
+      "loraCompatibility": {
+        "families": [],
+        "types": []
+      },
+      "ui": {
+        "label": "PiD Decoder (Qwen-Image)",
+        "description": "Optional pixel-diffusion decoder that replaces the VAE for Qwen-Image, Qwen-Image-Edit, and Krea 2 Turbo, decoding straight to 4x-larger (2K/4K) pixels with detail synthesis. NON-COMMERCIAL: research/evaluation use only — the restriction applies to images decoded with PiD.",
+        "recommendedFor": ["image_generate"],
+        "promptGuide": {
+          "title": "PiD Decoder Guide",
+          "path": "/prompt-guides/pid.md",
+          "sources": [
+            { "label": "PiD project page", "url": "https://research.nvidia.com/labs/sil/projects/pid/" },
+            { "label": "PiD model card (nvidia/PiD)", "url": "https://huggingface.co/nvidia/PiD" },
+            { "label": "PiD GitHub (nv-tlabs/pid)", "url": "https://github.com/nv-tlabs/pid" }
+          ]
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
Phase-3 download wiring for the **PiD pixel-diffusion decoder** (epic 7840, qwenimage backbone — the first quality-GO checkpoint, sc-7845). Makes the converted+re-hosted PiD checkpoint a downloadable in-app artifact so the worker (`image_jobs/pid.rs`, sc-7849) resolves it from the HF cache instead of users BYO-downloading.

## ⛔ DO NOT MERGE until `SceneWorks/pid-qwenimage` is published on HF
The catalog entry points at `SceneWorks/pid-qwenimage`; merging before that repo is live would 404 the Model Manager download. The turnkey package (converted safetensors + verbatim NVIDIA License + NOTICE + model card) is staged locally at `~/pid-rehost/pid-qwenimage/` ready to `hf upload` with an org write token. Until published, the worker's `resolve_pid_weights` returns `None` → native VAE (behavior-preserving), so nothing breaks on `main` regardless.

## Changes
- **`config/manifests/builtin.models.jsonc`** — new `type:"utility"` entry `pid_qwenimage_decoder` (mirrors the upscaler / prompt_refine / joycaption provisioning pattern): `autoDownload:false`, `nonCommercial:true`; `downloads[]` for the `SceneWorks/pid-qwenimage` checkpoint (`files:[]` so LICENSE/NOTICE/README travel with the weights) + the `gemma-2-2b-it` caption encoder; `resources.pidDecoders.qwenimage` with repo/file/gemmaRepo + `license`/`licenseUrl`/`nonCommercial` (aura_sr_v2 license-field precedent); NC ui copy + prompt guide.
- **`apps/web/public/prompt-guides/pid.md`** — PiD decoder guide (NC research/evaluation-only first; high-res-output + latency + memory expectations).

## License compliance (sc-7842)
The re-hosted checkpoint ships the **verbatim "NVIDIA License"** (HF-tagged NSCLv1) + NVIDIA attribution + retained notices. ⚠️ The actual LICENSE is titled "NVIDIA License", *not* literally "NVIDIA Source Code License-NC" — same substance. §3.3 non-commercial = **research/evaluation only**, and the restriction **flows to PiD-decoded output** (surfaced on the web toggle, sc-7851).

## Validation
- `node scripts/check-scaffold.mjs` → **passed** (JSONC + model-manifest schema + prompt-guide path existence).
- No Rust source changed — the manifest is `include_str!`-embedded + runtime-parsed; `ModelManifest` round-trips unknown fields losslessly (contract_roundtrip `futureRoot` proof), so the additive `nonCommercial` / `resources.pidDecoders` fields are safe.

## Follow-ups
- **sc-8025** — turnkey non-gated `SceneWorks/gemma-2-2b-it` mirror (the caption encoder is a gated google repo today).
- Post-publish: fresh-install "downloads + resolves" validation on a Mac (the remaining sc-7852 success criterion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)