### PR TITLE
feat(worker): wire SD3.5 Large/Turbo native MLX t2i + register converters (sc-7871)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -520,7 +520,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -586,7 +586,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -601,7 +601,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -614,7 +614,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -626,7 +626,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -643,7 +643,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -669,7 +669,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -684,7 +684,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -702,7 +702,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -713,7 +713,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -726,7 +726,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -737,7 +737,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -750,7 +750,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -7805,7 +7805,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -520,7 +520,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -586,7 +586,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -601,7 +601,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -614,7 +614,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -626,7 +626,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -643,7 +643,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -669,7 +669,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -684,7 +684,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -702,7 +702,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -713,7 +713,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -726,7 +726,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -737,7 +737,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -750,7 +750,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4b80b77ca6827a4896c1a4a6e83a5ad69666e46#e4b80b77ca6827a4896c1a4a6e83a5ad69666e46"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -3455,7 +3455,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3467,7 +3467,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
 dependencies = [
  "image",
  "inventory",
@@ -3481,11 +3481,12 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
 dependencies = [
  "image",
  "inventory",
  "mlx-gen",
+ "mlx-gen-pid",
  "mlx-gen-z-image",
  "pmetal-mlx-rs",
  "serde_json",
@@ -3494,11 +3495,12 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
 dependencies = [
  "inventory",
  "mlx-gen",
  "mlx-gen-flux",
+ "mlx-gen-pid",
  "mlx-gen-z-image",
  "pmetal-mlx-rs",
 ]
@@ -3506,7 +3508,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3517,7 +3519,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3526,10 +3528,11 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
 dependencies = [
  "inventory",
  "mlx-gen",
+ "mlx-gen-pid",
  "mlx-gen-sdxl",
  "mlx-gen-z-image",
  "pmetal-mlx-rs",
@@ -3538,10 +3541,11 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
 dependencies = [
  "inventory",
  "mlx-gen",
+ "mlx-gen-pid",
  "mlx-llm",
  "pmetal-mlx-rs",
  "serde_json",
@@ -3550,11 +3554,12 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
 dependencies = [
  "inventory",
  "mlx-gen",
  "mlx-gen-flux2",
+ "mlx-gen-pid",
  "pmetal-mlx-rs",
  "serde_json",
 ]
@@ -3562,7 +3567,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3573,7 +3578,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3583,11 +3588,12 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
 dependencies = [
  "image",
  "inventory",
  "mlx-gen",
+ "mlx-gen-pid",
  "mlx-gen-sdxl",
  "pmetal-mlx-rs",
 ]
@@ -3595,7 +3601,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
 dependencies = [
  "image",
  "inventory",
@@ -3609,12 +3615,13 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
 dependencies = [
  "image",
  "inventory",
  "mlx-gen",
  "mlx-gen-flux2",
+ "mlx-gen-pid",
  "pmetal-mlx-rs",
  "serde_json",
 ]
@@ -3622,7 +3629,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
 dependencies = [
  "image",
  "inventory",
@@ -3634,7 +3641,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3645,7 +3652,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3657,7 +3664,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3668,7 +3675,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3677,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3686,7 +3693,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3696,13 +3703,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "mlx-gen-sd3"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
+dependencies = [
+ "inventory",
+ "mlx-gen",
+ "mlx-gen-flux",
+ "mlx-gen-sdxl",
+ "mlx-gen-z-image",
+ "pmetal-mlx-rs",
+ "serde_json",
+]
+
+[[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
 dependencies = [
  "image",
  "inventory",
  "mlx-gen",
+ "mlx-gen-pid",
  "pmetal-mlx-rs",
  "regex",
  "serde_json",
@@ -3711,7 +3733,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3722,7 +3744,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3734,7 +3756,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3745,7 +3767,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
 dependencies = [
  "image",
  "inventory",
@@ -3759,11 +3781,12 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
 dependencies = [
  "image",
  "inventory",
  "mlx-gen",
+ "mlx-gen-pid",
  "pmetal-mlx-rs",
 ]
 
@@ -5449,7 +5472,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c45caec6cb39274ddd8dd146cc5b020cdb2b6695#c45caec6cb39274ddd8dd146cc5b020cdb2b6695"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
 dependencies = [
  "core-llm",
  "inventory",
@@ -5562,6 +5585,7 @@ dependencies = [
  "mlx-gen-sam2",
  "mlx-gen-sam3",
  "mlx-gen-scail2",
+ "mlx-gen-sd3",
  "mlx-gen-sdxl",
  "mlx-gen-seedvr2",
  "mlx-gen-sensenova",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -520,7 +520,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -586,7 +586,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -601,7 +601,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -614,7 +614,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -626,7 +626,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -643,7 +643,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -669,7 +669,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -684,7 +684,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -702,7 +702,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -713,7 +713,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -726,7 +726,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -737,7 +737,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -750,7 +750,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2a73fc2a65360b8f4070232ae06ea8675c9dd6b6#2a73fc2a65360b8f4070232ae06ea8675c9dd6b6"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ff78878919480faa5954f42c9c9a2e16ba9b01f3#ff78878919480faa5954f42c9c9a2e16ba9b01f3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -3455,7 +3455,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3467,7 +3467,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
 dependencies = [
  "image",
  "inventory",
@@ -3481,7 +3481,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
 dependencies = [
  "image",
  "inventory",
@@ -3495,7 +3495,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3508,7 +3508,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3519,7 +3519,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3528,7 +3528,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3541,7 +3541,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3554,7 +3554,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3567,7 +3567,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3578,7 +3578,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3588,7 +3588,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
 dependencies = [
  "image",
  "inventory",
@@ -3601,7 +3601,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
 dependencies = [
  "image",
  "inventory",
@@ -3615,7 +3615,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
 dependencies = [
  "image",
  "inventory",
@@ -3629,7 +3629,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
 dependencies = [
  "image",
  "inventory",
@@ -3641,7 +3641,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3652,7 +3652,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3664,7 +3664,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3675,7 +3675,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3684,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3693,7 +3693,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3705,7 +3705,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3719,7 +3719,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
 dependencies = [
  "image",
  "inventory",
@@ -3733,7 +3733,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3744,7 +3744,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3756,7 +3756,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3767,7 +3767,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
 dependencies = [
  "image",
  "inventory",
@@ -3781,7 +3781,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
 dependencies = [
  "image",
  "inventory",
@@ -5472,7 +5472,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=7468d03e761f02d4955da79009177f75f1221e0f#7468d03e761f02d4955da79009177f75f1221e0f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
 dependencies = [
  "core-llm",
  "inventory",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -365,7 +365,7 @@ sceneworks-core = { path = "../sceneworks-core" }
 #      worker only force-links + `gen_core::load`s, so it is source-transparent (verified at build).
 # Candle moves in lockstep below (candle-gen #159 re-pins its gen-core 93ca0db -> c45caec) so
 # `--features backend-candle --target all` resolves the SINGLE gen-core rev c45caec.
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -707,7 +707,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -723,75 +723,83 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb3
 # exactly this rev, so the worker MUST match (a different rev would compile pmetal-mlx-sys twice). This
 # rebuilds MLX from source. Paired with mlx-llm `6c052ba` below (mlx-llm#45 carries the same fork pin).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
 # Krea 2 Turbo (native MLX, Krea 2 Community License; epic 7565, sc-7572). Same git rev as mlx-gen.
 # Self-registers `krea_2_turbo` (Qwen3-VL-4B TE + 28-block single-stream DiT + Qwen-Image VAE; CFG-free
 # rectified-flow few-step) via inventory only when force-linked (`use mlx_gen_krea as _;` in
 # image_jobs.rs). Loads the packed Q8/Q4 turnkey subdir (krea_model_subdir; the loader auto-detects the
 # packed quant, so the resolved `spec.quantize` is a no-op on it). Depends on mlx-gen-qwen-image for the
 # shared `AutoencoderKLQwenImage` VAE.
-mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
+mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
+# Stable Diffusion 3.5 provider (native MLX, Stability AI Community License; epic 7841, sc-7871). Same
+# git rev as mlx-gen so MLX builds once. Self-registers `sd3_5_large` (true-CFG, 28 steps / guidance 3.5)
+# + `sd3_5_large_turbo` (ADD-distilled few-step, CFG-off) via inventory only when force-linked
+# (`use mlx_gen_sd3 as _;` in image_jobs.rs). The MMDiT-X Medium variant has a converter (`Sd3Arch::medium`)
+# but NO registered generator yet (M3, deferred), so no `sd3_5_medium` MODEL_TABLE row. Reuses the SDXL
+# CLIP encoder (×2), the FLUX T5-XXL encoder, and the Z-Image 16-ch VAE — its `quantize_sd3_dir` converter
+# is wired in model_jobs.rs for the `sd3_5_{large,large_turbo,medium}_quant` install-time conversions.
+mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
 # CLIP ViT-L/14 image embedder for the Dataset Doctor analysis job (epic 6529 P2, sc-6535).
 # Self-registers `clip_vit_l14` (gen_core::ImageEmbedder) via inventory only when force-linked
 # (`use mlx_gen_clip as _;` in dataset_analysis_jobs.rs). Reuses mlx-gen-sdxl's CLIP body → same rev.
-mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
+mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -800,12 +808,12 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45cae
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -814,7 +822,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45cae
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -822,7 +830,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -833,7 +841,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45c
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -844,7 +852,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45ca
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -859,7 +867,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45cae
 # converted in-memory at load (no Python); the precomputed neg-prompt embedding is bundled in-crate. No
 # LoRA/guidance/CFG (one-step). 3B fp16 only here — 7B (sc-5197) + int8 (sc-5198) are engine-side and
 # unwired. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -870,7 +878,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
 # The unified LLM engine (epic 7153, sc-7158): the macOS `prompt_refine` job now runs through
 # mlx-llm's generic `mlx-llama` provider (a `core_llm::TextLlm`) resolved model-first via
 # `gen_core::core_llm::load_for_model`, RETIRING the bespoke `mlx-gen-prompt-refine` hand-rolled
@@ -896,7 +904,7 @@ mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "6c052ba6bbb81b
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45caec6cb39274ddd8dd146cc5b020cdb2b6695" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -1153,25 +1161,25 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c45c
 # on the #905 candle-worker CI. #161 bumps candle-gen-joycaption's candle-llm -> `54ef5a1` (== the worker's
 # candle-llm pin below) + adds `tool_calls: Vec::new()` to its `core_llm::Message` literals, so the worker
 # graph unifies ONE candle-llm. Still a single gen-core rev (c45caec) + now a single candle-llm (54ef5a1).
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1181,7 +1189,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1189,21 +1197,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1212,17 +1220,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1231,7 +1239,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1253,7 +1261,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "54ef5a1e
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1262,12 +1270,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1275,7 +1283,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1284,7 +1292,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1292,7 +1300,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1301,7 +1309,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1328,7 +1336,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4b80b77ca6827a4896c1a4a6e83a5ad69666e46", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1169,25 +1169,25 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a78
 # on the #905 candle-worker CI. #161 bumps candle-gen-joycaption's candle-llm -> `54ef5a1` (== the worker's
 # candle-llm pin below) + adds `tool_calls: Vec::new()` to its `core_llm::Message` literals, so the worker
 # graph unifies ONE candle-llm. Still a single gen-core rev (c45caec) + now a single candle-llm (54ef5a1).
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1197,7 +1197,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1205,21 +1205,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1228,17 +1228,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1247,7 +1247,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1269,7 +1269,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "54ef5a1e
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1278,12 +1278,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1291,7 +1291,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff788
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1300,7 +1300,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1308,7 +1308,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1317,7 +1317,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1344,7 +1344,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -365,7 +365,15 @@ sceneworks-core = { path = "../sceneworks-core" }
 #      worker only force-links + `gen_core::load`s, so it is source-transparent (verified at build).
 # Candle moves in lockstep below (candle-gen #159 re-pins its gen-core 93ca0db -> c45caec) so
 # `--features backend-candle --target all` resolves the SINGLE gen-core rev c45caec.
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
+# Bumped `c45caec` -> `7468d03` (epic 7841 SD3.5, sc-7871 / S2 first pass): a PURE gen-core lockstep
+# re-pin to pick up the new `mlx-gen-sd3` SD3.5 Large/Turbo generators. gen-core BYTE-IDENTICAL.
+# Bumped `7468d03` -> `1a784cd` (epic 7841 SD3.5, sc-7871 / S2 completion, M3 merged): re-pin to
+# mlx-gen main HEAD, which registers the `sd3_5_medium` MMDiT-X generator (mlx-gen-sd3 M3, sc-7869).
+# `git diff 7468d03..1a784cd -- gen-core/` is EMPTY — gen-core is byte-identical; the only delta is
+# mlx-gen-sd3 (Medium generator + e2e). The `sd3_5_medium` MODEL_TABLE row lands in this same PR.
+# Candle moves in lockstep below (candle-gen #162 re-pins its gen-core 7468d03 -> 1a784cd) so
+# `--features backend-candle --target all` resolves the SINGLE gen-core rev 1a784cd.
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -707,7 +715,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -723,83 +731,83 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761
 # exactly this rev, so the worker MUST match (a different rev would compile pmetal-mlx-sys twice). This
 # rebuilds MLX from source. Paired with mlx-llm `6c052ba` below (mlx-llm#45 carries the same fork pin).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
 # Krea 2 Turbo (native MLX, Krea 2 Community License; epic 7565, sc-7572). Same git rev as mlx-gen.
 # Self-registers `krea_2_turbo` (Qwen3-VL-4B TE + 28-block single-stream DiT + Qwen-Image VAE; CFG-free
 # rectified-flow few-step) via inventory only when force-linked (`use mlx_gen_krea as _;` in
 # image_jobs.rs). Loads the packed Q8/Q4 turnkey subdir (krea_model_subdir; the loader auto-detects the
 # packed quant, so the resolved `spec.quantize` is a no-op on it). Depends on mlx-gen-qwen-image for the
 # shared `AutoencoderKLQwenImage` VAE.
-mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
+mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
 # Stable Diffusion 3.5 provider (native MLX, Stability AI Community License; epic 7841, sc-7871). Same
 # git rev as mlx-gen so MLX builds once. Self-registers `sd3_5_large` (true-CFG, 28 steps / guidance 3.5)
-# + `sd3_5_large_turbo` (ADD-distilled few-step, CFG-off) via inventory only when force-linked
-# (`use mlx_gen_sd3 as _;` in image_jobs.rs). The MMDiT-X Medium variant has a converter (`Sd3Arch::medium`)
-# but NO registered generator yet (M3, deferred), so no `sd3_5_medium` MODEL_TABLE row. Reuses the SDXL
+# + `sd3_5_large_turbo` (ADD-distilled few-step, CFG-off) + `sd3_5_medium` (MMDiT-X, true-CFG, 40 steps /
+# guidance 5.0; M3 sc-7869, registered as of rev 1a784cd) via inventory only when force-linked
+# (`use mlx_gen_sd3 as _;` in image_jobs.rs). All three carry a `sd3_5_*_quant` converter. Reuses the SDXL
 # CLIP encoder (×2), the FLUX T5-XXL encoder, and the Z-Image 16-ch VAE — its `quantize_sd3_dir` converter
 # is wired in model_jobs.rs for the `sd3_5_{large,large_turbo,medium}_quant` install-time conversions.
-mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
+mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
 # CLIP ViT-L/14 image embedder for the Dataset Doctor analysis job (epic 6529 P2, sc-6535).
 # Self-registers `clip_vit_l14` (gen_core::ImageEmbedder) via inventory only when force-linked
 # (`use mlx_gen_clip as _;` in dataset_analysis_jobs.rs). Reuses mlx-gen-sdxl's CLIP body → same rev.
-mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
+mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -808,12 +816,12 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d0
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -822,7 +830,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d0
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -830,7 +838,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -841,7 +849,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -852,7 +860,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -867,7 +875,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d0
 # converted in-memory at load (no Python); the precomputed neg-prompt embedding is bundled in-crate. No
 # LoRA/guidance/CFG (one-step). 3B fp16 only here — 7B (sc-5197) + int8 (sc-5198) are engine-side and
 # unwired. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -878,7 +886,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "746
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
 # The unified LLM engine (epic 7153, sc-7158): the macOS `prompt_refine` job now runs through
 # mlx-llm's generic `mlx-llama` provider (a `core_llm::TextLlm`) resolved model-first via
 # `gen_core::core_llm::load_for_model`, RETIRING the bespoke `mlx-gen-prompt-refine` hand-rolled
@@ -904,7 +912,7 @@ mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "6c052ba6bbb81b
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468d03e761f02d4955da79009177f75f1221e0f" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -1161,25 +1169,25 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "7468
 # on the #905 candle-worker CI. #161 bumps candle-gen-joycaption's candle-llm -> `54ef5a1` (== the worker's
 # candle-llm pin below) + adds `tool_calls: Vec::new()` to its `core_llm::Message` literals, so the worker
 # graph unifies ONE candle-llm. Still a single gen-core rev (c45caec) + now a single candle-llm (54ef5a1).
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1189,7 +1197,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1197,21 +1205,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1220,17 +1228,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1239,7 +1247,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1261,7 +1269,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "54ef5a1e
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1270,12 +1278,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1283,7 +1291,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73f
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1292,7 +1300,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1300,7 +1308,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1309,7 +1317,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1336,7 +1344,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2a73fc2a65360b8f4070232ae06ea8675c9dd6b6", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ff78878919480faa5954f42c9c9a2e16ba9b01f3", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -419,6 +419,35 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
         default_guidance: 0.0,
         adapter_label: "mlx_krea",
     },
+    // Stable Diffusion 3.5 Large (epic 7841 / sc-7871) — native MLX, gated. 8B MMDiT + triple text
+    // encoder (CLIP-L + CLIP-G + T5-XXL) + 16-ch VAE. True-CFG flagship: 28 steps / guidance 3.5 +
+    // negative prompt (the `sd3_5_large` descriptor advertises supports_guidance + supports_negative
+    // + supports_true_cfg). Installs a packed Q8 dir (`sd3_5_large_quant` converter, model_jobs.rs).
+    ModelRow {
+        sceneworks_id: "sd3_5_large",
+        engine_id: "sd3_5_large",
+        default_repo: "stabilityai/stable-diffusion-3.5-large",
+        default_steps: 28,
+        default_guidance: 3.5,
+        adapter_label: "mlx_sd3",
+    },
+    // SD3.5 Large Turbo (epic 7841 / sc-7871) — the ADD-distilled few-step, CFG-free sibling: same 8B
+    // MMDiT + triple TE + 16-ch VAE backbone + snapshot layout, distilled checkpoint. 4 steps; guidance
+    // is INERT (the `sd3_5_large_turbo` descriptor advertises supports_guidance=false, so
+    // `resolve_guidance` returns None and never forwards a value — the pipeline's `denoise_cfg` skips the
+    // uncond forward at guidance 1.0). No negative prompt. The z_image_turbo / boogu / krea turbo pattern.
+    ModelRow {
+        sceneworks_id: "sd3_5_large_turbo",
+        engine_id: "sd3_5_large_turbo",
+        default_repo: "stabilityai/stable-diffusion-3.5-large-turbo",
+        default_steps: 4,
+        default_guidance: 0.0,
+        adapter_label: "mlx_sd3",
+    },
+    // NB: SD3.5 Medium (MMDiT-X) has a converter (`sd3_5_medium_quant`, registered in model_jobs.rs) but
+    // NO registered generator yet (M3 is a separate epic story), so it deliberately has no MODEL_TABLE row
+    // — a row here would fail `model_table_rows_resolve_and_flags_match_descriptor` ("no generator
+    // registered"). Add the row + force-linked generator together when M3 lands.
 ];
 
 /// The mlx-gen registry ids of the video generators this worker serves (the engine ids

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -444,10 +444,21 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
         default_guidance: 0.0,
         adapter_label: "mlx_sd3",
     },
-    // NB: SD3.5 Medium (MMDiT-X) has a converter (`sd3_5_medium_quant`, registered in model_jobs.rs) but
-    // NO registered generator yet (M3 is a separate epic story), so it deliberately has no MODEL_TABLE row
-    // — a row here would fail `model_table_rows_resolve_and_flags_match_descriptor` ("no generator
-    // registered"). Add the row + force-linked generator together when M3 lands.
+    // SD3.5 Medium (epic 7841 / sc-7869 M3, wired in sc-7871) — the MMDiT-X variant: 2.5B, 24 joint
+    // blocks (first 13 dual-attention), hidden 1536, `pos_embed_max_size` 384. True-CFG like Large but a
+    // distinct (smaller) transformer + its own recipe — 40 steps / guidance 5.0 (Stability's card notes
+    // Medium is more guidance-sensitive than Large). The `sd3_5_medium` descriptor advertises
+    // supports_guidance + supports_negative + supports_true_cfg. Installs a packed dir via the
+    // `sd3_5_medium_quant` converter (model_jobs.rs). The generator self-registers via the shared
+    // force-link (`use mlx_gen_sd3 as _;` in image_jobs.rs) now that M3 is on mlx-gen main (rev 1a784cd).
+    ModelRow {
+        sceneworks_id: "sd3_5_medium",
+        engine_id: "sd3_5_medium",
+        default_repo: "stabilityai/stable-diffusion-3.5-medium",
+        default_steps: 40,
+        default_guidance: 5.0,
+        adapter_label: "mlx_sd3",
+    },
 ];
 
 /// The mlx-gen registry ids of the video generators this worker serves (the engine ids

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -60,6 +60,12 @@ use mlx_gen_kolors as _;
 // drops its `ModelRegistration` and `gen_core::load("krea_2_turbo")` returns "no generator registered").
 #[cfg(target_os = "macos")]
 use mlx_gen_krea as _;
+// Stable Diffusion 3.5 (epic 7841 / sc-7871) — force-link so `inventory::submit!` registers
+// `sd3_5_large` (true-CFG) + `sd3_5_large_turbo` (ADD-distilled, CFG-off); else linker GC drops their
+// `ModelRegistration` and `gen_core::load("sd3_5_large")` returns "no generator registered". Both reach
+// the generic MODEL_TABLE / `generate_stream` path. (Medium has a converter but no generator yet — M3.)
+#[cfg(target_os = "macos")]
+use mlx_gen_sd3 as _;
 // Lens / Lens-Turbo (epic 3164 engine / sc-5105) — an inventory-registered `Generator` under the ids
 // `lens` + `lens_turbo`, reached through the generic MODEL_TABLE / `generate_stream` path. Force-link
 // or the linker GCs its `ModelRegistration` and `gen_core::load("lens_turbo")` returns "no generator

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -61,9 +61,9 @@ use mlx_gen_kolors as _;
 #[cfg(target_os = "macos")]
 use mlx_gen_krea as _;
 // Stable Diffusion 3.5 (epic 7841 / sc-7871) — force-link so `inventory::submit!` registers
-// `sd3_5_large` (true-CFG) + `sd3_5_large_turbo` (ADD-distilled, CFG-off); else linker GC drops their
-// `ModelRegistration` and `gen_core::load("sd3_5_large")` returns "no generator registered". Both reach
-// the generic MODEL_TABLE / `generate_stream` path. (Medium has a converter but no generator yet — M3.)
+// `sd3_5_large` (true-CFG) + `sd3_5_large_turbo` (ADD-distilled, CFG-off) + `sd3_5_medium` (MMDiT-X);
+// else linker GC drops their `ModelRegistration` and `gen_core::load("sd3_5_large")` returns "no
+// generator registered". All three reach the generic MODEL_TABLE / `generate_stream` path.
 #[cfg(target_os = "macos")]
 use mlx_gen_sd3 as _;
 // Lens / Lens-Turbo (epic 3164 engine / sc-5105) — an inventory-registered `Generator` under the ids

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -572,6 +572,90 @@ fn convert_flux2_dev_prequant(
     )
 }
 
+/// SD3.5 gated diffusers snapshot → packed Q`bits` MLX dir (sc-7871). SD3.5's snapshot is
+/// self-contained (its own transformer + triple text encoder + tokenizer + VAE), and the engine
+/// loader reads the diffusers layout directly, reusing the SDXL CLIP encoders, the FLUX T5 encoder,
+/// and the Z-Image 16-ch VAE — all loaded DENSE. So conversion pre-quantizes ONLY the MMDiT
+/// `transformer/` on disk (the bulk: an 8B DiT) and symlinks the unchanged text encoders / tokenizers
+/// / VAE / scheduler / model_index.json through. Absolute symlinks survive the worker's temp→final
+/// atomic rename, and `model_index.json` doubles as the catalog's "converted" marker. `variant`
+/// selects the MMDiT arch (Large/Turbo share one layout; Medium is the MMDiT-X dual-attention layout).
+/// Runs MLX, so macOS-only.
+#[cfg(target_os = "macos")]
+fn convert_sd3_prequant(
+    source_dir: &Path,
+    out_dir: &Path,
+    variant: Sd3Variant,
+    bits: i32,
+    group_size: i32,
+) -> Result<(), String> {
+    // CARVE-OUT(epic 3720): backend-specific weight converter; not a registry contract.
+    let arch = match variant {
+        Sd3Variant::Large | Sd3Variant::LargeTurbo => mlx_gen_sd3::Sd3Arch::large(),
+        Sd3Variant::Medium => mlx_gen_sd3::Sd3Arch::medium(),
+    };
+    std::fs::create_dir_all(out_dir).map_err(|error| error.to_string())?;
+    let src_transformer = source_dir.join("transformer");
+    if !src_transformer.is_dir() {
+        return Err(
+            "SD3.5 source is missing `transformer/` — expected the gated diffusers snapshot of \
+             stabilityai/stable-diffusion-3.5-* (transformer/ text_encoder/ text_encoder_2/ \
+             text_encoder_3/ tokenizer/ tokenizer_2/ tokenizer_3/ vae/ model_index.json)."
+                .to_owned(),
+        );
+    }
+    // Quantize the MMDiT transformer/ on disk (validates the arch first, writes a packed dir).
+    mlx_gen_sd3::quantize_sd3_dir(
+        &arch,
+        &src_transformer,
+        &out_dir.join("transformer"),
+        bits,
+        group_size,
+    )
+    .map_err(|error| format!("quantize SD3.5 transformer: {error}"))?;
+    // Symlink the dense (reused-as-is) text encoders / tokenizers / VAE / scheduler / model_index.json.
+    for sub in [
+        "text_encoder",
+        "text_encoder_2",
+        "text_encoder_3",
+        "tokenizer",
+        "tokenizer_2",
+        "tokenizer_3",
+        "vae",
+        "scheduler",
+        "model_index.json",
+    ] {
+        let src = source_dir.join(sub);
+        if !src.exists() {
+            // scheduler/ is optional metadata for the engine (the pipeline uses a static flow-match
+            // Euler schedule), so only the load-bearing modules are hard-required.
+            if sub == "scheduler" {
+                continue;
+            }
+            return Err(format!(
+                "SD3.5 source is missing `{sub}` — expected the full gated diffusers snapshot of \
+                 stabilityai/stable-diffusion-3.5-* (the triple text encoder + tokenizers + 16-ch VAE \
+                 are reused dense)."
+            ));
+        }
+        let canonical = std::fs::canonicalize(&src).map_err(|error| error.to_string())?;
+        std::os::unix::fs::symlink(&canonical, out_dir.join(sub))
+            .map_err(|error| error.to_string())?;
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn convert_sd3_prequant(
+    _source_dir: &Path,
+    _out_dir: &Path,
+    _variant: Sd3Variant,
+    _bits: i32,
+    _group_size: i32,
+) -> Result<(), String> {
+    Err("SD3.5 conversion requires macOS (mlx-gen-sd3); this model is macOS-only.".to_owned())
+}
+
 /// The base `Lightricks/LTX-2.3` latent upsampler the LTX loader hard-requires (emitted as
 /// `upsampler.safetensors` in the converted dir). Neither the eros nor the base single-file
 /// checkpoint bundles it, so the converter merges it from the base repo at convert time.
@@ -633,6 +717,28 @@ enum ConvertPlan {
         bits: i32,
         group_size: i32,
     },
+    /// SD3.5 gated diffusers snapshot → packed Q`bits` dir (sc-7871): pre-quantize ONLY the MMDiT
+    /// `transformer/` on disk (the triple text encoder + VAE are reused dense and symlinked through
+    /// unchanged). `variant` selects the MMDiT arch (Large/Turbo share one layout; Medium is MMDiT-X).
+    Sd3 {
+        source_dir: PathBuf,
+        variant: Sd3Variant,
+        bits: i32,
+        group_size: i32,
+    },
+}
+
+/// The SD3.5 MMDiT variant a `sd3_5_*_quant` conversion targets — a target-neutral mirror of
+/// `mlx_gen_sd3::Sd3Variant` (which is macOS-only), so [`ConvertPlan`] stays buildable on every
+/// target. The macOS converter maps it back to the engine variant in [`convert_sd3_prequant`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Sd3Variant {
+    /// `sd3_5_large_quant` — SD3.5 Large (8B MMDiT, true-CFG).
+    Large,
+    /// `sd3_5_large_turbo_quant` — SD3.5 Large Turbo (same MMDiT layout, ADD-distilled).
+    LargeTurbo,
+    /// `sd3_5_medium_quant` — SD3.5 Medium (2.5B MMDiT-X, dual-attention first 13 blocks).
+    Medium,
 }
 
 /// Convert a model's native checkpoint into the local MLX format on macOS/Apple Silicon, fully
@@ -640,7 +746,8 @@ enum ConvertPlan {
 /// be downloaded into the Hugging Face cache (via a model_download job). The converter is selected by
 /// the manifest `mlx.converter` discriminator: `flux2_klein_diffusers` (sc-3136), `ltx_video`
 /// (mlx-gen-ltx), or `flux2_dev_quant` (FLUX.2-dev pre-quantization, sc-5921) — the models that
-/// install via in-app conversion. The Python
+/// install via in-app conversion, plus `sd3_5_large_quant` / `sd3_5_large_turbo_quant` /
+/// `sd3_5_medium_quant` (SD3.5 transformer pre-quantization, sc-7871). The Python
 /// `mlx_video.convert_wan` subprocess + `SCENEWORKS_PYTHON` wiring were retired here (sc-3240); the
 /// Wan2.2 converters were decommissioned once those models flipped to pre-converted SceneWorks
 /// downloads (sc-5603, epic 5594).
@@ -818,6 +925,31 @@ pub(crate) async fn run_model_convert_job(
                 group_size,
             }
         }
+        // SD3.5 (epic 7841 / sc-7871) — the gated diffusers snapshot is self-contained (its own
+        // transformer/ + triple text encoder + tokenizer + VAE), so the whole snapshot dir is the
+        // convert source: pre-quantize ONLY the MMDiT transformer/ on disk and symlink the dense TE /
+        // VAE / tokenizer / scheduler / model_index.json through. Default Q8 / group-size 64 (the
+        // manifest `quantize: 8`, reference group size) when the request omits them. The converter id
+        // selects the MMDiT arch variant.
+        converter @ ("sd3_5_large_quant" | "sd3_5_large_turbo_quant" | "sd3_5_medium_quant") => {
+            let bits = quantize_bits.map_or(8, |bits| bits as i32);
+            let group_size = job
+                .payload
+                .get("quantizeGroupSize")
+                .and_then(Value::as_u64)
+                .map_or(64, |group| group as i32);
+            let variant = match converter {
+                "sd3_5_large_quant" => Sd3Variant::Large,
+                "sd3_5_large_turbo_quant" => Sd3Variant::LargeTurbo,
+                _ => Sd3Variant::Medium,
+            };
+            ConvertPlan::Sd3 {
+                source_dir: checkpoint_dir.clone(),
+                variant,
+                bits,
+                group_size,
+            }
+        }
         "" => {
             fail_job(
                 api,
@@ -916,6 +1048,17 @@ pub(crate) async fn run_model_convert_job(
         } => {
             tokio::task::spawn_blocking(move || {
                 convert_flux2_dev_prequant(&source_dir, &temp, bits, group_size)
+            })
+            .await
+        }
+        ConvertPlan::Sd3 {
+            source_dir,
+            variant,
+            bits,
+            group_size,
+        } => {
+            tokio::task::spawn_blocking(move || {
+                convert_sd3_prequant(&source_dir, &temp, variant, bits, group_size)
             })
             .await
         }

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -720,6 +720,13 @@ fn model_table_rows_resolve_and_flags_match_descriptor() {
         // (supports_guidance=false) with no user negative prompt (supports_negative_prompt=false) — the
         // z_image_turbo / boogu_image_turbo distilled-turbo pattern.
         ("krea_2_turbo", false, false),
+        // SD3.5 Large (epic 7841 / sc-7871): true-CFG MMDiT flagship — supports_guidance=true +
+        // supports_negative_prompt=true (the `sd3_5_large` descriptor advertises supports_true_cfg).
+        ("sd3_5_large", true, true),
+        // SD3.5 Large Turbo (epic 7841 / sc-7871): the ADD-distilled few-step, CFG-off sibling — the
+        // `sd3_5_large_turbo` descriptor drops guidance + negative prompt (supports_guidance=false,
+        // supports_negative_prompt=false), the distilled-turbo pattern.
+        ("sd3_5_large_turbo", false, false),
     ];
     // Every row is covered by the expectation table (no row added without a flag pair here).
     assert_eq!(MODEL_TABLE.len(), expected.len());

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -727,6 +727,10 @@ fn model_table_rows_resolve_and_flags_match_descriptor() {
         // `sd3_5_large_turbo` descriptor drops guidance + negative prompt (supports_guidance=false,
         // supports_negative_prompt=false), the distilled-turbo pattern.
         ("sd3_5_large_turbo", false, false),
+        // SD3.5 Medium (epic 7841 / sc-7869 M3, wired sc-7871): the MMDiT-X true-CFG variant —
+        // supports_guidance=true + supports_negative_prompt=true (the `sd3_5_medium` descriptor advertises
+        // supports_true_cfg, same as Large; only the transformer + step/guidance recipe differ).
+        ("sd3_5_medium", true, true),
     ];
     // Every row is covered by the expectation table (no row added without a flag pair here).
     assert_eq!(MODEL_TABLE.len(), expected.len());


### PR DESCRIPTION
## Summary

S2 of the native **SD3.5 (MLX)** port (epic 7841). Wires the SceneWorks worker so the SD3.5 manifest models added in S1 (sc-7870) actually run on macOS — MODEL_TABLE rows, force-link, converter registration, plain t2i routing — plus the mlx-gen pin bump and the candle-gen gen-core lockstep. **Now COMPLETE for all three models** (Large + Large-Turbo + Medium) after M3 (sc-7869) merged to mlx-gen main.

## Pin bump (the load-bearing part)

- **mlx-gen + `sceneworks-gen-core`: `c45caec` → `7468d03` → `1a784cd`** (all 28 mlx-gen-* pins move together so the `inventory` registry resolves ONE gen-core rev).
  - `c45caec` predated the SD3.5 engine (`mlx-gen-sd3` was a converter/config stub).
  - `7468d03` (first S2 pass) brought the full E2–E6 + M1 vertical: registered `sd3_5_large` (true-CFG) + `sd3_5_large_turbo` (ADD-distilled, CFG-off).
  - **`1a784cd`** (mlx-gen main HEAD, M3 merged) adds the **`sd3_5_medium`** MMDiT-X generator (sc-7869). gen-core is **BYTE-IDENTICAL** `7468d03..1a784cd` (`git diff … -- gen-core/` is **EMPTY**; the only delta is `mlx-gen-sd3`: the Medium generator + e2e), so this is a pure pick-up of the new generator.

## Candle lockstep (candle CI gates this PR)

- **candle-gen `2a73fc2` → `ff78878`** via candle-gen PR SceneWorks/candle-gen#162.
- A **PURE gen-core re-pin** (`7468d03` → `1a784cd`): gen-core is **BYTE-IDENTICAL**, so candle compiles **unchanged** — no candle source change, no new provider.
- **No SD3.5 in candle** (that is epic 7982). Purely the mechanical gen-core lockstep so the worker's `--features backend-candle` skew gate keeps ONE gen-core rev. Verified: candle-gen `cargo check --workspace` green against `1a784cd`.

## Worker wiring

- **MODEL_TABLE rows** (`engines.rs`) — all THREE:
  - `sd3_5_large` (28 steps / guidance 3.5 / true-CFG + negative)
  - `sd3_5_large_turbo` (4 steps / CFG-off)
  - **`sd3_5_medium`** (40 steps / guidance 5.0 / true-CFG + negative — MMDiT-X, more guidance-sensitive than Large per Stability's card)
  - all → their mlx-gen engine ids, adapter `mlx_sd3`.
- **Force-link** (`image_jobs.rs`): `use mlx_gen_sd3 as _;` under `#[cfg(target_os="macos")]` registers all three ids via `inventory::submit!` (else linker GC drops the `ModelRegistration`).
- **Converter registration** (`model_jobs.rs`): `sd3_5_large_quant` / `sd3_5_large_turbo_quant` / `sd3_5_medium_quant` → `ConvertPlan::Sd3` → `convert_sd3_prequant` (quantizes the MMDiT `transformer/` via `mlx_gen_sd3::quantize_sd3_dir`, symlinks dense triple TE / tokenizers / 16-ch VAE / scheduler through — the FLUX.2-dev pre-quant pattern; reuses SDXL CLIP ×2 + FLUX T5 + Z-Image VAE). Default Q8 / group-size 64.
- **t2i routing**: all ids flow through the generic `mlx_available` → `ImageRoute::Mlx` → `generate_stream` → `GenerationOutput::Images` path (no special-casing). Turbo's `guidanceScale: 1.0` is the CFG-off path (descriptor `supports_guidance=false` → `resolve_guidance` returns `None`); Medium is true-CFG like Large.

## Tests

- macOS worker build green; **`cargo test -p sceneworks-worker --lib`: 390 passed / 0 failed** (88 ignored real-weight).
- `model_table_rows_resolve_and_flags_match_descriptor` extended with all three: `sd3_5_large` (true, true) + `sd3_5_large_turbo` (false, false) + **`sd3_5_medium` (true, true)** — proves each resolves through the registry (pin + force-link) with the engine-advertised flags.
- Drift guard `manifest_menu_is_subset_of_descriptor` green (Medium now resolves through MODEL_TABLE).
- `clippy -p sceneworks-worker` + `fmt` clean.
- candle-gen `cargo check --workspace` green (lockstep PR, `1a784cd`).

## Out of scope (filed/deferred)

- S3: gated download / HF-token flow.
- S4: Image Studio surfacing.
- On-device real-weight render validation (needs Mac + gated weights + bundled-frontend build).

Links: sc-7871. Depends on candle lockstep SceneWorks/candle-gen#162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
