### PR TITLE
feat(web): Assets batch bar — bulk Discard + Move-to-character

### DIFF
--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -153,7 +153,7 @@ function AssetTags({ asset, availableTags = [], updateAssetTags = () => {} }) {
   );
 }
 
-function assetSupportsCharacterLink(asset) {
+export function assetSupportsCharacterLink(asset) {
   return (
     ["image", "frame", "upload", "video"].includes(asset?.type) ||
     asset?.file?.mimeType?.startsWith("image/") ||

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -9045,6 +9045,156 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("Added to Dax's assets.");
   });
 
+  it("bulk-discards every selected Library asset to the Trash", async () => {
+    const deleteAsset = vi.fn(async () => {});
+    const assetA = {
+      id: "asset-a",
+      projectId: "project-1",
+      type: "image",
+      displayName: "Plate A",
+      status: { favorite: false, rating: 0, rejected: false, trashed: false },
+    };
+    const assetB = {
+      id: "asset-b",
+      projectId: "project-1",
+      type: "image",
+      displayName: "Plate B",
+      status: { favorite: false, rating: 0, rejected: false, trashed: false },
+    };
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Characters" },
+            assets: [assetA, assetB],
+            characters: [],
+            addCharacterReference: vi.fn(),
+            jobs: [],
+            imageModels: [],
+            createVqaJob: vi.fn(),
+            deleteAsset,
+            purgeAsset: () => {},
+            importAsset: () => {},
+            setPreviewAsset: () => {},
+            sendAssetToImage: () => {},
+            sendAssetToVideo: () => {},
+            selectedAsset: null,
+            setSelectedAssetId: () => {},
+            setActiveView: () => {},
+            updateAssetStatus: () => {},
+            updateAssetTags: () => {},
+          },
+          <LibraryScreen />,
+        ),
+      );
+    });
+    await settle();
+
+    await act(async () => {
+      container.querySelector('input[aria-label="Select Plate A"]').click();
+    });
+    await act(async () => {
+      container.querySelector('input[aria-label="Select Plate B"]').click();
+    });
+    await settle();
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Discard").click();
+    });
+    await settle();
+
+    expect(deleteAsset).toHaveBeenCalledTimes(2);
+    expect(deleteAsset).toHaveBeenCalledWith(assetA);
+    expect(deleteAsset).toHaveBeenCalledWith(assetB);
+    // Selection clears once the fan-out finishes, so the bar disappears.
+    expect(container.querySelector(".batch-selection-bar")).toBeNull();
+  });
+
+  it("bulk-moves selected Library assets into a chosen character's assets", async () => {
+    const addCharacterReference = vi.fn(async () => ({ id: "char-2", references: [] }));
+    const assetA = {
+      id: "asset-a",
+      projectId: "project-1",
+      type: "image",
+      displayName: "Plate A",
+      status: { favorite: false, rating: 0, rejected: false, trashed: false },
+    };
+    const assetB = {
+      id: "asset-b",
+      projectId: "project-1",
+      type: "image",
+      displayName: "Plate B",
+      status: { favorite: false, rating: 0, rejected: false, trashed: false },
+    };
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Characters" },
+            assets: [assetA, assetB],
+            characters: [
+              { id: "char-1", name: "Mira", type: "person", references: [], approvedReferences: [], looks: [], loras: [] },
+              { id: "char-2", name: "Dax", type: "person", references: [], approvedReferences: [], looks: [], loras: [] },
+            ],
+            addCharacterReference,
+            jobs: [],
+            imageModels: [],
+            createVqaJob: vi.fn(),
+            deleteAsset: () => {},
+            purgeAsset: () => {},
+            importAsset: () => {},
+            setPreviewAsset: () => {},
+            sendAssetToImage: () => {},
+            sendAssetToVideo: () => {},
+            selectedAsset: null,
+            setSelectedAssetId: () => {},
+            setActiveView: () => {},
+            updateAssetStatus: () => {},
+            updateAssetTags: () => {},
+          },
+          <LibraryScreen />,
+        ),
+      );
+    });
+    await settle();
+
+    await act(async () => {
+      container.querySelector('input[aria-label="Select Plate A"]').click();
+    });
+    await act(async () => {
+      container.querySelector('input[aria-label="Select Plate B"]').click();
+    });
+    await settle();
+
+    // Reveal the inline character picker, target Dax, then confirm.
+    await act(async () => {
+      [...container.querySelectorAll(".batch-selection-bar button")].find((button) => button.textContent === "Move").click();
+    });
+    await settle();
+    await changeField(container.querySelector('select[aria-label="Move to character"]'), "char-2");
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent?.startsWith("Move 2 to assets")).click();
+    });
+    await settle();
+
+    expect(addCharacterReference).toHaveBeenCalledTimes(2);
+    expect(addCharacterReference).toHaveBeenCalledWith("char-2", {
+      assetId: "asset-a",
+      approved: false,
+      role: "asset",
+      notes: "Added from Asset Library.",
+    });
+    expect(addCharacterReference).toHaveBeenCalledWith("char-2", {
+      assetId: "asset-b",
+      approved: false,
+      role: "asset",
+      notes: "Added from Asset Library.",
+    });
+    expect(container.querySelector(".batch-selection-bar")).toBeNull();
+  });
+
   it("disables the Library move action for a character that already owns the asset", async () => {
     const addCharacterReference = vi.fn();
     const asset = {

--- a/apps/web/src/screens/LibraryScreen.jsx
+++ b/apps/web/src/screens/LibraryScreen.jsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { apiFetch } from "../api.js";
 import { foldUpscaledAssetVariants } from "../assetVariants.js";
 import { batchEligibleAssets, batchItemStatus, buildBatchJob, summarizeBatchProgress } from "../batchOps.js";
-import { AssetDetail, AssetGrid, emptyTrash } from "../components/assetPanels.jsx";
+import { AssetDetail, AssetGrid, assetSupportsCharacterLink, emptyTrash } from "../components/assetPanels.jsx";
 import { assetUrl } from "../components/assetMedia.jsx";
 import { BatchOperationsPanel } from "../components/BatchOperationsPanel.jsx";
 import { terminalStatuses } from "../constants.js";
@@ -65,6 +65,11 @@ export function LibraryScreen() {
   const [batchOpen, setBatchOpen] = useState(false);
   // While/after a batch runs: { op, items: [{ asset, jobId }], submitting }.
   const [batch, setBatch] = useState(null);
+  // Bulk Discard / Move-to-character on the current selection. `bulkAction` gates the
+  // buttons while a fan-out is in flight; `moveOpen` reveals the inline character picker.
+  const [bulkAction, setBulkAction] = useState(null);
+  const [moveOpen, setMoveOpen] = useState(false);
+  const [moveCharacterId, setMoveCharacterId] = useState("");
   // Asset Library hygiene (sc-2024): show only studio-generated and uploaded
   // media. Character Studio test outputs (origin "character_studio") live under
   // the character, not here. The backend also exposes `?scope=library`; we filter
@@ -150,7 +155,47 @@ export function LibraryScreen() {
       else next.add(id);
       return next;
     });
-  const clearSelection = () => setSelectedAssetIds(new Set());
+  const clearSelection = () => {
+    setSelectedAssetIds(new Set());
+    setMoveOpen(false);
+  };
+
+  // Move targets the same "Character Assets" link the per-asset panel uses (role "asset",
+  // unapproved) — NOT the character's reference images — so only link-capable media counts.
+  const availableCharacters = characters.filter((character) => !character?.archived);
+  const movableSelected = selectedAssetList.filter(assetSupportsCharacterLink);
+
+  // Send every selected asset to the Trash (reversible — the backend just flags `trashed`).
+  async function discardSelected() {
+    if (!selectedAssetList.length || bulkAction) return;
+    setBulkAction("discard");
+    try {
+      for (const asset of selectedAssetList) {
+        await deleteAsset(asset);
+      }
+      clearSelection();
+    } finally {
+      setBulkAction(null);
+    }
+  }
+
+  // Fan out the per-asset character link across every movable selection.
+  async function moveSelectedToCharacter() {
+    if (!moveCharacterId || !movableSelected.length || bulkAction) return;
+    setBulkAction("move");
+    try {
+      for (const asset of movableSelected) {
+        try {
+          await moveAssetToCharacter(asset, moveCharacterId);
+        } catch {
+          // One asset failing (e.g. already linked) shouldn't abort the rest.
+        }
+      }
+      clearSelection();
+    } finally {
+      setBulkAction(null);
+    }
+  }
 
   // Decode an asset's native pixel size (needed for an edit job — the worker fits the
   // source to width×height). Resolves null on a load failure so that item fails alone.
@@ -285,9 +330,65 @@ export function LibraryScreen() {
           <button className="primary" disabled={!eligibleSelected.length} onClick={() => setBatchOpen(true)} type="button">
             Batch…
           </button>
+          {assetMode === "assets" ? (
+            <button
+              className="danger-action"
+              disabled={Boolean(bulkAction)}
+              onClick={discardSelected}
+              type="button"
+            >
+              {bulkAction === "discard" ? "Discarding…" : "Discard"}
+            </button>
+          ) : null}
+          {availableCharacters.length ? (
+            <button
+              disabled={!movableSelected.length || Boolean(bulkAction)}
+              onClick={() =>
+                setMoveOpen((open) => {
+                  const next = !open;
+                  if (next && !moveCharacterId) {
+                    setMoveCharacterId(availableCharacters[0]?.id ?? "");
+                  }
+                  return next;
+                })
+              }
+              title={movableSelected.length ? undefined : "No movable media selected"}
+              type="button"
+            >
+              Move
+            </button>
+          ) : null}
           <button onClick={clearSelection} type="button">
             Clear
           </button>
+          {moveOpen && availableCharacters.length ? (
+            <div className="batch-move-picker">
+              <select
+                aria-label="Move to character"
+                onChange={(event) => setMoveCharacterId(event.target.value)}
+                value={moveCharacterId}
+              >
+                {availableCharacters.map((character) => (
+                  <option key={character.id} value={character.id}>
+                    {character.name}
+                  </option>
+                ))}
+              </select>
+              <button
+                className="primary"
+                disabled={!moveCharacterId || !movableSelected.length || Boolean(bulkAction)}
+                onClick={moveSelectedToCharacter}
+                type="button"
+              >
+                {bulkAction === "move"
+                  ? "Moving…"
+                  : `Move ${movableSelected.length} to assets`}
+              </button>
+              <button onClick={() => setMoveOpen(false)} type="button">
+                Cancel
+              </button>
+            </div>
+          ) : null}
         </div>
       ) : null}
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3718,6 +3718,7 @@ label {
 /* Batch selection toolbar — shown above the grid while ≥1 asset is selected. */
 .batch-selection-bar {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: var(--gap-3);
   margin-bottom: var(--gap-3);
@@ -3730,6 +3731,22 @@ label {
 .batch-selection-bar span {
   margin-right: auto;
   font-weight: 600;
+}
+
+/* Inline character picker the "Move" button reveals; drops to its own full-width
+   row beneath the action buttons. */
+.batch-move-picker {
+  flex-basis: 100%;
+  display: flex;
+  align-items: center;
+  gap: var(--gap-2);
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+
+.batch-move-picker select {
+  flex: 1;
+  min-width: 0;
 }
 
 .asset-detail {


### PR DESCRIPTION
## What

Adds two bulk actions to the **Assets** page selection bar, alongside the existing **Batch…** and **Clear**:

- **Discard** — sends every selected asset to the Trash using the existing reversible `deleteAsset` (the same `trashed`-flag DELETE the per-asset Discard uses). Shown only in **Assets** mode (in Trashcan mode the relevant action remains Empty Trash).
- **Move** — reveals an inline character picker on its own row; confirming fans out the **same** "Character Assets" link the per-asset panel uses (`role: "asset"`, `approved: false`) across link-capable selections. This targets the character's **Assets**, not its reference images, as requested. The button is gated on there being movable media selected and at least one non-archived character.

## Why

The Assets page Batch mode previously only supported Upscale/Detail/Edit fan-outs. Discarding or filing many assets to a character required doing it one at a time via the per-asset detail panel. These two bulk actions close that gap using the exact same backend semantics as the single-asset flows.

## Notes for reviewers

- Both actions run as **serial per-asset fan-outs** (mirroring the existing `runBatch` pattern), show in-progress labels (`Discarding…` / `Moving…`), and clear the selection on completion. Move tolerates per-item failures (e.g. an asset already linked to the character) without aborting the rest.
- Exported the existing `assetSupportsCharacterLink` helper from `assetPanels.jsx` for reuse — no behavior change.
- Two decisions worth a look: bulk **Discard** runs without a confirm dialog (matching the reversible single-asset Discard, not the permanent Empty Trash which does confirm), and Discard is hidden in Trashcan mode.

## Testing

- `npm test`: **804 passed** (46 files), including two new integration tests that mount the real `LibraryScreen` and exercise bulk discard + bulk move end-to-end.
- ESLint clean on all touched files.
- Not verified via browser preview: exercising the live selection bar needs the full Rust backend plus a project with selectable assets; coverage is via the jsdom integration suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)