### PR TITLE
sc-7851: web per-generation PiD decoder toggle (gating + NC label + 2K/4K UX)

### DIFF
--- a/apps/web/src/pidEligibility.js
+++ b/apps/web/src/pidEligibility.js
@@ -1,0 +1,51 @@
+// PiD (pixel-diffusion) decoder eligibility/availability for the per-generation toggle
+// (epic 7840, sc-7851). PiD is an OPTIONAL replacement for a model's VAE decoder: when a
+// generation opts in (`advanced.usePid`), the worker swaps `vae.decode()` for a PiD
+// decode + 2K/4K super-resolve pass (sc-7849). PiD is tied to a LATENT SPACE, not a model,
+// so eligibility keys on the model's declared backbone checkpoint (`ui.pid.checkpointId`,
+// mirroring the worker `pid_backbone_for` map). The checkpoint is a separate, non-commercial
+// (NSCLv1) download provisioned by sc-7852; until it is installed the toggle stays hidden so
+// the user never flips a decoder that would silently fall back to the native VAE.
+//
+// The two gates the Studio applies (Success criteria: "Toggle appears only for eligible +
+// available models"):
+//   (a) pidToggleEligible(model)          — the model's latent space has a PiD backbone.
+//   (b) pidDecoderAvailable(model, models) — that backbone's PiD checkpoint is installed.
+// pidToggleVisible(model, models) is both — the single predicate the toggle renders on.
+
+// The catalog id of the PiD checkpoint download a model's latent space needs, or null when
+// the model has no PiD backbone (non-eligible — the SenseNova et al. guard). Pure manifest
+// read: the eligible models declare `ui.pid.checkpointId` (qwenimage today; flux/flux2/sdxl
+// light up as sc-7846/47/48 land their backbones).
+export function pidCheckpointId(model) {
+  const id = model?.ui?.pid?.checkpointId;
+  return typeof id === "string" && id.length ? id : null;
+}
+
+// (a) Does the model's latent space have a PiD backbone at all? Independent of whether the
+// checkpoint is downloaded — this is the "hidden for non-eligible models" gate.
+export function pidToggleEligible(model) {
+  return pidCheckpointId(model) !== null;
+}
+
+// (b) Is the PiD checkpoint for this model's backbone downloaded? The checkpoint rides the
+// normal catalog as its own entry (sc-7852, a utility/decoder asset); we reuse the shared
+// `installState` mechanism rather than a bespoke availability field. Returns false for a
+// non-eligible model, or when the checkpoint entry is absent from / not installed in the
+// catalog (fail-closed: the worker would no-op to the native VAE, so a hidden toggle is the
+// honest UX).
+export function pidDecoderAvailable(model, models) {
+  const checkpointId = pidCheckpointId(model);
+  if (!checkpointId) {
+    return false;
+  }
+  return (models ?? []).some(
+    (entry) => entry?.id === checkpointId && entry?.installState === "installed",
+  );
+}
+
+// Both gates: the toggle is shown only when the model is eligible AND its checkpoint is
+// installed. This is the predicate the Image Studio advanced panel renders the toggle on.
+export function pidToggleVisible(model, models) {
+  return pidToggleEligible(model) && pidDecoderAvailable(model, models);
+}

--- a/apps/web/src/pidEligibility.test.js
+++ b/apps/web/src/pidEligibility.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  pidCheckpointId,
+  pidDecoderAvailable,
+  pidToggleEligible,
+  pidToggleVisible,
+} from "./pidEligibility.js";
+
+const qwen = { id: "qwen_image", ui: { pid: { checkpointId: "pid_qwenimage" } } };
+const krea = { id: "krea_2_turbo", ui: { pid: { checkpointId: "pid_qwenimage" } } };
+const sensenova = { id: "sensenova_u1_8b", ui: {} };
+const installedCkpt = { id: "pid_qwenimage", installState: "installed" };
+const missingCkpt = { id: "pid_qwenimage", installState: "missing" };
+
+describe("pidEligibility", () => {
+  it("pidCheckpointId reads ui.pid.checkpointId, null when absent", () => {
+    expect(pidCheckpointId(qwen)).toBe("pid_qwenimage");
+    expect(pidCheckpointId(sensenova)).toBe(null);
+    expect(pidCheckpointId({ ui: { pid: { checkpointId: "" } } })).toBe(null);
+    expect(pidCheckpointId(undefined)).toBe(null);
+  });
+
+  it("pidToggleEligible is true only for models with a PiD backbone", () => {
+    expect(pidToggleEligible(qwen)).toBe(true);
+    expect(pidToggleEligible(krea)).toBe(true);
+    expect(pidToggleEligible(sensenova)).toBe(false);
+  });
+
+  it("pidDecoderAvailable requires the checkpoint catalog entry to be installed", () => {
+    expect(pidDecoderAvailable(qwen, [qwen, installedCkpt])).toBe(true);
+    // Eligible but checkpoint not installed → not available (fail-closed).
+    expect(pidDecoderAvailable(qwen, [qwen, missingCkpt])).toBe(false);
+    // Eligible but checkpoint entry absent from the catalog (pre-sc-7852) → not available.
+    expect(pidDecoderAvailable(qwen, [qwen])).toBe(false);
+    // Non-eligible model is never available even if some pid checkpoint is installed.
+    expect(pidDecoderAvailable(sensenova, [sensenova, installedCkpt])).toBe(false);
+  });
+
+  it("pidToggleVisible requires both eligibility and an installed checkpoint", () => {
+    expect(pidToggleVisible(qwen, [qwen, installedCkpt])).toBe(true);
+    expect(pidToggleVisible(qwen, [qwen, missingCkpt])).toBe(false);
+    expect(pidToggleVisible(qwen, [qwen])).toBe(false);
+    expect(pidToggleVisible(sensenova, [sensenova, installedCkpt])).toBe(false);
+  });
+});

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -94,6 +94,7 @@ import {
 import { useAppContext } from "../context/AppContext.js";
 import { ModelAvailabilityGate } from "../components/ModelAvailabilityGate.jsx";
 import { downloadOffersFor, imageModelUsable } from "../modelEligibility.js";
+import { pidToggleVisible } from "../pidEligibility.js";
 import { PROMPT_REFINE_MODEL_ID } from "../constants.js";
 import {
   DEFAULT_MAC_CAPABILITIES,
@@ -392,6 +393,12 @@ export function ImageStudio() {
   // Boogu precision toggle (sc-6568): off = the packed Q8 default; on emits `advanced.mlxQuantize: 0`
   // (the full-precision bf16 build, fetched on demand by the worker). Sticky pref, default off (Q8).
   const [bf16Precision, setBf16Precision] = useState(saved.bf16Precision ?? false);
+  // PiD decoder toggle (epic 7840, sc-7851): off = the model's native VAE decode; on emits
+  // `advanced.usePid: true`, routing decode through the optional PiD pixel-diffusion decoder
+  // (decode + 2K/4K super-resolve, non-commercial output). Sticky pref, default off; the
+  // toggle only renders + emits when the model is PiD-eligible AND its checkpoint is installed
+  // (showPidToggle), so a stale `true` on a non-eligible model is inert — mirrors bf16Precision.
+  const [usePid, setUsePid] = useState(saved.usePid ?? false);
   const [faceRestore, setFaceRestore] = useState(false);
   // User-created poses (reserved global project) join the built-in library in both
   // the picker and the id→keypoints resolver below, so saved poses can generate.
@@ -589,6 +596,11 @@ export function ImageStudio() {
   // Whether the model ships a packed default + a hosted full-precision bf16 build, exposing the
   // Studio "Full precision (bf16)" toggle (sc-6568) — Boogu Base/Turbo/Edit.
   const precisionToggle = Boolean(selectedModel?.ui?.precisionToggle);
+  // PiD decoder toggle visibility (epic 7840, sc-7851): the model's latent space has a PiD
+  // backbone (ui.pid) AND that backbone's PiD checkpoint is installed. Hidden otherwise — for
+  // non-eligible models (e.g. SenseNova) and for eligible models whose checkpoint isn't
+  // downloaded yet (provisioned by sc-7852), where the worker would no-op to the native VAE.
+  const showPidToggle = useMemo(() => pidToggleVisible(selectedModel, models), [selectedModel, models]);
   // Whether the model supports multi-image reference editing (sc-6211) — edit_image mode shows a
   // multi-select reference picker (plural `referenceAssetIds`) instead of the single source picker.
   // FLUX.2-dev only (its DiT sequence-gated chunking keeps the multi-reference edit under 96 GB).
@@ -1022,6 +1034,7 @@ export function ImageStudio() {
     flashAttn,
     enhancePrompt,
     bf16Precision,
+    usePid,
   });
 
   // Snapshot the current working config into a named recipe preset in the
@@ -1257,6 +1270,13 @@ export function ImageStudio() {
           // exposes the precision toggle AND bf16 is selected; the default Q8 emits nothing (the
           // worker reads manifest mlx.quantize and fetches the `<variant>-bf16/` subfolder on demand).
           ...(precisionToggle && bf16Precision ? { mlxQuantize: 0 } : {}),
+          // PiD decoder (epic 7840, sc-7851): emit usePid:true only when the toggle is shown
+          // (model PiD-eligible AND checkpoint installed) AND on. The worker swaps the native
+          // VAE for the PiD decode + 2K/4K super-resolve pass; it rides `advanced` (opaque
+          // pass-through, zero contract-snapshot drift) and is cloned into the asset's
+          // rawAdapterSettings — that recorded `usePid:true` is the output's non-commercial
+          // marker. The worker independently no-ops to the native VAE if the checkpoint is gone.
+          ...(showPidToggle && usePid ? { usePid: true } : {}),
           // IP-Adapter / InstantID reference strength only applies when a character
           // reference is attached AND the model uses the IP-Adapter knob; Qwen's
           // edit pipeline ignores this scalar (hideReferenceStrength gates it out).
@@ -1863,6 +1883,19 @@ export function ImageStudio() {
                       type="checkbox"
                     />
                     Full precision (bf16)
+                  </label>
+                ) : null}
+                {showPidToggle ? (
+                  <label
+                    className="checkline pid-decoder-toggle"
+                    title="Decode this generation through NVIDIA's PiD pixel-diffusion decoder instead of the model's VAE: it decodes and super-resolves in one pass, so output comes out at 2K/4K (sharper detail, but slower and more memory). Non-commercial use only — PiD output is licensed for research/evaluation, unlike the rest of the pipeline. Off = the model's native VAE at the selected resolution."
+                  >
+                    <input
+                      checked={usePid}
+                      onChange={(event) => setUsePid(event.target.checked)}
+                      type="checkbox"
+                    />
+                    PiD decoder · 2K/4K <span className="badge badge-nc">NC</span>
                   </label>
                 ) : null}
                 <label className="checkline upscale-toggle">

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -919,3 +919,96 @@ describe("ImageStudio Ideogram 4 auto-expand on plain-text Generate (sc-6501)", 
     expect(surfaced).toBe(true);
   });
 });
+
+describe("ImageStudio PiD decoder toggle (sc-7851)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <ImageStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  // PiD-eligible image model: declares the qwenimage backbone via ui.pid (mirrors the
+  // manifest + worker pid_backbone_for). The checkpoint rides the full catalog (`models`)
+  // as its own installable entry (sc-7852), distinct from the image-model picker.
+  const PID_QWEN = { ...Z_IMAGE, id: "qwen_image", name: "Qwen Image", ui: { pid: { checkpointId: "pid_qwenimage" } } };
+  const PID_CKPT = (installState) => ({ id: "pid_qwenimage", type: "utility", installState });
+
+  const openAdvanced = async () =>
+    click([...container.querySelectorAll("button")].find((b) => b.textContent === "Advanced"));
+  const pidLabel = () =>
+    [...container.querySelectorAll("label")].find((l) => l.textContent.includes("PiD decoder"));
+  const generateButton = () =>
+    [...container.querySelectorAll("button")].find((b) => b.textContent === "Generate");
+
+  it("shows the toggle (default off) when eligible AND the checkpoint is installed", async () => {
+    await render(baseContext({ imageModels: [PID_QWEN], models: [PID_QWEN, PID_CKPT("installed")] }));
+    await openAdvanced();
+    await act(async () => {});
+    const toggle = pidLabel();
+    expect(toggle).toBeTruthy();
+    // NC marker is surfaced on the toggle copy.
+    expect(toggle.textContent).toContain("NC");
+    expect(toggle.querySelector('input[type="checkbox"]').checked).toBe(false);
+  });
+
+  it("hides the toggle when the checkpoint is present but not installed (fail-closed)", async () => {
+    await render(baseContext({ imageModels: [PID_QWEN], models: [PID_QWEN, PID_CKPT("missing")] }));
+    await openAdvanced();
+    await act(async () => {});
+    expect(pidLabel()).toBeFalsy();
+  });
+
+  it("hides the toggle when the checkpoint entry is absent from the catalog (today's pre-sc-7852 state)", async () => {
+    await render(baseContext({ imageModels: [PID_QWEN], models: [PID_QWEN] }));
+    await openAdvanced();
+    await act(async () => {});
+    expect(pidLabel()).toBeFalsy();
+  });
+
+  it("hides the toggle for a non-eligible model even when a PiD checkpoint is installed", async () => {
+    await render(baseContext({ imageModels: [Z_IMAGE], models: [Z_IMAGE, PID_CKPT("installed")] }));
+    await openAdvanced();
+    await act(async () => {});
+    expect(pidLabel()).toBeFalsy();
+  });
+
+  it("emits advanced.usePid:true only when shown AND toggled on", async () => {
+    const createImageJob = vi.fn(async () => ({ id: "job-1" }));
+    await render(
+      baseContext({ createImageJob, imageModels: [PID_QWEN], models: [PID_QWEN, PID_CKPT("installed")] }),
+    );
+    await openAdvanced();
+    await act(async () => {});
+
+    // Default off → no usePid in the payload.
+    await click(generateButton());
+    expect(createImageJob.mock.calls[0][0].advanced).not.toHaveProperty("usePid");
+
+    // Toggle on → usePid:true rides advanced.
+    await act(async () => pidLabel().querySelector('input[type="checkbox"]').click());
+    await click(generateButton());
+    expect(createImageJob.mock.calls[1][0].advanced.usePid).toBe(true);
+  });
+});

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3474,6 +3474,20 @@ label {
   width: auto;
 }
 
+/* Non-commercial marker on the PiD decoder toggle (epic 7840): PiD output is
+   licensed for research/evaluation only, unlike the rest of the pipeline. */
+.badge-nc {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 5px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  background: var(--warn-soft, var(--danger-soft));
+  color: var(--warn, var(--danger));
+}
+
 /* ---------- Library grid ---------- */
 .library-layout {
   display: grid;

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -205,6 +205,13 @@
         "label": "Qwen Image",
         "description": "Higher-control Qwen text-to-image target backed by Diffusers.",
         "recommendedFor": ["text_to_image", "style_variations"],
+        // PiD pixel-diffusion decoder (epic 7840): an optional per-generation VAE
+        // replacement that decodes + super-resolves to 2K/4K in one pass. `checkpointId`
+        // names the downloadable PiD checkpoint for this latent space (qwenimage); the
+        // Studio surfaces the toggle only once that checkpoint catalog entry is installed
+        // (provisioned by sc-7852). Eligibility mirrors the worker `pid_backbone_for` map
+        // (sc-7849). PiD output is non-commercial (research/evaluation) only.
+        "pid": { "checkpointId": "pid_qwenimage" },
         "promptGuide": {
           "title": "Qwen Image Prompt Guide",
           "path": "/prompt-guides/qwen-image.md",
@@ -274,6 +281,9 @@
         "label": "Qwen Image Edit (2511)",
         "description": "December 2025 iteration of Qwen-Image-Edit (Qwen/Qwen-Image-Edit-2511) on the multi-image `QwenImageEditPlusPipeline`. Mitigates image drift, improves character consistency in multi-person scenes, integrates popular LoRAs into the base, and strengthens geometric reasoning. Apache-2.0, ungated. Recommended 40 steps at trueCfgScale 4.0 / guidanceScale 1.0; bf16 MPS-supported per Qwen. trueCfgScale is the slider lever — identity stays steady across the range, the knob is a prompt-adherence vs reference-surroundings tradeoff (sc-2013 spike on the 2509 release; same Plus pipeline shape).",
         "recommendedFor": ["edit_image", "character_image"],
+        // PiD decoder (epic 7840, qwenimage latent space) — optional per-generation
+        // VAE replacement, decode + 2K/4K SR; NC output. See `qwen_image` for detail.
+        "pid": { "checkpointId": "pid_qwenimage" },
         // Qwen-Image-Edit's slider is true_cfg_scale (not an IP-Adapter
         // reference-strength scalar): the existing "Reference strength" slider
         // would be a no-op here. Hide it and surface variationStrength instead so
@@ -347,6 +357,9 @@
         "label": "Qwen Image Edit (2511) Lightning",
         "description": "4-step distilled Qwen-Image-Edit-2511 — ~10× faster at a small quality trade-off. Shares the Qwen-Image-Edit-2511 base weights; the lightx2v 4-step distill LoRA fuses on first use. CFG is disabled by default (distill drops the guidance signal); the variation knob (trueCfgScale) pins to 1.0. Apache-2.0 base + LoRA.",
         "recommendedFor": ["edit_image", "character_image"],
+        // PiD decoder (epic 7840, qwenimage latent space) — optional per-generation
+        // VAE replacement, decode + 2K/4K SR; NC output. See `qwen_image` for detail.
+        "pid": { "checkpointId": "pid_qwenimage" },
         "hideReferenceStrength": true,
         // Distill is trained at cfg 1.0; the variation slider is exposed only as
         // a narrow safety lever (1.0–2.0) for users willing to trade some
@@ -1398,6 +1411,10 @@
         "label": "Krea 2 Turbo",
         "description": "Krea 2 Turbo — Krea AI's from-scratch foundation image model, distilled to a fast few-step (~8), CFG-free variant: a 28-block single-stream rectified-flow DiT with a Qwen3-VL-4B text encoder, native MLX (Apple Silicon). Strong photorealism up to 2048². Pre-quantized Q8 (~20.5 GB download, default). Krea 2 Community License (non-commercial). Needs a 48 GB-class Mac.",
         "recommendedFor": ["text_to_image"],
+        // PiD decoder (epic 7840, qwenimage latent space — Krea 2 Turbo reuses the Qwen
+        // VAE) — optional per-generation VAE replacement, decode + 2K/4K SR; NC output.
+        // See `qwen_image` for detail.
+        "pid": { "checkpointId": "pid_qwenimage" },
         "promptGuide": {
           "title": "Krea 2 Prompt Guide",
           "path": "/prompt-guides/krea-2.md",


### PR DESCRIPTION
Surfaces the optional **PiD pixel-diffusion decoder** as a per-generation toggle in Image Studio (epic 7840, Phase 3). Builds on the worker `usePid` routing from [sc-7849 / #906](https://github.com/SceneWorks/SceneWorks/pull/906): the toggle writes `advanced.usePid: true`, which the worker routes to the PiD decode + 2K/4K super-resolve pass — or no-ops to the native VAE if the checkpoint isn't cached.

## Changes
- **Manifest** (`config/manifests/builtin.models.jsonc`): `ui.pid.checkpointId: "pid_qwenimage"` on the 4 catalogued PiD-eligible models (`qwen_image`, `qwen_image_edit_2511`, `qwen_image_edit_2511_lightning`, `krea_2_turbo`), mirroring the worker `pid_backbone_for` map. `ui` is a free-form `JsonObject` in Rust + permissive in the JSON schema → zero schema/Rust impact.
- **`apps/web/src/pidEligibility.js`** (+ tests): `pidToggleEligible` (gate a — model has a PiD backbone), `pidDecoderAvailable` (gate b — checkpoint installed, via the shared `installState` mechanism), `pidToggleVisible` (both). Generic across backbones — flux/flux2/sdxl (sc-7846/47/48) and zimage (sc-8033) need only their manifest flag + worker routing, no web change.
- **`ImageStudio.jsx`**: `usePid` sticky-pref state; gated Advanced-panel toggle with **NC badge + 2K/4K copy**; emits `advanced.usePid:true` only when shown AND on. The worker clones `advanced` into the asset `rawAdapterSettings`, so the recorded `usePid:true` is the output's **non-commercial metadata marker**. `styles.css`: `.badge-nc`.

## Gating (fail-closed)
The toggle is hidden until the `pid_qwenimage` checkpoint catalog entry is installed (provisioned by **sc-7852**), so nothing is user-visible or breakable pre-provisioning. NC copy uses settled "research/evaluation only" language (exact NSCLv1 string is sc-7842, not needed for the label).

## Tests
`pidEligibility` (4) + `ImageStudio` PiD describe (4 — visibility across eligible/available/missing/non-eligible, NC copy, `usePid` emission). Full web suite green: **732 passed / 44 files**; ESLint 0 errors.

## Known limitation (upstream dependency, not incomplete scope)
In-app end-to-end validation of success criteria #1 (eligible **+ available**) and #3 (real 2K/4K render/save) is gated on **sc-7852** publishing the `pid_qwenimage` checkpoint catalog entry + download (it owns "wire availability detection that the web gating consumes"). The render branch + payload are proven at the jsdom-component level against a mocked installed checkpoint. The availability contract sc-7852 must satisfy is documented on that story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)