### PR TITLE
refactor(worker): shared strict-control driver collapses the MLX Fun-Union paths (sc-8243)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -1475,6 +1475,11 @@ include!("image_jobs/base.rs");
 // Per-generation PiD (pixel-diffusion) super-resolving decoder routing (epic 7840, sc-7849).
 include!("image_jobs/pid.rs");
 #[cfg(target_os = "macos")]
+// Shared strict-control driver (epic 8236, sc-8243): the `(engine_id, control_repo, supported_kinds)`
+// single source of truth + the preprocess (pose/canny/depth/user-passthrough) → `Conditioning::Control`
+// core the three MLX registry strict-control paths (zimage/flux2/qwen below) route through.
+include!("image_jobs/strict_control.rs");
+#[cfg(target_os = "macos")]
 // Z-Image strict-pose and prompt augmentation helpers.
 include!("image_jobs/zimage.rs");
 #[cfg(target_os = "macos")]

--- a/crates/sceneworks-worker/src/image_jobs/flux2.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2.rs
@@ -490,9 +490,9 @@ async fn generate_flux2_edit_stream(
 
 /// The engine registry id for the FLUX.2-dev Fun-Controlnet-Union variant (sc-2292).
 const FLUX2_DEV_CONTROL_ENGINE_ID: &str = "flux2_dev_control";
-/// Default Fun-Controlnet-Union control-weights repo + the `-2602` CFG-distilled variant (the
-/// recommended one — the previous version lost CFG distillation after control training).
-const FLUX2_CONTROL_REPO: &str = "alibaba-pai/FLUX.2-dev-Fun-Controlnet-Union";
+/// Default Fun-Controlnet-Union control-weights filename — the `-2602` CFG-distilled variant (the
+/// recommended one — the previous version lost CFG distillation after control training). The default
+/// *repo* is the shared strict-control table (single source of truth — `STRICT_CONTROL_ENGINES`).
 const FLUX2_CONTROL_FILE: &str = "FLUX.2-dev-Fun-Controlnet-Union-2602.safetensors";
 /// The asset `adapter` id recorded on FLUX.2-dev strict-pose assets (the dev base MLX label).
 const FLUX2_CONTROL_ADAPTER_LABEL: &str = "mlx_flux2";
@@ -525,7 +525,12 @@ fn flux2_control_repo_file(request: &ImageRequest) -> (String, String) {
             .to_owned()
     };
     (
-        pick("repo", FLUX2_CONTROL_REPO),
+        // Default repo from the shared strict-control table (single source of truth); the file stays
+        // engine-specific.
+        pick(
+            "repo",
+            strict_control_default_repo(FLUX2_DEV_CONTROL_ENGINE_ID),
+        ),
         pick("filename", FLUX2_CONTROL_FILE),
     )
 }
@@ -577,10 +582,10 @@ fn flux2_control_scale(request: &ImageRequest) -> f32 {
     advanced::f32_clamped(&request.advanced, "controlScale", 0.75, 0.0..=2.0)
 }
 
-/// Generate one FLUX.2-dev strict-pose image: the `control` skeleton drives the Fun-Controlnet-Union
-/// pose branch at `control_scale`. dev is guidance-distilled (embedded scalar) — `guidance` rides the
-/// transformer's guidance embedder (no true-CFG). `reference` is the optional identity img2img-init
-/// shared across the pose set (opt-in, off by default).
+/// Generate one FLUX.2-dev strict-pose image: the pre-built `conditioning` (the required `Control` plus an
+/// optional identity `Reference`, assembled by the shared [`build_control_conditioning`] driver) drives the
+/// Fun-Controlnet-Union branch. dev is guidance-distilled (embedded scalar) — `guidance` rides the
+/// transformer's guidance embedder (no true-CFG).
 #[allow(clippy::too_many_arguments)]
 fn flux2_control_generate_one(
     generator: &dyn Generator,
@@ -590,23 +595,10 @@ fn flux2_control_generate_one(
     seed: i64,
     steps: u32,
     guidance: Option<f32>,
-    control: Image,
-    control_scale: f32,
-    reference: Option<&(Image, f32)>,
+    conditioning: Vec<Conditioning>,
     cancel: &CancelFlag,
     on_progress: &mut dyn FnMut(Progress),
 ) -> WorkerResult<(u32, u32, Vec<u8>)> {
-    let mut conditioning = vec![Conditioning::Control {
-        image: control,
-        kind: ControlKind::Pose,
-        scale: control_scale,
-    }];
-    if let Some((image, strength)) = reference {
-        conditioning.push(Conditioning::Reference {
-            image: image.clone(),
-            strength: Some(*strength),
-        });
-    }
     let request = GenerationRequest {
         prompt: prompt.to_owned(),
         width,
@@ -776,6 +768,13 @@ async fn generate_flux2_dev_control_stream(
     let control_scale = flux2_control_scale(request);
     let adapters = resolve_adapters(request, settings)?;
     let repo = model_repo(request, &model);
+    // Shared strict-control driver: validate the requested ControlKind against the engine's
+    // supported_kinds (flux2_dev_control = {Pose, Canny, Depth}) + resolve an optional user-supplied
+    // control-map passthrough. The current (pose-only) job sets no `controlMode`, so `kind == Pose` and the
+    // skeleton preprocessor runs exactly as before.
+    let control_kind = requested_control_kind(request)?;
+    validate_control_kind(FLUX2_DEV_CONTROL_ENGINE_ID, &control_kind)?;
+    let user_control = resolve_user_control_map(request, settings, project_path)?;
     let poses = parse_poses(request);
     let count = poses.len();
     let raw_settings = flux2_control_raw_settings(
@@ -804,20 +803,23 @@ async fn generate_flux2_dev_control_stream(
         "FLUX.2-dev control load failed".to_owned(),
         move |generator, tx, cancel| {
             let identity_init = identity_init.as_ref();
+            let user_control = user_control.as_ref();
             drive_gen_items(tx, poses, move |_index, pose, on_progress| {
-                let skeleton = crate::openpose_skeleton::draw_wholebody(
+                let control = preprocess_control_entry(
+                    &control_kind,
+                    user_control,
+                    Some(&pose),
+                    None,
                     width,
                     height,
-                    &pose.keypoints,
-                    pose.hands.as_deref(),
-                    pose.face.as_deref(),
                     stickwidth,
+                )?;
+                let conditioning = build_control_conditioning(
+                    control,
+                    control_kind.clone(),
+                    control_scale,
+                    identity_init,
                 );
-                let control = Image {
-                    width,
-                    height,
-                    pixels: skeleton.into_raw(),
-                };
                 let (out_w, out_h, pixels) = flux2_control_generate_one(
                     generator,
                     &prompt,
@@ -826,9 +828,7 @@ async fn generate_flux2_dev_control_stream(
                     seed,
                     steps,
                     guidance,
-                    control,
-                    control_scale,
-                    identity_init,
+                    conditioning,
                     &cancel,
                     on_progress,
                 )?;

--- a/crates/sceneworks-worker/src/image_jobs/qwen.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen.rs
@@ -16,7 +16,14 @@ fn qwen_control_available(request: &ImageRequest, settings: &Settings) -> bool {
 }
 
 fn resolve_qwen_control_weights(request: &ImageRequest, settings: &Settings) -> Option<PathBuf> {
-    resolve_control_weights_for(request, settings, QWEN_CONTROL_REPO, QWEN_CONTROL_FILE)
+    // Default repo from the shared strict-control table (single source of truth); the file stays
+    // engine-specific.
+    resolve_control_weights_for(
+        request,
+        settings,
+        strict_control_default_repo(QWEN_CONTROL_ENGINE_ID),
+        QWEN_CONTROL_FILE,
+    )
 }
 
 /// Load the Qwen-Image ControlNet-Union generator (base snapshot + InstantX control overlay).
@@ -50,8 +57,9 @@ fn qwen_control_load(
     })
 }
 
-/// Generate one Qwen strict-pose image: the pose skeleton drives the InstantX control branch at
-/// `control_scale`; prompt, true CFG, negative prompt, quant, and LoRA/LoKr mirror base Qwen.
+/// Generate one Qwen strict-pose image: the pre-built `conditioning` (the required `Control`, assembled by
+/// the shared [`build_control_conditioning`] driver) drives the InstantX control branch; prompt, true CFG,
+/// negative prompt, quant, and LoRA/LoKr mirror base Qwen.
 #[allow(clippy::too_many_arguments)]
 fn qwen_control_generate_one(
     generator: &dyn Generator,
@@ -62,8 +70,7 @@ fn qwen_control_generate_one(
     seed: i64,
     steps: u32,
     guidance: f32,
-    control: Image,
-    control_scale: f32,
+    conditioning: Vec<Conditioning>,
     use_pid: bool,
     cancel: &CancelFlag,
     on_progress: &mut dyn FnMut(Progress),
@@ -78,11 +85,7 @@ fn qwen_control_generate_one(
         steps: Some(steps),
         guidance: Some(guidance),
         use_pid,
-        conditioning: vec![Conditioning::Control {
-            image: control,
-            kind: ControlKind::Pose,
-            scale: control_scale,
-        }],
+        conditioning,
         cancel: cancel.clone(),
         ..Default::default()
     };
@@ -158,6 +161,13 @@ async fn generate_qwen_control_stream(
     let control_scale = resolve_control_scale(request);
     let adapters = resolve_adapters(request, settings)?;
     let repo = model_repo(request, &qwen);
+    // Shared strict-control driver: validate the requested ControlKind against the engine's
+    // supported_kinds (qwen_image_control = {Pose} only — qwen stays pose-only until sc-8250) + resolve an
+    // optional user-supplied control-map passthrough. The current (pose-only) job sets no `controlMode`, so
+    // `kind == Pose` and the skeleton preprocessor runs exactly as before.
+    let control_kind = requested_control_kind(request)?;
+    validate_control_kind(QWEN_CONTROL_ENGINE_ID, &control_kind)?;
+    let user_control = resolve_user_control_map(request, settings, project_path)?;
     let poses = parse_poses(request);
     let count = poses.len();
     let raw_settings = qwen_control_raw_settings(
@@ -191,20 +201,21 @@ async fn generate_qwen_control_stream(
         spec,
         "Qwen strict-pose control load failed".to_owned(),
         move |generator, tx, cancel| {
+            let user_control = user_control.as_ref();
             drive_gen_items(tx, poses, move |_index, pose, on_progress| {
-                let skeleton = crate::openpose_skeleton::draw_wholebody(
+                let control = preprocess_control_entry(
+                    &control_kind,
+                    user_control,
+                    Some(&pose),
+                    None,
                     width,
                     height,
-                    &pose.keypoints,
-                    pose.hands.as_deref(),
-                    pose.face.as_deref(),
                     stickwidth,
-                );
-                let control = Image {
-                    width,
-                    height,
-                    pixels: skeleton.into_raw(),
-                };
+                )?;
+                // qwen ignores a reference (identity comes from character LoRA on the base transformer),
+                // so no identity-init `Reference` — pose-only `Control` conditioning, byte-identical.
+                let conditioning =
+                    build_control_conditioning(control, control_kind.clone(), control_scale, None);
                 let (out_w, out_h, pixels) = qwen_control_generate_one(
                     generator,
                     &prompt,
@@ -214,8 +225,7 @@ async fn generate_qwen_control_stream(
                     seed,
                     steps,
                     guidance,
-                    control,
-                    control_scale,
+                    conditioning,
                     use_pid,
                     &cancel,
                     on_progress,

--- a/crates/sceneworks-worker/src/image_jobs/strict_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/strict_control.rs
@@ -1,0 +1,272 @@
+// Shared worker strict-control driver (epic 8236, sc-8243). The single source of truth for the
+// Fun-Union family of strict-control engines and the one preprocess → conditioning core all of them
+// share. Collapses the per-engine duplication that previously lived in `zimage.rs` / `flux2.rs` /
+// `qwen.rs` (the three MLX registry-backed strict-control paths): every one of them rendered a DWPose
+// skeleton, wrapped it in `Conditioning::Control { kind: Pose, scale }`, and (flux2 / z-image) appended
+// an optional identity `Reference`. That core is now ONE function here; the per-engine streams keep only
+// their genuinely-divergent numerics (guidance mode, negative prompt, PiD, weight resolution, raw_settings
+// keys, control_scale defaults).
+//
+// **Single source of truth for `supported_kinds`.** [`STRICT_CONTROL_ENGINES`] is the authority sc-8244
+// (manifest) and sc-8245 (web picker) consume — and the gate the worker uses to reject an unsupported
+// `ControlKind` for a given engine. Today every reachable job is pose-only (`controlMode` unset →
+// [`ControlKind::Pose`]); the canny / depth / user-supplied-passthrough branches are structurally present
+// (so the driver is capable per S0) but only reached once the per-model exposure stories (sc-8248
+// flux2 +canny/+depth, sc-8249 z-image +canny/+depth, sc-8250 qwen +canny/+depth) flip the request to set
+// `advanced.controlMode`. Pose stays the proven path and is byte-preserved.
+//
+// macOS-only: the registry strict-control engines this drives are MLX (`gen_core::load(engine_id, …)`);
+// the candle siblings (`qwen_control.rs` / `zimage_control.rs` / `flux2_control_candle.rs`) are bespoke
+// non-registry providers and are NOT collapsed here (see the sc-8243 PR / follow-up).
+
+/// One Fun-Union strict-control engine: its registry id, default control-weights repo, and the set of
+/// [`ControlKind`]s it accepts. THE authority for `supported_kinds` (sc-8244 manifest / sc-8245 web
+/// picker consume the same notion). `repo` is the *default* Fun-Union control repo for the engine; the
+/// per-engine stream still honors an `advanced.controlWeights.{repo,filename}` override when resolving
+/// the actual checkpoint (this row is the catalog default, not a hard pin).
+#[derive(Clone, Copy, Debug)]
+struct StrictControlEngine {
+    /// The mlx-gen registry id (`gen_core::load(engine_id, spec)`).
+    engine_id: &'static str,
+    /// The default Fun-Union control-weights HF repo for this engine.
+    repo: &'static str,
+    /// The `ControlKind`s this engine accepts. Pose is the proven tier on every engine; canny / depth
+    /// are unlocked per-model by sc-8248 / sc-8249 / sc-8250 (the driver supports them generically here).
+    supported_kinds: &'static [ControlKind],
+}
+
+/// The Fun-Union strict-control catalog (S0 table). SINGLE SOURCE OF TRUTH for `(engine_id, control_repo,
+/// supported_kinds)`:
+/// - `flux2_dev_control` — `{Pose, Canny, Depth}`
+/// - `z_image_turbo_control` — `{Pose, Canny, Depth}`
+/// - `qwen_image_control` — `{Pose}` only (qwen stays pose-only until sc-8250)
+///
+/// `flux1_dev_control` is added as another row once E2 (sc-8239) lands — not present yet. The SDXL tile
+/// detail-upscale path (`ControlKind::Other("tile")`, `image_jobs/detail.rs`) is OUTSIDE this family and
+/// is deliberately NOT listed.
+const STRICT_CONTROL_ENGINES: &[StrictControlEngine] = &[
+    StrictControlEngine {
+        engine_id: "flux2_dev_control",
+        repo: "alibaba-pai/FLUX.2-dev-Fun-Controlnet-Union",
+        supported_kinds: &[ControlKind::Pose, ControlKind::Canny, ControlKind::Depth],
+    },
+    StrictControlEngine {
+        engine_id: "z_image_turbo_control",
+        repo: "alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1",
+        supported_kinds: &[ControlKind::Pose, ControlKind::Canny, ControlKind::Depth],
+    },
+    StrictControlEngine {
+        engine_id: "qwen_image_control",
+        repo: "InstantX/Qwen-Image-ControlNet-Union",
+        supported_kinds: &[ControlKind::Pose],
+    },
+];
+
+/// The catalog row for a registry strict-control engine id, or `None` if it is not a Fun-Union
+/// strict-control engine (e.g. the SDXL tile detail path, which must never route through this driver).
+fn strict_control_engine(engine_id: &str) -> Option<&'static StrictControlEngine> {
+    STRICT_CONTROL_ENGINES
+        .iter()
+        .find(|entry| entry.engine_id == engine_id)
+}
+
+/// The catalog DEFAULT control-weights repo for a Fun-Union strict-control engine — the single source of
+/// truth each engine's `controlWeights.repo`-override resolver falls back to. Panics on a non-Fun-Union
+/// engine id (a programming error: only the three registry strict-control streams call this with their
+/// own engine id).
+fn strict_control_default_repo(engine_id: &str) -> &'static str {
+    strict_control_engine(engine_id)
+        .unwrap_or_else(|| panic!("{engine_id} is not a Fun-Union strict-control engine"))
+        .repo
+}
+
+/// Validate a requested [`ControlKind`] against an engine's `supported_kinds` (the [`STRICT_CONTROL_ENGINES`]
+/// authority). `Ok(())` when supported; a clear, actionable `InvalidPayload` otherwise. An unknown engine
+/// id is itself an error — only the Fun-Union catalog engines route here.
+fn validate_control_kind(engine_id: &str, kind: &ControlKind) -> WorkerResult<()> {
+    let Some(entry) = strict_control_engine(engine_id) else {
+        return Err(WorkerError::InvalidPayload(format!(
+            "{engine_id} is not a Fun-Union strict-control engine"
+        )));
+    };
+    if entry.supported_kinds.contains(kind) {
+        return Ok(());
+    }
+    let supported = entry
+        .supported_kinds
+        .iter()
+        .map(control_kind_label)
+        .collect::<Vec<_>>()
+        .join(", ");
+    Err(WorkerError::InvalidPayload(format!(
+        "{engine_id} does not support {} control (supported: {supported})",
+        control_kind_label(kind),
+    )))
+}
+
+/// A stable lowercase label for a [`ControlKind`] (telemetry / error messages / the `controlMode` request
+/// field). `Other(name)` carries its bespoke name verbatim.
+fn control_kind_label(kind: &ControlKind) -> String {
+    match kind {
+        ControlKind::Pose => "pose".to_owned(),
+        ControlKind::Canny => "canny".to_owned(),
+        ControlKind::Depth => "depth".to_owned(),
+        ControlKind::Other(name) => name.clone(),
+    }
+}
+
+/// Parse the requested control kind from the job. The default is [`ControlKind::Pose`] (the proven tier;
+/// every current job omits `controlMode`, so existing pose jobs are byte-preserved). `advanced.controlMode`
+/// — when a future per-model exposure story sets it — selects `canny` / `depth` / `pose`. An unknown value
+/// is rejected loudly rather than silently falling back.
+fn requested_control_kind(request: &ImageRequest) -> WorkerResult<ControlKind> {
+    let Some(mode) = request
+        .advanced
+        .get("controlMode")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(ControlKind::Pose);
+    };
+    match mode.to_ascii_lowercase().as_str() {
+        "pose" => Ok(ControlKind::Pose),
+        "canny" => Ok(ControlKind::Canny),
+        "depth" => Ok(ControlKind::Depth),
+        other => Err(WorkerError::InvalidPayload(format!(
+            "unknown controlMode '{other}' (expected pose, canny, or depth)"
+        ))),
+    }
+}
+
+/// A decoded user-supplied control map (`advanced.controlImage` asset id), already at native resolution.
+/// Present iff the job carries an explicit control map to use verbatim instead of a preprocessor.
+fn resolve_user_control_map(
+    request: &ImageRequest,
+    settings: &Settings,
+    project_path: &Path,
+) -> WorkerResult<Option<Image>> {
+    let Some(asset_id) = request
+        .advanced
+        .get("controlImage")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+    else {
+        return Ok(None);
+    };
+    let image = load_reference_image(&settings.data_dir, &request.project_id, asset_id, project_path)?;
+    Ok(Some(image))
+}
+
+/// Estimate a depth control map from an arbitrary input image.
+///
+/// **Seam for sc-8242 (auto depth estimator).** The estimator has not landed yet, so for now depth
+/// requires a user-supplied control map (passed through unchanged). When sc-8242 lands, its
+/// `depth_control_image(&RgbImage) -> RgbImage` (sibling of `openpose_skeleton::draw_wholebody` /
+/// `canny::canny_control_image`) plugs in HERE — replacing the error with the estimator call — and the
+/// rest of the driver is unchanged.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn depth_control_image(_source: Option<&Image>) -> WorkerResult<Image> {
+    Err(WorkerError::InvalidPayload(
+        "depth control currently requires a user-supplied control map \
+         (advanced.controlImage); automatic depth estimation lands in sc-8242"
+            .to_owned(),
+    ))
+}
+
+/// Preprocess one control entry into the control [`Image`] the engine consumes.
+///
+/// Dispatch by [`ControlKind`]:
+/// - **user-supplied passthrough** — if `user_control` is `Some`, it is used verbatim for ANY kind (the
+///   caller already validated the kind), skipping preprocessing. This is the only path for `Other(_)`.
+/// - **pose** — render the DWPose whole-body skeleton from `pose` via
+///   [`crate::openpose_skeleton::draw_wholebody`] (body + hands 21×2 + face 68 when carried). Byte-identical
+///   to the old per-engine pose preprocessing.
+/// - **canny** — [`crate::canny::canny_control_image_default`] over `source` (a user-supplied source
+///   image). Requires a source — canny has no synthetic input.
+/// - **depth** — [`depth_control_image`] (sc-8242 seam; today user-supplied only).
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+#[allow(clippy::too_many_arguments)]
+fn preprocess_control_entry(
+    kind: &ControlKind,
+    user_control: Option<&Image>,
+    pose: Option<&PoseInput>,
+    source: Option<&Image>,
+    width: u32,
+    height: u32,
+    stickwidth: u32,
+) -> WorkerResult<Image> {
+    if let Some(image) = user_control {
+        return Ok(image.clone());
+    }
+    match kind {
+        ControlKind::Pose => {
+            let pose = pose.ok_or_else(|| {
+                WorkerError::InvalidPayload("pose control requires a pose entry".to_owned())
+            })?;
+            let skeleton = crate::openpose_skeleton::draw_wholebody(
+                width,
+                height,
+                &pose.keypoints,
+                pose.hands.as_deref(),
+                pose.face.as_deref(),
+                stickwidth,
+            );
+            Ok(Image {
+                width,
+                height,
+                pixels: skeleton.into_raw(),
+            })
+        }
+        ControlKind::Canny => {
+            let source = source.ok_or_else(|| {
+                WorkerError::InvalidPayload(
+                    "canny control requires a source image (advanced.controlImage)".to_owned(),
+                )
+            })?;
+            let rgb = image::RgbImage::from_raw(source.width, source.height, source.pixels.clone())
+                .ok_or_else(|| {
+                    WorkerError::InvalidPayload("canny source buffer size mismatch".to_owned())
+                })?;
+            let edges = crate::canny::canny_control_image_default(&rgb);
+            Ok(Image {
+                width: edges.width(),
+                height: edges.height(),
+                pixels: edges.into_raw(),
+            })
+        }
+        ControlKind::Depth => depth_control_image(source),
+        ControlKind::Other(name) => Err(WorkerError::InvalidPayload(format!(
+            "{name} control requires a user-supplied control map (advanced.controlImage)"
+        ))),
+    }
+}
+
+/// Build the strict-control conditioning for one entry: the required control plus an optional shared
+/// identity img2img-init `Reference` (flux2 / z-image opt-in tier). [`ControlKind::Depth`] uses the
+/// dedicated `Conditioning::Depth` variant; every other kind uses `Conditioning::Control { kind, scale }`.
+/// Byte-identical to the old per-engine construction for the pose tier.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn build_control_conditioning(
+    control: Image,
+    kind: ControlKind,
+    scale: f32,
+    identity_init: Option<&(Image, f32)>,
+) -> Vec<Conditioning> {
+    let mut conditioning = match kind {
+        ControlKind::Depth => vec![Conditioning::Depth { image: control }],
+        kind => vec![Conditioning::Control {
+            image: control,
+            kind,
+            scale,
+        }],
+    };
+    if let Some((image, strength)) = identity_init {
+        conditioning.push(Conditioning::Reference {
+            image: image.clone(),
+            strength: Some(*strength),
+        });
+    }
+    conditioning
+}

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -2076,6 +2076,7 @@ fn sc3031_ab_dump_pose() {
 
     let generator = zimage_control_load(weights, control_weights, quant, adapters).expect("load");
     let cancel = CancelFlag::new();
+    let conditioning = build_control_conditioning(control, ControlKind::Pose, control_scale, None);
     let (ow, oh, pixels) = zimage_control_generate_one(
         generator.as_ref(),
         &req.prompt,
@@ -2083,9 +2084,7 @@ fn sc3031_ab_dump_pose() {
         h,
         seed,
         steps,
-        control,
-        control_scale,
-        None,
+        conditioning,
         &cancel,
         &mut |_| {},
     )
@@ -2250,6 +2249,7 @@ fn zimage_control_real_weights_generates_one_pose() {
 
     let cancel = gen_core::CancelFlag::new();
     let mut steps_seen = 0u32;
+    let conditioning = build_control_conditioning(control, ControlKind::Pose, 0.9, None);
     let (w, h, pixels) = zimage_control_generate_one(
         generator.as_ref(),
         "a person standing in a meadow",
@@ -2257,9 +2257,7 @@ fn zimage_control_real_weights_generates_one_pose() {
         512,
         42,
         8,
-        control,
-        0.9,
-        None,
+        conditioning,
         &cancel,
         &mut |p| {
             if let gen_core::Progress::Step { current, .. } = p {
@@ -2330,6 +2328,7 @@ fn qwen_control_real_weights_generates_one_pose() {
 
     let cancel = gen_core::CancelFlag::new();
     let mut steps_seen = 0u32;
+    let conditioning = build_control_conditioning(control, ControlKind::Pose, 0.9, None);
     let (w, h, pixels) = qwen_control_generate_one(
         generator.as_ref(),
         "a person standing in a meadow",
@@ -2339,8 +2338,7 @@ fn qwen_control_real_weights_generates_one_pose() {
         42,
         4,
         4.0,
-        control,
-        0.9,
+        conditioning,
         false,
         &cancel,
         &mut |p| {
@@ -2487,7 +2485,12 @@ fn flux2_control_scale_defaults_and_clamps() {
 #[test]
 fn flux2_control_repo_file_defaults_and_overrides() {
     let (repo, file) = flux2_control_repo_file(&request(json!({ "projectId": "p" })));
-    assert_eq!(repo, FLUX2_CONTROL_REPO);
+    // The default repo now comes from the shared strict-control table (single source of truth).
+    assert_eq!(
+        repo,
+        strict_control_default_repo(FLUX2_DEV_CONTROL_ENGINE_ID)
+    );
+    assert_eq!(repo, "alibaba-pai/FLUX.2-dev-Fun-Controlnet-Union");
     assert_eq!(file, FLUX2_CONTROL_FILE);
     // `advanced.controlWeights` overrides repo + filename (parity with the Z-Image resolver).
     let (repo, file) = flux2_control_repo_file(&request(json!({
@@ -2625,6 +2628,7 @@ fn flux2_dev_control_real_weights_generates_one_pose() {
 
     let cancel = gen_core::CancelFlag::new();
     let mut steps_seen = 0u32;
+    let conditioning = build_control_conditioning(control, ControlKind::Pose, 0.75, None);
     let (w, h, pixels) = flux2_control_generate_one(
         generator.as_ref(),
         "a person standing in a meadow, photorealistic",
@@ -2633,9 +2637,7 @@ fn flux2_dev_control_real_weights_generates_one_pose() {
         42,
         8,
         Some(4.0), // dev embedded guidance
-        control,
-        0.75,
-        None,
+        conditioning,
         &cancel,
         &mut |p| {
             if let gen_core::Progress::Step { current, .. } = p {
@@ -4822,4 +4824,236 @@ fn boogu_real_weights_generates_base_turbo_edit() {
         root.display()
     );
     eprintln!("boogu real-weights smoke: {ran}/3 variants validated");
+}
+
+// ---------------------------------------------------------------------------
+// Shared strict-control driver (sc-8243): the `(engine_id, control_repo, supported_kinds)` single
+// source of truth + the preprocess → conditioning core the three MLX registry strict-control paths
+// (z-image / flux2 / qwen) route through. macOS-only (the driver is macOS-gated).
+// ---------------------------------------------------------------------------
+
+/// A small solid RGB control [`Image`] for passthrough / canny-source fixtures.
+#[cfg(target_os = "macos")]
+fn control_fixture(w: u32, h: u32, rgb: [u8; 3]) -> Image {
+    Image {
+        width: w,
+        height: h,
+        pixels: rgb
+            .iter()
+            .cycle()
+            .take((w * h * 3) as usize)
+            .copied()
+            .collect(),
+    }
+}
+
+/// A single pose entry parsed from a job (reuses `parse_poses` so the test exercises the real path).
+#[cfg(target_os = "macos")]
+fn one_pose() -> PoseInput {
+    let req = request(json!({
+        "projectId": "p", "model": "z_image_turbo", "prompt": "a knight",
+        "advanced": { "poses": [{ "keypoints": [[0.5, 0.5]] }] }
+    }));
+    parse_poses(&req).pop().expect("one pose")
+}
+
+/// SINGLE SOURCE OF TRUTH: the S0 `(engine_id, control_repo, supported_kinds)` table. Exercises the
+/// `repo` field (the catalog default sc-8244/sc-8245 consume) and the per-engine kind sets:
+/// flux2/z-image = {Pose, Canny, Depth}; qwen = {Pose} only.
+#[cfg(target_os = "macos")]
+#[test]
+fn strict_control_table_is_the_authority() {
+    let flux2 = strict_control_engine("flux2_dev_control").expect("flux2 row");
+    assert_eq!(flux2.repo, "alibaba-pai/FLUX.2-dev-Fun-Controlnet-Union");
+    assert_eq!(
+        flux2.supported_kinds,
+        &[ControlKind::Pose, ControlKind::Canny, ControlKind::Depth]
+    );
+
+    let zimage = strict_control_engine("z_image_turbo_control").expect("z-image row");
+    assert_eq!(
+        zimage.repo,
+        "alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1"
+    );
+    assert_eq!(
+        zimage.supported_kinds,
+        &[ControlKind::Pose, ControlKind::Canny, ControlKind::Depth]
+    );
+
+    let qwen = strict_control_engine("qwen_image_control").expect("qwen row");
+    assert_eq!(qwen.repo, "InstantX/Qwen-Image-ControlNet-Union");
+    // qwen stays pose-only until sc-8250 — canny/depth must NOT be unlocked here.
+    assert_eq!(qwen.supported_kinds, &[ControlKind::Pose]);
+
+    // The SDXL tile detail path is NOT a Fun-Union strict-control engine and must never route here.
+    assert!(strict_control_engine("flux2_dev").is_none());
+    assert!(strict_control_engine("sdxl_tile_control").is_none());
+}
+
+/// supported_kinds validation: pose accepted on every engine; canny/depth accepted on flux2/z-image
+/// but REJECTED on qwen; an unknown engine id is itself an error.
+#[cfg(target_os = "macos")]
+#[test]
+fn validate_control_kind_accepts_and_rejects_per_table() {
+    // Pose is the proven tier on all three.
+    for engine in [
+        "flux2_dev_control",
+        "z_image_turbo_control",
+        "qwen_image_control",
+    ] {
+        assert!(validate_control_kind(engine, &ControlKind::Pose).is_ok());
+    }
+    // Canny + Depth: flux2 / z-image accept.
+    for engine in ["flux2_dev_control", "z_image_turbo_control"] {
+        assert!(validate_control_kind(engine, &ControlKind::Canny).is_ok());
+        assert!(validate_control_kind(engine, &ControlKind::Depth).is_ok());
+    }
+    // qwen rejects canny + depth (pose-only until sc-8250) with an actionable message.
+    let err = validate_control_kind("qwen_image_control", &ControlKind::Canny)
+        .expect_err("qwen canny rejected");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("qwen_image_control") && msg.contains("canny"),
+        "{msg}"
+    );
+    assert!(
+        validate_control_kind("qwen_image_control", &ControlKind::Depth).is_err(),
+        "qwen depth rejected"
+    );
+    // Unknown / non-Fun-Union engine id is rejected outright.
+    assert!(validate_control_kind("sdxl_tile_control", &ControlKind::Pose).is_err());
+}
+
+/// `requested_control_kind`: default Pose (no `controlMode` → byte-preserved pose path); parse
+/// canny/depth/pose; reject an unknown value.
+#[cfg(target_os = "macos")]
+#[test]
+fn requested_control_kind_defaults_to_pose_and_parses_modes() {
+    let kind = |adv: Value| {
+        requested_control_kind(&request(json!({
+            "projectId": "p", "model": "z_image_turbo", "prompt": "x", "advanced": adv
+        })))
+    };
+    // Every current job omits controlMode → Pose (the proven, byte-preserved tier).
+    assert_eq!(kind(json!({})).unwrap(), ControlKind::Pose);
+    assert_eq!(
+        kind(json!({ "controlMode": "pose" })).unwrap(),
+        ControlKind::Pose
+    );
+    assert_eq!(
+        kind(json!({ "controlMode": "Canny" })).unwrap(),
+        ControlKind::Canny
+    );
+    assert_eq!(
+        kind(json!({ "controlMode": "depth" })).unwrap(),
+        ControlKind::Depth
+    );
+    assert!(kind(json!({ "controlMode": "scribble" })).is_err());
+}
+
+/// Preprocessor dispatch by kind: pose → `draw_wholebody` (byte-identical to a direct call);
+/// user-supplied control map → verbatim passthrough for ANY kind; canny → edge map over a source;
+/// depth without a user map → the sc-8242 seam error.
+#[cfg(target_os = "macos")]
+#[test]
+fn preprocess_control_entry_dispatches_by_kind() {
+    let (w, h) = (64u32, 48u32);
+    let pose = one_pose();
+    let stick = crate::openpose_skeleton::body_stickwidth(w, h);
+
+    // Pose: byte-identical to the old per-engine skeleton render.
+    let got = preprocess_control_entry(&ControlKind::Pose, None, Some(&pose), None, w, h, stick)
+        .expect("pose preprocess");
+    let want = crate::openpose_skeleton::draw_wholebody(
+        w,
+        h,
+        &pose.keypoints,
+        pose.hands.as_deref(),
+        pose.face.as_deref(),
+        stick,
+    );
+    assert_eq!(got.width, w);
+    assert_eq!(got.height, h);
+    assert_eq!(
+        got.pixels,
+        want.into_raw(),
+        "pose preprocessor must be byte-identical"
+    );
+
+    // User-supplied passthrough wins for ANY kind (verbatim, skip preprocessing).
+    let supplied = control_fixture(w, h, [10, 20, 30]);
+    for kind in [ControlKind::Pose, ControlKind::Canny, ControlKind::Depth] {
+        let out = preprocess_control_entry(&kind, Some(&supplied), Some(&pose), None, w, h, stick)
+            .expect("passthrough");
+        assert_eq!(
+            out.pixels, supplied.pixels,
+            "{kind:?} passthrough must be verbatim"
+        );
+    }
+
+    // Canny over a source: produces a same-dimension RGB edge map (grayscale broadcast).
+    let source = control_fixture(w, h, [128, 128, 128]);
+    let canny =
+        preprocess_control_entry(&ControlKind::Canny, None, None, Some(&source), w, h, stick)
+            .expect("canny preprocess");
+    assert_eq!((canny.width, canny.height), (w, h));
+    assert_eq!(canny.pixels.len(), (w * h * 3) as usize);
+
+    // Canny without a source is an error (no synthetic input).
+    assert!(
+        preprocess_control_entry(&ControlKind::Canny, None, None, None, w, h, stick).is_err(),
+        "canny needs a source"
+    );
+
+    // Depth without a user map → the sc-8242 estimator seam error (not a silent pass).
+    let err = preprocess_control_entry(&ControlKind::Depth, None, None, None, w, h, stick)
+        .expect_err("depth seam");
+    assert!(err.to_string().contains("sc-8242"), "{}", err);
+}
+
+/// Conditioning construction: pose builds `Control { kind: Pose, scale }` (byte-identical to the old
+/// hand-built shape), optionally followed by the identity `Reference`; depth uses the dedicated
+/// `Depth` variant.
+#[cfg(target_os = "macos")]
+#[test]
+fn build_control_conditioning_matches_legacy_shape() {
+    let control = control_fixture(8, 8, [1, 2, 3]);
+
+    // Pose, no identity init → exactly the old `vec![Control { Pose, scale }]`.
+    let cond = build_control_conditioning(control.clone(), ControlKind::Pose, 0.9, None);
+    assert_eq!(cond.len(), 1);
+    match &cond[0] {
+        Conditioning::Control { image, kind, scale } => {
+            assert_eq!(image.pixels, control.pixels);
+            assert_eq!(*kind, ControlKind::Pose);
+            assert!((*scale - 0.9).abs() < 1e-6);
+        }
+        other => panic!("expected Control, got {other:?}"),
+    }
+
+    // Pose + identity init → Control then Reference (the flux2 / z-image opt-in tier).
+    let init = control_fixture(8, 8, [9, 9, 9]);
+    let cond = build_control_conditioning(
+        control.clone(),
+        ControlKind::Pose,
+        0.75,
+        Some(&(init.clone(), 0.6)),
+    );
+    assert_eq!(cond.len(), 2);
+    assert!(matches!(cond[0], Conditioning::Control { .. }));
+    match &cond[1] {
+        Conditioning::Reference { image, strength } => {
+            assert_eq!(image.pixels, init.pixels);
+            assert_eq!(*strength, Some(0.6));
+        }
+        other => panic!("expected Reference, got {other:?}"),
+    }
+
+    // Depth → the dedicated `Depth` variant (not `Control`).
+    let cond = build_control_conditioning(control.clone(), ControlKind::Depth, 1.0, None);
+    assert_eq!(cond.len(), 1);
+    assert!(
+        matches!(cond[0], Conditioning::Depth { .. }),
+        "depth uses Conditioning::Depth"
+    );
 }

--- a/crates/sceneworks-worker/src/image_jobs/zimage.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage.rs
@@ -46,9 +46,16 @@ fn resolve_control_weights_for(
     path.exists().then_some(path)
 }
 
-/// Resolve the Z-Image Fun-Controlnet-Union checkpoint.
+/// Resolve the Z-Image Fun-Controlnet-Union checkpoint. The default repo comes from the shared
+/// strict-control table (single source of truth — `STRICT_CONTROL_ENGINES`); the file default stays
+/// engine-specific.
 fn resolve_control_weights(request: &ImageRequest, settings: &Settings) -> Option<PathBuf> {
-    resolve_control_weights_for(request, settings, ZIMAGE_CONTROL_REPO, ZIMAGE_CONTROL_FILE)
+    resolve_control_weights_for(
+        request,
+        settings,
+        strict_control_default_repo(ZIMAGE_CONTROL_ENGINE_ID),
+        ZIMAGE_CONTROL_FILE,
+    )
 }
 
 /// Pose ControlNet lock strength: `advanced.controlScale` (default 0.9, clamp [0,2]).
@@ -98,13 +105,9 @@ fn zimage_control_load(
         .map_err(|error| WorkerError::Engine(format!("Z-Image control load failed: {error}")))
 }
 
-/// Generate one strict-pose image: the `control` skeleton drives the Fun-Controlnet-Union
-/// pose branch at `control_scale`. Z-Image-Turbo is guidance-distilled (no CFG / negative).
-///
-/// `reference` is the optional identity img2img-init shared across the pose set (sc-3146):
-/// `(image, strength)` adds a `Reference` conditioning next to the required `Control`, seeding
-/// the denoise from the reference latents. `strength` is the engine's img2img strength (mflux
-/// `image_strength` convention: higher = more init kept). `None` → the pose-only tier.
+/// Generate one strict-pose image: the pre-built `conditioning` (the required `Control` plus an optional
+/// identity `Reference`, assembled by the shared [`build_control_conditioning`] driver) drives the
+/// Fun-Controlnet-Union branch. Z-Image-Turbo is guidance-distilled (no CFG / negative).
 #[allow(clippy::too_many_arguments)]
 fn zimage_control_generate_one(
     generator: &dyn Generator,
@@ -113,23 +116,10 @@ fn zimage_control_generate_one(
     height: u32,
     seed: i64,
     steps: u32,
-    control: Image,
-    control_scale: f32,
-    reference: Option<&(Image, f32)>,
+    conditioning: Vec<Conditioning>,
     cancel: &CancelFlag,
     on_progress: &mut dyn FnMut(Progress),
 ) -> WorkerResult<(u32, u32, Vec<u8>)> {
-    let mut conditioning = vec![Conditioning::Control {
-        image: control,
-        kind: ControlKind::Pose,
-        scale: control_scale,
-    }];
-    if let Some((image, strength)) = reference {
-        conditioning.push(Conditioning::Reference {
-            image: image.clone(),
-            strength: Some(*strength),
-        });
-    }
     let request = GenerationRequest {
         prompt: prompt.to_owned(),
         width,
@@ -217,6 +207,13 @@ async fn generate_zimage_control_stream(
     let control_scale = resolve_control_scale(request);
     let adapters = resolve_adapters(request, settings)?;
     let repo = model_repo(request, &zimage);
+    // Shared strict-control driver: validate the requested ControlKind against the engine's
+    // supported_kinds (z_image_turbo_control = {Pose, Canny, Depth}) and resolve an optional user-supplied
+    // control-map passthrough. The current (pose-only) job sets no `controlMode`, so `kind == Pose` and the
+    // skeleton preprocessor below runs exactly as before.
+    let control_kind = requested_control_kind(request)?;
+    validate_control_kind(ZIMAGE_CONTROL_ENGINE_ID, &control_kind)?;
+    let user_control = resolve_user_control_map(request, settings, project_path)?;
     let poses = parse_poses(request);
     let count = poses.len();
     let raw_settings =
@@ -238,20 +235,23 @@ async fn generate_zimage_control_stream(
         "Z-Image control load failed".to_owned(),
         move |generator, tx, cancel| {
             let identity_init = identity_init.as_ref();
+            let user_control = user_control.as_ref();
             drive_gen_items(tx, poses, move |_index, pose, on_progress| {
-                let skeleton = crate::openpose_skeleton::draw_wholebody(
+                let control = preprocess_control_entry(
+                    &control_kind,
+                    user_control,
+                    Some(&pose),
+                    None,
                     width,
                     height,
-                    &pose.keypoints,
-                    pose.hands.as_deref(),
-                    pose.face.as_deref(),
                     stickwidth,
+                )?;
+                let conditioning = build_control_conditioning(
+                    control,
+                    control_kind.clone(),
+                    control_scale,
+                    identity_init,
                 );
-                let control = Image {
-                    width,
-                    height,
-                    pixels: skeleton.into_raw(),
-                };
                 let (out_w, out_h, pixels) = zimage_control_generate_one(
                     generator,
                     &prompt,
@@ -259,9 +259,7 @@ async fn generate_zimage_control_stream(
                     height,
                     seed,
                     steps,
-                    control,
-                    control_scale,
-                    identity_init,
+                    conditioning,
                     &cancel,
                     on_progress,
                 )?;

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -160,9 +160,9 @@ mod openpose_skeleton;
 // Native canny edge-map preprocessor for the Fun-Controlnet-Union canny head
 // (epic 8236, sc-8240). Pure CPU raster (cross-platform + testable everywhere),
 // sibling of `openpose_skeleton`: arbitrary image → `ControlKind::Canny` control
-// image. Not yet wired into the control driver (sc-8243 / extend stories), so its
-// items are unused on every target for now — allow dead_code until then.
-#[allow(dead_code)]
+// image. Consumed by the shared strict-control driver (sc-8243) on macOS; the
+// off-Mac candle lane has no registry strict-control path, so it stays unused there.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 mod canny;
 // DWPose pose detection via onnxruntime (epic 3482, sc-3487). On Mac the CoreML EP +
 // on the off-Mac candle GPU-worker lane the CUDA EP (sc-5496, epic 5482) run the same


### PR DESCRIPTION
## sc-8243 — S2: shared worker strict-control driver

Collapses the duplicated MLX strict-control paths into **one driver** parametrized by a single-source-of-truth `(engine_id, control_repo, supported_kinds)` table, and wires in the sc-8240 canny preprocessor. Part of epic 8236 (Unified ControlNet pipeline).

### Driver design
New module `crates/sceneworks-worker/src/image_jobs/strict_control.rs` (macOS-gated):

- **`STRICT_CONTROL_ENGINES`** — THE authority for `(engine_id, control_repo, supported_kinds)`. sc-8244 (manifest) and sc-8245 (web picker) consume the same notion; each engine's default control repo now resolves from this table (`strict_control_default_repo`).

  | engine_id | control_repo (default) | supported_kinds |
  |---|---|---|
  | `flux2_dev_control` | `alibaba-pai/FLUX.2-dev-Fun-Controlnet-Union` | Pose, Canny, Depth |
  | `z_image_turbo_control` | `alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1` | Pose, Canny, Depth |
  | `qwen_image_control` | `InstantX/Qwen-Image-ControlNet-Union` | Pose **only** |

  (`flux1_dev_control` is added as another row once E2/sc-8239 lands.)

- **`requested_control_kind`** — parses `advanced.controlMode` (default `Pose`; `canny`/`depth`/`pose`; unknown → loud error).
- **`validate_control_kind`** — rejects an unsupported kind for the engine (qwen canny/depth rejected) and rejects non-Fun-Union engine ids.
- **`preprocess_control_entry`** — dispatch by `ControlKind`:
  - **pose** → `openpose_skeleton::draw_wholebody` (body + hands + face)
  - **canny** → `canny::canny_control_image_default` over a source image
  - **user-supplied control map** (`advanced.controlImage`) → verbatim passthrough for ANY kind
  - **depth** → `depth_control_image` (sc-8242 seam, see below)
- **`build_control_conditioning`** — `Conditioning::Control{kind,scale}` (+ optional identity `Reference`) for pose/canny; the dedicated `Conditioning::Depth` for depth.

### Paths collapsed
The **three MLX registry** strict-control streams now route their preprocess + conditioning-construction + kind-validation through the driver:
- `image_jobs/zimage.rs` `generate_zimage_control_stream`
- `image_jobs/flux2.rs` `generate_flux2_dev_control_stream`
- `image_jobs/qwen.rs` `generate_qwen_control_stream`

Their genuinely-divergent numerics (guidance mode / negative prompt / PiD / identity-init / control_scale defaults / raw_settings keys / weight resolution) stay in place — only the shared core moved.

### Pose behavior byte-preserved (regression-critical)
With no `controlMode` (every current job), `kind == Pose`: `preprocess_control_entry` renders the **identical** `draw_wholebody` skeleton into the same `Image{width,height,pixels}`, and `build_control_conditioning(control, Pose, scale, identity_init)` produces the **identical** `vec![Control{kind:Pose,scale}]` (+ optional `Reference`) the old inline code built. raw_settings, adapter labels (`mlx_z_image` / `mlx_flux2` / `mlx_qwen`), shared-seed per-pose iteration: unchanged. The new validation always returns `Ok` for pose jobs, and `controlImage` is unset so no new I/O. V/sc-8247 re-proves on real weights.

### Depth-estimator seam (sc-8242)
`depth_control_image()` is the single call site where the auto depth estimator plugs in. Today depth requires a user-supplied control map; when sc-8242 lands, its `depth_control_image(&RgbImage)` replaces the error and the rest of the driver is unchanged.

### Tile path NOT swallowed
The SDXL tile detail-upscale ControlNet (`ControlKind::Other("tile")`, `image_jobs/detail.rs`) is OUTSIDE the Fun-Union family — deliberately **not** in `STRICT_CONTROL_ENGINES` and never routes through this driver (asserted in tests).

### Scope boundaries (what other stories still own)
- **sc-8248 / sc-8249 / sc-8250** own the per-model *exposure* of canny/depth for flux2 / z-image / qwen (manifest + request wiring that sets `controlMode` and feeds a canny/depth *source*). This PR makes the driver **capable** of canny/depth/passthrough generically but keeps pose as the proven, byte-preserved path — it does not flip the per-model exposure or unlock qwen beyond pose.
- **sc-8242** owns the auto depth estimator (seam left here).
- **sc-8304** (filed, relates-to sc-8243) owns routing the **candle** strict-control trio (`zimage_control.rs` / `flux2_control_candle.rs` / `qwen_control.rs`) through a shared driver — they're bespoke non-registry providers (raw `&control` Image, not `Conditioning::Control`), a different mechanism needing a provider trait.

### Tests
Added (macOS): table authority + per-engine supported_kinds accept/reject; `controlMode` parsing + default-Pose; preprocessor dispatch (pose **byte-identical** to `draw_wholebody`, user-passthrough, canny over a source, depth seam error); conditioning golden shape (pose `Control`(+`Reference`), depth `Depth`). Existing real-weight smoke tests updated to the new `generate_one` signature.

`cargo build` / `cargo test -p sceneworks-worker --lib` (421 passed, 95 ignored) / `cargo fmt --all --check` / `cargo clippy -p sceneworks-worker --all-targets -D warnings`: all green.

Story: https://app.shortcut.com/trefry/story/8243

🤖 Generated with [Claude Code](https://claude.com/claude-code)