### PR TITLE
feat(web): SD3.5 gated download — HF repo link + in-app license-ack gate (sc-7872)

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -1792,4 +1792,50 @@ mod gated_credential_tests {
     fn no_downloads_yields_none() {
         assert_eq!(derive_credential_host(&map(json!({}))), None);
     }
+
+    // sc-7872: the SD3.5 gated entries download direct from the gated stabilityai/*
+    // repos (no re-host), so the credential host derives to huggingface.co exactly
+    // like FLUX.2-dev — driving the same stored-HF-token download path.
+    #[test]
+    fn derives_huggingface_host_for_stabilityai_sd3_5_repos() {
+        for repo in [
+            "stabilityai/stable-diffusion-3.5-large",
+            "stabilityai/stable-diffusion-3.5-large-turbo",
+            "stabilityai/stable-diffusion-3.5-medium",
+        ] {
+            let model = map(json!({
+                "downloads": [{ "provider": "huggingface", "repo": repo, "files": ["transformer/*"] }]
+            }));
+            assert_eq!(
+                derive_credential_host(&model).as_deref(),
+                Some("huggingface.co"),
+                "repo {repo} should derive huggingface.co",
+            );
+        }
+    }
+
+    // sc-7872: a gated SD3.5 entry round-trips through apply_gating_fields with its
+    // explicit huggingface.co credential host preserved (the field the web client
+    // reads to gate the download + surface the credential prompt). licenseUrl is
+    // untouched, so the model card links the stabilityai license page.
+    #[test]
+    fn sd3_5_gated_entry_preserves_credential_host_and_license() {
+        let mut model = map(json!({
+            "id": "sd3_5_large",
+            "gated": true,
+            "credentialHost": "huggingface.co",
+            "licenseUrl": "https://huggingface.co/stabilityai/stable-diffusion-3.5-large",
+            "downloads": [{ "provider": "huggingface", "repo": "stabilityai/stable-diffusion-3.5-large", "files": ["transformer/*"] }]
+        }));
+        apply_gating_fields(&mut model);
+        assert_eq!(model.get("gated").and_then(Value::as_bool), Some(true));
+        assert_eq!(
+            model.get("credentialHost").and_then(Value::as_str),
+            Some("huggingface.co"),
+        );
+        assert_eq!(
+            model.get("licenseUrl").and_then(Value::as_str),
+            Some("https://huggingface.co/stabilityai/stable-diffusion-3.5-large"),
+        );
+    }
 }

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -150,6 +150,45 @@ function gatedRepoUrl(model) {
   return repo ? `https://${host}/${repo}` : null;
 }
 
+// Per-model license acknowledgment (sc-7872). Gated models (FLUX.2 [dev],
+// SD3.5 Large/Turbo/Medium, …) carry a non-commercial / community license the
+// user must accept on Hugging Face before access is granted; we also require an
+// explicit in-app acknowledgment before queuing the download so the license terms
+// are surfaced and confirmed at the point of action. The ack is persisted per
+// model id in localStorage (origin-scoped, same store as the theme/token caches);
+// it's a UX gate only — the server-side download still needs the HF credential +
+// granted access. localStorage may be unavailable (private mode, quota), so the
+// getters/setters swallow failures and default to "not acknowledged".
+const LICENSE_ACK_KEY_PREFIX = "sceneworks-license-ack:";
+
+function readLicenseAck(modelId) {
+  if (!modelId) {
+    return false;
+  }
+  try {
+    return window.localStorage.getItem(`${LICENSE_ACK_KEY_PREFIX}${modelId}`) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function writeLicenseAck(modelId, acknowledged) {
+  if (!modelId) {
+    return;
+  }
+  try {
+    const key = `${LICENSE_ACK_KEY_PREFIX}${modelId}`;
+    if (acknowledged) {
+      window.localStorage.setItem(key, "true");
+    } else {
+      window.localStorage.removeItem(key);
+    }
+  } catch {
+    // localStorage unavailable — the ack just won't persist this session. The
+    // in-memory state still gates the download for the current view.
+  }
+}
+
 // Gated models (e.g. FLUX.1 [dev]) need an accepted license + a saved credential
 // before a download can succeed. The catalog flags these with `gated`/
 // `credentialHost`/`licenseUrl` (sc-1898). When the matching credential is already
@@ -159,7 +198,17 @@ function gatedRepoUrl(model) {
 // `repoUrl` links the gated repo so the user can request access (sc-5999); shown
 // alongside `licenseUrl` only when the license lives on a different page (e.g.
 // Ideogram 4, whose terms are on the source repo but access is on the SceneWorks repo).
-function GatedModelNotice({ host, repoUrl, licenseUrl, present, onOpenSettings }) {
+// `acknowledged`/`onAcknowledgeChange` drive the in-app license-acknowledgment gate
+// (sc-7872): the download button stays disabled until the user checks the box.
+function GatedModelNotice({
+  host,
+  repoUrl,
+  licenseUrl,
+  present,
+  acknowledged,
+  onAcknowledgeChange,
+  onOpenSettings,
+}) {
   const hostLabel = host || "the required service";
   const showSeparateLicense = licenseUrl && licenseUrl !== repoUrl;
   return (
@@ -186,6 +235,14 @@ function GatedModelNotice({ host, repoUrl, licenseUrl, present, onOpenSettings }
           </a>
         ) : null}
       </div>
+      <label className="model-license-ack">
+        <input
+          type="checkbox"
+          checked={acknowledged}
+          onChange={(event) => onAcknowledgeChange(event.target.checked)}
+        />
+        <span>I have read and accept this model&rsquo;s license.</span>
+      </label>
     </div>
   );
 }
@@ -298,6 +355,21 @@ export function ModelManagerScreen() {
   // Gated-model credential presence (sc-1898): only fetched when the catalog has a
   // gated model, so non-gated deployments make no extra credential request.
   const [credentials, setCredentials] = useState([]);
+  // Per-model license acknowledgments (sc-7872), seeded from localStorage so a
+  // returning user keeps prior accepts. Keyed by model id; toggling the gated
+  // notice checkbox both updates this map and persists to localStorage.
+  const [licenseAcks, setLicenseAcks] = useState(() =>
+    models.reduce((acc, model) => {
+      if (model.gated && readLicenseAck(model.id)) {
+        acc[model.id] = true;
+      }
+      return acc;
+    }, {}),
+  );
+  const setLicenseAck = (modelId, acknowledged) => {
+    writeLicenseAck(modelId, acknowledged);
+    setLicenseAcks((current) => ({ ...current, [modelId]: acknowledged }));
+  };
   const hasGatedModel = models.some((model) => model.gated);
   const visibleLoras = loras.filter((lora) => matchesFamily(lora, familyFilter));
   // Wan A14B MoE paired upload (sc-1991): when the user targets the wan-video
@@ -595,6 +667,11 @@ export function ModelManagerScreen() {
     const showConvertButton = mlxState === "needs_conversion" || mlxState === "converted";
     const gated = Boolean(model.gated);
     const credentialPresent = gated && hasPresentCredential(credentials, model.credentialHost);
+    // License-acknowledgment gate (sc-7872): an uninstalled gated model can't be
+    // downloaded until the user accepts its license in-app. Already-installed
+    // gated models (no notice shown) are never blocked.
+    const licenseAcknowledged = licenseAcks[model.id] === true;
+    const licenseAckRequired = gated && !installed && !licenseAcknowledged;
     return (
       <article className="model-card" key={model.id}>
         <div>
@@ -630,6 +707,8 @@ export function ModelManagerScreen() {
             repoUrl={gatedRepoUrl(model) ?? model.licenseUrl ?? null}
             licenseUrl={model.licenseUrl}
             present={credentialPresent}
+            acknowledged={licenseAcknowledged}
+            onAcknowledgeChange={(checked) => setLicenseAck(model.id, checked)}
             onOpenSettings={() => setActiveView("Settings")}
           />
         ) : null}
@@ -692,7 +771,8 @@ export function ModelManagerScreen() {
         ) : null}
         <div className="model-card-actions">
           <button
-            disabled={(installed && !incomplete) || !model.downloadable || Boolean(downloadJob)}
+            disabled={(installed && !incomplete) || !model.downloadable || Boolean(downloadJob) || licenseAckRequired}
+            title={licenseAckRequired ? "Accept the license above before downloading." : undefined}
             onClick={() =>
               failedDownload
                 ? onResumeDownloadJob(localDownloadJob, { payloadChanges: { downloadAction: "resume" } })

--- a/apps/web/src/screens/ModelManagerScreen.test.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.test.jsx
@@ -51,12 +51,33 @@ const PLAIN_MODEL = {
   ui: { description: "Open model." },
 };
 
+// SD3.5 Large is gated on the stabilityai/* repo with the Stability AI Community
+// License (sc-7872). It must surface the HF repo link + license-ack gate exactly
+// like FLUX.2-dev, driven entirely off the manifest `gated`/`credentialHost`/
+// `licenseUrl` fields — no per-model code.
+const SD3_5_MODEL = {
+  id: "sd3_5_large",
+  name: "Stable Diffusion 3.5 Large",
+  type: "image",
+  family: "sd3.5",
+  installState: "missing",
+  downloadable: true,
+  gated: true,
+  credentialHost: "huggingface.co",
+  licenseUrl: "https://huggingface.co/stabilityai/stable-diffusion-3.5-large",
+  downloads: [
+    { provider: "huggingface", repo: "stabilityai/stable-diffusion-3.5-large", files: ["transformer/*"] },
+  ],
+  ui: { description: "Gated SD3.5 Large model." },
+};
+
 describe("ModelManagerScreen gated-model notice", () => {
   let container;
   let root;
   let invoke;
   let credentials;
   let setActiveView;
+  let createModelDownloadJob;
   let ModelManagerScreen;
   let AppContext;
 
@@ -64,6 +85,12 @@ describe("ModelManagerScreen gated-model notice", () => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
     credentials = [];
     setActiveView = vi.fn();
+    createModelDownloadJob = vi.fn();
+    try {
+      window.localStorage.clear();
+    } catch {
+      // ignore — jsdom localStorage is always available
+    }
     invoke = vi.fn(async (command) => {
       switch (command) {
         case "get_gpu_info":
@@ -103,7 +130,7 @@ describe("ModelManagerScreen gated-model notice", () => {
       setActiveView,
       deleteLora: () => {},
       deleteModel: () => {},
-      createModelDownloadJob: () => {},
+      createModelDownloadJob,
       createModelConvertJob: () => {},
       createLoraImportJob: () => {},
       createModelImportJob: () => {},
@@ -165,6 +192,77 @@ describe("ModelManagerScreen gated-model notice", () => {
     expect(invoke).not.toHaveBeenCalledWith("list_credentials", undefined);
     expect(container.textContent).not.toContain("Gated download");
     expect(container.querySelector(".model-gated-notice")).toBeNull();
+  });
+
+  // sc-7872: the SD3.5 gated entries surface the stabilityai HF repo link on the
+  // card exactly like FLUX.2-dev, driven off the manifest fields with no per-model
+  // code. The license URL equals the access repo, so a single request-access link.
+  it("surfaces the stabilityai HF repo link on the SD3.5 model card (sc-7872)", async () => {
+    await render([SD3_5_MODEL]);
+    expect(container.textContent).toContain("Gated download");
+    const links = [...container.querySelectorAll(".model-gated-actions a")];
+    expect(links).toHaveLength(1);
+    expect(links[0].textContent).toBe("Request access on Hugging Face");
+    expect(links[0].getAttribute("href")).toBe(
+      "https://huggingface.co/stabilityai/stable-diffusion-3.5-large",
+    );
+  });
+
+  // sc-7872: the in-app license-acknowledgment gate blocks the download until the
+  // user checks the box. Applies generically to every gated model (FLUX.2-dev +
+  // SD3.5). The download button is disabled until then.
+  it("blocks the gated download until the license is acknowledged (sc-7872)", async () => {
+    await render([SD3_5_MODEL]);
+    const downloadButton = [...container.querySelectorAll(".model-card-actions button")].find(
+      (button) => button.textContent.startsWith("Download"),
+    );
+    expect(downloadButton).toBeTruthy();
+    expect(downloadButton.disabled).toBe(true);
+
+    // Clicking while blocked does not queue a download.
+    await click(downloadButton);
+    expect(createModelDownloadJob).not.toHaveBeenCalled();
+
+    // Acknowledge the license → button enables and the download queues.
+    const ackCheckbox = container.querySelector(".model-license-ack input");
+    expect(ackCheckbox).toBeTruthy();
+    await act(async () => {
+      // Drive the checkbox through React's value tracker (a bare `.checked =`
+      // assignment is pre-recorded by React and the onChange is skipped).
+      Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "checked").set.call(
+        ackCheckbox,
+        true,
+      );
+      ackCheckbox.dispatchEvent(new window.Event("click", { bubbles: true }));
+    });
+    expect(downloadButton.disabled).toBe(false);
+    await click(downloadButton);
+    expect(createModelDownloadJob).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "sd3_5_large" }),
+    );
+  });
+
+  // sc-7872: the ack persists to localStorage, so a returning user keeps a prior
+  // accept and the download is unblocked on first render.
+  it("seeds the license-ack from localStorage so a prior accept stays unblocked (sc-7872)", async () => {
+    window.localStorage.setItem("sceneworks-license-ack:sd3_5_large", "true");
+    await render([SD3_5_MODEL]);
+    const ackCheckbox = container.querySelector(".model-license-ack input");
+    expect(ackCheckbox.checked).toBe(true);
+    const downloadButton = [...container.querySelectorAll(".model-card-actions button")].find(
+      (button) => button.textContent.startsWith("Download"),
+    );
+    expect(downloadButton.disabled).toBe(false);
+  });
+
+  // sc-7872: a non-gated model has no ack gate — its download stays enabled.
+  it("does not gate a non-gated model's download on any acknowledgment (sc-7872)", async () => {
+    await render([PLAIN_MODEL]);
+    expect(container.querySelector(".model-license-ack")).toBeNull();
+    const downloadButton = [...container.querySelectorAll(".model-card-actions button")].find(
+      (button) => button.textContent.startsWith("Download"),
+    );
+    expect(downloadButton.disabled).toBe(false);
   });
 });
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4104,6 +4104,20 @@ details[open] > summary.lora-scope-group-heading::before,
   font-size: 13px;
 }
 
+/* License-acknowledgment gate (sc-7872): the download button stays disabled
+   until this box is checked for an uninstalled gated model. */
+.model-license-ack {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.model-license-ack input {
+  margin: 0;
+}
+
 .mlx-status {
   display: grid;
   gap: 8px;


### PR DESCRIPTION
## Summary

S3 of the native SD3.5 port (epic 7841). Makes the gated download of the three SD3.5 models work end to end from the user's stored HF token, surfaces the gated HF repo link on each model card, and gates the download behind an in-app license acknowledgment — mirroring the existing FLUX.2-dev gated pattern. **No SceneWorks re-host**: downloads come direct from `stabilityai/stable-diffusion-3.5-large` / `-large-turbo` / `-medium`.

Depends on S1 (manifest entries) and S2 (worker table + converters), both merged.

## What was already manifest-driven (verified, no code change)

The gated machinery is generic — keyed off the manifest `gated` / `credentialHost` / `licenseUrl` fields, with no per-model/family hardcoding. The S1 sd3_5_* entries therefore already inherit the exact FLUX.2-dev plumbing:

- **Gated download honoring the stored HF token.** The worker resolves the HF token lazily (`credentials_ipc::resolve_hf_token`: `Settings::huggingface_token` → keychain credential-socket pull for `huggingface.co` on desktop / `SCENEWORKS_CREDENTIALS` file/env on server) and attaches it as `Authorization: Bearer …` (`with_hf_auth`) / `HF_TOKEN` to every HF tree + file request. A user who accepted the Stability AI Community License and saved a token downloads direct from `stabilityai/*`.
- **HF repo link on the model card.** `gatedRepoUrl()` derives `https://huggingface.co/<repo>` from `downloads[].repo`, surfaced in `GatedModelNotice` as "Request access on Hugging Face" (plus a separate "Review license" only when the license lives on a different page). The sd3_5 cards get this automatically.

I locked both in with Rust tests (below) so a future manifest change can't silently break the sd3_5 credential derivation.

## What this PR adds — the in-app license-acknowledgment gate

FLUX.2-dev's gated notice was informational only; nothing blocked the download. This adds the acknowledgment **gate** the AC calls for, generically for every gated model:

- A checkbox on the gated notice: *"I have read and accept this model's license."*
- An uninstalled gated model's **Download button stays disabled until it's checked** (with an explanatory `title`).
- The ack is persisted **per model id in `localStorage`** (`sceneworks-license-ack:<id>`, origin-scoped, same store as the theme/token caches), so a returning user keeps prior accepts; getters/setters swallow `localStorage` failures and default to not-acknowledged.
- Applies to FLUX.2-dev + all three SD3.5 models with **no per-model code** — purely off `model.gated`.

## Files

- `apps/web/src/screens/ModelManagerScreen.jsx` — license-ack state (seeded from localStorage), `GatedModelNotice` checkbox, download-button gating.
- `apps/web/src/styles.css` — `.model-license-ack` styling.
- `apps/web/src/screens/ModelManagerScreen.test.jsx` — new tests (below).
- `apps/rust-api/src/models.rs` — new gated-credential tests for the stabilityai/* repos.

## Tests

**web (vitest, 736/736 pass):**
- SD3.5 surfaces the `stabilityai/...` HF repo link on the card.
- The gated download is blocked until the license is acknowledged, then queues.
- The ack seeds from localStorage so a prior accept stays unblocked on first render.
- A non-gated model has no ack gate and its download stays enabled.

**rust-api (6/6 gated tests pass; clippy clean):**
- `stabilityai/stable-diffusion-3.5-large` / `-large-turbo` / `-medium` → `huggingface.co` credential-host derivation.
- A gated SD3.5 entry round-trips `gated`/`credentialHost`/`licenseUrl` through `apply_gating_fields`.

Production web build (`vite build`) succeeds.

## Scope

Gated download + HF link + license-ack only. Image Studio surfacing / eligibility gating is S4 (out of scope here). Worker routing was S2 (merged). A browser preview of the Models page needs the full API/worker/credentials stack, so observable behavior is covered by the component-level vitest suite rather than a live preview.

Story: sc-7872