### PR TITLE
feat(sd3): SD3.5 T3 — worker + UI LoRA-training wiring + pin bump (sc-7884)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=83621680ade1a66f7da742c2af2c59a8d531a5b6#83621680ade1a66f7da742c2af2c59a8d531a5b6"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=83621680ade1a66f7da742c2af2c59a8d531a5b6#83621680ade1a66f7da742c2af2c59a8d531a5b6"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=83621680ade1a66f7da742c2af2c59a8d531a5b6#83621680ade1a66f7da742c2af2c59a8d531a5b6"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=83621680ade1a66f7da742c2af2c59a8d531a5b6#83621680ade1a66f7da742c2af2c59a8d531a5b6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=83621680ade1a66f7da742c2af2c59a8d531a5b6#83621680ade1a66f7da742c2af2c59a8d531a5b6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=83621680ade1a66f7da742c2af2c59a8d531a5b6#83621680ade1a66f7da742c2af2c59a8d531a5b6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -520,7 +520,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=83621680ade1a66f7da742c2af2c59a8d531a5b6#83621680ade1a66f7da742c2af2c59a8d531a5b6"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=83621680ade1a66f7da742c2af2c59a8d531a5b6#83621680ade1a66f7da742c2af2c59a8d531a5b6"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=83621680ade1a66f7da742c2af2c59a8d531a5b6#83621680ade1a66f7da742c2af2c59a8d531a5b6"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=83621680ade1a66f7da742c2af2c59a8d531a5b6#83621680ade1a66f7da742c2af2c59a8d531a5b6"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=83621680ade1a66f7da742c2af2c59a8d531a5b6#83621680ade1a66f7da742c2af2c59a8d531a5b6"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -586,7 +586,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=83621680ade1a66f7da742c2af2c59a8d531a5b6#83621680ade1a66f7da742c2af2c59a8d531a5b6"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -601,7 +601,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=83621680ade1a66f7da742c2af2c59a8d531a5b6#83621680ade1a66f7da742c2af2c59a8d531a5b6"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -614,7 +614,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=83621680ade1a66f7da742c2af2c59a8d531a5b6#83621680ade1a66f7da742c2af2c59a8d531a5b6"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -626,7 +626,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=83621680ade1a66f7da742c2af2c59a8d531a5b6#83621680ade1a66f7da742c2af2c59a8d531a5b6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -643,7 +643,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=83621680ade1a66f7da742c2af2c59a8d531a5b6#83621680ade1a66f7da742c2af2c59a8d531a5b6"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=83621680ade1a66f7da742c2af2c59a8d531a5b6#83621680ade1a66f7da742c2af2c59a8d531a5b6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -669,7 +669,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=83621680ade1a66f7da742c2af2c59a8d531a5b6#83621680ade1a66f7da742c2af2c59a8d531a5b6"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -684,7 +684,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=83621680ade1a66f7da742c2af2c59a8d531a5b6#83621680ade1a66f7da742c2af2c59a8d531a5b6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -702,7 +702,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=83621680ade1a66f7da742c2af2c59a8d531a5b6#83621680ade1a66f7da742c2af2c59a8d531a5b6"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -713,7 +713,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=83621680ade1a66f7da742c2af2c59a8d531a5b6#83621680ade1a66f7da742c2af2c59a8d531a5b6"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -726,7 +726,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=83621680ade1a66f7da742c2af2c59a8d531a5b6#83621680ade1a66f7da742c2af2c59a8d531a5b6"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -737,7 +737,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=83621680ade1a66f7da742c2af2c59a8d531a5b6#83621680ade1a66f7da742c2af2c59a8d531a5b6"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -750,7 +750,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1a343a22ad83e8429dd8b1525b31b67b9221d283#1a343a22ad83e8429dd8b1525b31b67b9221d283"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=83621680ade1a66f7da742c2af2c59a8d531a5b6#83621680ade1a66f7da742c2af2c59a8d531a5b6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -3455,7 +3455,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=221a171f7c73d6d5b40af1809aa72517345bab11#221a171f7c73d6d5b40af1809aa72517345bab11"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3467,7 +3467,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=221a171f7c73d6d5b40af1809aa72517345bab11#221a171f7c73d6d5b40af1809aa72517345bab11"
 dependencies = [
  "image",
  "inventory",
@@ -3481,7 +3481,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=221a171f7c73d6d5b40af1809aa72517345bab11#221a171f7c73d6d5b40af1809aa72517345bab11"
 dependencies = [
  "image",
  "inventory",
@@ -3495,7 +3495,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=221a171f7c73d6d5b40af1809aa72517345bab11#221a171f7c73d6d5b40af1809aa72517345bab11"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3508,7 +3508,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=221a171f7c73d6d5b40af1809aa72517345bab11#221a171f7c73d6d5b40af1809aa72517345bab11"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3519,7 +3519,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=221a171f7c73d6d5b40af1809aa72517345bab11#221a171f7c73d6d5b40af1809aa72517345bab11"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3528,7 +3528,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=221a171f7c73d6d5b40af1809aa72517345bab11#221a171f7c73d6d5b40af1809aa72517345bab11"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3541,7 +3541,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=221a171f7c73d6d5b40af1809aa72517345bab11#221a171f7c73d6d5b40af1809aa72517345bab11"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3554,7 +3554,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=221a171f7c73d6d5b40af1809aa72517345bab11#221a171f7c73d6d5b40af1809aa72517345bab11"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3567,7 +3567,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=221a171f7c73d6d5b40af1809aa72517345bab11#221a171f7c73d6d5b40af1809aa72517345bab11"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3578,7 +3578,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=221a171f7c73d6d5b40af1809aa72517345bab11#221a171f7c73d6d5b40af1809aa72517345bab11"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3588,7 +3588,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=221a171f7c73d6d5b40af1809aa72517345bab11#221a171f7c73d6d5b40af1809aa72517345bab11"
 dependencies = [
  "image",
  "inventory",
@@ -3601,7 +3601,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=221a171f7c73d6d5b40af1809aa72517345bab11#221a171f7c73d6d5b40af1809aa72517345bab11"
 dependencies = [
  "image",
  "inventory",
@@ -3615,7 +3615,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=221a171f7c73d6d5b40af1809aa72517345bab11#221a171f7c73d6d5b40af1809aa72517345bab11"
 dependencies = [
  "image",
  "inventory",
@@ -3629,7 +3629,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=221a171f7c73d6d5b40af1809aa72517345bab11#221a171f7c73d6d5b40af1809aa72517345bab11"
 dependencies = [
  "image",
  "inventory",
@@ -3641,7 +3641,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=221a171f7c73d6d5b40af1809aa72517345bab11#221a171f7c73d6d5b40af1809aa72517345bab11"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3652,7 +3652,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=221a171f7c73d6d5b40af1809aa72517345bab11#221a171f7c73d6d5b40af1809aa72517345bab11"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3664,7 +3664,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=221a171f7c73d6d5b40af1809aa72517345bab11#221a171f7c73d6d5b40af1809aa72517345bab11"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3675,7 +3675,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=221a171f7c73d6d5b40af1809aa72517345bab11#221a171f7c73d6d5b40af1809aa72517345bab11"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3684,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=221a171f7c73d6d5b40af1809aa72517345bab11#221a171f7c73d6d5b40af1809aa72517345bab11"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3693,7 +3693,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=221a171f7c73d6d5b40af1809aa72517345bab11#221a171f7c73d6d5b40af1809aa72517345bab11"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3705,8 +3705,9 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=221a171f7c73d6d5b40af1809aa72517345bab11#221a171f7c73d6d5b40af1809aa72517345bab11"
 dependencies = [
+ "image",
  "inventory",
  "mlx-gen",
  "mlx-gen-flux",
@@ -3719,7 +3720,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=221a171f7c73d6d5b40af1809aa72517345bab11#221a171f7c73d6d5b40af1809aa72517345bab11"
 dependencies = [
  "image",
  "inventory",
@@ -3733,7 +3734,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=221a171f7c73d6d5b40af1809aa72517345bab11#221a171f7c73d6d5b40af1809aa72517345bab11"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3744,7 +3745,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=221a171f7c73d6d5b40af1809aa72517345bab11#221a171f7c73d6d5b40af1809aa72517345bab11"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3756,7 +3757,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=221a171f7c73d6d5b40af1809aa72517345bab11#221a171f7c73d6d5b40af1809aa72517345bab11"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3767,7 +3768,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=221a171f7c73d6d5b40af1809aa72517345bab11#221a171f7c73d6d5b40af1809aa72517345bab11"
 dependencies = [
  "image",
  "inventory",
@@ -3781,7 +3782,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=221a171f7c73d6d5b40af1809aa72517345bab11#221a171f7c73d6d5b40af1809aa72517345bab11"
 dependencies = [
  "image",
  "inventory",
@@ -5472,7 +5473,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a784cd74d067bb95483d2dba3b4b79bc7aa6b85#1a784cd74d067bb95483d2dba3b4b79bc7aa6b85"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=221a171f7c73d6d5b40af1809aa72517345bab11#221a171f7c73d6d5b40af1809aa72517345bab11"
 dependencies = [
  "core-llm",
  "inventory",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -5122,13 +5122,17 @@ fn video_mode_is_mlx_eligible(model: &str, mode: &str) -> bool {
 /// gained a native mlx-gen-lens trainer in sc-5148, cut over here in sc-5180 (off-Mac
 /// keeps the Python sidecar trainer). `krea_lora` is the native `mlx-gen-krea` trainer
 /// (sc-7577); it has no torch path, so it is also listed in `MLX_ONLY_TRAINING_KERNELS`
-/// (sc-7578). A kernel absent here is never routed to the mlx worker.
+/// (sc-7578). `sd3_lora` is the native `mlx-gen-sd3` trainer (sc-7883/7885; Large +
+/// MMDiT-X Medium training bases), cut over here in sc-7884; it has no torch path either,
+/// so it is also in `MLX_ONLY_TRAINING_KERNELS`. A kernel absent here is never routed to
+/// the mlx worker.
 const MLX_ROUTED_TRAINING_KERNELS: &[&str] = &[
     "z_image_lora",
     "sdxl_lora",
     "kolors_lora",
     "lens_lora",
     "krea_lora",
+    "sd3_lora",
     "wan_lora",
     "wan_moe_lora",
     "ltx_mlx_lora",
@@ -5309,7 +5313,9 @@ fn video_upscale_job_is_candle_eligible(job: &JobSnapshot) -> bool {
 /// (z-image/sdxl/wan) keep their Python trainer as the Windows path + Mac fallback, so
 /// they are deliberately NOT listed here. `krea_lora` (epic 7565 P3) is MLX-native with
 /// no torch trainer — like LTX — so it is listed here (the candle Krea trainer is sc P4).
-const MLX_ONLY_TRAINING_KERNELS: &[&str] = &["ltx_mlx_lora", "krea_lora"];
+/// `sd3_lora` (epic 7841 T3 sc-7884) is likewise MLX-native with no torch trainer — the
+/// off-Mac/candle SD3.5 trainer is epic 7982 — so it is listed here too.
+const MLX_ONLY_TRAINING_KERNELS: &[&str] = &["ltx_mlx_lora", "krea_lora", "sd3_lora"];
 
 /// Whether this `lora_train` job targets a kernel with no non-Rust fallback (see
 /// [`MLX_ONLY_TRAINING_KERNELS`]). Such a job can only run on the mlx worker.

--- a/crates/sceneworks-core/src/training.rs
+++ b/crates/sceneworks-core/src/training.rs
@@ -422,6 +422,8 @@ pub fn builtin_training_targets() -> TrainingTargetRegistry {
             kolors_lora_target(),
             lens_turbo_lora_target(),
             krea_raw_lora_target(),
+            sd3_large_lora_target(),
+            sd3_medium_lora_target(),
             ltx_video_lora_target(),
             wan_lora_target(),
             wan_t2v_14b_lora_target(),
@@ -1302,6 +1304,182 @@ fn krea_raw_lora_target() -> TrainingTarget {
         ui: object(json!({
             "label": "Krea 2 LoRA",
             "description": "Train an image LoRA for Krea 2 (Qwen3-VL-4B text encoder + Qwen-Image VAE). Trains on the undistilled Krea 2 Raw base and applies to Krea 2 Turbo. Apple Silicon only (native MLX).",
+            "recommendedFor": ["character", "style"],
+            "appleSiliconOnly": true,
+            "backend": "mlx",
+            "datasetModality": "image"
+        })),
+        extra: ExtraFields::new(),
+    }
+}
+
+/// Native MLX LoRA/LoKr training for Stable Diffusion 3.5 **Large** (epic 7841, T3 sc-7884).
+///
+/// LoRAs train on the `stabilityai/stable-diffusion-3.5-large` MMDiT (the `sd3_lora` kernel →
+/// `mlx-gen-sd3` `register_trainer` id `sd3_5_large`, T2 sc-7883) and apply back at `sd3_5_large`
+/// — and the family-arch-identical `sd3_5_large_turbo` — inference via the `sd3` LoRA family
+/// (no base-model gating; the family match alone gates eligibility, mirroring Krea Raw→Turbo).
+/// Native MLX only (no torch SD3 trainer; off-Mac/candle is epic 7982), so Apple-Silicon-gated.
+fn sd3_large_lora_target() -> TrainingTarget {
+    TrainingTarget {
+        id: "sd3_5_large_lora".to_owned(),
+        name: "SD3.5 Large LoRA".to_owned(),
+        modality: TrainingModality::Image,
+        output_kind: TrainingOutputKind::Lora,
+        family: "sd3".to_owned(),
+        base_model: "sd3_5_large".to_owned(),
+        base_model_repo: Some("stabilityai/stable-diffusion-3.5-large".to_owned()),
+        kernel: "sd3_lora".to_owned(),
+        defaults: TrainingConfig {
+            rank: 16,
+            alpha: 16,
+            learning_rate: ContractNumber::from_f64(0.0001).expect("0.0001 is finite"),
+            steps: 3000,
+            batch_size: 1,
+            gradient_accumulation: 1,
+            resolution: 1024,
+            save_every: 250,
+            seed: 42,
+            // MLX training aliases `adamw8bit` → AdamW (bitsandbytes 8-bit is CUDA-only); the label
+            // stays consistent with the other native image targets (the engine normalizes it).
+            optimizer: "adamw8bit".to_owned(),
+            trigger_word: None,
+            advanced: object(json!({
+                "mixedPrecision": "bf16",
+                "cacheLatents": true,
+                "cacheTextEmbeddings": true,
+                "gradientCheckpointing": true,
+                "networkType": "lora",
+                // SD3.5 native flow-match noise sampling: logit-normal (the SD3 training recipe — the
+                // `mlx-gen-sd3` trainer default). No high/low-noise bias (neutral) — SD3.5 trains the
+                // full schedule, unlike the distilled-Turbo families that bias toward the few-step
+                // region.
+                "timestepType": "logit_normal",
+                "lossType": "mse",
+                "weightDecay": 0.0001,
+                // Learning-rate scheduler (see the Z-Image target); the worker honors
+                // `constant`/`linear`/`cosine` with an optional warmup.
+                "lrScheduler": "constant",
+                // SD3.5 MMDiT joint-block attention: the image stream (`to_q`/`to_k`/`to_v`/`to_out.0`)
+                // plus the text stream (`add_q_proj`/`add_k_proj`/`add_v_proj`/`to_add_out`) — the
+                // `mlx-gen-sd3` trainer's DEFAULT_TARGET_MODULES (both joint streams).
+                "loraTargetModules": ["to_q", "to_k", "to_v", "to_out.0", "add_q_proj", "add_k_proj", "add_v_proj", "to_add_out"],
+                // In-training previews render on the loaded Large base with its real-CFG settings
+                // (true classifier-free guidance 3.5, ~28 steps — SD3.5 Large is not distilled).
+                "sampleEvery": 500,
+                "sampleSteps": 28,
+                "sampleGuidanceScale": 3.5,
+                "qualityPreset": "balanced",
+                "outputScope": "project",
+                "requestedGpu": "auto",
+                // Native MLX trainer (surfaced for the UI; Apple-Silicon only).
+                "backend": "mlx"
+            })),
+            extra: ExtraFields::new(),
+        },
+        limits: object(json!({
+            "rank": [4, 128],
+            "alpha": [1, 128],
+            "steps": [200, 6000],
+            "resolutions": [768, 1024, 1536],
+            "batchSize": [1, 4],
+            "optimizers": ["adamw8bit", "adamw", "adam", "prodigyopt", "rose"],
+            // Both LoRA and LoKr round-trip the engine's `apply_sd3_adapters` seam at inference
+            // (the `mlx-gen-sd3` trainer builds both; `supports_lokr: true`).
+            "networkTypes": ["lora", "lokr"],
+            "lrSchedulers": ["constant", "linear", "cosine"],
+            "qualityPresets": ["speed", "balanced", "quality"],
+            "outputScopes": ["project", "global"],
+            // Native MLX trainer — no torch SD3 path (mirrors the Krea / LTX MLX targets).
+            "requiresBackend": "mlx",
+            "appleSiliconOnly": true
+        })),
+        ui: object(json!({
+            "label": "SD3.5 Large LoRA",
+            "description": "Train an image LoRA for Stable Diffusion 3.5 Large (triple text encoder CLIP-L + CLIP-G + T5-XXL, 16-channel VAE). Trains on the SD3.5 Large MMDiT and applies to SD3.5 Large and Large Turbo. Apple Silicon only (native MLX).",
+            "recommendedFor": ["character", "style"],
+            "appleSiliconOnly": true,
+            "backend": "mlx",
+            "datasetModality": "image"
+        })),
+        extra: ExtraFields::new(),
+    }
+}
+
+/// Native MLX LoRA/LoKr training for Stable Diffusion 3.5 **Medium** (MMDiT-X) (epic 7841, T4
+/// sc-7885 base; T3 sc-7884 wiring).
+///
+/// Body-identical to the Large target (same LoRA/LoKr capability surface, same logit-normal recipe,
+/// same joint-block attention targets) — it differs only in the base model / trainer id. LoRAs train
+/// on the `stabilityai/stable-diffusion-3.5-medium` MMDiT-X (dual-attention; the `sd3_lora` kernel →
+/// `mlx-gen-sd3` `register_trainer` id `sd3_5_medium`) and apply back at `sd3_5_medium` inference via
+/// the `sd3` LoRA family (no base-model gating). Apple-Silicon-gated (native MLX only).
+fn sd3_medium_lora_target() -> TrainingTarget {
+    TrainingTarget {
+        id: "sd3_5_medium_lora".to_owned(),
+        name: "SD3.5 Medium LoRA".to_owned(),
+        modality: TrainingModality::Image,
+        output_kind: TrainingOutputKind::Lora,
+        family: "sd3".to_owned(),
+        base_model: "sd3_5_medium".to_owned(),
+        base_model_repo: Some("stabilityai/stable-diffusion-3.5-medium".to_owned()),
+        kernel: "sd3_lora".to_owned(),
+        defaults: TrainingConfig {
+            rank: 16,
+            alpha: 16,
+            learning_rate: ContractNumber::from_f64(0.0001).expect("0.0001 is finite"),
+            steps: 3000,
+            batch_size: 1,
+            gradient_accumulation: 1,
+            resolution: 1024,
+            save_every: 250,
+            seed: 42,
+            optimizer: "adamw8bit".to_owned(),
+            trigger_word: None,
+            advanced: object(json!({
+                "mixedPrecision": "bf16",
+                "cacheLatents": true,
+                "cacheTextEmbeddings": true,
+                "gradientCheckpointing": true,
+                "networkType": "lora",
+                // SD3.5 native logit-normal flow-match recipe (the `mlx-gen-sd3` trainer default).
+                "timestepType": "logit_normal",
+                "lossType": "mse",
+                "weightDecay": 0.0001,
+                "lrScheduler": "constant",
+                // SD3.5 MMDiT-X joint-block attention (the trainer's DEFAULT_TARGET_MODULES — body
+                // identical to Large; the dual-attention `attn2` is validated at load).
+                "loraTargetModules": ["to_q", "to_k", "to_v", "to_out.0", "add_q_proj", "add_k_proj", "add_v_proj", "to_add_out"],
+                // SD3.5 Medium is not distilled — previews use real CFG (~40 steps / guidance 4.5,
+                // matching the Medium inference defaults).
+                "sampleEvery": 500,
+                "sampleSteps": 40,
+                "sampleGuidanceScale": 4.5,
+                "qualityPreset": "balanced",
+                "outputScope": "project",
+                "requestedGpu": "auto",
+                "backend": "mlx"
+            })),
+            extra: ExtraFields::new(),
+        },
+        limits: object(json!({
+            "rank": [4, 128],
+            "alpha": [1, 128],
+            "steps": [200, 6000],
+            // SD3.5 Medium renders up to 1440²; allow the higher training bucket.
+            "resolutions": [768, 1024, 1440],
+            "batchSize": [1, 4],
+            "optimizers": ["adamw8bit", "adamw", "adam", "prodigyopt", "rose"],
+            "networkTypes": ["lora", "lokr"],
+            "lrSchedulers": ["constant", "linear", "cosine"],
+            "qualityPresets": ["speed", "balanced", "quality"],
+            "outputScopes": ["project", "global"],
+            "requiresBackend": "mlx",
+            "appleSiliconOnly": true
+        })),
+        ui: object(json!({
+            "label": "SD3.5 Medium LoRA",
+            "description": "Train an image LoRA for Stable Diffusion 3.5 Medium (MMDiT-X dual-attention; triple text encoder, 16-channel VAE). Trains on the SD3.5 Medium MMDiT-X and applies to SD3.5 Medium. Apple Silicon only (native MLX).",
             "recommendedFor": ["character", "style"],
             "appleSiliconOnly": true,
             "backend": "mlx",

--- a/crates/sceneworks-core/tests/training_contracts.rs
+++ b/crates/sceneworks-core/tests/training_contracts.rs
@@ -111,7 +111,9 @@ fn builtin_targets_gate_network_types() {
     // the Wan2.2 5B video backend (sc-2211). Krea 2 (epic 7565) is the first *native-MLX*
     // LoKr target: its `mlx-gen-krea` trainer reports `supports_lokr` and builds LoKr targets
     // natively, and the Turbo inference loader applies LoKr through the shared adapter seam
-    // (sc-7911). The older MLX-only LTX and the Wan MoE targets stay lora-only.
+    // (sc-7911). SD3.5 Large + Medium (epic 7841 T3 sc-7884) are likewise native-MLX LoKr
+    // targets — the `mlx-gen-sd3` trainer reports `supports_lokr` and the `apply_sd3_adapters`
+    // seam loads both. The older MLX-only LTX and the Wan MoE targets stay lora-only.
     let lokr_targets: Vec<&str> = registry
         .targets
         .iter()
@@ -134,6 +136,8 @@ fn builtin_targets_gate_network_types() {
             "kolors_lora",
             "lens_turbo_lora",
             "krea_2_raw_lora",
+            "sd3_5_large_lora",
+            "sd3_5_medium_lora",
             "wan_lora"
         ]
     );
@@ -328,6 +332,70 @@ fn builtin_registry_exposes_krea_target() {
         target.limits.get("appleSiliconOnly"),
         Some(&serde_json::Value::Bool(true))
     );
+}
+
+#[test]
+fn builtin_registry_exposes_sd3_targets() {
+    // SD3.5 (epic 7841 T3 sc-7884) exposes TWO native-MLX LoRA/LoKr training bases on the shared
+    // `sd3_lora` kernel: Large (`mlx-gen-sd3` trainer id `sd3_5_large`) and the MMDiT-X Medium
+    // (`sd3_5_medium`). Both stamp `family: sd3` and apply back at their base via the
+    // `apply_sd3_adapters` seam (family-match, no base-model gating). Native MLX, Apple-Silicon only.
+    let registry = builtin_training_targets();
+
+    let joint_modules = serde_json::json!([
+        "to_q", "to_k", "to_v", "to_out.0", "add_q_proj", "add_k_proj", "add_v_proj", "to_add_out"
+    ]);
+
+    for (id, base_model, repo) in [
+        (
+            "sd3_5_large_lora",
+            "sd3_5_large",
+            "stabilityai/stable-diffusion-3.5-large",
+        ),
+        (
+            "sd3_5_medium_lora",
+            "sd3_5_medium",
+            "stabilityai/stable-diffusion-3.5-medium",
+        ),
+    ] {
+        let target = registry
+            .targets
+            .iter()
+            .find(|target| target.id == id)
+            .unwrap_or_else(|| panic!("{id} target present"));
+
+        assert_eq!(target.modality, TrainingModality::Image);
+        assert_eq!(target.output_kind, TrainingOutputKind::Lora);
+        assert_eq!(target.family, "sd3", "{id} stamps the sd3 LoRA family");
+        assert_eq!(target.base_model, base_model);
+        assert_eq!(target.kernel, "sd3_lora");
+        assert_eq!(target.base_model_repo.as_deref(), Some(repo));
+        // SD3.5 MMDiT joint-block attention: both joint streams (image + text), matching the
+        // `mlx-gen-sd3` trainer's DEFAULT_TARGET_MODULES.
+        assert_eq!(
+            target.defaults.advanced.get("loraTargetModules"),
+            Some(&joint_modules),
+            "{id} targets both joint attention streams"
+        );
+        // SD3 native logit-normal flow-match recipe (the trainer default).
+        assert_eq!(
+            target.defaults.advanced.get("timestepType"),
+            Some(&serde_json::json!("logit_normal")),
+            "{id} uses the SD3 logit-normal recipe"
+        );
+        // Native-MLX LoRA + LoKr (supports_lokr + apply_sd3_adapters).
+        assert_eq!(
+            target.limits.get("networkTypes"),
+            Some(&serde_json::json!(["lora", "lokr"])),
+            "{id} advertises lora + lokr"
+        );
+        // No torch SD3 trainer — Apple-Silicon/MLX-only (off-Mac/candle is epic 7982).
+        assert_eq!(
+            target.limits.get("appleSiliconOnly"),
+            Some(&serde_json::Value::Bool(true)),
+            "{id} is Apple-Silicon only"
+        );
+    }
 }
 
 #[test]

--- a/crates/sceneworks-core/tests/training_contracts.rs
+++ b/crates/sceneworks-core/tests/training_contracts.rs
@@ -343,7 +343,14 @@ fn builtin_registry_exposes_sd3_targets() {
     let registry = builtin_training_targets();
 
     let joint_modules = serde_json::json!([
-        "to_q", "to_k", "to_v", "to_out.0", "add_q_proj", "add_k_proj", "add_v_proj", "to_add_out"
+        "to_q",
+        "to_k",
+        "to_v",
+        "to_out.0",
+        "add_q_proj",
+        "add_k_proj",
+        "add_v_proj",
+        "to_add_out"
     ]);
 
     for (id, base_model, repo) in [

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -373,7 +373,16 @@ sceneworks-core = { path = "../sceneworks-core" }
 # mlx-gen-sd3 (Medium generator + e2e). The `sd3_5_medium` MODEL_TABLE row lands in this same PR.
 # Candle moves in lockstep below (candle-gen #162 re-pins its gen-core 7468d03 -> 1a784cd) so
 # `--features backend-candle --target all` resolves the SINGLE gen-core rev 1a784cd.
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
+# Bumped `1a784cd` -> `221a171` (epic 7841 SD3.5, sc-7884 / T3 worker+UI LoRA-training wiring): re-pin to
+# mlx-gen main HEAD, which adds the native MLX SD3.5 LoRA **trainer** (mlx-gen-sd3 `register_trainer`
+# family "sd3", T2 sc-7883), the **Medium** (MMDiT-X) LoRA-training base (T4 sc-7885), the
+# `apply_sd3_adapters` inference seam, and E7 Q8/Q4 quant. gen-core is ADDITIVE-ONLY across
+# 1a784cd..221a171 (`git diff` = +14 generator.rs `GenerationRequest.pid_capture_sigma: Option<f32>`
+# defaulted `None` + a new sampling.rs `flow_capture_plan` free fn — both PiD sc-7993, no existing
+# field/signature changed). Candle moves in lockstep below (candle-gen #163 re-pins its gen-core
+# 1a784cd -> 221a171; squashed merge rev 8362168) so `--features backend-candle --target all` resolves
+# the SINGLE gen-core rev 221a171.
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "221a171f7c73d6d5b40af1809aa72517345bab11" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -715,7 +724,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "221a171f7c73d6d5b40af1809aa72517345bab11" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -731,23 +740,23 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d0
 # exactly this rev, so the worker MUST match (a different rev would compile pmetal-mlx-sys twice). This
 # rebuilds MLX from source. Paired with mlx-llm `6c052ba` below (mlx-llm#45 carries the same fork pin).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "221a171f7c73d6d5b40af1809aa72517345bab11" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "221a171f7c73d6d5b40af1809aa72517345bab11" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "221a171f7c73d6d5b40af1809aa72517345bab11" }
 # Krea 2 Turbo (native MLX, Krea 2 Community License; epic 7565, sc-7572). Same git rev as mlx-gen.
 # Self-registers `krea_2_turbo` (Qwen3-VL-4B TE + 28-block single-stream DiT + Qwen-Image VAE; CFG-free
 # rectified-flow few-step) via inventory only when force-linked (`use mlx_gen_krea as _;` in
 # image_jobs.rs). Loads the packed Q8/Q4 turnkey subdir (krea_model_subdir; the loader auto-detects the
 # packed quant, so the resolved `spec.quantize` is a no-op on it). Depends on mlx-gen-qwen-image for the
 # shared `AutoencoderKLQwenImage` VAE.
-mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
+mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "221a171f7c73d6d5b40af1809aa72517345bab11" }
 # Stable Diffusion 3.5 provider (native MLX, Stability AI Community License; epic 7841, sc-7871). Same
 # git rev as mlx-gen so MLX builds once. Self-registers `sd3_5_large` (true-CFG, 28 steps / guidance 3.5)
 # + `sd3_5_large_turbo` (ADD-distilled few-step, CFG-off) + `sd3_5_medium` (MMDiT-X, true-CFG, 40 steps /
@@ -755,59 +764,59 @@ mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784c
 # (`use mlx_gen_sd3 as _;` in image_jobs.rs). All three carry a `sd3_5_*_quant` converter. Reuses the SDXL
 # CLIP encoder (×2), the FLUX T5-XXL encoder, and the Z-Image 16-ch VAE — its `quantize_sd3_dir` converter
 # is wired in model_jobs.rs for the `sd3_5_{large,large_turbo,medium}_quant` install-time conversions.
-mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
+mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "221a171f7c73d6d5b40af1809aa72517345bab11" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "221a171f7c73d6d5b40af1809aa72517345bab11" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "221a171f7c73d6d5b40af1809aa72517345bab11" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "221a171f7c73d6d5b40af1809aa72517345bab11" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "221a171f7c73d6d5b40af1809aa72517345bab11" }
 # CLIP ViT-L/14 image embedder for the Dataset Doctor analysis job (epic 6529 P2, sc-6535).
 # Self-registers `clip_vit_l14` (gen_core::ImageEmbedder) via inventory only when force-linked
 # (`use mlx_gen_clip as _;` in dataset_analysis_jobs.rs). Reuses mlx-gen-sdxl's CLIP body → same rev.
-mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
+mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "221a171f7c73d6d5b40af1809aa72517345bab11" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "221a171f7c73d6d5b40af1809aa72517345bab11" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "221a171f7c73d6d5b40af1809aa72517345bab11" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "221a171f7c73d6d5b40af1809aa72517345bab11" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "221a171f7c73d6d5b40af1809aa72517345bab11" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "221a171f7c73d6d5b40af1809aa72517345bab11" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "221a171f7c73d6d5b40af1809aa72517345bab11" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "221a171f7c73d6d5b40af1809aa72517345bab11" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -816,12 +825,12 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784c
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "221a171f7c73d6d5b40af1809aa72517345bab11" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "221a171f7c73d6d5b40af1809aa72517345bab11" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -830,7 +839,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784c
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "221a171f7c73d6d5b40af1809aa72517345bab11" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -838,7 +847,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "221a171f7c73d6d5b40af1809aa72517345bab11" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -849,7 +858,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a78
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "221a171f7c73d6d5b40af1809aa72517345bab11" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -860,7 +869,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "221a171f7c73d6d5b40af1809aa72517345bab11" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -875,7 +884,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784c
 # converted in-memory at load (no Python); the precomputed neg-prompt embedding is bundled in-crate. No
 # LoRA/guidance/CFG (one-step). 3B fp16 only here — 7B (sc-5197) + int8 (sc-5198) are engine-side and
 # unwired. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "221a171f7c73d6d5b40af1809aa72517345bab11" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -886,7 +895,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a7
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "221a171f7c73d6d5b40af1809aa72517345bab11" }
 # The unified LLM engine (epic 7153, sc-7158): the macOS `prompt_refine` job now runs through
 # mlx-llm's generic `mlx-llama` provider (a `core_llm::TextLlm`) resolved model-first via
 # `gen_core::core_llm::load_for_model`, RETIRING the bespoke `mlx-gen-prompt-refine` hand-rolled
@@ -912,7 +921,7 @@ mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "6c052ba6bbb81b
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a784cd74d067bb95483d2dba3b4b79bc7aa6b85" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "221a171f7c73d6d5b40af1809aa72517345bab11" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -1169,25 +1178,25 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a78
 # on the #905 candle-worker CI. #161 bumps candle-gen-joycaption's candle-llm -> `54ef5a1` (== the worker's
 # candle-llm pin below) + adds `tool_calls: Vec::new()` to its `core_llm::Message` literals, so the worker
 # graph unifies ONE candle-llm. Still a single gen-core rev (c45caec) + now a single candle-llm (54ef5a1).
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "83621680ade1a66f7da742c2af2c59a8d531a5b6", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "83621680ade1a66f7da742c2af2c59a8d531a5b6", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "83621680ade1a66f7da742c2af2c59a8d531a5b6", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "83621680ade1a66f7da742c2af2c59a8d531a5b6", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "83621680ade1a66f7da742c2af2c59a8d531a5b6", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "83621680ade1a66f7da742c2af2c59a8d531a5b6", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "83621680ade1a66f7da742c2af2c59a8d531a5b6", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1197,7 +1206,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "83621680ade1a66f7da742c2af2c59a8d531a5b6", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1205,21 +1214,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "83621680ade1a66f7da742c2af2c59a8d531a5b6", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "83621680ade1a66f7da742c2af2c59a8d531a5b6", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "83621680ade1a66f7da742c2af2c59a8d531a5b6", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "83621680ade1a66f7da742c2af2c59a8d531a5b6", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1228,17 +1237,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "83621680ade1a66f7da742c2af2c59a8d531a5b6", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "83621680ade1a66f7da742c2af2c59a8d531a5b6", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "83621680ade1a66f7da742c2af2c59a8d531a5b6", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1247,7 +1256,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "83621680ade1a66f7da742c2af2c59a8d531a5b6", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1269,7 +1278,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "54ef5a1e
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "83621680ade1a66f7da742c2af2c59a8d531a5b6", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1278,12 +1287,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "83621680ade1a66f7da742c2af2c59a8d531a5b6", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "83621680ade1a66f7da742c2af2c59a8d531a5b6", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1291,7 +1300,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "83621680ade1a66f7da742c2af2c59a8d531a5b6", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1300,7 +1309,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "83621680ade1a66f7da742c2af2c59a8d531a5b6", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1308,7 +1317,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "83621680ade1a66f7da742c2af2c59a8d531a5b6", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1317,7 +1326,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "83621680ade1a66f7da742c2af2c59a8d531a5b6", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1344,7 +1353,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1a343a22ad83e8429dd8b1525b31b67b9221d283", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "83621680ade1a66f7da742c2af2c59a8d531a5b6", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -491,6 +491,11 @@ pub(crate) const TRAINER_IDS: &[&str] = &[
     "sdxl",
     "kolors",
     "lens",
+    // SD3.5 LoRA-training bases (epic 7841 T3 sc-7884): the engine registers the LoRA/LoKr trainer
+    // under the same id as the inference generator of the training base — Large (sc-7883) and the
+    // MMDiT-X Medium (sc-7885). mlx-only (no candle SD3 trainer; epic 7982).
+    "sd3_5_large",
+    "sd3_5_medium",
     "ltx_2_3",
     "wan2_2_ti2v_5b",
     "wan2_2_t2v_14b",

--- a/crates/sceneworks-worker/src/lora_train_driver.rs
+++ b/crates/sceneworks-worker/src/lora_train_driver.rs
@@ -343,6 +343,131 @@ mod driver {
         assert!(out.final_loss.is_finite(), "final loss finite");
     }
 
+    /// sc-7884 — SceneWorks-WIRING real-weight smoke for the native MLX SD3.5 LoRA trainer.
+    ///
+    /// Exercises the EXACT path the worker's `lora_train` job uses — `gen_core::load_trainer(id, …)`
+    /// over the SD3.5 diffusers snapshot, force-linked here via `training_jobs`' `use mlx_gen_sd3 as _`
+    /// — to prove the trainer is reachable from the SceneWorks process and emits a usable adapter that
+    /// the inference loader (`apply_sd3_adapters`) can pick up at `sd3_5_*` generation. The deeper
+    /// numeric round-trip (loss descends, adapter shapes match, applies + renders) is already proven by
+    /// the mlx-gen-sd3 T2/T4 `#[ignore]` tests; this asserts the SceneWorks wiring specifically.
+    ///
+    /// `SD3_TRAINER_ID` selects the training base (`sd3_5_large` default, or `sd3_5_medium`);
+    /// `SD3_BASE` points at the diffusers snapshot dir for that base. Heavy (loads the MMDiT + the
+    /// triple TE) — Mac + Metal + the gated weights only; `RUST_TEST_THREADS=1` (MLX is `!Send`).
+    ///
+    /// ```sh
+    /// SD3_TRAINER_ID=sd3_5_large \
+    ///   SD3_BASE=~/.cache/huggingface/hub/models--stabilityai--stable-diffusion-3.5-large/snapshots/<rev> \
+    ///   TRAIN_DIR=~/Datasets/lora-eval/basim-train-cal OUTPUT_DIR=~/Datasets/lora-eval/adapters \
+    ///   ADAPTER_NAME=sd3-large-smoke.safetensors TRIGGER="sks man" SD3_STEPS=20 SD3_RESOLUTION=512 \
+    ///   RUST_TEST_THREADS=1 cargo test -p sceneworks-worker --lib train_sd3_lora -- --ignored --nocapture
+    /// ```
+    #[test]
+    #[ignore = "real-weight: trains a SD3.5 LoRA via the worker's trainer path; needs the gated SD3.5 diffusers snapshot + Metal. Set SD3_BASE/TRAIN_DIR/OUTPUT_DIR (+ SD3_TRAINER_ID)"]
+    fn train_sd3_lora() {
+        let trainer_id = env_str("SD3_TRAINER_ID", "sd3_5_large");
+        assert!(
+            trainer_id == "sd3_5_large" || trainer_id == "sd3_5_medium",
+            "SD3_TRAINER_ID must be sd3_5_large or sd3_5_medium (got {trainer_id:?})"
+        );
+        let base = require_env("SD3_BASE");
+        let train_dir = require_env("TRAIN_DIR");
+        let output_dir = require_env("OUTPUT_DIR");
+        std::fs::create_dir_all(&output_dir).unwrap();
+        let trigger = env_str("TRIGGER", "sks man");
+        let caption = format!("a photo of {trigger}");
+        let file_name = env_str("ADAPTER_NAME", "sd3-lora-smoke.safetensors");
+
+        let items: Vec<TrainingItem> = image_files(&train_dir)
+            .into_iter()
+            .map(|image_path| TrainingItem {
+                image_path,
+                caption: caption.clone(),
+            })
+            .collect();
+        assert!(
+            !items.is_empty(),
+            "no training images in {}",
+            train_dir.display()
+        );
+        println!(
+            "[{trainer_id}] training on {} images, trigger {trigger:?}, caption {caption:?}",
+            items.len()
+        );
+
+        let rank = env_u32("SD3_RANK", 16);
+        let config = TrainingConfig {
+            rank,
+            alpha: rank as f32,
+            learning_rate: env_f32("SD3_LR", 1e-4),
+            // A short run — this is a wiring smoke, not a quality run.
+            steps: env_u32("SD3_STEPS", 20),
+            resolution: env_u32("SD3_RESOLUTION", 512),
+            save_every: 0,
+            seed: env_u32("SD3_SEED", 7) as u64,
+            train_dtype: "bf16".to_string(),
+            // SD3 native flow-match recipe (matches the SceneWorks sd3_5_*_lora target defaults).
+            timestep_type: "logit_normal".to_string(),
+            ..Default::default()
+        };
+        println!(
+            "[{trainer_id}] config: rank {} steps {} res {} lr {} timestep {}",
+            config.rank,
+            config.steps,
+            config.resolution,
+            config.learning_rate,
+            config.timestep_type
+        );
+
+        let req = TrainingRequest {
+            items,
+            config,
+            output_dir,
+            file_name,
+            trigger_words: vec![trigger],
+            cancel: CancelFlag::new(),
+        };
+
+        // The worker reaches the trainer through this exact registry call (see
+        // `training_jobs::engine_trainer_id` → `sd3_5_large`/`sd3_5_medium`). The `mlx_gen_sd3` crate
+        // is force-linked by `training_jobs` so its `register_trainer!` survives linker GC.
+        let mut trainer = gen_core::load_trainer(
+            &trainer_id,
+            &LoadSpec::new(WeightsSource::Dir(base)),
+        )
+        .unwrap_or_else(|e| panic!("load {trainer_id} trainer (is mlx_gen_sd3 linked?): {e}"));
+        trainer.validate(&req).expect("validate training request");
+
+        let mut last_loss = f32::NAN;
+        let out = trainer
+            .train(&req, &mut |p| match p {
+                TrainingProgress::Caching { current, total } => {
+                    if current == 1 || current == total {
+                        println!("caching {current}/{total}");
+                    }
+                }
+                TrainingProgress::Training { step, total, loss } => {
+                    last_loss = loss;
+                    if step == 1 || step % 5 == 0 || step == total {
+                        println!("step {step}/{total} loss {loss:.4}");
+                    }
+                }
+                TrainingProgress::Checkpoint { step } => println!("checkpoint @ {step}"),
+                _ => {}
+            })
+            .expect("train");
+
+        println!(
+            "DONE [{trainer_id}] adapter={} steps={} final_loss={} (last_seen={last_loss:.4})",
+            out.adapter_path.display(),
+            out.steps,
+            out.final_loss
+        );
+        assert!(out.adapter_path.exists(), "adapter file written");
+        assert!(out.final_loss.is_finite(), "final loss finite");
+    }
+
     /// Generate the fixed prompt grid into `GEN_DIR` (+ a `prompts.json` map the eval harness
     /// reads for prompt adherence). `ADAPTER_PATH` set → use that LoRA at `ADAPTER_SCALE`;
     /// unset → the no-LoRA baseline. `GEN_SEEDS` is a comma list (default `42,1234`).

--- a/crates/sceneworks-worker/src/lora_train_driver.rs
+++ b/crates/sceneworks-worker/src/lora_train_driver.rs
@@ -432,11 +432,11 @@ mod driver {
         // The worker reaches the trainer through this exact registry call (see
         // `training_jobs::engine_trainer_id` → `sd3_5_large`/`sd3_5_medium`). The `mlx_gen_sd3` crate
         // is force-linked by `training_jobs` so its `register_trainer!` survives linker GC.
-        let mut trainer = gen_core::load_trainer(
-            &trainer_id,
-            &LoadSpec::new(WeightsSource::Dir(base)),
-        )
-        .unwrap_or_else(|e| panic!("load {trainer_id} trainer (is mlx_gen_sd3 linked?): {e}"));
+        let mut trainer =
+            gen_core::load_trainer(&trainer_id, &LoadSpec::new(WeightsSource::Dir(base)))
+                .unwrap_or_else(|e| {
+                    panic!("load {trainer_id} trainer (is mlx_gen_sd3 linked?): {e}")
+                });
         trainer.validate(&req).expect("validate training request");
 
         let mut last_loss = f32::NAN;

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -10,10 +10,13 @@
 //! `register_trained_lora`), so the streamed `result` here is informational/UI only.
 //!
 //! Routing (sc-3049, sc-7817): the API sends native-trainable families
-//! (`z_image_lora`/`sdxl_lora`/`kolors_lora`/`lens_lora`/`wan_lora`/`wan_moe_lora`/`ltx_mlx_lora`)
+//! (`z_image_lora`/`sdxl_lora`/`kolors_lora`/`lens_lora`/`krea_lora`/`sd3_lora`/`wan_lora`/
+//! `wan_moe_lora`/`ltx_mlx_lora`)
 //! here (`jobs_store::training_job_is_mlx_eligible` on Mac, `…_is_candle_eligible` off-Mac).
 //! `kolors_lora` joined the native trainers in sc-4732 (engine trainer sc-4568); `lens_lora` in
-//! sc-5180. The dry-run validator is cross-platform. The real run executes in-process on the macOS
+//! sc-5180; `krea_lora` in sc-7577/7578; `sd3_lora` (Large + MMDiT-X Medium training bases) in
+//! sc-7884 (engine trainer sc-7883/7885), native-MLX/Apple-Silicon only. The dry-run validator is
+//! cross-platform. The real run executes in-process on the macOS
 //! MLX engine OR — the off-Mac cutover (sc-7817, epic 5164) — on the candle Windows/CUDA + Linux
 //! engine, for the four families with a candle trainer (`sdxl`/`z_image_turbo`/`lens`/the Wan A14B
 //! **T2V** `wan2_2_t2v_14b`). The Python torch trainer stays the fallback for everything off-Mac
@@ -48,6 +51,8 @@ use mlx_gen_krea as _;
 use mlx_gen_lens as _;
 #[cfg(target_os = "macos")]
 use mlx_gen_ltx as _;
+#[cfg(target_os = "macos")]
+use mlx_gen_sd3 as _;
 #[cfg(target_os = "macos")]
 use mlx_gen_sdxl as _;
 #[cfg(target_os = "macos")]
@@ -313,6 +318,16 @@ fn engine_trainer_id(plan: &TrainingPlan) -> Option<&'static str> {
         // Krea trains the undistilled `krea/Krea-2-Raw` DiT; the engine registers its LoRA/LoKr
         // trainer under the base id `"krea_2_raw"` (arch-identical to krea_2_turbo), sc-7577/7578.
         "krea_lora" => Some("krea_2_raw"),
+        // SD3.5 (epic 7841, T3 sc-7884): the engine registers its LoRA/LoKr trainer under the same
+        // id as the inference generator of the training base — `sd3_5_large` (T2 sc-7883) and the
+        // MMDiT-X `sd3_5_medium` (T4 sc-7885). The trained adapter records `family: sd3` and applies
+        // back at that base (Large also covers the family-arch-identical `sd3_5_large_turbo`) via the
+        // `apply_sd3_adapters` seam — no base-model gating (family-match, like Krea Raw→Turbo).
+        "sd3_lora" => match plan.target.base_model.as_str() {
+            "sd3_5_large" => Some("sd3_5_large"),
+            "sd3_5_medium" => Some("sd3_5_medium"),
+            _ => None,
+        },
         "ltx_mlx_lora" => Some("ltx_2_3"),
         // Dense Wan2.2-TI2V-5B.
         "wan_lora" => Some("wan2_2_ti2v_5b"),
@@ -1698,6 +1713,12 @@ mod tests {
             // Krea trains the undistilled Raw DiT; the engine trainer registers under the base id
             // `"krea_2_raw"` (sc-7577/7578).
             ("krea_lora", "krea_2_raw", Some("krea_2_raw")),
+            // SD3.5 (sc-7884): the `sd3_lora` kernel splits by training base — the engine trainer
+            // registers under the inference-generator id of each base.
+            ("sd3_lora", "sd3_5_large", Some("sd3_5_large")),
+            ("sd3_lora", "sd3_5_medium", Some("sd3_5_medium")),
+            // Unknown SD3.5 base model variant (e.g. Turbo is NOT a training base).
+            ("sd3_lora", "sd3_5_large_turbo", None),
             // Unknown A14B base model variant.
             ("wan_moe_lora", "wan_2_2_mystery", None),
         ];

--- a/tests/fixtures/rust_migration_contracts/training/target-registry.json
+++ b/tests/fixtures/rust_migration_contracts/training/target-registry.json
@@ -507,6 +507,228 @@
       }
     },
     {
+      "id": "sd3_5_large_lora",
+      "name": "SD3.5 Large LoRA",
+      "modality": "image",
+      "outputKind": "lora",
+      "family": "sd3",
+      "baseModel": "sd3_5_large",
+      "baseModelRepo": "stabilityai/stable-diffusion-3.5-large",
+      "kernel": "sd3_lora",
+      "defaults": {
+        "rank": 16,
+        "alpha": 16,
+        "learningRate": 0.0001,
+        "steps": 3000,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 1024,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "backend": "mlx",
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": true,
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0",
+            "add_q_proj",
+            "add_k_proj",
+            "add_v_proj",
+            "to_add_out"
+          ],
+          "lossType": "mse",
+          "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
+          "outputScope": "project",
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 500,
+          "sampleGuidanceScale": 3.5,
+          "sampleSteps": 28,
+          "timestepType": "logit_normal",
+          "weightDecay": 0.0001
+        }
+      },
+      "limits": {
+        "alpha": [
+          1,
+          128
+        ],
+        "appleSiliconOnly": true,
+        "batchSize": [
+          1,
+          4
+        ],
+        "lrSchedulers": [
+          "constant",
+          "linear",
+          "cosine"
+        ],
+        "networkTypes": [
+          "lora",
+          "lokr"
+        ],
+        "optimizers": [
+          "adamw8bit",
+          "adamw",
+          "adam",
+          "prodigyopt",
+          "rose"
+        ],
+        "outputScopes": [
+          "project",
+          "global"
+        ],
+        "qualityPresets": [
+          "speed",
+          "balanced",
+          "quality"
+        ],
+        "rank": [
+          4,
+          128
+        ],
+        "requiresBackend": "mlx",
+        "resolutions": [
+          768,
+          1024,
+          1536
+        ],
+        "steps": [
+          200,
+          6000
+        ]
+      },
+      "ui": {
+        "appleSiliconOnly": true,
+        "backend": "mlx",
+        "datasetModality": "image",
+        "description": "Train an image LoRA for Stable Diffusion 3.5 Large (triple text encoder CLIP-L + CLIP-G + T5-XXL, 16-channel VAE). Trains on the SD3.5 Large MMDiT and applies to SD3.5 Large and Large Turbo. Apple Silicon only (native MLX).",
+        "label": "SD3.5 Large LoRA",
+        "recommendedFor": [
+          "character",
+          "style"
+        ]
+      }
+    },
+    {
+      "id": "sd3_5_medium_lora",
+      "name": "SD3.5 Medium LoRA",
+      "modality": "image",
+      "outputKind": "lora",
+      "family": "sd3",
+      "baseModel": "sd3_5_medium",
+      "baseModelRepo": "stabilityai/stable-diffusion-3.5-medium",
+      "kernel": "sd3_lora",
+      "defaults": {
+        "rank": 16,
+        "alpha": 16,
+        "learningRate": 0.0001,
+        "steps": 3000,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 1024,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "backend": "mlx",
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": true,
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0",
+            "add_q_proj",
+            "add_k_proj",
+            "add_v_proj",
+            "to_add_out"
+          ],
+          "lossType": "mse",
+          "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
+          "outputScope": "project",
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 500,
+          "sampleGuidanceScale": 4.5,
+          "sampleSteps": 40,
+          "timestepType": "logit_normal",
+          "weightDecay": 0.0001
+        }
+      },
+      "limits": {
+        "alpha": [
+          1,
+          128
+        ],
+        "appleSiliconOnly": true,
+        "batchSize": [
+          1,
+          4
+        ],
+        "lrSchedulers": [
+          "constant",
+          "linear",
+          "cosine"
+        ],
+        "networkTypes": [
+          "lora",
+          "lokr"
+        ],
+        "optimizers": [
+          "adamw8bit",
+          "adamw",
+          "adam",
+          "prodigyopt",
+          "rose"
+        ],
+        "outputScopes": [
+          "project",
+          "global"
+        ],
+        "qualityPresets": [
+          "speed",
+          "balanced",
+          "quality"
+        ],
+        "rank": [
+          4,
+          128
+        ],
+        "requiresBackend": "mlx",
+        "resolutions": [
+          768,
+          1024,
+          1440
+        ],
+        "steps": [
+          200,
+          6000
+        ]
+      },
+      "ui": {
+        "appleSiliconOnly": true,
+        "backend": "mlx",
+        "datasetModality": "image",
+        "description": "Train an image LoRA for Stable Diffusion 3.5 Medium (MMDiT-X dual-attention; triple text encoder, 16-channel VAE). Trains on the SD3.5 Medium MMDiT-X and applies to SD3.5 Medium. Apple Silicon only (native MLX).",
+        "label": "SD3.5 Medium LoRA",
+        "recommendedFor": [
+          "character",
+          "style"
+        ]
+      }
+    },
+    {
       "id": "ltx_video_lora",
       "name": "LTX-2.3 Video LoRA",
       "modality": "video",


### PR DESCRIPTION
## Summary

Wires the native MLX **SD3.5 LoRA trainer** end-to-end into SceneWorks (epic 7841, T3), mirroring the Krea Raw-LoRA training path (epic 7565, Raw→Turbo family-match). Two training bases — **Large** (`mlx-gen-sd3` trainer id `sd3_5_large`, T2 sc-7883) and the **MMDiT-X Medium** (`sd3_5_medium`, T4 sc-7885) — share a new `sd3_lora` kernel and apply back at their inference base via the `apply_sd3_adapters` seam (family `sd3`, **no base-model gating** — family-match, like Krea Raw→Turbo; Large also covers the family-arch-identical `sd3_5_large_turbo`). Native MLX / Apple-Silicon only (off-Mac/candle is epic 7982).

## Pin bump + candle lockstep

- **Worker mlx-gen pins** `1a784cd` → **`221a171`** (all 28 `mlx-gen-*` refs) — mlx-gen main HEAD: the T2 trainer + `register_trainer` for sd3, the T4 Medium training base, the `apply_sd3_adapters` inference seam, and E7 quant.
- gen-core is **additive-only** across `1a784cd..221a171`: new `GenerationRequest.pid_capture_sigma: Option<f32>` (defaulted `None`) + a new `sampling::flow_capture_plan` free fn — both PiD sc-7993. No existing field/signature changed.
- **Candle lockstep:** candle-gen [#163](https://github.com/SceneWorks/candle-gen/pull/163) re-pins its gen-core `1a784cd` → `221a171` — a **pure rev re-pin** (candle source unchanged; every `GenerationRequest` literal already uses `..Default::default()`; `cargo check --workspace` green). Merged (squash `8362168`); the worker `candle-gen-*` pins move `1a343a2` → `8362168` so the `--features backend-candle` skew gate resolves a single gen-core rev.

## Wiring

- **`sceneworks-core/training.rs`** — `sd3_large_lora_target` + `sd3_medium_lora_target` (family `sd3`, kernel `sd3_lora`, logit-normal SD3 recipe, both-joint-stream LoRA target modules, `lora`+`lokr`, `appleSiliconOnly`). Registered in `builtin_training_targets`; the committed registry fixture is regenerated.
- **`sceneworks-core/jobs_store.rs`** — `sd3_lora` added to `MLX_ROUTED_TRAINING_KERNELS` (which derives the web `training.supportedKernels` gate) + `MLX_ONLY_TRAINING_KERNELS` (no torch fallback).
- **`worker/training_jobs.rs`** — `engine_trainer_id` maps `sd3_lora` → `sd3_5_large`/`sd3_5_medium` by base model (Turbo is **not** a training base → `None`); `use mlx_gen_sd3 as _` force-links the trainer so its `register_trainer!` survives linker GC.
- **`worker/engines.rs`** — `sd3_5_large` + `sd3_5_medium` added to `TRAINER_IDS`.
- **UI** is manifest-driven (targets fetched from `/api/v1/training/targets`; the model-picker gate reads `supportedKernels` derived from `MLX_ROUTED_TRAINING_KERNELS`) — **no hardcoded web kernel list to touch**. SD3.5 surfaces automatically as a trainable base, macOnly.

## Base-model resolution (family-match)

`sd3_lora` is **not** added to any base-model-gating. The trained adapter stamps `family: sd3`; S5's `sd3` LoRA family loader accepts it and `apply_sd3_adapters` applies it at `sd3_5_large`/`sd3_5_large_turbo`/`sd3_5_medium` generation — exactly the Krea Raw→Turbo shape (per memory, Krea did NOT add `krea_2` to `is_base_model_gated_family`).

## Tests / validation

- **sceneworks-core:** `training_contracts` (snapshot + new `builtin_registry_exposes_sd3_targets` + the lokr-gate list) all green; 327 lib tests green.
- **worker:** `engine_trainer_id` mapping (new sd3 cases incl. Turbo→None) + `engines`/`training_jobs` green; clippy clean.
- **rust-api:** training tests green. **web:** `macGating`/`constants`/`TrainingStudio` green.
- **Real-weight WIRING smoke** (new `#[ignore]` `lora_train_driver::train_sd3_lora`): on a 64 GB Mac, trained an 8-step LoRA via the worker's exact `gen_core::load_trainer` path over the gated SD3.5 diffusers snapshots for **both** bases — **Large** (909 tensors, finite loss 0.0345) and **Medium** (729 tensors incl. 156 `attn2` MMDiT-X dual-attention keys, finite loss 0.0283) — emitting valid diffusers-keyed adapters (`rank=8 alpha=8 networkType=lora`) that the `apply_sd3_adapters` seam consumes. The deeper numeric **apply+render** round-trip is already proven by the mlx-gen-sd3 T2/T4 `#[ignore]` tests.

### Needs on-device (out of scope here = S6)
Full in-app e2e (the bundled-frontend/desktop build: dataset upload → job submit through the API → trained LoRA appears in the Image Studio picker → render at `sd3_5_*`) — this PR validates the worker/trainer/adapter layer; the cross-model final e2e is S6.

Refs sc-7884. Depends on T2 (sc-7883) + T4 (sc-7885) + S5. Candle PR: SceneWorks/candle-gen#163.