### PR TITLE
fix(worker): restore inline Image Studio "Upscale" (SeedVR2/Real-ESRGAN) dropped by native port (sc-8091)

### DIFF
--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -654,6 +654,15 @@ impl ImageUpscaleRequest {
     pub fn is_disabled(&self) -> bool {
         !self.enabled
     }
+
+    /// SeedVR2-only input pre-blur (0..1), carried in the flattened extras. 0.0 ⇒ none.
+    pub fn softness(&self) -> f32 {
+        self.extra
+            .get("softness")
+            .and_then(Value::as_f64)
+            .map(|value| value.clamp(0.0, 1.0) as f32)
+            .unwrap_or(0.0)
+    }
 }
 
 pub const fn default_image_upscale_factor() -> u8 {

--- a/crates/sceneworks-core/src/image_request.rs
+++ b/crates/sceneworks-core/src/image_request.rs
@@ -9,7 +9,7 @@
 
 use serde_json::Value;
 
-use crate::contracts::JsonObject;
+use crate::contracts::{ImageUpscaleRequest, JsonObject};
 
 /// Default model when the payload omits one (matches the Python worker).
 const DEFAULT_MODEL: &str = "z_image_turbo";
@@ -55,6 +55,10 @@ pub struct ImageRequest {
     pub model_manifest_entry: JsonObject,
     /// Per-family advanced knobs (steps, guidanceScale, mlxQuantize, …), passed through.
     pub advanced: JsonObject,
+    /// Image Studio "Upscale" toggle (sc-8091): when `enabled`, the worker upscales each
+    /// generated image with `engine` (`seedvr2` / `real-esrgan`) at `factor` and writes a
+    /// second "(Nx upscaled)" asset — mirroring the Python worker. Disabled when omitted.
+    pub upscale: ImageUpscaleRequest,
 }
 
 impl ImageRequest {
@@ -84,6 +88,7 @@ impl ImageRequest {
             fit_mode: normalize_fit_mode(payload.get("fitMode").and_then(Value::as_str)),
             model_manifest_entry: object_or_empty(payload, "modelManifestEntry"),
             advanced: object_or_empty(payload, "advanced"),
+            upscale: parse_upscale(payload),
         }
     }
 
@@ -96,6 +101,17 @@ impl ImageRequest {
         }
         self.seed.map(|base| base.wrapping_add(index as i64))
     }
+}
+
+/// Parse the optional `upscale` object (the Image Studio "Upscale" toggle). A missing or
+/// malformed value falls back to the disabled default, so a bad payload never aborts a
+/// generation — it just skips upscaling.
+fn parse_upscale(payload: &JsonObject) -> ImageUpscaleRequest {
+    payload
+        .get("upscale")
+        .cloned()
+        .and_then(|value| serde_json::from_value(value).ok())
+        .unwrap_or_default()
 }
 
 fn string_or(payload: &JsonObject, key: &str, default: &str) -> String {
@@ -238,6 +254,26 @@ mod tests {
         assert!(request.seeds.is_empty());
         assert!(request.loras.is_empty());
         assert!(request.advanced.is_empty());
+        // No `upscale` object ⇒ the disabled default (the Image Studio toggle is off).
+        assert!(request.upscale.is_disabled());
+    }
+
+    #[test]
+    fn parses_inline_upscale_request() {
+        let request = ImageRequest::from_payload(&payload(json!({
+            "projectId": "p",
+            "upscale": { "enabled": true, "engine": "seedvr2", "factor": 4, "softness": 0.5 }
+        })));
+        assert!(request.upscale.enabled);
+        assert_eq!(request.upscale.engine, "seedvr2");
+        assert_eq!(request.upscale.factor, 4);
+        assert!((request.upscale.softness() - 0.5).abs() < 1e-6);
+
+        // A malformed `upscale` value never aborts parsing — it falls back to disabled.
+        let bad = ImageRequest::from_payload(&payload(json!({
+            "projectId": "p", "upscale": "yes please"
+        })));
+        assert!(bad.upscale.is_disabled());
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -1152,7 +1152,10 @@ async fn apply_inline_upscale(
                 JobStatus::Running,
                 ProgressStage::Running,
                 0.9,
-                &format!("Upscaling image {}/{total} {factor}x with {engine_id}.", i + 1),
+                &format!(
+                    "Upscaling image {}/{total} {factor}x with {engine_id}.",
+                    i + 1
+                ),
                 Some(streaming_result(plan, asset_writes)),
                 backend,
             ),

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -306,6 +306,7 @@ use crate::engines::{mlx_model, ResolvedModel};
 pub(crate) async fn run_image_generate_job(
     api: &ApiClient,
     settings: &Settings,
+    http_client: &reqwest::Client,
     job: &JobSnapshot,
 ) -> WorkerResult<()> {
     let request = ImageRequest::from_payload(&job.payload);
@@ -319,6 +320,21 @@ pub(crate) async fn run_image_generate_job(
     let project_path = PathBuf::from(project.path);
     tokio::fs::create_dir_all(project_path.join("assets").join("images")).await?;
 
+    // sc-8091: when the Image Studio "Upscale" toggle is on, each generated image also yields a
+    // second "(Nx upscaled)" asset, so the generation set expects twice as many images. The inline
+    // upscale post-pass only runs where the upscaler engines compile (macOS / candle); the
+    // stub-only build keeps the base count.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    let upscale_mult: u32 = if request.upscale.enabled { 2 } else { 1 };
+    #[cfg(not(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    )))]
+    let upscale_mult: u32 = 1;
+
     // Resolve the MLX dispatch branch once, then bake that branch's real total into
     // the plan so the generation set + streamed `expectedCount` match what lands in
     // the gallery.
@@ -327,7 +343,7 @@ pub(crate) async fn run_image_generate_job(
     #[cfg(target_os = "macos")]
     let plan = ImagePlan::with_count(
         &request,
-        route.map_or(request.count, |route| route.image_count(&request, settings)),
+        route.map_or(request.count, |route| route.image_count(&request, settings)) * upscale_mult,
     );
     // Windows/CUDA candle lane: an InstantID angle/pose set produces N images (the active angle
     // collection's length, or the pose count), not `request.count` — bake the real total into the plan
@@ -340,13 +356,13 @@ pub(crate) async fn run_image_generate_job(
         } else {
             request.count
         };
-        ImagePlan::with_count(&request, count)
+        ImagePlan::with_count(&request, count * upscale_mult)
     };
     #[cfg(all(
         not(target_os = "macos"),
         not(all(not(target_os = "macos"), feature = "backend-candle"))
     ))]
-    let plan = ImagePlan::with_count(&request, request.count);
+    let plan = ImagePlan::with_count(&request, request.count * upscale_mult);
 
     // Pre-flight LoRA family-compat guardrail (sc-3027): reject an incompatible LoRA
     // (e.g. a Flux LoRA on an SDXL model, or a Wan 5B LoRA on the 14B base) before any
@@ -840,6 +856,33 @@ pub(crate) async fn run_image_generate_job(
         .await?;
     }
 
+    // sc-8091: Image Studio "Upscale" toggle. The native worker never ported the Python inline-upscale
+    // path, so the UI's `upscale` request was silently dropped (images came out at the base size). Mirror
+    // Python: after the base images land, upscale each with the selected engine and append a second
+    // "(Nx upscaled)" asset. Gated to where the upscaler engines compile (macOS / candle).
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    if request.upscale.enabled {
+        apply_inline_upscale(
+            api,
+            settings,
+            http_client,
+            job,
+            &plan,
+            &project_path,
+            backend,
+            &mut asset_writes,
+        )
+        .await?;
+    }
+    #[cfg(not(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    )))]
+    let _ = http_client;
+
     update_job(
         api,
         &job.id,
@@ -1032,6 +1075,193 @@ pub(crate) fn write_image_asset(
         "rawAdapterSettings": raw_settings,
     });
     Ok(fact.as_object().cloned().expect("json! object literal"))
+}
+
+/// Normalise the UI's upscale engine id to the canonical worker id. SeedVR2 stays itself;
+/// everything else (`real-esrgan` / `realesrgan` / the dropped `aura-sr` / unknown) maps to
+/// Real-ESRGAN, so a bad engine string never hard-fails a whole generation.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn normalize_upscale_engine(engine: &str) -> &'static str {
+    match engine.trim().to_ascii_lowercase().as_str() {
+        "seedvr2" => "seedvr2",
+        _ => "real-esrgan",
+    }
+}
+
+/// Inline upscale post-pass (sc-8091): upscale every base image the generation produced and append a
+/// second "(Nx upscaled)" asset, mirroring the Python worker. Reuses the same in-memory upscalers as the
+/// standalone `image_upscale` job — Real-ESRGAN via `ort`, SeedVR2 via the registry generator — provisioning
+/// weights on first use. Runs after the base images have already been streamed (so they persist even if a
+/// late upscale step errors and fails the job).
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+#[allow(clippy::too_many_arguments)]
+async fn apply_inline_upscale(
+    api: &ApiClient,
+    settings: &Settings,
+    http_client: &reqwest::Client,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+    let factor: u8 = if request.upscale.factor == 4 { 4 } else { 2 };
+    let engine_id = normalize_upscale_engine(&request.upscale.engine);
+    let softness = request.upscale.softness();
+    // The generate payload carries the *generation* model's manifest, not an upscaler one; pass Null
+    // so the weight resolvers fall back to the default HF repos (download-on-first-use).
+    let manifest = Value::Null;
+    let cancel = CancelFlag::new();
+
+    // Snapshot the base image assets (we append the upscaled variants as we go).
+    let base_facts: Vec<JsonObject> = asset_writes
+        .iter()
+        .filter_map(Value::as_object)
+        .filter(|fact| fact.get("type").and_then(Value::as_str) == Some("image"))
+        .cloned()
+        .collect();
+    let total = base_facts.len();
+
+    for (i, base_fact) in base_facts.iter().enumerate() {
+        check_cancel(api, &job.id, "Image upscale canceled by user.").await?;
+
+        let media_rel = base_fact
+            .get("mediaPath")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                WorkerError::InvalidPayload("upscale source asset missing mediaPath".to_owned())
+            })?;
+        let source = crate::image_decode::decode_image_any(project_path.join(media_rel))
+            .map_err(|error| {
+                WorkerError::InvalidPayload(format!("Upscale source could not be loaded: {error}"))
+            })?
+            .to_rgb8();
+        let seed = base_fact.get("seed").and_then(Value::as_i64).unwrap_or(0);
+
+        update_job(
+            api,
+            &job.id,
+            image_progress(
+                JobStatus::Running,
+                ProgressStage::Running,
+                0.9,
+                &format!("Upscaling image {}/{total} {factor}x with {engine_id}.", i + 1),
+                Some(streaming_result(plan, asset_writes)),
+                backend,
+            ),
+        )
+        .await?;
+
+        let upscaled = crate::upscale_jobs::upscale_image_in_memory(
+            api,
+            settings,
+            http_client,
+            job,
+            &manifest,
+            engine_id,
+            factor,
+            softness,
+            seed.max(0) as u64,
+            source,
+            &cancel,
+        )
+        .await?;
+
+        let fact = write_upscaled_asset(
+            plan,
+            base_fact,
+            &upscaled,
+            engine_id,
+            factor,
+            softness,
+            project_path,
+        )?;
+        asset_writes.push(Value::Object(fact));
+        heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+    }
+    Ok(())
+}
+
+/// Write the upscaled variant of a base image as its own asset (sc-8091): same metadata as the base
+/// fact, but a fresh `assetId`, the `_up{factor}x` file, the upscaled dimensions, a "(Nx upscaled)"
+/// display-name suffix, and a `rawAdapterSettings.upscale` record (so preset-restore reads it back).
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn write_upscaled_asset(
+    plan: &ImagePlan,
+    base_fact: &JsonObject,
+    upscaled: &image::RgbImage,
+    engine_id: &str,
+    factor: u8,
+    softness: f32,
+    project_path: &Path,
+) -> WorkerResult<JsonObject> {
+    let request = &plan.request;
+    let index = base_fact.get("index").and_then(Value::as_u64).unwrap_or(0) as usize;
+    let (width, height) = (upscaled.width(), upscaled.height());
+
+    let filename = format!(
+        "{}_{}_{}_{:04}_up{factor}x.png",
+        &plan.created_at[..10],
+        request.model,
+        plan.slug,
+        index + 1
+    );
+    let media_rel = format!("assets/images/{}/{filename}", plan.genset_id);
+    let media_path = project_path.join(&media_rel);
+    if let Some(parent) = media_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let temp_path = media_path.with_extension("tmp.png");
+    upscaled
+        .save_with_format(&temp_path, image::ImageFormat::Png)
+        .map_err(|error| WorkerError::Io(std::io::Error::other(error)))?;
+    std::fs::rename(&temp_path, &media_path).inspect_err(|_| {
+        let _ = std::fs::remove_file(&temp_path);
+    })?;
+
+    let base_display = base_fact
+        .get("displayName")
+        .and_then(Value::as_str)
+        .unwrap_or("Generated image");
+    let display_name = format!("{base_display} ({factor}x upscaled)");
+
+    // rawAdapterSettings: the base settings + an `upscale` record (mirrors the Python worker so the
+    // gallery / preset restore can read back the engine/factor/softness).
+    let mut raw_settings = base_fact
+        .get("rawAdapterSettings")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    let upscale_record = if engine_id == "seedvr2" {
+        json!({ "enabled": true, "engine": engine_id, "factor": factor, "softness": softness })
+    } else {
+        json!({ "enabled": true, "engine": engine_id, "factor": factor })
+    };
+    raw_settings.insert("upscale".to_owned(), upscale_record);
+
+    let mut fact = base_fact.clone();
+    fact.insert("assetId".to_owned(), json!(fresh_asset_id()));
+    fact.insert("mediaPath".to_owned(), json!(media_rel));
+    fact.insert("width".to_owned(), json!(width));
+    fact.insert("height".to_owned(), json!(height));
+    fact.insert("displayName".to_owned(), json!(display_name));
+    fact.insert("createdAt".to_owned(), json!(now_rfc3339()));
+    fact.insert("rawAdapterSettings".to_owned(), Value::Object(raw_settings));
+    fact.insert(
+        "upscaledFrom".to_owned(),
+        base_fact.get("assetId").cloned().unwrap_or(Value::Null),
+    );
+    Ok(fact)
 }
 
 /// The job-result shape the API streams from: `assetWrites` + the `generationSet`

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -622,7 +622,7 @@ async fn run_utility_job(
         // Native MLX image generation, served in-process by the linked mlx-gen
         // engine on the macOS Apple-Silicon GPU worker (epic 3018). Off macOS the
         // capability is never advertised, so this arm is unreachable there.
-        JobType::ImageGenerate => run_image_generate_job(api, settings, &job)
+        JobType::ImageGenerate => run_image_generate_job(api, settings, http_client, &job)
             .await
             .map_err(|error| ("Image generation failed.", error)),
         // Plain Image Edit (sc-3513): the distinct `image_edit` job type (`mode=edit_image`
@@ -630,7 +630,7 @@ async fn run_utility_job(
         // payload model+mode (qwen/flux2/sdxl edit streams), not job type. The API only
         // routes MLX-eligible edit models here (jobs_store::image_job_is_mlx_eligible); off
         // macOS the `image_edit` capability is never advertised, so this arm is unreachable.
-        JobType::ImageEdit => run_image_generate_job(api, settings, &job)
+        JobType::ImageEdit => run_image_generate_job(api, settings, http_client, &job)
             .await
             .map_err(|error| ("Image edit failed.", error)),
         // Native MLX tile-ControlNet detail refine (epic 3041, sc-3060), served in-process

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -895,9 +895,10 @@ async fn image_edit_job_dispatches_to_image_generate_handler() {
     }))
     .expect("image_edit job snapshot deserializes");
 
-    let error = super::image_jobs::run_image_generate_job(&api, &settings, &job)
-        .await
-        .expect_err("missing projectId is rejected by the image handler");
+    let error =
+        super::image_jobs::run_image_generate_job(&api, &settings, &reqwest::Client::new(), &job)
+            .await
+            .expect_err("missing projectId is rejected by the image handler");
     assert!(
         matches!(&error, WorkerError::InvalidPayload(message) if message.contains("projectId")),
         "expected a projectId payload error from the image handler, got {error:?}",

--- a/crates/sceneworks-worker/src/upscale_jobs.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs.rs
@@ -566,6 +566,43 @@ async fn run_seedvr2_upscale(
     .await
 }
 
+/// Upscale one in-memory RGB image with the selected engine, returning the upscaled image.
+/// Shared by the standalone `image_upscale` job and the Image Studio inline "Upscale" toggle
+/// (sc-8091): Real-ESRGAN runs via the cached `ort` session on a blocking thread; SeedVR2 runs
+/// in-process through the registry generator. `manifest_entry` may be `Value::Null` (the inline
+/// path carries the *generation* model's manifest, not an upscaler one) — the weight resolvers
+/// then fall back to the default HF repos. `engine_id` is the canonical id (`seedvr2`, else
+/// Real-ESRGAN); the caller normalises before passing it in.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn upscale_image_in_memory(
+    api: &ApiClient,
+    settings: &Settings,
+    http_client: &reqwest::Client,
+    job: &JobSnapshot,
+    manifest_entry: &Value,
+    engine_id: &str,
+    factor: u8,
+    softness: f32,
+    seed: u64,
+    source: RgbImage,
+    cancel: &CancelFlag,
+) -> WorkerResult<RgbImage> {
+    match engine_id {
+        "seedvr2" => {
+            let dir =
+                ensure_seedvr2_checkpoint(api, settings, http_client, job, manifest_entry).await?;
+            run_seedvr2_upscale(dir, source, factor, softness, seed, cancel.clone()).await
+        }
+        _ => {
+            let onnx = ensure_onnx(api, settings, http_client, job, factor, manifest_entry).await?;
+            let cancel = cancel.clone();
+            tokio::task::spawn_blocking(move || upscale_blocking(onnx, factor, source, cancel))
+                .await
+                .map_err(|error| task_join_error("inline upscale", error))?
+        }
+    }
+}
+
 async fn run_upscale_with_heartbeat<R>(
     api: &ApiClient,
     settings: &Settings,


### PR DESCRIPTION
## Problem

In Image Studio (Text to Image), the **Upscale** toggle (SeedVR2 / Real-ESRGAN, 2x/4x) did **nothing** — generated images came out at the base resolution, identical to upscale-off. User-reported with SeedVR2.

Root cause: the inline upscale step was never ported from the Python worker. The UI ([`ImageStudio.jsx`](apps/web/src/screens/ImageStudio.jsx)) and API DTO (`ImageUpscaleRequest`) carried the `upscale` field, but `ImageRequest::from_payload` never parsed it and no generate path applied it, so the worker silently dropped it. The standalone Image Editor `image_upscale` job was unaffected — only the *inline-during-generation* path was missing. Affects **both** engines, not just SeedVR2.

## Fix

Mirror the Python behavior (keep the base image **and** add a second "(Nx upscaled)" asset), reusing the standalone job's in-memory upscalers rather than reimplementing:

- **core** — `ImageRequest` now parses the `upscale` field (lenient: malformed ⇒ disabled); added `ImageUpscaleRequest::softness()`.
- **worker** — new `upscale_jobs::upscale_image_in_memory(...)`: one entry point branching SeedVR2 (registry generator via `ensure_seedvr2_checkpoint` + `run_seedvr2_upscale`) vs Real-ESRGAN (`ensure_onnx` + `upscale_blocking` on a blocking thread); `Null` manifest ⇒ default-HF weight fallback.
- **worker** — a post-generation pass `apply_inline_upscale(...)` in `run_image_generate_job` (gated to macOS/candle, the single chokepoint after `asset_writes` is populated) upscales each base image and appends `write_upscaled_asset(...)` (fresh `assetId`, `_up{N}x` file, upscaled dims, "(Nx upscaled)" name, `rawAdapterSettings.upscale` record). The `ImagePlan` count doubles when upscale is on so `expectedCount`/genset `count` cover base + upscaled.
- threaded `http_client` into the ImageGenerate/ImageEdit dispatch arms.

## Design note

Keeps the **faithful** Python behavior — both the original and the upscaled asset (two gallery items), hence the `expectedCount` doubling. A simpler alternative is replace-in-place (one upscaled asset, no count coupling); easy to switch if preferred. Errors propagate (job fails loudly), but base images were already streamed/persisted, so they survive a late upscale failure.

## Verification

- ✅ `cargo check -p sceneworks-worker` — clean, full macOS mlx-gen stack (exit 0).
- ✅ `cargo test -p sceneworks-core --lib image_request` — 6/6, incl. the new `parses_inline_upscale_request` (default-disabled, enabled SeedVR2 + softness, malformed-fallback).
- ⏳ **On-device real-weight E2E pending** — running a Mac generate with SeedVR2/Real-ESRGAN at 2x/4x and seeing the larger second asset can't be exercised from a worktree. Tracked as a task on sc-8091.

Closes [sc-8091](https://app.shortcut.com/trefry/story/8091) (epic 4811) once the on-device check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)