### PR TITLE
feat(web): reference-image picker + Generate-JSON-from-image button (Ideogram t2i) (sc-8108)

### DIFF
--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -11,6 +11,9 @@ pub(crate) struct JobsQuery {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct PromptRefineRequest {
+    // Optional so the `image_caption` task (epic 8102, sc-8108) — driven by a reference image, not
+    // text — can omit it. The handler still requires a non-empty prompt for every other task.
+    #[serde(default)]
     pub(crate) prompt: String,
     pub(crate) model_id: Option<String>,
     pub(crate) workflow: Option<String>,
@@ -18,12 +21,24 @@ pub(crate) struct PromptRefineRequest {
     /// worker can build a guide-aware system prompt without filesystem access to
     /// the web assets.
     pub(crate) guide: Option<String>,
-    /// `"refine"` (default) or `"magic_prompt"` — the latter expands a plain idea
-    /// into a structured Ideogram 4 JSON caption (epic 4725, sc-5997).
+    /// `"refine"` (default), `"magic_prompt"` (expand a plain idea into a structured
+    /// Ideogram 4 JSON caption, epic 4725/sc-5997), or `"image_caption"` (turn a
+    /// reference image into the same structured caption via the vision model, epic
+    /// 8102/sc-8108). The latter carries a `source_asset_id` + `project_id` instead of
+    /// a prompt; the handler resolves them to the worker's confined `imagePath`.
     pub(crate) task: Option<String>,
     /// Target image aspect ratio as `"W:H"` (magic-prompt only); drives bbox/layout
     /// decisions in the caption. Defaults to `"1:1"` worker-side when absent.
     pub(crate) aspect_ratio: Option<String>,
+    /// Reference image for the `image_caption` task: a project asset id resolved to a
+    /// confined on-disk path before the job is enqueued (epic 8102, sc-8108).
+    pub(crate) source_asset_id: Option<String>,
+    /// Project owning `source_asset_id` (required for the `image_caption` task so the
+    /// asset's relative `file.path` can be resolved to an absolute path).
+    pub(crate) project_id: Option<String>,
+    /// HF repo string of the model the worker should load (the worker resolves by repo,
+    /// not by catalog id). The web sends the vision model's repo for `image_caption`.
+    pub(crate) model: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/apps/rust-api/src/prompts.rs
+++ b/apps/rust-api/src/prompts.rs
@@ -9,13 +9,55 @@ pub(crate) async fn create_prompt_refine_job(
     State(state): State<AppState>,
     ApiJson(payload): ApiJson<PromptRefineRequest>,
 ) -> Result<(StatusCode, Json<JobSnapshot>), ApiError> {
+    let task = payload
+        .task
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    // The reference-image → JSON caption task (epic 8102, sc-8108) is driven by an image, not a text
+    // prompt: it carries a project `sourceAssetId` instead. Resolve that to the worker's confined
+    // on-disk `imagePath` and forward the vision model's repo; the prompt requirement is waived.
+    let is_image_caption = task == Some("image_caption");
+
     let prompt = payload.prompt.trim();
-    if prompt.is_empty() {
+    if prompt.is_empty() && !is_image_caption {
         return Err(ApiError::bad_request("Prompt cannot be empty"));
     }
 
     let mut job_payload = JsonObject::new();
-    job_payload.insert("prompt".to_owned(), Value::String(prompt.to_owned()));
+    if !prompt.is_empty() {
+        job_payload.insert("prompt".to_owned(), Value::String(prompt.to_owned()));
+    }
+
+    if is_image_caption {
+        let asset_id = payload
+            .source_asset_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                ApiError::bad_request("sourceAssetId is required for image_caption")
+            })?;
+        let project_id = payload
+            .project_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| ApiError::bad_request("projectId is required for image_caption"))?;
+        let image_path =
+            resolve_image_caption_path(state.clone(), project_id, asset_id).await?;
+        job_payload.insert("imagePath".to_owned(), Value::String(image_path));
+        // The vision model is named by its HF repo string; the worker resolves it by repo (like the
+        // refiner), so it must be carried verbatim rather than as a catalog id.
+        if let Some(model) = payload
+            .model
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            job_payload.insert("model".to_owned(), Value::String(model.to_owned()));
+        }
+    }
 
     let workflow = payload
         .workflow
@@ -65,4 +107,44 @@ pub(crate) async fn create_prompt_refine_job(
     )
     .await?;
     Ok((StatusCode::CREATED, Json(job)))
+}
+
+/// Resolve an `image_caption` reference asset to an absolute on-disk path. Mirrors the worker's
+/// `resolve_asset_path`: read the asset record's relative `file.path`, join it under the owning
+/// project's directory using only `Normal` path components (rejecting `..`/absolute traversal), and
+/// confirm the file exists. The worker independently re-confines this path to an app-managed root
+/// before opening it (epic 4484 untrusted-input policy), so this is defence-in-depth, not the sole
+/// guard. Returns a 400 for a missing/garbled asset record or a path that escapes the project root.
+async fn resolve_image_caption_path(
+    state: AppState,
+    project_id: &str,
+    asset_id: &str,
+) -> Result<String, ApiError> {
+    let project_path = project_path_for_id(state.clone(), project_id).await?;
+    let project_id_owned = project_id.to_owned();
+    let asset_id_owned = asset_id.to_owned();
+    let asset = project_call(state, move |store| {
+        store.get_asset(&project_id_owned, &asset_id_owned)
+    })
+    .await?;
+    let rel = asset
+        .get("file")
+        .and_then(|file| file.get("path"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| ApiError::bad_request("Reference asset has no file path"))?;
+    let mut path = project_path;
+    for component in std::path::Path::new(rel).components() {
+        match component {
+            std::path::Component::Normal(value) => path.push(value),
+            _ => {
+                return Err(ApiError::bad_request(
+                    "Reference asset path must stay inside the project directory",
+                ))
+            }
+        }
+    }
+    if !path.exists() {
+        return Err(ApiError::bad_request("Reference image not found on disk"));
+    }
+    Ok(path.display().to_string())
 }

--- a/apps/rust-api/src/prompts.rs
+++ b/apps/rust-api/src/prompts.rs
@@ -35,17 +35,14 @@ pub(crate) async fn create_prompt_refine_job(
             .as_deref()
             .map(str::trim)
             .filter(|value| !value.is_empty())
-            .ok_or_else(|| {
-                ApiError::bad_request("sourceAssetId is required for image_caption")
-            })?;
+            .ok_or_else(|| ApiError::bad_request("sourceAssetId is required for image_caption"))?;
         let project_id = payload
             .project_id
             .as_deref()
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .ok_or_else(|| ApiError::bad_request("projectId is required for image_caption"))?;
-        let image_path =
-            resolve_image_caption_path(state.clone(), project_id, asset_id).await?;
+        let image_path = resolve_image_caption_path(state.clone(), project_id, asset_id).await?;
         job_payload.insert("imagePath".to_owned(), Value::String(image_path));
         // The vision model is named by its HF repo string; the worker resolves it by repo (like the
         // refiner), so it must be carried verbatim rather than as a catalog id.

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -4101,7 +4101,10 @@ async fn image_caption_refine_job_resolves_asset_to_confined_image_path() {
     .await;
     assert_eq!(status, StatusCode::CREATED);
     let asset_id = asset["id"].as_str().expect("asset id").to_owned();
-    let rel_path = asset["file"]["path"].as_str().expect("file path").to_owned();
+    let rel_path = asset["file"]["path"]
+        .as_str()
+        .expect("file path")
+        .to_owned();
 
     let (status, job) = request(
         app.clone(),

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -4073,6 +4073,92 @@ async fn non_ideogram_image_job_skips_auto_caption() {
 }
 
 #[tokio::test]
+async fn image_caption_refine_job_resolves_asset_to_confined_image_path() {
+    // epic 8102 / sc-8108: the reference-image → JSON caption flow POSTs `task: "image_caption"` with a
+    // project `sourceAssetId` (+ `projectId`) and the vision model's repo. The handler resolves the
+    // asset to an absolute on-disk `imagePath` (inside the project dir), forwards the model verbatim,
+    // and enqueues a `prompt_refine` job carrying that image-caption payload (no text prompt required).
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Caption Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id").to_owned();
+    let project_path = std::path::PathBuf::from(project["path"].as_str().unwrap());
+
+    let (status, asset) = request_multipart_upload(
+        app.clone(),
+        &format!("/api/v1/projects/{project_id}/assets"),
+        "Reference.PNG",
+        "image/png",
+        b"png-bytes",
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let asset_id = asset["id"].as_str().expect("asset id").to_owned();
+    let rel_path = asset["file"]["path"].as_str().expect("file path").to_owned();
+
+    let (status, job) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/prompts/refine",
+        json!({
+            "task": "image_caption",
+            "sourceAssetId": asset_id,
+            "projectId": project_id,
+            "model": "huihui-ai/Huihui-Qwen3-VL-8B-Instruct-abliterated"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(job["type"], "prompt_refine");
+    assert_eq!(job["payload"]["task"], "image_caption");
+    assert_eq!(
+        job["payload"]["model"],
+        "huihui-ai/Huihui-Qwen3-VL-8B-Instruct-abliterated"
+    );
+    // No text prompt is required for an image-caption job.
+    assert!(job["payload"].get("prompt").is_none());
+    // The resolved imagePath is the asset's absolute on-disk location inside the project dir.
+    let expected = project_path.join(&rel_path);
+    assert_eq!(
+        job["payload"]["imagePath"].as_str().unwrap(),
+        expected.display().to_string()
+    );
+}
+
+#[tokio::test]
+async fn image_caption_refine_job_requires_source_asset_and_project() {
+    // sc-8108: the image-caption task is driven by a reference asset, so it must reject a request that
+    // omits the `sourceAssetId` or `projectId` rather than enqueue an unresolvable job.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    let (status, _) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/prompts/refine",
+        json!({ "task": "image_caption", "projectId": "project-1" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    let (status, _) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/prompts/refine",
+        json!({ "task": "image_caption", "sourceAssetId": "asset-1" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn image_and_video_job_routes_normalize_payloads() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let app = create_app(test_settings(&temp_dir)).expect("app creates");

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1477,6 +1477,44 @@ export function App() {
     [token],
   );
 
+  // Reference-image → JSON caption (epic 8102, sc-8108): same `prompts/refine` endpoint + poll-to-
+  // completion contract as magic-prompt, but `task: "image_caption"` drives the worker's `core_llm`
+  // VISION path (sc-8105). The reference image is supplied as a project `sourceAssetId` (+ `projectId`),
+  // which the API resolves to a confined on-disk `imagePath`; the vision model is named by its HF repo
+  // string in `model` (the worker resolves it by repo, like the refiner). The caller parses + validates
+  // the returned JSON with `parseVisionCaption` (aspect_ratio stripped, bboxes KEPT). C1: the image is
+  // consumed only to produce the caption — it is NEVER passed to generation as img2img conditioning.
+  const imageCaption = useCallback(
+    async ({ sourceAssetId, projectId, model, signal }) => {
+      const created = await apiFetch("/api/v1/prompts/refine", token, {
+        method: "POST",
+        signal,
+        body: JSON.stringify({ task: "image_caption", sourceAssetId, projectId, model }),
+      });
+      const jobId = created?.id;
+      if (!jobId) {
+        throw new Error("Could not start image captioning.");
+      }
+      const deadline = Date.now() + 180000;
+      while (Date.now() < deadline) {
+        await abortableDelay(1000, signal);
+        const job = await apiFetch(`/api/v1/jobs/${jobId}`, token, { signal });
+        if (job.status === "completed") {
+          const caption = job.result?.refinedPrompt;
+          if (!caption) {
+            throw new Error("Image captioning returned an empty caption.");
+          }
+          return caption;
+        }
+        if (job.status === "failed" || job.status === "canceled" || job.status === "interrupted") {
+          throw new Error(job.message || job.error || "Image captioning failed.");
+        }
+      }
+      throw new Error("Image captioning timed out. Is the captioning runtime running?");
+    },
+    [token],
+  );
+
   const createVqaJob = useCallback(
     async (asset, question, maxNewTokens) => {
       if (!activeProject) {
@@ -1841,6 +1879,7 @@ export function App() {
     createImageJob,
     refinePrompt,
     magicPrompt,
+    imageCaption,
     latestVideoAssets,
     recentImageAssets,
     recentVideoAssets,
@@ -1937,7 +1976,7 @@ export function App() {
     updateAssetStatus, updateAssetTags, latestImageAssets,
     jobs, jobAction, createVqaJob, createInterleaveJob, createPlaceholderJob, filteredJobs,
     jobPrompt, setJobPrompt, projectFilter, setProjectFilter, projects, visibleWorkers, workersById,
-    createVideoJob, createVideoUpscaleJob, createImageJob, refinePrompt, magicPrompt, latestVideoAssets, recentImageAssets,
+    createVideoJob, createVideoUpscaleJob, createImageJob, refinePrompt, magicPrompt, imageCaption, latestVideoAssets, recentImageAssets,
     recentVideoAssets, videoLocalJobs, imageLocalJobs, documentLocalJobs, studioLaunch,
     rememberLocalGenerationJob, personTracks, personReadiness, createPersonDetectionJob,
     createPersonTrackJob, saveTrackCorrections, imageModels, videoModels, models, macCapabilities,

--- a/apps/web/src/components/StructuredPromptBuilder.jsx
+++ b/apps/web/src/components/StructuredPromptBuilder.jsx
@@ -24,6 +24,8 @@ import {
   STYLE_PALETTE_MAX,
 } from "../ideogramCaption.js";
 import PaletteEditor from "./PaletteEditor.jsx";
+import { ImageEditSourcePickerField } from "./AssetPicker.jsx";
+import { assetUrl } from "./assetMedia.jsx";
 
 const MODES = [
   ["form", "Builder"],
@@ -103,10 +105,21 @@ export default function StructuredPromptBuilder({
   onDownloadMagicModel,
   // sc-8109 / epic 8102 seam: invoked with the natural (width, height) of an uploaded
   // reference image so the parent can auto-preset the generation resolution to the
-  // nearest aspect (the caption's bboxes are normalized 0–1000 to the frame). The
-  // reference-image picker that calls this lands in sc-8108; until then this is unused.
-  // eslint-disable-next-line no-unused-vars
+  // nearest aspect (the caption's bboxes are normalized 0–1000 to the frame).
   onReferenceImageLoaded,
+  // Reference-image → JSON caption (epic 8102, sc-8108). When `onImageCaption` is supplied
+  // (Ideogram 4 + text-to-image only — the parent gates it), the Plain-text tab also offers a
+  // reference-image picker + "Generate JSON from image" button. `onImageCaption(assetId)` runs
+  // the worker's `image_caption` job and resolves to the RAW model reply; this component parses
+  // it with `parseVisionCaption` (bboxes KEPT, aspect_ratio stripped) and injects it, switching
+  // to the Builder. C1: the image is captioning-only — it is never sent to generation.
+  onImageCaption,
+  referenceAssets = [],
+  referenceCharacters = [],
+  importAsset,
+  projectId,
+  visionModelMissing = false,
+  onDownloadVisionModel,
 }) {
   const composition = getComposition(caption);
   const elements = getElements(caption);
@@ -117,6 +130,68 @@ export default function StructuredPromptBuilder({
   const [magicDownloadRequested, setMagicDownloadRequested] = useState(false);
   const magicModelNeeded =
     magicModelMissing || /not cached|not installed|snapshot is not/i.test(magicError);
+
+  // Reference-image → JSON caption state (epic 8102, sc-8108). Mirrors the magic-prompt loading +
+  // error + download affordance, but the trigger is an uploaded reference image rather than text.
+  const [referenceAssetId, setReferenceAssetId] = useState("");
+  const [captionBusy, setCaptionBusy] = useState(false);
+  const [captionError, setCaptionError] = useState("");
+  const [captionDownloadRequested, setCaptionDownloadRequested] = useState(false);
+  const captionModelNeeded =
+    visionModelMissing || /not cached|not installed|snapshot is not/i.test(captionError);
+
+  // Feed the uploaded image's natural dimensions to the sc-8109 auto-preset seam so the resolution
+  // snaps to the nearest aspect before generation (the caption's bboxes are frame-normalized).
+  function reportReferenceDimensions(asset) {
+    if (typeof onReferenceImageLoaded !== "function" || !asset) return;
+    const src = assetUrl(asset);
+    if (!src || typeof Image === "undefined") return;
+    const probe = new Image();
+    probe.onload = () => {
+      if (probe.naturalWidth && probe.naturalHeight) {
+        onReferenceImageLoaded(probe.naturalWidth, probe.naturalHeight);
+      }
+    };
+    probe.src = src;
+  }
+
+  function handleReferenceChange(assetId) {
+    setReferenceAssetId(assetId);
+    setCaptionError("");
+    const asset = referenceAssets.find((item) => item.id === assetId);
+    if (asset) reportReferenceDimensions(asset);
+  }
+
+  async function handleImageCaption() {
+    if (typeof onImageCaption !== "function" || !referenceAssetId || captionBusy) return;
+    setCaptionBusy(true);
+    setCaptionError("");
+    try {
+      const next = await onImageCaption(referenceAssetId);
+      // `next` is an already-parsed caption object (the parent runs parseVisionCaption); a falsy
+      // result means the reply was not a usable structured caption.
+      if (next) {
+        onCaptionChange(next);
+        onModeChange("form"); // drop the user into the editable builder, like magic-prompt
+      } else {
+        setCaptionError("The image did not produce a usable caption. Try another reference.");
+      }
+    } catch (e) {
+      setCaptionError(e?.message || "Could not caption the image.");
+    } finally {
+      setCaptionBusy(false);
+    }
+  }
+
+  async function handleDownloadVisionModel() {
+    if (typeof onDownloadVisionModel !== "function") return;
+    try {
+      const job = await onDownloadVisionModel();
+      if (job) setCaptionDownloadRequested(true);
+    } catch (e) {
+      setCaptionError(e?.message || "Could not start the model download.");
+    }
+  }
 
   async function handleMagicExpand() {
     if (typeof onMagicExpand !== "function" || !plainText.trim() || magicBusy) return;
@@ -350,6 +425,63 @@ export default function StructuredPromptBuilder({
               ) : magicError ? (
                 <p className="structured-error" role="alert">
                   {magicError}
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+
+          {/* Reference-image → JSON caption (epic 8102, sc-8108). Gated by the parent to Ideogram 4 +
+              text-to-image: upload/pick a reference, generate a grounded JSON caption from it, and drop
+              into the Builder to edit before generating. The image is captioning-only (C1) — it is never
+              sent to generation as img2img conditioning. */}
+          {typeof onImageCaption === "function" ? (
+            <div className="structured-reference">
+              <p className="structured-hint">
+                Or start from a reference image — the captioner reads it into a grounded JSON caption you
+                can edit. The image is only used to write the caption; it isn’t sent to generation.
+              </p>
+              <ImageEditSourcePickerField
+                assets={referenceAssets}
+                buttonLabel="Select reference image"
+                changeLabel="Change reference"
+                characters={referenceCharacters}
+                emptyLabel="No reference image selected"
+                importAsset={importAsset}
+                label="Reference image"
+                onChange={handleReferenceChange}
+                projectId={projectId}
+                value={referenceAssetId}
+              />
+              <button
+                type="button"
+                className="secondary-action"
+                disabled={!referenceAssetId || captionBusy}
+                onClick={handleImageCaption}
+              >
+                {captionBusy ? "Captioning…" : "✨ Generate JSON from image"}
+              </button>
+              {captionError && captionModelNeeded ? (
+                <div className="structured-magic-missing" role="alert">
+                  {captionDownloadRequested ? (
+                    <p className="structured-hint">
+                      Downloading the vision captioner… track it on the Models screen, then try again.
+                    </p>
+                  ) : (
+                    <>
+                      <p className="structured-error">The vision captioner model isn’t installed yet.</p>
+                      {typeof onDownloadVisionModel === "function" ? (
+                        <button type="button" className="secondary-action" onClick={handleDownloadVisionModel}>
+                          Download vision captioner
+                        </button>
+                      ) : (
+                        <p className="structured-hint">Open the Models screen to download it.</p>
+                      )}
+                    </>
+                  )}
+                </div>
+              ) : captionError ? (
+                <p className="structured-error" role="alert">
+                  {captionError}
                 </p>
               ) : null}
             </div>

--- a/apps/web/src/components/StructuredPromptBuilder.test.jsx
+++ b/apps/web/src/components/StructuredPromptBuilder.test.jsx
@@ -23,7 +23,20 @@ describe("StructuredPromptBuilder", () => {
 
   // Stateful wrapper so we can drive the controlled component and read back the
   // caption it builds.
-  function Harness({ initialMode = "form", initialCaption, initialPlain = "", onMagicExpand, magicModelMissing = false, onDownloadMagicModel }) {
+  function Harness({
+    initialMode = "form",
+    initialCaption,
+    initialPlain = "",
+    onMagicExpand,
+    magicModelMissing = false,
+    onDownloadMagicModel,
+    onImageCaption,
+    referenceAssets = [],
+    projectId = "",
+    visionModelMissing = false,
+    onDownloadVisionModel,
+    onReferenceImageLoaded,
+  }) {
     const [caption, setCaption] = useState(initialCaption ?? emptyCaption());
     const [mode, setMode] = useState(initialMode);
     const [plain, setPlain] = useState(initialPlain);
@@ -41,6 +54,12 @@ describe("StructuredPromptBuilder", () => {
         onMagicExpand={onMagicExpand}
         magicModelMissing={magicModelMissing}
         onDownloadMagicModel={onDownloadMagicModel}
+        onImageCaption={onImageCaption}
+        referenceAssets={referenceAssets}
+        projectId={projectId}
+        visionModelMissing={visionModelMissing}
+        onDownloadVisionModel={onDownloadVisionModel}
+        onReferenceImageLoaded={onReferenceImageLoaded}
       />
     );
   }
@@ -214,6 +233,90 @@ describe("StructuredPromptBuilder", () => {
   it("hides the magic-prompt button when no expander is provided", async () => {
     await mount({ initialMode: "plain", initialPlain: "an idea" });
     expect(buttonByText("✨ Expand to caption")).toBeFalsy();
+  });
+
+  // ----- reference-image → JSON caption (epic 8102, sc-8108) -----
+
+  const refAsset = {
+    id: "ref-1",
+    type: "image",
+    projectId: "proj-1",
+    file: { path: "uploads/ref.png", mimeType: "image/png" },
+  };
+
+  // Pick a reference image through the asset picker modal so the caption button enables.
+  async function selectReference() {
+    await clickAndSettle(buttonByText("Select reference image"));
+    const card = container.querySelector(".asset-picker-card");
+    await clickAndSettle(card);
+    await clickAndSettle(buttonByText("Use Selection"));
+  }
+
+  it("captions a picked reference image into the editable builder (sc-8108)", async () => {
+    const captioned = {
+      high_level_description: "a red fox",
+      compositional_deconstruction: {
+        background: "snow",
+        elements: [{ type: "obj", bbox: [100, 100, 500, 500], desc: "a red fox" }],
+      },
+    };
+    const onImageCaption = vi.fn(async () => captioned);
+    await mount({ initialMode: "plain", onImageCaption, referenceAssets: [refAsset], projectId: "proj-1" });
+    await selectReference();
+    await clickAndSettle(buttonByText("✨ Generate JSON from image"));
+
+    expect(onImageCaption).toHaveBeenCalledWith("ref-1");
+    expect(snap.mode).toBe("form"); // dropped into the builder
+    // bboxes are KEPT (parseVisionCaption strips aspect_ratio only).
+    expect(snap.caption).toEqual(captioned);
+  });
+
+  it("keeps the caption button disabled until a reference is selected (sc-8108)", async () => {
+    const onImageCaption = vi.fn(async () => ({}));
+    await mount({ initialMode: "plain", onImageCaption, referenceAssets: [refAsset], projectId: "proj-1" });
+    expect(buttonByText("✨ Generate JSON from image").disabled).toBe(true);
+    await selectReference();
+    expect(buttonByText("✨ Generate JSON from image").disabled).toBe(false);
+  });
+
+  it("surfaces an image-caption error and stays on plain text (sc-8108)", async () => {
+    const onImageCaption = vi.fn(async () => {
+      throw new Error("captioning blew up");
+    });
+    await mount({ initialMode: "plain", onImageCaption, referenceAssets: [refAsset], projectId: "proj-1" });
+    await selectReference();
+    await clickAndSettle(buttonByText("✨ Generate JSON from image"));
+
+    expect(container.querySelector(".structured-error")?.textContent).toContain("captioning blew up");
+    expect(snap.mode).toBe("plain");
+  });
+
+  it("offers a vision-model download when the captioner is missing (sc-8108)", async () => {
+    const onImageCaption = vi.fn(async () => {
+      throw new Error("snapshot is not cached");
+    });
+    const onDownloadVisionModel = vi.fn(async () => ({ id: "job1" }));
+    await mount({
+      initialMode: "plain",
+      onImageCaption,
+      referenceAssets: [refAsset],
+      projectId: "proj-1",
+      visionModelMissing: true,
+      onDownloadVisionModel,
+    });
+    await selectReference();
+    await clickAndSettle(buttonByText("✨ Generate JSON from image"));
+
+    const download = buttonByText("Download vision captioner");
+    expect(download).toBeTruthy();
+    await clickAndSettle(download);
+    expect(onDownloadVisionModel).toHaveBeenCalled();
+  });
+
+  it("hides the reference-image flow when no captioner is wired (gating, sc-8108)", async () => {
+    await mount({ initialMode: "plain", initialPlain: "an idea" });
+    expect(buttonByText("✨ Generate JSON from image")).toBeFalsy();
+    expect(container.querySelector(".structured-reference")).toBeFalsy();
   });
 
   it("reports blocking validation errors in the preview (out-of-range bbox)", async () => {

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -29,6 +29,14 @@ export const PROMPT_REFINE_MODEL_ID = "prompt_refine_anubis_8b";
 // this id to look up install state and offer a download in the caption dialog when missing.
 export const JOY_CAPTION_MODEL_ID = "joycaption_beta_one";
 
+// Vision captioner (epic 8102, sc-8107/8108). Turns an uploaded reference image into a structured
+// Ideogram-style JSON caption (style + grounded composition) for Ideogram 4 text-to-image variations.
+// As with PROMPT_REFINE_MODEL_ID, the native worker resolves the model by its HF repo string (carried
+// in the job payload's `model` field); the web uses the catalog id only to look up install state and
+// offer a download (the eligibility gate is the sibling sc-8110). macOnly in the catalog.
+export const VISION_CAPTION_MODEL_ID = "vision_caption_qwen3vl_8b";
+export const VISION_CAPTION_MODEL_REPO = "huihui-ai/Huihui-Qwen3-VL-8B-Instruct-abliterated";
+
 // Default interleave system prompt (the think/no-think protocol). Prefilled in
 // Document Studio; the worker falls back to this same text when the field is blank.
 // Keep in sync with apps/worker/scene_worker/image_adapters.py::_INTERLEAVE_SYSTEM_MESSAGE.

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -13,6 +13,7 @@ import {
   emptyCaption,
   orderCaption,
   parseMagicPromptCaption,
+  parseVisionCaption,
   serializeCaption,
   validateCaption,
 } from "../ideogramCaption.js";
@@ -95,7 +96,7 @@ import { useAppContext } from "../context/AppContext.js";
 import { ModelAvailabilityGate } from "../components/ModelAvailabilityGate.jsx";
 import { downloadOffersFor, imageModelUsable } from "../modelEligibility.js";
 import { pidToggleVisible } from "../pidEligibility.js";
-import { PROMPT_REFINE_MODEL_ID } from "../constants.js";
+import { PROMPT_REFINE_MODEL_ID, VISION_CAPTION_MODEL_ID, VISION_CAPTION_MODEL_REPO } from "../constants.js";
 import { pickClosestResolution } from "../resolutionMatch.js";
 import {
   DEFAULT_MAC_CAPABILITIES,
@@ -264,6 +265,7 @@ export function ImageStudio() {
     createPreset,
     refinePrompt,
     magicPrompt,
+    imageCaption,
     createModelDownloadJob,
     deleteAsset,
     purgeAsset,
@@ -293,6 +295,13 @@ export function ImageStudio() {
   // model isn't provisioned on the native worker.
   const refineModel = useMemo(
     () => models.find((entry) => entry.id === PROMPT_REFINE_MODEL_ID),
+    [models],
+  );
+  // Vision-captioner catalog entry (sc-8107) — drives the "download the vision model" affordance in
+  // the reference-image caption flow (sc-8108) when captioning fails because the model isn't installed.
+  // The eligibility/download gate proper is the sibling sc-8110; this is the inline fallback affordance.
+  const visionModel = useMemo(
+    () => models.find((entry) => entry.id === VISION_CAPTION_MODEL_ID),
     [models],
   );
   // Recent Assets list (sc-2088). When the new context value is available, use
@@ -955,6 +964,35 @@ export function ImageStudio() {
     [magicPrompt, model, width, height],
   );
 
+  // Reference-image → JSON caption (epic 8102, sc-8108): run the worker's `image_caption` vision job on
+  // the picked reference asset and parse the reply into an editable caption. Uses `parseVisionCaption`
+  // (strips the non-schema `aspect_ratio`, KEEPS the grounded bboxes — they are derived from the actual
+  // image, unlike magic-prompt's guessed boxes). Throws on a malformed/non-caption reply so the builder
+  // surfaces the error and lets the user retry, mirroring the magic-prompt error UX. C1: the image is
+  // captioning-only — it is consumed here to produce JSON and never passed to generation.
+  const onImageCaption = useCallback(
+    async (sourceAssetId) => {
+      if (typeof imageCaption !== "function") {
+        throw new Error("Image captioning is unavailable.");
+      }
+      if (!activeProject?.id) {
+        throw new Error("Open a project first.");
+      }
+      const raw = await imageCaption({
+        sourceAssetId,
+        projectId: activeProject.id,
+        model: VISION_CAPTION_MODEL_REPO,
+      });
+      const { caption: parsed, error } = parseVisionCaption(raw);
+      if (error || !parsed) {
+        throw new Error(error || "The image did not produce a usable caption.");
+      }
+      setMagicPromptBackend(VISION_CAPTION_MODEL_ID);
+      return parsed;
+    },
+    [imageCaption, activeProject?.id],
+  );
+
   // When restoring a snapshot, the saved count/resolution/negativePrompt already
   // reflect the user's last state — skip the one preset-default pass that fires as the
   // restored preset resolves so it doesn't overwrite them. "None" applies no defaults,
@@ -1400,10 +1438,20 @@ export function ImageStudio() {
                 onMagicExpand={magicPrompt ? onMagicExpand : undefined}
                 magicModelMissing={magicModelMissing}
                 onDownloadMagicModel={refineModel ? () => createModelDownloadJob(refineModel) : undefined}
-                // sc-8109 seam: the reference-image picker (sc-8108) calls this with the
-                // uploaded image's natural dimensions to auto-preset the resolution to the
-                // nearest aspect. No-op until that picker lands.
+                // sc-8109 seam: the reference-image picker calls this with the uploaded image's
+                // natural dimensions to auto-preset the resolution to the nearest aspect.
                 onReferenceImageLoaded={onReferenceImageLoaded}
+                // Reference-image → JSON caption (epic 8102, sc-8108). Gated to text-to-image ONLY:
+                // edit/character modes condition on their own source/identity image, so a fresh
+                // scene caption written from a different reference would conflict. The image is
+                // captioning-only (C1) — never sent to generation.
+                onImageCaption={mode === "text_to_image" && imageCaption ? onImageCaption : undefined}
+                referenceAssets={editImageAssets}
+                referenceCharacters={characters}
+                importAsset={importAsset}
+                projectId={activeProject?.id ?? ""}
+                visionModelMissing={visionModel?.installState === "missing"}
+                onDownloadVisionModel={visionModel ? () => createModelDownloadJob(visionModel) : undefined}
               />
             ) : (
               <textarea

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -798,6 +798,112 @@ describe("ImageStudio structured-prompt recipe round-trip (sc-6147)", () => {
   });
 });
 
+describe("ImageStudio reference-image → JSON caption (epic 8102, sc-8108)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <ImageStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  const IDEOGRAM = {
+    ...Z_IMAGE,
+    id: "ideogram_4",
+    name: "Ideogram 4",
+    family: "ideogram",
+    capabilities: ["text_to_image"],
+    structuredPrompt: true,
+  };
+
+  const REF_ASSET = {
+    id: "ref-asset-1",
+    type: "image",
+    projectId: "project_1",
+    file: { path: "uploads/ref.png", mimeType: "image/png" },
+  };
+
+  // The vision model reply carries a grounded bbox; parseVisionCaption KEEPS bboxes (strips only
+  // aspect_ratio), so the injected caption must still carry the box.
+  const VISION_REPLY = JSON.stringify({
+    aspect_ratio: "1:1",
+    high_level_description: "a red fox in the snow",
+    compositional_deconstruction: {
+      background: "a snowy forest",
+      elements: [{ type: "obj", bbox: [100, 100, 600, 600], desc: "a red fox" }],
+    },
+  });
+
+  const buttonByText = (text) =>
+    [...container.querySelectorAll("button")].find((b) => b.textContent.trim() === text);
+
+  // Switch the structured builder to its Plain-text tab, where the reference-image flow lives.
+  async function openPlainTab() {
+    const plainTab = [...container.querySelectorAll(".structured-mode button")].find(
+      (b) => b.textContent.trim() === "Plain text",
+    );
+    await click(plainTab);
+  }
+
+  it("shows the reference-image flow for Ideogram 4 in text-to-image mode", async () => {
+    await render(baseContext({ imageModels: [IDEOGRAM], imageCaption: vi.fn() }));
+    await openPlainTab();
+    expect(buttonByText("✨ Generate JSON from image")).toBeTruthy();
+    expect(container.querySelector(".structured-reference")).toBeTruthy();
+  });
+
+  it("captions a reference image into the builder, keeping bboxes (sc-8108)", async () => {
+    const imageCaption = vi.fn(async () => VISION_REPLY);
+    await render(
+      baseContext({ imageModels: [IDEOGRAM], assets: [REF_ASSET], imageCaption }),
+    );
+    await openPlainTab();
+
+    // Pick the reference through the asset picker modal so the button enables.
+    await click(buttonByText("Select reference image"));
+    await click(container.querySelector(".asset-picker-card"));
+    await click(buttonByText("Use Selection"));
+
+    await click(buttonByText("✨ Generate JSON from image"));
+    await act(async () => {});
+
+    // Dispatched with the asset id, the project id, and the vision model's HF repo string.
+    expect(imageCaption).toHaveBeenCalledTimes(1);
+    const arg = imageCaption.mock.calls[0][0];
+    expect(arg.sourceAssetId).toBe("ref-asset-1");
+    expect(arg.projectId).toBe("project_1");
+    expect(arg.model).toBe("huihui-ai/Huihui-Qwen3-VL-8B-Instruct-abliterated");
+
+    // The builder is populated (it switched to the form) and the grounded bbox survived.
+    const preview = container.querySelector('[aria-label="Caption preview"]');
+    expect(preview).toBeTruthy();
+    expect(preview.textContent).toContain("a red fox");
+    expect(preview.textContent).toContain("100");
+    // aspect_ratio is NOT a schema key and must be stripped.
+    expect(preview.textContent).not.toContain("aspect_ratio");
+  });
+});
+
 describe("ImageStudio Ideogram 4 auto-expand on plain-text Generate (sc-6501)", () => {
   let container;
   let root;


### PR DESCRIPTION
## What changed

Adds the user-facing **reference-image → JSON caption** flow to the Ideogram 4 **text-to-image** Image Studio panel (epic 8102, sc-8108). Upload/pick a reference image, click **Generate JSON from image**, and a grounded Ideogram-style JSON caption populates the structured builder for editing before generation.

### Web
- **StructuredPromptBuilder** (Plain-text tab): a reference-image picker (`ImageEditSourcePickerField` — drag-drop + import + character tabs) plus a **✨ Generate JSON from image** button. Mirrors the magic-prompt UX: busy/loading state, inline error, and a "download the vision captioner" affordance when the model is missing.
- **ImageStudio** wires `onImageCaption`: dispatches the worker `image_caption` job (sc-8105) with the picked asset + the vision model's HF repo, parses the reply with `parseVisionCaption` (sc-8111 — strips `aspect_ratio`, **KEEPS** the grounded bboxes), injects via `setCaption`, and switches to the Builder `form` mode. Feeds the image's natural dimensions to the sc-8109 auto-preset seam.
- **App.jsx** `imageCaption` hook reuses the `prompts/refine` poll-to-completion contract (same mechanism as `magicPrompt`). New `VISION_CAPTION_MODEL_ID` / `VISION_CAPTION_MODEL_REPO` constants.

### API
- `POST /api/v1/prompts/refine` now handles `task: "image_caption"`: waives the text-prompt requirement, resolves `sourceAssetId` (+ `projectId`) to a confined absolute `imagePath` (joined under the project dir with `Normal`-only components — the worker independently re-confines it), and forwards the vision model repo verbatim. `PromptRefineRequest.prompt` is now optional.

## Scope vs acceptance criteria
- ✅ Reference-image picker (drag-drop + import) — adapts `ImageEditSourcePickerField`.
- ✅ "Generate JSON from image" button mirroring `onMagicExpand` — dispatches `image_caption` with image + vision model id, awaits the result.
- ✅ Inject via the existing caption seam (`onCaptionChange` → `setCaption`), switch to `form` mode.
- ✅ Strip `aspect_ratio`, KEEP bboxes via `parseVisionCaption`.
- ✅ Gated to Ideogram 4 (`structuredPrompt`) + `text_to_image` mode ONLY.
- ✅ C1: the reference image is captioning-only — never passed to generation as img2img conditioning.

## Tests
- **StructuredPromptBuilder.test.jsx** (+5): caption inject keeps bboxes & switches to form; button disabled until a reference is selected; error path stays on plain text; vision-model-missing download affordance; flow hidden when no captioner is wired (gating).
- **ImageStudio.test.jsx** (+2): t2i + Ideogram shows the flow; click dispatches with the asset id, project id, and vision model repo, and the injected caption strips `aspect_ratio` while keeping the grounded bbox.
- **rust-api tests.rs** (+2): `sourceAssetId` → confined absolute `imagePath` resolution + payload shape; required-field (sourceAssetId/projectId) validation → 400.
- Web: `npm test` 792 passed, `npm run build` clean, `npm run lint` 0 errors. API: 140 passed, clippy clean on changed files.

## Notes
- The eligibility / `ModelAvailabilityGate` download-offer wrapping is the **sibling story sc-8110** — not implemented here (this PR builds the picker + button + inject + gating; sc-8110 wraps it). The inline "download vision captioner" affordance on a failed caption is included as the magic-prompt-parity fallback.
- macOS-first; the vision model is `macOnly` in the catalog. On-device E2E (real weights) is out of scope for this web/API slice.

Story: sc-8108

🤖 Generated with [Claude Code](https://claude.com/claude-code)