### PR TITLE
chore(web): hide redundant read-only caption preview on JSON tab (sc-8114)

### DIFF
--- a/apps/web/src/components/StructuredPromptBuilder.jsx
+++ b/apps/web/src/components/StructuredPromptBuilder.jsx
@@ -478,8 +478,15 @@ export default function StructuredPromptBuilder({
 
       {mode !== "plain" ? (
         <div className="structured-preview">
-          <div className="structured-preview-head">Generated caption (sent to the model)</div>
-          <pre aria-label="Caption preview">{prettyCaption(caption)}</pre>
+          {/* The JSON tab's textarea already shows the canonical JSON, so the
+              read-only preview pane is a duplicate there — only render it in the
+              form builder. Schema errors/warnings stay on both tabs (sc-8114). */}
+          {mode === "form" ? (
+            <>
+              <div className="structured-preview-head">Generated caption (sent to the model)</div>
+              <pre aria-label="Caption preview">{prettyCaption(caption)}</pre>
+            </>
+          ) : null}
           {errors.length ? (
             <ul className="structured-issues structured-issues-error">
               {errors.map((issue, i) => (

--- a/apps/web/src/components/StructuredPromptBuilder.test.jsx
+++ b/apps/web/src/components/StructuredPromptBuilder.test.jsx
@@ -227,4 +227,38 @@ describe("StructuredPromptBuilder", () => {
     expect(snap.validation.ok).toBe(false);
     expect(container.querySelector(".structured-issues-error")).toBeTruthy();
   });
+
+  it("shows the read-only caption preview in form mode (sc-8114)", async () => {
+    await mount({ initialMode: "form" });
+    expect(container.querySelector('[aria-label="Caption preview"]')).toBeTruthy();
+  });
+
+  it("hides the duplicate read-only caption preview on the JSON tab (sc-8114)", async () => {
+    await mount({ initialMode: "json" });
+    // The JSON textarea already shows the canonical JSON, so the duplicate
+    // read-only <pre> preview must NOT render on the JSON tab.
+    expect(container.querySelector('[aria-label="Caption preview"]')).toBeFalsy();
+    // The editable JSON textarea is still present.
+    expect(container.querySelector('textarea[aria-label="JSON caption"]')).toBeTruthy();
+  });
+
+  it("hides the read-only caption preview in plain mode (sc-8114)", async () => {
+    await mount({ initialMode: "plain" });
+    expect(container.querySelector('[aria-label="Caption preview"]')).toBeFalsy();
+  });
+
+  it("still surfaces schema validation errors on the JSON tab without the preview (sc-8114)", async () => {
+    const bad = {
+      compositional_deconstruction: {
+        background: "bg",
+        elements: [{ type: "obj", bbox: [0, 0, 5000, 10], desc: "d" }],
+      },
+    };
+    await mount({ initialMode: "json", initialCaption: bad });
+    // No duplicate preview pane...
+    expect(container.querySelector('[aria-label="Caption preview"]')).toBeFalsy();
+    // ...but the schema validation errors are still visible on the JSON tab.
+    expect(snap.validation.ok).toBe(false);
+    expect(container.querySelector(".structured-issues-error")).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## What changed

On the **JSON tab** of the Ideogram structured-prompt builder, the read-only "Generated caption (sent to the model)" `<pre>` preview duplicated the editable `jsonDraft` textarea directly above it (both show the same canonical JSON) and wasted vertical space.

The preview `<pre>` lived inside a `mode !== "plain"` block in `apps/web/src/components/StructuredPromptBuilder.jsx`, so it rendered on **both** the Builder (form) tab and the JSON tab.

**Change:** the read-only `<pre>` caption preview (and its "Generated caption…" heading) now renders **only in `form` mode**. It no longer appears on the JSON tab or in plain mode.

## The kept-validation wrinkle

That same `mode !== "plain"` container also rendered the schema `errors`/`warnings` lists — and those **are** wanted on the JSON tab (they are distinct from the parse-level `jsonError` shown under the JSON textarea). The errors/warnings block is intentionally **kept** for `mode !== "plain"` (form + json), so schema validation issues still surface on the JSON tab. Only the duplicate `<pre>` preview was gated down to `form`.

## Tests

Extended `StructuredPromptBuilder.test.jsx`:
- preview `<pre>` (`aria-label="Caption preview"`) is **present** in `form` mode
- preview `<pre>` is **absent** on the **JSON** tab, while the editable `JSON caption` textarea is still present
- preview `<pre>` is **absent** in `plain` mode
- on the JSON tab with an out-of-range bbox: preview `<pre>` is absent **but** the schema validation errors (`.structured-issues-error`) still render

## How verified

- `apps/web` vitest suite: **746 passed (45 files)** including the new cases
- `npm run lint`: **0 errors** in the changed files (pre-existing unrelated `react-hooks/exhaustive-deps` warnings elsewhere untouched)

Improvement to the existing Ideogram 4725 builder (sc-5994). Closes sc-8114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)