### PR TITLE
chore(engine): Qwen3-VL (qwen3_vl) engine bump for image_caption (sc-8171)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=63288213e4b92e446c2b77ab094f1f2d5c4fd320#63288213e4b92e446c2b77ab094f1f2d5c4fd320"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=63288213e4b92e446c2b77ab094f1f2d5c4fd320#63288213e4b92e446c2b77ab094f1f2d5c4fd320"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=63288213e4b92e446c2b77ab094f1f2d5c4fd320#63288213e4b92e446c2b77ab094f1f2d5c4fd320"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=63288213e4b92e446c2b77ab094f1f2d5c4fd320#63288213e4b92e446c2b77ab094f1f2d5c4fd320"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=63288213e4b92e446c2b77ab094f1f2d5c4fd320#63288213e4b92e446c2b77ab094f1f2d5c4fd320"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=63288213e4b92e446c2b77ab094f1f2d5c4fd320#63288213e4b92e446c2b77ab094f1f2d5c4fd320"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -520,7 +520,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=63288213e4b92e446c2b77ab094f1f2d5c4fd320#63288213e4b92e446c2b77ab094f1f2d5c4fd320"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=63288213e4b92e446c2b77ab094f1f2d5c4fd320#63288213e4b92e446c2b77ab094f1f2d5c4fd320"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=63288213e4b92e446c2b77ab094f1f2d5c4fd320#63288213e4b92e446c2b77ab094f1f2d5c4fd320"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=63288213e4b92e446c2b77ab094f1f2d5c4fd320#63288213e4b92e446c2b77ab094f1f2d5c4fd320"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=63288213e4b92e446c2b77ab094f1f2d5c4fd320#63288213e4b92e446c2b77ab094f1f2d5c4fd320"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -586,7 +586,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=63288213e4b92e446c2b77ab094f1f2d5c4fd320#63288213e4b92e446c2b77ab094f1f2d5c4fd320"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -601,7 +601,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=63288213e4b92e446c2b77ab094f1f2d5c4fd320#63288213e4b92e446c2b77ab094f1f2d5c4fd320"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -614,7 +614,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=63288213e4b92e446c2b77ab094f1f2d5c4fd320#63288213e4b92e446c2b77ab094f1f2d5c4fd320"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -626,7 +626,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=63288213e4b92e446c2b77ab094f1f2d5c4fd320#63288213e4b92e446c2b77ab094f1f2d5c4fd320"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -643,7 +643,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=63288213e4b92e446c2b77ab094f1f2d5c4fd320#63288213e4b92e446c2b77ab094f1f2d5c4fd320"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=63288213e4b92e446c2b77ab094f1f2d5c4fd320#63288213e4b92e446c2b77ab094f1f2d5c4fd320"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -669,7 +669,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=63288213e4b92e446c2b77ab094f1f2d5c4fd320#63288213e4b92e446c2b77ab094f1f2d5c4fd320"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -684,7 +684,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=63288213e4b92e446c2b77ab094f1f2d5c4fd320#63288213e4b92e446c2b77ab094f1f2d5c4fd320"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -702,7 +702,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=63288213e4b92e446c2b77ab094f1f2d5c4fd320#63288213e4b92e446c2b77ab094f1f2d5c4fd320"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -713,7 +713,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=63288213e4b92e446c2b77ab094f1f2d5c4fd320#63288213e4b92e446c2b77ab094f1f2d5c4fd320"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -726,7 +726,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=63288213e4b92e446c2b77ab094f1f2d5c4fd320#63288213e4b92e446c2b77ab094f1f2d5c4fd320"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -737,7 +737,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=63288213e4b92e446c2b77ab094f1f2d5c4fd320#63288213e4b92e446c2b77ab094f1f2d5c4fd320"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -750,7 +750,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=63288213e4b92e446c2b77ab094f1f2d5c4fd320#63288213e4b92e446c2b77ab094f1f2d5c4fd320"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1059,7 +1059,7 @@ dependencies = [
 [[package]]
 name = "core-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/core-llm?branch=main#a49ca6d9738d5e0786f29634d57c8d1bd1939c38"
+source = "git+https://github.com/SceneWorks/core-llm?branch=main#3870ed1c7495caa6bcb8cc0836b9dd4356969737"
 dependencies = [
  "inventory",
  "minijinja",
@@ -3455,7 +3455,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1d2479b09a86140b808cee840267c24185c7f664#1d2479b09a86140b808cee840267c24185c7f664"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e9682318606b082e5696c3e436e88ca72d95b8d4#e9682318606b082e5696c3e436e88ca72d95b8d4"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3468,7 +3468,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1d2479b09a86140b808cee840267c24185c7f664#1d2479b09a86140b808cee840267c24185c7f664"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e9682318606b082e5696c3e436e88ca72d95b8d4#e9682318606b082e5696c3e436e88ca72d95b8d4"
 dependencies = [
  "image",
  "inventory",
@@ -3482,7 +3482,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1d2479b09a86140b808cee840267c24185c7f664#1d2479b09a86140b808cee840267c24185c7f664"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e9682318606b082e5696c3e436e88ca72d95b8d4#e9682318606b082e5696c3e436e88ca72d95b8d4"
 dependencies = [
  "image",
  "inventory",
@@ -3496,7 +3496,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1d2479b09a86140b808cee840267c24185c7f664#1d2479b09a86140b808cee840267c24185c7f664"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e9682318606b082e5696c3e436e88ca72d95b8d4#e9682318606b082e5696c3e436e88ca72d95b8d4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3509,7 +3509,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1d2479b09a86140b808cee840267c24185c7f664#1d2479b09a86140b808cee840267c24185c7f664"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e9682318606b082e5696c3e436e88ca72d95b8d4#e9682318606b082e5696c3e436e88ca72d95b8d4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3520,7 +3520,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1d2479b09a86140b808cee840267c24185c7f664#1d2479b09a86140b808cee840267c24185c7f664"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e9682318606b082e5696c3e436e88ca72d95b8d4#e9682318606b082e5696c3e436e88ca72d95b8d4"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3529,7 +3529,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1d2479b09a86140b808cee840267c24185c7f664#1d2479b09a86140b808cee840267c24185c7f664"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e9682318606b082e5696c3e436e88ca72d95b8d4#e9682318606b082e5696c3e436e88ca72d95b8d4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3542,7 +3542,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1d2479b09a86140b808cee840267c24185c7f664#1d2479b09a86140b808cee840267c24185c7f664"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e9682318606b082e5696c3e436e88ca72d95b8d4#e9682318606b082e5696c3e436e88ca72d95b8d4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3555,7 +3555,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1d2479b09a86140b808cee840267c24185c7f664#1d2479b09a86140b808cee840267c24185c7f664"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e9682318606b082e5696c3e436e88ca72d95b8d4#e9682318606b082e5696c3e436e88ca72d95b8d4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3568,7 +3568,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1d2479b09a86140b808cee840267c24185c7f664#1d2479b09a86140b808cee840267c24185c7f664"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e9682318606b082e5696c3e436e88ca72d95b8d4#e9682318606b082e5696c3e436e88ca72d95b8d4"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3579,7 +3579,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1d2479b09a86140b808cee840267c24185c7f664#1d2479b09a86140b808cee840267c24185c7f664"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e9682318606b082e5696c3e436e88ca72d95b8d4#e9682318606b082e5696c3e436e88ca72d95b8d4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3589,7 +3589,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1d2479b09a86140b808cee840267c24185c7f664#1d2479b09a86140b808cee840267c24185c7f664"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e9682318606b082e5696c3e436e88ca72d95b8d4#e9682318606b082e5696c3e436e88ca72d95b8d4"
 dependencies = [
  "image",
  "inventory",
@@ -3602,7 +3602,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1d2479b09a86140b808cee840267c24185c7f664#1d2479b09a86140b808cee840267c24185c7f664"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e9682318606b082e5696c3e436e88ca72d95b8d4#e9682318606b082e5696c3e436e88ca72d95b8d4"
 dependencies = [
  "image",
  "inventory",
@@ -3616,7 +3616,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1d2479b09a86140b808cee840267c24185c7f664#1d2479b09a86140b808cee840267c24185c7f664"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e9682318606b082e5696c3e436e88ca72d95b8d4#e9682318606b082e5696c3e436e88ca72d95b8d4"
 dependencies = [
  "image",
  "inventory",
@@ -3630,7 +3630,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1d2479b09a86140b808cee840267c24185c7f664#1d2479b09a86140b808cee840267c24185c7f664"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e9682318606b082e5696c3e436e88ca72d95b8d4#e9682318606b082e5696c3e436e88ca72d95b8d4"
 dependencies = [
  "image",
  "inventory",
@@ -3642,7 +3642,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1d2479b09a86140b808cee840267c24185c7f664#1d2479b09a86140b808cee840267c24185c7f664"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e9682318606b082e5696c3e436e88ca72d95b8d4#e9682318606b082e5696c3e436e88ca72d95b8d4"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3653,7 +3653,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1d2479b09a86140b808cee840267c24185c7f664#1d2479b09a86140b808cee840267c24185c7f664"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e9682318606b082e5696c3e436e88ca72d95b8d4#e9682318606b082e5696c3e436e88ca72d95b8d4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3665,7 +3665,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1d2479b09a86140b808cee840267c24185c7f664#1d2479b09a86140b808cee840267c24185c7f664"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e9682318606b082e5696c3e436e88ca72d95b8d4#e9682318606b082e5696c3e436e88ca72d95b8d4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3676,7 +3676,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1d2479b09a86140b808cee840267c24185c7f664#1d2479b09a86140b808cee840267c24185c7f664"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e9682318606b082e5696c3e436e88ca72d95b8d4#e9682318606b082e5696c3e436e88ca72d95b8d4"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3685,7 +3685,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1d2479b09a86140b808cee840267c24185c7f664#1d2479b09a86140b808cee840267c24185c7f664"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e9682318606b082e5696c3e436e88ca72d95b8d4#e9682318606b082e5696c3e436e88ca72d95b8d4"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3694,7 +3694,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1d2479b09a86140b808cee840267c24185c7f664#1d2479b09a86140b808cee840267c24185c7f664"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e9682318606b082e5696c3e436e88ca72d95b8d4#e9682318606b082e5696c3e436e88ca72d95b8d4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3706,7 +3706,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1d2479b09a86140b808cee840267c24185c7f664#1d2479b09a86140b808cee840267c24185c7f664"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e9682318606b082e5696c3e436e88ca72d95b8d4#e9682318606b082e5696c3e436e88ca72d95b8d4"
 dependencies = [
  "image",
  "inventory",
@@ -3721,7 +3721,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1d2479b09a86140b808cee840267c24185c7f664#1d2479b09a86140b808cee840267c24185c7f664"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e9682318606b082e5696c3e436e88ca72d95b8d4#e9682318606b082e5696c3e436e88ca72d95b8d4"
 dependencies = [
  "image",
  "inventory",
@@ -3735,7 +3735,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1d2479b09a86140b808cee840267c24185c7f664#1d2479b09a86140b808cee840267c24185c7f664"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e9682318606b082e5696c3e436e88ca72d95b8d4#e9682318606b082e5696c3e436e88ca72d95b8d4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3746,7 +3746,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1d2479b09a86140b808cee840267c24185c7f664#1d2479b09a86140b808cee840267c24185c7f664"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e9682318606b082e5696c3e436e88ca72d95b8d4#e9682318606b082e5696c3e436e88ca72d95b8d4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3758,7 +3758,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1d2479b09a86140b808cee840267c24185c7f664#1d2479b09a86140b808cee840267c24185c7f664"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e9682318606b082e5696c3e436e88ca72d95b8d4#e9682318606b082e5696c3e436e88ca72d95b8d4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3769,7 +3769,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1d2479b09a86140b808cee840267c24185c7f664#1d2479b09a86140b808cee840267c24185c7f664"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e9682318606b082e5696c3e436e88ca72d95b8d4#e9682318606b082e5696c3e436e88ca72d95b8d4"
 dependencies = [
  "image",
  "inventory",
@@ -3783,7 +3783,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1d2479b09a86140b808cee840267c24185c7f664#1d2479b09a86140b808cee840267c24185c7f664"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e9682318606b082e5696c3e436e88ca72d95b8d4#e9682318606b082e5696c3e436e88ca72d95b8d4"
 dependencies = [
  "image",
  "inventory",
@@ -3807,7 +3807,7 @@ dependencies = [
 [[package]]
 name = "mlx-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/mlx-llm?rev=6c052ba6bbb81be0b95bd5e4ba650d25edb62896#6c052ba6bbb81be0b95bd5e4ba650d25edb62896"
+source = "git+https://github.com/SceneWorks/mlx-llm?rev=7041411f395e43c542770d1cfb3c3945c8c9a875#7041411f395e43c542770d1cfb3c3945c8c9a875"
 dependencies = [
  "core-llm",
  "half",
@@ -4113,7 +4113,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5474,7 +5474,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1d2479b09a86140b808cee840267c24185c7f664#1d2479b09a86140b808cee840267c24185c7f664"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e9682318606b082e5696c3e436e88ca72d95b8d4#e9682318606b082e5696c3e436e88ca72d95b8d4"
 dependencies = [
  "core-llm",
  "inventory",
@@ -7807,7 +7807,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3701a9a482df4d3488b2d1b97630d280a0d15771#3701a9a482df4d3488b2d1b97630d280a0d15771"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3701a9a482df4d3488b2d1b97630d280a0d15771#3701a9a482df4d3488b2d1b97630d280a0d15771"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3701a9a482df4d3488b2d1b97630d280a0d15771#3701a9a482df4d3488b2d1b97630d280a0d15771"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3701a9a482df4d3488b2d1b97630d280a0d15771#3701a9a482df4d3488b2d1b97630d280a0d15771"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3701a9a482df4d3488b2d1b97630d280a0d15771#3701a9a482df4d3488b2d1b97630d280a0d15771"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3701a9a482df4d3488b2d1b97630d280a0d15771#3701a9a482df4d3488b2d1b97630d280a0d15771"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -520,7 +520,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3701a9a482df4d3488b2d1b97630d280a0d15771#3701a9a482df4d3488b2d1b97630d280a0d15771"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3701a9a482df4d3488b2d1b97630d280a0d15771#3701a9a482df4d3488b2d1b97630d280a0d15771"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3701a9a482df4d3488b2d1b97630d280a0d15771#3701a9a482df4d3488b2d1b97630d280a0d15771"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3701a9a482df4d3488b2d1b97630d280a0d15771#3701a9a482df4d3488b2d1b97630d280a0d15771"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3701a9a482df4d3488b2d1b97630d280a0d15771#3701a9a482df4d3488b2d1b97630d280a0d15771"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -586,7 +586,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3701a9a482df4d3488b2d1b97630d280a0d15771#3701a9a482df4d3488b2d1b97630d280a0d15771"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -601,7 +601,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3701a9a482df4d3488b2d1b97630d280a0d15771#3701a9a482df4d3488b2d1b97630d280a0d15771"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -614,7 +614,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3701a9a482df4d3488b2d1b97630d280a0d15771#3701a9a482df4d3488b2d1b97630d280a0d15771"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -626,7 +626,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3701a9a482df4d3488b2d1b97630d280a0d15771#3701a9a482df4d3488b2d1b97630d280a0d15771"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -643,7 +643,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3701a9a482df4d3488b2d1b97630d280a0d15771#3701a9a482df4d3488b2d1b97630d280a0d15771"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3701a9a482df4d3488b2d1b97630d280a0d15771#3701a9a482df4d3488b2d1b97630d280a0d15771"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -669,7 +669,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3701a9a482df4d3488b2d1b97630d280a0d15771#3701a9a482df4d3488b2d1b97630d280a0d15771"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -684,7 +684,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3701a9a482df4d3488b2d1b97630d280a0d15771#3701a9a482df4d3488b2d1b97630d280a0d15771"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -702,7 +702,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3701a9a482df4d3488b2d1b97630d280a0d15771#3701a9a482df4d3488b2d1b97630d280a0d15771"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -713,7 +713,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3701a9a482df4d3488b2d1b97630d280a0d15771#3701a9a482df4d3488b2d1b97630d280a0d15771"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -726,7 +726,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3701a9a482df4d3488b2d1b97630d280a0d15771#3701a9a482df4d3488b2d1b97630d280a0d15771"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -737,7 +737,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3701a9a482df4d3488b2d1b97630d280a0d15771#3701a9a482df4d3488b2d1b97630d280a0d15771"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -750,7 +750,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f95230fae8695d76099223a6729a137ca8d5e133#f95230fae8695d76099223a6729a137ca8d5e133"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3701a9a482df4d3488b2d1b97630d280a0d15771#3701a9a482df4d3488b2d1b97630d280a0d15771"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -774,7 +774,7 @@ dependencies = [
 [[package]]
 name = "candle-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/candle-llm?rev=54ef5a1ed43b8918f01858fe431bfec0eb2a3f25#54ef5a1ed43b8918f01858fe431bfec0eb2a3f25"
+source = "git+https://github.com/SceneWorks/candle-llm?rev=bf99e5b48082fa09eaec6eb98c1245d92feed5ae#bf99e5b48082fa09eaec6eb98c1245d92feed5ae"
 dependencies = [
  "candle-core",
  "candle-nn",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -388,7 +388,20 @@ sceneworks-core = { path = "../sceneworks-core" }
 # maxBufferLength). `git diff 221a171..1d2479b -- gen-core/` is EMPTY — gen-core byte-identical; the
 # delta is mlx-gen core (memory module + mlx-sys dep) + mlx-gen-seedvr2 only. mlx-rs/candle-gen
 # unchanged → single gen-core rev 1d2479b, skew gate green, NO candle-gen re-pin needed for this bump.
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479b09a86140b808cee840267c24185c7f664" }
+# Bumped `1d2479b` -> `e9682318` (sc-8171, epic 8102): teach the engine the Qwen3-VL (`qwen3_vl`) arch so
+# the merged sc-8105 image_caption job can load the default `huihui-ai/Huihui-Qwen3-VL-8B-Instruct-
+# abliterated`. The new mlx-gen rev bumps every mlx-llm pin (mlx-gen-sensenova/flux2/joycaption) 6c052ba
+# -> 7041411 (mlx-llm PR #53 / sc-8081 — adds `Architecture::Qwen3Vl` + the per-snapshot `weightless_vision`
+# probe). `git diff 1d2479b..e9682318 -- gen-core/` is EMPTY (gen-core byte-identical; only sibling mlx-llm
+# pins + mlx-gen's Cargo.lock moved). The mlx-llm bump pulls core-llm forward a49ca6d -> 3870ed1 (REQUIRED:
+# mlx-llm 7041411 sets `TextLlmRegistration.weightless_vision`, the field added in core-llm sc-8077; against
+# a49ca6d the worker fails to compile). The worker's own `mlx-llm` pin (below) moves 6c052ba -> 7041411 in
+# lockstep so cargo unifies ONE mlx-llm. candle-gen re-pinned to e9682318 in lockstep (block below) so the
+# skew gate resolves the SINGLE gen-core rev e9682318 on both lanes. KNOWN: the `--features backend-candle`
+# BUILD (windows-candle.yml) is red because the unported candle-llm `54ef5a1` does not compile against the
+# now-mandatory core-llm 3870ed1 (new Content::Video / supports_video / weightless_vision) — tracked as the
+# candle compile-compat blocker sc-8177 (epic 8084). macOS/MLX path (the sc-8171 goal) is complete + green.
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e9682318606b082e5696c3e436e88ca72d95b8d4" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -730,7 +743,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479b09a86140b808cee840267c24185c7f664" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e9682318606b082e5696c3e436e88ca72d95b8d4" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -746,23 +759,23 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479b09a8
 # exactly this rev, so the worker MUST match (a different rev would compile pmetal-mlx-sys twice). This
 # rebuilds MLX from source. Paired with mlx-llm `6c052ba` below (mlx-llm#45 carries the same fork pin).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479b09a86140b808cee840267c24185c7f664" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e9682318606b082e5696c3e436e88ca72d95b8d4" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479b09a86140b808cee840267c24185c7f664" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e9682318606b082e5696c3e436e88ca72d95b8d4" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479b09a86140b808cee840267c24185c7f664" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e9682318606b082e5696c3e436e88ca72d95b8d4" }
 # Krea 2 Turbo (native MLX, Krea 2 Community License; epic 7565, sc-7572). Same git rev as mlx-gen.
 # Self-registers `krea_2_turbo` (Qwen3-VL-4B TE + 28-block single-stream DiT + Qwen-Image VAE; CFG-free
 # rectified-flow few-step) via inventory only when force-linked (`use mlx_gen_krea as _;` in
 # image_jobs.rs). Loads the packed Q8/Q4 turnkey subdir (krea_model_subdir; the loader auto-detects the
 # packed quant, so the resolved `spec.quantize` is a no-op on it). Depends on mlx-gen-qwen-image for the
 # shared `AutoencoderKLQwenImage` VAE.
-mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479b09a86140b808cee840267c24185c7f664" }
+mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e9682318606b082e5696c3e436e88ca72d95b8d4" }
 # Stable Diffusion 3.5 provider (native MLX, Stability AI Community License; epic 7841, sc-7871). Same
 # git rev as mlx-gen so MLX builds once. Self-registers `sd3_5_large` (true-CFG, 28 steps / guidance 3.5)
 # + `sd3_5_large_turbo` (ADD-distilled few-step, CFG-off) + `sd3_5_medium` (MMDiT-X, true-CFG, 40 steps /
@@ -770,59 +783,59 @@ mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479
 # (`use mlx_gen_sd3 as _;` in image_jobs.rs). All three carry a `sd3_5_*_quant` converter. Reuses the SDXL
 # CLIP encoder (×2), the FLUX T5-XXL encoder, and the Z-Image 16-ch VAE — its `quantize_sd3_dir` converter
 # is wired in model_jobs.rs for the `sd3_5_{large,large_turbo,medium}_quant` install-time conversions.
-mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479b09a86140b808cee840267c24185c7f664" }
+mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e9682318606b082e5696c3e436e88ca72d95b8d4" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479b09a86140b808cee840267c24185c7f664" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e9682318606b082e5696c3e436e88ca72d95b8d4" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479b09a86140b808cee840267c24185c7f664" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e9682318606b082e5696c3e436e88ca72d95b8d4" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479b09a86140b808cee840267c24185c7f664" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e9682318606b082e5696c3e436e88ca72d95b8d4" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479b09a86140b808cee840267c24185c7f664" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e9682318606b082e5696c3e436e88ca72d95b8d4" }
 # CLIP ViT-L/14 image embedder for the Dataset Doctor analysis job (epic 6529 P2, sc-6535).
 # Self-registers `clip_vit_l14` (gen_core::ImageEmbedder) via inventory only when force-linked
 # (`use mlx_gen_clip as _;` in dataset_analysis_jobs.rs). Reuses mlx-gen-sdxl's CLIP body → same rev.
-mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479b09a86140b808cee840267c24185c7f664" }
+mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e9682318606b082e5696c3e436e88ca72d95b8d4" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479b09a86140b808cee840267c24185c7f664" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e9682318606b082e5696c3e436e88ca72d95b8d4" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479b09a86140b808cee840267c24185c7f664" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e9682318606b082e5696c3e436e88ca72d95b8d4" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479b09a86140b808cee840267c24185c7f664" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e9682318606b082e5696c3e436e88ca72d95b8d4" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479b09a86140b808cee840267c24185c7f664" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e9682318606b082e5696c3e436e88ca72d95b8d4" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479b09a86140b808cee840267c24185c7f664" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e9682318606b082e5696c3e436e88ca72d95b8d4" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479b09a86140b808cee840267c24185c7f664" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e9682318606b082e5696c3e436e88ca72d95b8d4" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479b09a86140b808cee840267c24185c7f664" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e9682318606b082e5696c3e436e88ca72d95b8d4" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -831,12 +844,12 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479b09a86140b808cee840267c24185c7f664" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e9682318606b082e5696c3e436e88ca72d95b8d4" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479b09a86140b808cee840267c24185c7f664" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e9682318606b082e5696c3e436e88ca72d95b8d4" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -845,7 +858,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479b09a86140b808cee840267c24185c7f664" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e9682318606b082e5696c3e436e88ca72d95b8d4" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -853,7 +866,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479b09a86140b808cee840267c24185c7f664" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e9682318606b082e5696c3e436e88ca72d95b8d4" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -864,7 +877,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d24
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479b09a86140b808cee840267c24185c7f664" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e9682318606b082e5696c3e436e88ca72d95b8d4" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -875,7 +888,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d247
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479b09a86140b808cee840267c24185c7f664" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e9682318606b082e5696c3e436e88ca72d95b8d4" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -890,7 +903,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479
 # converted in-memory at load (no Python); the precomputed neg-prompt embedding is bundled in-crate. No
 # LoRA/guidance/CFG (one-step). 3B fp16 only here — 7B (sc-5197) + int8 (sc-5198) are engine-side and
 # unwired. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479b09a86140b808cee840267c24185c7f664" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e9682318606b082e5696c3e436e88ca72d95b8d4" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -901,7 +914,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479b09a86140b808cee840267c24185c7f664" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e9682318606b082e5696c3e436e88ca72d95b8d4" }
 # The unified LLM engine (epic 7153, sc-7158): the macOS `prompt_refine` job now runs through
 # mlx-llm's generic `mlx-llama` provider (a `core_llm::TextLlm`) resolved model-first via
 # `gen_core::core_llm::load_for_model`, RETIRING the bespoke `mlx-gen-prompt-refine` hand-rolled
@@ -915,7 +928,13 @@ mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2
 # mlx-gen #562 pins mlx-llm at exactly 6c052ba, so the worker matches to keep ONE mlx-llm / ONE MLX build.
 # This rev also brings Qwen3.6 work incl. `core_llm::Message.tool_calls` (additive; worker builds no
 # `Message {…}` literal, so source-transparent — verified at build).
-mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "6c052ba6bbb81be0b95bd5e4ba650d25edb62896" }
+# Bumped `6c052ba` -> `7041411` (sc-8171, epic 8102): mlx-llm PR #53 / sc-8081 adds `Architecture::Qwen3Vl`
+# + `Qwen3VLVisionModel` + the per-snapshot `weightless_vision` probe, so the engine resolves the `qwen3_vl`
+# default model (`huihui-ai/Huihui-Qwen3-VL-8B-Instruct-abliterated`) to a vision-capable provider for the
+# sc-8105 image_caption job. Must equal every mlx-llm pin in the mlx-gen crates (the e9682318 bump above
+# moved them in lockstep) so cargo unifies ONE mlx-llm. This rev REQUIRES core-llm 3870ed1 (it sets
+# `TextLlmRegistration.weightless_vision`); the worker's lock moves core-llm a49ca6d -> 3870ed1 to match.
+mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "7041411f395e43c542770d1cfb3c3945c8c9a875" }
 # SCAIL-2 (zai-org) end-to-end character-animation provider (epic 5439, sc-5448). An inventory-registered
 # `Generator` under id `scail2_14b` (`Modality::Video`): a Wan2.1-14B I2V DiT that animates a reference
 # character with a driving video's motion (`video_mode == "replacement"` flips the cross-identity
@@ -927,7 +946,7 @@ mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "6c052ba6bbb81b
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d2479b09a86140b808cee840267c24185c7f664" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e9682318606b082e5696c3e436e88ca72d95b8d4" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -1189,25 +1208,34 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1d24
 # re-pin `221a171` -> `1d2479b` (byte-identical; candle-gen #164), so `--features backend-candle --target
 # all` resolves the SINGLE gen-core rev 1d2479b (== this worker's mlx pin) again. candle builds nothing
 # new. ALL candle-gen-* rev lines move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63288213e4b92e446c2b77ab094f1f2d5c4fd320", features = ["cuda"], optional = true }
+# Bumped `63288213` -> `f95230fa` (sc-8171, epic 8102): lockstep with the mlx-gen pin moving 1d2479b ->
+# e9682318 (the qwen3_vl engine bump above). candle-gen `f95230fa` is a PURE gen-core re-pin 1d2479b ->
+# e9682318 (byte-identical gen-core; only mlx-llm sibling pins moved upstream, which candle-gen does not
+# consume), so the gen-core skew gate resolves the SINGLE rev e9682318 on `--features backend-candle
+# --target all`. NB: candle-gen's OWN lock holds core-llm at a49ca6d (candle-llm 54ef5a1 cannot compile
+# against 3870ed1), but in THIS worker's unified lock core-llm is forced to 3870ed1 by the mlx-llm 7041411
+# pin — so the candle BUILD (windows-candle.yml) is red until candle-llm is made compile-compatible with
+# core-llm 3870ed1 (the additive Content::Video / supports_video / weightless_vision handling). Tracked as
+# sc-8177 (epic 8084). ALL candle-gen-* rev lines move together.
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63288213e4b92e446c2b77ab094f1f2d5c4fd320", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63288213e4b92e446c2b77ab094f1f2d5c4fd320", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63288213e4b92e446c2b77ab094f1f2d5c4fd320", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63288213e4b92e446c2b77ab094f1f2d5c4fd320", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63288213e4b92e446c2b77ab094f1f2d5c4fd320", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63288213e4b92e446c2b77ab094f1f2d5c4fd320", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1217,7 +1245,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63288213e4b92e446c2b77ab094f1f2d5c4fd320", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1225,21 +1253,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63288213e4b92e446c2b77ab094f1f2d5c4fd320", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63288213e4b92e446c2b77ab094f1f2d5c4fd320", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63288213e4b92e446c2b77ab094f1f2d5c4fd320", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63288213e4b92e446c2b77ab094f1f2d5c4fd320", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1248,17 +1276,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63288213e4b92e446c2b77ab094f1f2d5c4fd320", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63288213e4b92e446c2b77ab094f1f2d5c4fd320", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63288213e4b92e446c2b77ab094f1f2d5c4fd320", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1267,7 +1295,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63288213e4b92e446c2b77ab094f1f2d5c4fd320", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1289,7 +1317,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "54ef5a1e
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63288213e4b92e446c2b77ab094f1f2d5c4fd320", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1298,12 +1326,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63288213e4b92e446c2b77ab094f1f2d5c4fd320", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63288213e4b92e446c2b77ab094f1f2d5c4fd320", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1311,7 +1339,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63288
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63288213e4b92e446c2b77ab094f1f2d5c4fd320", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1320,7 +1348,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63288213e4b92e446c2b77ab094f1f2d5c4fd320", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1328,7 +1356,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63288213e4b92e446c2b77ab094f1f2d5c4fd320", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1337,7 +1365,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63288213e4b92e446c2b77ab094f1f2d5c4fd320", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1364,7 +1392,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63288213e4b92e446c2b77ab094f1f2d5c4fd320", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1212,30 +1212,36 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e968
 # e9682318 (the qwen3_vl engine bump above). candle-gen `f95230fa` is a PURE gen-core re-pin 1d2479b ->
 # e9682318 (byte-identical gen-core; only mlx-llm sibling pins moved upstream, which candle-gen does not
 # consume), so the gen-core skew gate resolves the SINGLE rev e9682318 on `--features backend-candle
-# --target all`. NB: candle-gen's OWN lock holds core-llm at a49ca6d (candle-llm 54ef5a1 cannot compile
+# --target all`. NB: candle-gen's OWN lock held core-llm at a49ca6d (candle-llm 54ef5a1 cannot compile
 # against 3870ed1), but in THIS worker's unified lock core-llm is forced to 3870ed1 by the mlx-llm 7041411
-# pin — so the candle BUILD (windows-candle.yml) is red until candle-llm is made compile-compatible with
-# core-llm 3870ed1 (the additive Content::Video / supports_video / weightless_vision handling). Tracked as
-# sc-8177 (epic 8084). ALL candle-gen-* rev lines move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
+# pin.
+# Bumped `f95230fa` -> `3701a9a` (sc-8177, epic 8084): RESOLVES the candle-build red above. candle-llm is
+# re-pinned 54ef5a1 -> bf99e5b (candle-llm sc-8177: additive Content::Video / supports_video: false /
+# weightless_vision: None for the text-only candle-llama + image-caption candle-llava providers — the
+# missing match arm + two struct fields), making it compile against core-llm 3870ed1. candle-gen `3701a9a`
+# re-pins candle-llm bf99e5b + moves its own lock's core-llm off the a49ca6d stopgap to 3870ed1 to match
+# THIS worker's unified lock; gen-core stays e9682318 (== this worker's mlx pin), so the gen-core skew gate
+# still resolves the SINGLE rev e9682318 on `--features backend-candle --target all`. ALL candle-gen-* rev
+# lines move together.
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3701a9a482df4d3488b2d1b97630d280a0d15771", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3701a9a482df4d3488b2d1b97630d280a0d15771", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3701a9a482df4d3488b2d1b97630d280a0d15771", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3701a9a482df4d3488b2d1b97630d280a0d15771", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3701a9a482df4d3488b2d1b97630d280a0d15771", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3701a9a482df4d3488b2d1b97630d280a0d15771", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3701a9a482df4d3488b2d1b97630d280a0d15771", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1245,7 +1251,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3701a9a482df4d3488b2d1b97630d280a0d15771", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1253,21 +1259,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3701a9a482df4d3488b2d1b97630d280a0d15771", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3701a9a482df4d3488b2d1b97630d280a0d15771", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3701a9a482df4d3488b2d1b97630d280a0d15771", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3701a9a482df4d3488b2d1b97630d280a0d15771", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1276,17 +1282,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3701a9a482df4d3488b2d1b97630d280a0d15771", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3701a9a482df4d3488b2d1b97630d280a0d15771", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3701a9a482df4d3488b2d1b97630d280a0d15771", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1295,7 +1301,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3701a9a482df4d3488b2d1b97630d280a0d15771", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1312,12 +1318,12 @@ candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # (no-cuda): `candle-llm@54ef5a1` `cargo check` is green against `core-llm@a49ca6d9` (a49ca6d9 is 4
 # template/registry-only commits ahead of candle-llm's own validated `75873b48` — the tool-calling TYPES
 # are byte-identical between them, so a49ca6d9 is an API-superset for both mlx-llm and candle-llm).
-candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "54ef5a1ed43b8918f01858fe431bfec0eb2a3f25", features = ["cuda"], optional = true }
+candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "bf99e5b48082fa09eaec6eb98c1245d92feed5ae", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3701a9a482df4d3488b2d1b97630d280a0d15771", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1326,12 +1332,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3701a9a482df4d3488b2d1b97630d280a0d15771", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3701a9a482df4d3488b2d1b97630d280a0d15771", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1339,7 +1345,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f9523
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3701a9a482df4d3488b2d1b97630d280a0d15771", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1348,7 +1354,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3701a9a482df4d3488b2d1b97630d280a0d15771", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1356,7 +1362,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3701a9a482df4d3488b2d1b97630d280a0d15771", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1365,7 +1371,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `video_jobs::run_video_upscale_job` (video). Force-linked in image_jobs.rs + video_jobs.rs
 # (`use candle_gen_seedvr2 as _;`). Same git rev as every other candle-gen provider (one candle build,
 # single gen-core pin == the mlx-gen pin 3714e7b; carries sc-5157/5926/5927 from candle-gen #80/81/82).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3701a9a482df4d3488b2d1b97630d280a0d15771", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1392,7 +1398,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f95230fae8695d76099223a6729a137ca8d5e133", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3701a9a482df4d3488b2d1b97630d280a0d15771", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -1056,6 +1056,9 @@ mod tests {
             descriptor: stub_textllm_descriptor,
             load: stub_textllm_load,
             can_load: stub_textllm_can_load,
+            // No per-snapshot vision probe (sc-8077 / mlx-llm 7041411): this candle text-only stub
+            // never serves vision, so it stays as the static `supports_vision=false` descriptor says.
+            weightless_vision: None,
         }
     }
 

--- a/crates/sceneworks-worker/src/prompt_refine_jobs.rs
+++ b/crates/sceneworks-worker/src/prompt_refine_jobs.rs
@@ -1154,16 +1154,22 @@ mod tests {
         );
     }
 
-    /// Weightless resolution proof (the Issue-1 settler). With a Qwen-VL (`qwen3_5`) snapshot
-    /// `config.json` on disk and the real `mlx-llm` inventory linked, demanding `vision:true` +
-    /// `[Json]` (what `ModelRequirements::from_request` derives from an image request) makes core-llm's
-    /// model-first `select` FAIL with `Error::Unsupported` — no provider statically advertises BOTH
-    /// vision and Json for a Qwen-VL snapshot (`mlx-llama` is text+Json until load; `mlx-joycaption` is
-    /// vision-but-no-constraints + only serves LLaVA). This is the reviewer's BLOCKER, reproduced.
-    /// macOS-only (the `mlx-llm` providers link there); no weights — resolution reads only `config.json`.
+    /// Weightless resolution proof — UPDATED for the sc-8171 engine bump (mlx-llm 6c052ba → 7041411).
+    /// On the OLD engine, demanding `vision:true` + `[Json]` for a Qwen-VL (`qwen3_5`) snapshot FAILED
+    /// `select` with `Error::Unsupported`: `mlx-llama`'s STATIC descriptor was `supports_vision:false`
+    /// (vision flipped on only at LOAD), so no provider statically satisfied both vision and Json. The
+    /// bump adds the per-snapshot `weightless_vision` probe (mlx-llm provider.rs / core-llm sc-8077): the
+    /// resolver now recognizes a `qwen3_5`/`qwen3_vl` wrapper as vision-capable from `config.json` ALONE,
+    /// so vision+Json RESOLVES `mlx-llama` and reaches `load` (which then fails only on the missing
+    /// weight shards, NOT an `Unsupported` capability gap). This test pins that lifted limitation.
+    ///
+    /// NB: the PRODUCTION image_caption path is unaffected — it deliberately resolves on the JSON
+    /// constraint ALONE and acquires vision at load (see the resolution note on the blocking task), so it
+    /// worked before AND after the bump. This test just proves the resolver gained resolution-time vision
+    /// recognition. macOS-only (the `mlx-llm` providers link there); no weights — reads only `config.json`.
     #[cfg(target_os = "macos")]
     #[test]
-    fn vision_plus_json_resolution_fails_for_qwen_vl_snapshot() {
+    fn vision_plus_json_resolution_now_resolves_for_qwen_vl_snapshot() {
         use gen_core::core_llm::{load_for_model_with, Constraint, LoadSpec, ModelRequirements};
         use mlx_llm as _; // force-link the providers into core-llm's inventory
 
@@ -1174,22 +1180,24 @@ mod tests {
         let reqs = ModelRequirements::default()
             .with_vision()
             .with_constraint(Constraint::Json);
-        let result = load_for_model_with(
+        let err = load_for_model_with(
             &LoadSpec {
                 source: dir.path().to_string_lossy().into_owned(),
                 quantize: None,
             },
             &reqs,
-        );
-        let err = result
-            .err()
-            .expect("vision+Json must not resolve for a Qwen-VL snapshot");
+        )
+        .err()
+        .expect("no weight shards on disk, so the LOAD fails after the provider is selected");
         let msg = err.to_string();
-        // The failure is a capability/resolution gap (Unsupported), surfaced BEFORE any weight load —
-        // not a missing-weights load error. The message is core-llm's `unmet_caps_msg`.
+        // Post-bump: a provider WAS selected (the weightless_vision probe satisfied the vision gate), so
+        // the error is a weight-load failure — NOT the pre-bump `Unsupported` capability-resolution gap.
         assert!(
-            msg.contains("loadable, but no linked provider meets") || msg.contains("unsupported"),
-            "expected an Unsupported capability-resolution error, got: {msg}"
+            !msg.contains("no linked provider meets")
+                && !msg.contains("no registered provider can serve")
+                && !msg.contains("unsupported"),
+            "vision+Json must now resolve a provider for a Qwen-VL snapshot (then fail on missing \
+             weights) thanks to the weightless_vision probe; got: {msg}"
         );
     }
 
@@ -1269,6 +1277,122 @@ mod tests {
                 "vision_config":{"model_type":"qwen3_5","depth":27}}"#,
         )
         .expect("write qwen-vl config.json");
+    }
+
+    /// A minimal **`qwen3_vl`** VLM-wrapper `config.json` — the architecture of the chosen default
+    /// image_caption model (`huihui-ai/Huihui-Qwen3-VL-8B-Instruct-abliterated`). `model_type`
+    /// `qwen3_vl` (+ `text_config.model_type` `qwen3_vl_text`) is the family the sc-8171 engine bump
+    /// (mlx-llm 6c052ba → 7041411) teaches the inventory to recognize: before the bump `qwen3_vl`
+    /// silently fell through to a text-only `Architecture::Qwen3` (no vision tower); after it,
+    /// `Architecture::Qwen3Vl` + the per-snapshot `weightless_vision` probe make a `qwen3_vl` snapshot
+    /// resolve vision-capable. No weight shards / tokenizer: resolution reads only this file.
+    #[cfg(target_os = "macos")]
+    fn write_qwen3_vl_config(dir: &Path) {
+        std::fs::write(
+            dir.join("config.json"),
+            br#"{"architectures":["Qwen3VLForConditionalGeneration"],
+                "model_type":"qwen3_vl",
+                "text_config":{"model_type":"qwen3_vl_text"},
+                "vision_config":{"model_type":"qwen3_vl","depth":27}}"#,
+        )
+        .expect("write qwen3_vl config.json");
+    }
+
+    /// Weightless resolution proof for the **`qwen3_vl`** default model (sc-8171, the whole point of
+    /// the engine bump). The SAME shape as `json_only_resolution_selects_a_provider_for_qwen_vl_snapshot`
+    /// but on a `qwen3_vl` snapshot: under the worker's image_caption requirements (JSON constraint
+    /// ALONE), core-llm's `select` admits `mlx-llama` for the `qwen3_vl` wrapper. CRUCIALLY this test
+    /// ALSO proves the bump's purpose — that the SAME `qwen3_vl` snapshot resolves to a *vision-capable*
+    /// provider — by replicating core-llm's per-snapshot vision predicate (`weightless_vision` probe →
+    /// `serves_vision`) over the live registry. On the OLD engine (mlx-llm 6c052ba) a `qwen3_vl`
+    /// `config.json` parsed to a text-only `Architecture::Qwen3` with NO `weightless_vision` probe, so
+    /// this vision assertion would fail; on the bumped engine (7041411) it passes. macOS-only (the
+    /// `mlx-llm` providers link there); no weights — resolution reads only `config.json`.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn json_only_resolution_selects_vision_capable_provider_for_qwen3_vl_snapshot() {
+        use gen_core::core_llm::{
+            load_for_model_with, textllms, Constraint, LoadSpec, ModelRequirements,
+        };
+        use mlx_llm as _; // force-link the providers into core-llm's inventory
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_qwen3_vl_config(dir.path());
+        let spec = LoadSpec {
+            source: dir.path().to_string_lossy().into_owned(),
+            quantize: None,
+        };
+
+        // (1) Selection: the worker's image_caption resolution requirements (JSON constraint only)
+        // resolve a provider for the qwen3_vl snapshot — the LOAD then fails on missing weights, NOT
+        // the `Unsupported` capability-resolution error (proving a provider WAS selected).
+        let reqs = ModelRequirements::default().with_constraint(Constraint::Json);
+        let err = load_for_model_with(&spec, &reqs)
+            .err()
+            .expect("no weights on disk, so the LOAD fails after the provider is selected");
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("no linked provider meets")
+                && !msg.contains("no registered provider can serve"),
+            "JSON-only requirements must resolve a provider for a qwen3_vl snapshot (then fail on \
+             missing weights), got: {msg}"
+        );
+
+        // (2) The selected Json provider for this qwen3_vl snapshot is `mlx-llama` — the one whose
+        // loaded Qwen3-VL tower reads the `Content::Image` at generate time.
+        let json_viable: Vec<String> = textllms()
+            .filter(|r| (r.can_load)(&spec))
+            .filter(|r| {
+                let caps = (r.descriptor)().capabilities;
+                reqs.constraints
+                    .iter()
+                    .all(|c| caps.supports_constraint(*c))
+            })
+            .map(|r| (r.descriptor)().id)
+            .collect();
+        assert!(
+            json_viable.iter().any(|id| id == "mlx-llama"),
+            "JSON-only resolution must admit `mlx-llama` for a qwen3_vl snapshot; viable: {json_viable:?}"
+        );
+
+        // (3) THE BUMP'S PURPOSE: the same qwen3_vl snapshot is recognized as vision-capable. Replicate
+        // core-llm's per-snapshot vision predicate (the `weightless_vision` probe added in mlx-llm
+        // 7041411 / sc-8077, OR a statically-vision descriptor) over the live registry. At least one
+        // provider that `can_load` this snapshot must serve it WITH vision — impossible on the old
+        // engine, where `qwen3_vl` was a text-only `Qwen3` with no probe.
+        let vision_capable: Vec<String> = textllms()
+            .filter(|r| (r.can_load)(&spec))
+            .filter(|r| {
+                r.weightless_vision.map(|p| p(&spec)).unwrap_or(false)
+                    || (r.descriptor)().capabilities.supports_vision
+            })
+            .map(|r| (r.descriptor)().id)
+            .collect();
+        assert!(
+            vision_capable.iter().any(|id| id == "mlx-llama"),
+            "the sc-8171 bump must make a qwen3_vl snapshot resolve to a vision-capable `mlx-llama` \
+             provider (weightless_vision probe); vision-capable providers were: {vision_capable:?}"
+        );
+
+        // (4) End-to-end resolver proof of the bump: demanding vision + Json at RESOLUTION now RESOLVES
+        // a provider for the qwen3_vl snapshot (the `weightless_vision` probe satisfies the vision gate
+        // from `config.json` alone), reaching `load` — which fails only on the missing weight shards, NOT
+        // the pre-bump `Unsupported` capability gap. (Production still resolves on Json alone and acquires
+        // vision at load; this assertion proves the resolver itself gained resolution-time vision.)
+        let vision_json = ModelRequirements::default()
+            .with_vision()
+            .with_constraint(Constraint::Json);
+        let vj_msg = load_for_model_with(&spec, &vision_json)
+            .err()
+            .expect("no weight shards on disk, so the LOAD fails after the provider is selected")
+            .to_string();
+        assert!(
+            !vj_msg.contains("no linked provider meets")
+                && !vj_msg.contains("no registered provider can serve")
+                && !vj_msg.contains("unsupported"),
+            "vision+Json must now resolve a provider for a qwen3_vl snapshot (then fail on missing \
+             weights) thanks to the weightless_vision probe; got: {vj_msg}"
+        );
     }
 
     /// Real-weight image-caption smoke (sc-8105 → validated under sc-8113): examines a reference image


### PR DESCRIPTION
## What

Engine pin bump so SceneWorks's engine supports the **Qwen3-VL** architecture (`model_type "qwen3_vl"`), enabling the merged sc-8105 `image_caption` job to load the chosen default model `huihui-ai/Huihui-Qwen3-VL-8B-Instruct-abliterated`.

Story: **sc-8171** (epic 8102).

## Pin changes (`crates/sceneworks-worker/Cargo.toml`)

| Dep | From | To | Notes |
|---|---|---|---|
| mlx-gen (28 crate pins) | `1d2479b` | **`e9682318`** | New mlx-gen rev; gen-core source byte-identical |
| mlx-llm (direct worker pin) | `6c052ba` | **`7041411`** | mlx-llm PR #53 / sc-8081: adds `Architecture::Qwen3Vl` + `Qwen3VLVisionModel` + `weightless_vision` probe |
| candle-gen (24 crate pins) | `63288213` | **`f95230fa`** | Lockstep gen-core re-pin → single gen-core rev on both lanes |
| core-llm (lockfile) | `a49ca6d` | **`3870ed1`** | Required by mlx-llm 7041411 (`weightless_vision` field, core-llm sc-8077) |

New engine revs pushed:
- **mlx-gen** `e9682318606b082e5696c3e436e88ca72d95b8d4` (branch `michaeltrefry1818/sc-8171/bump-mlx-llm-qwen3vl`) — bumps every mlx-llm pin (sensenova/flux2/joycaption) `6c052ba`→`7041411`.
- **candle-gen** `f95230fae8695d76099223a6729a137ca8d5e133` (branch `michaeltrefry1818/sc-8171/lockstep-gen-core-e9682318`) — pure gen-core re-pin (17 lines: workspace + 16 per-crate `gen-core-testkit`).

## Topology finding (did gen-core's rev change?)

The gen-core **content** is byte-identical (`git diff 1d2479b..e9682318 -- gen-core/` is empty — only mlx-llm sibling pins + mlx-gen's Cargo.lock moved). But the gen-core **git rev** changed, so the candle-gen lockstep was required to keep the gen-core skew gate single-rev. Verified: `check-gen-core-skew.sh` resolves exactly one gen-core (`e9682318`) on **both** the default and `--features backend-candle --target all` lanes.

## Resolution test (the point of the bump)

`prompt_refine_jobs.rs`:
- **New:** `json_only_resolution_selects_vision_capable_provider_for_qwen3_vl_snapshot` — proves a `qwen3_vl` snapshot resolves to a **vision-capable** `mlx-llama` under the worker's JSON-only image_caption requirements (impossible on the old engine, where `qwen3_vl` fell through to a text-only `Qwen3`).
- **Updated:** the prior qwen-vl `vision+Json` resolution test to the new behavior — the `weightless_vision` probe now lets `vision+Json` resolve a provider pre-load (was previously `Unsupported`). Production still resolves on JSON-only and acquires vision at load, so the image_caption path is unaffected.

`engines.rs`: added `weightless_vision: None` to the candle text-only test-stub `TextLlmRegistration` (trivial forward-compat for the new core-llm field).

## Build / parity verification (macOS / MLX)

- `cargo build -p sceneworks-worker` — clean
- `cargo test -p sceneworks-worker --lib` — **401 passed / 0 failed** (incl. the new + updated qwen3_vl resolution tests)
- gen-core skew gate — single rev `e9682318` on default **and** candle lanes
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- mlx-gen + candle-gen each built/clippy-clean standalone before their pushes

## ⚠️ Known blocker — `candle-worker` (windows-candle.yml) WILL be red

The `--features backend-candle` build is red, tracked as **sc-8177** (epic 8084). The qwen3_vl bump forces core-llm forward to `3870ed1` (mandatory for mlx-llm 7041411), but the **unported `candle-llm 54ef5a1`** does not compile against it — core-llm 3870ed1 added `Content::Video`, `TextLlmCapabilities.supports_video`, and `TextLlmRegistration.weightless_vision`, which candle-llm hasn't adopted (6 errors: non-exhaustive `Content` matches + 2 missing struct fields). The fix is a narrow, additive candle-llm compile-compat change (`Content::Video(_)` arms + `supports_video: false` + `weightless_vision: None`) plus a re-pin cascade (candle-llm → candle-gen → SceneWorks) — out of scope for this pin bump, filed as sc-8177.

**The macOS/MLX path (the actual sc-8171 goal) is complete and green.** Coordinator: decide whether to merge with the `candle-worker` check red + sc-8177 tracked, or hold for the candle-llm fix.

Closes sc-8171 (MLX scope). Blocked-by sc-8177 for the candle lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
