### PR TITLE
feat(instantid): angle-set controlnet default 0.65 + surface lock slider (sc-8354)

### DIFF
--- a/apps/web/src/components/CharacterAdvancedOptions.jsx
+++ b/apps/web/src/components/CharacterAdvancedOptions.jsx
@@ -30,13 +30,23 @@ import {
 // forward-compatible: it lights up the moment the manifest + worker land, with no
 // change here.
 
-export function useCharacterAdvancedOptions(model, { defaultNegativePrompt = "" } = {}) {
+export function useCharacterAdvancedOptions(
+  model,
+  { defaultNegativePrompt = "", identityStructureMode = "single" } = {},
+) {
   const ui = model?.ui ?? {};
   const referenceStrengthDefault =
     typeof ui.referenceStrengthDefault === "number" ? ui.referenceStrengthDefault : 0.8;
   const identityStructure = ui.identityStructure ?? null;
+  // The Identity-structure (controlnetConditioningScale) lock defaults lower for an angle set than
+  // for single-image generation (sc-8354): the softer lock sharpens the off-axis views. Track the
+  // backbone's `angleSetDefault` in that mode, falling back to the single-image `default`.
   const identityStructureDefault =
-    typeof identityStructure?.default === "number" ? identityStructure.default : 0.8;
+    identityStructureMode === "angleSet" && typeof identityStructure?.angleSetDefault === "number"
+      ? identityStructure.angleSetDefault
+      : typeof identityStructure?.default === "number"
+        ? identityStructure.default
+        : 0.8;
 
   const samplerOptions = samplerOptionsFromModel(model);
   const schedulerOptions = schedulerOptionsFromModel(model);

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -359,7 +359,18 @@ export const fallbackModels = [
       // Identity tuning: reference strength (ipAdapterScale) defaults higher for
       // InstantID; identityStructure adds the controlnetConditioningScale slider.
       referenceStrengthDefault: 0.8,
-      identityStructure: { label: "Identity structure", default: 0.8, min: 0.3, max: 1.0, step: 0.05 },
+      // `default` is the single-image (Image Studio) lock; `angleSetDefault` is the softer
+      // angle-set lock the worker also applies (sc-8354 — 0.65 clears the most off-axis views
+      // above the blur floor at a small identity cost). The Angle Set card seeds its slider from
+      // `angleSetDefault` so the surfaced value matches what the backbone runs.
+      identityStructure: {
+        label: "Identity structure",
+        default: 0.8,
+        angleSetDefault: 0.65,
+        min: 0.3,
+        max: 1.0,
+        step: 0.05,
+      },
       // Canonical head angles (advanced.viewAngle; built-in landmark pack drives pose).
       viewAngles: [
         { id: "three_quarter_left", label: "Three-quarter left" },

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -2862,6 +2862,88 @@ describe("SceneWorks app shell", () => {
     expect(baseContext.rememberLocalGenerationJob).toHaveBeenCalledWith("image", { id: "job-angle" });
   });
 
+  it("seeds the angle-set Identity-structure lock from angleSetDefault (sc-8354)", async () => {
+    const createImageJob = vi.fn(async () => ({ id: "job-angle-cn" }));
+    const baseContext = {
+      activeProject: { id: "project-1", name: "Noir" },
+      addCharacterReference: () => {},
+      archiveCharacter: () => {},
+      assets: [],
+      attachCharacterLora: () => {},
+      characters: [
+        {
+          id: "char-1",
+          name: "Mira",
+          type: "person",
+          references: [],
+          approvedReferences: [{ assetId: "ref-1", role: "hero", asset: { id: "ref-1", type: "image", displayName: "Mira ref" } }],
+          looks: [],
+          loras: [],
+        },
+      ],
+      createCharacter: () => {},
+      createCharacterLook: () => {},
+      createCharacterTestJob: () => {},
+      createImageJob,
+      importAsset: vi.fn(),
+      imageLocalJobs: [],
+      rememberLocalGenerationJob: vi.fn(),
+      deleteAsset: () => {},
+      deleteCharacterLook: () => {},
+      detachCharacterLora: () => {},
+      imageModels: [
+        {
+          id: "instantid_realvisxl",
+          name: "InstantID (RealVisXL)",
+          type: "image",
+          ui: {
+            referenceStrengthDefault: 0.8,
+            identityStructure: { label: "Identity structure", default: 0.8, angleSetDefault: 0.65, min: 0.3, max: 1.0, step: 0.05 },
+            viewAngles: [{ id: "front", label: "Front" }, { id: "left_profile", label: "Left profile" }],
+          },
+        },
+      ],
+      latestImageAssets: [],
+      loras: [],
+      setPreviewAsset: () => {},
+      sendCharacterToImage: () => {},
+      sendCharacterToVideo: () => {},
+      purgeAsset: () => {},
+      removeCharacterReference: () => {},
+      updateAssetStatus: () => {},
+      updateCharacter: () => {},
+      updateCharacterLook: () => {},
+      updateCharacterLora: () => {},
+      updateCharacterReference: () => {},
+    };
+    root = createRoot(container);
+    await act(async () => {
+      root.render(withAppContext(baseContext, <CharacterStudio />));
+    });
+
+    // The Identity-structure slider seeds from angleSetDefault, not the 0.80 single-image default.
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Advanced")?.click();
+    });
+    const lockSlider = [...container.querySelectorAll(".reference-strength")].find((label) =>
+      label.textContent.includes("Identity structure"),
+    );
+    expect(lockSlider?.querySelector("span")?.textContent).toBe("0.65");
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent.startsWith("Generate angle set")).click();
+    });
+
+    // The softer lock rides advanced.controlnetConditioningScale so the worker's angle-set default
+    // isn't pinned back to the single-image 0.80.
+    expect(createImageJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "character_image",
+        advanced: expect.objectContaining({ angleSet: true, controlnetConditioningScale: 0.65 }),
+      }),
+    );
+  });
+
   it("fires a pose-library batch job from the Character Studio pose picker", async () => {
     const poseKeypoints = Array.from({ length: 18 }, (_, i) => [0.5, i / 18]);
     global.fetch = vi.fn(async () => ({

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -524,6 +524,7 @@ function CharacterGenerationPanel({
   // active backbone; values fold into the job's `advanced` dict at submit.
   const advanced = useCharacterAdvancedOptions(activeModel, {
     defaultNegativePrompt: mode.defaultNegativePrompt,
+    identityStructureMode: mode.identityStructureMode,
   });
   const [referenceAssetId, setReferenceAssetId] = React.useState("");
   const [prompt, setPrompt] = React.useState("");
@@ -765,6 +766,11 @@ function useAngleController({ activeModel, loraSelection }) {
 const ANGLE_MODE = {
   eyebrow: "Angle set",
   title: (activeModel) => `${activeModel.name} turnaround`,
+  // The set runs a softer landmark lock by default than single-image (sc-8354). Seed the
+  // Identity-structure slider from the backbone's `identityStructure.angleSetDefault` so the
+  // surfaced control matches what the worker runs (and the emitted value doesn't pin it back to
+  // the single-image 0.80).
+  identityStructureMode: "angleSet",
   defaultNegativePrompt: ANGLE_SET_NEGATIVE_PROMPT,
   referenceRole: "angle-set-reference",
   referenceNoun: "angle-set reference",
@@ -777,11 +783,20 @@ const ANGLE_MODE = {
     return `${appearance}, head and shoulders, neutral expression, consistent outfit, plain grey background, face clearly visible, sharp focus, photorealistic`;
   },
   renderIntro: (activeModel) => (
-    <p>
-      Generate {activeModel?.ui?.viewAngles?.length ?? 0} consistent views of this character (front, three-quarters,
-      profiles, up/down and the diagonals) from one reference, in a single job. A good starting set for curating a
-      character LoRA.
-    </p>
+    <>
+      <p>
+        Generate {activeModel?.ui?.viewAngles?.length ?? 0} consistent views of this character (front, three-quarters,
+        profiles, up/down and the diagonals) from one reference, in a single job. A good starting set for curating a
+        character LoRA.
+      </p>
+      {activeModel?.ui?.identityStructure ? (
+        <p className="structured-hint">
+          Lower <strong>Identity structure</strong> (under Advanced) to sharpen the off-axis views — it trades a little
+          identity for a cleaner image. It can't fully rescue the most extreme up/down angles, and the set stays softer
+          than a real photo; for a final pass, run the outputs through the image refine path.
+        </p>
+      ) : null}
+    </>
   ),
   useController: useAngleController,
 };

--- a/crates/sceneworks-worker/src/image_jobs/instantid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/instantid.rs
@@ -23,6 +23,13 @@ const INSTANTID_DEFAULT_STEPS: u32 = 30;
 const INSTANTID_DEFAULT_GUIDANCE: f32 = 3.0;
 const INSTANTID_IP_SCALE: f32 = 0.8;
 const INSTANTID_CONTROLNET_SCALE: f32 = 0.8;
+/// Angle-set default `controlnetConditioningScale` (sc-8354). The sc-8222 real-weight A/B (full
+/// 5-point cn sweep, paired on the built-in 11-angle set) found the landmark-ControlNet lock is the
+/// only viable lever that sharpens angle-set output: lowering it from 0.80 to 0.65 lifts median blur
+/// variance ~+11% and clears the most angles above the person blur floor (9/11) at a small identity
+/// cost (−0.012 mean ArcFace cosine, well inside the InstantID ~0.82 envelope). Identity / pose modes
+/// keep the 0.80 default — this softer lock is angle-set-only.
+const INSTANTID_ANGLE_CONTROLNET_SCALE: f32 = 0.65;
 /// xinsir OpenPose-SDXL ControlNet (the pose-mode second branch, sc-3117). Loads via the stock
 /// `load_controlnet` (no conversion) — `image_adapters.py:615-617` parity.
 const INSTANTID_OPENPOSE_REPO: &str = "xinsir/controlnet-openpose-sdxl-1.0";
@@ -557,10 +564,21 @@ async fn generate_instantid_stream(
         INSTANTID_IP_SCALE,
         0.0..=1.0,
     );
+    let mode = instantid_mode(request);
+    let angle_set = matches!(mode, InstantIdMode::AngleSet);
+    let pose_set = matches!(mode, InstantIdMode::PoseSet(_));
+    // The angle set runs a softer landmark lock by default (sc-8354) so the off-axis views clear the
+    // blur floor; identity/pose modes keep the standard 0.80. An explicit slider value (now surfaced
+    // on the Angle Set card) still wins via the same `controlnetConditioningScale` key.
+    let controlnet_default = if angle_set {
+        INSTANTID_ANGLE_CONTROLNET_SCALE
+    } else {
+        INSTANTID_CONTROLNET_SCALE
+    };
     let controlnet_scale = advanced::f32_clamped(
         &request.advanced,
         "controlnetConditioningScale",
-        INSTANTID_CONTROLNET_SCALE,
+        controlnet_default,
         0.0..=2.0,
     );
     let repo = request
@@ -571,9 +589,6 @@ async fn generate_instantid_stream(
         .filter(|value| !value.is_empty())
         .unwrap_or(INSTANTID_SDXL_REPO)
         .to_owned();
-    let mode = instantid_mode(request);
-    let angle_set = matches!(mode, InstantIdMode::AngleSet);
-    let pose_set = matches!(mode, InstantIdMode::PoseSet(_));
     // The active Key Point Library collection drives the angle set (sc-4450): per-generation
     // override > user default > built-in 11. Resolved once (and only for angle jobs).
     let angle_collection = angle_set.then(|| active_angle_collection(request, settings));


### PR DESCRIPTION
## What

Lowers the InstantID **angle-set** default `controlnetConditioningScale` from 0.80 to **0.65** and ensures the existing "Identity structure" slider surfaces/sends that value for angle sets.

## Why

The [sc-8222](https://app.shortcut.com/trefry/story/8222) real-weight A/B (full 5-point cn-scale sweep, paired on the built-in 11-angle InstantID set, scored with the real `eval_lora_outputs` harness) found that **lowering `controlnetConditioningScale` is the only viable lever that sharpens InstantID angle-set output**, with a clean, monotonic tradeoff. At 0.65 the set clears the most angles above the person blur floor (9/11) at a small identity cost (−0.012 mean ArcFace cosine, well inside the InstantID ~0.82 envelope). Implements [sc-8354](https://app.shortcut.com/trefry/story/8354).

## Changes

- **Worker** (`crates/sceneworks-worker/src/image_jobs/instantid.rs`): new `INSTANTID_ANGLE_CONTROLNET_SCALE = 0.65`; the `controlnetConditioningScale` fallback is now mode-aware — angle set → 0.65, identity/pose keep 0.80. An explicit slider value still wins via the same key, so API/non-web clients are covered too.
- **`constants.js`**: added `identityStructure.angleSetDefault: 0.65` to InstantID.
- **`CharacterAdvancedOptions.jsx`**: `useCharacterAdvancedOptions` takes `identityStructureMode`; seeds the lock from `angleSetDefault` in `"angleSet"` mode, else `default`. Without this, `buildAdvanced` would have emitted the single-image 0.80 and **pinned the worker's new 0.65 back to 0.80** for the angle card.
- **`characterPanels.jsx`**: `ANGLE_MODE` passes `identityStructureMode: "angleSet"`; added a hint under the angle-set intro documenting the hard limit (can't rescue extreme up/down angles; set stays softer than a real photo; use the refine path for a final pass) so the UI doesn't over-promise.
- Image Studio single-image is untouched (still 0.80).

## Reviewer notes

- **0.65 vs 0.70:** the story flagged 0.70 as a conservative identity-max alternative. Went with **0.65** (the primary recommendation — clears 9/11 above floor). Trivial to flip (one constant + one `angleSetDefault`).
- This lever is a *global* lift and caps at ~9/11 above-floor; the remaining gap needs the whole-image refine path (sc-8228 / sc-8229), out of scope here.

## Testing

- New test `seeds the angle-set Identity-structure lock from angleSetDefault (sc-8354)` — asserts the slider renders 0.65 and the job emits `controlnetConditioningScale: 0.65`.
- Web suite **186/186** pass (post-merge with main), eslint 0 errors.
- Worker `cargo check` / `fmt --check` / `clippy` clean (macOS/MLX path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)