### PR TITLE
fix(api): normalize detected LoRA family before compatibility check (krea_2 false reject) — sc-8185

### DIFF
--- a/apps/rust-api/src/loras.rs
+++ b/apps/rust-api/src/loras.rs
@@ -833,6 +833,13 @@ pub(crate) fn validate_lora_specs_for_model(
         }
         let header = validate_lora_safetensors_header(lora_id, lora)?;
         if let Some(detected_family) = header.as_ref().and_then(detect_lora_family) {
+            // `model_families` are normalized (via `model_lora_families` →
+            // `normalize_lora_family`, `_`→`-`), but `detect_lora_family` returns the catalog/
+            // trainer-verbatim token (e.g. `krea_2`, underscore — chosen so import-time
+            // reconciliation matches the catalog string raw). Normalize the detected family to the
+            // same canonical form before the membership test, else a krea_2 LoRA is falsely
+            // rejected against a `krea-2`-normalized model surface (sc-8185).
+            let detected_family = normalize_lora_family(&detected_family);
             if !model_families
                 .iter()
                 .any(|model_family| model_family == &detected_family)
@@ -1234,5 +1241,41 @@ mod base_model_gating_tests {
         let lora = json!({ "id": "legacy", "families": ["wan-video"] });
         validate_lora_specs_for_model(&models, &[], "wan_2_2_t2v_14b", &[lora], true, "LoRA")
             .expect("family-only LoRA must still pass");
+    }
+
+    /// Minimal valid safetensors with one krea-identifying tensor key (`text_fusion`), so
+    /// `detect_lora_family` returns the catalog/trainer-verbatim `krea_2` (underscore).
+    fn write_krea_lora(dir: &std::path::Path) {
+        use std::io::Write;
+        let header = r#"{"diffusion_model.text_fusion.projector.weight":{"dtype":"F32","shape":[1],"data_offsets":[0,4]}}"#;
+        let mut bytes = (header.len() as u64).to_le_bytes().to_vec();
+        bytes.extend_from_slice(header.as_bytes());
+        bytes.extend_from_slice(&[0u8; 4]);
+        std::fs::File::create(dir.join("krea.safetensors"))
+            .unwrap()
+            .write_all(&bytes)
+            .unwrap();
+    }
+
+    /// sc-8185: a Krea LoRA's header detects as `krea_2` (underscore — the verbatim catalog/
+    /// trainer token), but the model surface declares `krea_2` which `model_lora_families`
+    /// normalizes to `krea-2`. The detected family must be normalized before the membership test,
+    /// else the LoRA is falsely rejected as "appears to be a krea_2 LoRA ... not compatible".
+    #[test]
+    fn krea_lora_passes_detected_family_check_despite_underscore() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_krea_lora(tmp.path());
+        let models = vec![json!({
+            "id": "krea_2_turbo",
+            "loraCompatibility": { "families": ["krea_2"] }
+        })];
+        let lora = json!({
+            "id": "krea_2_mysticxxx",
+            "installState": "installed",
+            "installedPath": tmp.path().to_str().unwrap(),
+            "families": ["krea_2"],
+        });
+        validate_lora_specs_for_model(&models, &[], "krea_2_turbo", &[lora], true, "LoRA")
+            .expect("krea_2 detected family must pass against a krea_2 (→krea-2) model surface");
     }
 }


### PR DESCRIPTION
## Problem
After the engine adapter-naming fix landed, selecting a community Krea 2 LoRA now fails at generate time with:

```
LoRA krea_2_mysticxxx appears to be a krea_2 LoRA, which is not compatible with model krea_2_turbo (krea-2)
```

Note the token mismatch: detected `krea_2` (underscore) vs the model surface `krea-2` (hyphen).

## Root cause
`detect_lora_family` (sceneworks-core) returns the **catalog/trainer-verbatim** family token `krea_2` (the krea detection was deliberately added with an underscore so *import-time* reconciliation — `model_jobs.rs`, raw-vs-raw — matches the catalog string). But `model_lora_families` runs the model's declared families through `normalize_lora_family` (`_`→`-`), producing `krea-2`. The runtime check in `validate_lora_specs_for_model` (`apps/rust-api/src/loras.rs:835`) compared the **raw** detected family against the **normalized** model families → `krea_2` != `krea-2` → false rejection. Every other detected family is already hyphenated (`wan-video`, `z-image`, …), so krea was the only one that tripped this.

## Fix
Normalize the detected family with the same `normalize_lora_family` before the membership test. One line. The declared-family check just below already normalizes both sides; the import-time path (`model_jobs.rs`, raw-vs-raw) is unaffected.

## Test
`krea_lora_passes_detected_family_check_despite_underscore` writes a minimal safetensors with a `text_fusion` tensor key (→ `detect_lora_family` = `krea_2`) and asserts it passes against a `krea_2`-declaring `krea_2_turbo` surface. Fails before the fix (raw `krea_2` ≠ `krea-2`), passes after. Existing wan gating + core krea detection tests still green.

Follow-on to the engine adapter-naming fix (mlx-gen #592 / candle-gen #165 / worker #933). Shortcut: sc-8185 (epic 7565).

🤖 Generated with [Claude Code](https://claude.com/claude-code)