### PR TITLE
feat(training): backfill pre-existing AVIF/HEIC dataset images to PNG pre-train (sc-8225)

### DIFF
--- a/apps/rust-api/src/training.rs
+++ b/apps/rust-api/src/training.rs
@@ -1148,13 +1148,14 @@ pub(crate) async fn create_training_job(
 
     // Load the dataset, its absolute root, and the project name for the queue.
     let dataset_id = payload.dataset_id.clone();
-    let (dataset, dataset_root, project_name) = project_call(state.clone(), {
+    let (mut dataset, dataset_root, project_name) = project_call(state.clone(), {
         let project_id = project_id.clone();
         move |store| store.training_dataset_for_plan(&project_id, &dataset_id)
     })
     .await?;
 
-    // We persist only the dataset's current version, so an older pin is unrunnable.
+    // We persist only the dataset's current version, so an older pin is unrunnable. Checked against
+    // the version the caller saw, before the pre-train backfill below may bump it.
     if let Some(requested_version) = payload.dataset_version {
         if requested_version != dataset.version {
             return Err(ApiError::bad_request(format!(
@@ -1162,6 +1163,23 @@ pub(crate) async fn create_training_job(
                 dataset.id, dataset.version
             )));
         }
+    }
+
+    // sc-8225: a real run hands each dataset image path straight to the engine, which decodes it with
+    // no backstop. Datasets built before normalization (sc-6143 / sc-8224) can still hold a valid-but-
+    // unsupported image (AVIF/HEIC) on disk, which would fail the run. Backfill it to PNG in place
+    // first (idempotent; only bumps the version if it actually rewrote a file), then build the plan
+    // from the normalized dataset. A dry run only resolves/validates the plan (no decode), so it stays
+    // side-effect-free and skips this.
+    if !payload.dry_run {
+        let dataset_id = payload.dataset_id.clone();
+        dataset = project_call(state.clone(), {
+            let project_id = project_id.clone();
+            move |store| {
+                store.normalize_training_dataset_unsupported_images(&project_id, &dataset_id)
+            }
+        })
+        .await?;
     }
 
     // Resolve absolute on-host paths and ids the kernel will consume. The job id

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -594,6 +594,19 @@ impl ProjectStore {
             .repoint_dataset_items(project_id, dataset_id, repoints)
     }
 
+    /// Backfill a training dataset's valid-but-unsupported images (AVIF/HEIC/…) to PNG in place
+    /// (sc-8225) — the one-time fix for datasets built before normalization, run pre-train so the
+    /// engine (which reads dataset images with no decode backstop) never sees an undecodable format.
+    /// Locked wrapper over [`TrainingDatasetStore::normalize_unsupported_images`].
+    pub fn normalize_training_dataset_unsupported_images(
+        &self,
+        project_id: &str,
+        dataset_id: &str,
+    ) -> ProjectStoreResult<TrainingDataset> {
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
+        TrainingDatasetStore::new(project_path).normalize_unsupported_images(project_id, dataset_id)
+    }
+
     /// Read the dataset's CLIP embeddings sidecar (`None` if the analysis job hasn't run). Locked
     /// wrapper over [`TrainingDatasetStore::read_dataset_embeddings`].
     pub fn read_dataset_embeddings(

--- a/crates/sceneworks-core/src/training_store.rs
+++ b/crates/sceneworks-core/src/training_store.rs
@@ -607,6 +607,83 @@ impl TrainingDatasetStore {
         Ok(dataset)
     }
 
+    /// Backfill: transcode any dataset item whose stored bytes are a valid-but-unsupported format
+    /// (AVIF/HEIC/HEIF/TIFF/BMP/GIF) to lossless PNG in place, repointing the item (sc-8225). A
+    /// one-time fix for datasets built before import/build normalization (sc-6143 / sc-8224): the
+    /// trainer reads dataset images straight through the engine with NO decode backstop, so a
+    /// pre-existing AVIF would fail an actual LoRA run. Idempotent — a dataset whose images are all
+    /// natively supported (or unreadable/unrecognized) is returned unchanged with no version bump.
+    /// Repoints exactly like [`Self::repoint_dataset_items`] (new dims + content hash, stale Tier-0 /
+    /// quality-ack caches cleared, version bumped) since the bytes genuinely change; the item id,
+    /// caption, and asset lineage are preserved — the source is the item's own re-encoded image.
+    pub fn normalize_unsupported_images(
+        &self,
+        project_id: &str,
+        dataset_id: &str,
+    ) -> ProjectStoreResult<TrainingDataset> {
+        let mut dataset = self.read_dataset_by_id(dataset_id)?;
+        ensure_dataset_project(project_id, &dataset)?;
+        let root = dataset_root(&self.project_path, &dataset.id);
+        let media_dir = root.join("images");
+        let mut changed = false;
+        for index in 0..dataset.items.len() {
+            let source = root.join(&dataset.items[index].path);
+            let Some(kind) = crate::media_convert::sniff_image_kind_at(&source) else {
+                // Unreadable / unrecognized (e.g. a missing file or SVG) — leave it for the engine's
+                // own error path; we only rewrite a format we positively recognize as transcodable.
+                continue;
+            };
+            if kind.is_natively_supported() {
+                continue;
+            }
+            let item_id = dataset.items[index].id.clone();
+            fs::create_dir_all(&media_dir)?;
+            // Transcode to a temp PNG first, then move it into the canonical slot. This also covers a
+            // mislabeled `.png` whose bytes are really AVIF (source == target) without a sips
+            // read-while-write clobber.
+            let temp = media_dir.join(format!(".{item_id}.transcode.png"));
+            crate::media_convert::transcode_to_png(&source, &temp).map_err(|error| {
+                let _ = fs::remove_file(&temp);
+                ProjectStoreError::BadRequest(format!(
+                    "Could not convert {} dataset image to a supported format: {error}",
+                    kind.label()
+                ))
+            })?;
+            let relative_path = format!("images/{item_id}.png");
+            let target = root.join(&relative_path);
+            if fs::rename(&temp, &target).is_err() {
+                fs::copy(&temp, &target)?;
+                let _ = fs::remove_file(&temp);
+            }
+            // Drop the original if it was a differently-named file (e.g. `.avif`), to avoid orphans.
+            if source != target && source.exists() {
+                let _ = fs::remove_file(&source);
+            }
+            let (width, height) = match crate::media_convert::image_dimensions(&target) {
+                Some((file_w, file_h)) => (Some(file_w), Some(file_h)),
+                None => (None, None),
+            };
+            let content_hash = crate::media_convert::file_content_hash(&target).ok();
+            dataset.items[index] = repoint_item(
+                &dataset.items[index],
+                RepointSource {
+                    asset_id: dataset.items[index].asset_id.clone(),
+                    path: relative_path,
+                    width,
+                    height,
+                    content_hash,
+                },
+            );
+            changed = true;
+        }
+        if changed {
+            dataset.version = dataset.version.saturating_add(1);
+            dataset.updated_at = utc_now();
+            self.save_dataset(&dataset)?;
+        }
+        Ok(dataset)
+    }
+
     pub fn write_caption_sidecars(
         &self,
         project_id: &str,
@@ -1915,6 +1992,59 @@ mod tests {
         );
         assert!(root.join("images/item_1.png").exists(), "new png written");
         assert!(!old_jpg.exists(), "the orphaned .jpg is removed");
+    }
+
+    /// sc-8225 backfill: a dataset built before normalization that still holds an AVIF/BMP on disk
+    /// is transcoded to PNG in place and the item repointed (path, dims, hash, caches cleared, version
+    /// bumped); a second pass is a no-op. macOS-only (relies on `sips`); the ffmpeg path is identical.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn normalize_unsupported_images_transcodes_preexisting_items_and_is_idempotent() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = saved_dataset(dir.path()); // ds_test @ v1, items item_1 + item_2 (both .png paths)
+        let root = dataset_root(&store.project_path, "ds_test");
+        let images = root.join("images");
+        std::fs::create_dir_all(&images).unwrap();
+
+        // Simulate a pre-normalization dataset: item_1's on-disk file is really a BMP (the same decode
+        // gap AVIF hits); item_2 is a genuine (already-supported) PNG that must be left untouched.
+        let mut dataset = store.get_dataset("proj", "ds_test").expect("read");
+        dataset.items[0].path = "images/item_1.bmp".to_owned();
+        dataset.items[0].tier0_scalars = None;
+        store.save_dataset(&dataset).expect("save");
+        std::fs::write(images.join("item_1.bmp"), one_pixel_bmp()).unwrap();
+        std::fs::write(images.join("item_2.png"), b"\x89PNG\r\n\x1a\n fake png").unwrap();
+        let version_before = store.get_dataset("proj", "ds_test").unwrap().version;
+
+        let updated = store
+            .normalize_unsupported_images("proj", "ds_test")
+            .expect("backfill");
+
+        // BMP item repointed to a real PNG; the orphaned .bmp is gone; version bumped once.
+        assert_eq!(updated.version, version_before + 1);
+        let item1 = updated.items.iter().find(|i| i.id == "item_1").unwrap();
+        assert_eq!(item1.path, "images/item_1.png");
+        assert!(!images.join("item_1.bmp").exists(), "orphaned .bmp removed");
+        let stored = std::fs::read(images.join("item_1.png")).unwrap();
+        assert_eq!(
+            crate::media_convert::sniff_image_kind(&stored),
+            Some(crate::media_convert::ImageKind::Png),
+            "stored bytes are genuinely PNG"
+        );
+        assert_eq!((item1.width, item1.height), (Some(1), Some(1)));
+        assert!(
+            item1.tier0_scalars.is_none() && item1.quality_ack.is_none(),
+            "stale caches cleared"
+        );
+        // The already-supported PNG item is left exactly as-is.
+        let item2 = updated.items.iter().find(|i| i.id == "item_2").unwrap();
+        assert_eq!(item2.path, "images/item_2.png");
+
+        // Idempotent: nothing unsupported remains, so a second pass does not bump the version.
+        let again = store
+            .normalize_unsupported_images("proj", "ds_test")
+            .expect("second backfill");
+        assert_eq!(again.version, updated.version);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to [sc-8224](https://app.shortcut.com/trefry/story/8224) — the residual it left open. The trainer hands each dataset image path **straight to the engine**, which decodes it with no backstop (`crates/sceneworks-core/src/project_store.rs:442`). Datasets built before normalization ([sc-6143](https://app.shortcut.com/trefry/story/6143) / sc-8224) can still hold a valid-but-unsupported image (AVIF/HEIC/TIFF/BMP/GIF) **on disk**, which fails an actual LoRA run even now that uploads, dataset builds, and the Dataset Doctor are all covered.

## Decision (recorded on sc-8225): pre-train guarantee, no engine change

The only creator of `lora_train` jobs is the API's `create_training_job`. Normalizing the dataset there — persistently, with repoint — closes the gap without touching the pinned engine crates (mlx-gen / candle-gen) or the training hot path. Considered and declined: an engine-side decode backstop (cross-repo, higher risk, and redundant once the dataset is guaranteed PNG before dispatch).

## Changes

- **core** `TrainingDatasetStore::normalize_unsupported_images` — one-time backfill: sniffs each item's **stored bytes** and transcodes a recognized unsupported format to lossless PNG in place, repointing the item exactly like `repoint_dataset_items` (new `path`/dims/`content_hash`, stale `tier0_scalars` + `quality_ack` cleared, `version` bumped). Idempotent; preserves item id / caption / asset lineage. Transcodes via a temp file so a mislabeled `.png` whose bytes are really AVIF (source == target) doesn't clobber under `sips`.
- **core** `ProjectStore::normalize_training_dataset_unsupported_images` — locked wrapper.
- **api** `create_training_job` runs the backfill **after the version-pin check**, on real runs only (a dry run resolves/validates without decoding, so it stays side-effect-free), then builds the plan from the normalized dataset.

## Testing

- Regression test (macOS `sips`): transcodes a pre-existing BMP dataset item, repoints it, bumps the version, leaves an already-supported PNG untouched, and is a no-op on a second pass.
- `cargo test` `sceneworks-core` 334 green; `cargo clippy` clean for `sceneworks-core` + `sceneworks-rust-api`; `cargo fmt --check` clean.

## Scope note

A `lora_train` job queued *before* this deploy with AVIF paths is the only uncovered case (transient); every job created after dispatch is backfilled. Closes sc-8225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)