### PR TITLE
fix(web): Asset Library origin allow-list + scoped detail sidebar (sc-8339)

### DIFF
--- a/apps/web/src/components/DatasetAddDialog.jsx
+++ b/apps/web/src/components/DatasetAddDialog.jsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState } from "react";
+import { isLibraryAsset } from "../constants.js";
 import { AssetThumbnail, assetCanRenderAsImage } from "./assetMedia.jsx";
 import { Modal } from "./Modal.jsx";
 
@@ -83,14 +84,15 @@ export function DatasetAddDialog({
 
   const memberSet = useMemo(() => new Set(memberIds), [memberIds]);
 
-  // Library tab: studio + uploaded media only — never Character Studio test
-  // outputs (origin gating from sc-2024) — and nothing already in the dataset.
+  // Library tab: studio + uploaded media only via the shared library allow-list
+  // (sc-2024 / sc-8339) — never Character Studio test outputs, Pose/Key Point library
+  // assets, or unknown origins — and nothing already in the dataset.
   const libraryCandidates = useMemo(
     () =>
       assets.filter(
         (asset) =>
           assetCanRenderAsImage(asset) &&
-          asset.origin !== "character_studio" &&
+          isLibraryAsset(asset) &&
           !memberSet.has(asset.id) &&
           !asset.status?.trashed,
       ),

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -3,6 +3,23 @@
 // unaffected.
 export { terminalStatuses, actionStatuses } from "./jobTypes.js";
 
+// Asset Library hygiene (sc-2024 / sc-8339): the Main Asset Library shows ONLY media
+// produced by the Image / Video / Document studios plus manual uploads. This is a
+// positive allow-list (not a single `!== "character_studio"` exclusion) so anything
+// else — Character Studio outputs (`character_studio`), Pose/Key Point library assets
+// (`pose_library` / `keypoint_library`), and any future origin — stays out by default.
+// Origins are assigned by the backend (`crates/sceneworks-core/src/asset_index.rs`).
+export const LIBRARY_ORIGINS = new Set(["image_studio", "video_studio", "document_studio", "upload"]);
+
+// True when an asset belongs in the Main Asset Library. A missing origin is treated as
+// eligible: the normalized API always stamps one, so only legacy/non-normalized records
+// lack it, and hiding them would be worse than showing them. A *recorded* origin must be
+// in the allow-list.
+export function isLibraryAsset(asset) {
+  const origin = asset?.origin;
+  return !origin || LIBRARY_ORIGINS.has(origin);
+}
+
 // SenseNova-U1 interleave resolution buckets (distinct from plain text-to-image).
 // Mirrors the worker's interleave_resolution_for / upstream examples/interleave.
 export const INTERLEAVE_RESOLUTION_OPTIONS = [

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -9462,6 +9462,119 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).not.toContain("Character Test");
   });
 
+  it("Asset Library is a positive origin allow-list, not just a character exclusion (sc-8339)", async () => {
+    const mk = (id, origin, displayName) => ({
+      id,
+      projectId: "project-1",
+      type: "image",
+      displayName,
+      ...(origin === undefined ? {} : { origin }),
+      recipe: { prompt: displayName },
+      status: { favorite: false, rating: 0, rejected: false, trashed: false },
+    });
+    const assets = [
+      mk("a-image", "image_studio", "Image Studio"),
+      mk("a-video", "video_studio", "Video Studio"),
+      mk("a-doc", "document_studio", "Doc Studio"),
+      mk("a-upload", "upload", "Uploaded"),
+      mk("a-legacy", undefined, "Legacy No Origin"),
+      mk("a-character", "character_studio", "Character Out"),
+      mk("a-pose", "pose_library", "Pose Out"),
+      mk("a-keypoint", "keypoint_library", "Keypoint Out"),
+      mk("a-future", "some_future_studio", "Future Out"),
+    ];
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Scoped" },
+            assets,
+            jobs: [],
+            imageModels: [],
+            createVqaJob: vi.fn(),
+            deleteAsset: () => {},
+            purgeAsset: () => {},
+            importAsset: () => {},
+            setPreviewAsset: () => {},
+            sendAssetToImage: () => {},
+            sendAssetToVideo: () => {},
+            selectedAsset: assets[0],
+            setSelectedAssetId: () => {},
+            setActiveView: () => {},
+            updateAssetStatus: () => {},
+          },
+          <LibraryScreen />,
+        ),
+      );
+    });
+    await settle();
+
+    const tileText = [...container.querySelectorAll(".asset-tile")].map((tile) => tile.textContent).join(" ");
+    // Allow-listed origins + legacy (no origin) appear.
+    for (const name of ["Image Studio", "Video Studio", "Doc Studio", "Uploaded", "Legacy No Origin"]) {
+      expect(tileText).toContain(name);
+    }
+    // Everything else stays out — character, pose/keypoint library, and unknown future origins.
+    for (const name of ["Character Out", "Pose Out", "Keypoint Out", "Future Out"]) {
+      expect(container.textContent).not.toContain(name);
+    }
+  });
+
+  it("Library detail sidebar falls back to a library asset, not the global (character) selection (sc-8339)", async () => {
+    const studioImage = {
+      id: "asset-studio",
+      projectId: "project-1",
+      type: "image",
+      displayName: "Studio Render",
+      origin: "image_studio",
+      recipe: { prompt: "studio render" },
+      status: { favorite: false, rating: 0, rejected: false, trashed: false },
+    };
+    const characterImage = {
+      id: "asset-character",
+      projectId: "project-1",
+      type: "image",
+      displayName: "Character Test",
+      origin: "character_studio",
+      recipe: { prompt: "character test" },
+      status: { favorite: false, rating: 0, rejected: false, trashed: false },
+    };
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Scoped" },
+            assets: [characterImage, studioImage],
+            jobs: [],
+            imageModels: [],
+            createVqaJob: vi.fn(),
+            deleteAsset: () => {},
+            purgeAsset: () => {},
+            importAsset: () => {},
+            setPreviewAsset: () => {},
+            sendAssetToImage: () => {},
+            sendAssetToVideo: () => {},
+            // The global selection is the most-recent (character) asset — the bug case.
+            selectedAsset: characterImage,
+            setSelectedAssetId: () => {},
+            setActiveView: () => {},
+            updateAssetStatus: () => {},
+          },
+          <LibraryScreen />,
+        ),
+      );
+    });
+    await settle();
+
+    // The detail panel shows the most-recent LIBRARY asset, never the character image.
+    const detail = container.querySelector(".asset-detail");
+    expect(detail).toBeTruthy();
+    expect(detail.querySelector("h3").textContent).toBe("Studio Render");
+    expect(container.textContent).not.toContain("Character Test");
+  });
+
   it("folds original and upscaled library variants into one representative tile", async () => {
     const setPreviewAsset = vi.fn();
     const original = {

--- a/apps/web/src/screens/LibraryScreen.jsx
+++ b/apps/web/src/screens/LibraryScreen.jsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { AssetBatchModal, AssetSelectionBar, useAssetBatch } from "../assetBatch.jsx";
 import { foldUpscaledAssetVariants } from "../assetVariants.js";
 import { AssetDetail, AssetGrid, emptyTrash } from "../components/assetPanels.jsx";
-import { terminalStatuses } from "../constants.js";
+import { isLibraryAsset, terminalStatuses } from "../constants.js";
 import { useAppContext } from "../context/AppContext.js";
 
 export function LibraryScreen() {
@@ -38,29 +38,19 @@ export function LibraryScreen() {
     setActiveView("Editor");
   };
   const vqaEnabled = Boolean(createVqaJob) && imageModels.some((model) => (model.capabilities ?? []).includes("vqa"));
-  const assetVqaJobs = selectedAsset
-    ? jobs.filter((job) => job.type === "image_vqa" && job.payload?.sourceAssetId === selectedAsset.id)
-    : [];
-  const vqaEntries = assetVqaJobs
-    .filter((job) => job.status === "completed" && job.result?.answer)
-    .map((job) => ({
-      jobId: job.id,
-      question: job.result?.question ?? job.payload?.question ?? "",
-      answer: job.result.answer,
-    }));
-  const vqaPending = assetVqaJobs.some((job) => !terminalStatuses.has(job.status));
   const [typeFilter, setTypeFilter] = useState("all");
   const [tagFilter, setTagFilter] = useState("all");
   const [showRejected, setShowRejected] = useState(false);
   const [assetMode, setAssetMode] = useState("assets");
   const [isImporting, setIsImporting] = useState(false);
-  // Asset Library hygiene (sc-2024): show only studio-generated and uploaded
-  // media. Character Studio test outputs (origin "character_studio") live under
-  // the character, not here. The backend also exposes `?scope=library`; we filter
-  // on the authoritative `origin` field client-side to reuse the shared asset
-  // feed instead of loading a second scoped copy. Dataset images never reach the
-  // Library — they are stored outside the indexed asset folders.
-  const libraryAssets = assets.filter((asset) => asset.origin !== "character_studio");
+  // Asset Library hygiene (sc-2024 / sc-8339): show only studio-generated and uploaded
+  // media via a positive origin allow-list (isLibraryAsset). Character Studio outputs,
+  // Pose/Key Point library assets, and any future/foreign origin stay out by default —
+  // a single `!== "character_studio"` exclusion let everything else leak in. The backend
+  // also exposes `?scope=library`; we filter on the authoritative `origin` field
+  // client-side to reuse the shared asset feed instead of loading a second scoped copy.
+  // Dataset images never reach the Library — they are stored outside the indexed folders.
+  const libraryAssets = assets.filter(isLibraryAsset);
   const visibleAssets = foldUpscaledAssetVariants(libraryAssets.filter((asset) => {
     if (typeFilter !== "all" && asset.type !== typeFilter) {
       return false;
@@ -79,6 +69,25 @@ export function LibraryScreen() {
     }
     return true;
   }));
+  // Detail-sidebar selection, scoped to the Library (sc-8339). The global `selectedAsset`
+  // falls back to the most-recent asset across ALL studios, so without scoping the panel
+  // can show a freshly generated Character Studio image instead of a library asset. Keep
+  // the global selection only when it is itself a library asset (even if the current
+  // tag/type filter hides it); otherwise fall back to the most-recent visible asset —
+  // never a non-library (e.g. character) asset.
+  const librarySelectedAsset =
+    libraryAssets.find((asset) => asset.id === selectedAsset?.id) ?? visibleAssets[0] ?? null;
+  const assetVqaJobs = librarySelectedAsset
+    ? jobs.filter((job) => job.type === "image_vqa" && job.payload?.sourceAssetId === librarySelectedAsset.id)
+    : [];
+  const vqaEntries = assetVqaJobs
+    .filter((job) => job.status === "completed" && job.result?.answer)
+    .map((job) => ({
+      jobId: job.id,
+      question: job.result?.question ?? job.payload?.question ?? "",
+      answer: job.result.answer,
+    }));
+  const vqaPending = assetVqaJobs.some((job) => !terminalStatuses.has(job.status));
   // All discarded assets within the current type/tag filters — the exact scope
   // the "Empty Trash" button purges (unfolded, so folded variants go too).
   const trashedInView = libraryAssets.filter((asset) => {
@@ -199,13 +208,13 @@ export function LibraryScreen() {
         <AssetGrid
           assets={visibleAssets}
           onPreview={onPreview}
-          selectedAsset={selectedAsset}
+          selectedAsset={librarySelectedAsset}
           setSelectedAssetId={setSelectedAssetId}
           selectedIds={batch.selectedAssetIds}
           onToggleSelect={batch.toggleSelect}
         />
         <AssetDetail
-          asset={selectedAsset}
+          asset={librarySelectedAsset}
           deleteAsset={deleteAsset}
           purgeAsset={purgeAsset}
           onPreview={onPreview}


### PR DESCRIPTION
## What

Fixes two Main Asset Library scope leaks ([sc-8339](https://app.shortcut.com/trefry/story/8339), epic 2019):

1. **Grid leak → positive origin allow-list.** The Library was filtered by a single negative `origin !== "character_studio"` exclusion, so anything else (pose/keypoint-library assets, future/unknown origins) could slip in. Added `LIBRARY_ORIGINS` + `isLibraryAsset()` to `constants.js` (allow-list: `image_studio` / `video_studio` / `document_studio` / `upload`). `LibraryScreen` and the dataset Add dialog's Library tab both use it now.
2. **Detail sidebar not scoped.** The right-hand `AssetDetail` showed the global `selectedAsset`, which falls back to the most-recent asset across **all** studios — so right after a Character Studio render the Library panel showed that character image. `LibraryScreen` now derives a library-scoped selection and feeds it to AssetDetail / AssetGrid / VQA.

## Why

The Library is meant to contain only Image/Video/Document-Studio output + uploads (epic 2019 "asset separation / Library hygiene"). The negative filter was fragile and the detail panel wasn't scoped at all, surfacing character images in the Library.

## How

- `isLibraryAsset(asset)` — a **recorded** origin must be in the allow-list; a **missing** origin is treated as eligible (the normalized API always stamps one, so only legacy/non-normalized records lack it, and hiding those would be worse than showing them).
- `librarySelectedAsset = libraryAssets.find(id === global selectedAsset.id) ?? visibleAssets[0]` — keeps a selected library asset even when a tag/type filter hides it (so narrowing a filter doesn't drop your selection), but never shows a non-library asset; defaults on load to the most-recent library asset.

## Reviewer notes

- **Frames stay in the Library by design.** Extracted frames (`frame_extract`, origin `image_studio`) are user-initiated stills that appear today; I did not regress them. The story's original AC speculatively listed "frame" as should-not-appear — if we want them out, the clean follow-up is a dedicated `frame_extract` origin (backend) or a `type: frame` exclusion. Flagged on the story for a decision.
- **Confirmed non-issues during impl:** dataset images never reach the project asset feed (`training_store` writes dataset items separately, no `index_asset`); poses/keypoints live in a separate global project with explicit non-library origins. The allow-list keeps both out regardless.
- **No backend / origin-model change** — `derive_origin` is unchanged; this is purely consumer-side scoping. Web-only.

## Testing

- `npm test` → **809 passing** (46 files), including 2 new sc-8339 tests: (a) positive allow-list shows allow-listed + legacy-no-origin assets and excludes character/pose/keypoint/unknown origins; (b) the detail sidebar falls back to the most-recent library asset when the global selection is a character image. Existing sc-2024 exclusion + tag-filter tests still pass.
- ESLint clean on touched files.
- Not browser-verified end-to-end (needs the full backend + a project with mixed-origin assets); covered by the integration tests, which mount the real `LibraryScreen`.

Refs sc-8339.

🤖 Generated with [Claude Code](https://claude.com/claude-code)