### PR TITLE
feat(web): SD3.5 S4 — Image Studio surfacing + eligibility/gating (sc-7873)

### DIFF
--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -407,6 +407,69 @@ export const fallbackModels = [
     },
   },
   {
+    // Stable Diffusion 3.5 Large Turbo (epic 7841 / S4 sc-7873) — the fast default
+    // of the SD3.5 family: ADD-distilled few-step (~4), CFG-free 8B MMDiT, native
+    // MLX (Apple Silicon). Catalog-driven gating (macOnly + gated) comes from the
+    // manifest/macSupport; this fallback entry only seeds the picker + per-variant
+    // defaults until the live catalog loads. Recommended (the fast SD3.5 default).
+    id: "sd3_5_large_turbo",
+    name: "Stable Diffusion 3.5 Large Turbo",
+    type: "image",
+    capabilities: ["text_to_image", "style_variations"],
+    // Few-step CFG-free: 4 steps, guidance ~1.0 (the negative prompt is inert).
+    defaults: { steps: 4, guidanceScale: 1.0, sampler: "euler", scheduler: "default" },
+    limits: {
+      samplers: ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+      schedulers: ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"],
+    },
+    ui: {
+      description:
+        "Stable Diffusion 3.5 Large Turbo — the few-step (~4), CFG-free distilled SD3.5 flagship: fast iteration at flagship quality on the native MLX engine (Apple Silicon). Best for quick text-to-image; native 1024×1024. Stability AI Community License (gated).",
+      promptGuide: { title: "Stable Diffusion 3.5 Prompt Guide", path: "/prompt-guides/sd3-5.md" },
+    },
+  },
+  {
+    // Stable Diffusion 3.5 Large (epic 7841 / S4 sc-7873) — the high-fidelity
+    // flagship: 8B MMDiT + triple text encoder + true CFG with negative prompts.
+    // ~28 steps at guidance 3.5. Native MLX (Apple Silicon), gated.
+    id: "sd3_5_large",
+    name: "Stable Diffusion 3.5 Large",
+    type: "image",
+    capabilities: ["text_to_image", "style_variations"],
+    // High-fidelity true-CFG flagship: 28 steps, guidance 3.5 (+negative prompt).
+    defaults: { steps: 28, guidanceScale: 3.5, sampler: "euler", scheduler: "default" },
+    limits: {
+      samplers: ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+      schedulers: ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"],
+    },
+    ui: {
+      description:
+        "Stability AI Stable Diffusion 3.5 Large — the 8B multimodal diffusion transformer (MMDiT) flagship for the highest fidelity, native MLX (Apple Silicon). Triple text encoder for strong prompt adherence and in-image text; true CFG with negative prompts. ~28 steps at guidance 3.5; native 1024×1024. Stability AI Community License (gated).",
+      promptGuide: { title: "Stable Diffusion 3.5 Prompt Guide", path: "/prompt-guides/sd3-5.md" },
+    },
+  },
+  {
+    // Stable Diffusion 3.5 Medium (epic 7841 / S4 sc-7873) — the smaller-RAM
+    // mid-tier: 2.5B MMDiT-X (dual-attention) + the same triple TE + true CFG,
+    // renders up to 1440². ~40 steps at guidance 4.5. Native MLX (Apple Silicon),
+    // gated; the lightest SD3.5 footprint.
+    id: "sd3_5_medium",
+    name: "Stable Diffusion 3.5 Medium",
+    type: "image",
+    capabilities: ["text_to_image", "style_variations"],
+    // Smaller-RAM mid-tier: a few more steps + slightly higher guidance than Large.
+    defaults: { steps: 40, guidanceScale: 4.5, sampler: "euler", scheduler: "default" },
+    limits: {
+      samplers: ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+      schedulers: ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"],
+    },
+    ui: {
+      description:
+        "Stability AI Stable Diffusion 3.5 Medium — the 2.5B MMDiT-X (dual-attention) mid-tier with the lightest SD3.5 memory footprint, native MLX (Apple Silicon). Same triple text encoder and true CFG as Large; renders up to 1440×1440. ~40 steps at guidance 4.5. Stability AI Community License (gated).",
+      promptGuide: { title: "Stable Diffusion 3.5 Prompt Guide", path: "/prompt-guides/sd3-5.md" },
+    },
+  },
+  {
     id: "ltx_2_3",
     name: "LTX-2.3",
     type: "video",

--- a/apps/web/src/constants.test.js
+++ b/apps/web/src/constants.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { fallbackModels } from "./constants.js";
+
+// SD3.5 Image Studio surfacing (epic 7841 / sc-7873). The fallbackModels list seeds the picker
+// before the live catalog loads; the three SD3.5 variants must be present as text-to-image image
+// models with the SD3.5 prompt guide and per-variant defaults (Turbo fast, Large high-fidelity,
+// Medium smaller-RAM). The real macOnly/gated/minMemoryGb gating comes from the manifest/macSupport
+// at runtime — these fallback entries only carry the picker shape + per-variant defaults.
+describe("fallbackModels SD3.5 surfacing (sc-7873)", () => {
+  const byId = (id) => fallbackModels.find((model) => model.id === id);
+
+  it("includes all three SD3.5 variants as text-to-image image models", () => {
+    for (const id of ["sd3_5_large", "sd3_5_large_turbo", "sd3_5_medium"]) {
+      const model = byId(id);
+      expect(model, `${id} must be present in fallbackModels`).toBeTruthy();
+      expect(model.type).toBe("image");
+      expect(model.capabilities).toContain("text_to_image");
+      expect(model.ui?.promptGuide?.path).toBe("/prompt-guides/sd3-5.md");
+    }
+  });
+
+  it("Turbo is the fast default: few-step, CFG-free", () => {
+    const turbo = byId("sd3_5_large_turbo");
+    expect(turbo.defaults.steps).toBe(4);
+    expect(turbo.defaults.guidanceScale).toBe(1.0);
+  });
+
+  it("Large is high-fidelity: more steps + true CFG", () => {
+    const large = byId("sd3_5_large");
+    expect(large.defaults.steps).toBe(28);
+    expect(large.defaults.guidanceScale).toBe(3.5);
+  });
+
+  it("Medium is the smaller-RAM mid-tier: its own recipe", () => {
+    const medium = byId("sd3_5_medium");
+    expect(medium.defaults.steps).toBe(40);
+    expect(medium.defaults.guidanceScale).toBe(4.5);
+  });
+});

--- a/apps/web/src/modelEligibility.test.js
+++ b/apps/web/src/modelEligibility.test.js
@@ -52,6 +52,30 @@ describe("modelEligibility predicates", () => {
     expect(hasUsableModelFor([missing], imageModelUsable, caps)).toBe(false);
   });
 
+  // SD3.5 surfacing + eligibility/gating (epic 7841 / sc-7873). The three native MLX variants are
+  // text-to-image image models, so they are usable on Image Studio (text_to_image mode) when their
+  // macSupport oracle reports supported. Under active Mac gating an unsupported variant (e.g. one
+  // without an MLX engine, or any model off-Mac) is blocked from the picker; with gating off the Mac
+  // blocks are no-ops so they always surface (Image Studio is the macOnly-aware path).
+  it("imageModelUsable surfaces the SD3.5 variants and respects Mac gating", () => {
+    const activeCaps = { ...DEFAULT_MAC_CAPABILITIES, macGatingActive: true, platform: "macos" };
+    for (const id of ["sd3_5_large", "sd3_5_large_turbo", "sd3_5_medium"]) {
+      const supported = {
+        id,
+        type: "image",
+        capabilities: ["text_to_image", "style_variations"],
+        macSupport: { supported: true, features: {} },
+      };
+      // Mac-supported native MLX variant → usable on Image Studio under active gating.
+      expect(imageModelUsable(supported, activeCaps)).toBe(true);
+      // Gating off (non-Mac / observe mode) → Mac block is a no-op, still usable.
+      expect(imageModelUsable(supported, caps)).toBe(true);
+      // Unsupported (no MLX engine for this variant) → hidden from the picker under active gating.
+      const unsupported = { ...supported, macSupport: { supported: false } };
+      expect(imageModelUsable(unsupported, activeCaps)).toBe(false);
+    }
+  });
+
   it("downloadOffersFor prefers recommended, falls back to any eligible, skips installed", () => {
     const models = [
       { id: "rec", type: "image", capabilities: ["text_to_image"], installState: "missing", recommended: true },

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -370,6 +370,27 @@ export function ModelManagerScreen() {
     writeLicenseAck(modelId, acknowledged);
     setLicenseAcks((current) => ({ ...current, [modelId]: acknowledged }));
   };
+  // The `useState` initializer above runs only on first mount, but `models`
+  // arrives asynchronously (the catalog fetch resolves after the screen mounts).
+  // A returning user's persisted localStorage ack would otherwise never re-seed
+  // for gated models that weren't in the initial (often empty) catalog. Re-seed
+  // whenever the catalog changes: merge in any persisted ack for a gated model
+  // we haven't already recorded, without clobbering an in-session toggle (the
+  // user's explicit checkbox state always wins over the persisted value).
+  useEffect(() => {
+    setLicenseAcks((current) => {
+      let next = current;
+      for (const model of models) {
+        if (model.gated && current[model.id] === undefined && readLicenseAck(model.id)) {
+          if (next === current) {
+            next = { ...current };
+          }
+          next[model.id] = true;
+        }
+      }
+      return next;
+    });
+  }, [models]);
   const hasGatedModel = models.some((model) => model.gated);
   const visibleLoras = loras.filter((lora) => matchesFamily(lora, familyFilter));
   // Wan A14B MoE paired upload (sc-1991): when the user targets the wan-video

--- a/apps/web/src/screens/ModelManagerScreen.test.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.test.jsx
@@ -255,6 +255,26 @@ describe("ModelManagerScreen gated-model notice", () => {
     expect(downloadButton.disabled).toBe(false);
   });
 
+  // sc-7873 (Fix B): the catalog arrives asynchronously, so the screen may mount with an empty
+  // `models` list before the gated model loads. The once-only useState initializer would then miss
+  // a returning user's persisted ack; a `useEffect([models])` re-seeds from localStorage when the
+  // catalog updates. Render empty first (initializer sees no gated model), then re-render with the
+  // SD3.5 model after the ack is persisted → the download must be unblocked without a manual check.
+  it("re-seeds the license-ack from localStorage when the catalog loads late (sc-7873)", async () => {
+    window.localStorage.setItem("sceneworks-license-ack:sd3_5_large", "true");
+    // Initial mount with an empty catalog (initializer records nothing).
+    await render([]);
+    // Catalog resolves asynchronously, bringing in the gated SD3.5 model.
+    await render([SD3_5_MODEL]);
+    const ackCheckbox = container.querySelector(".model-license-ack input");
+    expect(ackCheckbox).toBeTruthy();
+    expect(ackCheckbox.checked).toBe(true);
+    const downloadButton = [...container.querySelectorAll(".model-card-actions button")].find(
+      (button) => button.textContent.startsWith("Download"),
+    );
+    expect(downloadButton.disabled).toBe(false);
+  });
+
   // sc-7872: a non-gated model has no ack gate — its download stays enabled.
   it("does not gate a non-gated model's download on any acknowledgment (sc-7872)", async () => {
     await render([PLAIN_MODEL]);

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2198,10 +2198,10 @@
       "mlx": {
         // 8B MMDiT + triple text encoder (CLIP-L + CLIP-G + ~4.7B T5-XXL) + 16-ch VAE. Converted to
         // a packed MLX dir at install (mlx.requiresConversion + the `sd3_5_large_quant` converter,
-        // REGISTERED IN S2/S3 — this entry only declares it). minMemoryGb is a PLACEHOLDER consistent
-        // with sibling large flow models (krea_2 48, Boogu 64); E5 measured Large Q8 ~2.67 GB RSS but
-        // MLX Metal-wired memory is higher and generate is activation-bound — E7 (sc-78xx) refines.
-        "minMemoryGb": 48,
+        // REGISTERED IN S2/S3 — this entry only declares it). minMemoryGb 64 — E7 profiled the real
+        // OS peak memory footprint at ~59 GB Q8 (MLX Metal-wired memory, not RSS, dominated by the
+        // T5-XXL TE + activations); 64 leaves headroom over that measured peak.
+        "minMemoryGb": 64,
         "quantize": 8,
         "requiresConversion": true,
         "converter": "sd3_5_large_quant",
@@ -2293,9 +2293,10 @@
       },
       "mlx": {
         // Same footprint as Large (same backbone weights, few-step schedule). Converted to a packed
-        // MLX dir at install (`sd3_5_large_turbo_quant` converter, REGISTERED IN S2/S3). minMemoryGb
-        // PLACEHOLDER mirroring Large; E7 refines.
-        "minMemoryGb": 48,
+        // MLX dir at install (`sd3_5_large_turbo_quant` converter, REGISTERED IN S2/S3). minMemoryGb 64
+        // — E7 measured the same ~59 GB Q8 OS peak footprint as Large (identical backbone); 64 with
+        // headroom.
+        "minMemoryGb": 64,
         "quantize": 8,
         "requiresConversion": true,
         "converter": "sd3_5_large_turbo_quant",
@@ -2380,11 +2381,12 @@
         "types": ["style", "enhance", "character"]
       },
       "mlx": {
-        // 2.5B MMDiT-X + the same triple TE + 16-ch VAE (the TEs dominate the footprint, so Medium is
-        // not dramatically lighter than Large at load). Converted to a packed MLX dir at install
-        // (`sd3_5_medium_quant` converter, REGISTERED IN S2/S3). minMemoryGb PLACEHOLDER (lower than
-        // Large given the smaller backbone, but the triple TE keeps it non-trivial); E7 refines.
-        "minMemoryGb": 32,
+        // 2.5B MMDiT-X + the same triple TE + 16-ch VAE (the smaller backbone keeps the footprint
+        // well under Large). Converted to a packed MLX dir at install (`sd3_5_medium_quant` converter,
+        // REGISTERED IN S2/S3). minMemoryGb 16 — M3 measured the real OS peak at ~16 GB Q8 / ~12 GB Q4;
+        // 16 admits Medium on smaller Apple Silicon (the lightest SD3.5 tier) while gating Large/Turbo
+        // to 64 GB machines.
+        "minMemoryGb": 16,
         "quantize": 8,
         "requiresConversion": true,
         "converter": "sd3_5_medium_quant",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3615,6 +3615,13 @@ const MLX_ROUTED_MODELS: &[&str] = &[
     // Krea 2 Turbo (epic 7565 / sc-7572): native `mlx-gen-krea` text-to-image engine
     // (adapter `mlx_krea`) over the packed Q8/Q4 turnkey. CFG-free Turbo is text-to-image only.
     "krea_2_turbo",
+    // Stable Diffusion 3.5 (epic 7841 / S2 sc-7871 worker MODEL_TABLE, surfaced S4 sc-7873): the three
+    // native `mlx-gen-sd3` variants (adapter `mlx_sd3`), macOS-only (no torch backend, gated). All are
+    // text-to-image only — Large + Medium run true CFG (28 / 40 steps), Turbo is the CFG-free few-step
+    // distill (4 steps). `edit_image` has no source/reference path, so it's rejected (mirrors Krea/Lens).
+    "sd3_5_large",
+    "sd3_5_large_turbo",
+    "sd3_5_medium",
 ];
 
 /// Epic 3018 routing — does this image job belong on the in-process Rust MLX
@@ -3678,6 +3685,7 @@ fn image_request_mlx_eligible(model: &str, payload: &Map<String, Value>) -> bool
         "ideogram_4" | "ideogram_4_turbo" => ideogram_mlx_eligible(payload),
         "boogu_image" | "boogu_image_turbo" | "boogu_image_edit" => boogu_mlx_eligible(payload),
         "krea_2_turbo" => krea_mlx_eligible(payload),
+        "sd3_5_large" | "sd3_5_large_turbo" | "sd3_5_medium" => sd3_5_mlx_eligible(payload),
         // Every model in MLX_ROUTED_MODELS must have an arm.
         _ => false,
     }
@@ -4945,6 +4953,16 @@ fn boogu_mlx_eligible(payload: &Map<String, Value>) -> bool {
 /// engine serves the Turbo text-to-image surface only; `edit_image` has no source/reference
 /// path, so reject that defensive shape the same way Lens does.
 fn krea_mlx_eligible(payload: &Map<String, Value>) -> bool {
+    payload.get("mode").and_then(Value::as_str) != Some("edit_image")
+}
+
+/// Stable Diffusion 3.5 Large / Large Turbo / Medium (epic 7841, surfaced S4 sc-7873) MLX-eligibility.
+/// The native `mlx-gen-sd3` engine serves the **text-to-image** surface only (Large + Medium run true
+/// CFG, Turbo is the CFG-free few-step distill); there is no source/reference/edit path, so an
+/// `edit_image` request is rejected (the same defensive shape Krea / Lens reject). This keeps
+/// `model_mac_support`'s `features.edit` false for all three (it probes with `mode: edit_image`).
+/// macOS-only (the catalog flags `macOnly`); off-Mac no `mlx` worker registers so nothing defers.
+fn sd3_5_mlx_eligible(payload: &Map<String, Value>) -> bool {
     payload.get("mode").and_then(Value::as_str) != Some("edit_image")
 }
 
@@ -8144,6 +8162,40 @@ mod mlx_routing_tests {
         let support = model_mac_support("krea_2_turbo", "image");
         assert!(support.supported, "krea_2_turbo must be Mac-supported");
         assert!(!support.features.edit, "krea_2_turbo is text-to-image only");
+    }
+
+    #[test]
+    fn sd3_5_text_to_image_routes_to_mlx() {
+        // sc-7873 (epic 7841): the three SD3.5 variants have native `mlx-gen-sd3` text-to-image engines
+        // (S2 MODEL_TABLE), so they must reach the Text → Image picker (macSupport.supported) rather than
+        // being hidden as torch-only. All three are text-to-image only — `edit_image` is rejected.
+        for model in ["sd3_5_large", "sd3_5_large_turbo", "sd3_5_medium"] {
+            assert!(
+                image_request_mlx_eligible(
+                    model,
+                    &object(json!({ "model": model, "prompt": "a misty alpine lake at dawn" }))
+                ),
+                "{model} text-to-image must route to MLX"
+            );
+            assert!(
+                image_request_mlx_eligible(model, &Map::new()),
+                "{model} bare payload"
+            );
+            assert!(
+                !image_request_mlx_eligible(
+                    model,
+                    &object(
+                        json!({ "model": model, "mode": "edit_image", "sourceAssetId": "asset_1" })
+                    )
+                ),
+                "{model} edit is not supported (text-to-image only)"
+            );
+
+            // UI gating oracle: Mac-supported (reaches the picker), text-to-image only (no edit tab).
+            let support = model_mac_support(model, "image");
+            assert!(support.supported, "{model} must be Mac-supported");
+            assert!(!support.features.edit, "{model} is text-to-image only");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

S4 of the SD3.5 native port (epic 7841): make all three native-MLX SD3.5 variants usable from **Image Studio txt2img** with proper per-variant defaults and eligibility/gating, plus two carried-in fixes (E7/M3 `minMemoryGb`, S3 ack-seed). Builds on S1 (manifest entries), S2 (worker `MODEL_TABLE` + routing), S3 (gated download + license-ack).

Links sc-7873.

## Image Studio surfacing
- `apps/web/src/constants.js` `fallbackModels`: add the three variants with per-variant defaults so the picker seeds correctly before the live catalog loads:
  - **`sd3_5_large_turbo`** — fast default: few-step (4), CFG-free (guidance ~1.0).
  - **`sd3_5_large`** — high-fidelity: 28 steps, true CFG 3.5 (+ negative prompt).
  - **`sd3_5_medium`** — smaller-RAM mid-tier: 40 steps, guidance 4.5.
  - All carry the shared `/prompt-guides/sd3-5.md` guide + the curated SD3.5 sampler/scheduler menus. Largely manifest-driven: `macOnly` / `gated` / `minMemoryGb` come from the manifest + `macSupport` at runtime.

## Eligibility / gating
- `crates/sceneworks-core/src/jobs_store.rs`: register `sd3_5_large` / `sd3_5_large_turbo` / `sd3_5_medium` in `MLX_ROUTED_MODELS` with a text-to-image-only dispatch arm (`sd3_5_mlx_eligible`, rejects `edit_image` like Krea/Lens). This makes `model_mac_support` report `supported: true` on Mac so the variants reach the **Text → Image** picker — and are hidden off-Mac / when unsupported. `modelEligibility.js` / `ModelAvailabilityGate` already key off `macSupport`, so no per-Studio change was needed (epic 5941 pattern).

## Carried-in Fix A — E7/M3 `minMemoryGb` (`config/manifests/builtin.models.jsonc`)
- `sd3_5_large` 48 → **64** (E7 OS peak ~59 GB Q8 + headroom).
- `sd3_5_large_turbo` 48 → **64** (same backbone footprint).
- `sd3_5_medium` 32 → **16** (M3 measured ~16 GB Q8 / ~12 GB Q4 — the lightest SD3.5 tier; admits Medium on smaller Apple Silicon while gating Large/Turbo to 64 GB).
- `estimatedSizeBytes` remain documented **placeholders** (diffusers-subset estimates; refine on a measured pull).

## Carried-in Fix B — S3 ack-seed (`apps/web/src/screens/ModelManagerScreen.jsx`)
- The once-only `useState` lazy initializer seeded `licenseAcks` from `models`, which arrives async — a returning user's persisted ack was missed if the screen mounted before the catalog loaded. Added a `useEffect([models])` that re-seeds gated acks from localStorage on late catalog arrival, without clobbering an in-session checkbox toggle.

## Tests
- `apps/web/src/constants.test.js` (new): SD3.5 `fallbackModels` presence + per-variant defaults.
- `apps/web/src/modelEligibility.test.js`: the three variants are usable on Image Studio when Mac-supported; hidden when unsupported under active Mac gating; no-op off-Mac.
- `apps/web/src/screens/ModelManagerScreen.test.jsx`: late-catalog (empty → SD3.5) ack re-seed unblocks the download (Fix B).
- `crates/sceneworks-core/src/jobs_store.rs`: `sd3_5_text_to_image_routes_to_mlx` — routing + `model_mac_support` oracle (supported, edit gated off) for all three.

**Results:** all **742** web vitest tests pass; `sceneworks-core` mlx-routing (21) + jobs_store mac-support (2) + `sceneworks-rust-api` sd3_5 (2) pass; `node scripts/check-scaffold.mjs` passes (manifest + prompt-guide after the `minMemoryGb` edits); web ESLint 0 errors; `cargo clippy -p sceneworks-core` + `cargo fmt` clean.

## Out of scope
- S6 (e2e validation), T3 (training UI) — not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)