### PR TITLE
fix(worker): require exactly one style_description discriminator in image_caption prompt (sc-8194)

### DIFF
--- a/crates/sceneworks-worker/src/ideogram_image_caption_v1.txt
+++ b/crates/sceneworks-worker/src/ideogram_image_caption_v1.txt
@@ -37,13 +37,18 @@ Every field is grounded in the pixels:
 
 ## `style_description` — how the image is rendered (observe the medium + look)
 
-A JSON object capturing the visual style you observe. Use these keys (omit a key only when it genuinely does not apply):
+A JSON object capturing the visual style you observe. ALWAYS include `aesthetics`, `lighting`, `medium`, `color_palette`, AND exactly one discriminator key (`photo` or `art_style` — see the hard rule below):
 - `aesthetics`: the overall visual character (e.g. `cinematic`, `flat vector illustration`, `gritty documentary`, `soft pastel`).
 - `lighting`: the light you see (direction, hardness, color temperature, time-of-day cues) — `hard side light from the left, warm golden-hour tone`.
 - `medium`: the production medium — `photograph`, `3D render`, `oil painting`, `watercolor`, `digital illustration`, `pencil sketch`. Pick the one that matches what you see.
-- `photo` (only when `medium` is a photograph): camera/photographic character — `35mm`, `shallow depth of field`, `wide angle`. When present, place it in the discriminator slot right after `medium` is implied by it.
-- `art_style` (only when `medium` is NOT a photograph): the named art style — `art nouveau`, `cel-shaded anime`, `low-poly`, `impressionist`.
 - `color_palette`: the dominant colors actually present, as a short list of concrete color names.
+
+### REQUIRED discriminator — emit EXACTLY ONE of `photo` or `art_style` (never both, never neither)
+
+`style_description` MUST contain exactly ONE of these two keys. This is mandatory: emitting BOTH is invalid, and omitting BOTH is invalid. Always commit to one.
+- If the image is a real PHOTOGRAPH (camera capture — film grain, lens character, photographic depth of field), emit `photo` and DO NOT emit `art_style`. `photo` = the camera/photographic character (`35mm`, `shallow depth of field`, `wide angle`). Place it right after `medium`.
+- Otherwise — for ANYTHING that is not a real photograph (illustration, 3D/CGI render, painting, sketch, vector art, anime, photoreal render) — emit `art_style` and DO NOT emit `photo`. `art_style` = the named look (`art nouveau`, `cel-shaded anime`, `low-poly`, `impressionist`, `photorealistic 3D render`). Place it right after `medium`.
+- When unsure, decide from `medium`: a `photograph` medium → `photo`; any other medium → `art_style`. Never leave both out. If no specific value comes to mind, still emit the key with a concrete generic value (`photo`: `standard lens`; `art_style`: `realistic digital illustration`).
 
 Observe the medium from the pixels — film grain and lens character mean photograph; visible brushstrokes mean a painting; clean flat fills and outlines mean vector illustration. Do not assume.
 

--- a/crates/sceneworks-worker/src/prompt_refine_jobs.rs
+++ b/crates/sceneworks-worker/src/prompt_refine_jobs.rs
@@ -958,6 +958,18 @@ mod tests {
             system.contains("KEEP these bboxes"),
             "system pins that grounded bboxes are kept"
         );
+        // sc-8194: the schema requires EXACTLY ONE of `style_description.photo` / `art_style`
+        // (both present OR neither present = validation error). The prompt must make that mandatory.
+        assert!(
+            system.contains("EXACTLY ONE"),
+            "system mandates exactly one style discriminator"
+        );
+        assert!(
+            system.contains("never both, never neither"),
+            "system forbids emitting both or neither discriminator key"
+        );
+        assert!(system.contains("photo"));
+        assert!(system.contains("art_style"));
         // Output is fenced so it survives markdown.
         assert!(system.contains("```json"));
         // The `[META]` thinking flag does not bleed into the system body.


### PR DESCRIPTION
## sc-8194 — image_caption prompt: require EXACTLY ONE of `style_description.photo` / `art_style`

### Schema rule
The Ideogram caption schema requires `style_description` to contain **exactly one** of `photo` or `art_style`. Both present OR neither present is a validation error (see `apps/web/src/ideogramCaption.js:436-455`).

### Root cause
The vision captioner's system prompt (`crates/sceneworks-worker/src/ideogram_image_caption_v1.txt`) framed both keys as optional ("only when... ", "omit a key only when it genuinely does not apply"). The model therefore frequently emitted captions with **neither** key, which the gate rejects.

### Prompt change
Rewrote the `## style_description` section:
- The lead-in now says ALWAYS include `aesthetics`, `lighting`, `medium`, `color_palette`, AND exactly one discriminator key.
- Removed the per-key "only when..." optionality on `photo`/`art_style`.
- Added a dedicated **REQUIRED discriminator** subsection: emit EXACTLY ONE of `photo` / `art_style`, "never both, never neither"; photograph → `photo`, anything else → `art_style`; decide from `medium` when unsure; emit a concrete generic value rather than omit.

No other section was touched — the BBOX `[y1, x1, y2, x2]` / `1000` / `KEEP these bboxes` text and all other sections are intact.

### Test
Extended `prompt_refine_jobs::tests::image_caption_asset_extracts_system_and_user_blocks` (the existing embedded-system-prompt substring test) to assert the discriminator guidance is present: `EXACTLY ONE`, `never both, never neither`, and both `photo` and `art_style`. The existing BBOX assertions are unchanged.

### Build status
- `cargo fmt --all -- --check`: clean
- `cargo test -p sceneworks-worker --lib`: 401 passed, 0 failed, 94 ignored
- Existing prompt-substring (BBOX) assertions still pass.

Links sc-8194.

🤖 Generated with [Claude Code](https://claude.com/claude-code)