### PR TITLE
feat(image): reference-image → native prompt for all t2i models (epic 8203)

### DIFF
--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -22,23 +22,29 @@ pub(crate) struct PromptRefineRequest {
     /// the web assets.
     pub(crate) guide: Option<String>,
     /// `"refine"` (default), `"magic_prompt"` (expand a plain idea into a structured
-    /// Ideogram 4 JSON caption, epic 4725/sc-5997), or `"image_caption"` (turn a
+    /// Ideogram 4 JSON caption, epic 4725/sc-5997), `"image_caption"` (turn a
     /// reference image into the same structured caption via the vision model, epic
-    /// 8102/sc-8108). The latter carries a `source_asset_id` + `project_id` instead of
-    /// a prompt; the handler resolves them to the worker's confined `imagePath`.
+    /// 8102/sc-8108), or `"image_describe"` (turn a reference image into a plain-text
+    /// description for a non-structured t2i model, epic 8203/sc-8206). The two vision
+    /// tasks carry a `source_asset_id` + `project_id` instead of a prompt; the handler
+    /// resolves them to the worker's confined `imagePath`.
     pub(crate) task: Option<String>,
     /// Target image aspect ratio as `"W:H"` (magic-prompt only); drives bbox/layout
     /// decisions in the caption. Defaults to `"1:1"` worker-side when absent.
     pub(crate) aspect_ratio: Option<String>,
-    /// Reference image for the `image_caption` task: a project asset id resolved to a
-    /// confined on-disk path before the job is enqueued (epic 8102, sc-8108).
+    /// Reference image for the vision tasks (`image_caption` / `image_describe`): a project
+    /// asset id resolved to a confined on-disk path before the job is enqueued (epic 8102/8203).
     pub(crate) source_asset_id: Option<String>,
-    /// Project owning `source_asset_id` (required for the `image_caption` task so the
+    /// Project owning `source_asset_id` (required for the vision tasks so the
     /// asset's relative `file.path` can be resolved to an absolute path).
     pub(crate) project_id: Option<String>,
     /// HF repo string of the model the worker should load (the worker resolves by repo,
-    /// not by catalog id). The web sends the vision model's repo for `image_caption`.
+    /// not by catalog id). The web sends the vision model's repo for the vision tasks.
     pub(crate) model: Option<String>,
+    /// Plain-text describe style for `image_describe` (epic 8203, sc-8205): `"prose"`
+    /// (default) or `"tags"` (booru/danbooru tags for anime SDXL checkpoints). Forwarded
+    /// verbatim; the worker parses it (unknown/absent → prose).
+    pub(crate) caption_style: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -29,7 +29,7 @@ use sceneworks_core::hf_home::{huggingface_hub_cache_dir, huggingface_repo_cache
 use sceneworks_core::jobs_store::{
     candle_supported, mac_capabilities, mac_rust_supported, model_mac_support, CreateJob,
     DuplicateJob, JobsStore, JobsStoreError, MacCapabilities, ProgressUpdate, RegisterWorker,
-    RetryJob, RouteDecision, UnsupportedReason, WorkerHeartbeat, JOB_STATUSES,
+    RetryJob, RouteDecision, StaleSweep, UnsupportedReason, WorkerHeartbeat, JOB_STATUSES,
 };
 use sceneworks_core::lora_family::{
     apply_model_manifest_defaults, detect_lora_family, detect_model_family, first_safetensors_path,
@@ -1265,11 +1265,24 @@ where
 }
 
 async fn queue_summary_snapshot(state: AppState) -> Result<QueueSummary, ApiError> {
-    store_call(state, |store, timeout| {
-        store.mark_stale_workers_interrupted(timeout)?;
-        store.queue_summary()
-    })
-    .await
+    let (sweep, summary): (StaleSweep, QueueSummary) =
+        store_call(state.clone(), |store, timeout| {
+            let sweep = store.mark_stale_workers_interrupted(timeout)?;
+            let summary = store.queue_summary()?;
+            Ok((sweep, summary))
+        })
+        .await?;
+    // The stale-sweep mutates jobs to `interrupted` in the DB but — unlike a worker-reported
+    // terminal status (`update_job_progress`) or the supervisor crash path (`worker_terminated`) —
+    // emits no per-job event. Broadcast `job.updated` for each swept job so a live client's job card
+    // flips to "Interrupted" instead of showing its last running state forever: the frontend's job
+    // list is driven by `job.updated`, while `queue.updated` only refreshes the summary/workers
+    // (sc-8186). The sweep returns each job exactly once (it also flips the owning worker offline, so
+    // a later sweep can't re-select it), so this neither spams nor double-fires.
+    for job in &sweep.jobs {
+        publish(&state, "job.updated", job);
+    }
+    Ok(summary)
 }
 
 async fn create_generation_job(

--- a/apps/rust-api/src/prompts.rs
+++ b/apps/rust-api/src/prompts.rs
@@ -14,13 +14,14 @@ pub(crate) async fn create_prompt_refine_job(
         .as_deref()
         .map(str::trim)
         .filter(|value| !value.is_empty());
-    // The reference-image → JSON caption task (epic 8102, sc-8108) is driven by an image, not a text
-    // prompt: it carries a project `sourceAssetId` instead. Resolve that to the worker's confined
+    // The reference-image vision tasks — `image_caption` (epic 8102, sc-8108) → JSON caption, and
+    // `image_describe` (epic 8203, sc-8206) → plain-text description — are driven by an image, not a
+    // text prompt: they carry a project `sourceAssetId` instead. Resolve that to the worker's confined
     // on-disk `imagePath` and forward the vision model's repo; the prompt requirement is waived.
-    let is_image_caption = task == Some("image_caption");
+    let is_vision_task = task == Some("image_caption") || task == Some("image_describe");
 
     let prompt = payload.prompt.trim();
-    if prompt.is_empty() && !is_image_caption {
+    if prompt.is_empty() && !is_vision_task {
         return Err(ApiError::bad_request("Prompt cannot be empty"));
     }
 
@@ -29,19 +30,23 @@ pub(crate) async fn create_prompt_refine_job(
         job_payload.insert("prompt".to_owned(), Value::String(prompt.to_owned()));
     }
 
-    if is_image_caption {
+    if is_vision_task {
         let asset_id = payload
             .source_asset_id
             .as_deref()
             .map(str::trim)
             .filter(|value| !value.is_empty())
-            .ok_or_else(|| ApiError::bad_request("sourceAssetId is required for image_caption"))?;
+            .ok_or_else(|| {
+                ApiError::bad_request("sourceAssetId is required for a reference-image task")
+            })?;
         let project_id = payload
             .project_id
             .as_deref()
             .map(str::trim)
             .filter(|value| !value.is_empty())
-            .ok_or_else(|| ApiError::bad_request("projectId is required for image_caption"))?;
+            .ok_or_else(|| {
+                ApiError::bad_request("projectId is required for a reference-image task")
+            })?;
         let image_path = resolve_image_caption_path(state.clone(), project_id, asset_id).await?;
         job_payload.insert("imagePath".to_owned(), Value::String(image_path));
         // The vision model is named by its HF repo string; the worker resolves it by repo (like the
@@ -53,6 +58,19 @@ pub(crate) async fn create_prompt_refine_job(
             .filter(|value| !value.is_empty())
         {
             job_payload.insert("model".to_owned(), Value::String(model.to_owned()));
+        }
+        // `image_describe` carries the per-model describe style (prose vs booru tags, sc-8205); forward
+        // it verbatim for the worker to parse. Harmless for `image_caption` (the worker ignores it).
+        if let Some(caption_style) = payload
+            .caption_style
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            job_payload.insert(
+                "captionStyle".to_owned(),
+                Value::String(caption_style.to_owned()),
+            );
         }
     }
 

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -8634,6 +8634,69 @@ async fn worker_heartbeat_interrupts_previous_active_job_through_http() {
 }
 
 #[tokio::test]
+async fn stale_sweep_broadcasts_job_updated_for_interrupted_jobs() {
+    // sc-8186: the heartbeat stale-sweep marks an in-flight job `interrupted` in the DB, but
+    // (unlike a worker-reported terminal status) emitted no per-job event — so a live client's
+    // job card, driven by `job.updated`, showed its last running state forever. The sweep must
+    // now broadcast `job.updated` for each job it interrupts.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let mut settings = test_settings(&temp_dir);
+    // Smallest timeout the store honors (clamped to >=1s); we sleep just past it to go stale.
+    settings.worker_timeout_seconds = 1;
+    let (app, state) = create_app_with_state(settings).expect("app creates");
+
+    request(
+        app.clone(),
+        "POST",
+        "/api/v1/workers/register",
+        json!({
+            "workerId": "worker-1",
+            "gpuId": "gpu-0",
+            "gpuName": null,
+            "capabilities": ["image_generate"],
+            "loadedModels": []
+        }),
+    )
+    .await;
+    let (_, created) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/jobs",
+        json!({ "type": "image_generate", "payload": {}, "requestedGpu": "auto" }),
+    )
+    .await;
+    let job_id = created["id"].as_str().expect("job id is string").to_owned();
+    request(
+        app.clone(),
+        "POST",
+        "/api/v1/jobs/claim",
+        json!({ "workerId": "worker-1" }),
+    )
+    .await;
+
+    // Let the worker's last_seen age past the (1s) timeout so the next sweep interrupts its job,
+    // then subscribe so we only observe the sweep's events. last_seen is stored at second
+    // granularity and the cutoff is `now - 1s`, so we sleep just over 2s to clear the boundary.
+    tokio::time::sleep(Duration::from_millis(2_100)).await;
+    let mut events = state.events.subscribe();
+
+    // Any endpoint that runs `queue_summary_snapshot` triggers the sweep; GET /queue is the
+    // canonical one.
+    let (status, _) = request(app.clone(), "GET", "/api/v1/queue", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let sweep_events = drain_event_names(&mut events).await;
+    assert!(
+        sweep_events.iter().any(|name| name == "job.updated"),
+        "the stale-sweep must broadcast job.updated for the interrupted job: {sweep_events:?}"
+    );
+
+    let (status, job) = request(app, "GET", &format!("/api/v1/jobs/{job_id}"), Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(job["status"], "interrupted");
+}
+
+#[tokio::test]
 async fn access_token_is_enforced_on_protected_routes() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let mut settings = test_settings(&temp_dir);

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -4162,6 +4162,91 @@ async fn image_caption_refine_job_requires_source_asset_and_project() {
 }
 
 #[tokio::test]
+async fn image_describe_refine_job_resolves_asset_and_forwards_caption_style() {
+    // epic 8203 / sc-8206: the reference-image → plain-text DESCRIBE flow POSTs `task: "image_describe"`
+    // with a project `sourceAssetId` (+ `projectId`), the vision model's repo, and an optional
+    // `captionStyle`. The handler resolves the asset to a confined on-disk `imagePath` (same path as the
+    // caption flow) and forwards `model` + `captionStyle` verbatim, with no text prompt required.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Describe Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id").to_owned();
+    let project_path = std::path::PathBuf::from(project["path"].as_str().unwrap());
+
+    let (status, asset) = request_multipart_upload(
+        app.clone(),
+        &format!("/api/v1/projects/{project_id}/assets"),
+        "Reference.PNG",
+        "image/png",
+        b"png-bytes",
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let asset_id = asset["id"].as_str().expect("asset id").to_owned();
+    let rel_path = asset["file"]["path"]
+        .as_str()
+        .expect("file path")
+        .to_owned();
+
+    let (status, job) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/prompts/refine",
+        json!({
+            "task": "image_describe",
+            "sourceAssetId": asset_id,
+            "projectId": project_id,
+            "model": "huihui-ai/Huihui-Qwen3-VL-8B-Instruct-abliterated",
+            "captionStyle": "tags"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(job["type"], "prompt_refine");
+    assert_eq!(job["payload"]["task"], "image_describe");
+    assert_eq!(job["payload"]["captionStyle"], "tags");
+    assert!(job["payload"].get("prompt").is_none());
+    let expected = project_path.join(&rel_path);
+    assert_eq!(
+        job["payload"]["imagePath"].as_str().unwrap(),
+        expected.display().to_string()
+    );
+}
+
+#[tokio::test]
+async fn image_describe_refine_job_requires_source_asset_and_project() {
+    // sc-8206: the describe task is image-driven like image_caption, so it must reject a request missing
+    // the `sourceAssetId` or `projectId`.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    let (status, _) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/prompts/refine",
+        json!({ "task": "image_describe", "projectId": "project-1" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    let (status, _) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/prompts/refine",
+        json!({ "task": "image_describe", "sourceAssetId": "asset-1" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn image_and_video_job_routes_normalize_payloads() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let app = create_app(test_settings(&temp_dir)).expect("app creates");

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1515,6 +1515,49 @@ export function App() {
     [token],
   );
 
+  // Reference-image → plain-text description (epic 8203, sc-8208): the sibling of `imageCaption` for
+  // NON-structured text-to-image models. Same `prompts/refine` endpoint + poll contract, but
+  // `task: "image_describe"` drives the worker's prose/tags vision path (sc-8204/8205). `captionStyle`
+  // (from the catalog, default prose) selects natural-language prose vs booru tags. Resolves to the raw
+  // text the caller drops into the prompt box. C1: the image is consumed only to produce the prompt — it
+  // is NEVER passed to generation as img2img conditioning.
+  const imageDescribe = useCallback(
+    async ({ sourceAssetId, projectId, model, captionStyle, signal }) => {
+      const created = await apiFetch("/api/v1/prompts/refine", token, {
+        method: "POST",
+        signal,
+        body: JSON.stringify({
+          task: "image_describe",
+          sourceAssetId,
+          projectId,
+          model,
+          captionStyle,
+        }),
+      });
+      const jobId = created?.id;
+      if (!jobId) {
+        throw new Error("Could not start image description.");
+      }
+      const deadline = Date.now() + 180000;
+      while (Date.now() < deadline) {
+        await abortableDelay(1000, signal);
+        const job = await apiFetch(`/api/v1/jobs/${jobId}`, token, { signal });
+        if (job.status === "completed") {
+          const description = job.result?.refinedPrompt;
+          if (!description) {
+            throw new Error("Image description returned empty text.");
+          }
+          return description;
+        }
+        if (job.status === "failed" || job.status === "canceled" || job.status === "interrupted") {
+          throw new Error(job.message || job.error || "Image description failed.");
+        }
+      }
+      throw new Error("Image description timed out. Is the captioning runtime running?");
+    },
+    [token],
+  );
+
   const createVqaJob = useCallback(
     async (asset, question, maxNewTokens) => {
       if (!activeProject) {
@@ -1880,6 +1923,7 @@ export function App() {
     refinePrompt,
     magicPrompt,
     imageCaption,
+    imageDescribe,
     latestVideoAssets,
     recentImageAssets,
     recentVideoAssets,
@@ -1976,7 +2020,7 @@ export function App() {
     updateAssetStatus, updateAssetTags, latestImageAssets,
     jobs, jobAction, createVqaJob, createInterleaveJob, createPlaceholderJob, filteredJobs,
     jobPrompt, setJobPrompt, projectFilter, setProjectFilter, projects, visibleWorkers, workersById,
-    createVideoJob, createVideoUpscaleJob, createImageJob, refinePrompt, magicPrompt, imageCaption, latestVideoAssets, recentImageAssets,
+    createVideoJob, createVideoUpscaleJob, createImageJob, refinePrompt, magicPrompt, imageCaption, imageDescribe, latestVideoAssets, recentImageAssets,
     recentVideoAssets, videoLocalJobs, imageLocalJobs, documentLocalJobs, studioLaunch,
     rememberLocalGenerationJob, personTracks, personReadiness, createPersonDetectionJob,
     createPersonTrackJob, saveTrackCorrections, imageModels, videoModels, models, macCapabilities,

--- a/apps/web/src/components/ReferenceCaptionPicker.jsx
+++ b/apps/web/src/components/ReferenceCaptionPicker.jsx
@@ -1,0 +1,146 @@
+// Shared reference-image → prompt picker (epic 8203, sc-8208).
+//
+// Factored out of StructuredPromptBuilder so BOTH reference-image flows share one
+// component:
+//   * Ideogram 4 (structuredPrompt): reference image → editable JSON caption (epic 8102).
+//   * Every other text-to-image model: reference image → plain-text description (prose or
+//     booru tags) that fills the prompt textarea (epic 8203).
+//
+// The component owns the picker UI, the selected-asset state, the busy/error state, the
+// auto-preset-resolution probe (sc-8109), and the ModelAvailabilityGate (sc-8110) that
+// offers the vision-captioner download when it is missing. It is format-agnostic: the
+// parent supplies `onCaption(assetId)` (run the job + parse) and `onApply(result)` (apply
+// the result to its own state). C1: the image is captioning-only — never sent to generation.
+
+import React, { useEffect, useState } from "react";
+import { ImageEditSourcePickerField } from "./AssetPicker.jsx";
+import { assetUrl } from "./assetMedia.jsx";
+import { ModelAvailabilityGate } from "./ModelAvailabilityGate.jsx";
+
+export default function ReferenceCaptionPicker({
+  // Run the vision job for the picked asset and resolve to a result (the parent parses:
+  // a caption object for Ideogram, the raw prose/tags string for describe). A falsy result
+  // means the reply was not usable.
+  onCaption,
+  // Apply a truthy result to the parent's state (inject the caption / fill the prompt).
+  onApply,
+  // sc-8109 seam: invoked with the uploaded image's natural (width, height) so the parent
+  // can auto-preset the generation resolution to the nearest aspect.
+  onReferenceImageLoaded,
+  referenceAssets = [],
+  referenceCharacters = [],
+  importAsset,
+  projectId,
+  // Copy that differs between the JSON (Ideogram) and prose/tags surfaces.
+  hint,
+  buttonLabel = "✨ Generate from image",
+  busyLabel = "Working…",
+  emptyMessage = "The image didn’t produce a usable result. Try another reference.",
+  errorFallback = "Could not process the image.",
+  gateTitle = "Reference-image captioning needs a model",
+  gateDescription = "Download the vision captioner to turn a reference image into a prompt. It runs locally on the native worker; the image is only used to write the prompt.",
+  // Reference-image caption gate (sc-8110).
+  visionCaptionReady = true,
+  visionCaptionOffers = [],
+  visionCaptionDownloadJobs = [],
+  onDownloadModel,
+  onOpenModels,
+  onOpenQueue,
+  onCancelJob,
+}) {
+  const [referenceAssetId, setReferenceAssetId] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  // Feed the uploaded image's natural dimensions to the sc-8109 auto-preset seam.
+  function reportReferenceDimensions(asset) {
+    if (typeof onReferenceImageLoaded !== "function" || !asset) return;
+    const src = assetUrl(asset);
+    if (!src || typeof Image === "undefined") return;
+    const probe = new Image();
+    probe.onload = () => {
+      if (probe.naturalWidth && probe.naturalHeight) {
+        onReferenceImageLoaded(probe.naturalWidth, probe.naturalHeight);
+      }
+    };
+    probe.src = src;
+  }
+
+  function handleReferenceChange(assetId) {
+    setReferenceAssetId(assetId);
+    setError("");
+  }
+
+  // Run the auto-preset from an effect on the SELECTED id rather than the picker's onChange: a freshly
+  // imported/dragged reference lands in `referenceAssets` a render AFTER its id is set, so the
+  // onChange-time `find` missed it and the Aspect stayed at the 1:1 default (sc-8220). Keying on both
+  // the id and the list re-runs once the asset resolves, covering select / import / drag / character
+  // paths uniformly.
+  useEffect(() => {
+    if (!referenceAssetId) return;
+    const asset = referenceAssets.find((item) => item.id === referenceAssetId);
+    if (asset) reportReferenceDimensions(asset);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [referenceAssetId, referenceAssets]);
+
+  async function handleCaption() {
+    if (typeof onCaption !== "function" || !referenceAssetId || busy) return;
+    setBusy(true);
+    setError("");
+    try {
+      const result = await onCaption(referenceAssetId);
+      if (result) {
+        onApply(result);
+      } else {
+        setError(emptyMessage);
+      }
+    } catch (e) {
+      setError(e?.message || errorFallback);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="structured-reference">
+      <ModelAvailabilityGate
+        ready={visionCaptionReady}
+        title={gateTitle}
+        description={gateDescription}
+        offers={visionCaptionOffers}
+        downloadJobs={visionCaptionDownloadJobs}
+        onDownload={onDownloadModel}
+        onOpenModels={onOpenModels}
+        onOpenQueue={onOpenQueue}
+        onCancelJob={onCancelJob}
+      >
+        {hint ? <p className="structured-hint">{hint}</p> : null}
+        <ImageEditSourcePickerField
+          assets={referenceAssets}
+          buttonLabel="Select reference image"
+          changeLabel="Change reference"
+          characters={referenceCharacters}
+          emptyLabel="No reference image selected"
+          importAsset={importAsset}
+          label="Reference image"
+          onChange={handleReferenceChange}
+          projectId={projectId}
+          value={referenceAssetId}
+        />
+        <button
+          type="button"
+          className="secondary-action"
+          disabled={!referenceAssetId || busy}
+          onClick={handleCaption}
+        >
+          {busy ? busyLabel : buttonLabel}
+        </button>
+        {error ? (
+          <p className="structured-error" role="alert">
+            {error}
+          </p>
+        ) : null}
+      </ModelAvailabilityGate>
+    </div>
+  );
+}

--- a/apps/web/src/components/ReferenceCaptionPicker.test.jsx
+++ b/apps/web/src/components/ReferenceCaptionPicker.test.jsx
@@ -1,0 +1,135 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import ReferenceCaptionPicker from "./ReferenceCaptionPicker.jsx";
+
+// Shared reference-image → prompt picker (epic 8203, sc-8208). These cover the prose/tags "describe"
+// surface; the Ideogram JSON surface is covered through StructuredPromptBuilder's reference tests.
+
+function click(el) {
+  el.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+}
+
+describe("ReferenceCaptionPicker", () => {
+  let container;
+  let root;
+
+  async function clickAndSettle(el) {
+    await act(async () => {
+      click(el);
+      await new Promise((r) => setTimeout(r, 0));
+    });
+  }
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  const buttonByText = (text) =>
+    [...container.querySelectorAll("button")].find((b) => b.textContent.trim() === text);
+
+  const refAsset = {
+    id: "ref-1",
+    type: "image",
+    projectId: "proj-1",
+    file: { path: "uploads/ref.png", mimeType: "image/png" },
+  };
+
+  async function selectReference() {
+    await clickAndSettle(buttonByText("Select reference image"));
+    const card = container.querySelector(".asset-picker-card");
+    await clickAndSettle(card);
+    await clickAndSettle(buttonByText("Use Selection"));
+  }
+
+  async function mount(props = {}) {
+    await act(async () =>
+      root.render(
+        <ReferenceCaptionPicker
+          onCaption={props.onCaption}
+          onApply={props.onApply ?? (() => {})}
+          referenceAssets={props.referenceAssets ?? [refAsset]}
+          projectId="proj-1"
+          buttonLabel="✨ Describe image"
+          busyLabel="Describing…"
+          {...props}
+        />,
+      ),
+    );
+  }
+
+  it("keeps the describe button disabled until a reference is selected", async () => {
+    await mount({ onCaption: vi.fn(async () => "a fox") });
+    expect(buttonByText("✨ Describe image").disabled).toBe(true);
+    await selectReference();
+    expect(buttonByText("✨ Describe image").disabled).toBe(false);
+  });
+
+  it("runs the caption for the picked asset and applies the result", async () => {
+    const onCaption = vi.fn(async () => "a red fox in snow, cinematic photograph");
+    const onApply = vi.fn();
+    await mount({ onCaption, onApply });
+    await selectReference();
+    await clickAndSettle(buttonByText("✨ Describe image"));
+
+    expect(onCaption).toHaveBeenCalledWith("ref-1");
+    expect(onApply).toHaveBeenCalledWith("a red fox in snow, cinematic photograph");
+  });
+
+  it("shows the empty message and does not apply when the result is falsy", async () => {
+    const onApply = vi.fn();
+    await mount({
+      onCaption: vi.fn(async () => ""),
+      onApply,
+      emptyMessage: "No usable description.",
+    });
+    await selectReference();
+    await clickAndSettle(buttonByText("✨ Describe image"));
+
+    expect(onApply).not.toHaveBeenCalled();
+    expect(container.querySelector(".structured-error")?.textContent).toContain(
+      "No usable description.",
+    );
+  });
+
+  it("surfaces a thrown error from the caption call", async () => {
+    await mount({
+      onCaption: vi.fn(async () => {
+        throw new Error("describe blew up");
+      }),
+    });
+    await selectReference();
+    await clickAndSettle(buttonByText("✨ Describe image"));
+
+    expect(container.querySelector(".structured-error")?.textContent).toContain("describe blew up");
+  });
+
+  it("gates behind the download offer (no picker/button) when the captioner is missing", async () => {
+    const onDownloadModel = vi.fn();
+    const offer = { id: "vision_caption_qwen3vl_8b", name: "Vision Captioner", downloadSizeLabel: "18 GB" };
+    await mount({
+      onCaption: vi.fn(async () => "x"),
+      visionCaptionReady: false,
+      visionCaptionOffers: [offer],
+      onDownloadModel,
+    });
+
+    expect(buttonByText("✨ Describe image")).toBeFalsy();
+    expect(buttonByText("Select reference image")).toBeFalsy();
+    expect(container.querySelector(".model-availability-gate")).toBeTruthy();
+    const download = buttonByText("Download");
+    expect(download).toBeTruthy();
+    await clickAndSettle(download);
+    expect(onDownloadModel).toHaveBeenCalledWith(offer);
+  });
+});

--- a/apps/web/src/components/StructuredPromptBuilder.jsx
+++ b/apps/web/src/components/StructuredPromptBuilder.jsx
@@ -24,9 +24,7 @@ import {
   STYLE_PALETTE_MAX,
 } from "../ideogramCaption.js";
 import PaletteEditor from "./PaletteEditor.jsx";
-import { ImageEditSourcePickerField } from "./AssetPicker.jsx";
-import { assetUrl } from "./assetMedia.jsx";
-import { ModelAvailabilityGate } from "./ModelAvailabilityGate.jsx";
+import ReferenceCaptionPicker from "./ReferenceCaptionPicker.jsx";
 
 const MODES = [
   ["form", "Builder"],
@@ -144,65 +142,13 @@ export default function StructuredPromptBuilder({
   const magicModelNeeded =
     magicModelMissing || /not cached|not installed|snapshot is not/i.test(magicError);
 
-  // Reference-image → JSON caption state (epic 8102, sc-8108). The "model not installed" path is now
-  // owned proactively by the ModelAvailabilityGate (sc-8110) — when the captioner is missing the
-  // picker/button never render, so this state only tracks the live-flow loading + runtime errors
-  // (e.g. an unusable reply), not the missing-model affordance.
-  const [referenceAssetId, setReferenceAssetId] = useState("");
-  const [captionBusy, setCaptionBusy] = useState(false);
-  const [captionError, setCaptionError] = useState("");
-
-  // Feed the uploaded image's natural dimensions to the sc-8109 auto-preset seam so the resolution
-  // snaps to the nearest aspect before generation (the caption's bboxes are frame-normalized).
-  function reportReferenceDimensions(asset) {
-    if (typeof onReferenceImageLoaded !== "function" || !asset) return;
-    const src = assetUrl(asset);
-    if (!src || typeof Image === "undefined") return;
-    const probe = new Image();
-    probe.onload = () => {
-      if (probe.naturalWidth && probe.naturalHeight) {
-        onReferenceImageLoaded(probe.naturalWidth, probe.naturalHeight);
-      }
-    };
-    probe.src = src;
-  }
-
-  function handleReferenceChange(assetId) {
-    setReferenceAssetId(assetId);
-    setCaptionError("");
-  }
-
-  // Run the auto-preset from an effect on the SELECTED id rather than the picker's onChange: a
-  // freshly imported/dragged reference lands in `referenceAssets` a render AFTER its id is set, so
-  // the onChange-time `find` missed it and the Aspect stayed at the 1:1 default (sc-8220). Keying on
-  // both the id and the list re-runs once the asset resolves, covering select / import / drag /
-  // character paths uniformly.
-  useEffect(() => {
-    if (!referenceAssetId) return;
-    const asset = referenceAssets.find((item) => item.id === referenceAssetId);
-    if (asset) reportReferenceDimensions(asset);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [referenceAssetId, referenceAssets]);
-
-  async function handleImageCaption() {
-    if (typeof onImageCaption !== "function" || !referenceAssetId || captionBusy) return;
-    setCaptionBusy(true);
-    setCaptionError("");
-    try {
-      const next = await onImageCaption(referenceAssetId);
-      // `next` is an already-parsed caption object (the parent runs parseVisionCaption); a falsy
-      // result means the reply was not a usable structured caption.
-      if (next) {
-        onCaptionChange(next);
-        onModeChange("form"); // drop the user into the editable builder, like magic-prompt
-      } else {
-        setCaptionError("The image did not produce a usable caption. Try another reference.");
-      }
-    } catch (e) {
-      setCaptionError(e?.message || "Could not caption the image.");
-    } finally {
-      setCaptionBusy(false);
-    }
+  // Reference-image → JSON caption (epic 8102): the picker UI, selected-asset state, busy/error, the
+  // auto-preset probe (incl. the sc-8220 effect-based import/drag fix), and the captioner-download gate
+  // now live in the shared ReferenceCaptionPicker (sc-8208). Here we only supply the Ideogram-specific
+  // apply: inject the parsed caption and drop the user into the editable Builder, like magic-prompt.
+  function applyImageCaption(caption) {
+    onCaptionChange(caption);
+    onModeChange("form");
   }
 
   async function handleMagicExpand() {
@@ -442,56 +388,35 @@ export default function StructuredPromptBuilder({
             </div>
           ) : null}
 
-          {/* Reference-image → JSON caption (epic 8102, sc-8108 + sc-8110). The parent only wires
-              `onImageCaption` for Ideogram 4 + text-to-image (both macOnly), so the section is already
-              hidden off-Mac. Within it the ModelAvailabilityGate (sc-8110) gates on the vision captioner
-              being installed: when ready it shows the reference picker + "Generate JSON from image"
-              button (live); when missing it shows the shared download offer instead of a button that
-              would only fail on click. The image is captioning-only (C1) — never sent to generation. */}
+          {/* Reference-image → JSON caption (epic 8102, sc-8108 + sc-8110 → shared in sc-8208). The
+              parent only wires `onImageCaption` for Ideogram 4 + text-to-image (both macOnly), so the
+              section is already hidden off-Mac. The shared picker's ModelAvailabilityGate gates on the
+              vision captioner being installed (download offer when missing). The image is captioning-only
+              (C1) — never sent to generation. `onImageCaption` resolves to an already-parsed caption
+              object (the parent runs parseVisionCaption); applyImageCaption injects it + opens Builder. */}
           {typeof onImageCaption === "function" ? (
-            <div className="structured-reference">
-              <ModelAvailabilityGate
-                ready={visionCaptionReady}
-                title="Reference-image captioning needs a model"
-                description="Download the vision captioner to turn a reference image into an editable JSON caption. It runs locally on the native worker; the image is only used to write the caption."
-                offers={visionCaptionOffers}
-                downloadJobs={visionCaptionDownloadJobs}
-                onDownload={onDownloadModel}
-                onOpenModels={onOpenModels}
-                onOpenQueue={onOpenQueue}
-                onCancelJob={onCancelJob}
-              >
-                <p className="structured-hint">
-                  Or start from a reference image — the captioner reads it into a grounded JSON caption you
-                  can edit. The image is only used to write the caption; it isn’t sent to generation.
-                </p>
-                <ImageEditSourcePickerField
-                  assets={referenceAssets}
-                  buttonLabel="Select reference image"
-                  changeLabel="Change reference"
-                  characters={referenceCharacters}
-                  emptyLabel="No reference image selected"
-                  importAsset={importAsset}
-                  label="Reference image"
-                  onChange={handleReferenceChange}
-                  projectId={projectId}
-                  value={referenceAssetId}
-                />
-                <button
-                  type="button"
-                  className="secondary-action"
-                  disabled={!referenceAssetId || captionBusy}
-                  onClick={handleImageCaption}
-                >
-                  {captionBusy ? "Captioning…" : "✨ Generate JSON from image"}
-                </button>
-                {captionError ? (
-                  <p className="structured-error" role="alert">
-                    {captionError}
-                  </p>
-                ) : null}
-              </ModelAvailabilityGate>
-            </div>
+            <ReferenceCaptionPicker
+              onCaption={onImageCaption}
+              onApply={applyImageCaption}
+              onReferenceImageLoaded={onReferenceImageLoaded}
+              referenceAssets={referenceAssets}
+              referenceCharacters={referenceCharacters}
+              importAsset={importAsset}
+              projectId={projectId}
+              hint="Or start from a reference image — the captioner reads it into a grounded JSON caption you can edit. The image is only used to write the caption; it isn’t sent to generation."
+              buttonLabel="✨ Generate JSON from image"
+              busyLabel="Captioning…"
+              emptyMessage="The image did not produce a usable caption. Try another reference."
+              errorFallback="Could not caption the image."
+              gateDescription="Download the vision captioner to turn a reference image into an editable JSON caption. It runs locally on the native worker; the image is only used to write the caption."
+              visionCaptionReady={visionCaptionReady}
+              visionCaptionOffers={visionCaptionOffers}
+              visionCaptionDownloadJobs={visionCaptionDownloadJobs}
+              onDownloadModel={onDownloadModel}
+              onOpenModels={onOpenModels}
+              onOpenQueue={onOpenQueue}
+              onCancelJob={onCancelJob}
+            />
           ) : null}
         </div>
       ) : null}

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -8,6 +8,7 @@ import { PromptGuideModal } from "../components/PromptGuideModal.jsx";
 import { PoseLibraryPicker } from "../components/PoseLibraryPicker.jsx";
 import { RefinePromptControl } from "../components/RefinePromptControl.jsx";
 import StructuredPromptBuilder from "../components/StructuredPromptBuilder.jsx";
+import ReferenceCaptionPicker from "../components/ReferenceCaptionPicker.jsx";
 import {
   buildStructuredPromptRecipe,
   emptyCaption,
@@ -266,6 +267,7 @@ export function ImageStudio() {
     refinePrompt,
     magicPrompt,
     imageCaption,
+    imageDescribe,
     createModelDownloadJob,
     deleteAsset,
     purgeAsset,
@@ -1005,6 +1007,37 @@ export function ImageStudio() {
     [imageCaption, activeProject?.id],
   );
 
+  // Reference-image → plain-text description (epic 8203, sc-8208): the NON-structured sibling of
+  // onImageCaption. Runs the worker's `image_describe` job on the picked reference and resolves to the
+  // raw description text — prose by default, or booru tags when the model declares `captionStyle:"tags"`
+  // (sc-8205). The shared picker drops the returned text into the prompt textarea. Gated to
+  // text-to-image only, like the caption flow. C1: the image is consumed to produce the prompt and is
+  // never passed to generation.
+  const describeCaptionStyle = selectedModel?.captionStyle;
+  const onImageDescribe = useCallback(
+    async (sourceAssetId) => {
+      if (typeof imageDescribe !== "function") {
+        throw new Error("Image description is unavailable.");
+      }
+      if (!activeProject?.id) {
+        throw new Error("Open a project first.");
+      }
+      const text = await imageDescribe({
+        sourceAssetId,
+        projectId: activeProject.id,
+        model: VISION_CAPTION_MODEL_REPO,
+        captionStyle: describeCaptionStyle,
+      });
+      const trimmed = (text || "").trim();
+      if (!trimmed) {
+        throw new Error("The image did not produce a usable description.");
+      }
+      setMagicPromptBackend(VISION_CAPTION_MODEL_ID);
+      return trimmed;
+    },
+    [imageDescribe, activeProject?.id, describeCaptionStyle],
+  );
+
   // When restoring a snapshot, the saved count/resolution/negativePrompt already
   // reflect the user's last state — skip the one preset-default pass that fires as the
   // restored preset resolves so it doesn't overwrite them. "None" applies no defaults,
@@ -1495,6 +1528,40 @@ export function ImageStudio() {
             <p className="structured-error" role="alert">
               {submitError}
             </p>
+          ) : null}
+
+          {/* Reference-image → plain-text prompt (epic 8203, sc-8208). For NON-structured t2i models,
+              offer the same "start from a reference image" affordance Ideogram has — but it fills the
+              plain prompt box with a description (prose, or booru tags for `captionStyle:"tags"` models).
+              Gated to text-to-image only; the section is hidden unless the macOS-first captioner is
+              platform-eligible (ready, or an install offer exists — both false off-Mac, so it stays
+              hidden there, matching the Ideogram surface). C1: captioning-only, never sent to generation. */}
+          {!structuredPromptModel &&
+          mode === "text_to_image" &&
+          typeof imageDescribe === "function" &&
+          (visionCaptionReady || visionCaptionOffers.length > 0) ? (
+            <ReferenceCaptionPicker
+              onCaption={onImageDescribe}
+              onApply={(text) => setPromptFromUser(text)}
+              onReferenceImageLoaded={onReferenceImageLoaded}
+              referenceAssets={editImageAssets}
+              referenceCharacters={characters}
+              importAsset={importAsset}
+              projectId={activeProject?.id ?? ""}
+              hint="Start from a reference image — the captioner reads it into a detailed prompt you can edit. The image is only used to write the prompt; it isn’t sent to generation."
+              buttonLabel="✨ Describe image"
+              busyLabel="Describing…"
+              emptyMessage="The image did not produce a usable description. Try another reference."
+              errorFallback="Could not describe the image."
+              gateDescription="Download the vision captioner to turn a reference image into a prompt. It runs locally on the native worker; the image is only used to write the prompt."
+              visionCaptionReady={visionCaptionReady}
+              visionCaptionOffers={visionCaptionOffers}
+              visionCaptionDownloadJobs={modelDownloadJobs}
+              onDownloadModel={createModelDownloadJob}
+              onOpenModels={() => setActiveView("Models")}
+              onOpenQueue={onOpenQueue}
+              onCancelJob={onCancelJob}
+            />
           ) : null}
 
           {/* Plain-text refine + scene suggestions only make sense for free-text

--- a/crates/sceneworks-worker/src/image_describe_tags_v1.txt
+++ b/crates/sceneworks-worker/src/image_describe_tags_v1.txt
@@ -1,0 +1,35 @@
+[META]
+frozen: false
+description: Image-grounded TAG-STYLE description (epic 8203, sc-8205) — examine a reference image and emit a comma-separated booru/danbooru-style tag list usable directly as a prompt for an anime/booru SDXL checkpoint. Vision system prompt for the core_llm TextLlm path; NO JSON, NO prose sentences. Thinking off.
+thinking_mode: disabled
+
+[SYSTEM]
+You are a vision tagger. You are given ONE reference image. You EXAMINE the image and emit a single comma-separated list of booru/danbooru-style tags describing what is actually visible, in the form an anime/illustration SDXL checkpoint consumes as a prompt. You OBSERVE the image — you never invent or add tags for content that is not present in the picture.
+
+## OUTPUT CONTRACT — emit ONE comma-separated tag list
+
+- Output ONLY the tag list: lowercase tags separated by ", " (comma-space), on a single line. No JSON, no code fences, no sentences, no headings, no numbering, no commentary, no preamble. Just the tags.
+- Tags use underscores for multi-word concepts in the danbooru convention (long_hair, looking_at_viewer, white_dress, depth_of_field), and spaces only where that is the conventional tag.
+- Order from most to least salient, roughly: count/subject (1girl, 1boy, 2girls, no_humans), then subject attributes, then clothing, then pose/expression/action, then setting/background, then composition/framing, then medium/style, then lighting/color, then a few quality/aesthetic tags.
+- Aim for roughly 15–35 tags. Specific over generic; do not pad with redundant or speculative tags.
+- Reproduce clearly legible rendered text only if a tag conventionally captures it (e.g. text, english_text); do not invent unreadable text.
+
+## WHAT TO TAG — observe, don't populate
+
+Ground every tag in the pixels:
+- Subject(s): count first (1girl/1boy/2girls/multiple_girls/no_humans), then visible attributes — hair color/length/style, eye color, skin tone, expression, gaze (looking_at_viewer, looking_away).
+- Clothing & accessories: each visible garment and accessory with its color (white_shirt, pleated_skirt, glasses, hat).
+- Pose / action: what the subject is doing (sitting, standing, arms_up, holding_cup).
+- Setting / background: location and notable props actually visible (indoors, forest, city, simple_background, transparent background → use the tag transparent_background).
+- Composition / framing: shot type and crop (full_body, upper_body, portrait, close-up, from_above, from_side, cowboy_shot).
+- Medium / style: the rendered look (anime_coloring, realistic, watercolor_(medium), 3d, sketch, flat_color, cel_shading).
+- Lighting / color: notable lighting and palette cues (backlighting, rim_light, sunlight, monochrome, pastel_colors).
+- A few aesthetic/quality tags that match what you see (highres, detailed, masterpiece) — only if warranted, never as filler.
+
+Rules:
+- Tag colors, garments, poses, and layout you can SEE — not what is plausible or typical for the subject.
+- Do not add subjects, props, weather, logos, or background features that are not in the image. If a detail is occluded or unreadable, omit it — never fabricate a tag.
+- This is a faithful tagging of THIS picture, written so a renderer can produce a NEW image in the same style and composition.
+
+[USER]
+Examine the reference image attached to this message and emit the single comma-separated booru-style tag list as specified. Tag only what is visible in the image.

--- a/crates/sceneworks-worker/src/image_describe_v1.txt
+++ b/crates/sceneworks-worker/src/image_describe_v1.txt
@@ -1,0 +1,31 @@
+[META]
+frozen: false
+description: Image-grounded plain-text PROSE description (epic 8203, sc-8204) — examine a reference image and emit a detailed natural-language description usable directly as a text-to-image prompt for a non-structured model. Vision system prompt for the core_llm TextLlm path; NO JSON, NO bboxes. Thinking off.
+thinking_mode: disabled
+
+[SYSTEM]
+You are a vision describer. You are given ONE reference image. You EXAMINE the image and write a single detailed, natural-language description of what is actually visible, in the form a text-to-image model consumes as a prompt. You OBSERVE the image — you never invent, embellish, or add content that is not present in the picture.
+
+## OUTPUT CONTRACT — emit ONE plain-text description
+
+- Output ONLY the description itself: flowing natural-language prose. No JSON, no code fences, no bullet lists, no headings, no bbox coordinates, no key/value fields, no commentary, no preamble ("This image shows…", "The description is…"). Start immediately with the subject.
+- One coherent paragraph (occasionally two for a complex scene). Aim for roughly 60–120 words — long enough to be specific, short enough to read as a prompt.
+- Preserve non-ASCII characters as-is (CJK, Cyrillic, Devanagari, Arabic, accented Latin). Never transliterate or escape. Reproduce any clearly legible rendered text verbatim, in single quotes (a sign reading 'OPEN'); if text is illegible or cut off, say so rather than guessing.
+
+## WHAT TO DESCRIBE — observe, don't populate
+
+Ground every detail in the pixels. Cover, in a natural order:
+- Subject(s): who/what is present, their identity, count, pose, expression, clothing/material, and one distinguishing visible detail each. Name recognizable real-world entities by full name only when you can clearly identify them (Eiffel Tower, Nike Air Jordan 1).
+- Setting / background: location, surfaces, props, depth, and any environmental cues actually visible.
+- Composition & framing: how the subject sits in the frame (close-up, wide shot, centered, rule-of-thirds, low/high angle, foreground/background relationships).
+- Medium & style: photograph vs illustration vs 3D render vs painting vs sketch; the named look or aesthetic; for a photo, lens/depth-of-field character.
+- Lighting: direction, hardness, color temperature, time-of-day cues.
+- Color: the dominant colors and overall palette/mood, named plainly (warm amber and deep teal, muted pastels).
+
+Rules:
+- Describe colors, materials, poses, garments, text, and layout you can SEE — not what is plausible or typical for the subject.
+- Do not add subjects, props, weather, logos, or background features that are not in the image. If a detail is occluded or unreadable, omit it or note it is obscured — never fabricate it.
+- This is a faithful description of THIS picture, written so a renderer can produce a NEW image in the same style and composition — not an analysis of it.
+
+[USER]
+Examine the reference image attached to this message and write the single detailed plain-text description as specified. Describe only what is visible in the image.

--- a/crates/sceneworks-worker/src/prompt_refine_jobs.rs
+++ b/crates/sceneworks-worker/src/prompt_refine_jobs.rs
@@ -63,14 +63,27 @@ const DEFAULT_CAPTION_MAX_NEW_TOKENS: u32 = 4096;
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 const DEFAULT_REFINE_MAX_NEW_TOKENS: u32 = 512;
-// Resolve the output token budget: an explicit positive `maxNewTokens` override wins; otherwise the
-// per-task default (caption tasks need the larger cap so the JSON closes).
+// The prose/tags `image_describe` task (epic 8203) is shorter than a full structured JSON caption but
+// longer than a one-line rewrite; give it a generous budget so a detailed paragraph is never truncated.
 #[cfg(any(
     test,
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
-fn resolve_max_new_tokens(payload: &serde_json::Map<String, Value>, is_caption_task: bool) -> u32 {
+const DEFAULT_DESCRIBE_MAX_NEW_TOKENS: u32 = 1024;
+// Resolve the output token budget: an explicit positive `maxNewTokens` override wins; otherwise the
+// per-task default (caption tasks need the larger cap so the JSON closes; the prose-describe task sits
+// in between).
+#[cfg(any(
+    test,
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn resolve_max_new_tokens(
+    payload: &serde_json::Map<String, Value>,
+    is_caption_task: bool,
+    is_image_describe: bool,
+) -> u32 {
     payload
         .get("maxNewTokens")
         .and_then(Value::as_u64)
@@ -78,6 +91,8 @@ fn resolve_max_new_tokens(payload: &serde_json::Map<String, Value>, is_caption_t
         .filter(|value| *value > 0)
         .unwrap_or(if is_caption_task {
             DEFAULT_CAPTION_MAX_NEW_TOKENS
+        } else if is_image_describe {
+            DEFAULT_DESCRIBE_MAX_NEW_TOKENS
         } else {
             DEFAULT_REFINE_MAX_NEW_TOKENS
         })
@@ -292,6 +307,29 @@ const MAGIC_PROMPT_V1: &str = include_str!("ideogram_magic_prompt_v1.txt");
 ))]
 const IMAGE_CAPTION_V1: &str = include_str!("ideogram_image_caption_v1.txt");
 
+/// Plain-text PROSE image-description system prompt (epic 8203, sc-8204), embedded verbatim and
+/// versioned like [`IMAGE_CAPTION_V1`]. Drives the SAME `prompt_refine` `core_llm` vision path as
+/// `image_caption`, but for NON-structured text-to-image models: the model EXAMINES a reference image
+/// and emits a detailed natural-language description usable directly as a t2i prompt — NO JSON, NO
+/// bboxes, NO output constraint. Parsed for its `[SYSTEM]` + `[USER]` sections by [`magic_section_from`].
+#[cfg(any(
+    test,
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+const IMAGE_DESCRIBE_V1: &str = include_str!("image_describe_v1.txt");
+
+/// TAG-STYLE image-description system prompt (epic 8203, sc-8205), the booru/danbooru variant of
+/// [`IMAGE_DESCRIBE_V1`]. Selected when the job payload carries `captionStyle:"tags"` — for anime/booru
+/// SDXL checkpoints that consume comma-separated tags rather than prose. Same vision path, same prose
+/// cleanup (a flat tag string, no JSON).
+#[cfg(any(
+    test,
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+const IMAGE_DESCRIBE_TAGS_V1: &str = include_str!("image_describe_tags_v1.txt");
+
 /// Body of a `[NAME]` section in the magic-prompt file (port of the reference `_load_sections`):
 /// section markers are a bracketed single word alone on a line. Returns the trimmed body, or empty.
 #[cfg(any(
@@ -393,6 +431,70 @@ pub(crate) fn build_image_caption_messages() -> (String, String) {
     (system, user)
 }
 
+/// The plain-text describe style selected by the job payload's `captionStyle` field (epic 8203):
+/// `Prose` (default — natural-language sentences, sc-8204) or `Tags` (booru/danbooru comma-tags for
+/// anime/booru SDXL checkpoints, sc-8205). Any unknown/absent value falls back to `Prose` (defensive).
+#[cfg(any(
+    test,
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum DescribeStyle {
+    Prose,
+    Tags,
+}
+
+#[cfg(any(
+    test,
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+impl DescribeStyle {
+    /// Parse the `captionStyle` payload value; only `"tags"` (case-insensitive) selects tags, everything
+    /// else — including absent/empty/unknown — is prose.
+    pub(crate) fn from_payload(value: Option<&str>) -> Self {
+        match value.map(str::trim) {
+            Some(v) if v.eq_ignore_ascii_case("tags") => DescribeStyle::Tags,
+            _ => DescribeStyle::Prose,
+        }
+    }
+}
+
+/// The `(system, user)` chat text for an image-DESCRIBE run (epic 8203): the `[SYSTEM]` + `[USER]`
+/// blocks of the embedded describe asset for the chosen [`DescribeStyle`] — [`IMAGE_DESCRIBE_V1`]
+/// (prose, sc-8204) or [`IMAGE_DESCRIBE_TAGS_V1`] (tags, sc-8205). Like [`build_image_caption_messages`]
+/// the reference image is attached to the user turn as a separate `Content::Image` block by the caller;
+/// this only supplies the text. Unlike the caption path the model emits plain text (no JSON constraint).
+#[cfg(any(
+    test,
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+pub(crate) fn build_image_describe_messages(style: DescribeStyle) -> (String, String) {
+    let asset = match style {
+        DescribeStyle::Prose => IMAGE_DESCRIBE_V1,
+        DescribeStyle::Tags => IMAGE_DESCRIBE_TAGS_V1,
+    };
+    let system = magic_section_from(asset, "SYSTEM");
+    let mut user = magic_section_from(asset, "USER");
+    if user.is_empty() {
+        user = match style {
+            DescribeStyle::Prose => {
+                "Examine the reference image attached to this message and write the single detailed \
+                 plain-text description as specified. Describe only what is visible in the image."
+            }
+            DescribeStyle::Tags => {
+                "Examine the reference image attached to this message and emit the single \
+                 comma-separated booru-style tag list as specified. Tag only what is visible in the \
+                 image."
+            }
+        }
+        .to_owned();
+    }
+    (system, user)
+}
+
 /// Decode a reference image off disk into a `core_llm::ImageRef` (RGB8), mirroring the JoyCaption
 /// `load_caption_image` pattern (`decode_image_any` → `to_rgb8`) but producing the vision contract's
 /// tensor-free image type instead of the captioner's `gen_core::Image`. Used by the `image_caption`
@@ -479,15 +581,21 @@ pub(crate) async fn run_prompt_refine_job(
         .unwrap_or_default();
     let is_magic = task.eq_ignore_ascii_case("magic_prompt");
     let is_image_caption = task.eq_ignore_ascii_case("image_caption");
+    // sc-8204 (epic 8203): `image_describe` is the plain-text sibling of `image_caption` — the SAME
+    // `core_llm` vision path, but for NON-structured t2i models it emits a natural-language PROSE
+    // description (no JSON constraint, no `is_caption` validation). Both vision tasks carry a reference
+    // image and need no text prompt.
+    let is_image_describe = task.eq_ignore_ascii_case("image_describe");
+    let is_vision_task = is_image_caption || is_image_describe;
     let original_prompt = payload
         .get("prompt")
         .and_then(Value::as_str)
         .map(str::trim)
         .unwrap_or_default()
         .to_owned();
-    // The image-caption task is driven by the reference image, not a text prompt, so it does not
-    // require a `prompt`; every other task does.
-    if original_prompt.is_empty() && !is_image_caption {
+    // The vision tasks (image_caption / image_describe) are driven by the reference image, not a text
+    // prompt, so they do not require a `prompt`; every other task does.
+    if original_prompt.is_empty() && !is_vision_task {
         return Err(WorkerError::InvalidPayload(
             "Prompt refinement requires a non-empty prompt.".to_owned(),
         ));
@@ -499,7 +607,7 @@ pub(crate) async fn run_prompt_refine_job(
     // InstantID/captioner reference reads, the LoRA load path) — confine it to an app-managed root via
     // `normalize_app_managed_model_path` BEFORE opening it. That rejects `..` traversal and any absolute
     // path outside the app data dir / HF hub cache, closing the arbitrary-file-read gap.
-    let image_ref = if is_image_caption {
+    let image_ref = if is_vision_task {
         let image_path = payload
             .get("imagePath")
             .or_else(|| payload.get("referencePath"))
@@ -508,14 +616,11 @@ pub(crate) async fn run_prompt_refine_job(
             .filter(|value| !value.is_empty())
             .ok_or_else(|| {
                 WorkerError::InvalidPayload(
-                    "Image caption requires a non-empty `imagePath` reference image.".to_owned(),
+                    "This task requires a non-empty `imagePath` reference image.".to_owned(),
                 )
             })?;
-        let safe_path = normalize_app_managed_model_path(
-            settings,
-            image_path,
-            "Image caption reference image",
-        )?;
+        let safe_path =
+            normalize_app_managed_model_path(settings, image_path, "Vision reference image")?;
         Some(load_caption_image_ref(&safe_path)?)
     } else {
         None
@@ -539,10 +644,18 @@ pub(crate) async fn run_prompt_refine_job(
         .filter(|value| !value.is_empty())
         .unwrap_or(DEFAULT_REFINE_MODEL)
         .to_owned();
-    let max_new_tokens = resolve_max_new_tokens(payload, is_caption_task);
-    let temperature = if is_caption_task { 0.4 } else { 0.7 };
+    let max_new_tokens = resolve_max_new_tokens(payload, is_caption_task, is_image_describe);
+    // Both the JSON caption tasks and the prose-describe task sample cool for a faithful, steady
+    // description; the free-text rewrite stays warmer for creative variation.
+    let temperature = if is_caption_task || is_image_describe {
+        0.4
+    } else {
+        0.7
+    };
     let work_message = if is_image_caption {
         "Captioning image…"
+    } else if is_image_describe {
+        "Describing image…"
     } else if is_magic {
         "Expanding to a caption…"
     } else {
@@ -550,12 +663,20 @@ pub(crate) async fn run_prompt_refine_job(
     };
     let done_message = if is_caption_task {
         "Caption ready."
+    } else if is_image_describe {
+        "Description ready."
     } else {
         "Prompt refined."
     };
 
     let (system, user_message) = if is_image_caption {
         build_image_caption_messages()
+    } else if is_image_describe {
+        // sc-8205: the describe style (prose vs booru tags) is selected per-model by the `captionStyle`
+        // payload field the web forwards from the catalog; absent/unknown → prose.
+        let style =
+            DescribeStyle::from_payload(payload.get("captionStyle").and_then(Value::as_str));
+        build_image_describe_messages(style)
     } else if is_magic {
         let aspect_ratio = payload
             .get("aspectRatio")
@@ -631,9 +752,9 @@ pub(crate) async fn run_prompt_refine_job(
             if !system.trim().is_empty() {
                 messages.push(Message::system(system));
             }
-            // The image-caption user turn carries the reference image (a `Content::Image` block)
-            // alongside the instruction text, so the loaded provider examines the picture at generate
-            // time. Every other task is a plain text user turn.
+            // A vision task (image_caption / image_describe) user turn carries the reference image (a
+            // `Content::Image` block) alongside the instruction text, so the loaded provider examines the
+            // picture at generate time. Every other task is a plain text user turn.
             let carries_image = image_ref.is_some();
             match image_ref {
                 Some(image) => messages.push(Message {
@@ -666,11 +787,13 @@ pub(crate) async fn run_prompt_refine_job(
             // Build the resolution requirements WITHOUT the auto-vision `from_request` derives from an
             // image block (see the resolution note above): a Qwen-VL snapshot has no statically
             // vision+Json provider, so demanding vision here would fail `select` before `load`. Require
-            // only the request's output constraint (the JSON grammar for a caption task) — that selects
-            // the text+Json `mlx-llama`, which loads the Qwen-VL snapshot and flips to vision at load.
+            // only the request's output constraint — the JSON grammar for a caption task; NONE for the
+            // prose `image_describe` task (sc-8204), which therefore resolves on architecture `can_load`
+            // ALONE. That still admits `mlx-llama` (the only provider that `can_load`s a Qwen-VL wrapper —
+            // `mlx-joycaption` only loads LLaVA), which loads the snapshot and flips to vision at load.
             // (`carries_image` is asserted so the unused-binding lint stays satisfied and the intent —
             // "an image is present, yet we deliberately do NOT set the vision filter" — is explicit.)
-            debug_assert!(carries_image == is_image_caption);
+            debug_assert!(carries_image == is_vision_task);
             let mut reqs = ModelRequirements::default();
             for constraint in request.constraint.iter().copied() {
                 reqs = reqs.with_constraint(constraint);
@@ -866,26 +989,47 @@ mod tests {
         // (sc-8210: 2048 truncated rich captions mid-`elements`).
         let obj = |value: serde_json::Value| value.as_object().unwrap().clone();
         assert_eq!(
-            resolve_max_new_tokens(&obj(serde_json::json!({})), true),
+            resolve_max_new_tokens(&obj(serde_json::json!({})), true, false),
             4096
+        );
+        // The prose-describe task (epic 8203) gets the in-between default.
+        assert_eq!(
+            resolve_max_new_tokens(&obj(serde_json::json!({})), false, true),
+            1024
         );
         // The free-text rewrite stays at the small default.
         assert_eq!(
-            resolve_max_new_tokens(&obj(serde_json::json!({})), false),
+            resolve_max_new_tokens(&obj(serde_json::json!({})), false, false),
             512
         );
-        // An explicit positive override wins for either task.
+        // An explicit positive override wins for any task.
         assert_eq!(
-            resolve_max_new_tokens(&obj(serde_json::json!({ "maxNewTokens": 6000 })), true),
+            resolve_max_new_tokens(
+                &obj(serde_json::json!({ "maxNewTokens": 6000 })),
+                true,
+                false
+            ),
+            6000
+        );
+        assert_eq!(
+            resolve_max_new_tokens(
+                &obj(serde_json::json!({ "maxNewTokens": 6000 })),
+                false,
+                true
+            ),
             6000
         );
         // Zero / invalid overrides fall back to the per-task default.
         assert_eq!(
-            resolve_max_new_tokens(&obj(serde_json::json!({ "maxNewTokens": 0 })), true),
+            resolve_max_new_tokens(&obj(serde_json::json!({ "maxNewTokens": 0 })), true, false),
             4096
         );
         assert_eq!(
-            resolve_max_new_tokens(&obj(serde_json::json!({ "maxNewTokens": "nope" })), false),
+            resolve_max_new_tokens(
+                &obj(serde_json::json!({ "maxNewTokens": "nope" })),
+                false,
+                false
+            ),
             512
         );
     }
@@ -1078,6 +1222,136 @@ mod tests {
         assert!(!user.trim().is_empty(), "user block is non-empty");
         // The builder takes no aspect ratio / prompt placeholders (the image is the input).
         assert!(!user.contains("{{"));
+    }
+
+    // ── sc-8204 (epic 8203): image_describe task (reference image → plain-text PROSE description) ──
+
+    #[test]
+    fn image_describe_asset_extracts_system_and_user_blocks() {
+        // The embedded `image_describe_v1.txt` parses with the same bracketed-marker parser as the
+        // other prompt assets, and its SYSTEM block pins the PROSE / no-JSON contract.
+        let system = magic_section_from(IMAGE_DESCRIBE_V1, "SYSTEM");
+        assert!(!system.trim().is_empty(), "system block is non-empty");
+        // Plain-text prose, explicitly NOT the structured JSON caption path.
+        assert!(
+            system.contains("No JSON") || system.contains("no JSON"),
+            "system forbids JSON output"
+        );
+        assert!(
+            !system.contains("compositional_deconstruction"),
+            "describe path must NOT carry the Ideogram JSON schema"
+        );
+        // Observe-don't-invent grounding, like the caption path.
+        assert!(
+            system.to_lowercase().contains("observe"),
+            "system pins observe-don't-invent grounding"
+        );
+        // The `[META]` thinking flag does not bleed into the system body.
+        assert!(!system.contains("thinking_mode"));
+
+        let user = magic_section_from(IMAGE_DESCRIBE_V1, "USER");
+        assert!(
+            user.to_lowercase().contains("reference image"),
+            "user turn instructs examining the reference image"
+        );
+        assert!(
+            !user.contains("{{"),
+            "no template placeholders (the image is the input)"
+        );
+    }
+
+    #[test]
+    fn build_image_describe_messages_returns_prose_system_and_user() {
+        let (system, user) = build_image_describe_messages(DescribeStyle::Prose);
+        assert!(!system.trim().is_empty(), "system block is non-empty");
+        assert!(
+            !system.contains("compositional_deconstruction"),
+            "describe system prompt is prose, not the JSON caption schema"
+        );
+        assert!(!user.trim().is_empty(), "user block is non-empty");
+        assert!(!user.contains("{{"));
+    }
+
+    // ── sc-8205 (epic 8203): captionStyle="tags" describe variant ──
+
+    #[test]
+    fn describe_style_from_payload_only_tags_selects_tags() {
+        assert_eq!(
+            DescribeStyle::from_payload(Some("tags")),
+            DescribeStyle::Tags
+        );
+        assert_eq!(
+            DescribeStyle::from_payload(Some("TAGS")),
+            DescribeStyle::Tags
+        );
+        assert_eq!(
+            DescribeStyle::from_payload(Some(" tags ")),
+            DescribeStyle::Tags
+        );
+        // Default / empty / unknown → prose (defensive).
+        assert_eq!(DescribeStyle::from_payload(None), DescribeStyle::Prose);
+        assert_eq!(DescribeStyle::from_payload(Some("")), DescribeStyle::Prose);
+        assert_eq!(
+            DescribeStyle::from_payload(Some("prose")),
+            DescribeStyle::Prose
+        );
+        assert_eq!(
+            DescribeStyle::from_payload(Some("nonsense")),
+            DescribeStyle::Prose
+        );
+    }
+
+    #[test]
+    fn image_describe_tags_asset_extracts_a_booru_tag_contract() {
+        let system = magic_section_from(IMAGE_DESCRIBE_TAGS_V1, "SYSTEM");
+        assert!(!system.trim().is_empty(), "tags system block is non-empty");
+        assert!(
+            system.contains("comma-separated"),
+            "tags system pins a comma-separated tag list"
+        );
+        assert!(
+            system.to_lowercase().contains("booru") || system.to_lowercase().contains("danbooru"),
+            "tags system names the booru/danbooru convention"
+        );
+        assert!(
+            !system.contains("compositional_deconstruction"),
+            "tags path must NOT carry the JSON caption schema"
+        );
+        assert!(
+            system.to_lowercase().contains("observe"),
+            "tags system pins observe-don't-invent grounding"
+        );
+        assert!(!system.contains("thinking_mode"));
+    }
+
+    #[test]
+    fn build_image_describe_messages_selects_the_style_asset() {
+        let (prose_sys, _) = build_image_describe_messages(DescribeStyle::Prose);
+        let (tags_sys, tags_user) = build_image_describe_messages(DescribeStyle::Tags);
+        assert_ne!(
+            prose_sys, tags_sys,
+            "prose and tags select DIFFERENT system prompts"
+        );
+        assert!(
+            tags_sys.contains("comma-separated"),
+            "tags style loads the booru tag-list system prompt"
+        );
+        assert!(
+            tags_user.to_lowercase().contains("tag"),
+            "tags user turn instructs tagging"
+        );
+    }
+
+    #[test]
+    fn clean_refine_output_passes_prose_through_unwrapping_a_fence() {
+        // The describe path cleans with `clean_refine_output` (prose), NOT `clean_json_output`: a plain
+        // paragraph survives verbatim, and an accidental ```text fence is unwrapped without any
+        // JSON-object extraction.
+        let prose = "A red fox stands in deep snow at golden hour, side-lit, shot on a 50mm lens with \
+                     a shallow depth of field; muted whites and warm amber tones, cinematic photograph.";
+        assert_eq!(clean_refine_output(prose), prose);
+        let fenced = format!("```\n{prose}\n```");
+        assert_eq!(clean_refine_output(&fenced), prose);
     }
 
     #[test]
@@ -1493,6 +1767,68 @@ mod tests {
         );
     }
 
+    /// THE sc-8204 RISK GATE (epic 8203). The prose `image_describe` task drives the same Qwen-VL vision
+    /// path but emits NO JSON, so it sets NO output constraint — its resolution requirements are EMPTY
+    /// (`ModelRequirements::default()`). This proves that with no constraint AND no vision filter, the
+    /// resolver STILL admits `mlx-llama` for a `qwen3_vl` snapshot on architecture `can_load` alone: it
+    /// is the only provider that `can_load`s a Qwen-VL wrapper (`mlx-joycaption` only loads LLaVA), so an
+    /// unconstrained `select` cannot pick a wrong provider. Same weightless shape as the JSON-only tests:
+    /// resolution reaches `load`, which fails only on the missing weight shards — NOT an `Unsupported`
+    /// capability gap. macOS-only (the `mlx-llm` providers link there); no weights — reads only
+    /// `config.json`.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn unconstrained_resolution_selects_a_provider_for_qwen3_vl_snapshot() {
+        use gen_core::core_llm::{load_for_model_with, textllms, LoadSpec, ModelRequirements};
+        use mlx_llm as _; // force-link the providers into core-llm's inventory
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_qwen3_vl_config(dir.path());
+        let spec = LoadSpec {
+            source: dir.path().to_string_lossy().into_owned(),
+            quantize: None,
+        };
+
+        // The worker's image_describe resolution requirements: no constraint, no vision filter.
+        let reqs = ModelRequirements::default();
+        let err = load_for_model_with(&spec, &reqs)
+            .err()
+            .expect("no weights on disk, so the LOAD fails after the provider is selected");
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("no linked provider meets")
+                && !msg.contains("no registered provider can serve"),
+            "unconstrained requirements must resolve a provider for a qwen3_vl snapshot (then fail on \
+             missing weights), got: {msg}"
+        );
+
+        // The provider admitted under EMPTY requirements for this qwen3_vl snapshot must be `mlx-llama`
+        // — the only one that `can_load`s a Qwen-VL wrapper. With no constraint/vision filter the viable
+        // predicate reduces to `can_load` alone, so a regression that admitted a non-image provider (or
+        // failed to admit `mlx-llama`) surfaces here.
+        let viable: Vec<String> = textllms()
+            .filter(|r| (r.can_load)(&spec))
+            .map(|r| (r.descriptor)().id)
+            .collect();
+        assert!(
+            viable.iter().any(|id| id == "mlx-llama"),
+            "unconstrained resolution must admit `mlx-llama` for a qwen3_vl snapshot; viable: {viable:?}"
+        );
+        // And the admitted provider is vision-capable at load (the weightless_vision probe), so the prose
+        // describe path examines the `Content::Image` exactly like the caption path does.
+        let vision_capable = textllms()
+            .filter(|r| (r.can_load)(&spec))
+            .filter(|r| (r.descriptor)().id == "mlx-llama")
+            .any(|r| {
+                r.weightless_vision.map(|p| p(&spec)).unwrap_or(false)
+                    || (r.descriptor)().capabilities.supports_vision
+            });
+        assert!(
+            vision_capable,
+            "the unconstrained-resolved `mlx-llama` must be vision-capable for a qwen3_vl snapshot"
+        );
+    }
+
     /// Real-weight image-caption smoke (sc-8105 → validated under sc-8113): examines a reference image
     /// and emits an Ideogram JSON caption through the unified mlx-llm VISION engine —
     /// `gen_core::core_llm::load_for_model_with` resolves `mlx-llama` on a Qwen-VL snapshot. The pick is
@@ -1573,6 +1909,81 @@ mod tests {
         assert!(
             sceneworks_core::ideogram_caption::is_caption(&parsed),
             "reply is a schema-valid Ideogram caption"
+        );
+    }
+
+    /// Real-weight image-DESCRIBE smoke (sc-8204, epic 8203): the prose sibling of
+    /// `image_caption_examines_reference_image`. Examines a reference image and emits a PLAIN-TEXT
+    /// description through the SAME mlx-llm vision engine — but with NO output constraint, so resolution
+    /// runs on architecture `can_load` ALONE (the sc-8204 risk gate, pinned weightlessly by
+    /// `unconstrained_resolution_selects_a_provider_for_qwen3_vl_snapshot`). The cleaned reply must be a
+    /// non-empty paragraph that is NOT JSON. `#[ignore]` — the weights live outside CI; run on a Mac:
+    ///   VISION_CAPTION_SNAPSHOT=<snapshot dir> IMAGE_CAPTION_REF=<image path> \
+    ///   cargo test -p sceneworks-worker --lib -- --ignored image_describe_examines_reference --nocapture
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "real-weight (sc-8209): needs a vision model snapshot + reference image; set VISION_CAPTION_SNAPSHOT + IMAGE_CAPTION_REF"]
+    fn image_describe_examines_reference_image() {
+        use gen_core::core_llm::{
+            load_for_model_with, Content, LoadSpec, Message, ModelRequirements, Role, Sampling,
+            StreamEvent, TextLlmRequest,
+        };
+        use mlx_llm as _;
+
+        let snapshot = std::env::var("VISION_CAPTION_SNAPSHOT")
+            .expect("set VISION_CAPTION_SNAPSHOT to a vision model snapshot dir");
+        let ref_path = std::env::var("IMAGE_CAPTION_REF")
+            .expect("set IMAGE_CAPTION_REF to a reference image path");
+
+        let image =
+            load_caption_image_ref(std::path::Path::new(&ref_path)).expect("decode ref image");
+        let (system, user) = build_image_describe_messages(DescribeStyle::Prose);
+        let request = TextLlmRequest {
+            messages: vec![
+                Message::system(system),
+                Message {
+                    role: Role::User,
+                    content: vec![Content::Image(image), Content::text(user)],
+                    thinking: None,
+                    tool_calls: Vec::new(),
+                },
+            ],
+            sampling: Sampling {
+                temperature: 0.4,
+                top_p: 0.9,
+                ..Sampling::default()
+            },
+            max_new_tokens: 1024,
+            seed: None,
+            // The describe path emits prose — NO JSON constraint.
+            constraint: None,
+            ..Default::default()
+        };
+        // Resolution requirements the SAME way the production image_describe path builds them: EMPTY
+        // (no constraint, no vision filter). `can_load` alone admits `mlx-llama`, which flips to vision at
+        // load — the risk gate this smoke exercises on real weights.
+        let reqs = ModelRequirements::default();
+        let describer = load_for_model_with(
+            &LoadSpec {
+                source: snapshot,
+                quantize: None,
+            },
+            &reqs,
+        )
+        .expect("load a vision provider via core-llm model-first unconstrained resolution");
+
+        let mut sink = |_event: StreamEvent| {};
+        let output = describer.generate(&request, &mut sink).expect("generate");
+        let prose = clean_refine_output(&output.text);
+        eprintln!("image-describe prose:\n{prose}");
+
+        assert!(
+            !prose.is_empty(),
+            "describe reply is a non-empty description"
+        );
+        assert!(
+            serde_json::from_str::<Value>(&prose).is_err(),
+            "describe reply is plain prose, not a JSON object"
         );
     }
 

--- a/crates/sceneworks-worker/src/upscale_jobs.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs.rs
@@ -587,18 +587,41 @@ pub(crate) async fn upscale_image_in_memory(
     source: RgbImage,
     cancel: &CancelFlag,
 ) -> WorkerResult<RgbImage> {
+    // Both branches run their long compute under `run_upscale_with_heartbeat` so the worker keeps
+    // emitting `Busy` heartbeats (every 5-15s) during model load + diffusion. Without it, an inline
+    // SeedVR2 upscale (model load + one-step diffusion, easily > the API's 90s worker-timeout) goes
+    // silent and the stale-sweep marks the in-flight image-generate job `interrupted` mid-flight —
+    // then the worker's terminal post is rejected (409) and the job looks stuck (sc-8186). The
+    // standalone `image_upscale` job already wraps the same compute this way.
     match engine_id {
         "seedvr2" => {
             let dir =
                 ensure_seedvr2_checkpoint(api, settings, http_client, job, manifest_entry).await?;
-            run_seedvr2_upscale(dir, source, factor, softness, seed, cancel.clone()).await
+            let task_cancel = cancel.clone();
+            run_upscale_with_heartbeat(
+                api,
+                settings,
+                &job.id,
+                cancel.clone(),
+                tokio::spawn(async move {
+                    run_seedvr2_upscale(dir, source, factor, softness, seed, task_cancel).await
+                }),
+            )
+            .await
         }
         _ => {
             let onnx = ensure_onnx(api, settings, http_client, job, factor, manifest_entry).await?;
-            let cancel = cancel.clone();
-            tokio::task::spawn_blocking(move || upscale_blocking(onnx, factor, source, cancel))
-                .await
-                .map_err(|error| task_join_error("inline upscale", error))?
+            let task_cancel = cancel.clone();
+            run_upscale_with_heartbeat(
+                api,
+                settings,
+                &job.id,
+                cancel.clone(),
+                tokio::task::spawn_blocking(move || {
+                    upscale_blocking(onnx, factor, source, task_cancel)
+                }),
+            )
+            .await
         }
     }
 }

--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -203,6 +203,10 @@
             "additionalProperties": {
               "type": "object"
             }
+          },
+          "captionStyle": {
+            "enum": ["prose", "tags"],
+            "description": "Reference-image → prompt describe style (epic 8203). 'prose' (default when absent) emits a natural-language description; 'tags' emits a comma-separated booru/danbooru tag list for anime/booru SDXL checkpoints. The web forwards this to the image_describe job. Ignored by structuredPrompt models (Ideogram), which use the JSON caption path instead."
           }
         }
       }


### PR DESCRIPTION
## Summary
Generalizes the epic [8102](https://app.shortcut.com/trefry/epic/8102) reference-image → prompt concept from **Ideogram 4 only** to **every text-to-image model**. Upload a reference image, run the vision captioner to describe it in detail, and inject the result into the model's prompt input so you can author new images that capture the same **concept** (style + composition).

**Format matches the model** (settled with Michael): `structuredPrompt` models (Ideogram 4) keep their JSON caption path (epic 8102, unchanged); every other t2i model gets a **plain-text** description — natural-language **prose** by default, or comma-separated **booru tags** for `captionStyle:"tags"` models. Captioning-only (the image is never sent to generation), text-to-image mode only, **macOS-first** (Windows/Linux candle = epic 8103, like 8102). Reuses 8102's `qwen3_vl` `core_llm` vision path, the single vision-captioner utility model, and the `ModelAvailabilityGate`.

Epic: [8203](https://app.shortcut.com/trefry/epic/8203) · Stories: [sc-8204](https://app.shortcut.com/trefry/story/8204) [sc-8205](https://app.shortcut.com/trefry/story/8205) [sc-8206](https://app.shortcut.com/trefry/story/8206) [sc-8207](https://app.shortcut.com/trefry/story/8207) [sc-8208](https://app.shortcut.com/trefry/story/8208) [sc-8209](https://app.shortcut.com/trefry/story/8209)

## Changes
- **Worker** (sc-8204/8205): new `task:"image_describe"` sharing the `image_caption` vision image-load + `Content::Image` path, but with **no** `Constraint::Json`, **no** `is_caption` validation, prose cleanup via `clean_refine_output`. New `image_describe_v1.txt` (prose) / `image_describe_tags_v1.txt` (booru tags) assets selected by `DescribeStyle{Prose,Tags}::from_payload(captionStyle)`.
- **API** (sc-8206): `/prompts/refine` accepts `image_describe` (`is_vision_task` covers both image tasks) and forwards `captionStyle`; reuses the existing path-confined asset resolution.
- **Catalog/schema** (sc-8207): `captionStyle` enum (`"prose"|"tags"`) added to the model-manifest schema.
- **Web** (sc-8208): factored the reference picker out of `StructuredPromptBuilder` into a shared `ReferenceCaptionPicker`; new `App.jsx` `imageDescribe` helper; `ImageStudio` renders a "✨ Describe image" button on the plain-textarea path for non-structured t2i models, gated to text-to-image + captioner platform-eligibility (hidden off-Mac).

## Risk gate (resolved, high confidence)
Dropping the JSON constraint does **not** break resolution: with empty `ModelRequirements` the resolver selects the vision-capable `mlx-llama` for a `qwen3_vl` snapshot on `can_load` alone (it's the only provider that can load that wrapper). Pinned by `unconstrained_resolution_selects_a_provider_for_qwen3_vl_snapshot`.

## Notes
- **No `tags` catalog target today.** All `sdxl`-family models are photoreal/base (natural-language); the tags mechanism is fully built and activates when an anime/booru SDXL is added to the catalog. Forcing `tags` onto a photoreal model would be wrong, so none is marked. (See [sc-8207](https://app.shortcut.com/trefry/story/8207).)
- **No engine bump** (reuses the 8102 `qwen3_vl` path) → no pin lockstep.

## Testing
- Worker: 27 tests (incl. the risk-gate resolution test + env-gated `#[ignore]` real-weight smoke); fmt + clippy clean.
- rust-api: 2 new tests (asset resolve + `captionStyle` passthrough; missing source → 400); fmt + clippy clean.
- web: eslint 0 errors; 801 tests / 46 files pass (5 new `ReferenceCaptionPicker` tests); production `vite build` succeeds.
- **Remaining:** on-device real-weight visual validation ([sc-8209](https://app.shortcut.com/trefry/story/8209)) — needs a Mac + the captioner weights + human judgment; run recipe on the story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)