### PR TITLE
feat(web): vision-caption eligibility predicate + ModelAvailabilityGate (sc-8110)

### DIFF
--- a/apps/web/src/components/StructuredPromptBuilder.jsx
+++ b/apps/web/src/components/StructuredPromptBuilder.jsx
@@ -26,6 +26,7 @@ import {
 import PaletteEditor from "./PaletteEditor.jsx";
 import { ImageEditSourcePickerField } from "./AssetPicker.jsx";
 import { assetUrl } from "./assetMedia.jsx";
+import { ModelAvailabilityGate } from "./ModelAvailabilityGate.jsx";
 
 const MODES = [
   ["form", "Builder"],
@@ -118,8 +119,20 @@ export default function StructuredPromptBuilder({
   referenceCharacters = [],
   importAsset,
   projectId,
-  visionModelMissing = false,
-  onDownloadVisionModel,
+  // Reference-image caption gate (sc-8110). The reference picker + "Generate JSON from image" button
+  // only render when the vision captioner is present + usable (`visionCaptionReady`, derived from the
+  // catalog via visionCaptionModelUsable in the parent). When it's false, the shared
+  // ModelAvailabilityGate renders a download offer instead — formalizing sc-8108's inline,
+  // error-driven "Download vision captioner" affordance into ONE coherent, proactive gate that mirrors
+  // the per-Studio model gates. macOnly keeps the whole section hidden off Mac (the parent only wires
+  // `onImageCaption` for Ideogram 4 + text-to-image, both macOnly).
+  visionCaptionReady = true,
+  visionCaptionOffers = [],
+  visionCaptionDownloadJobs = [],
+  onDownloadModel,
+  onOpenModels,
+  onOpenQueue,
+  onCancelJob,
 }) {
   const composition = getComposition(caption);
   const elements = getElements(caption);
@@ -131,14 +144,13 @@ export default function StructuredPromptBuilder({
   const magicModelNeeded =
     magicModelMissing || /not cached|not installed|snapshot is not/i.test(magicError);
 
-  // Reference-image → JSON caption state (epic 8102, sc-8108). Mirrors the magic-prompt loading +
-  // error + download affordance, but the trigger is an uploaded reference image rather than text.
+  // Reference-image → JSON caption state (epic 8102, sc-8108). The "model not installed" path is now
+  // owned proactively by the ModelAvailabilityGate (sc-8110) — when the captioner is missing the
+  // picker/button never render, so this state only tracks the live-flow loading + runtime errors
+  // (e.g. an unusable reply), not the missing-model affordance.
   const [referenceAssetId, setReferenceAssetId] = useState("");
   const [captionBusy, setCaptionBusy] = useState(false);
   const [captionError, setCaptionError] = useState("");
-  const [captionDownloadRequested, setCaptionDownloadRequested] = useState(false);
-  const captionModelNeeded =
-    visionModelMissing || /not cached|not installed|snapshot is not/i.test(captionError);
 
   // Feed the uploaded image's natural dimensions to the sc-8109 auto-preset seam so the resolution
   // snaps to the nearest aspect before generation (the caption's bboxes are frame-normalized).
@@ -180,16 +192,6 @@ export default function StructuredPromptBuilder({
       setCaptionError(e?.message || "Could not caption the image.");
     } finally {
       setCaptionBusy(false);
-    }
-  }
-
-  async function handleDownloadVisionModel() {
-    if (typeof onDownloadVisionModel !== "function") return;
-    try {
-      const job = await onDownloadVisionModel();
-      if (job) setCaptionDownloadRequested(true);
-    } catch (e) {
-      setCaptionError(e?.message || "Could not start the model download.");
     }
   }
 
@@ -430,60 +432,55 @@ export default function StructuredPromptBuilder({
             </div>
           ) : null}
 
-          {/* Reference-image → JSON caption (epic 8102, sc-8108). Gated by the parent to Ideogram 4 +
-              text-to-image: upload/pick a reference, generate a grounded JSON caption from it, and drop
-              into the Builder to edit before generating. The image is captioning-only (C1) — it is never
-              sent to generation as img2img conditioning. */}
+          {/* Reference-image → JSON caption (epic 8102, sc-8108 + sc-8110). The parent only wires
+              `onImageCaption` for Ideogram 4 + text-to-image (both macOnly), so the section is already
+              hidden off-Mac. Within it the ModelAvailabilityGate (sc-8110) gates on the vision captioner
+              being installed: when ready it shows the reference picker + "Generate JSON from image"
+              button (live); when missing it shows the shared download offer instead of a button that
+              would only fail on click. The image is captioning-only (C1) — never sent to generation. */}
           {typeof onImageCaption === "function" ? (
             <div className="structured-reference">
-              <p className="structured-hint">
-                Or start from a reference image — the captioner reads it into a grounded JSON caption you
-                can edit. The image is only used to write the caption; it isn’t sent to generation.
-              </p>
-              <ImageEditSourcePickerField
-                assets={referenceAssets}
-                buttonLabel="Select reference image"
-                changeLabel="Change reference"
-                characters={referenceCharacters}
-                emptyLabel="No reference image selected"
-                importAsset={importAsset}
-                label="Reference image"
-                onChange={handleReferenceChange}
-                projectId={projectId}
-                value={referenceAssetId}
-              />
-              <button
-                type="button"
-                className="secondary-action"
-                disabled={!referenceAssetId || captionBusy}
-                onClick={handleImageCaption}
+              <ModelAvailabilityGate
+                ready={visionCaptionReady}
+                title="Reference-image captioning needs a model"
+                description="Download the vision captioner to turn a reference image into an editable JSON caption. It runs locally on the native worker; the image is only used to write the caption."
+                offers={visionCaptionOffers}
+                downloadJobs={visionCaptionDownloadJobs}
+                onDownload={onDownloadModel}
+                onOpenModels={onOpenModels}
+                onOpenQueue={onOpenQueue}
+                onCancelJob={onCancelJob}
               >
-                {captionBusy ? "Captioning…" : "✨ Generate JSON from image"}
-              </button>
-              {captionError && captionModelNeeded ? (
-                <div className="structured-magic-missing" role="alert">
-                  {captionDownloadRequested ? (
-                    <p className="structured-hint">
-                      Downloading the vision captioner… track it on the Models screen, then try again.
-                    </p>
-                  ) : (
-                    <>
-                      <p className="structured-error">The vision captioner model isn’t installed yet.</p>
-                      {typeof onDownloadVisionModel === "function" ? (
-                        <button type="button" className="secondary-action" onClick={handleDownloadVisionModel}>
-                          Download vision captioner
-                        </button>
-                      ) : (
-                        <p className="structured-hint">Open the Models screen to download it.</p>
-                      )}
-                    </>
-                  )}
-                </div>
-              ) : captionError ? (
-                <p className="structured-error" role="alert">
-                  {captionError}
+                <p className="structured-hint">
+                  Or start from a reference image — the captioner reads it into a grounded JSON caption you
+                  can edit. The image is only used to write the caption; it isn’t sent to generation.
                 </p>
-              ) : null}
+                <ImageEditSourcePickerField
+                  assets={referenceAssets}
+                  buttonLabel="Select reference image"
+                  changeLabel="Change reference"
+                  characters={referenceCharacters}
+                  emptyLabel="No reference image selected"
+                  importAsset={importAsset}
+                  label="Reference image"
+                  onChange={handleReferenceChange}
+                  projectId={projectId}
+                  value={referenceAssetId}
+                />
+                <button
+                  type="button"
+                  className="secondary-action"
+                  disabled={!referenceAssetId || captionBusy}
+                  onClick={handleImageCaption}
+                >
+                  {captionBusy ? "Captioning…" : "✨ Generate JSON from image"}
+                </button>
+                {captionError ? (
+                  <p className="structured-error" role="alert">
+                    {captionError}
+                  </p>
+                ) : null}
+              </ModelAvailabilityGate>
             </div>
           ) : null}
         </div>

--- a/apps/web/src/components/StructuredPromptBuilder.test.jsx
+++ b/apps/web/src/components/StructuredPromptBuilder.test.jsx
@@ -33,8 +33,13 @@ describe("StructuredPromptBuilder", () => {
     onImageCaption,
     referenceAssets = [],
     projectId = "",
-    visionModelMissing = false,
-    onDownloadVisionModel,
+    visionCaptionReady = true,
+    visionCaptionOffers = [],
+    visionCaptionDownloadJobs = [],
+    onDownloadModel,
+    onOpenModels,
+    onOpenQueue,
+    onCancelJob,
     onReferenceImageLoaded,
   }) {
     const [caption, setCaption] = useState(initialCaption ?? emptyCaption());
@@ -57,8 +62,13 @@ describe("StructuredPromptBuilder", () => {
         onImageCaption={onImageCaption}
         referenceAssets={referenceAssets}
         projectId={projectId}
-        visionModelMissing={visionModelMissing}
-        onDownloadVisionModel={onDownloadVisionModel}
+        visionCaptionReady={visionCaptionReady}
+        visionCaptionOffers={visionCaptionOffers}
+        visionCaptionDownloadJobs={visionCaptionDownloadJobs}
+        onDownloadModel={onDownloadModel}
+        onOpenModels={onOpenModels}
+        onOpenQueue={onOpenQueue}
+        onCancelJob={onCancelJob}
         onReferenceImageLoaded={onReferenceImageLoaded}
       />
     );
@@ -291,26 +301,47 @@ describe("StructuredPromptBuilder", () => {
     expect(snap.mode).toBe("plain");
   });
 
-  it("offers a vision-model download when the captioner is missing (sc-8108)", async () => {
-    const onImageCaption = vi.fn(async () => {
-      throw new Error("snapshot is not cached");
-    });
-    const onDownloadVisionModel = vi.fn(async () => ({ id: "job1" }));
+  it("shows the gate download offer (not the button) when the captioner is missing (sc-8110)", async () => {
+    // sc-8110: when the vision captioner isn't installed the section is gated PROACTIVELY through the
+    // shared ModelAvailabilityGate — the reference picker + caption button never render, and a download
+    // offer is shown instead of a button that would only fail on click.
+    const onImageCaption = vi.fn(async () => ({}));
+    const onDownloadModel = vi.fn();
+    const offer = { id: "vision_caption_qwen3vl_8b", name: "Vision Captioner", downloadSizeLabel: "18 GB" };
     await mount({
       initialMode: "plain",
       onImageCaption,
       referenceAssets: [refAsset],
       projectId: "proj-1",
-      visionModelMissing: true,
-      onDownloadVisionModel,
+      visionCaptionReady: false,
+      visionCaptionOffers: [offer],
+      onDownloadModel,
     });
-    await selectReference();
-    await clickAndSettle(buttonByText("✨ Generate JSON from image"));
 
-    const download = buttonByText("Download vision captioner");
+    // The live-feature controls are hidden behind the gate.
+    expect(buttonByText("✨ Generate JSON from image")).toBeFalsy();
+    expect(buttonByText("Select reference image")).toBeFalsy();
+    // The gate renders its download offer for the captioner.
+    expect(container.querySelector(".model-availability-gate")).toBeTruthy();
+    const download = buttonByText("Download");
     expect(download).toBeTruthy();
     await clickAndSettle(download);
-    expect(onDownloadVisionModel).toHaveBeenCalled();
+    expect(onDownloadModel).toHaveBeenCalledWith(offer);
+  });
+
+  it("shows the live reference flow (no gate) when the captioner is present (sc-8110)", async () => {
+    const onImageCaption = vi.fn(async () => ({}));
+    await mount({
+      initialMode: "plain",
+      onImageCaption,
+      referenceAssets: [refAsset],
+      projectId: "proj-1",
+      visionCaptionReady: true,
+    });
+    // Ready → the live picker + button render, and the gate is NOT shown.
+    expect(container.querySelector(".model-availability-gate")).toBeFalsy();
+    expect(buttonByText("Select reference image")).toBeTruthy();
+    expect(buttonByText("✨ Generate JSON from image")).toBeTruthy();
   });
 
   it("hides the reference-image flow when no captioner is wired (gating, sc-8108)", async () => {

--- a/apps/web/src/modelEligibility.js
+++ b/apps/web/src/modelEligibility.js
@@ -4,6 +4,7 @@
 // exactly which models qualify. Predicates are capability + Mac-gating only (no install
 // state) — callers layer installState via the helpers at the bottom.
 import { macModelBlock, macModelFeatureBlock, macVideoModeBlock } from "./macGating.js";
+import { VISION_CAPTION_MODEL_ID } from "./constants.js";
 
 // Image generation modes a model can serve (ImageStudio mode tabs).
 const IMAGE_MODES = ["text_to_image", "edit_image", "character_image", "style_variations"];
@@ -75,6 +76,33 @@ export function documentModelUsable(model, caps) {
     Array.isArray(model?.capabilities) &&
     model.capabilities.includes("interleave")
   );
+}
+
+// Reference-image → JSON caption (epic 8102, sc-8110). The vision captioner is a single,
+// catalog-pinned utility model (`vision_caption_qwen3vl_8b`), so usability is "this IS the
+// captioner model AND it can run here", not a capability sweep. Two gates, mirroring the
+// magic-prompt model gate:
+//   * macModelBlock — the active-gating Rust/MLX oracle (a no-op off Mac / in observe mode).
+//   * macOnly — the captioner is macOS-first (catalog `macOnly: true`). The Rust/MLX engine for
+//     qwen3_vl ships on Apple Silicon first; the Windows/candle path is epic 8103. Until then the
+//     feature stays HIDDEN on Windows/Linux. `caps.platform` is the API host's OS (mac_capabilities
+//     in workers.rs); when it hasn't loaded yet (`""`) we don't block, matching the no-op-pre-load
+//     convention of the macGating helpers — and the reference flow is also gated to Ideogram 4
+//     (itself macOnly) by the parent, so a non-Mac client never reaches it anyway.
+export function visionCaptionModelUsable(model, caps) {
+  if (model?.id !== VISION_CAPTION_MODEL_ID) {
+    return false;
+  }
+  if (macModelBlock(model, caps)) {
+    return false;
+  }
+  if (model?.macOnly === true) {
+    const platform = caps?.platform ?? "";
+    if (platform && platform !== "macos") {
+      return false;
+    }
+  }
+  return true;
 }
 
 // Character Studio — mirrors CharacterStudio.jsx angle/pose predicates.

--- a/apps/web/src/modelEligibility.test.js
+++ b/apps/web/src/modelEligibility.test.js
@@ -9,7 +9,9 @@ import {
   imageModelUsable,
   poseModelUsable,
   videoModelUsable,
+  visionCaptionModelUsable,
 } from "./modelEligibility.js";
+import { VISION_CAPTION_MODEL_ID } from "./constants.js";
 
 const caps = DEFAULT_MAC_CAPABILITIES; // gating off → Mac blocks are no-ops
 
@@ -74,6 +76,40 @@ describe("modelEligibility predicates", () => {
       const unsupported = { ...supported, macSupport: { supported: false } };
       expect(imageModelUsable(unsupported, activeCaps)).toBe(false);
     }
+  });
+
+  // Reference-image vision captioner gate (epic 8102, sc-8110). The captioner is a single pinned
+  // utility model; usability = "this IS that model AND it can run here", and macOnly keeps it hidden
+  // on non-macOS platforms until the candle path (epic 8103) lands.
+  it("visionCaptionModelUsable matches only the captioner model and respects macOnly", () => {
+    const captioner = { id: VISION_CAPTION_MODEL_ID, type: "utility", macOnly: true };
+    // macOS (or pre-load empty platform) → usable.
+    expect(visionCaptionModelUsable(captioner, { ...caps, platform: "macos" })).toBe(true);
+    expect(visionCaptionModelUsable(captioner, caps)).toBe(true); // platform "" → no-op pre-load
+    // Non-Mac platform with a macOnly model → hidden (epic 8103 flips this).
+    expect(visionCaptionModelUsable(captioner, { ...caps, platform: "windows" })).toBe(false);
+    expect(visionCaptionModelUsable(captioner, { ...caps, platform: "linux" })).toBe(false);
+    // A different model id is never the captioner.
+    expect(visionCaptionModelUsable({ id: "some_other_model", macOnly: true }, { ...caps, platform: "macos" })).toBe(false);
+    // Active Mac gating with the model's MLX oracle reporting unsupported → blocked.
+    const blockedCaps = { ...DEFAULT_MAC_CAPABILITIES, macGatingActive: true, platform: "macos" };
+    const unsupported = { ...captioner, macSupport: { supported: false } };
+    expect(visionCaptionModelUsable(unsupported, blockedCaps)).toBe(false);
+  });
+
+  it("hasUsableModelFor / downloadOffersFor drive the captioner gate (sc-8110)", () => {
+    const macCaps = { ...caps, platform: "macos" };
+    const installed = { id: VISION_CAPTION_MODEL_ID, type: "utility", macOnly: true, installState: "installed" };
+    const missing = { id: VISION_CAPTION_MODEL_ID, type: "utility", macOnly: true, installState: "missing", recommended: true };
+    // Present (installed) → screen is "ready".
+    expect(hasUsableModelFor([installed], visionCaptionModelUsable, macCaps)).toBe(true);
+    // Absent (missing) → not ready, and it surfaces as a recommended-first download offer.
+    expect(hasUsableModelFor([missing], visionCaptionModelUsable, macCaps)).toBe(false);
+    expect(downloadOffersFor([missing], visionCaptionModelUsable, macCaps).map((m) => m.id)).toEqual([
+      VISION_CAPTION_MODEL_ID,
+    ]);
+    // On Windows the predicate rejects it, so there is no offer (feature stays hidden).
+    expect(downloadOffersFor([missing], visionCaptionModelUsable, { ...caps, platform: "windows" })).toEqual([]);
   });
 
   it("downloadOffersFor prefers recommended, falls back to any eligible, skips installed", () => {

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -94,7 +94,7 @@ import {
 } from "./generationStudio.jsx";
 import { useAppContext } from "../context/AppContext.js";
 import { ModelAvailabilityGate } from "../components/ModelAvailabilityGate.jsx";
-import { downloadOffersFor, imageModelUsable } from "../modelEligibility.js";
+import { downloadOffersFor, imageModelUsable, visionCaptionModelUsable } from "../modelEligibility.js";
 import { pidToggleVisible } from "../pidEligibility.js";
 import { PROMPT_REFINE_MODEL_ID, VISION_CAPTION_MODEL_ID, VISION_CAPTION_MODEL_REPO } from "../constants.js";
 import { pickClosestResolution } from "../resolutionMatch.js";
@@ -297,12 +297,24 @@ export function ImageStudio() {
     () => models.find((entry) => entry.id === PROMPT_REFINE_MODEL_ID),
     [models],
   );
-  // Vision-captioner catalog entry (sc-8107) — drives the "download the vision model" affordance in
-  // the reference-image caption flow (sc-8108) when captioning fails because the model isn't installed.
-  // The eligibility/download gate proper is the sibling sc-8110; this is the inline fallback affordance.
+  // Vision-captioner catalog entry (sc-8107) — drives the reference-image caption flow (sc-8108).
   const visionModel = useMemo(
     () => models.find((entry) => entry.id === VISION_CAPTION_MODEL_ID),
     [models],
+  );
+  // Reference-image caption gate (sc-8110): the picker + "Generate JSON from image" button only goes
+  // live once the vision captioner is present (installed/incomplete) AND usable on this platform
+  // (visionCaptionModelUsable respects macOnly + Mac gating). When it's absent the section renders the
+  // shared ModelAvailabilityGate download offer instead of a button that would only fail on click —
+  // ONE coherent gate, formalizing sc-8108's inline error-driven affordance. `ready` matches the
+  // catalog state (hasUsableModelFor counts non-missing models); offers come from downloadOffersFor.
+  const visionCaptionReady =
+    Boolean(visionModel) &&
+    visionModel.installState !== "missing" &&
+    visionCaptionModelUsable(visionModel, macCapabilities);
+  const visionCaptionOffers = useMemo(
+    () => downloadOffersFor(models, visionCaptionModelUsable, macCapabilities),
+    [models, macCapabilities],
   );
   // Recent Assets list (sc-2088). When the new context value is available, use
   // the bounded 20-most-recent list; fall back to the legacy single-generation
@@ -1450,8 +1462,16 @@ export function ImageStudio() {
                 referenceCharacters={characters}
                 importAsset={importAsset}
                 projectId={activeProject?.id ?? ""}
-                visionModelMissing={visionModel?.installState === "missing"}
-                onDownloadVisionModel={visionModel ? () => createModelDownloadJob(visionModel) : undefined}
+                // Reference-image caption gate (sc-8110): the section's availability is now driven by the
+                // catalog (visionCaptionReady) through the shared ModelAvailabilityGate, not an inline
+                // error-after-click affordance. When the captioner is missing, the gate offers a download.
+                visionCaptionReady={visionCaptionReady}
+                visionCaptionOffers={visionCaptionOffers}
+                visionCaptionDownloadJobs={modelDownloadJobs}
+                onDownloadModel={createModelDownloadJob}
+                onOpenModels={() => setActiveView("Models")}
+                onOpenQueue={onOpenQueue}
+                onCancelJob={onCancelJob}
               />
             ) : (
               <textarea

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -18,7 +18,7 @@ import {
   parseMagicPromptCaption,
   serializeCaption,
 } from "../ideogramCaption.js";
-import { PROMPT_REFINE_MODEL_ID } from "../constants.js";
+import { PROMPT_REFINE_MODEL_ID, VISION_CAPTION_MODEL_ID } from "../constants.js";
 import { ImageStudio } from "./ImageStudio.jsx";
 
 const Z_IMAGE = {
@@ -843,6 +843,15 @@ describe("ImageStudio reference-image → JSON caption (epic 8102, sc-8108)", ()
     file: { path: "uploads/ref.png", mimeType: "image/png" },
   };
 
+  // sc-8110: the reference-image flow goes live only when the vision captioner is installed (the
+  // ModelAvailabilityGate gates it). Supply the catalog entry so the live picker + button render.
+  const VISION_MODEL_INSTALLED = {
+    id: VISION_CAPTION_MODEL_ID,
+    type: "utility",
+    macOnly: true,
+    installState: "installed",
+  };
+
   // The vision model reply carries a grounded bbox; parseVisionCaption KEEPS bboxes (strips only
   // aspect_ratio), so the injected caption must still carry the box.
   const VISION_REPLY = JSON.stringify({
@@ -866,16 +875,34 @@ describe("ImageStudio reference-image → JSON caption (epic 8102, sc-8108)", ()
   }
 
   it("shows the reference-image flow for Ideogram 4 in text-to-image mode", async () => {
-    await render(baseContext({ imageModels: [IDEOGRAM], imageCaption: vi.fn() }));
+    await render(
+      baseContext({ imageModels: [IDEOGRAM], models: [VISION_MODEL_INSTALLED], imageCaption: vi.fn() }),
+    );
     await openPlainTab();
     expect(buttonByText("✨ Generate JSON from image")).toBeTruthy();
     expect(container.querySelector(".structured-reference")).toBeTruthy();
   });
 
+  it("gates the reference flow behind a download offer when the captioner is missing (sc-8110)", async () => {
+    await render(
+      baseContext({
+        imageModels: [IDEOGRAM],
+        models: [{ ...VISION_MODEL_INSTALLED, installState: "missing", recommended: true, name: "Vision Captioner" }],
+        imageCaption: vi.fn(),
+      }),
+    );
+    await openPlainTab();
+    // The section is present (Ideogram 4 + t2i), but the live button is hidden behind the gate.
+    expect(container.querySelector(".structured-reference")).toBeTruthy();
+    expect(buttonByText("✨ Generate JSON from image")).toBeFalsy();
+    expect(container.querySelector(".model-availability-gate")).toBeTruthy();
+    expect(buttonByText("Download")).toBeTruthy();
+  });
+
   it("captions a reference image into the builder, keeping bboxes (sc-8108)", async () => {
     const imageCaption = vi.fn(async () => VISION_REPLY);
     await render(
-      baseContext({ imageModels: [IDEOGRAM], assets: [REF_ASSET], imageCaption }),
+      baseContext({ imageModels: [IDEOGRAM], models: [VISION_MODEL_INSTALLED], assets: [REF_ASSET], imageCaption }),
     );
     await openPlainTab();
 


### PR DESCRIPTION
## What changed

Formalizes the reference-image → JSON caption gate (epic 8102) into the project's standard **eligibility-predicate + ModelAvailabilityGate** pattern, gating the feature on the vision-caption model being installed, per-platform.

- **`modelEligibility.js`** — new `visionCaptionModelUsable(model, caps)` predicate. The captioner is a single catalog-pinned utility model (`vision_caption_qwen3vl_8b`), so usability is "this IS that model AND it can run here":
  - matches the model id (reusing `VISION_CAPTION_MODEL_ID` from `constants.js`, not a new hardcode),
  - honors the active Mac/MLX oracle via `macModelBlock` (no-op off-Mac / in observe mode),
  - respects `macOnly`: hidden on non-macOS platforms (`caps.platform`) until the candle path (epic 8103) flips it. Pre-load (`platform: ""`) is a no-op, matching the macGating helpers.
- **`ImageStudio.jsx`** — derives `visionCaptionReady` (captioner present **and** usable) and `visionCaptionOffers` (`downloadOffersFor(models, visionCaptionModelUsable, …)`), and passes the gate context into `StructuredPromptBuilder`.
- **`StructuredPromptBuilder.jsx`** — the reference picker + "Generate JSON from image" button are now wrapped in `ModelAvailabilityGate`: **live** when ready, a **download offer** when the captioner is missing.

## Reconciliation with sc-8108's inline affordance

sc-8108 (#930) shipped an **inline, error-after-click** affordance: the button rendered unconditionally and only surfaced "Download vision captioner" *after* a failed caption click. This PR **removes** that competing affordance and replaces it with the proactive `ModelAvailabilityGate` so there is **one coherent gate** mirroring the per-Studio model gates / magic-prompt "model not installed" handling. The inline state and the `visionModelMissing`/`onDownloadVisionModel` props are gone; the section's runtime-error display (e.g. an unusable reply) is preserved inside the live branch.

## Scope vs acceptance

- ✅ `visionCaptionModelUsable(model, caps)` added to `modelEligibility.js`.
- ✅ Reference-upload + button section wired through `ModelAvailabilityGate` — download affordance when missing, live feature when present.
- ✅ `macOnly` respected — hidden on Windows/Linux until epic 8103.
- ✅ Acceptance: model absent → download offer instead of a broken button; model present (macOS) → feature live.

## Tests

- `modelEligibility.test.js` — predicate true/false: id match, macOnly per-platform, active-gating Mac block; plus `hasUsableModelFor`/`downloadOffersFor` driving the gate.
- `StructuredPromptBuilder.test.jsx` — gate shows the download offer (not the button) when missing; live picker + button (no gate) when present.
- `ImageStudio.test.jsx` — live reference flow with the captioner installed; gated download offer when missing.

Verification: full web suite **796/796 green**, `npm run lint` **0 errors** (pre-existing warnings only), `npm run build` green.

Story: sc-8110 (epic 8102).

🤖 Generated with [Claude Code](https://claude.com/claude-code)