### PR TITLE
chore(worker): upgrade Qwen-Image t2i base → Qwen/Qwen-Image-2512 (sc-8271)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -159,13 +159,13 @@
       "downloads": [
         {
           "provider": "huggingface",
-          "repo": "Qwen/Qwen-Image",
+          "repo": "Qwen/Qwen-Image-2512",
           "files": [],
           "estimatedSizeBytes": 57704594653
         }
       ],
       "paths": {
-        "model": "${HF_CACHE}/Qwen/Qwen-Image"
+        "model": "${HF_CACHE}/Qwen/Qwen-Image-2512"
       },
       "defaults": {
         "resolution": "1024x1024",

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -104,7 +104,7 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
         // (epic 3401 / sc-3575).
         sceneworks_id: "qwen_image",
         engine_id: "qwen_image",
-        default_repo: "Qwen/Qwen-Image",
+        default_repo: "Qwen/Qwen-Image-2512",
         default_steps: 20,
         default_guidance: 4.0,
         adapter_label: "mlx_qwen",

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -354,6 +354,13 @@ const DERIVED_TOKENIZER_OVERLAYS: &[DerivedTokenizerOverlay] = &[
         base_repo: "Qwen/Qwen-Image",
         tokenizer_repo: "SceneWorks/qwen-image-tokenizer",
     },
+    // Qwen-Image-2512 (sc-8271): the Dec-2025 base refresh is architecturally identical to
+    // `Qwen/Qwen-Image` and reuses the same Qwen2 BPE tokenizer (unchanged across the line),
+    // so it points at the same hosted overlay repo.
+    DerivedTokenizerOverlay {
+        base_repo: "Qwen/Qwen-Image-2512",
+        tokenizer_repo: "SceneWorks/qwen-image-tokenizer",
+    },
 ];
 
 /// The hosted tokenizer repo + overlay dest for a just-downloaded `repo`, or `None` when `repo` is not


### PR DESCRIPTION
## What

Drop-in weight swap of the `qwen_image` text-to-image base from `Qwen/Qwen-Image` to the Dec-2025 `Qwen/Qwen-Image-2512` refresh.

- **`config/manifests/builtin.models.jsonc`** — `qwen_image` download `repo` + `paths.model` → `Qwen/Qwen-Image-2512`. `estimatedSizeBytes` left as-is (2512 safetensors total ≈ 57.7 GB ≈ existing value); `mlx.minMemoryGb`/`quantize` untouched.
- **`crates/sceneworks-worker/src/engines.rs`** — `qwen_image` ModelRow `default_repo` → `Qwen/Qwen-Image-2512`.
- **`crates/sceneworks-worker/src/model_jobs.rs`** — added a `Qwen/Qwen-Image-2512` row to `DERIVED_TOKENIZER_OVERLAYS` reusing the existing `SceneWorks/qwen-image-tokenizer` repo (the Qwen2.5-VL/Qwen2 BPE tokenizer is unchanged across the Qwen-Image line). The existing `Qwen/Qwen-Image` row is kept.

## Why

`Qwen/Qwen-Image-2512` is **architecturally identical** to `Qwen/Qwen-Image`: same `_class_name` `QwenImageTransformer2DModel`, `num_layers=60`, `attention_head_dim=128`, `num_attention_heads=24`, `in_channels=64`, `out_channels=16`, `joint_attention_dim=3584`, `axes_dims_rope=[16,56,56]`, `guidance_embeds=false`. 2512 merely drops an unused `pooled_projection_dim` key. So this is a pure catalog/loader weight swap — **not an engine port**. Apache-2.0, ungated.

## Out of scope (intentional)

- `qwen_control.rs` `QWEN_CONTROL_DEFAULT_REPO = "Qwen/Qwen-Image"` is **left on `Qwen/Qwen-Image`** — the control path migrates to 2512 together with the control checkpoint in **sc-8267**. Running InstantX-control on a 2512 base now would be incoherent.
- `apps/worker/scene_worker/image_adapters.py` is test-only (no python runtime image-gen path), so it is not touched.

## Tests

- `cargo build -p sceneworks-worker` — green.
- `cargo test -p sceneworks-worker` — 411 passed, 0 failed.
- `cargo test -p sceneworks-core --lib` (incl. `builtin_manifests::tests::seeds_every_manifest_into_a_fresh_dir`) — 333 passed, 0 failed; confirms the edited jsonc still parses + seeds.
- `cargo fmt --all --check` — clean (CI parity).

## Remaining gate (on-device)

The only remaining validation is an **on-device real-weight Mac smoke** the maintainer runs: a Q8 1024² coherent text-to-image generation on the 2512 weights, to confirm the new checkpoint loads and renders cleanly through the unchanged engine. This cannot be done in CI (no GPU/weights).

Story: sc-8271