### PR TITLE
fix(worker): pad odd-dimension upscale tiles to even for Real-ESRGAN x2 (sc-8218)

### DIFF
--- a/crates/sceneworks-worker/src/upscale_jobs.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs.rs
@@ -157,6 +157,37 @@ fn crop_to_chw(
     (data, cw, ch)
 }
 
+/// Real-ESRGAN's x2 model begins with `pixel_unshuffle(x, 2)` (see the RRDBNet port in
+/// `scripts/spikes/sc3489_export_reference.py:88`), which reshapes the spatial dims
+/// `(H, W) -> (H/2, 2, W/2, 2)` and therefore **requires even input height and width**. A
+/// library/dataset image (or edge tile) with an odd dimension — e.g. 528×323 — otherwise blows
+/// up the onnx `Reshape` node (`input_shape % requested_shape != 0`). Pad the CHW crop up to
+/// even dims by **replicating** the last column/row, so no dark seam bleeds into the readable
+/// region through the conv receptive field. The extra `factor` output px on the padded edge fall
+/// outside the inner (unpadded) region the caller copies back, so they are simply discarded.
+/// Harmless for x4 (its RRDBNet has no `pixel_unshuffle`, so odd dims already work) — applied
+/// unconditionally to keep the call site simple.
+fn pad_chw_even(data: Vec<f32>, cw: usize, ch: usize) -> (Vec<f32>, usize, usize) {
+    let pw = cw + (cw & 1);
+    let ph = ch + (ch & 1);
+    if pw == cw && ph == ch {
+        return (data, cw, ch);
+    }
+    let mut out = vec![0.0f32; 3 * ph * pw];
+    for c in 0..3 {
+        let src_plane = c * ch * cw;
+        let dst_plane = c * ph * pw;
+        for yy in 0..ph {
+            let sy = yy.min(ch - 1);
+            for xx in 0..pw {
+                let sx = xx.min(cw - 1);
+                out[dst_plane + yy * pw + xx] = data[src_plane + sy * cw + sx];
+            }
+        }
+    }
+    (out, pw, ph)
+}
+
 fn validate_upscale_target_dimensions(width: u32, height: u32) -> WorkerResult<()> {
     let pixels = u64::from(width) * u64::from(height);
     if width > MAX_UPSCALE_TARGET_DIMENSION
@@ -261,6 +292,9 @@ impl Upscaler {
             let cx1 = (tl.x1 + TILE_PAD).min(w);
             let cy1 = (tl.y1 + TILE_PAD).min(h);
             let (data, cw, ch) = crop_to_chw(img, cx0, cy0, cx1, cy1);
+            // Pad to even dims for the x2 model's `pixel_unshuffle(2)` (odd W/H else fails the
+            // onnx Reshape, e.g. a 323px-wide image); padded edge px are discarded below.
+            let (data, cw, ch) = pad_chw_even(data, cw, ch);
 
             let tensor =
                 Tensor::from_array((vec![1i64, 3, ch as i64, cw as i64], data)).map_err(ort_err)?;

--- a/crates/sceneworks-worker/src/upscale_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs/tests.rs
@@ -146,6 +146,60 @@ fn crop_to_chw_subregion() {
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 #[test]
+fn pad_chw_even_replicates_to_even_dims_for_pixel_unshuffle() {
+    // odd width (the 323px-wide regression): 3x2 CHW → padded to 4x2, the new column replicates
+    // the last (no dark seam to bleed into the readable region via the x2 unshuffle conv).
+    let (data, cw, ch) = crop_chw_const_gradient(3, 2);
+    let (padded, pw, ph) = pad_chw_even(data.clone(), cw, ch);
+    assert_eq!((pw, ph), (4, 2));
+    assert_eq!(padded.len(), 3 * 4 * 2);
+    for c in 0..3 {
+        for y in 0..2 {
+            // the appended column (x=3) equals the original last column (x=2)
+            let last = data[c * ch * cw + y * cw + 2];
+            let appended = padded[c * ph * pw + y * pw + 3];
+            assert!((appended - last).abs() < 1e-6);
+            // existing columns are preserved
+            for x in 0..3 {
+                assert!(
+                    (padded[c * ph * pw + y * pw + x] - data[c * ch * cw + y * cw + x]).abs() < 1e-6
+                );
+            }
+        }
+    }
+
+    // odd height too → row replicated; even×even is returned untouched (no copy).
+    let (d2, _, _) = crop_chw_const_gradient(2, 3);
+    let (_, pw2, ph2) = pad_chw_even(d2, 2, 3);
+    assert_eq!((pw2, ph2), (2, 4));
+    let (d3, _, _) = crop_chw_const_gradient(4, 2);
+    let (out3, pw3, ph3) = pad_chw_even(d3.clone(), 4, 2);
+    assert_eq!((pw3, ph3), (4, 2));
+    assert_eq!(out3, d3, "already-even dims are returned unchanged");
+}
+
+/// Tiny deterministic CHW buffer (each channel a distinct gradient) for the padding test.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn crop_chw_const_gradient(cw: usize, ch: usize) -> (Vec<f32>, usize, usize) {
+    let mut data = vec![0.0f32; 3 * cw * ch];
+    for c in 0..3 {
+        for y in 0..ch {
+            for x in 0..cw {
+                data[c * ch * cw + y * cw + x] = (c * 100 + y * 10 + x) as f32 / 255.0;
+            }
+        }
+    }
+    (data, cw, ch)
+}
+
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+#[test]
 fn onnx_filename_per_factor() {
     assert_eq!(onnx_file(2), "real_esrgan_x2.onnx");
     assert_eq!(onnx_file(4), "real_esrgan_x4.onnx");

--- a/crates/sceneworks-worker/src/upscale_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs/tests.rs
@@ -162,7 +162,8 @@ fn pad_chw_even_replicates_to_even_dims_for_pixel_unshuffle() {
             // existing columns are preserved
             for x in 0..3 {
                 assert!(
-                    (padded[c * ph * pw + y * pw + x] - data[c * ch * cw + y * cw + x]).abs() < 1e-6
+                    (padded[c * ph * pw + y * pw + x] - data[c * ch * cw + y * cw + x]).abs()
+                        < 1e-6
                 );
             }
         }


### PR DESCRIPTION
## Summary
The Dataset Doctor **"Upscale N low-res images"** one-tap fix (sc-6539) — and the standalone/inline `image_upscale` path that shares the same engine — crashed for any source image with an **odd width or height** at the default factor 2:

```
onnxruntime: Non-zero status code returned while running Reshape node. Name:'/Reshape_1'
requested_shape_size != 0 && (input_shape_size % requested_shape_size) == 0 was false.
Input shape:{1,3,264,2,323}, requested shape:{1,3,264,2,-1,2}
```

## Root cause
The default upscaler is Real-ESRGAN **x2**, whose RRDBNet begins with `F.pixel_unshuffle(x, 2)` (`scripts/spikes/sc3489_export_reference.py:88`). That op reshapes the spatial dims `(H, W) → (H/2, 2, W/2, 2)` and therefore **requires even H and W**. An odd width (e.g. 323) can't be split into `(W/2, 2)`, so the onnx `/Reshape_1` node fails `input_size % requested_size == 0`. The **x4** model has no `pixel_unshuffle` (it feeds `x` directly), so only **x2** — the default factor — was affected.

This path is **fully native Rust** (`ort`/onnxruntime via the `ort` crate, CoreML on Mac / CUDA off-Mac) — no Python involved. The `/Users/cloudtest/...` path in the error string is baked into the prebuilt libonnxruntime C++ binary, not a local Python stack.

## Fix
Added a pure `pad_chw_even` helper in `upscale_jobs.rs` that pads each input tile's CHW buffer up to even dims by **edge-replicating** the last column/row (replication, not zeros, so no dark seam bleeds into the readable region through the conv receptive field). Applied in `Upscaler::upscale` right before building the onnx input tensor. The extra `factor` output px on the padded edge fall outside the inner (unpadded) region the caller copies back, so the output stays exactly `factor×` the source and dimensions are unchanged. No-op for already-even inputs; harmless for x4 — applied unconditionally to keep the call site simple.

## Test plan
- Added `pad_chw_even_replicates_to_even_dims_for_pixel_unshuffle` (odd-width, odd-height, even-input passthrough).
- `cargo test -p sceneworks-worker --lib upscale_jobs::` → 14 passed, 0 failed (1 ignored real-weight smoke).
- `cargo clippy -p sceneworks-worker --lib` → clean.

Story: [sc-8218](https://app.shortcut.com/trefry/story/8218) (epic 6529 — Dataset Doctor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)