### PR TITLE
fix(worker): image_caption color_palette must be #RRGGBB hex, max 5 (sc-8197)

### DIFF
--- a/crates/sceneworks-worker/src/ideogram_image_caption_v1.txt
+++ b/crates/sceneworks-worker/src/ideogram_image_caption_v1.txt
@@ -41,7 +41,7 @@ A JSON object capturing the visual style you observe. ALWAYS include `aesthetics
 - `aesthetics`: the overall visual character (e.g. `cinematic`, `flat vector illustration`, `gritty documentary`, `soft pastel`).
 - `lighting`: the light you see (direction, hardness, color temperature, time-of-day cues) — `hard side light from the left, warm golden-hour tone`.
 - `medium`: the production medium — `photograph`, `3D render`, `oil painting`, `watercolor`, `digital illustration`, `pencil sketch`. Pick the one that matches what you see.
-- `color_palette`: the dominant colors actually present, as a short list of concrete color names.
+- `color_palette`: the dominant colors actually present, as a list of UPPERCASE `#RRGGBB` hex codes — MAXIMUM 5 colors. Use hex codes, NOT color names: write `#F5F5DC`, never `beige`; `#8B5A2B`, never `brown`. Pick the up-to-5 most dominant colors you actually see and give each as a `#RRGGBB` hex value (e.g. `["#1A2B3C", "#F5F5DC", "#8B5A2B"]`).
 
 ### REQUIRED discriminator — emit EXACTLY ONE of `photo` or `art_style` (never both, never neither)
 

--- a/crates/sceneworks-worker/src/prompt_refine_jobs.rs
+++ b/crates/sceneworks-worker/src/prompt_refine_jobs.rs
@@ -970,6 +970,17 @@ mod tests {
         );
         assert!(system.contains("photo"));
         assert!(system.contains("art_style"));
+        // sc-8197: `style_description.color_palette` must be #RRGGBB hex codes (the web schema's
+        // `verifyColorPalette` rejects color names) with a maximum of 5 entries. The prompt must
+        // require uppercase hex codes and cap the list.
+        assert!(
+            system.contains("#RRGGBB"),
+            "system requires color_palette as #RRGGBB hex codes (not color names)"
+        );
+        assert!(
+            system.contains("MAXIMUM 5"),
+            "system caps color_palette at a maximum of 5 colors"
+        );
         // Output is fenced so it survives markdown.
         assert!(system.contains("```json"));
         // The `[META]` thinking flag does not bleed into the system body.


### PR DESCRIPTION
## sc-8197 — image_caption prompt: color_palette must be #RRGGBB hex (not names), max 5 colors

### Problem
The Ideogram caption schema requires `style_description.color_palette` entries to be `#RRGGBB` hex codes (`apps/web/src/ideogramCaption.js` → `verifyColorPalette`). The vision captioner was emitting **color names** ("beige", "brown", "cream", "gold"), producing validation errors like:

> `style_description.color_palette[0]: 'beige' is not a valid #RRGGBB hex color`

### Schema rule
- `color_palette` entries must be UPPERCASE `#RRGGBB` hex codes — never color names.
- **Maximum 5** colors.

### Prompt change
In `crates/sceneworks-worker/src/ideogram_image_caption_v1.txt`, the `style_description.color_palette` bullet now requires UPPERCASE `#RRGGBB` hex codes, MAXIMUM 5 colors, with explicit name→hex examples (`#F5F5DC` not `beige`; `#8B5A2B` not `brown`).

Only the one `color_palette` LIST bullet governs palette output. Prose color words inside element `desc` (e.g. "each garment with color") are intentionally left as prose — the hex requirement applies only to the `color_palette` list field. The discriminator rule and BBOX section (`[y1, x1, y2, x2]` / `1000` / `KEEP these bboxes`) are untouched.

### Test
Extended `image_caption_asset_extracts_system_and_user_blocks` in `crates/sceneworks-worker/src/prompt_refine_jobs.rs` to also assert the system prompt contains `#RRGGBB` and `MAXIMUM 5`, keeping all existing discriminator + BBOX assertions.

### Build status
- `cargo fmt --all` + `--check`: clean
- `cargo test -p sceneworks-worker --lib`: **401 passed, 0 failed, 94 ignored** — existing discriminator + BBOX prompt assertions still pass.

Closes sc-8197.

🤖 Generated with [Claude Code](https://claude.com/claude-code)