### PR TITLE
fix(worker+api): inline upscale heartbeat keepalive + broadcast job.updated on stale-sweep (sc-8200)

### DIFF
--- a/crates/sceneworks-worker/src/ideogram_image_caption_v1.txt
+++ b/crates/sceneworks-worker/src/ideogram_image_caption_v1.txt
@@ -41,7 +41,7 @@ A JSON object capturing the visual style you observe. ALWAYS include `aesthetics
 - `aesthetics`: the overall visual character (e.g. `cinematic`, `flat vector illustration`, `gritty documentary`, `soft pastel`).
 - `lighting`: the light you see (direction, hardness, color temperature, time-of-day cues) — `hard side light from the left, warm golden-hour tone`.
 - `medium`: the production medium — `photograph`, `3D render`, `oil painting`, `watercolor`, `digital illustration`, `pencil sketch`. Pick the one that matches what you see.
-- `color_palette`: the dominant colors actually present, as a list of UPPERCASE `#RRGGBB` hex codes — MAXIMUM 5 colors. Use hex codes, NOT color names: write `#F5F5DC`, never `beige`; `#8B5A2B`, never `brown`. Pick the up-to-5 most dominant colors you actually see and give each as a `#RRGGBB` hex value (e.g. `["#1A2B3C", "#F5F5DC", "#8B5A2B"]`).
+- `color_palette`: the whole-image dominant colors actually present, as a list of UPPERCASE `#RRGGBB` hex codes — up to 16, ordered most→least prominent (use as many as the image genuinely shows; more colors = richer palette). Use hex codes, NOT color names: write `#F5F5DC`, never `beige`; `#8B5A2B`, never `brown` (e.g. `["#1A2B3C", "#F5F5DC", "#8B5A2B"]`).
 
 ### REQUIRED discriminator — emit EXACTLY ONE of `photo` or `art_style` (never both, never neither)
 
@@ -56,8 +56,8 @@ Observe the medium from the pixels — film grain and lens character mean photog
 
 Each visible subject is one element:
 ```
-{"type":"obj","bbox":[y1,x1,y2,x2],"desc":"..."}
-{"type":"text","bbox":[y1,x1,y2,x2],"text":"LINE ONE\nLINE TWO","desc":"..."}
+{"type":"obj","bbox":[y1,x1,y2,x2],"desc":"...","color_palette":["#RRGGBB", ...]}
+{"type":"text","bbox":[y1,x1,y2,x2],"text":"LINE ONE\nLINE TWO","desc":"...","color_palette":["#RRGGBB", ...]}
 ```
 
 ### SINGLE SUBJECT = SINGLE ELEMENT
@@ -65,6 +65,12 @@ Each visible subject is one element:
 A coherent subject you can see — one animal, person, vehicle, building, plant, instrument, machine — is exactly ONE `obj` element. Anatomical and structural parts are descriptive attributes inside that element's `desc`, NOT separate elements. A bee is one element, not eight (thorax/abdomen/wings/...). When MULTIPLE distinct subjects appear (a person AND a dog; two bees), use MULTIPLE elements — one per visible subject.
 
 **Test:** part-of-one-thing → goes in that thing's desc. Separate thing you can see → its own element.
+
+### Element `color_palette` — OPTIONAL, per subject
+
+Each element MAY carry its own `color_palette` as the LAST key (after `desc`; for a `text` element, after `desc`). Include it ONLY when the subject has a clear, distinct palette worth recording — omit it entirely otherwise (it is optional, never required).
+- These are the colors of THAT subject specifically — distinct from `style_description.color_palette`, which is the whole-image palette.
+- Same format as the style palette: UPPERCASE `#RRGGBB` hex codes, NOT color names. 2–4 colors typical, **MAXIMUM 5**.
 
 ### Element desc — what to write (30–60 words, 60-word HARD CAP)
 

--- a/crates/sceneworks-worker/src/ideogram_image_caption_v1.txt
+++ b/crates/sceneworks-worker/src/ideogram_image_caption_v1.txt
@@ -41,7 +41,7 @@ A JSON object capturing the visual style you observe. ALWAYS include `aesthetics
 - `aesthetics`: the overall visual character (e.g. `cinematic`, `flat vector illustration`, `gritty documentary`, `soft pastel`).
 - `lighting`: the light you see (direction, hardness, color temperature, time-of-day cues) — `hard side light from the left, warm golden-hour tone`.
 - `medium`: the production medium — `photograph`, `3D render`, `oil painting`, `watercolor`, `digital illustration`, `pencil sketch`. Pick the one that matches what you see.
-- `color_palette`: the dominant colors actually present, as a short list of concrete color names.
+- `color_palette`: the dominant colors actually present, as a list of UPPERCASE `#RRGGBB` hex codes — MAXIMUM 5 colors. Use hex codes, NOT color names: write `#F5F5DC`, never `beige`; `#8B5A2B`, never `brown`. Pick the up-to-5 most dominant colors you actually see and give each as a `#RRGGBB` hex value (e.g. `["#1A2B3C", "#F5F5DC", "#8B5A2B"]`).
 
 ### REQUIRED discriminator — emit EXACTLY ONE of `photo` or `art_style` (never both, never neither)
 

--- a/crates/sceneworks-worker/src/prompt_refine_jobs.rs
+++ b/crates/sceneworks-worker/src/prompt_refine_jobs.rs
@@ -970,16 +970,29 @@ mod tests {
         );
         assert!(system.contains("photo"));
         assert!(system.contains("art_style"));
-        // sc-8197: `style_description.color_palette` must be #RRGGBB hex codes (the web schema's
-        // `verifyColorPalette` rejects color names) with a maximum of 5 entries. The prompt must
-        // require uppercase hex codes and cap the list.
+        // sc-8197: `color_palette` must be #RRGGBB hex codes (the web schema's `verifyColorPalette`
+        // rejects color names). The prompt must require uppercase hex codes.
         assert!(
             system.contains("#RRGGBB"),
             "system requires color_palette as #RRGGBB hex codes (not color names)"
         );
+        // sc-8199: the STYLE palette now allows richer palettes (up to 16, STYLE_PALETTE_MAX),
+        // restored from the mistaken cap of 5.
+        assert!(
+            system.contains("up to 16"),
+            "system allows the style color_palette up to 16 entries"
+        );
+        // sc-8199: each ELEMENT may carry its own optional `color_palette` (last key). The element
+        // format example must show the optional per-subject palette.
+        assert!(
+            system.contains("\"color_palette\":[\"#RRGGBB\""),
+            "element format example carries an optional per-subject color_palette"
+        );
+        // sc-8199: the per-element palette is capped at 5 (ELEMENT_PALETTE_MAX); the `MAXIMUM 5`
+        // copy now lives in the element guidance subsection.
         assert!(
             system.contains("MAXIMUM 5"),
-            "system caps color_palette at a maximum of 5 colors"
+            "system caps the element color_palette at a maximum of 5 colors"
         );
         // Output is fenced so it survives markdown.
         assert!(system.contains("```json"));

--- a/crates/sceneworks-worker/src/prompt_refine_jobs.rs
+++ b/crates/sceneworks-worker/src/prompt_refine_jobs.rs
@@ -970,6 +970,17 @@ mod tests {
         );
         assert!(system.contains("photo"));
         assert!(system.contains("art_style"));
+        // sc-8197: `style_description.color_palette` must be #RRGGBB hex codes (the web schema's
+        // `verifyColorPalette` rejects color names) with a maximum of 5 entries. The prompt must
+        // require uppercase hex codes and cap the list.
+        assert!(
+            system.contains("#RRGGBB"),
+            "system requires color_palette as #RRGGBB hex codes (not color names)"
+        );
+        assert!(
+            system.contains("MAXIMUM 5"),
+            "system caps color_palette at a maximum of 5 colors"
+        );
         // Output is fenced so it survives markdown.
         assert!(system.contains("```json"));
         // The `[META]` thinking flag does not bleed into the system body.


### PR DESCRIPTION
## Symptom
A SeedVR2 Image Studio upscale left the worker UI stuck on **"Upscaling…" forever**, while the worker logged:
```
MLX-WORKER ERROR utility_job_failed jobId=job_… error=API 409 Conflict: Job job_… is already interrupted; terminal jobs cannot be updated.
```
(The worker was actually idle — `generator_cache_idle_evicted` fired ~5 min later. Only the UI was wrong.)

## Root cause — two compounding bugs

**Bug A — inline upscale had no heartbeat keepalive (the trigger).** The Rust worker sends no periodic heartbeat on its own during a job; long jobs survive only via a spawned keepalive (every 5–15s, `progress_report_interval`). Posting *progress* doesn't refresh the worker's `last_seen` — only the heartbeat does — so the heartbeat is the only thing holding off the API's stale-sweep (`SCENEWORKS_WORKER_TIMEOUT_SECONDS`, default **90s**). The standalone `image_upscale` job wraps the SeedVR2 compute in `run_upscale_with_heartbeat`, but the inline path restored in sc-8091 (`upscale_image_in_memory`) called the engine **directly**. SeedVR2 load + one-step diffusion exceeds 90s → the worker goes silent → the stale-sweep marks the in-flight `image_generate` job `interrupted` mid-flight → the worker's terminal post 409s and the work is lost.

**Bug B — the stale-sweep never broadcasts `job.updated` (why the UI hangs).** The sweep mutates jobs to `interrupted` in the DB but emits no per-job SSE event, unlike the worker-reported terminal (`update_job_progress`) and supervisor-crash (`worker_terminated`) paths. The web job cards are driven by `job.updated` → `setJobs`; `queue.updated` only refreshes the summary/workers. So the card keeps its last running state indefinitely. (Pre-existing latent defect, independent of upscale.)

## Fix
- **worker** (`crates/sceneworks-worker/src/upscale_jobs.rs`): `upscale_image_in_memory` now runs **both** engines (SeedVR2 + Real-ESRGAN) under `run_upscale_with_heartbeat`, mirroring the standalone job — keepalive heartbeats + cooperative cancel during model load + diffusion. Removes the false 90s interrupt.
- **api** (`apps/rust-api/src/lib.rs`): `queue_summary_snapshot` captures the sweep result and broadcasts `job.updated` for each interrupted job, so a genuinely-stalled/dead worker's job flips to "Interrupted" live instead of spinning forever. The sweep returns each job exactly once (it also flips the worker offline) → no spam.
- **test** (`apps/rust-api/src/tests.rs`): regression `stale_sweep_broadcasts_job_updated_for_interrupted_jobs`.

## Validation
- `cargo check` + `clippy --all-targets -- -D warnings` clean (`sceneworks-worker` + `sceneworks-rust-api`); `cargo fmt --all --check` clean.
- Full `sceneworks-rust-api` lib suite **142 passed** (incl. the new regression).
- **Remaining gate:** on-device real-weight — a long inline SeedVR2 upscale on a Mac (e.g. 2x, which fits per sc-8135) completing without a spurious `interrupted`/409 and the card resolving normally. Can't run in a worktree (needs Mac + licensed checkpoint).

Story: [sc-8200](https://app.shortcut.com/trefry/story/8200) (epic 4811). Relates to sc-8091, sc-8135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)