### PR TITLE
fix(web): reference auto-preset fires for imported images, snaps Aspect (sc-8220)

### DIFF
--- a/apps/web/src/components/StructuredPromptBuilder.jsx
+++ b/apps/web/src/components/StructuredPromptBuilder.jsx
@@ -170,9 +170,19 @@ export default function StructuredPromptBuilder({
   function handleReferenceChange(assetId) {
     setReferenceAssetId(assetId);
     setCaptionError("");
-    const asset = referenceAssets.find((item) => item.id === assetId);
-    if (asset) reportReferenceDimensions(asset);
   }
+
+  // Run the auto-preset from an effect on the SELECTED id rather than the picker's onChange: a
+  // freshly imported/dragged reference lands in `referenceAssets` a render AFTER its id is set, so
+  // the onChange-time `find` missed it and the Aspect stayed at the 1:1 default (sc-8220). Keying on
+  // both the id and the list re-runs once the asset resolves, covering select / import / drag /
+  // character paths uniformly.
+  useEffect(() => {
+    if (!referenceAssetId) return;
+    const asset = referenceAssets.find((item) => item.id === referenceAssetId);
+    if (asset) reportReferenceDimensions(asset);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [referenceAssetId, referenceAssets]);
 
   async function handleImageCaption() {
     if (typeof onImageCaption !== "function" || !referenceAssetId || captionBusy) return;

--- a/apps/web/src/components/StructuredPromptBuilder.test.jsx
+++ b/apps/web/src/components/StructuredPromptBuilder.test.jsx
@@ -281,6 +281,39 @@ describe("StructuredPromptBuilder", () => {
     expect(snap.caption).toEqual(captioned);
   });
 
+  it("reports the reference image's dimensions for the resolution auto-preset (sc-8109/sc-8220)", async () => {
+    // Stub the dimension probe so the <img> "loads" as a 1280×720 landscape reference.
+    const RealImage = global.Image;
+    global.Image = class {
+      set src(_value) {
+        this.naturalWidth = 1280;
+        this.naturalHeight = 720;
+        queueMicrotask(() => this.onload && this.onload());
+      }
+    };
+    try {
+      const onReferenceImageLoaded = vi.fn();
+      const onImageCaption = vi.fn(async () => ({}));
+      await mount({
+        initialMode: "plain",
+        onImageCaption,
+        referenceAssets: [refAsset],
+        projectId: "proj-1",
+        onReferenceImageLoaded,
+      });
+      await selectReference();
+      // Let the effect + the probe's onload microtask settle.
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 0));
+      });
+      // The auto-preset fires from an effect on the selected id (not the picker onChange), so it
+      // also covers a freshly imported asset that lands in the list a render later (sc-8220).
+      expect(onReferenceImageLoaded).toHaveBeenCalledWith(1280, 720);
+    } finally {
+      global.Image = RealImage;
+    }
+  });
+
   it("keeps the caption button disabled until a reference is selected (sc-8108)", async () => {
     const onImageCaption = vi.fn(async () => ({}));
     await mount({ initialMode: "plain", onImageCaption, referenceAssets: [refAsset], projectId: "proj-1" });


### PR DESCRIPTION
## Problem
The reference-image auto-preset (sc-8109 — snap the generation **Aspect** to the closest aspect of the uploaded reference) didn't work for the common path of importing/dragging a new reference: the Aspect stayed at the 1:1 default (`1024x1024`).

## Root cause
The probe only ran synchronously in the picker's `onChange` (`handleReferenceChange` → `referenceAssets.find(assetId)`). A freshly imported asset lands in `referenceAssets` a render **after** its id is set, so `find()` returned undefined and the dimensions were never read → `pickClosestResolution` never ran → resolution untouched at the 1:1 default.

Clarifications: `pickClosestResolution` always returns the closest aspect (no 1:1 fallback) — the matcher was never the issue. The caption `aspect_ratio` is only stripped by `parseVisionCaption`, never used to set the Aspect. Ideogram's coarse buckets (1:1/16:9/9:16) also mean near-square references correctly resolve to 1:1.

## Fix
Move the dimension probe to a `useEffect` keyed on `[referenceAssetId, referenceAssets]` so it re-runs once the selected/imported asset resolves in the list — covering select / import / drag / character paths uniformly. Ground-truth image pixels + `pickClosestResolution` unchanged.

Test mocks the `<img>` probe and asserts `onReferenceImageLoaded` fires with the reference's dimensions after selection. Full web suite 797 passing; lint + build clean.

sc-8220