### PR TITLE
feat: CFG++ guidance surface — per-backend manifest vocab + Image Studio picker (sc-7447 / sc-7449)

### DIFF
--- a/apps/web/src/samplerOptions.js
+++ b/apps/web/src/samplerOptions.js
@@ -29,6 +29,18 @@ export const SCHEDULER_LABELS = {
   ddim_uniform: "DDIM uniform",
 };
 
+// Classifier-free-guidance policy (the orthogonal guidance axis, epic 7434). Names
+// match gen-core's GuidanceMethod registry exactly. "cfg" is the engine's standard
+// guidance (the N1 no-op the studio defaults to); the rest are advertised per-model-
+// per-backend only where the linked engine honors them — CFG++ (cfg_pp) is MLX-only
+// today (sc-8256), so the picker only appears for the SDXL family on the MLX backend.
+export const GUIDANCE_METHOD_LABELS = {
+  cfg: "CFG (standard)",
+  cfg_rescale: "CFG rescale",
+  apg: "APG (adaptive)",
+  cfg_pp: "CFG++",
+};
+
 const SAMPLER_ORDER = [
   "default",
   "euler",
@@ -50,6 +62,7 @@ const SCHEDULER_ORDER = [
   "beta",
   "ddim_uniform",
 ];
+const GUIDANCE_METHOD_ORDER = ["cfg", "cfg_rescale", "apg", "cfg_pp"];
 
 function uniqueOrdered(values, order) {
   const seen = new Set();
@@ -94,6 +107,16 @@ export function schedulerOptionsFromModel(model, backend) {
   return uniqueOrdered(values, SCHEDULER_ORDER);
 }
 
+// The guidance-method menu the active backend honors for this model (epic 7434).
+// Falls back to the engine's standard ["cfg"] when the model advertises none — the
+// studio hides the picker when fewer than 2 methods are offered (length > 1 gate),
+// so only models that actually expose an alternative (CFG++ on SDXL/MLX) show it.
+export function guidanceMethodOptionsFromModel(model, backend) {
+  const limits = effectiveLimits(model, backend);
+  const values = Array.isArray(limits?.guidanceMethods) ? limits.guidanceMethods : ["cfg"];
+  return uniqueOrdered(values, GUIDANCE_METHOD_ORDER);
+}
+
 // Per-model defaults (UI initial values). The worker never reads these — they
 // only set the studio form's initial sampler/scheduler choice. Falls back to
 // "default" when the manifest doesn't pin one.
@@ -105,6 +128,14 @@ export function samplerDefaultFromModel(model) {
 export function schedulerDefaultFromModel(model) {
   const value = model?.defaults?.scheduler;
   return typeof value === "string" && value.length ? value : "default";
+}
+
+// The guidance method the studio selects initially. Defaults to "cfg" (the engine's
+// standard guidance, the N1 no-op) so existing recipes are unchanged; a model may
+// pin a different default via `defaults.guidanceMethod`.
+export function guidanceMethodDefaultFromModel(model) {
+  const value = model?.defaults?.guidanceMethod;
+  return typeof value === "string" && value.length ? value : "cfg";
 }
 
 export function schedulerShiftDefaultFromModel(model) {

--- a/apps/web/src/samplerOptions.test.js
+++ b/apps/web/src/samplerOptions.test.js
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
+  GUIDANCE_METHOD_LABELS,
   SAMPLER_LABELS,
   SCHEDULER_LABELS,
   guidanceDefaultFromModel,
+  guidanceMethodDefaultFromModel,
+  guidanceMethodOptionsFromModel,
   samplerDefaultFromModel,
   samplerOptionsFromModel,
   schedulerDefaultFromModel,
@@ -83,6 +86,42 @@ describe("samplerOptions", () => {
     expect(schedulerShiftDefaultFromModel({ defaults: { schedulerShift: -1 } })).toBe(3.0);
     expect(stepsDefaultFromModel({ defaults: { steps: 0 } })).toBeNull();
     expect(guidanceDefaultFromModel({ defaults: { guidanceScale: "n/a" } })).toBeNull();
+  });
+
+  it("guidance methods fall back to cfg-only and order canonically (epic 7434)", () => {
+    // No advertisement → cfg-only, so the studio hides the picker (length 1).
+    expect(guidanceMethodOptionsFromModel(undefined)).toEqual(["cfg"]);
+    expect(guidanceMethodOptionsFromModel({})).toEqual(["cfg"]);
+    // Manifest ordering is normalized to the canonical guidance order.
+    const model = { limits: { guidanceMethods: ["cfg_pp", "cfg"] } };
+    expect(guidanceMethodOptionsFromModel(model)).toEqual(["cfg", "cfg_pp"]);
+  });
+
+  it("resolves guidance methods per-backend — CFG++ is MLX-only (sc-7447)", () => {
+    // SDXL-shaped: MLX advertises cfg_pp via the mlx override; candle (base) is cfg-only.
+    const sdxl = {
+      limits: { guidanceMethods: ["cfg"] },
+      mlx: { limits: { guidanceMethods: ["cfg", "cfg_pp"] } },
+    };
+    expect(guidanceMethodOptionsFromModel(sdxl, "mlx")).toEqual(["cfg", "cfg_pp"]);
+    expect(guidanceMethodOptionsFromModel(sdxl, "candle")).toEqual(["cfg"]);
+    // No / unknown backend falls back to the base (cfg-only) menu.
+    expect(guidanceMethodOptionsFromModel(sdxl)).toEqual(["cfg"]);
+  });
+
+  it("guidance default is cfg unless the model pins one", () => {
+    expect(guidanceMethodDefaultFromModel(undefined)).toBe("cfg");
+    expect(guidanceMethodDefaultFromModel({})).toBe("cfg");
+    expect(guidanceMethodDefaultFromModel({ defaults: { guidanceMethod: "" } })).toBe("cfg");
+    expect(guidanceMethodDefaultFromModel({ defaults: { guidanceMethod: "cfg_pp" } })).toBe(
+      "cfg_pp",
+    );
+  });
+
+  it("guidance labels cover the full vocabulary (epic 7434)", () => {
+    for (const key of ["cfg", "cfg_rescale", "apg", "cfg_pp"]) {
+      expect(GUIDANCE_METHOD_LABELS[key]).toBeTruthy();
+    }
   });
 
   it("labels cover the full curated menu (epic 7114)", () => {

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -110,9 +110,12 @@ import {
 import { loadStudioSettings, useStudioSettingsWriter } from "../hooks/useStudioSettings.js";
 import { FitModeControl, effectiveFitMode } from "../components/FitModeControl.jsx";
 import {
+  GUIDANCE_METHOD_LABELS,
   SAMPLER_LABELS,
   SCHEDULER_LABELS,
   guidanceDefaultFromModel,
+  guidanceMethodDefaultFromModel,
+  guidanceMethodOptionsFromModel,
   samplerDefaultFromModel,
   samplerOptionsFromModel,
   schedulerDefaultFromModel,
@@ -401,6 +404,10 @@ export function ImageStudio() {
   const [sampler, setSampler] = useState(saved.sampler ?? "default");
   const [scheduler, setScheduler] = useState(saved.scheduler ?? "default");
   const [schedulerShift, setSchedulerShift] = useState(saved.schedulerShift ?? 3.0);
+  // Guidance method (epic 7434). "cfg" is the engine-standard no-op default; the
+  // picker only surfaces alternatives a model advertises on the active backend
+  // (CFG++ on the SDXL family / MLX). Rides `advanced.guidanceMethod`.
+  const [guidanceMethod, setGuidanceMethod] = useState(saved.guidanceMethod ?? "cfg");
   // Steps / guidance: previously worker-only knobs surfaced via this same
   // advanced panel. "" represents "use the model default" so the user can
   // clear the override.
@@ -776,8 +783,13 @@ export function ImageStudio() {
     () => schedulerOptionsFromModel(selectedModel, activeBackend),
     [selectedModel, activeBackend],
   );
+  const guidanceMethodOptions = useMemo(
+    () => guidanceMethodOptionsFromModel(selectedModel, activeBackend),
+    [selectedModel, activeBackend],
+  );
   const showSamplerPicker = samplerOptions.length > 1;
   const showSchedulerPicker = schedulerOptions.length > 1;
+  const showGuidanceMethodPicker = guidanceMethodOptions.length > 1;
   const advancedDefaultsModel = useRef(model);
   const skipAdvancedDefaultsReset = useRef(false);
   useEffect(() => {
@@ -792,10 +804,20 @@ export function ImageStudio() {
     setSampler(preferredOption(samplerDefaultFromModel(selectedModel), samplerOptions));
     setScheduler(preferredOption(schedulerDefaultFromModel(selectedModel), schedulerOptions));
     setSchedulerShift(schedulerShiftDefaultFromModel(selectedModel));
+    setGuidanceMethod(
+      preferredOption(guidanceMethodDefaultFromModel(selectedModel), guidanceMethodOptions),
+    );
     setResolution(preferredResolution(selectedModel, resolutionOptions));
     setStepsOverride("");
     setGuidanceOverride("");
-  }, [model, resolutionOptions, samplerOptions, schedulerOptions, selectedModel]);
+  }, [
+    model,
+    resolutionOptions,
+    samplerOptions,
+    schedulerOptions,
+    guidanceMethodOptions,
+    selectedModel,
+  ]);
   // Snap the sampler / scheduler back to the model's declared default when the
   // current value is no longer in the menu (e.g. user switched to a sealed
   // model whose only option is "default"). Mirrors the resolution-snap effect.
@@ -811,6 +833,17 @@ export function ImageStudio() {
     }
     setScheduler(preferredOption(schedulerDefaultFromModel(selectedModel), schedulerOptions));
   }, [schedulerOptions, scheduler, selectedModel]);
+  // Snap the guidance method back to "cfg" when the current choice isn't honored by
+  // the active backend for this model (e.g. switching off the SDXL family drops
+  // CFG++) — the N3 guard at the UI layer, so an unsupported method is never sent.
+  useEffect(() => {
+    if (guidanceMethodOptions.includes(guidanceMethod)) {
+      return;
+    }
+    setGuidanceMethod(
+      preferredOption(guidanceMethodDefaultFromModel(selectedModel), guidanceMethodOptions),
+    );
+  }, [guidanceMethodOptions, guidanceMethod, selectedModel]);
   // Keep the selected resolution valid for the current model's buckets. Switching
   // to a model whose options exclude the current value snaps to its default (or
   // 1024x1024, then the first option) rather than leaving a stale, unselectable value.
@@ -929,6 +962,7 @@ export function ImageStudio() {
     setSampler(rawSettings.sampler ?? "default");
     setScheduler(rawSettings.scheduler ?? "default");
     setSchedulerShift(rawSettings.schedulerShift ?? rawSettings.timestepShift ?? 3.0);
+    setGuidanceMethod(rawSettings.guidanceMethod ?? "cfg");
     setCharacterId(settings.characterId ?? "");
     setCharacterLookId(settings.characterLookId ?? "");
     setReferenceAssetId(rawSettings.referenceAssetId ?? launchRequest.referenceAssetId ?? "");
@@ -1061,6 +1095,7 @@ export function ImageStudio() {
     ["sampler", setSampler],
     ["scheduler", setScheduler],
     ["schedulerShift", setSchedulerShift],
+    ["guidanceMethod", setGuidanceMethod],
     ["ipAdapterScale", setIpAdapterScale],
     ["controlnetScale", setControlnetScale],
     ["trueCfgScale", setTrueCfgScale],
@@ -1128,6 +1163,7 @@ export function ImageStudio() {
     sampler,
     scheduler,
     schedulerShift,
+    guidanceMethod,
     steps: stepsOverride,
     guidanceScale: guidanceOverride,
     flashAttn,
@@ -1176,6 +1212,7 @@ export function ImageStudio() {
         sampler,
         scheduler,
         schedulerShift,
+        guidanceMethod,
         upscaleEnabled,
         upscaleFactor,
         upscaleEngine,
@@ -1341,6 +1378,11 @@ export function ImageStudio() {
           // values unconditionally is safe — invalid values are ignored.
           ...(sampler && sampler !== "default" ? { sampler } : {}),
           ...(scheduler && scheduler !== "default" ? { scheduler } : {}),
+          // Guidance method (epic 7434). "cfg" is the engine-standard no-op, so it is
+          // omitted — keeping existing recipes byte-identical; only a non-default
+          // method (CFG++) rides the payload. The worker N3-falls an unadvertised
+          // method back to the default, so an invalid value is harmless.
+          ...(guidanceMethod && guidanceMethod !== "cfg" ? { guidanceMethod } : {}),
           // The schedule shift (time-shift mu) is only honored when a curated
           // (non-default) scheduler is active — it shapes that curated schedule;
           // the default scheduler keeps the engine's resolution-native shift, so
@@ -2003,6 +2045,27 @@ export function ImageStudio() {
                     value={guidanceOverride}
                   />
                 </label>
+                {showGuidanceMethodPicker ? (
+                  <label>
+                    Guidance method
+                    <select
+                      onChange={(event) => setGuidanceMethod(event.target.value)}
+                      value={guidanceMethod}
+                    >
+                      {guidanceMethodOptions.map((key) => (
+                        <option key={key} value={key}>
+                          {GUIDANCE_METHOD_LABELS[key] ?? key}
+                        </option>
+                      ))}
+                    </select>
+                    {guidanceMethod === "cfg_pp" ? (
+                      <span className="field-hint">
+                        CFG++ reparameterizes guidance — use a low CFG (~1.5–2.5); high
+                        values over-saturate.
+                      </span>
+                    ) : null}
+                  </label>
+                ) : null}
                 <label
                   className="checkline flash-attn-toggle"
                   title="Fused flash-attention on the candle (Windows/CUDA) SDXL backend — faster and lower VRAM. Ignored on other backends."

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -286,6 +286,112 @@ describe("ImageStudio advanced model defaults", () => {
   });
 });
 
+describe("ImageStudio guidance method picker (epic 7434, sc-7449)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <ImageStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  // SDXL-shaped fixture: advertises CFG++ on the base menu so the picker renders
+  // regardless of the test backend (the per-backend resolution is unit-tested in
+  // samplerOptions.test.js).
+  const SDXL = {
+    ...Z_IMAGE,
+    id: "sdxl",
+    name: "Stable Diffusion XL",
+    family: "sdxl",
+    defaults: { resolution: "1024x1024", guidanceScale: 7 },
+    limits: { resolutions: ["1024x1024"], guidanceMethods: ["cfg", "cfg_pp"] },
+  };
+
+  const openAdvanced = async () =>
+    click([...container.querySelectorAll("button")].find((b) => b.textContent === "Advanced"));
+  const generate = async () =>
+    click([...container.querySelectorAll("button")].find((b) => b.textContent === "Generate"));
+
+  it("hides the picker for a model that advertises no alternate methods", async () => {
+    await render(baseContext({ imageModels: [Z_IMAGE] }));
+    await openAdvanced();
+    expect(field(container, "Guidance method")).toBeUndefined();
+  });
+
+  it("shows CFG++, defaults to the cfg no-op, and omits it from the payload", async () => {
+    const createImageJob = vi.fn(async () => ({ id: "job-1" }));
+    await render(baseContext({ createImageJob, imageModels: [SDXL] }));
+    await openAdvanced();
+    const picker = field(container, "Guidance method");
+    expect(picker).toBeTruthy();
+    expect([...picker.options].map((o) => o.value)).toEqual(["cfg", "cfg_pp"]);
+    expect(picker.value).toBe("cfg");
+    // The CFG++ low-cfg hint only appears once cfg_pp is selected.
+    expect(container.textContent).not.toContain("reparameterizes guidance");
+
+    await generate();
+    // cfg is the N1 no-op — never sent, so existing recipes stay byte-identical.
+    expect(createImageJob.mock.calls[0][0].advanced).not.toHaveProperty("guidanceMethod");
+  });
+
+  it("emits the selected non-default method and surfaces the low-cfg hint", async () => {
+    const createImageJob = vi.fn(async () => ({ id: "job-1" }));
+    await render(baseContext({ createImageJob, imageModels: [SDXL] }));
+    await openAdvanced();
+    await act(async () => setSelect(field(container, "Guidance method"), "cfg_pp"));
+    expect(container.textContent).toContain("reparameterizes guidance");
+
+    await generate();
+    expect(createImageJob.mock.calls[0][0].advanced.guidanceMethod).toBe("cfg_pp");
+  });
+
+  it("round-trips the guidance method from a recipe (restore → re-emit)", async () => {
+    const createImageJob = vi.fn(async () => ({ id: "job-1" }));
+    await render(
+      baseContext({
+        createImageJob,
+        imageModels: [SDXL],
+        studioLaunch: {
+          id: "launch-1",
+          view: "Image",
+          assetId: "asset-1",
+          recipe: {
+            model: "sdxl",
+            mode: "text_to_image",
+            prompt: "a fox",
+            rawAdapterSettings: { guidanceMethod: "cfg_pp" },
+          },
+        },
+      }),
+    );
+    await openAdvanced();
+    expect(field(container, "Guidance method").value).toBe("cfg_pp");
+
+    await generate();
+    expect(createImageJob.mock.calls[0][0].advanced.guidanceMethod).toBe("cfg_pp");
+  });
+});
+
 describe("ImageStudio edit source picker", () => {
   let container;
   let root;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5834,6 +5834,17 @@ details[open] > summary.lora-scope-group-heading::before,
   margin-top: 8px;
 }
 
+/* Generic inline helper text under a form control (e.g. the CFG++ low-cfg note,
+   sc-7449). The scoped `.control-scale-field .field-hint` above keeps its own
+   margins via higher specificity. */
+.field-hint {
+  display: block;
+  margin-top: 4px;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
 .control-scale-field .field-hint {
   margin: 6px 10px 0;
   color: var(--text-muted);

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2521,7 +2521,14 @@
       // block will need the same default-only override as the mflux family
       // entries.
       "mlx": {
-        "minMemoryGb": 50
+        "minMemoryGb": 50,
+        // CFG++ (epic 7434, sc-8256) is MLX-only today: the reparameterized-guidance
+        // dispatch lives in mlx-gen-sdxl, so only the MLX backend advertises it. The base
+        // `limits` carries no guidanceMethods, so the candle lane shows the standard CFG
+        // surface (and picks up cfg_pp when sc-8257 lands a candle dispatch + descriptor).
+        "limits": {
+          "guidanceMethods": ["cfg", "cfg_pp"]
+        }
       },
       "ui": {
         "label": "Stable Diffusion XL",
@@ -2584,6 +2591,14 @@
         // family rather than an empty list, which would match every LoRA).
         "families": ["sdxl"],
         "types": ["style", "enhance", "character"]
+      },
+      "mlx": {
+        // CFG++ (epic 7434, sc-8256) is MLX-only today — same `sdxl` engine, same
+        // reparameterized-guidance dispatch as the base SDXL entry. Scoped to the MLX
+        // backend so the candle lane keeps the standard CFG surface (sc-8257 follow-on).
+        "limits": {
+          "guidanceMethods": ["cfg", "cfg_pp"]
+        }
       },
       "ui": {
         "label": "RealVisXL (photoreal SDXL)",

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -895,7 +895,7 @@ mod tests {
             // (`video_descriptor`); the bespoke out-of-MODEL_TABLE image models (InstantID / PuLID,
             // sc-7432) via `bespoke_advertised`. A model with no source on the active backend is skipped
             // (e.g. the mlx-only `wan_2_2_vace_fun_14b` on the candle lane).
-            let Some((adv_samplers, adv_schedulers)) = mlx_model(id)
+            let Some((adv_samplers, adv_schedulers, adv_guidance)) = mlx_model(id)
                 .map(|resolved| resolved.descriptor)
                 .or_else(|| video_descriptor(id))
                 .map(|descriptor| {
@@ -912,14 +912,29 @@ mod tests {
                             .iter()
                             .map(|s| s.to_string())
                             .collect::<Vec<_>>(),
+                        // sc-7447: the guidance axis (epic 7434) — the manifest's per-backend
+                        // `limits.guidanceMethods` MUST be a subset of what the engine descriptor
+                        // honors, exactly like samplers/schedulers.
+                        descriptor
+                            .capabilities
+                            .supported_guidance_methods
+                            .iter()
+                            .map(|s| s.to_string())
+                            .collect::<Vec<_>>(),
                     )
                 })
-                .or_else(|| bespoke_advertised(id))
+                // Bespoke out-of-MODEL_TABLE models advertise no descriptor guidance vocab; they
+                // also advertise no `limits.guidanceMethods` in the manifest, so the guidance axis is
+                // simply absent for them (empty advertised set + `effective_list` => None).
+                .or_else(|| bespoke_advertised(id).map(|(s, sc)| (s, sc, Vec::new())))
             else {
                 continue;
             };
-            for (axis, advertised) in [("samplers", &adv_samplers), ("schedulers", &adv_schedulers)]
-            {
+            for (axis, advertised) in [
+                ("samplers", &adv_samplers),
+                ("schedulers", &adv_schedulers),
+                ("guidanceMethods", &adv_guidance),
+            ] {
                 if let Some(list) = effective_list(model, backend, axis) {
                     for name in list {
                         if name == "default" {
@@ -936,10 +951,46 @@ mod tests {
         }
         assert!(
             violations.is_empty(),
-            "manifest advertises {} sampler/scheduler name(s) the {backend} engine does not honor:\n  {}",
+            "manifest advertises {} sampler/scheduler/guidance name(s) the {backend} engine does not honor:\n  {}",
             violations.len(),
             violations.join("\n  ")
         );
+    }
+
+    // sc-7447: the subset guard above only EXERCISES the guidance axis if a model actually advertises a
+    // `limits.guidanceMethods` list — otherwise the new axis is vacuously green (the same trap sc-7432
+    // closed for the bespoke sampler menus). Pin the CFG++ surface down on the MLX lane: `sdxl` +
+    // `realvisxl` (epic 7434 / sc-8256) must advertise `cfg_pp`, and the linked engine descriptor must
+    // honor it. Candle has no cfg_pp dispatch yet (sc-8257), so the base `limits` carries no guidance
+    // vocab and this is a macOS-only assertion — the candle lane keeps the standard CFG-only surface.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn sdxl_family_advertises_cfgpp_on_mlx() {
+        let manifest = parse_builtin_models();
+        let models = manifest["models"].as_array().expect("models array");
+        for id in ["sdxl", "realvisxl"] {
+            let model = models
+                .iter()
+                .find(|m| m["id"].as_str() == Some(id))
+                .unwrap_or_else(|| panic!("{id}: manifest entry must exist"));
+            let methods = effective_list(model, "mlx", "guidanceMethods")
+                .unwrap_or_else(|| panic!("{id}: must advertise mlx limits.guidanceMethods"));
+            assert!(
+                methods.iter().any(|m| m == "cfg_pp"),
+                "{id}: mlx must advertise cfg_pp (advertised: {methods:?})"
+            );
+            let descriptor = mlx_model(id)
+                .map(|r| r.descriptor)
+                .unwrap_or_else(|| panic!("{id}: must resolve an mlx descriptor"));
+            assert!(
+                descriptor
+                    .capabilities
+                    .supported_guidance_methods
+                    .contains(&"cfg_pp"),
+                "{id}: engine descriptor must honor cfg_pp (advertised: {:?})",
+                descriptor.capabilities.supported_guidance_methods
+            );
+        }
     }
 
     // sc-7432: the subset guard above only EXERCISES the bespoke out-of-MODEL_TABLE models if

--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -34,9 +34,19 @@
       ],
       "description": "Sigma schedule from the unified curated framework (epic 7114, decision 2). Names match gen-core's Scheduler registry exactly. \"default\" preserves the engine's native schedule. The epic-1753 \"shift\" pseudo-scheduler is gone — the per-generation time shift is the orthogonal defaults.schedulerShift / advanced.schedulerShift knob, not a scheduler choice."
     },
+    "guidanceMethodKey": {
+      "type": "string",
+      "enum": [
+        "cfg",
+        "cfg_rescale",
+        "apg",
+        "cfg_pp"
+      ],
+      "description": "Classifier-free-guidance policy from the unified guidance axis (epic 7434). Names match gen-core's GuidanceMethod registry exactly. \"cfg\" is the standard guidance the engine applies by default (the N1 no-op); \"cfg_rescale\" (Lens-style std-rescale), \"apg\" (Bernini adaptive-projected guidance), and \"cfg_pp\" (CFG++, reparameterized low-cfg guidance) are advertised per-model-per-backend only where the linked engine descriptor honors them. The worker N3-falls an unadvertised method back to the engine default."
+    },
     "samplerLimits": {
       "type": "object",
-      "description": "Per-model sampler / scheduler capability lists used to gate Image / Video Studio dropdowns. Omit the keys entirely to disable the controls; include single-element [\"default\"] arrays for sealed adapters so the manifest is still self-describing.",
+      "description": "Per-model sampler / scheduler / guidance capability lists used to gate Image / Video Studio dropdowns. Omit the keys entirely to disable the controls; include single-element [\"default\"] arrays for sealed adapters so the manifest is still self-describing.",
       "properties": {
         "samplers": {
           "type": "array",
@@ -49,6 +59,12 @@
           "minItems": 1,
           "uniqueItems": true,
           "items": { "$ref": "#/$defs/schedulerKey" }
+        },
+        "guidanceMethods": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/guidanceMethodKey" }
         }
       }
     }
@@ -75,7 +91,7 @@
           },
           "limits": {
             "type": "object",
-            "description": "Per-model capability lists. Sampler / scheduler arrays gate the Image / Video Studio dropdowns; omit them to hide the controls.",
+            "description": "Per-model capability lists. Sampler / scheduler / guidance arrays gate the Image / Video Studio dropdowns; omit them to hide the controls.",
             "properties": {
               "samplers": {
                 "type": "array",
@@ -88,6 +104,12 @@
                 "minItems": 1,
                 "uniqueItems": true,
                 "items": { "$ref": "#/$defs/schedulerKey" }
+              },
+              "guidanceMethods": {
+                "type": "array",
+                "minItems": 1,
+                "uniqueItems": true,
+                "items": { "$ref": "#/$defs/guidanceMethodKey" }
               }
             }
           },


### PR DESCRIPTION
Closes the P5 user-facing surface of epic 7434 (unified guidance axis) for CFG++: the manifest now advertises the guidance vocabulary per-model-per-backend, and Image Studio gets a guidance-method picker so **CFG++ is finally clickable** for the SDXL family on MLX.

Builds on the now-merged backend: gen-core CFG++ (mlx-gen #594/#605), worker `guidance_method` dispatch (#958), and the lockstep pin bump (#961).

## sc-7447 — manifest vocab + drift guard + schema
- **Schema** (`packages/schemas/model-manifest.schema.json`): new `guidanceMethodKey` enum (`cfg` / `cfg_rescale` / `apg` / `cfg_pp`) + a `guidanceMethods` list on both the top-level `limits` and the per-backend `samplerLimits` override.
- **Manifest** (`builtin.models.jsonc`): `sdxl` + `realvisxl` advertise `mlx.limits.guidanceMethods: ["cfg","cfg_pp"]`. CFG++ is MLX-only today (sc-8256), so it is **scoped to the MLX backend** — the candle lane keeps the standard CFG surface until sc-8257. `realvisxl_lightning` is excluded (CFG-distilled — cfg_pp is inert).
- **Drift guard** (`engines.rs`): `manifest_menu_is_subset_of_descriptor` gains a third `guidanceMethods` axis sourced from the engine descriptor's `supported_guidance_methods`, so the manifest can never advertise a method the engine won't honor. New `sdxl_family_advertises_cfgpp_on_mlx` keeps the axis non-vacuous (the trap sc-7432 closed for samplers).

## sc-7449 — Image Studio picker
- `samplerOptions.js`: `GUIDANCE_METHOD_LABELS` + `guidanceMethodOptionsFromModel` / `guidanceMethodDefaultFromModel`, reading the per-backend `limits.guidanceMethods`. Default `cfg` (the N1 no-op).
- `ImageStudio.jsx`: a "Guidance method" picker gated on >1 advertised method (so it only appears for SDXL/MLX where CFG++ is live), snapping back to default when the backend stops honoring the choice (N3 at the UI). `cfg` is omitted from the payload → existing recipes byte-identical; only `cfg_pp` rides `advanced.guidanceMethod`. Recipe + preset round-trip; low-CFG hint when CFG++ is selected.

## Deferred (filed, not dropped)
- **APG param controls (eta/momentum/norm_threshold) → sc-8363** — the worker threads only `guidance_method` and no image model advertises `apg`, so the controls would be unreachable dead UI.
- **Video Studio picker → sc-8364** — the video job path has no guidance dispatch yet (blocked on sc-7444).

## Verification
- Worker: `engines::tests` 9/9 green (drift guard + new pin); `cargo fmt --all --check` + `cargo clippy -p sceneworks-worker --all-targets` clean.
- Scaffold: `node scripts/check-scaffold.mjs` validates the manifest against the updated schema.
- Web: full vitest suite **815/815** (incl. new guidance helper + picker + recipe-round-trip tests); `eslint src` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)