### PR TITLE
Control-surface exposure: flux1_dev_control wiring + live canny/depth for flux2 & z-image (sc-8244 / sc-8248 / sc-8249)

### DIFF
--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -65,6 +65,12 @@ export const fallbackModels = [
       // Strict ControlNet → expose a pose-lock-strength slider (advanced.controlScale).
       // Best-effort tiers (Qwen/Flux2) have no strength control, so they omit this.
       poseControlScale: true,
+      // Strict-control modes the Z-Image Fun-Controlnet-Union branch admits (sc-8249): pose
+      // (skeleton), canny (auto edge map from the input image), depth (auto Depth-Anything-V2). Mirrors
+      // the manifest `controlModes` (single source of truth: STRICT_CONTROL_ENGINES). controlScale is
+      // the structured control-lock-strength knob (advanced.controlScale).
+      controlModes: ["pose", "canny", "depth"],
+      controlScale: { label: "Control strength", default: 0.9, min: 0.0, max: 2.0, step: 0.05 },
     },
   },
   {
@@ -81,6 +87,9 @@ export const fallbackModels = [
       poseLibrary: true,
       // Strict ControlNet → pose-lock-strength slider (advanced.controlScale).
       poseControlScale: true,
+      // Qwen stays POSE-ONLY (qwen_image_control = {pose}); canny/depth + 2512-Fun is sc-8267/sc-8250.
+      controlModes: ["pose"],
+      controlScale: { label: "Control strength", default: 0.9, min: 0.0, max: 2.0, step: 0.05 },
     },
   },
   {
@@ -237,6 +246,13 @@ export const fallbackModels = [
       // FLUX is guidance-distilled; real CFG rides on the parallel trueCfgScale
       // kwarg, distinct from the IP-Adapter reference-strength scalar (sc-2017).
       variationStrength: { label: "Variation", default: 4.0, min: 1.0, max: 10.0, step: 0.5 },
+      // Strict control tier (sc-8244): MLX Shakker FLUX.1-dev-ControlNet-Union-Pro-2.0 — pose (skeleton),
+      // canny (auto edge map), depth (auto Depth-Anything-V2), one image per pose. Mirrors the manifest
+      // (single source of truth: STRICT_CONTROL_ENGINES flux1_dev_control = {pose,canny,depth}).
+      poseLibrary: true,
+      poseControlScale: true,
+      controlModes: ["pose", "canny", "depth"],
+      controlScale: { label: "Control strength", default: 0.7, min: 0.0, max: 2.0, step: 0.05 },
     },
   },
   {

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -94,7 +94,15 @@
         // Strict ControlNet → expose the pose-lock-strength slider
         // (advanced.controlScale, read by MlxZImageAdapter._control_scale). The
         // best-effort tiers have no strength control, so they omit this flag.
-        "poseControlScale": true
+        "poseControlScale": true,
+        // Strict-control modes the Z-Image Fun-Controlnet-Union branch admits (sc-8249): pose (skeleton),
+        // canny (auto edge map from the input image), depth (auto Depth-Anything-V2 map). SINGLE SOURCE
+        // OF TRUTH for the worker is `STRICT_CONTROL_ENGINES` (z_image_turbo_control = {pose,canny,depth});
+        // this advertises the same set so the picker offers a control-mode selector (advanced.controlMode).
+        "controlModes": ["pose", "canny", "depth"],
+        // The control-lock-strength knob (advanced.controlScale; worker default 0.9, clamp [0,2]). The
+        // structured form of the `poseControlScale` flag — drives the slider for every control mode.
+        "controlScale": { "label": "Control strength", "default": 0.9, "min": 0.0, "max": 2.0, "step": 0.05 }
       }
     },
     {
@@ -233,7 +241,13 @@
         "poseLibrary": true,
         // Strict ControlNet → expose the pose-lock-strength slider
         // (advanced.controlScale, read by QwenImageAdapter._pose_control_scale).
-        "poseControlScale": true
+        "poseControlScale": true,
+        // Qwen stays POSE-ONLY for now (`qwen_image_control` = {pose} in STRICT_CONTROL_ENGINES). Its
+        // canny/depth + 2512-Fun migration is sc-8267/sc-8250 — do NOT advertise canny/depth here.
+        "controlModes": ["pose"],
+        // The control-lock-strength knob (advanced.controlScale; worker default 0.9). Structured form of
+        // the `poseControlScale` flag.
+        "controlScale": { "label": "Control strength", "default": 0.9, "min": 0.0, "max": 2.0, "step": 0.05 }
       }
     },
     {
@@ -833,6 +847,22 @@
           "max": 10.0,
           "step": 0.5
         },
+        // Strict control tier (sc-8244; engine E2 sc-8239): on macOS MLX the worker renders the selected
+        // library pose to an OpenPose skeleton — or, with advanced.controlMode = canny|depth, derives a
+        // canny edge map / Depth-Anything-V2 depth map from the input image — and conditions the ported
+        // Shakker `FLUX.1-dev-ControlNet-Union-Pro-2.0` branch on it (true structural lock, one image per
+        // pose) via the `flux1_dev_control` registry generator. The control checkpoint (~3.5 GB) is
+        // fetched on the first control job. Surfaces flux_dev in the Character Studio pose picker
+        // (character_image not required — poseLibrary gates it). MLX-only (no candle control lane yet).
+        "poseLibrary": true,
+        // Strict ControlNet → expose the control-lock-strength slider (advanced.controlScale; the Shakker
+        // Union-Pro-2.0 README recommends ~0.7, worker default 0.7).
+        "poseControlScale": true,
+        // Control modes the Shakker Union-Pro-2.0 union ControlNet admits (SINGLE SOURCE OF TRUTH:
+        // STRICT_CONTROL_ENGINES `flux1_dev_control` = {pose,canny,depth}); the picker offers the
+        // control-mode selector (advanced.controlMode).
+        "controlModes": ["pose", "canny", "depth"],
+        "controlScale": { "label": "Control strength", "default": 0.7, "min": 0.0, "max": 2.0, "step": 0.05 },
         "promptGuide": {
           "title": "FLUX.1 [dev] Prompt Guide",
           "path": "/prompt-guides/flux-dev.md",
@@ -1865,6 +1895,14 @@
         // Strict ControlNet → expose the pose-lock-strength slider (advanced.controlScale;
         // the dev Fun-Controlnet-Union README recommends 0.65–0.80, worker default 0.75).
         "poseControlScale": true,
+        // Strict-control modes the FLUX.2-dev Fun-Controlnet-Union branch admits (sc-8248): pose
+        // (skeleton), canny (auto edge map from the input image), depth (auto Depth-Anything-V2 map).
+        // SINGLE SOURCE OF TRUTH is STRICT_CONTROL_ENGINES (flux2_dev_control = {pose,canny,depth}); the
+        // picker offers the control-mode selector (advanced.controlMode).
+        "controlModes": ["pose", "canny", "depth"],
+        // The control-lock-strength knob (advanced.controlScale; worker default 0.75). Structured form of
+        // the `poseControlScale` flag.
+        "controlScale": { "label": "Control strength", "default": 0.75, "min": 0.0, "max": 2.0, "step": 0.05 },
         // FLUX.2-dev's built-in caption upsampler (sc-6030/sc-6135): an opt-in "Enhance prompt"
         // toggle that has the model's own Mistral3 LLM rewrite the prompt before the diffusion
         // encode — text-only for txt2img, and image-conditioned on the reference for edit (it reads

--- a/crates/sceneworks-worker/src/flux1_control_mlx_smoke.rs
+++ b/crates/sceneworks-worker/src/flux1_control_mlx_smoke.rs
@@ -1,0 +1,226 @@
+//! Local real-weight MLX smokes for the FLUX.1-dev strict-control worker lane (sc-8244; engine E2
+//! sc-8239). `#[ignore]`d — run by hand on an Apple-Silicon Mac with the gated FLUX.1-dev snapshot + the
+//! Shakker `FLUX.1-dev-ControlNet-Union-Pro-2.0` checkpoint. They drive the real native-MLX
+//! `flux1_dev_control` engine via `gen_core::load("flux1_dev_control")` with a `Dir` base + `with_control`
+//! overlay — the exact runtime seam `generate_flux1_dev_control_stream` builds (`flux1_control_spec`),
+//! minus the API/job plumbing. The point is to prove the **worker crate links + drives the engine
+//! end-to-end** per control mode (the `use mlx_gen_flux as _;` force-link anchor in `image_jobs.rs` keeps
+//! `inventory::submit!` from being GC'd), not just the engine crate in isolation (that's
+//! `mlx-gen-flux`'s own `control_real_weights` test).
+//!
+//! Each mode asserts a control-vs-control-free **steer**: the same prompt/seed rendered control-free vs
+//! with the `kind`-tagged control conditioning must differ meaningfully (mean abs Δ over the decode) —
+//! the structural hint actually bent the output. pose/canny/depth all flow through the SAME input-agnostic
+//! Shakker Union-Pro-2.0 branch (only the control image differs), so one harness drives all three.
+//!
+//! Setup (point at the gated dense FLUX.1-dev diffusers snapshot + the Shakker control checkpoint):
+//! ```text
+//! FLUX1_DEV_DIR=~/.cache/huggingface/.../FLUX.1-dev \
+//! FLUX1_CONTROL=~/.cache/huggingface/.../diffusion_pytorch_model.safetensors \
+//! cargo test -p sceneworks-worker --release flux1_dev_control_mlx_smoke -- --ignored --nocapture
+//! ```
+
+#![cfg(all(test, target_os = "macos"))]
+
+use std::path::PathBuf;
+
+use gen_core::{
+    Conditioning, ControlKind, GenerationOutput, GenerationRequest, Image, LoadSpec, WeightsSource,
+};
+
+fn env_path(key: &str) -> PathBuf {
+    PathBuf::from(
+        std::env::var(key)
+            .unwrap_or_else(|_| panic!("set ${key}"))
+            .trim(),
+    )
+}
+
+fn env_or(key: &str, default: &str) -> String {
+    std::env::var(key)
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| default.to_string())
+}
+
+/// A synthetic single-channel-ish control fixture (a smooth top-to-bottom luminance ramp broadcast to
+/// RGB) — enough to exercise the VAE-encode of the control hint on real weights without shipping a
+/// per-mode fixture (the engine treats pose/canny/depth maps the same way: VAE-encode + pack). Distinct
+/// from a flat field so the control latent isn't degenerate.
+fn ramp_rgb(w: u32, h: u32) -> Image {
+    let (wu, hu) = (w as usize, h as usize);
+    let mut pixels = vec![0u8; wu * hu * 3];
+    for y in 0..hu {
+        let v = ((y * 255) / hu.max(1)) as u8;
+        for x in 0..wu {
+            let i = (y * wu + x) * 3;
+            pixels[i] = v;
+            pixels[i + 1] = v;
+            pixels[i + 2] = v;
+        }
+    }
+    Image {
+        width: w,
+        height: h,
+        pixels,
+    }
+}
+
+/// Mean absolute per-pixel difference between two same-shape decodes — the control-vs-control-free steer
+/// metric (0 = identical = the control did nothing). Panics on a shape mismatch (a bug, not a render).
+fn mean_abs_delta(a: &Image, b: &Image) -> f64 {
+    assert_eq!(
+        (a.width, a.height, a.pixels.len()),
+        (b.width, b.height, b.pixels.len()),
+        "decodes must share a shape to diff"
+    );
+    if a.pixels.is_empty() {
+        return 0.0;
+    }
+    a.pixels
+        .iter()
+        .zip(&b.pixels)
+        .map(|(&x, &y)| (x as f64 - y as f64).abs())
+        .sum::<f64>()
+        / a.pixels.len() as f64
+}
+
+/// Mean per-pixel std-dev — a cheap "is the decode non-degenerate (not all-black/NaN)" floor.
+fn image_std(img: &Image) -> f64 {
+    let n = img.pixels.len() as f64;
+    if n == 0.0 {
+        return 0.0;
+    }
+    let mean = img.pixels.iter().map(|&p| p as f64).sum::<f64>() / n;
+    let var = img
+        .pixels
+        .iter()
+        .map(|&p| (p as f64 - mean).powi(2))
+        .sum::<f64>()
+        / n;
+    var.sqrt()
+}
+
+/// Render one image through the loaded `flux1_dev_control` generator with the given conditioning (empty =
+/// control-free baseline).
+fn render(
+    generator: &dyn gen_core::Generator,
+    prompt: &str,
+    w: u32,
+    h: u32,
+    steps: u32,
+    guidance: f32,
+    conditioning: Vec<Conditioning>,
+) -> Image {
+    let req = GenerationRequest {
+        prompt: prompt.to_owned(),
+        width: w,
+        height: h,
+        count: 1,
+        seed: Some(42),
+        steps: Some(steps),
+        guidance: Some(guidance),
+        conditioning,
+        ..Default::default()
+    };
+    let output = generator
+        .generate(&req, &mut |_| {})
+        .expect("flux1_dev_control generate");
+    match output {
+        GenerationOutput::Images(mut images) => images.pop().expect("engine returned no image"),
+        other => panic!("expected Images output, got {other:?}"),
+    }
+}
+
+/// Real-weight MLX smoke: load `flux1_dev_control` once, render a control-free baseline, then a render per
+/// control mode (pose/canny/depth), and assert each mode (a) is non-degenerate and (b) steers the output
+/// away from the control-free baseline (the structural hint bent the result). The control image is the
+/// same synthetic ramp for every mode (Union-Pro-2.0 is input-agnostic — pose/canny/depth differ only by
+/// the upstream preprocessor, which these worker smokes deliberately bypass: the per-preprocessor
+/// derivation is unit-tested in `image_jobs::tests`).
+#[test]
+#[ignore = "real-weight MLX smoke; needs the gated FLUX.1-dev snapshot + the Shakker Union-Pro-2.0 ckpt on an Apple-Silicon Mac"]
+fn flux1_dev_control_mlx_smoke() {
+    let weights_dir = env_path("FLUX1_DEV_DIR");
+    let control_ckpt = env_path("FLUX1_CONTROL");
+    assert!(
+        weights_dir.join("model_index.json").is_file() || weights_dir.join("transformer").is_dir(),
+        "FLUX1_DEV_DIR must point at the dense FLUX.1-dev diffusers snapshot: {}",
+        weights_dir.display()
+    );
+    let out_dir = PathBuf::from(env_or("FLUX1_OUT_DIR", "flux1-control-smoke"));
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+    let w: u32 = env_or("FLUX1_W", "768").parse().expect("FLUX1_W");
+    let h: u32 = env_or("FLUX1_H", "768").parse().expect("FLUX1_H");
+    let steps: u32 = env_or("FLUX1_STEPS", "28").parse().expect("FLUX1_STEPS");
+    let guidance: f32 = env_or("FLUX1_GUIDANCE", "3.5")
+        .parse()
+        .expect("FLUX1_GUIDANCE");
+    let control_scale: f32 = env_or("FLUX1_CONTROL_SCALE", "0.7")
+        .parse()
+        .expect("FLUX1_CONTROL_SCALE");
+    let prompt = env_or(
+        "FLUX1_PROMPT",
+        "a knight in ornate steel armor, dramatic cinematic lighting, sharp focus",
+    );
+
+    // Same seam the worker's `flux1_control_spec` builds: a Dir base + the Shakker control overlay.
+    let spec = LoadSpec::new(WeightsSource::Dir(weights_dir.clone()))
+        .with_control(WeightsSource::File(control_ckpt.clone()));
+    let generator =
+        gen_core::load("flux1_dev_control", &spec).expect("load flux1_dev_control provider");
+
+    // Control-free baseline (no conditioning → the union ControlNet branch is inert).
+    let baseline = render(&*generator, &prompt, w, h, steps, guidance, Vec::new());
+    let base_std = image_std(&baseline);
+    image::RgbImage::from_raw(w, h, baseline.pixels.clone())
+        .expect("rgb")
+        .save(out_dir.join("flux1_control_baseline.png"))
+        .expect("save baseline");
+    assert!(
+        base_std > 5.0,
+        "control-free baseline looks degenerate (std {base_std:.2})"
+    );
+
+    let control_map = ramp_rgb(w, h);
+    for kind in [ControlKind::Pose, ControlKind::Canny, ControlKind::Depth] {
+        let label = match kind {
+            ControlKind::Pose => "pose",
+            ControlKind::Canny => "canny",
+            ControlKind::Depth => "depth",
+            ControlKind::Other(_) => "other",
+        };
+        // Depth uses the dedicated `Depth` conditioning; pose/canny use `Control { kind, scale }` — the
+        // same split the worker's `build_control_conditioning` makes.
+        let conditioning = match kind {
+            ControlKind::Depth => vec![Conditioning::Depth {
+                image: control_map.clone(),
+            }],
+            kind => vec![Conditioning::Control {
+                image: control_map.clone(),
+                kind,
+                scale: control_scale,
+            }],
+        };
+        let image = render(&*generator, &prompt, w, h, steps, guidance, conditioning);
+        let std = image_std(&image);
+        let steer = mean_abs_delta(&image, &baseline);
+        image::RgbImage::from_raw(w, h, image.pixels.clone())
+            .expect("rgb")
+            .save(out_dir.join(format!("flux1_control_{label}.png")))
+            .expect("save control render");
+        println!("[smoke] flux1 {label}: std {std:.2}, steer(meanAbsΔ vs control-free) {steer:.2}");
+        assert_eq!((image.width, image.height), (w, h));
+        assert!(
+            std > 5.0,
+            "flux1 {label} control render looks degenerate (std {std:.2})"
+        );
+        assert!(
+            steer > 1.0,
+            "flux1 {label} control did not steer the output away from the control-free baseline \
+             (meanAbsΔ {steer:.2}) — the structural hint was inert"
+        );
+    }
+    println!("[smoke] DONE: flux1_dev_control pose/canny/depth all coherent + steering");
+}

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -441,6 +441,20 @@ pub(crate) async fn run_image_generate_job(
                 )
                 .await?;
             }
+            ImageRoute::Flux1DevControl => {
+                // FLUX.1-dev strict control (advanced.poses) → Shakker Union-Pro-2.0, one image per pose
+                // (pose / canny / depth via advanced.controlMode).
+                generate_flux1_dev_control_stream(
+                    api,
+                    settings,
+                    job,
+                    &plan,
+                    &project_path,
+                    backend,
+                    &mut asset_writes,
+                )
+                .await?;
+            }
             ImageRoute::Flux2DevControl => {
                 // FLUX.2-dev strict-pose (advanced.poses) → Fun-Controlnet-Union, one image per pose.
                 generate_flux2_dev_control_stream(
@@ -1485,6 +1499,9 @@ include!("image_jobs/zimage.rs");
 #[cfg(target_os = "macos")]
 // FLUX.2 edit routing and conditioning.
 include!("image_jobs/flux2.rs");
+#[cfg(target_os = "macos")]
+// FLUX.1-dev strict-control (Shakker Union-Pro-2.0) routing.
+include!("image_jobs/flux1_control.rs");
 #[cfg(target_os = "macos")]
 // Qwen control/edit routing.
 include!("image_jobs/qwen.rs");

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -83,6 +83,7 @@ enum ImageRoute {
     ZImageControl,
     QwenControl,
     KolorsControl,
+    Flux1DevControl,
     Flux2DevControl,
     Flux2Edit,
     QwenEdit,
@@ -102,6 +103,10 @@ fn resolve_image_route(request: &ImageRequest, settings: &Settings) -> Option<Im
         Some(ImageRoute::QwenControl)
     } else if kolors_control_available(request, settings) {
         Some(ImageRoute::KolorsControl)
+    } else if flux1_dev_control_available(request, settings) {
+        // FLUX.1-dev strict control (advanced.poses on flux_dev) → Shakker Union-Pro-2.0. Wins over the
+        // PuLID-FLUX / generic MLX arms below: a flux_dev pose job is the real ControlNet path (sc-8244).
+        Some(ImageRoute::Flux1DevControl)
     } else if flux2_dev_control_available(request, settings) {
         // FLUX.2-dev strict pose (advanced.poses) → Fun-Controlnet-Union. Wins over the edit/
         // best-effort pose tier below (`flux2_edit_available` needs a reference; a flux2_dev pose
@@ -139,6 +144,7 @@ impl ImageRoute {
             ImageRoute::ZImageControl
             | ImageRoute::QwenControl
             | ImageRoute::KolorsControl
+            | ImageRoute::Flux1DevControl
             | ImageRoute::Flux2DevControl => pose_entries(request).len() as u32,
             ImageRoute::Flux2Edit | ImageRoute::QwenEdit => grouped_edit_image_count(request),
             ImageRoute::InstantId => instantid_image_count(request, settings),

--- a/crates/sceneworks-worker/src/image_jobs/flux1_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux1_control.rs
@@ -1,0 +1,340 @@
+// ---------------------------------------------------------------------------
+// FLUX.1-dev strict-control Fun-Controlnet-Union (macOS, sc-8244; engine E2 sc-8239):
+// the `flux1_dev_control` registry generator — the Shakker
+// `FLUX.1-dev-ControlNet-Union-Pro-2.0` branch on the FLUX.1-dev base. One image per
+// library pose (pose tier) — or, with `advanced.controlMode = canny|depth` + an input
+// image, a canny edge / Depth-Anything-V2 control map auto-derived from that image — fed
+// to the union ControlNet (TRUE structural lock, not the best-effort `[skeleton, reference]`
+// edit tier). FLUX.1-dev on macOS routes here only for a strict-control job; plain txt2img
+// + IP-Adapter keep their existing paths. Mirrors `generate_flux2_dev_control_stream`.
+// ---------------------------------------------------------------------------
+
+/// The engine registry id for the FLUX.1-dev Fun-Controlnet-Union variant (E2 sc-8239).
+const FLUX1_DEV_CONTROL_ENGINE_ID: &str = "flux1_dev_control";
+/// The Shakker Union-Pro-2.0 control-weights filename — the single `.safetensors` shipped in the repo
+/// (the diffusers checkpoint). The default *repo* is the shared strict-control table (single source of
+/// truth — `STRICT_CONTROL_ENGINES`).
+const FLUX1_CONTROL_FILE: &str = "diffusion_pytorch_model.safetensors";
+/// The asset `adapter` id recorded on FLUX.1-dev strict-control assets (the dev base MLX label —
+/// shared with the plain FLUX.1 path).
+const FLUX1_CONTROL_ADAPTER_LABEL: &str = "mlx_flux";
+
+/// True when this is a FLUX.1-dev strict-control job (`flux_dev` + ≥1 pose, not edit mode) whose base
+/// weights resolve — routed to the Shakker Fun-Controlnet-Union path rather than plain txt2img or the
+/// IP-Adapter reference tier. Gated to `flux_dev` (schnell has no control checkpoint). Control-weights
+/// presence is NOT part of the gate: they are fetched on first use in the stream (a missing checkpoint
+/// downloads, then errors loudly only on a real failure — never silently drops the poses). The pose
+/// entry is the structural hint carrier for every kind (pose renders a skeleton; canny/depth pair the
+/// pose with `advanced.controlMode` + an input image — the pose set still drives the per-image loop).
+fn flux1_dev_control_available(request: &ImageRequest, settings: &Settings) -> bool {
+    request.model == "flux_dev"
+        && request.mode != "edit_image"
+        && !pose_entries(request).is_empty()
+        && matches!(resolve_weights_dir(request, settings), Ok(Some(_)))
+}
+
+/// The (repo, filename) of the FLUX.1-dev control weights — `advanced.controlWeights.{repo,filename}`
+/// overrides, else the Shakker Union-Pro-2.0 default (parity with the FLUX.2 / Z-Image resolvers).
+fn flux1_control_repo_file(request: &ImageRequest) -> (String, String) {
+    let cw = request
+        .advanced
+        .get("controlWeights")
+        .and_then(Value::as_object);
+    let pick = |key: &str, default: &str| {
+        cw.and_then(|m| m.get(key))
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+            .unwrap_or(default)
+            .to_owned()
+    };
+    (
+        // Default repo from the shared strict-control table (single source of truth); the file stays
+        // engine-specific.
+        pick(
+            "repo",
+            strict_control_default_repo(FLUX1_DEV_CONTROL_ENGINE_ID),
+        ),
+        pick("filename", FLUX1_CONTROL_FILE),
+    )
+}
+
+/// Resolve the Shakker Union-Pro-2.0 checkpoint the engine loads, downloading on first use. Order: an
+/// env-pinned file (`SCENEWORKS_CONTROLNET_FLUX1`) → a whole-repo HF cache snapshot → download into the
+/// app cache. Mirrors [`ensure_flux2_control_weights`]. The control checkpoint is lazy-fetched only on
+/// the first strict-control job (vs bloating the base download).
+async fn ensure_flux1_control_weights(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &ImageRequest,
+) -> WorkerResult<PathBuf> {
+    let (repo, file) = flux1_control_repo_file(request);
+    if let Ok(p) = std::env::var("SCENEWORKS_CONTROLNET_FLUX1") {
+        let p = PathBuf::from(p);
+        if p.is_file() {
+            return Ok(p);
+        }
+    }
+    if let Some(snapshot) = huggingface_snapshot_dir(&settings.data_dir, &repo) {
+        let f = snapshot.join(&file);
+        if f.is_file() {
+            return Ok(f);
+        }
+    }
+    let client = reqwest::Client::new();
+    let context = crate::downloads::DownloadContext {
+        api,
+        client: &client,
+        settings,
+        job_id: &job.id,
+        cancel_message: "FLUX.1-dev strict-control generation canceled while fetching control weights.",
+        fresh_download: false,
+    };
+    let dst = settings
+        .data_dir
+        .join("cache")
+        .join("controlnet-flux1")
+        .join(&file);
+    crate::downloads::ensure_hf_cached_file(&context, &repo, "main", &file, &dst).await
+}
+
+/// Control lock strength for FLUX.1-dev: `advanced.controlScale` (default 0.7, clamp [0,2]). The Shakker
+/// Union-Pro-2.0 README recommends ~0.7 (the engine default too), so the worker default matches.
+fn flux1_control_scale(request: &ImageRequest) -> f32 {
+    advanced::f32_clamped(&request.advanced, "controlScale", 0.7, 0.0..=2.0)
+}
+
+/// Generate one FLUX.1-dev strict-control image: the pre-built `conditioning` (the required `Control` /
+/// `Depth`, assembled by the shared [`build_control_conditioning`] driver) drives the Shakker
+/// Union-Pro-2.0 branch. dev is guidance-distilled (embedded scalar) — `guidance` rides the
+/// transformer's guidance embedder (no true-CFG). FLUX.1 control has no img2img-init seam (unlike
+/// FLUX.2), so no identity `Reference` is appended.
+#[allow(clippy::too_many_arguments)]
+fn flux1_control_generate_one(
+    generator: &dyn Generator,
+    prompt: &str,
+    width: u32,
+    height: u32,
+    seed: i64,
+    steps: u32,
+    guidance: Option<f32>,
+    conditioning: Vec<Conditioning>,
+    cancel: &CancelFlag,
+    on_progress: &mut dyn FnMut(Progress),
+) -> WorkerResult<(u32, u32, Vec<u8>)> {
+    let request = GenerationRequest {
+        prompt: prompt.to_owned(),
+        width,
+        height,
+        count: 1,
+        seed: Some(seed as u64),
+        steps: Some(steps),
+        guidance,
+        conditioning,
+        cancel: cancel.clone(),
+        ..Default::default()
+    };
+    let output = generator.generate(&request, on_progress).map_err(|error| {
+        WorkerError::Engine(format!("FLUX.1-dev control generation failed: {error}"))
+    })?;
+    match output {
+        GenerationOutput::Images(mut images) => {
+            let image = images.pop().ok_or_else(|| {
+                WorkerError::Engine("FLUX.1-dev control generator produced no image".to_owned())
+            })?;
+            Ok((image.width, image.height, image.pixels))
+        }
+        _ => Err(WorkerError::Engine(
+            "FLUX.1-dev control generator returned non-image output".to_owned(),
+        )),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn flux1_control_raw_settings(
+    request: &ImageRequest,
+    repo: &str,
+    steps: u32,
+    quant_bits: Option<i64>,
+    guidance: Option<f32>,
+    control_scale: f32,
+    pose_count: usize,
+) -> JsonObject {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("repo".to_owned(), Value::String(repo.to_owned()));
+    raw.insert("numInferenceSteps".to_owned(), json!(steps));
+    raw.insert(
+        "guidanceScale".to_owned(),
+        guidance.map(|value| json!(value)).unwrap_or(Value::Null),
+    );
+    raw.insert(
+        "mlxQuantize".to_owned(),
+        quant_bits.map(|bits| json!(bits)).unwrap_or(Value::Null),
+    );
+    raw.insert("controlScale".to_owned(), json!(control_scale));
+    raw.insert("poseCount".to_owned(), json!(pose_count));
+    raw.insert(
+        "controlEngine".to_owned(),
+        Value::String(FLUX1_DEV_CONTROL_ENGINE_ID.to_owned()),
+    );
+    raw
+}
+
+/// Build the FLUX.1-dev control LoadSpec: the base dev snapshot + the Shakker Union-Pro-2.0 overlay
+/// (+ quant + adapters). The dev base + control overlay load dense bf16 and quantize in place under
+/// `with_quant` (the FLUX.1 control loader only wires dense bf16 + spec.quantize).
+fn flux1_control_spec(
+    weights_dir: PathBuf,
+    control_weights: PathBuf,
+    quant: Option<Quant>,
+    adapters: Vec<AdapterSpec>,
+) -> LoadSpec {
+    let mut spec = LoadSpec::new(WeightsSource::Dir(weights_dir))
+        .with_control(WeightsSource::File(control_weights));
+    if let Some(quant) = quant {
+        spec = spec.with_quant(quant);
+    }
+    if !adapters.is_empty() {
+        spec = spec.with_adapters(adapters);
+    }
+    spec
+}
+
+#[cfg(all(target_os = "macos", test))]
+fn flux1_control_load(
+    weights_dir: PathBuf,
+    control_weights: PathBuf,
+    quant: Option<Quant>,
+    adapters: Vec<AdapterSpec>,
+) -> WorkerResult<Box<dyn Generator>> {
+    let spec = flux1_control_spec(weights_dir, control_weights, quant, adapters);
+    gen_core::load(FLUX1_DEV_CONTROL_ENGINE_ID, &spec)
+        .map_err(|error| WorkerError::Engine(format!("FLUX.1-dev control load failed: {error}")))
+}
+
+/// Real FLUX.1-dev strict-control generation: one image per pose, each conditioned on the requested
+/// control map locked by the Shakker Union-Pro-2.0 branch (sc-8244; engine E2 sc-8239). Mirrors
+/// [`generate_flux2_dev_control_stream`] — the control checkpoint is fetched on first use, then the dev
+/// control engine loads once on the blocking thread and renders one image per pose (shared seed so only
+/// the control changes across the set). dev keeps its embedded guidance (no CFG). `advanced.controlMode`
+/// (pose | canny | depth) selects the preprocessor; pose is the default (byte-preserved skeleton path).
+async fn generate_flux1_dev_control_stream(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+
+    let weights_dir = resolve_weights_dir(request, settings)?
+        .ok_or_else(|| WorkerError::InvalidPayload("FLUX.1-dev weights not found".to_owned()))?;
+    let control_weights = ensure_flux1_control_weights(api, settings, job, request).await?;
+    let (quant, quant_bits) = resolve_quant(request);
+    let model = mlx_model("flux_dev")
+        .ok_or_else(|| WorkerError::InvalidPayload("flux_dev model row missing".to_owned()))?;
+    let steps = resolve_steps(request, &model);
+    let guidance = resolve_guidance(request, &model);
+    let control_scale = flux1_control_scale(request);
+    let adapters = resolve_adapters(request, settings)?;
+    let repo = model_repo(request, &model);
+    // Shared strict-control driver: validate the requested ControlKind against the engine's
+    // supported_kinds (flux1_dev_control = {Pose, Canny, Depth}) + resolve an optional user-supplied
+    // control-map passthrough. A pose-only job sets no `controlMode`, so `kind == Pose` and the skeleton
+    // preprocessor runs.
+    let control_kind = requested_control_kind(request)?;
+    validate_control_kind(FLUX1_DEV_CONTROL_ENGINE_ID, &control_kind)?;
+    let user_control = resolve_user_control_map(request, settings, project_path)?;
+    // sc-8244 source threading: for canny/depth WITHOUT a user-supplied control map, the control map is
+    // auto-derived from the input image. The pose tier never needs a source (the skeleton is synthetic).
+    let control_source = resolve_control_source(request, settings, project_path)?;
+    // Auto depth-estimator weights: provisioned only when this is a depth job WITHOUT a user-supplied
+    // depth map (the passthrough short-circuits estimation). Shared across the set; fetched once on the
+    // first depth job (sc-8242).
+    let depth_weights_dir = if control_kind == ControlKind::Depth && user_control.is_none() {
+        Some(ensure_depth_estimator_dir(api, settings, job).await?)
+    } else {
+        None
+    };
+    let poses = parse_poses(request);
+    let count = poses.len();
+    let raw_settings = flux1_control_raw_settings(
+        request,
+        &repo,
+        steps,
+        quant_bits,
+        guidance,
+        control_scale,
+        count,
+    );
+    // Strict control shares one seed across the set so noise-derived attributes (hair, wardrobe,
+    // lighting) stay constant while only the control changes (FLUX.2 / Z-Image parity).
+    let seed = resolve_seed(request, 0);
+
+    let prompt = request.prompt.clone();
+    let (width, height) = (request.width, request.height);
+    let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
+    let adapter_count = adapters.len();
+    let spec = flux1_control_spec(weights_dir, control_weights, quant, adapters);
+    let (cancel, rx, blocking) = start_cached_gen_stream(
+        job.id.clone(),
+        FLUX1_DEV_CONTROL_ENGINE_ID,
+        adapter_count,
+        spec,
+        "FLUX.1-dev control load failed".to_owned(),
+        move |generator, tx, cancel| {
+            let user_control = user_control.as_ref();
+            let control_source = control_source.as_ref();
+            let depth_weights_dir = depth_weights_dir.as_deref();
+            drive_gen_items(tx, poses, move |_index, pose, on_progress| {
+                let control = preprocess_control_entry(
+                    &control_kind,
+                    user_control,
+                    Some(&pose),
+                    control_source,
+                    width,
+                    height,
+                    stickwidth,
+                    depth_weights_dir,
+                )?;
+                // FLUX.1 control has no img2img-init seam — no identity Reference (None).
+                let conditioning =
+                    build_control_conditioning(control, control_kind.clone(), control_scale, None);
+                let (out_w, out_h, pixels) = flux1_control_generate_one(
+                    generator,
+                    &prompt,
+                    width,
+                    height,
+                    seed,
+                    steps,
+                    guidance,
+                    conditioning,
+                    &cancel,
+                    on_progress,
+                )?;
+                Ok(Some((seed, out_w, out_h, pixels)))
+            })
+        },
+    );
+
+    consume_gen_events(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        FLUX1_CONTROL_ADAPTER_LABEL,
+        &raw_settings,
+        count,
+        rx,
+        cancel,
+        blocking,
+        asset_writes,
+    )
+    .await
+}

--- a/crates/sceneworks-worker/src/image_jobs/flux2.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2.rs
@@ -775,6 +775,10 @@ async fn generate_flux2_dev_control_stream(
     let control_kind = requested_control_kind(request)?;
     validate_control_kind(FLUX2_DEV_CONTROL_ENGINE_ID, &control_kind)?;
     let user_control = resolve_user_control_map(request, settings, project_path)?;
+    // sc-8248 source threading: for canny/depth WITHOUT a user-supplied control map, the control map is
+    // auto-derived from the input image (canny edges / Depth-Anything-V2). The pose tier never needs a
+    // source (the skeleton is synthetic).
+    let control_source = resolve_control_source(request, settings, project_path)?;
     // Auto depth-estimator weights: provisioned only when this is a depth job WITHOUT a user-supplied
     // depth map (the passthrough short-circuits estimation). Shared across the set; fetched once on the
     // first depth job (sc-8242).
@@ -812,13 +816,14 @@ async fn generate_flux2_dev_control_stream(
         move |generator, tx, cancel| {
             let identity_init = identity_init.as_ref();
             let user_control = user_control.as_ref();
+            let control_source = control_source.as_ref();
             let depth_weights_dir = depth_weights_dir.as_deref();
             drive_gen_items(tx, poses, move |_index, pose, on_progress| {
                 let control = preprocess_control_entry(
                     &control_kind,
                     user_control,
                     Some(&pose),
-                    None,
+                    control_source,
                     width,
                     height,
                     stickwidth,

--- a/crates/sceneworks-worker/src/image_jobs/strict_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/strict_control.rs
@@ -37,14 +37,19 @@ struct StrictControlEngine {
 
 /// The Fun-Union strict-control catalog (S0 table). SINGLE SOURCE OF TRUTH for `(engine_id, control_repo,
 /// supported_kinds)`:
+/// - `flux1_dev_control` — `{Pose, Canny, Depth}` (Shakker Union-Pro-2.0; E2 sc-8239 / wiring sc-8244)
 /// - `flux2_dev_control` — `{Pose, Canny, Depth}`
 /// - `z_image_turbo_control` — `{Pose, Canny, Depth}`
 /// - `qwen_image_control` — `{Pose}` only (qwen stays pose-only until sc-8250)
 ///
-/// `flux1_dev_control` is added as another row once E2 (sc-8239) lands — not present yet. The SDXL tile
-/// detail-upscale path (`ControlKind::Other("tile")`, `image_jobs/detail.rs`) is OUTSIDE this family and
-/// is deliberately NOT listed.
+/// The SDXL tile detail-upscale path (`ControlKind::Other("tile")`, `image_jobs/detail.rs`) is OUTSIDE
+/// this family and is deliberately NOT listed.
 const STRICT_CONTROL_ENGINES: &[StrictControlEngine] = &[
+    StrictControlEngine {
+        engine_id: "flux1_dev_control",
+        repo: "Shakker-Labs/FLUX.1-dev-ControlNet-Union-Pro-2.0",
+        supported_kinds: &[ControlKind::Pose, ControlKind::Canny, ControlKind::Depth],
+    },
     StrictControlEngine {
         engine_id: "flux2_dev_control",
         repo: "alibaba-pai/FLUX.2-dev-Fun-Controlnet-Union",
@@ -153,6 +158,46 @@ fn resolve_user_control_map(
         .map(str::trim)
         .filter(|id| !id.is_empty())
     else {
+        return Ok(None);
+    };
+    let image = load_reference_image(&settings.data_dir, &request.project_id, asset_id, project_path)?;
+    Ok(Some(image))
+}
+
+/// The asset id canny / depth auto-derive their control map FROM (sc-8244 source threading), or `None`
+/// when the job carries no input image. Precedence: the Image-Edit / control `sourceAssetId` (the
+/// canonical "input image" the picker sends), else the character `referenceAssetId` (so a control job
+/// that only carried a reference still has something to derive from). Pure (request only) so the
+/// precedence is unit-testable without asset I/O.
+fn control_source_asset_id(request: &ImageRequest) -> Option<&str> {
+    request
+        .source_asset_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .or_else(|| {
+            request
+                .reference_asset_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|id| !id.is_empty())
+        })
+}
+
+/// The decoded input image canny / depth auto-derive their control map FROM (sc-8244 source threading).
+///
+/// This is the raw photo the preprocessor runs over for `controlMode = canny | depth` when no explicit
+/// `controlImage` passthrough is given — distinct from [`resolve_user_control_map`], which is a *pre-made*
+/// control map used verbatim. The asset id is picked by [`control_source_asset_id`]; `None` when neither
+/// a source nor a reference is present — the pose tier never needs a source (its skeleton is synthetic),
+/// and canny/depth then surface the shared driver's clear "requires a source image" error rather than
+/// silently producing nothing.
+fn resolve_control_source(
+    request: &ImageRequest,
+    settings: &Settings,
+    project_path: &Path,
+) -> WorkerResult<Option<Image>> {
+    let Some(asset_id) = control_source_asset_id(request) else {
         return Ok(None);
     };
     let image = load_reference_image(&settings.data_dir, &request.project_id, asset_id, project_path)?;

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -2652,6 +2652,82 @@ fn flux2_dev_control_real_weights_generates_one_pose() {
     assert!(pixels.windows(2).any(|w| w[0] != w[1]));
 }
 
+/// Real-weights smoke: FLUX.1-dev strict-control via the Shakker `FLUX.1-dev-ControlNet-Union-Pro-2.0`
+/// branch (sc-8244; engine E2 sc-8239). Loads the gated dev snapshot + the cached Shakker control
+/// checkpoint through the worker's own `flux1_control_load` (the `flux1_control_spec` seam) and renders
+/// ONE image per control mode (pose / canny / depth) — Union-Pro-2.0 is input-agnostic, so the same
+/// synthetic control map drives all three; the per-preprocessor derivation (skeleton / edge / depth) is
+/// unit-tested in `preprocess_control_entry_dispatches_by_kind`. Each mode must produce a non-degenerate
+/// 512² decode. Needs both weight sets + a Metal device; run on demand:
+/// `cargo test -p sceneworks-worker --lib -- --ignored flux1_dev_control_real_weights`.
+#[cfg(target_os = "macos")]
+#[test]
+#[ignore = "needs the gated FLUX.1-dev snapshot + the Shakker Union-Pro-2.0 ckpt + a Metal device"]
+fn flux1_dev_control_real_weights_generates_each_mode() {
+    let base = std::env::var("SCENEWORKS_FLUX1_DEV_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            std::fs::read_dir(
+                dirs_home()
+                    .join(".cache/huggingface/hub/models--black-forest-labs--FLUX.1-dev/snapshots"),
+            )
+            .expect("FLUX.1-dev snapshots dir")
+            .flatten()
+            .map(|entry| entry.path())
+            .find(|path| path.join("model_index.json").is_file())
+            .expect("a FLUX.1-dev snapshot dir")
+        });
+    let control = std::env::var("SCENEWORKS_CONTROLNET_FLUX1")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            std::fs::read_dir(dirs_home().join(
+                ".cache/huggingface/hub/models--Shakker-Labs--FLUX.1-dev-ControlNet-Union-Pro-2.0/snapshots",
+            ))
+            .expect("control snapshots dir")
+            .flatten()
+            .map(|entry| entry.path())
+            .find(|path| path.is_dir())
+            .map(|dir| dir.join(FLUX1_CONTROL_FILE))
+            .filter(|path| path.exists())
+            .expect("control weights file")
+        });
+
+    let generator =
+        flux1_control_load(base, control, Some(gen_core::Quant::Q8), Vec::new()).unwrap();
+
+    // A flat 512² control map — enough to exercise the VAE-encode of the control hint on real weights;
+    // the real per-mode preprocessing (skeleton / canny / depth) is unit-tested separately.
+    let control_map = gen_core::Image {
+        width: 512,
+        height: 512,
+        pixels: vec![128u8; 512 * 512 * 3],
+    };
+    let cancel = gen_core::CancelFlag::new();
+    for kind in [ControlKind::Pose, ControlKind::Canny, ControlKind::Depth] {
+        // pose/canny → Control { kind, scale }; depth → the dedicated Depth variant (build_control_*).
+        let conditioning = build_control_conditioning(control_map.clone(), kind.clone(), 0.7, None);
+        let (w, h, pixels) = flux1_control_generate_one(
+            generator.as_ref(),
+            "a person standing in a meadow, photorealistic",
+            512,
+            512,
+            42,
+            28,
+            Some(3.5), // dev embedded guidance
+            conditioning,
+            &cancel,
+            &mut |_| {},
+        )
+        .unwrap_or_else(|e| panic!("{kind:?} render failed: {e}"));
+        assert_eq!((w, h), (512, 512), "{kind:?}");
+        assert_eq!(pixels.len(), 512 * 512 * 3, "{kind:?}");
+        assert!(
+            pixels.windows(2).any(|w| w[0] != w[1]),
+            "{kind:?} render is degenerate (flat)"
+        );
+    }
+}
+
 #[cfg(target_os = "macos")]
 #[test]
 fn flux2_edit_reference_ids_prefers_reference_then_source() {
@@ -3089,6 +3165,16 @@ fn image_route_count_follows_dispatch_order() {
         route.image_count(&sensenova_angle, &settings),
         CHARACTER_ANGLE_SET_ORDER.len() as u32
     );
+
+    // FLUX.1-dev strict control (sc-8244): flux_dev + ≥1 pose (not edit_image) → the Shakker
+    // Union-Pro-2.0 path, one image per pose. Wins over PuLID-FLUX / generic MLX.
+    let flux1_control = request(json!({
+        "projectId": "p", "model": "flux_dev", "count": 9,
+        "advanced": { "modelPath": model_path.clone(), "poses": [{ "id": "a" }, { "id": "b" }, { "id": "c" }, { "id": "d" }] }
+    }));
+    let route = resolve_image_route(&flux1_control, &settings).unwrap();
+    assert_eq!(route, ImageRoute::Flux1DevControl);
+    assert_eq!(route.image_count(&flux1_control, &settings), 4);
 
     let plain_mlx = request(json!({
         "projectId": "p", "model": "z_image_turbo", "count": 6,
@@ -4863,6 +4949,16 @@ fn one_pose() -> PoseInput {
 #[cfg(target_os = "macos")]
 #[test]
 fn strict_control_table_is_the_authority() {
+    let flux1 = strict_control_engine("flux1_dev_control").expect("flux1 row");
+    assert_eq!(
+        flux1.repo,
+        "Shakker-Labs/FLUX.1-dev-ControlNet-Union-Pro-2.0"
+    );
+    assert_eq!(
+        flux1.supported_kinds,
+        &[ControlKind::Pose, ControlKind::Canny, ControlKind::Depth]
+    );
+
     let flux2 = strict_control_engine("flux2_dev_control").expect("flux2 row");
     assert_eq!(flux2.repo, "alibaba-pai/FLUX.2-dev-Fun-Controlnet-Union");
     assert_eq!(
@@ -4895,16 +4991,21 @@ fn strict_control_table_is_the_authority() {
 #[cfg(target_os = "macos")]
 #[test]
 fn validate_control_kind_accepts_and_rejects_per_table() {
-    // Pose is the proven tier on all three.
+    // Pose is the proven tier on every engine.
     for engine in [
+        "flux1_dev_control",
         "flux2_dev_control",
         "z_image_turbo_control",
         "qwen_image_control",
     ] {
         assert!(validate_control_kind(engine, &ControlKind::Pose).is_ok());
     }
-    // Canny + Depth: flux2 / z-image accept.
-    for engine in ["flux2_dev_control", "z_image_turbo_control"] {
+    // Canny + Depth: flux1 / flux2 / z-image accept.
+    for engine in [
+        "flux1_dev_control",
+        "flux2_dev_control",
+        "z_image_turbo_control",
+    ] {
         assert!(validate_control_kind(engine, &ControlKind::Canny).is_ok());
         assert!(validate_control_kind(engine, &ControlKind::Depth).is_ok());
     }
@@ -5098,5 +5199,109 @@ fn build_control_conditioning_matches_legacy_shape() {
     assert!(
         matches!(cond[0], Conditioning::Depth { .. }),
         "depth uses Conditioning::Depth"
+    );
+}
+
+/// sc-8248 / sc-8249 source threading: the input image canny/depth auto-derive their control map FROM
+/// resolves with the right precedence (sourceAssetId wins, else referenceAssetId), and a pose-only job
+/// (no source / reference) resolves to `None` — proving the live canny/depth path now has an input image
+/// to preprocess (previously the per-engine streams hard-coded `source: None`), while pose stays
+/// source-free (byte-preserved).
+#[cfg(target_os = "macos")]
+#[test]
+fn control_source_asset_id_precedence_and_pose_is_source_free() {
+    // sourceAssetId wins (the canonical control input image).
+    assert_eq!(
+        control_source_asset_id(&request(json!({
+            "projectId": "p", "model": "z_image_turbo",
+            "sourceAssetId": "src", "referenceAssetId": "ref",
+            "advanced": { "controlMode": "canny" }
+        }))),
+        Some("src")
+    );
+    // No source → fall back to the character reference (a control job that only carried a reference).
+    assert_eq!(
+        control_source_asset_id(&request(json!({
+            "projectId": "p", "model": "flux2_dev", "referenceAssetId": "ref",
+            "advanced": { "controlMode": "depth" }
+        }))),
+        Some("ref")
+    );
+    // A pose-only job carries neither → None (the skeleton is synthetic; no input image needed). This is
+    // the byte-preserved pose tier — the threaded source stays `None` exactly as before.
+    assert_eq!(
+        control_source_asset_id(&request(json!({
+            "projectId": "p", "model": "flux_dev",
+            "advanced": { "poses": [{ "id": "a" }] }
+        }))),
+        None
+    );
+    // Blank ids are treated as absent.
+    assert_eq!(
+        control_source_asset_id(&request(json!({
+            "projectId": "p", "model": "z_image_turbo",
+            "sourceAssetId": "   ", "referenceAssetId": ""
+        }))),
+        None
+    );
+}
+
+/// sc-8248 / sc-8249 live enablement: with `controlMode = canny` and a threaded source image, the shared
+/// preprocessor (the one every strict-control engine stream now feeds the input image into) produces a
+/// real edge-map control conditioning — NOT the pose skeleton and NOT a no-op. This is the unit-level
+/// proof that auto-canny/auto-depth now fire for flux1/flux2/z-image once the source is threaded (the
+/// stream wiring passes `control_source` where it previously passed `None`). Depth dispatch is covered by
+/// `preprocess_control_entry_dispatches_by_kind` (routes into the estimator); the real per-mode renders
+/// are the on-device smokes.
+#[cfg(target_os = "macos")]
+#[test]
+fn threaded_source_drives_auto_canny_control_conditioning() {
+    let (w, h) = (64u32, 48u32);
+    let pose = one_pose();
+    let stick = crate::openpose_skeleton::body_stickwidth(w, h);
+    // A threaded input "photo" (a flat fixture is enough — canny returns a same-dimension RGB edge map).
+    let source = control_fixture(w, h, [128, 128, 128]);
+
+    // canny + a threaded source (NO user passthrough, NO depth weights) → an edge-map control image.
+    let control = preprocess_control_entry(
+        &ControlKind::Canny,
+        None,
+        Some(&pose),
+        Some(&source),
+        w,
+        h,
+        stick,
+        None,
+    )
+    .expect("auto-canny over the threaded source");
+    assert_eq!((control.width, control.height), (w, h));
+
+    // It must NOT be the pose skeleton (proving the source — not the synthetic skeleton — drove it).
+    let skeleton = crate::openpose_skeleton::draw_wholebody(
+        w,
+        h,
+        &pose.keypoints,
+        pose.hands.as_deref(),
+        pose.face.as_deref(),
+        stick,
+    );
+    assert_ne!(
+        control.pixels,
+        skeleton.into_raw(),
+        "auto-canny must derive from the source image, not render the pose skeleton"
+    );
+
+    // And it builds a `Control { kind: Canny }` conditioning (the engine's structural hint).
+    let cond = build_control_conditioning(control, ControlKind::Canny, 0.75, None);
+    assert_eq!(cond.len(), 1);
+    assert!(
+        matches!(
+            &cond[0],
+            Conditioning::Control {
+                kind: ControlKind::Canny,
+                ..
+            }
+        ),
+        "canny builds a Control conditioning"
     );
 }

--- a/crates/sceneworks-worker/src/image_jobs/zimage.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage.rs
@@ -214,6 +214,10 @@ async fn generate_zimage_control_stream(
     let control_kind = requested_control_kind(request)?;
     validate_control_kind(ZIMAGE_CONTROL_ENGINE_ID, &control_kind)?;
     let user_control = resolve_user_control_map(request, settings, project_path)?;
+    // sc-8249 source threading: for canny/depth WITHOUT a user-supplied control map, the control map is
+    // auto-derived from the input image (canny edges / Depth-Anything-V2). The pose tier never needs a
+    // source (the skeleton is synthetic).
+    let control_source = resolve_control_source(request, settings, project_path)?;
     // Auto depth-estimator weights: provisioned only for a depth job WITHOUT a user-supplied depth map
     // (passthrough short-circuits estimation). Shared across the set; fetched once on first depth job
     // (sc-8242).
@@ -244,13 +248,14 @@ async fn generate_zimage_control_stream(
         move |generator, tx, cancel| {
             let identity_init = identity_init.as_ref();
             let user_control = user_control.as_ref();
+            let control_source = control_source.as_ref();
             let depth_weights_dir = depth_weights_dir.as_deref();
             drive_gen_items(tx, poses, move |_index, pose, on_progress| {
                 let control = preprocess_control_entry(
                     &control_kind,
                     user_control,
                     Some(&pose),
-                    None,
+                    control_source,
                     width,
                     height,
                     stickwidth,

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -140,6 +140,12 @@ mod flux2_dev_gpu_smoke;
 // the worker-lane validation (the crate links + drives the engine), not just the mlx-gen-krea crate.
 #[cfg(all(test, target_os = "macos"))]
 mod krea_turbo_mlx_smoke;
+// Real-weight MLX smoke for the FLUX.1-dev strict-control worker lane (sc-8244; engine E2 sc-8239).
+// Test-only + macOS-only; drives `gen_core::load("flux1_dev_control")` (Dir base + Shakker control
+// overlay) per control mode (pose/canny/depth) and asserts a control-vs-control-free steer — the
+// worker-lane validation that the crate links + drives the registered control generator end-to-end.
+#[cfg(all(test, target_os = "macos"))]
+mod flux1_control_mlx_smoke;
 // Real-weight MLX smokes for the SD3.5 worker lane (epic 7841 S6 sc-7875 — the MLX-path validation
 // boundary). Test-only + macOS-only; drive `gen_core::load("sd3_5_large" | "sd3_5_large_turbo" |
 // "sd3_5_medium")` against the gated stabilityai/* diffusers snapshots (the worker crate links + drives


### PR DESCRIPTION
Phase: expose the strict-control surface across the Fun-Union backbones (epic 8236). One PR, three per-story commits.

## Stories
- **sc-8244** — Manifest/catalog: per-backbone control modes + control-scale knob + the FLUX.1-dev control wiring that makes the merged `flux1_dev_control` generator runnable.
- **sc-8248** — FLUX.2-dev control: pose-only → +canny +depth, LIVE end-to-end.
- **sc-8249** — Z-Image-Turbo control: pose-only → +canny +depth, LIVE end-to-end.

## Commit 1 — sc-8244 (FLUX.1 wiring + manifest)
Makes the merged mlx-gen `flux1_dev_control` (Shakker `FLUX.1-dev-ControlNet-Union-Pro-2.0`) runnable and advertises the per-backbone control surface.
- **Stream**: new `generate_flux1_dev_control_stream` (`image_jobs/flux1_control.rs`), mirroring the FLUX.2 control stream — lazy control-weights provisioning (`ensure_flux1_control_weights`, env → HF snapshot → download-on-first-use of `diffusion_pytorch_model.safetensors`), `controlScale` default 0.7, shared strict-control driver (`validate_control_kind` + `preprocess_control_entry` + `build_control_conditioning`), one image per pose. FLUX.1 has no img2img-init seam, so no identity `Reference`.
- **Driver row**: `STRICT_CONTROL_ENGINES` += `flux1_dev_control → Shakker Union-Pro-2.0, {Pose,Canny,Depth}` (the single source of truth manifest/picker consume).
- **Catalog**: `flux_dev` manifest entry gains `poseLibrary` + `poseControlScale` + `controlModes: [pose,canny,depth]` + structured `controlScale`; `flux2_dev`/`z_image_turbo` gain `controlModes` + `controlScale`; `qwen_image` advertises `controlModes: [pose]` only (its canny/depth + 2512-Fun migration is sc-8267/8250, untouched here). Mirrored into `apps/web/src/constants.js`.
- **Routing**: `ImageRoute::Flux1DevControl` + `flux1_dev_control_available` (flux_dev + ≥1 pose, not edit_image), winning over PuLID/generic MLX; image-count + dispatch arm.

## Commit 2 — sc-8248 / Commit 3 — sc-8249 (live enablement)
The key fix: the FLUX.2 (`flux2.rs`) and Z-Image (`zimage.rs`) per-image control call sites passed `source: None`, so auto-canny/auto-depth could never fire from a live job. They now thread the user's input image via the shared `resolve_control_source` (`sourceAssetId` else `referenceAssetId`) into `preprocess_control_entry`. With `controlMode = canny|depth` + an input image, the control map is auto-derived end-to-end (canny via `canny.rs`, depth via the merged Depth-Anything-V2 estimator); pose still renders `draw_wholebody`; a user-supplied `controlImage` still passes through verbatim.

## Regression safety
Additive only on the canny/depth/source paths — the pose tier is byte-identical (the S2 strict-control golden + driver tests are unchanged and pass). `qwen` control is untouched beyond advertising pose.

## Tests
- Unit/integration (green): strict-control table + `validate_control_kind` include flux1; `image_route_count_follows_dispatch_order` asserts `Flux1DevControl` resolves + routes; `control_source_asset_id` precedence (pose stays source-free); `threaded_source_drives_auto_canny_control_conditioning` proves auto-canny fires from a threaded source (not the skeleton).
- On-device per-mode smokes (`#[ignore]`, GPU+weights): `flux1_control_mlx_smoke` (via `gen_core::load`, asserts control-vs-control-free steer per pose/canny/depth) and `flux1_dev_control_real_weights_generates_each_mode` (via the worker `flux1_control_load`, pose/canny/depth).
- `cargo build` / `cargo clippy --all-targets -D warnings` / `cargo test` (workspace) / `cargo fmt --all --check` all green; `apps/web` vitest 804/804 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)