### PR TITLE
sc-8025: PiD gemma encoder → non-gated SceneWorks/gemma-2-2b-it mirror

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -4121,7 +4121,7 @@
       // model that reuses QwenVae — Qwen-Image, Qwen-Image-Edit (all variants), and Krea 2 Turbo.
       //
       // The native worker (`image_jobs/pid.rs`, sc-7849) resolves the weights by REPO STRING
-      // (`SceneWorks/pid-qwenimage` checkpoint + `google/gemma-2-2b-it` caption encoder), not by this
+      // (`SceneWorks/pid-qwenimage` checkpoint + `SceneWorks/gemma-2-2b-it` caption encoder), not by this
       // catalog id — cataloging it lets Model Manager download both into the HF cache the worker reads.
       // `resolve_pid_weights` returns `None` (→ native VAE, behavior-preserving) until BOTH snapshots are
       // cached, so this is a safe, opt-in, on-demand asset (autoDownload:false) with no auto-pull.
@@ -4133,9 +4133,10 @@
       // attribution + provenance + the exact lossless conversion) + a model-card README; `files: []`
       // pulls those alongside the weights so the obligation travels with the bytes (§3.1).
       //
-      // gemma-2-2b-it is the PiD caption encoder. It is a GATED upstream Google repo today (the download
-      // needs a user HF token that has accepted the Gemma terms); a turnkey non-gated SceneWorks mirror
-      // is tracked as a follow-up so this entry stays focused on the PiD checkpoint re-host.
+      // gemma-2-2b-it is the PiD caption encoder. Re-hosted (sc-8025) at the non-gated
+      // `SceneWorks/gemma-2-2b-it` mirror — stock weights pulled as-is (no conversion), shipping the
+      // verbatim Gemma Terms of Use + Prohibited Use Policy alongside (Gemma Terms §3.1 permit the
+      // mirror). So the in-app download needs NO Gemma-gated HF token, completing the turnkey goal.
       "id": "pid_qwenimage_decoder",
       "autoDownload": false,
       "nonCommercial": true,
@@ -4155,12 +4156,12 @@
           "estimatedSizeBytes": 2724745532
         },
         {
-          // PiD caption encoder (Gemma-2-2B-IT). GATED upstream repo — download needs an HF token that
-          // has accepted the Gemma terms. Pulled as-is (no conversion); the mlx-gen-pid / candle-gen-pid
+          // PiD caption encoder (Gemma-2-2B-IT). Non-gated `SceneWorks/gemma-2-2b-it` mirror (sc-8025) —
+          // no HF token needed. Stock weights pulled as-is (no conversion); the mlx-gen-pid / candle-gen-pid
           // Gemma-2 port reads the stock config/safetensors/tokenizer directly. `files: []` pulls the
-          // repo's own license/policy files alongside the weights.
+          // mirror's LICENSE (Gemma Terms) + Prohibited Use Policy + NOTICE alongside the weights.
           "provider": "huggingface",
-          "repo": "google/gemma-2-2b-it",
+          "repo": "SceneWorks/gemma-2-2b-it",
           "files": [],
           "estimatedSizeBytes": 5228717488
         }
@@ -4173,7 +4174,7 @@
           "qwenimage": {
             "repo": "SceneWorks/pid-qwenimage",
             "file": "pid_qwenimage_2kto4k.safetensors",
-            "gemmaRepo": "google/gemma-2-2b-it",
+            "gemmaRepo": "SceneWorks/gemma-2-2b-it",
             "nonCommercial": true,
             "license": "NVIDIA License (NSCLv1)",
             "licenseUrl": "https://huggingface.co/nvidia/PixelDiT-1300M-1024px/blob/main/LICENSE",
@@ -4230,7 +4231,7 @@
         },
         {
           "provider": "huggingface",
-          "repo": "google/gemma-2-2b-it",
+          "repo": "SceneWorks/gemma-2-2b-it",
           "files": [],
           "estimatedSizeBytes": 5228717488
         }
@@ -4243,7 +4244,7 @@
           "flux": {
             "repo": "SceneWorks/pid-flux",
             "file": "pid_flux_2kto4k.safetensors",
-            "gemmaRepo": "google/gemma-2-2b-it",
+            "gemmaRepo": "SceneWorks/gemma-2-2b-it",
             "nonCommercial": true,
             "license": "NVIDIA License (NSCLv1)",
             "licenseUrl": "https://huggingface.co/nvidia/PixelDiT-1300M-1024px/blob/main/LICENSE",
@@ -4299,7 +4300,7 @@
         },
         {
           "provider": "huggingface",
-          "repo": "google/gemma-2-2b-it",
+          "repo": "SceneWorks/gemma-2-2b-it",
           "files": [],
           "estimatedSizeBytes": 5228717488
         }
@@ -4312,7 +4313,7 @@
           "flux2": {
             "repo": "SceneWorks/pid-flux2",
             "file": "pid_flux2_2kto4k.safetensors",
-            "gemmaRepo": "google/gemma-2-2b-it",
+            "gemmaRepo": "SceneWorks/gemma-2-2b-it",
             "nonCommercial": true,
             "license": "NVIDIA License (NSCLv1)",
             "licenseUrl": "https://huggingface.co/nvidia/PixelDiT-1300M-1024px/blob/main/LICENSE",
@@ -4368,7 +4369,7 @@
         },
         {
           "provider": "huggingface",
-          "repo": "google/gemma-2-2b-it",
+          "repo": "SceneWorks/gemma-2-2b-it",
           "files": [],
           "estimatedSizeBytes": 5228717488
         }
@@ -4381,7 +4382,7 @@
           "sdxl": {
             "repo": "SceneWorks/pid-sdxl",
             "file": "pid_sdxl_2kto4k.safetensors",
-            "gemmaRepo": "google/gemma-2-2b-it",
+            "gemmaRepo": "SceneWorks/gemma-2-2b-it",
             "nonCommercial": true,
             "license": "NVIDIA License (NSCLv1)",
             "licenseUrl": "https://huggingface.co/nvidia/PixelDiT-1300M-1024px/blob/main/LICENSE",

--- a/crates/sceneworks-worker/src/image_jobs/pid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/pid.rs
@@ -27,9 +27,12 @@ const PID_FLUX2_REPO: &str = "SceneWorks/pid-flux2";
 const PID_FLUX2_FILE: &str = "pid_flux2_2kto4k.safetensors";
 const PID_SDXL_REPO: &str = "SceneWorks/pid-sdxl";
 const PID_SDXL_FILE: &str = "pid_sdxl_2kto4k.safetensors";
-// gemma-2-2b-it is the PiD caption encoder (shared by every backbone). sc-8025 tracks a turnkey
-// non-gated SceneWorks mirror; the default points at the canonical (gated) id for now.
-const PID_GEMMA_REPO: &str = "google/gemma-2-2b-it";
+// gemma-2-2b-it is the PiD caption encoder (shared by every backbone). sc-8025 re-hosts the stock
+// weights (no conversion) at the non-gated `SceneWorks/gemma-2-2b-it` mirror so the in-app download
+// needs no Gemma-gated HF token; the catalog `downloads[]` + `pidDecoders.<bb>.gemmaRepo` point here
+// too (they must agree, or this snapshot is never cached → native VAE). The `advanced.pidGemma`
+// per-request override still wins. Gemma Terms §3.1 permit the mirror (terms ship alongside the weights).
+const PID_GEMMA_REPO: &str = "SceneWorks/gemma-2-2b-it";
 
 /// Map a SceneWorks image model id to its PiD latent-space backbone, or `None` when the model has no
 /// PiD backbone (so `usePid` is silently ignored — the guard for SenseNova et al.). All four wired


### PR DESCRIPTION
## sc-8025 — turnkey non-gated mirror of the PiD `gemma-2-2b-it` caption encoder

Follow-up to sc-7852 (#909). PiD's Gemma-2 caption encoder pointed at the **gated** `google/gemma-2-2b-it`, so the in-app PiD download required a user HF token that had accepted Google's Gemma terms — breaking the turnkey "no BYO-download" goal. This flips every reference to a non-gated `SceneWorks/gemma-2-2b-it` mirror (stock weights, pulled as-is, no conversion).

### Flip surface (9 refs)
- **worker** `crates/sceneworks-worker/src/image_jobs/pid.rs`: `PID_GEMMA_REPO`. `advanced.pidGemma` per-request override untouched.
- **catalog** `config/manifests/builtin.models.jsonc`: all **4** PiD decoder entries (qwenimage/flux/flux2/sdxl), each `downloads[].repo` + `resources.pidDecoders.<backbone>.gemmaRepo`, + comments. (Story text named only qwenimage; flux/flux2/sdxl landed in #909 after it was filed — covering the full surface.)

Worker default and catalog repo **must agree** or `resolve_pid_weights()` looks for a snapshot the catalog never downloaded → silent fall-through to native VAE.

### Gemma Terms — legal check ✅ PASS
Verified verbatim against ai.google.dev/gemma/terms (last modified 2026-04-01). §3.1 permits a public non-gated mirror provided the Terms + Prohibited Use Policy travel with the weights and bind downstream recipients. The mirror ships `LICENSE` (verbatim Terms) + `PROHIBITED_USE_POLICY.md` + `NOTICE`, and the README **drops the `extra_gated_*` frontmatter keys** (those keys are what gate an HF repo — a naive verbatim mirror would silently re-gate). License-passthrough mirrors the joycaption/Anubis `files: []` discipline + the epic 5594 re-host pattern.

### ⛔ Merge gate
`SceneWorks/gemma-2-2b-it` is **not published yet** (`huggingface.co/api/models/SceneWorks/gemma-2-2b-it` → 401). Publishing is credential-gated (SceneWorks-org HF write token = Michael's step). **Do not merge until the mirror resolves unauthenticated**, or the in-app Gemma download 404s — same DO-NOT-MERGE discipline #909 used for `SceneWorks/pid-qwenimage`.

### Validation
- `node scripts/check-scaffold.mjs` → passed (JSONC + manifest schema).
- No `google/gemma-2-2b-it` references remain anywhere.
- Worker change is a `&str` constant value swap (cannot affect compilation); untouched `pid.rs` tests don't assert the gemma repo string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)