### PR TITLE
feat(web): Character Assets batch toolbar + Assets-page card size + Move-to-Library (sc-8341)

### DIFF
--- a/apps/rust-api/src/assets.rs
+++ b/apps/rust-api/src/assets.rs
@@ -269,6 +269,18 @@ pub(crate) async fn update_asset_tags(
     ))
 }
 
+pub(crate) async fn move_asset_to_library(
+    State(state): State<AppState>,
+    Path((project_id, asset_id)): Path<(String, String)>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    Ok(Json(
+        project_call(state, move |store| {
+            store.move_asset_to_library(&project_id, &asset_id)
+        })
+        .await?,
+    ))
+}
+
 pub(crate) async fn delete_asset(
     State(state): State<AppState>,
     Path((project_id, asset_id)): Path<(String, String)>,

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -714,6 +714,10 @@ pub(crate) fn create_app_with_state(
             delete(purge_asset),
         )
         .route(
+            "/api/v1/projects/:project_id/assets/:asset_id/move-to-library",
+            post(move_asset_to_library),
+        )
+        .route(
             "/api/v1/projects/:project_id/assets/:asset_id/status",
             patch(update_asset_status),
         )

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1766,6 +1766,26 @@ export function App() {
     [token],
   );
 
+  // Promote a character asset into the Main Asset Library (sc-8341): a true move —
+  // the backend flips origin + detaches the character, so refresh characters too.
+  const moveAssetToLibrary = useCallback(
+    async (asset) => {
+      try {
+        const updated = await apiFetch(`/api/v1/projects/${asset.projectId}/assets/${asset.id}/move-to-library`, token, {
+          method: "POST",
+        });
+        setAssets((items) => items.map((item) => (item.id === updated.id ? updated : item)));
+        refreshCharactersRef.current?.(asset.projectId);
+        setError("");
+        return updated;
+      } catch (err) {
+        setError(err.message);
+        throw err;
+      }
+    },
+    [token],
+  );
+
   const deleteAsset = useCallback(
     async (asset) => {
       try {
@@ -1897,6 +1917,7 @@ export function App() {
     setSelectedAssetId,
     deleteAsset,
     purgeAsset,
+    moveAssetToLibrary,
     importAsset,
     updateAssetStatus,
     updateAssetTags,
@@ -2016,7 +2037,7 @@ export function App() {
     activeProject, mediaAssets, openPreview, sendAssetToImage, sendAssetToVideo,
     activeTimeline, timelines, selectedTimelineId, setSelectedTimelineId, setActiveTimeline,
     createTimeline, saveTimeline, exportTimeline, extractTimelineFrame, queueTimelineVideoJob,
-    assets, selectedAsset, setSelectedAssetId, deleteAsset, purgeAsset, importAsset,
+    assets, selectedAsset, setSelectedAssetId, deleteAsset, purgeAsset, moveAssetToLibrary, importAsset,
     updateAssetStatus, updateAssetTags, latestImageAssets,
     jobs, jobAction, createVqaJob, createInterleaveJob, createPlaceholderJob, filteredJobs,
     jobPrompt, setJobPrompt, projectFilter, setProjectFilter, projects, visibleWorkers, workersById,

--- a/apps/web/src/assetBatch.jsx
+++ b/apps/web/src/assetBatch.jsx
@@ -1,0 +1,313 @@
+import React, { useContext, useState } from "react";
+import { apiFetch } from "./api.js";
+import { batchEligibleAssets, batchItemStatus, buildBatchJob, summarizeBatchProgress } from "./batchOps.js";
+import { assetSupportsCharacterLink } from "./components/assetPanels.jsx";
+import { assetUrl } from "./components/assetMedia.jsx";
+import { BatchOperationsPanel } from "./components/BatchOperationsPanel.jsx";
+import { AppContext } from "./context/AppContext.js";
+import { detailCapableModels, editCapableModels, UPSCALE_ENGINES } from "./imageJobs.js";
+import { DEFAULT_MAC_CAPABILITIES, macUpscaleEngineBlocked } from "./macGating.js";
+
+// Sentinel "Move" target (sc-8341): selecting it promotes the assets into the Main Asset
+// Library (a true move) instead of linking them to a character. Namespaced so it can't
+// collide with a real character id.
+export const LIBRARY_MOVE_TARGET = "__sceneworks_library__";
+
+// Shared multi-asset batch selection (sc-6112) — selection state, the upscale/detail/edit
+// fan-out, and the bulk Discard / Move-to-character actions. Lifted out of LibraryScreen so
+// the Assets page and the Character Assets page drive the identical toolbar from one source.
+// The hook owns the selection; callers wire `selectedAssetIds`/`toggleSelect` into their grid
+// and render <AssetSelectionBar batch={…}/> + <AssetBatchModal batch={…}/>.
+export function useAssetBatch() {
+  // Read the app context optionally: the toolbar should stay inert (not crash) when a host
+  // component is rendered in isolation without an <AppContext.Provider> (e.g. unit tests).
+  const {
+    activeProject,
+    assets = [],
+    jobs = [],
+    imageModels = [],
+    characters = [],
+    deleteAsset,
+    addCharacterReference,
+    moveAssetToLibrary,
+    token = "",
+    requestedGpu = "auto",
+    macCapabilities = DEFAULT_MAC_CAPABILITIES,
+  } = useContext(AppContext) ?? {};
+
+  const [selectedAssetIds, setSelectedAssetIds] = useState(() => new Set());
+  const [batchOpen, setBatchOpen] = useState(false);
+  // While/after a batch runs: { op, items: [{ asset, jobId }], submitting }.
+  const [batch, setBatch] = useState(null);
+  // Bulk Discard / Move-to-character on the current selection. `bulkAction` gates the
+  // buttons while a fan-out is in flight; `moveOpen` reveals the inline character picker.
+  const [bulkAction, setBulkAction] = useState(null);
+  const [moveOpen, setMoveOpen] = useState(false);
+  const [moveCharacterId, setMoveCharacterId] = useState("");
+
+  // The current multi-selection, narrowed to the raster images a batch op can run on,
+  // and the upscale engines this platform actually supports.
+  const selectedAssetList = assets.filter((asset) => selectedAssetIds.has(asset.id));
+  const eligibleSelected = batchEligibleAssets(selectedAssetList);
+  const availableUpscaleEngines = UPSCALE_ENGINES.filter((engine) => !macUpscaleEngineBlocked(macCapabilities, engine.key));
+  const editModels = editCapableModels(imageModels);
+  const detailModels = detailCapableModels(imageModels);
+  // Move targets the same "Character Assets" link the per-asset panel uses (role "asset",
+  // unapproved) — NOT the character's reference images — so only link-capable media counts.
+  const availableCharacters = characters.filter((character) => !character?.archived);
+  const movableSelected = selectedAssetList.filter(assetSupportsCharacterLink);
+
+  // Per-item + aggregate progress for an in-flight/just-finished batch, read off the jobs feed.
+  const batchItems = batch
+    ? batch.items.map((item) => ({ asset: item.asset, status: batchItemStatus(item.jobId, jobs) }))
+    : null;
+  const batchProgress = batch ? summarizeBatchProgress(batch.items, jobs) : null;
+
+  const toggleSelect = (id) =>
+    setSelectedAssetIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  const clearSelection = () => {
+    setSelectedAssetIds(new Set());
+    setMoveOpen(false);
+  };
+
+  // Decode an asset's native pixel size (needed for an edit job — the worker fits the
+  // source to width×height). Resolves null on a load failure so that item fails alone.
+  function loadImageDims(asset) {
+    return new Promise((resolve) => {
+      const img = new Image();
+      img.onload = () => resolve({ width: img.naturalWidth, height: img.naturalHeight });
+      img.onerror = () => resolve(null);
+      img.src = assetUrl(asset);
+    });
+  }
+
+  // Fan out one job per selected image (NOT one mega-job): each posts independently so
+  // the worker processes them serially with its between-item cache release (sc-5567).
+  async function runBatch(op, params) {
+    if (!activeProject || !eligibleSelected.length) return;
+    const targets = eligibleSelected;
+    setBatch({ op, submitting: true, items: targets.map((asset) => ({ asset, jobId: null })) });
+    const items = [];
+    for (const asset of targets) {
+      try {
+        let dims = null;
+        if (op === "edit") {
+          dims = await loadImageDims(asset);
+          if (!dims) {
+            items.push({ asset, jobId: null });
+            continue;
+          }
+        }
+        const { endpoint, body } = buildBatchJob({ op, asset, params, project: activeProject, requestedGpu, dims });
+        const job = await apiFetch(endpoint, token, { method: "POST", body: JSON.stringify(body) });
+        items.push({ asset, jobId: job?.id ?? null });
+      } catch {
+        items.push({ asset, jobId: null });
+      }
+    }
+    setBatch({ op, submitting: false, items });
+  }
+
+  function closeBatch() {
+    setBatchOpen(false);
+    // Closing after a run clears the spent selection + progress; cancelling the form keeps it.
+    if (batch) {
+      setBatch(null);
+      clearSelection();
+    }
+  }
+
+  // Send every selected asset to the Trash (reversible — the backend just flags `trashed`).
+  async function discardSelected() {
+    if (!selectedAssetList.length || bulkAction) return;
+    setBulkAction("discard");
+    try {
+      for (const asset of selectedAssetList) {
+        await deleteAsset?.(asset);
+      }
+      clearSelection();
+    } finally {
+      setBulkAction(null);
+    }
+  }
+
+  // Fan out the move across every movable selection. The target is either the Main Asset
+  // Library (a true move — sc-8341) or a character (the per-asset link AssetDetail uses:
+  // role "asset", unapproved, library-member note).
+  async function moveSelectedToCharacter() {
+    if (!moveCharacterId || !movableSelected.length || bulkAction) return;
+    const toLibrary = moveCharacterId === LIBRARY_MOVE_TARGET;
+    if (toLibrary ? !moveAssetToLibrary : !addCharacterReference) return;
+    setBulkAction("move");
+    try {
+      for (const asset of movableSelected) {
+        try {
+          if (toLibrary) {
+            await moveAssetToLibrary(asset);
+          } else {
+            await addCharacterReference(moveCharacterId, {
+              assetId: asset.id,
+              approved: false,
+              role: "asset",
+              notes: "Added from Asset Library.",
+            });
+          }
+        } catch {
+          // One asset failing (e.g. already linked) shouldn't abort the rest.
+        }
+      }
+      clearSelection();
+    } finally {
+      setBulkAction(null);
+    }
+  }
+
+  return {
+    selectedAssetIds,
+    toggleSelect,
+    clearSelection,
+    selectedAssetList,
+    eligibleSelected,
+    movableSelected,
+    availableCharacters,
+    batchOpen,
+    setBatchOpen,
+    batch,
+    batchItems,
+    batchProgress,
+    runBatch,
+    closeBatch,
+    bulkAction,
+    discardSelected,
+    moveSelectedToCharacter,
+    moveOpen,
+    setMoveOpen,
+    moveCharacterId,
+    setMoveCharacterId,
+    editModels,
+    detailModels,
+    availableUpscaleEngines,
+  };
+}
+
+// The selection toolbar: appears once anything is selected. `showDiscard` lets a host hide
+// the trash action where it doesn't apply (e.g. a Trashcan view, where items are already
+// discarded). `allowLibraryTarget` adds "Assets Library" as a Move destination (sc-8341) —
+// used on the Character Assets page to promote media back into the Main Library.
+export function AssetSelectionBar({ batch, showDiscard = true, allowLibraryTarget = false }) {
+  const {
+    selectedAssetIds,
+    eligibleSelected,
+    movableSelected,
+    availableCharacters,
+    setBatchOpen,
+    bulkAction,
+    discardSelected,
+    moveOpen,
+    setMoveOpen,
+    moveCharacterId,
+    setMoveCharacterId,
+    moveSelectedToCharacter,
+    clearSelection,
+  } = batch;
+
+  if (selectedAssetIds.size === 0) return null;
+
+  // Move destinations: the Main Library (optional) followed by every non-archived character.
+  const moveTargets = [
+    ...(allowLibraryTarget ? [{ id: LIBRARY_MOVE_TARGET, name: "Assets Library" }] : []),
+    ...availableCharacters,
+  ];
+  const toLibrary = moveCharacterId === LIBRARY_MOVE_TARGET;
+
+  return (
+    <div className="batch-selection-bar">
+      <span>
+        {selectedAssetIds.size} selected
+        {eligibleSelected.length !== selectedAssetIds.size
+          ? ` · ${eligibleSelected.length} image${eligibleSelected.length === 1 ? "" : "s"}`
+          : ""}
+      </span>
+      <button className="primary" disabled={!eligibleSelected.length} onClick={() => setBatchOpen(true)} type="button">
+        Batch…
+      </button>
+      {showDiscard ? (
+        <button className="danger-action" disabled={Boolean(bulkAction)} onClick={discardSelected} type="button">
+          {bulkAction === "discard" ? "Discarding…" : "Discard"}
+        </button>
+      ) : null}
+      {moveTargets.length ? (
+        <button
+          disabled={!movableSelected.length || Boolean(bulkAction)}
+          onClick={() =>
+            setMoveOpen((open) => {
+              const next = !open;
+              if (next && !moveCharacterId) {
+                setMoveCharacterId(moveTargets[0]?.id ?? "");
+              }
+              return next;
+            })
+          }
+          title={movableSelected.length ? undefined : "No movable media selected"}
+          type="button"
+        >
+          Move
+        </button>
+      ) : null}
+      <button onClick={clearSelection} type="button">
+        Clear
+      </button>
+      {moveOpen && moveTargets.length ? (
+        <div className="batch-move-picker">
+          <select
+            aria-label="Move target"
+            onChange={(event) => setMoveCharacterId(event.target.value)}
+            value={moveCharacterId}
+          >
+            {moveTargets.map((target) => (
+              <option key={target.id} value={target.id}>
+                {target.name}
+              </option>
+            ))}
+          </select>
+          <button
+            className="primary"
+            disabled={!moveCharacterId || !movableSelected.length || Boolean(bulkAction)}
+            onClick={moveSelectedToCharacter}
+            type="button"
+          >
+            {bulkAction === "move"
+              ? "Moving…"
+              : `Move ${movableSelected.length} to ${toLibrary ? "library" : "assets"}`}
+          </button>
+          <button onClick={() => setMoveOpen(false)} type="button">
+            Cancel
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// The batch-operations modal (upscale / detail / edit). Renders only while open.
+export function AssetBatchModal({ batch }) {
+  if (!batch.batchOpen) return null;
+  return (
+    <BatchOperationsPanel
+      assets={batch.eligibleSelected}
+      editModels={batch.editModels}
+      detailModels={batch.detailModels}
+      upscaleEngines={batch.availableUpscaleEngines}
+      busy={Boolean(batch.batch?.submitting)}
+      items={batch.batchItems}
+      progress={batch.batchProgress}
+      onRun={batch.runBatch}
+      onClose={batch.closeBatch}
+    />
+  );
+}

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -2600,7 +2600,7 @@ describe("SceneWorks app shell", () => {
     );
     expect(section).toBeTruthy();
     // Both the still and the clip are listed; the clip renders as a <video>.
-    expect(section.querySelectorAll(".character-asset-thumb").length).toBe(2);
+    expect(section.querySelectorAll(".character-asset-card").length).toBe(2);
     expect(section.querySelector("video")).toBeTruthy();
     expect([...section.querySelectorAll("button")].some((button) => button.textContent.startsWith("Media (2)"))).toBe(true);
   });
@@ -2667,7 +2667,7 @@ describe("SceneWorks app shell", () => {
     );
     expect(section).toBeTruthy();
     expect(section.textContent).toContain("Generated for Mira (1)");
-    expect(section.querySelectorAll(".character-asset-thumb")).toHaveLength(1);
+    expect(section.querySelectorAll(".character-asset-card")).toHaveLength(1);
     expect([...section.querySelectorAll("button")].some((button) => button.textContent.startsWith("Media (1)"))).toBe(true);
   });
 
@@ -3270,6 +3270,162 @@ describe("SceneWorks app shell", () => {
     expect(container.querySelector('[title="p-img1"]')).not.toBeNull();
   });
 
+  it("bulk-discards selected media from the Character Assets toolbar", async () => {
+    const deleteAsset = vi.fn(async () => {});
+    const selectedCharacter = { id: "char-1", name: "Mira" };
+    const assets = [
+      {
+        id: "ca-1",
+        type: "image",
+        projectId: "project-1",
+        displayName: "Shot A",
+        recipe: { normalizedSettings: { characterId: "char-1" } },
+        status: { trashed: false },
+      },
+      {
+        id: "ca-2",
+        type: "image",
+        projectId: "project-1",
+        displayName: "Shot B",
+        recipe: { normalizedSettings: { characterId: "char-1" } },
+        status: { trashed: false },
+      },
+    ];
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Noir" },
+            assets,
+            characters: [selectedCharacter],
+            deleteAsset,
+            addCharacterReference: vi.fn(),
+            purgeAsset: () => {},
+            updateAssetStatus: () => {},
+            importAsset: () => {},
+            setPreviewAsset: () => {},
+            jobs: [],
+            imageModels: [],
+          },
+          <CharacterAssets
+            addCharacterReference={vi.fn()}
+            assets={assets}
+            deleteAsset={deleteAsset}
+            onPreview={vi.fn()}
+            projectId="project-1"
+            purgeAsset={() => {}}
+            selectedCharacter={selectedCharacter}
+            updateAssetStatus={() => {}}
+          />,
+        ),
+      );
+    });
+    await settle();
+
+    // Both character images render as full-size selectable cards (matching the Assets page).
+    expect(container.querySelectorAll(".character-asset-card")).toHaveLength(2);
+
+    await act(async () => {
+      container.querySelector('input[aria-label="Select Shot A"]').click();
+    });
+    await act(async () => {
+      container.querySelector('input[aria-label="Select Shot B"]').click();
+    });
+    await settle();
+
+    await act(async () => {
+      [...container.querySelectorAll(".batch-selection-bar button")].find((button) => button.textContent === "Discard").click();
+    });
+    await settle();
+
+    expect(deleteAsset).toHaveBeenCalledTimes(2);
+    expect(deleteAsset).toHaveBeenCalledWith(assets[0]);
+    expect(deleteAsset).toHaveBeenCalledWith(assets[1]);
+    expect(container.querySelector(".batch-selection-bar")).toBeNull();
+  });
+
+  it("bulk-moves selected character media to the Main Asset Library (sc-8341)", async () => {
+    const moveAssetToLibrary = vi.fn(async (asset) => asset);
+    const selectedCharacter = { id: "char-1", name: "Mira" };
+    const assets = [
+      {
+        id: "ca-1",
+        type: "image",
+        projectId: "project-1",
+        displayName: "Shot A",
+        recipe: { normalizedSettings: { characterId: "char-1" } },
+        status: { trashed: false },
+      },
+      {
+        id: "ca-2",
+        type: "image",
+        projectId: "project-1",
+        displayName: "Shot B",
+        recipe: { normalizedSettings: { characterId: "char-1" } },
+        status: { trashed: false },
+      },
+    ];
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Noir" },
+            assets,
+            characters: [selectedCharacter],
+            deleteAsset: () => {},
+            addCharacterReference: vi.fn(),
+            moveAssetToLibrary,
+            purgeAsset: () => {},
+            updateAssetStatus: () => {},
+            importAsset: () => {},
+            setPreviewAsset: () => {},
+            jobs: [],
+            imageModels: [],
+          },
+          <CharacterAssets
+            addCharacterReference={vi.fn()}
+            assets={assets}
+            deleteAsset={() => {}}
+            onPreview={vi.fn()}
+            projectId="project-1"
+            purgeAsset={() => {}}
+            selectedCharacter={selectedCharacter}
+            updateAssetStatus={() => {}}
+          />,
+        ),
+      );
+    });
+    await settle();
+
+    await act(async () => {
+      container.querySelector('input[aria-label="Select Shot A"]').click();
+    });
+    await act(async () => {
+      container.querySelector('input[aria-label="Select Shot B"]').click();
+    });
+    await settle();
+
+    // Open the Move picker; "Assets Library" is offered as the first target.
+    await act(async () => {
+      [...container.querySelectorAll(".batch-selection-bar button")].find((button) => button.textContent === "Move").click();
+    });
+    await settle();
+    const select = container.querySelector('select[aria-label="Move target"]');
+    expect([...select.options].map((option) => option.textContent)).toContain("Assets Library");
+    await changeField(select, "__sceneworks_library__");
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent?.startsWith("Move 2 to library")).click();
+    });
+    await settle();
+
+    expect(moveAssetToLibrary).toHaveBeenCalledTimes(2);
+    expect(moveAssetToLibrary).toHaveBeenCalledWith(assets[0]);
+    expect(moveAssetToLibrary).toHaveBeenCalledWith(assets[1]);
+    expect(container.querySelector(".batch-selection-bar")).toBeNull();
+  });
+
   it("lists a character's associated datasets and opens one (sc-2022)", async () => {
     const onOpenDataset = vi.fn();
     const onCreateDataset = vi.fn();
@@ -3506,7 +3662,7 @@ describe("SceneWorks app shell", () => {
       );
     const section = findSection();
     expect(section).toBeTruthy();
-    expect(section.querySelectorAll(".character-asset-thumb").length).toBe(1);
+    expect(section.querySelectorAll(".character-asset-card").length).toBe(1);
     // Heading count reflects active images only.
     expect(section.querySelector("h2").textContent).toContain("(1)");
 
@@ -3519,7 +3675,7 @@ describe("SceneWorks app shell", () => {
       trashButton.click();
     });
     const trashSection = findSection();
-    expect(trashSection.querySelectorAll(".character-asset-thumb").length).toBe(1);
+    expect(trashSection.querySelectorAll(".character-asset-card").length).toBe(1);
     const restore = [...trashSection.querySelectorAll("button")].find((button) => button.textContent === "Restore");
     const purge = [...trashSection.querySelectorAll("button")].find((button) => button.textContent === "Purge");
     expect(restore).toBeTruthy();
@@ -9173,7 +9329,7 @@ describe("SceneWorks app shell", () => {
       [...container.querySelectorAll(".batch-selection-bar button")].find((button) => button.textContent === "Move").click();
     });
     await settle();
-    await changeField(container.querySelector('select[aria-label="Move to character"]'), "char-2");
+    await changeField(container.querySelector('select[aria-label="Move target"]'), "char-2");
     await act(async () => {
       [...container.querySelectorAll("button")].find((button) => button.textContent?.startsWith("Move 2 to assets")).click();
     });

--- a/apps/web/src/screens/LibraryScreen.jsx
+++ b/apps/web/src/screens/LibraryScreen.jsx
@@ -1,14 +1,9 @@
 import React, { useState } from "react";
-import { apiFetch } from "../api.js";
+import { AssetBatchModal, AssetSelectionBar, useAssetBatch } from "../assetBatch.jsx";
 import { foldUpscaledAssetVariants } from "../assetVariants.js";
-import { batchEligibleAssets, batchItemStatus, buildBatchJob, summarizeBatchProgress } from "../batchOps.js";
-import { AssetDetail, AssetGrid, assetSupportsCharacterLink, emptyTrash } from "../components/assetPanels.jsx";
-import { assetUrl } from "../components/assetMedia.jsx";
-import { BatchOperationsPanel } from "../components/BatchOperationsPanel.jsx";
+import { AssetDetail, AssetGrid, emptyTrash } from "../components/assetPanels.jsx";
 import { terminalStatuses } from "../constants.js";
 import { useAppContext } from "../context/AppContext.js";
-import { detailCapableModels, editCapableModels, UPSCALE_ENGINES } from "../imageJobs.js";
-import { DEFAULT_MAC_CAPABILITIES, macUpscaleEngineBlocked } from "../macGating.js";
 
 export function LibraryScreen() {
   const {
@@ -30,10 +25,9 @@ export function LibraryScreen() {
     setActiveView,
     updateAssetStatus,
     updateAssetTags,
-    token = "",
-    requestedGpu = "auto",
-    macCapabilities = DEFAULT_MAC_CAPABILITIES,
   } = useAppContext();
+  // Shared multi-select + batch toolbar (selection state, fan-out, Discard/Move).
+  const batch = useAssetBatch();
   // Bind the fullscreen preview to the currently filtered library view so
   // navigation stays inside the same type/tag/trash scope the user is browsing.
   const onPreview = (asset) => setPreviewAsset(asset, visibleAssets);
@@ -60,16 +54,6 @@ export function LibraryScreen() {
   const [showRejected, setShowRejected] = useState(false);
   const [assetMode, setAssetMode] = useState("assets");
   const [isImporting, setIsImporting] = useState(false);
-  // Batch operations (sc-6112): a multi-asset selection + a fan-out of one job per asset.
-  const [selectedAssetIds, setSelectedAssetIds] = useState(() => new Set());
-  const [batchOpen, setBatchOpen] = useState(false);
-  // While/after a batch runs: { op, items: [{ asset, jobId }], submitting }.
-  const [batch, setBatch] = useState(null);
-  // Bulk Discard / Move-to-character on the current selection. `bulkAction` gates the
-  // buttons while a fan-out is in flight; `moveOpen` reveals the inline character picker.
-  const [bulkAction, setBulkAction] = useState(null);
-  const [moveOpen, setMoveOpen] = useState(false);
-  const [moveCharacterId, setMoveCharacterId] = useState("");
   // Asset Library hygiene (sc-2024): show only studio-generated and uploaded
   // media. Character Studio test outputs (origin "character_studio") live under
   // the character, not here. The backend also exposes `?scope=library`; we filter
@@ -135,116 +119,6 @@ export function LibraryScreen() {
   const videoCount = libraryAssets.filter((asset) => asset.type === "video").length;
   const uploadCount = libraryAssets.filter((asset) => asset.type === "upload").length;
   const availableTags = [...new Set(libraryAssets.flatMap((asset) => (Array.isArray(asset.tags) ? asset.tags : [])))].sort();
-
-  // ── Batch operations (sc-6112) ─────────────────────────────────────────────
-  // The current multi-selection, narrowed to the raster images a batch op can run on,
-  // and the upscale engines this platform actually supports.
-  const selectedAssetList = assets.filter((asset) => selectedAssetIds.has(asset.id));
-  const eligibleSelected = batchEligibleAssets(selectedAssetList);
-  const availableUpscaleEngines = UPSCALE_ENGINES.filter((engine) => !macUpscaleEngineBlocked(macCapabilities, engine.key));
-  // Per-item + aggregate progress for an in-flight/just-finished batch, read off the jobs feed.
-  const batchItems = batch
-    ? batch.items.map((item) => ({ asset: item.asset, status: batchItemStatus(item.jobId, jobs) }))
-    : null;
-  const batchProgress = batch ? summarizeBatchProgress(batch.items, jobs) : null;
-
-  const toggleSelect = (id) =>
-    setSelectedAssetIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-  const clearSelection = () => {
-    setSelectedAssetIds(new Set());
-    setMoveOpen(false);
-  };
-
-  // Move targets the same "Character Assets" link the per-asset panel uses (role "asset",
-  // unapproved) — NOT the character's reference images — so only link-capable media counts.
-  const availableCharacters = characters.filter((character) => !character?.archived);
-  const movableSelected = selectedAssetList.filter(assetSupportsCharacterLink);
-
-  // Send every selected asset to the Trash (reversible — the backend just flags `trashed`).
-  async function discardSelected() {
-    if (!selectedAssetList.length || bulkAction) return;
-    setBulkAction("discard");
-    try {
-      for (const asset of selectedAssetList) {
-        await deleteAsset(asset);
-      }
-      clearSelection();
-    } finally {
-      setBulkAction(null);
-    }
-  }
-
-  // Fan out the per-asset character link across every movable selection.
-  async function moveSelectedToCharacter() {
-    if (!moveCharacterId || !movableSelected.length || bulkAction) return;
-    setBulkAction("move");
-    try {
-      for (const asset of movableSelected) {
-        try {
-          await moveAssetToCharacter(asset, moveCharacterId);
-        } catch {
-          // One asset failing (e.g. already linked) shouldn't abort the rest.
-        }
-      }
-      clearSelection();
-    } finally {
-      setBulkAction(null);
-    }
-  }
-
-  // Decode an asset's native pixel size (needed for an edit job — the worker fits the
-  // source to width×height). Resolves null on a load failure so that item fails alone.
-  function loadImageDims(asset) {
-    return new Promise((resolve) => {
-      const img = new Image();
-      img.onload = () => resolve({ width: img.naturalWidth, height: img.naturalHeight });
-      img.onerror = () => resolve(null);
-      img.src = assetUrl(asset);
-    });
-  }
-
-  // Fan out one job per selected image (NOT one mega-job): each posts independently so
-  // the worker processes them serially with its between-item cache release (sc-5567).
-  // Library assets are persistent ids → no scratch upload and results persist as new
-  // assets (the auto asset-refresh on job completion surfaces them in the grid).
-  async function runBatch(op, params) {
-    if (!activeProject || !eligibleSelected.length) return;
-    const targets = eligibleSelected;
-    setBatch({ op, submitting: true, items: targets.map((asset) => ({ asset, jobId: null })) });
-    const items = [];
-    for (const asset of targets) {
-      try {
-        let dims = null;
-        if (op === "edit") {
-          dims = await loadImageDims(asset);
-          if (!dims) {
-            items.push({ asset, jobId: null });
-            continue;
-          }
-        }
-        const { endpoint, body } = buildBatchJob({ op, asset, params, project: activeProject, requestedGpu, dims });
-        const job = await apiFetch(endpoint, token, { method: "POST", body: JSON.stringify(body) });
-        items.push({ asset, jobId: job?.id ?? null });
-      } catch {
-        items.push({ asset, jobId: null });
-      }
-    }
-    setBatch({ op, submitting: false, items });
-  }
-
-  function closeBatch() {
-    setBatchOpen(false);
-    // Closing after a run clears the spent selection + progress; cancelling the form keeps it.
-    if (batch) {
-      setBatch(null);
-      clearSelection();
-    }
-  }
 
   return (
     <section className="main-surface library-surface">
@@ -319,78 +193,7 @@ export function LibraryScreen() {
         </div>
       </div>
 
-      {selectedAssetIds.size > 0 ? (
-        <div className="batch-selection-bar">
-          <span>
-            {selectedAssetIds.size} selected
-            {eligibleSelected.length !== selectedAssetIds.size
-              ? ` · ${eligibleSelected.length} image${eligibleSelected.length === 1 ? "" : "s"}`
-              : ""}
-          </span>
-          <button className="primary" disabled={!eligibleSelected.length} onClick={() => setBatchOpen(true)} type="button">
-            Batch…
-          </button>
-          {assetMode === "assets" ? (
-            <button
-              className="danger-action"
-              disabled={Boolean(bulkAction)}
-              onClick={discardSelected}
-              type="button"
-            >
-              {bulkAction === "discard" ? "Discarding…" : "Discard"}
-            </button>
-          ) : null}
-          {availableCharacters.length ? (
-            <button
-              disabled={!movableSelected.length || Boolean(bulkAction)}
-              onClick={() =>
-                setMoveOpen((open) => {
-                  const next = !open;
-                  if (next && !moveCharacterId) {
-                    setMoveCharacterId(availableCharacters[0]?.id ?? "");
-                  }
-                  return next;
-                })
-              }
-              title={movableSelected.length ? undefined : "No movable media selected"}
-              type="button"
-            >
-              Move
-            </button>
-          ) : null}
-          <button onClick={clearSelection} type="button">
-            Clear
-          </button>
-          {moveOpen && availableCharacters.length ? (
-            <div className="batch-move-picker">
-              <select
-                aria-label="Move to character"
-                onChange={(event) => setMoveCharacterId(event.target.value)}
-                value={moveCharacterId}
-              >
-                {availableCharacters.map((character) => (
-                  <option key={character.id} value={character.id}>
-                    {character.name}
-                  </option>
-                ))}
-              </select>
-              <button
-                className="primary"
-                disabled={!moveCharacterId || !movableSelected.length || Boolean(bulkAction)}
-                onClick={moveSelectedToCharacter}
-                type="button"
-              >
-                {bulkAction === "move"
-                  ? "Moving…"
-                  : `Move ${movableSelected.length} to assets`}
-              </button>
-              <button onClick={() => setMoveOpen(false)} type="button">
-                Cancel
-              </button>
-            </div>
-          ) : null}
-        </div>
-      ) : null}
+      <AssetSelectionBar batch={batch} showDiscard={assetMode === "assets"} />
 
       <div className="library-layout">
         <AssetGrid
@@ -398,8 +201,8 @@ export function LibraryScreen() {
           onPreview={onPreview}
           selectedAsset={selectedAsset}
           setSelectedAssetId={setSelectedAssetId}
-          selectedIds={selectedAssetIds}
-          onToggleSelect={toggleSelect}
+          selectedIds={batch.selectedAssetIds}
+          onToggleSelect={batch.toggleSelect}
         />
         <AssetDetail
           asset={selectedAsset}
@@ -421,19 +224,7 @@ export function LibraryScreen() {
         />
       </div>
 
-      {batchOpen ? (
-        <BatchOperationsPanel
-          assets={eligibleSelected}
-          editModels={editCapableModels(imageModels)}
-          detailModels={detailCapableModels(imageModels)}
-          upscaleEngines={availableUpscaleEngines}
-          busy={Boolean(batch?.submitting)}
-          items={batchItems}
-          progress={batchProgress}
-          onRun={runBatch}
-          onClose={closeBatch}
-        />
-      ) : null}
+      <AssetBatchModal batch={batch} />
     </section>
   );
 }

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { AssetBatchModal, AssetSelectionBar, useAssetBatch } from "../assetBatch.jsx";
 import { AssetPickerField, CharacterImportDialog } from "../components/AssetPicker.jsx";
 import { AssetCard, emptyTrash } from "../components/assetPanels.jsx";
 import { AssetMedia } from "../components/assetMedia.jsx";
@@ -806,6 +807,8 @@ export function CharacterAssets({
 }) {
   const [viewMode, setViewMode] = React.useState("active");
   const [importOpen, setImportOpen] = React.useState(false);
+  // Same multi-select + batch toolbar as the Assets page (Batch… / Discard / Move).
+  const batch = useAssetBatch();
   const characterId = selectedCharacter?.id;
   // sc-6042: attach project-selected or freshly-uploaded assets to this character.
   // addCharacterReference is the canonical asset↔character link (it writes both the
@@ -898,34 +901,51 @@ export function CharacterAssets({
           projectId={projectId}
         />
       ) : null}
+      {/* Hide Discard in the Trashcan view (already discarded); offer the Main Library as a
+          Move target so character media can be promoted back out (sc-8341). */}
+      <AssetSelectionBar batch={batch} showDiscard={!showingTrash} allowLibraryTarget />
       {visibleAssets.length ? (
-        <div className="reference-thumb-row">
+        <div className="asset-grid character-asset-grid">
           {visibleAssets.map((asset) => (
-            <div className="character-asset-thumb" key={asset.id}>
-              <button
-                aria-label={`Preview ${asset.displayName ?? asset.id}`}
-                className="reference-thumb"
-                onClick={() => onPreview?.(asset, visibleAssets)}
-                type="button"
-              >
-                <AssetMedia asset={asset} controls={false} />
-              </button>
-              <div className="character-asset-thumb-actions">
-                {showingTrash ? (
-                  <>
-                    <button onClick={() => updateAssetStatus?.(asset, { trashed: false })} type="button">
-                      Restore
+            <div
+              className={batch.selectedAssetIds.has(asset.id) ? "asset-tile-wrap selected" : "asset-tile-wrap"}
+              key={asset.id}
+            >
+              <label className="asset-tile-check">
+                <input
+                  aria-label={`Select ${asset.displayName ?? asset.id}`}
+                  checked={batch.selectedAssetIds.has(asset.id)}
+                  onChange={() => batch.toggleSelect(asset.id)}
+                  type="checkbox"
+                />
+              </label>
+              <article className="asset-tile character-asset-card">
+                <button
+                  aria-label={`Preview ${asset.displayName ?? asset.id}`}
+                  className="character-asset-media"
+                  onClick={() => onPreview?.(asset, visibleAssets)}
+                  type="button"
+                >
+                  <AssetMedia asset={asset} controls={false} />
+                </button>
+                <strong>{asset.displayName ?? asset.id}</strong>
+                <div className="character-asset-card-actions">
+                  {showingTrash ? (
+                    <>
+                      <button onClick={() => updateAssetStatus?.(asset, { trashed: false })} type="button">
+                        Restore
+                      </button>
+                      <button onClick={() => purgeAsset?.(asset)} type="button">
+                        Purge
+                      </button>
+                    </>
+                  ) : (
+                    <button onClick={() => deleteAsset?.(asset)} type="button">
+                      Discard
                     </button>
-                    <button onClick={() => purgeAsset?.(asset)} type="button">
-                      Purge
-                    </button>
-                  </>
-                ) : (
-                  <button onClick={() => deleteAsset?.(asset)} type="button">
-                    Discard
-                  </button>
-                )}
-              </div>
+                  )}
+                </div>
+              </article>
             </div>
           ))}
         </div>
@@ -936,6 +956,7 @@ export function CharacterAssets({
             : "No media yet. Angle sets, pose generations, character tests, and any character image or video render collect here automatically."}
         </p>
       )}
+      <AssetBatchModal batch={batch} />
     </section>
   );
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2136,25 +2136,30 @@ label {
   object-fit: cover;
 }
 
-/* Character assets grid: thumbnail with per-item discard / restore / purge. */
-.character-asset-thumb {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 4px;
-  width: 72px;
+/* Character assets grid: full-size tiles (matching the Assets page) with multi-select
+   plus per-item discard / restore / purge. Sizing is inherited from .asset-tile. */
+.character-asset-card {
+  cursor: default;
 }
 
-.character-asset-thumb-actions {
+.character-asset-media {
+  display: block;
+  width: 100%;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.character-asset-card-actions {
   display: flex;
   flex-wrap: wrap;
-  justify-content: center;
-  gap: 4px;
+  gap: 6px;
 }
 
-.character-asset-thumb-actions button {
-  padding: 2px 6px;
-  font-size: 10px;
+.character-asset-card-actions button {
+  padding: 4px 10px;
+  font-size: 12px;
   line-height: 1.2;
 }
 

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -2130,6 +2130,58 @@ impl ProjectStore {
         normalize_asset(project_id, &project_path, &sidecar_path)
     }
 
+    /// Promote a character asset into the Main Asset Library (sc-8341). This is a
+    /// true *move*: the asset leaves every character and surfaces in the Library.
+    /// Because the Library excludes `origin == "character_studio"` and the Character
+    /// Assets grid keys off `recipe.normalizedSettings.characterId` +
+    /// `metadata.characterReferences`, all three must change: flip `origin` to a
+    /// library-visible studio value, drop the recipe's `characterId`, and strip the
+    /// asset's `characterReferences`, then unlink it from every character sidecar.
+    pub fn move_asset_to_library(
+        &self,
+        project_id: &str,
+        asset_id: &str,
+    ) -> ProjectStoreResult<Value> {
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
+        let sidecar_path = self.find_asset_sidecar(&project_path, asset_id)?;
+        let mut asset = read_json(&sidecar_path)?;
+        {
+            let object = asset.as_object_mut().ok_or_else(|| {
+                ProjectStoreError::BadRequest("Asset sidecar must be an object".to_owned())
+            })?;
+            // Promote to a library-visible origin by media type so the
+            // `character_studio` exclusion (LibraryScreen) no longer applies.
+            let asset_type = object
+                .get("type")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            let origin = match asset_type {
+                "video" => "video_studio",
+                "document" => "document_studio",
+                _ => "image_studio",
+            };
+            object.insert("origin".to_owned(), Value::String(origin.to_owned()));
+            // Detach the character association the grid filters on.
+            if let Some(settings) = object
+                .get_mut("recipe")
+                .and_then(Value::as_object_mut)
+                .and_then(|recipe| recipe.get_mut("normalizedSettings"))
+                .and_then(Value::as_object_mut)
+            {
+                settings.remove("characterId");
+            }
+            if let Some(metadata) = object.get_mut("metadata").and_then(Value::as_object_mut) {
+                metadata.remove("characterReferences");
+            }
+        }
+        write_json(&sidecar_path, &asset)?;
+        index_asset(&project_path, &asset, Some(&sidecar_path))?;
+        // Drop the asset from every character's references[] (character sidecars + index).
+        CharacterStore::new(&self.data_dir, project_path.clone())
+            .remove_asset_references(asset_id)?;
+        normalize_asset(project_id, &project_path, &sidecar_path)
+    }
+
     pub fn get_asset(&self, project_id: &str, asset_id: &str) -> ProjectStoreResult<Value> {
         let project_path = self.find_project_path(project_id)?;
         let sidecar_path = self.find_asset_sidecar(&project_path, asset_id)?;
@@ -4296,6 +4348,99 @@ mod tests {
                 "each asset embeds the shared generation set"
             );
         }
+    }
+
+    #[test]
+    fn move_asset_to_library_promotes_origin_and_detaches_character() {
+        use crate::store_util::{read_json, write_json};
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Gallery").expect("project creates");
+
+        // A Character Studio output: persisted, then marked up to look like a
+        // character-scoped asset (origin character_studio + recipe characterId +
+        // characterReferences) — the state the Library excludes and the Character
+        // Assets grid keys on.
+        let fact = json!({
+            "assetId": "char_shot",
+            "mediaPath": "assets/images/genset_char/char_shot.png",
+            "mimeType": "image/png",
+            "displayName": "Mira test #1",
+            "createdAt": "2026-05-25T00:00:00Z",
+            "mode": "character_image",
+            "model": "z_image_turbo",
+            "adapter": "z_image_diffusers",
+            "prompt": "portrait",
+        });
+        store
+            .persist_generated_asset(&project.id, "job-1", "genset_char", &fact)
+            .expect("asset persists");
+
+        let project_path = store.find_project_path(&project.id).expect("project path");
+        let sidecar = project_path.join("assets/images/genset_char/char_shot.sceneworks.json");
+        {
+            let mut asset = read_json(&sidecar).expect("read sidecar");
+            let object = asset.as_object_mut().expect("asset object");
+            object.insert("origin".to_owned(), json!("character_studio"));
+            let recipe = object
+                .entry("recipe")
+                .or_insert_with(|| json!({}))
+                .as_object_mut()
+                .expect("recipe object");
+            recipe
+                .entry("normalizedSettings")
+                .or_insert_with(|| json!({}))
+                .as_object_mut()
+                .expect("normalizedSettings object")
+                .insert("characterId".to_owned(), json!("char-1"));
+            object
+                .entry("metadata")
+                .or_insert_with(|| json!({}))
+                .as_object_mut()
+                .expect("metadata object")
+                .insert(
+                    "characterReferences".to_owned(),
+                    json!([{ "characterId": "char-1" }]),
+                );
+            write_json(&sidecar, &asset).expect("write sidecar");
+        }
+        store
+            .index_asset_sidecar(&project.id, &sidecar)
+            .expect("reindex");
+
+        // Precondition: excluded from the Library by origin.
+        let before = store
+            .get_asset(&project.id, "char_shot")
+            .expect("get before");
+        assert_eq!(before["origin"], json!("character_studio"));
+
+        let moved = store
+            .move_asset_to_library(&project.id, "char_shot")
+            .expect("move to library");
+
+        // Origin promoted (image media -> image_studio), so the Library no longer excludes it.
+        assert_eq!(moved["origin"], json!("image_studio"));
+        // Character association dropped on both vectors the grid filters on.
+        assert!(
+            moved["recipe"]["normalizedSettings"]
+                .get("characterId")
+                .is_none(),
+            "recipe characterId is cleared"
+        );
+        assert!(
+            moved
+                .get("metadata")
+                .and_then(|metadata| metadata.get("characterReferences"))
+                .map(Value::is_null)
+                .unwrap_or(true),
+            "characterReferences is cleared"
+        );
+
+        // Persisted: a fresh read reflects the move.
+        let after = store
+            .get_asset(&project.id, "char_shot")
+            .expect("get after");
+        assert_eq!(after["origin"], json!("image_studio"));
     }
 
     /// V-4: a pre-migration project surfaces an EMPTY `assets` table even though


### PR DESCRIPTION
## What

Two things, both on the **Character Assets** page (Character Studio → Assets tab):

1. **The Assets-page batch toolbar** — multi-select checkboxes plus a selection bar (**Batch… / Discard / Move / Clear**) and the batch-operations modal, matching the main Assets page.
2. **Cards at the Assets-page size** — the old 72px thumbnails are replaced by full-size `.asset-grid` / `.asset-tile` cards (same columns, square media, hover), in both the Media and Trashcan views.

Plus a new capability the toolbar exposes there: **Move → Assets Library** ([sc-8341](https://app.shortcut.com/trefry/story/8341)).

## Why

The Character Assets page only had tiny per-card thumbnails and no bulk actions, unlike the main Assets page. And there was no way to promote character media (especially Character Studio generated images, which the Library excludes by `origin`) back into the Main Asset Library.

## How

**Shared module (de-dup).** The selection state, batch fan-out, and bulk Discard/Move were lifted out of `LibraryScreen` into `apps/web/src/assetBatch.jsx` — a `useAssetBatch()` hook + `AssetSelectionBar` / `AssetBatchModal`. `LibraryScreen` now consumes it (no behavior change; ~225 lines shorter). The Character Assets page uses the same module.

**Move to Main Asset Library — a true move** that works for *both* imported/linked media and Character Studio generated images:
- **Core** (`crates/sceneworks-core/src/project_store.rs`): `move_asset_to_library` flips `origin` to a library-visible studio value by media type, clears `recipe.normalizedSettings.characterId` + `metadata.characterReferences`, re-indexes, then unlinks from every character via the existing `remove_asset_references`. Returns the normalized asset.
- **API** (`apps/rust-api`): `POST /api/v1/projects/:project_id/assets/:asset_id/move-to-library`.
- **Web**: `moveAssetToLibrary` context action; the shared bar gains a `LIBRARY_MOVE_TARGET` sentinel + an `allowLibraryTarget` prop; the Character Assets Move dropdown lists **"Assets Library"** as the first destination.

## Reviewer notes

- The Move dropdown lists every non-archived character **and** (on this page) the Library; moving to a character the asset already belongs to is an idempotent no-op (per-item failures are caught so one bad item doesn't abort the batch).
- `AssetSelectionBar`'s select `aria-label` changed from `"Move to character"` → `"Move target"` (now that Library is also a target); the Library bulk-move test was updated accordingly.
- The hook reads app context *optionally* so isolated component tests still render without a provider.
- **Related cleanup filed separately:** [sc-8339](https://app.shortcut.com/trefry/story/8339) — the Main Library is scoped only by a single negative `origin !== "character_studio"` exclusion, and the detail sidebar isn't scoped to the Library at all (falls back to `assets[0]` of the global feed). Out of scope here; this PR's promoted origin is allow-list-friendly for that follow-up.

## Testing

- **Web**: `npm test` → **806 passing** (46 files), including new Character Assets *bulk-discard* and *bulk move-to-library (sc-8341)* cases, plus the refactored Library batch tests. 0 lint errors.
- **Rust**: new core test `move_asset_to_library_promotes_origin_and_detaches_character` (origin flip + association clear, persisted) passes; `rust-api` builds; `cargo clippy` clean on touched crates; `cargo fmt --all --check` clean.
- Not browser-verified end-to-end — exercising it live needs the full Rust backend + a character with generated assets; covered by the integration + core tests instead.

Refs sc-8341.

🤖 Generated with [Claude Code](https://claude.com/claude-code)