### PR TITLE
fix(web): restore hidden PiD checkbox + even variations/aspect columns

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2986,7 +2986,12 @@ label {
   color: var(--accent);
 }
 
-.preset-rail-row {
+/* Scoped to the rail ancestors so it outranks the `.control-grid` 3-column rule
+   the row element also carries (which appears later in the file at equal
+   specificity). VideoStudio's `.render-rail .preset-rail-row` already wins this
+   way; ImageStudio's rail needs the same. */
+.preset-rail .preset-rail-row,
+.render-rail .preset-rail-row {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 10px;
@@ -5567,18 +5572,27 @@ details[open] > summary.lora-scope-group-heading::before,
   border: 1px solid var(--border);
 }
 
-/* Checkbox toggles in the controls grid are single-line rows (checkbox + label
-   + any badge), not the stacked label-over-control grid every other field uses.
-   Without overriding the more-specific `.studio-controls label` grid rule they
-   stack vertically and stretch inline children (e.g. the PiD NC badge) to full
-   column width. Bottom-align them so each checkbox sits on the same baseline as
-   the select/input boxes beside it, keeping every row the same height. */
+/* Checkbox toggles are single-line rows (checkbox + label + any badge), not the
+   stacked label-over-control grid every other field uses — without overriding
+   the more-specific `.studio-controls label` grid rule they stack vertically and
+   stretch inline children (the PiD NC badge) to full column width. */
 .studio-controls label.checkline,
 .advanced-panel label.checkline {
   display: flex;
   align-items: center;
-  align-self: end;
   min-height: 38px;
+}
+
+/* Span the full grid: at the narrow 2-column cell width the checkbox was being
+   flex-shrunk to zero and the label/badge wrapped. Full width gives the checkbox,
+   label, and badge room to sit on one line. */
+.advanced-panel label.checkline {
+  grid-column: 1 / -1;
+}
+
+/* The checkbox itself must never shrink away inside the flex row. */
+.checkline input[type="checkbox"] {
+  flex: none;
 }
 
 .advanced-panel .prompt-field,


### PR DESCRIPTION
## What

Follow-up to #915, fixing two issues that the merged version of that PR shipped — both found by rendering the **real** stylesheet in a Vite preview harness and measuring computed layout (not by eyeballing).

### 1. The PiD decoder checkbox disappeared
In the narrow 2-column advanced-panel cell (~147px), the `.checkline` flex row had to fit the checkbox + "PiD decoder · 2K/4K" + the Non-Commercial badge. The unprotected `<input>` got flex-shrunk to **width 0** — the checkbox was simply gone.

Fix:
- Advanced-panel checkbox toggles now span the full grid (`grid-column: 1 / -1`), so checkbox + label + badge sit comfortably on one line.
- The checkbox gets `flex: none` so it can never shrink away.

### 2. Variations / Aspect rendered in three columns, not two
The row element also carries `.control-grid` (`grid-template-columns: repeat(3, …)`), which appears later in the file at equal specificity and won over the unscoped `.preset-rail-row` rule. Scoped it to `.preset-rail .preset-rail-row` (mirroring how VideoStudio's `.render-rail .preset-rail-row` already wins) so the two even columns actually apply.

## Verification (this time it was actually run)
Installed the web deps and ran the Vite dev server, then rendered the real `styles.css` against the exact preset-rail / advanced-panel DOM at the true 366px rail width. Measured computed layout:

| | before | after |
|---|---|---|
| PiD checkbox width | **0px (hidden)** | 13px (visible) |
| Variations/Aspect columns | `103px 103px 103px` | `160px 160px` |
| Advanced checkbox row heights | 38 / 45 (uneven) | 38 / 38 / 38 |

Badge sits inline on the same line as the checkbox; no wrapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)