### PR TITLE
fix(worker): image_caption palette — restore style→16, add optional element color_palette cap 5 (sc-8199)

### DIFF
--- a/crates/sceneworks-worker/src/ideogram_image_caption_v1.txt
+++ b/crates/sceneworks-worker/src/ideogram_image_caption_v1.txt
@@ -41,7 +41,7 @@ A JSON object capturing the visual style you observe. ALWAYS include `aesthetics
 - `aesthetics`: the overall visual character (e.g. `cinematic`, `flat vector illustration`, `gritty documentary`, `soft pastel`).
 - `lighting`: the light you see (direction, hardness, color temperature, time-of-day cues) — `hard side light from the left, warm golden-hour tone`.
 - `medium`: the production medium — `photograph`, `3D render`, `oil painting`, `watercolor`, `digital illustration`, `pencil sketch`. Pick the one that matches what you see.
-- `color_palette`: the dominant colors actually present, as a list of UPPERCASE `#RRGGBB` hex codes — MAXIMUM 5 colors. Use hex codes, NOT color names: write `#F5F5DC`, never `beige`; `#8B5A2B`, never `brown`. Pick the up-to-5 most dominant colors you actually see and give each as a `#RRGGBB` hex value (e.g. `["#1A2B3C", "#F5F5DC", "#8B5A2B"]`).
+- `color_palette`: the whole-image dominant colors actually present, as a list of UPPERCASE `#RRGGBB` hex codes — up to 16, ordered most→least prominent (use as many as the image genuinely shows; more colors = richer palette). Use hex codes, NOT color names: write `#F5F5DC`, never `beige`; `#8B5A2B`, never `brown` (e.g. `["#1A2B3C", "#F5F5DC", "#8B5A2B"]`).
 
 ### REQUIRED discriminator — emit EXACTLY ONE of `photo` or `art_style` (never both, never neither)
 
@@ -56,8 +56,8 @@ Observe the medium from the pixels — film grain and lens character mean photog
 
 Each visible subject is one element:
 ```
-{"type":"obj","bbox":[y1,x1,y2,x2],"desc":"..."}
-{"type":"text","bbox":[y1,x1,y2,x2],"text":"LINE ONE\nLINE TWO","desc":"..."}
+{"type":"obj","bbox":[y1,x1,y2,x2],"desc":"...","color_palette":["#RRGGBB", ...]}
+{"type":"text","bbox":[y1,x1,y2,x2],"text":"LINE ONE\nLINE TWO","desc":"...","color_palette":["#RRGGBB", ...]}
 ```
 
 ### SINGLE SUBJECT = SINGLE ELEMENT
@@ -65,6 +65,12 @@ Each visible subject is one element:
 A coherent subject you can see — one animal, person, vehicle, building, plant, instrument, machine — is exactly ONE `obj` element. Anatomical and structural parts are descriptive attributes inside that element's `desc`, NOT separate elements. A bee is one element, not eight (thorax/abdomen/wings/...). When MULTIPLE distinct subjects appear (a person AND a dog; two bees), use MULTIPLE elements — one per visible subject.
 
 **Test:** part-of-one-thing → goes in that thing's desc. Separate thing you can see → its own element.
+
+### Element `color_palette` — OPTIONAL, per subject
+
+Each element MAY carry its own `color_palette` as the LAST key (after `desc`; for a `text` element, after `desc`). Include it ONLY when the subject has a clear, distinct palette worth recording — omit it entirely otherwise (it is optional, never required).
+- These are the colors of THAT subject specifically — distinct from `style_description.color_palette`, which is the whole-image palette.
+- Same format as the style palette: UPPERCASE `#RRGGBB` hex codes, NOT color names. 2–4 colors typical, **MAXIMUM 5**.
 
 ### Element desc — what to write (30–60 words, 60-word HARD CAP)
 

--- a/crates/sceneworks-worker/src/prompt_refine_jobs.rs
+++ b/crates/sceneworks-worker/src/prompt_refine_jobs.rs
@@ -970,16 +970,29 @@ mod tests {
         );
         assert!(system.contains("photo"));
         assert!(system.contains("art_style"));
-        // sc-8197: `style_description.color_palette` must be #RRGGBB hex codes (the web schema's
-        // `verifyColorPalette` rejects color names) with a maximum of 5 entries. The prompt must
-        // require uppercase hex codes and cap the list.
+        // sc-8197: `color_palette` must be #RRGGBB hex codes (the web schema's `verifyColorPalette`
+        // rejects color names). The prompt must require uppercase hex codes.
         assert!(
             system.contains("#RRGGBB"),
             "system requires color_palette as #RRGGBB hex codes (not color names)"
         );
+        // sc-8199: the STYLE palette now allows richer palettes (up to 16, STYLE_PALETTE_MAX),
+        // restored from the mistaken cap of 5.
+        assert!(
+            system.contains("up to 16"),
+            "system allows the style color_palette up to 16 entries"
+        );
+        // sc-8199: each ELEMENT may carry its own optional `color_palette` (last key). The element
+        // format example must show the optional per-subject palette.
+        assert!(
+            system.contains("\"color_palette\":[\"#RRGGBB\""),
+            "element format example carries an optional per-subject color_palette"
+        );
+        // sc-8199: the per-element palette is capped at 5 (ELEMENT_PALETTE_MAX); the `MAXIMUM 5`
+        // copy now lives in the element guidance subsection.
         assert!(
             system.contains("MAXIMUM 5"),
-            "system caps color_palette at a maximum of 5 colors"
+            "system caps the element color_palette at a maximum of 5 colors"
         );
         // Output is fenced so it survives markdown.
         assert!(system.contains("```json"));


### PR DESCRIPTION
## Summary

Two fixes to the epic-8102 `image_caption` vision system prompt (`crates/sceneworks-worker/src/ideogram_image_caption_v1.txt`):

1. **Restore the style-level `color_palette` cap to 16** (`STYLE_PALETTE_MAX`). It had been mistakenly set to 5; richer whole-image palettes are wanted. Copy now reads "up to 16, ordered most→least prominent (use as many as the image genuinely shows; more colors = richer palette)".

2. **Add the optional per-element `color_palette` instruction** (cap 5, `ELEMENT_PALETTE_MAX`). It is the LAST key on each element:
   - `obj`: `type, bbox, desc, color_palette`
   - `text`: `type, bbox, text, desc, color_palette`

   The format examples now show `"color_palette":["#RRGGBB", ...]`, and a new "Element `color_palette` — OPTIONAL, per subject" guidance subsection documents it: optional (never required), the colors of THAT subject specifically (distinct from the whole-image `style_description.color_palette`), same `#RRGGBB` hex format, 2–4 typical, **MAXIMUM 5**.

No other part of the prompt changed — the discriminator rule, BBOX section (`[y1, x1, y2, x2]` / `1000` / `KEEP these bboxes`), OBSERVE/background/specificity sections are intact, and no `aspect_ratio` key was reintroduced.

## Tests

Updated the worker prompt-content test `image_caption_asset_extracts_system_and_user_blocks` in `crates/sceneworks-worker/src/prompt_refine_jobs.rs`:
- Keeps: `#RRGGBB`, discriminator (`EXACTLY ONE` / `never both, never neither`), and BBOX assertions.
- Adds: `up to 16` (richer style palette).
- Adds: `"color_palette":["#RRGGBB"` (the element format-block substring).
- Keeps: `MAXIMUM 5` (now the element cap).

## Build status

- `cargo fmt --all -- --check`: clean
- `cargo test -p sceneworks-worker --lib`: 401 passed, 0 failed, 94 ignored. Existing prompt tests still pass.

Story: sc-8199
🤖 Generated with [Claude Code](https://claude.com/claude-code)