### PR TITLE
fix(worker): kill image_detail boundary vignette (normalize by true feather weight) (sc-8229)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/detail.rs
+++ b/crates/sceneworks-worker/src/image_jobs/detail.rs
@@ -205,10 +205,24 @@ fn refine_tiled_detail(
             on_tile(done, total);
         }
     }
+    Ok((compose_feathered(&acc, &wsum, width, height), total))
+}
+
+/// Normalize the feather-weighted accumulator back to an RGB8 image.
+///
+/// Each pixel is the weighted mean `acc / wsum` of every tile that covered it. The divisor
+/// MUST be the true accumulated feather weight: a pixel on the IMAGE boundary is covered by a
+/// single edge tile whose raised-cosine feather ramps toward ~0 over the `overlap`-wide border
+/// (there is no neighboring tile to sum the partition-of-unity back to 1). A previous
+/// `.max(1.0)` guard divided those border pixels by 1.0 while `acc = src * f` (f→0), stamping a
+/// dark rounded-corner vignette — most of the frame in the common single-tile case. Guard only
+/// against a literal divide-by-zero; every pixel is covered by ≥1 tile because the tile origins
+/// are clamped to the boundary, so `wsum` is strictly positive in practice (sc-8229).
+fn compose_feathered(acc: &[f32], wsum: &[f32], width: u32, height: u32) -> image::RgbImage {
     let mut out = image::RgbImage::new(width, height);
     for gy in 0..height {
         for gx in 0..width {
-            let w = wsum[(gy * width + gx) as usize].max(1.0);
+            let w = wsum[(gy * width + gx) as usize].max(f32::EPSILON);
             let base = ((gy * width + gx) * 3) as usize;
             out.put_pixel(
                 gx,
@@ -221,7 +235,7 @@ fn refine_tiled_detail(
             );
         }
     }
-    Ok((out, total))
+    out
 }
 
 /// Build the detail child-asset fact (lineage to the source) + generation set, matching the

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -3742,6 +3742,37 @@ fn detail_feather_ramps_over_overlap() {
     assert!((at(8, 0) - at(8, 15)).abs() < 1e-6);
 }
 
+#[cfg(target_os = "macos")]
+#[test]
+fn compose_feathered_no_boundary_vignette() {
+    // sc-8229: a single edge tile covers the whole frame; its raised-cosine feather ramps
+    // toward ~0 over the `overlap` border. Recompose must normalize by the true accumulated
+    // weight so the border keeps its full source value (not a dark rounded-corner vignette).
+    let (width, height) = (32u32, 32u32);
+    let overlap = 8;
+    let feather = detail_feather(width, height, overlap);
+    let mut acc = vec![0.0f32; (width * height * 3) as usize];
+    let mut wsum = vec![0.0f32; (width * height) as usize];
+    // Uniform mid-gray source refined by one full-frame tile.
+    const SRC: f32 = 200.0;
+    for i in 0..(width * height) as usize {
+        let f = feather[i];
+        acc[i * 3] += SRC * f;
+        acc[i * 3 + 1] += SRC * f;
+        acc[i * 3 + 2] += SRC * f;
+        wsum[i] += f;
+    }
+    let out = compose_feathered(&acc, &wsum, width, height);
+    // Every pixel — corners and edges included — recovers the source value, not a ramp to black.
+    for (x, y) in [(0, 0), (0, height - 1), (width - 1, 0), (15, 0), (0, 15), (15, 15)] {
+        let px = out.get_pixel(x, y).0;
+        assert!(
+            px.iter().all(|&c| c.abs_diff(SRC as u8) <= 1),
+            "pixel ({x},{y}) = {px:?} darkened toward the border (expected ~{SRC})"
+        );
+    }
+}
+
 /// sc-3625 real-Mac E2E (epic 3621): drive the WORKER's FLUX.1 XLabs IP-Adapter reference path
 /// end to end on real weights — `resolve_flux_ip_adapter_dir` staging from the real HF cache +
 /// `load_engine` + a real `Conditioning::Reference` dev `true_cfg` render against the

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -3764,7 +3764,14 @@ fn compose_feathered_no_boundary_vignette() {
     }
     let out = compose_feathered(&acc, &wsum, width, height);
     // Every pixel — corners and edges included — recovers the source value, not a ramp to black.
-    for (x, y) in [(0, 0), (0, height - 1), (width - 1, 0), (15, 0), (0, 15), (15, 15)] {
+    for (x, y) in [
+        (0, 0),
+        (0, height - 1),
+        (width - 1, 0),
+        (15, 0),
+        (0, 15),
+        (15, 15),
+    ] {
         let px = out.get_pixel(x, y).0;
         assert!(
             px.iter().all(|&c| c.abs_diff(SRC as u8) <= 1),


### PR DESCRIPTION
## Problem
The standalone `image_detail` job (RealVisXL tile-ControlNet refine; Image Editor "Detail" tool) stamped a **dark rounded-corner border / vignette** on every output, and dragged the whole-image `blur_variance` sharpness metric *down* (86.7 vs 108.5 baseline). [sc-8229](https://app.shortcut.com/trefry/story/8229)

## Root cause
A recompose-normalization bug in `crates/sceneworks-worker/src/image_jobs/detail.rs` — not an engine/canvas-padding issue.

`refine_tiled_detail` accumulates each refined tile as `acc += src * feather` / `wsum += feather`, then divided by `wsum.max(1.0)`. The raised-cosine `detail_feather` ramps toward ~0 over the `overlap`-wide border of each tile. Interior overlaps form a partition of unity (two tiles' weights sum to ~1, so `wsum ≈ 1` and `.max(1.0)` is a no-op). But an **image-boundary** pixel is covered by a single edge tile with no neighbor to sum back to 1 — there `wsum = feather → 0`, yet the divisor was forced to `1.0`, producing `acc/1.0 = src*feather → ~0` (black), ramping over the border and rounded at the corners (product of the x/y ramps).

Worst in the common single-tile case: a 1024² image with the default `tile=1024 / overlap=128` is one tile, so the *entire* 128px border ramps to black — exactly the reported frame, and the smooth dark border collapses Laplacian variance.

## Fix
Extract the recompose into a pure `compose_feathered(...)` and normalize by the **true** accumulated weight, guarding only against literal divide-by-zero (`wsum.max(f32::EPSILON)`). Every pixel is covered by ≥1 tile (origins are clamped to the boundary), so the boundary ramp normalizes back to full source value; interior seams are unaffected.

## Validation
- Added `compose_feathered_no_boundary_vignette` regression test (single full-frame ramped tile → corners/edges recover the source value, not a ramp to black). Fails under the old `.max(1.0)`.
- macOS: new test + existing `detail_feather_ramps_over_overlap` + `engine_dim_rounds_up_to_mult8_and_clamps` all pass.

## Remaining (real-weight, out of CI)
The dark-border half of acceptance is fixed and unit-locked. The "whole-image sharpness ≥ input" half should be re-confirmed by re-running the `image_detail` A/B on Apple Silicon — with the border gone `blur_variance` should recover; any residual net-softening from the strength-0.55 refine is a separate tuning question (relates to sc-8222 arm (c)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)