### PR TITLE
chore(models): vision-caption utility model catalog entry + provisioning (sc-8107)

### DIFF
--- a/apps/web/public/prompt-guides/vision-caption.md
+++ b/apps/web/public/prompt-guides/vision-caption.md
@@ -1,0 +1,19 @@
+# Vision Captioner Guide
+
+The Vision Captioner is a vision-language model that turns a **reference image** into a structured Ideogram-style JSON caption — a style description plus a grounded list of the elements it sees (with bounding boxes). That caption feeds image-to-prompt **variations**: you give it a picture, it describes the style and composition, and that description becomes a prompt you can regenerate from. It does not generate images itself.
+
+The default model is an abliterated **Qwen3-VL-8B-Instruct**.
+
+## Installation
+
+The Vision Captioner runs in-process on the native MLX worker (Apple Silicon only for now). It is **not** auto-downloaded — install it once from the **Models** screen. It is about 18 GB and downloads into the shared Hugging Face cache, so other tools reuse the snapshot. A 64 GB-class Mac is recommended.
+
+## How It Works
+
+Point it at a reference image and it observes what is actually in the frame — it describes the style and the visible elements rather than inventing content. The output is JSON: a `style_description` plus grounded elements with bounding boxes, in the same shape Ideogram's prompt surface uses. The model is steered to emit valid JSON, and malformed output is rejected and retried.
+
+## Practical Notes
+
+The goal is **style and composition variations**, not a pixel-perfect reconstruction of the source. Expect the caption to capture the look, mood, palette, and layout — then vary the specifics when you regenerate.
+
+Captioning is a fast first pass. Review the generated caption and tweak it before generating if you want to push the result in a particular direction.

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -4436,6 +4436,83 @@
           ]
         }
       }
+    },
+    {
+      // Vision-caption utility LLM (epic 8102, sc-8107) — the model the `image_caption` worker path
+      // loads. The native worker (`prompt_refine_jobs.rs`, the `task: "image_caption"` branch, sc-8105)
+      // sends a reference image (Content::Image) + the embedded `ideogram_image_caption_v1.txt` system
+      // prompt through the `core_llm::TextLlm` VISION path and emits a JSON-constrained Ideogram caption
+      // (style + grounded composition, bboxes kept). It resolves the weights by REPO STRING (the job
+      // payload's `model`, default `DEFAULT_REFINE_MODEL`) via the same
+      // `resolve_app_managed_model_dir` → `huggingface_snapshot_dir` seam that only *resolves* an
+      // already-cached snapshot (no auto-download). Cataloging it lets Model Manager download the
+      // snapshot into the HF cache the worker reads from, so the job resolves on a fresh macOS install
+      // (mirrors `joycaption_beta_one` / `prompt_refine_anubis_8b`).
+      //
+      // CANONICAL ID `vision_caption_qwen3vl_8b` — sibling stories sc-8110 (web surface) and sc-8108
+      // (API headless) reference this id. Default model decided by Michael (sc-8112):
+      // `huihui-ai/Huihui-Qwen3-VL-8B-Instruct-abliterated` — an abliterated Qwen3-VL-8B-Instruct
+      // (`model_type: qwen3_vl`, 36-layer text + 27-layer vision tower, intact `vision_config`). Making
+      // the default a one-line `downloads.repo` + `paths.model` swap keeps the 8B-vs-27B gate cheap.
+      //
+      // DOWNLOAD SOURCE = DIRECT (no re-host, no tokenizer overlay). HF verification (2026-06-26,
+      // https://huggingface.co/huihui-ai/Huihui-Qwen3-VL-8B-Instruct-abliterated): the repo is
+      // apache-2.0 and NOT gated; ships a FAST `tokenizer.json` (11.4 MB) + `tokenizer_config.json` +
+      // `config.json` + 4 sharded `model-0000N-of-00004.safetensors` + `model.safetensors.index.json` +
+      // `preprocessor_config.json` + `chat_template.jinja` — the standard MLX-loadable layout the
+      // mlx-llm Qwen-VL loader reads directly (dense bf16, no MLX conversion/quant). So the epic-5594
+      // re-host pattern and the DERIVED_TOKENIZER_OVERLAYS pattern do NOT apply; `files: []` pulls the
+      // whole repo (weights + tokenizer + README/license) as-is. Total ~17.6 GB: 4 safetensors shards
+      // (5.0 + 4.92 + 4.92 + 2.7 ≈ 17.54e9) + tokenizer/vocab/merges (~0.3e9) ≈ 17.85e9 bytes. The
+      // `estimatedSizeBytes` below is only a fallback — the API queries HF for the live size at load.
+      //
+      // macOnly: true for now (the Candle lane is epic 8103). HARD DEPENDENCY (sc-8171): this entry only
+      // becomes end-to-end LOADABLE after the engine pin bump that teaches the pinned mlx-llm to build
+      // the qwen3_vl vision tower; until then the engine silently mis-loads qwen3_vl as text-only. This
+      // story (sc-8107) is provisioning only — it makes the model DOWNLOADABLE into the HF cache.
+      //
+      // autoDownload: false + minMemoryGb 64: ~18 GB bf16 / ~19 GB resident, badged-but-unchecked
+      // (pulled on demand via Model Manager / the caption affordance) and gated to 64 GB+ machines.
+      "id": "vision_caption_qwen3vl_8b",
+      "recommended": true,
+      "autoDownload": false,
+      "macOnly": true,
+      "minMemoryGb": 64,
+      "name": "Vision Captioner (Qwen3-VL-8B)",
+      "family": "vision-caption",
+      "type": "utility",
+      "adapter": "prompt-refine",
+      "capabilities": [],
+      "downloads": [
+        {
+          "provider": "huggingface",
+          "repo": "huihui-ai/Huihui-Qwen3-VL-8B-Instruct-abliterated",
+          "files": [],
+          "estimatedSizeBytes": 17850000000
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/huihui-ai/Huihui-Qwen3-VL-8B-Instruct-abliterated"
+      },
+      "defaults": {},
+      "limits": {},
+      "loraCompatibility": {
+        "families": [],
+        "types": []
+      },
+      "ui": {
+        "label": "Vision Captioner (Qwen3-VL-8B)",
+        "description": "Vision-language model used to turn a reference image into a structured Ideogram-style JSON caption (style + grounded composition) for image-to-prompt variations. Runs in-process on the native MLX worker (Apple Silicon).",
+        "recommendedFor": ["image_caption"],
+        "promptGuide": {
+          "title": "Vision Captioner Guide",
+          "path": "/prompt-guides/vision-caption.md",
+          "sources": [
+            { "label": "Huihui Qwen3-VL-8B-Instruct-abliterated model card", "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3-VL-8B-Instruct-abliterated" },
+            { "label": "Qwen3-VL-8B-Instruct (base) model card", "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct" }
+          ]
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
## sc-8107 — Vision-caption utility model: catalog entry + HF re-host + provisioning

Epic 8102 (reference-image → Ideogram-JSON caption). Provisions the vision model the `image_caption` worker path (sc-8105, merged) loads, as a native `type:"utility"` catalog entry so Model Manager downloads it into the HF cache the worker reads from — letting the `image_caption` job resolve the snapshot on a fresh macOS install.

### Chosen model id/key
`vision_caption_qwen3vl_8b` — **sibling stories sc-8110 (web surface) and sc-8108 (API headless) reference this id.**

Default model (decided by Michael, sc-8112): **`huihui-ai/Huihui-Qwen3-VL-8B-Instruct-abliterated`** (abliterated Qwen3-VL-8B-Instruct, `model_type qwen3_vl`). The default is a one-line `downloads.repo` + `paths.model` swap (keeps the 8B-vs-27B gate cheap).

### Download source decision: DIRECT (no re-host, no tokenizer overlay)
HF verification of `huihui-ai/Huihui-Qwen3-VL-8B-Instruct-abliterated` (2026-06-26):

| Check | Result |
|---|---|
| Fast `tokenizer.json`? | **Yes** (11.4 MB) + `tokenizer_config.json` |
| Safetensors layout | **Sharded** — 4× `model-0000N-of-00004.safetensors` + `model.safetensors.index.json` |
| `config.json` | `model_type: qwen3_vl`, 36-layer text + intact `vision_config` (27-layer vision tower, image/video tokens) |
| Gated? | **No** — apache-2.0, no license-acceptance banner |
| Total size | ~17.6 GB (estimatedSizeBytes 17.85e9 fallback; API queries HF for live size) |

Because the repo is ungated, ships a fast tokenizer, and has the standard MLX-loadable layout, **no SceneWorks/* re-host and no `DERIVED_TOKENIZER_OVERLAYS` entry are needed** — `files: []` pulls the whole repo as-is. (The epic-5594 conversion re-host pattern and the Kolors/Qwen-Image tokenizer-overlay pattern do not apply.)

### What changed
- `config/manifests/builtin.models.jsonc`: new `vision_caption_qwen3vl_8b` utility entry mirroring `joycaption_beta_one` / `prompt_refine_anubis_8b` (type:"utility", downloads, paths.model, ui.recommendedFor:["image_caption"], promptGuide). `recommended` + `macOnly: true` (candle = epic 8103), `autoDownload: false`, `minMemoryGb: 64`.
- `apps/web/public/prompt-guides/vision-caption.md`: the promptGuide target (one guide per model, matching every other entry).

### Provisioning end-to-end
The worker resolves the model by repo string via the same `resolve_app_managed_model_dir` → `huggingface_snapshot_dir` seam joycaption uses (resolves an already-cached snapshot; the catalog download populates the cache). No worker Rust change required.

### Manual / dependent steps still required
- **None for re-host** — direct download works (ungated + fast tokenizer + standard layout).
- **HARD DEPENDENCY (sc-8171):** this entry is *downloadable* now, but only becomes end-to-end *loadable* after the engine pin bump that teaches the pinned mlx-llm to build the qwen3_vl vision tower. Until then the engine silently mis-loads qwen3_vl as text-only. sc-8107 is scoped to provisioning (download into HF cache); the load path is sc-8171.

### Tests
- Manifest parses cleanly (52 models; entry verified: type utility, macOnly true, recommendedFor ["image_caption"], correct repo/path).
- `cargo test -p sceneworks-core --lib builtin_manifests` — 3 passed (embeds + seeds the manifest).
- `cargo test -p sceneworks-rust-api models` — 10 passed (catalog parse/validate, including `models_catalog_carries_mac_support_and_capabilities_endpoint`).

Story: https://app.shortcut.com/trefry/story/8107

🤖 Generated with [Claude Code](https://claude.com/claude-code)