### PR TITLE
feat(worker): base Z-Image t2i + ControlNet surface (sc-8320 / sc-8251)

### DIFF
--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -91,6 +91,28 @@ export const fallbackModels = [
     },
   },
   {
+    // Base (non-distilled) Z-Image (sc-8320): full real-CFG (~50 step) foundation target,
+    // distinct from Turbo's 4-step distill. Higher quality at a higher compute cost.
+    id: "z_image",
+    name: "Z-Image",
+    type: "image",
+    capabilities: ["text_to_image", "style_variations"],
+    ui: {
+      description: "Undistilled base Z-Image text-to-image (real CFG, ~50 steps).",
+      promptGuide: { title: "Z-Image Prompt Guide", path: "/prompt-guides/z-image-turbo.md" },
+      // Strict control tier (sc-8251): the worker conditions the base Z-Image
+      // Fun-Controlnet-Union branch (z_image_control) on a pose skeleton / auto-canny /
+      // auto-depth map. poseLibrary alone gates the pose picker (no character_image needed).
+      poseLibrary: true,
+      poseControlScale: true,
+      // Strict-control modes the base Z-Image Fun-Controlnet-Union branch admits (sc-8251): pose,
+      // canny, depth. Mirrors the manifest `controlModes` (single source of truth:
+      // STRICT_CONTROL_ENGINES z_image_control = {pose,canny,depth}).
+      controlModes: ["pose", "canny", "depth"],
+      controlScale: { label: "Control strength", default: 0.9, min: 0.0, max: 2.0, step: 0.05 },
+    },
+  },
+  {
     id: "qwen_image",
     name: "Qwen Image",
     type: "image",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -106,6 +106,94 @@
       }
     },
     {
+      // Base (non-distilled) Z-Image (epic 8236, sc-8320). The undistilled foundation
+      // model from the `Tongyi-MAI/Z-Image` diffusers snapshot — the same architecture as
+      // Turbo, but full real CFG (guidance 3.0–5.0, default 4.0) + negative prompt and ~50
+      // steps (shift=6.0 schedule) vs Turbo's 4-step CFG-free distill. Higher quality at a
+      // higher step/compute cost; selectable as its own t2i target and routed to the base
+      // engine path (`z_image`), distinct from Turbo. The base ships its own fast
+      // tokenizer, so no derived-tokenizer overlay is needed.
+      "id": "z_image",
+      "name": "Z-Image",
+      "family": "z-image",
+      "type": "image",
+      "adapter": "z_image_diffusers",
+      "capabilities": ["text_to_image", "style_variations"],
+      "downloads": [
+        // Refresh estimatedSizeBytes from the Hugging Face recursive tree API:
+        // https://huggingface.co/api/models/<repo>/tree/main?recursive=true
+        {
+          "provider": "huggingface",
+          "repo": "Tongyi-MAI/Z-Image",
+          "files": [],
+          "estimatedSizeBytes": 20547479575
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/Tongyi-MAI/Z-Image"
+      },
+      "defaults": {
+        "resolution": "1024x1024",
+        // Undistilled base — the card recommends 28–50 steps; 50 matches the reference
+        // `ZImagePipeline` example. Real CFG default 4.0 (the engine `supports_guidance`).
+        "steps": 50,
+        "guidanceScale": 4.0,
+        "count": 1,
+        "sampler": "default",
+        "scheduler": "default"
+      },
+      "limits": {
+        "resolutions": ["768x768", "1024x1024", "1280x720", "720x1280"],
+        "count": [1, 2, 4],
+        // Flow-matching DiT — full diffusers flow menu (epic 1753), shared with Turbo.
+        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+        "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
+      },
+      "loraCompatibility": {
+        "families": ["z-image"],
+        "types": ["style", "enhance", "character"]
+      },
+      // macOS-only native-MLX backend (epic 3018). minMemoryGb runs above Turbo's: the base
+      // is the full undistilled transformer + the real-CFG (cond+uncond) forward, so peak
+      // residency is higher even at the same resolution. Q4 brings this within tighter Mac
+      // budgets via advanced.mlxQuantize.
+      "mlx": {
+        "minMemoryGb": 48,
+        "quantize": 8,
+        "limits": {
+          "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+          "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
+        }
+      },
+      "ui": {
+        "label": "Z-Image",
+        "description": "Undistilled base Z-Image text-to-image (real CFG, ~50 steps); higher quality than Turbo at a higher compute cost.",
+        "recommendedFor": ["text_to_image", "style_variations"],
+        "pid": { "checkpointId": "pid_flux" },
+        "promptGuide": {
+          "title": "Z-Image Prompt Guide",
+          "path": "/prompt-guides/z-image-turbo.md",
+          "sources": [
+            { "label": "Z-Image model card", "url": "https://huggingface.co/Tongyi-MAI/Z-Image" },
+            { "label": "Z-Image-Turbo model card", "url": "https://huggingface.co/Tongyi-MAI/Z-Image-Turbo" }
+          ]
+        },
+        // Strict control tier (sc-8251): on the macOS MLX backend the worker conditions the
+        // base Z-Image Fun-Controlnet-Union branch (`z_image_control`) on a pose skeleton,
+        // auto-canny edge map, or auto-Depth-Anything-V2 map. poseLibrary alone gates the
+        // pose picker; the worker dispatches by model id.
+        "poseLibrary": true,
+        // Strict ControlNet → control-lock-strength slider (advanced.controlScale).
+        "poseControlScale": true,
+        // Strict-control modes the base Z-Image Fun-Controlnet-Union branch admits (sc-8251): pose
+        // (skeleton), canny (auto edge map from the input image), depth (auto Depth-Anything-V2 map).
+        // SINGLE SOURCE OF TRUTH for the worker is `STRICT_CONTROL_ENGINES` (z_image_control =
+        // {pose,canny,depth}); this advertises the same set so the picker offers a control-mode selector.
+        "controlModes": ["pose", "canny", "depth"],
+        "controlScale": { "label": "Control strength", "default": 0.9, "min": 0.0, "max": 2.0, "step": 0.05 }
+      }
+    },
+    {
       "id": "z_image_edit",
       "name": "Z-Image-Edit",
       "family": "z-image",

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -43,6 +43,21 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
         default_guidance: 0.0,
         adapter_label: "mlx_z_image",
     },
+    // Base (non-distilled) Z-Image (epic 8236, sc-8320). The undistilled foundation model from the
+    // `Tongyi-MAI/Z-Image` diffusers snapshot — the same `ZImageTransformer` as Turbo, but the
+    // `z_image` engine descriptor uses a shift=6.0 schedule, ~50 default steps, and REAL CFG
+    // (`supports_guidance` + negative prompt; the card recommends guidance 3.0–5.0, default 4.0) vs
+    // Turbo's 4-step guidance-distilled CFG-free path. Ships its own fast `tokenizer/tokenizer.json`,
+    // so it needs NO derived-tokenizer overlay. Routes to the base t2i path (not Turbo); strict-pose /
+    // canny / depth control routes to the `z_image_control` engine variant (sc-8251).
+    ModelRow {
+        sceneworks_id: "z_image",
+        engine_id: "z_image",
+        default_repo: "Tongyi-MAI/Z-Image",
+        default_steps: 50,
+        default_guidance: 4.0,
+        adapter_label: "mlx_z_image",
+    },
     // Ideogram 4 (epic 4725) — native MLX, gated. Structured JSON-caption text-to-image; the
     // turnkey ships packed q4/ (default) + q8/ subdirs (resolve_ideogram_model_dir picks one).
     // V4_QUALITY_48 preset default (48 steps); asymmetric-CFG guidance 7.0.
@@ -1164,6 +1179,37 @@ mod tests {
             !caps.contains(&Cap::ImageGenerate),
             "no enabled backend ⇒ no derived image_generate"
         );
+    }
+
+    // sc-8320: the base (non-distilled) `z_image` t2i row resolves to its OWN engine id (not Turbo's),
+    // points at the `Tongyi-MAI/Z-Image` base snapshot, and carries the undistilled defaults (real CFG
+    // guidance 4.0, ~50 steps) — proving it is selectable and routes to the base path distinct from
+    // `z_image_turbo` (which stays 8-step, CFG-free at `Tongyi-MAI/Z-Image-Turbo`).
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    #[test]
+    fn z_image_base_row_is_distinct_from_turbo() {
+        let base = MODEL_TABLE
+            .iter()
+            .find(|row| row.sceneworks_id == "z_image")
+            .expect("z_image base MODEL_TABLE row");
+        assert_eq!(base.engine_id, "z_image");
+        assert_eq!(base.default_repo, "Tongyi-MAI/Z-Image");
+        assert_eq!(base.default_steps, 50);
+        assert!((base.default_guidance - 4.0).abs() < f32::EPSILON);
+        assert_eq!(base.adapter_label, "mlx_z_image");
+
+        let turbo = MODEL_TABLE
+            .iter()
+            .find(|row| row.sceneworks_id == "z_image_turbo")
+            .expect("z_image_turbo MODEL_TABLE row");
+        // The base must NOT collapse onto the Turbo engine id / repo / step+CFG defaults.
+        assert_ne!(base.engine_id, turbo.engine_id);
+        assert_ne!(base.default_repo, turbo.default_repo);
+        assert_ne!(base.default_steps, turbo.default_steps);
+        assert_ne!(base.default_guidance, turbo.default_guidance);
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -414,6 +414,20 @@ pub(crate) async fn run_image_generate_job(
                 )
                 .await?;
             }
+            ImageRoute::ZImageBaseControl => {
+                // Base (full-CFG) Z-Image strict control (advanced.poses on `z_image`) → base
+                // Fun-Controlnet-Union, one image per pose (sc-8251).
+                generate_zimage_base_control_stream(
+                    api,
+                    settings,
+                    job,
+                    &plan,
+                    &project_path,
+                    backend,
+                    &mut asset_writes,
+                )
+                .await?;
+            }
             ImageRoute::QwenControl => {
                 // Qwen strict-pose (advanced.poses) → InstantX ControlNet-Union, one image per pose.
                 generate_qwen_control_stream(

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -81,6 +81,7 @@ fn mlx_available(request: &ImageRequest, settings: &Settings) -> bool {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ImageRoute {
     ZImageControl,
+    ZImageBaseControl,
     QwenControl,
     KolorsControl,
     Flux1DevControl,
@@ -99,6 +100,11 @@ enum ImageRoute {
 fn resolve_image_route(request: &ImageRequest, settings: &Settings) -> Option<ImageRoute> {
     if zimage_control_available(request, settings) {
         Some(ImageRoute::ZImageControl)
+    } else if zimage_base_control_available(request, settings) {
+        // Base (non-distilled, full-CFG) Z-Image strict control (advanced.poses on `z_image`) →
+        // base Fun-Controlnet-Union (`z_image_control`). The base mirror of the Turbo control arm
+        // above; keyed on the base model id so the Turbo path is untouched (sc-8251).
+        Some(ImageRoute::ZImageBaseControl)
     } else if qwen_control_available(request, settings) {
         Some(ImageRoute::QwenControl)
     } else if kolors_control_available(request, settings) {
@@ -142,6 +148,7 @@ impl ImageRoute {
     fn image_count(self, request: &ImageRequest, settings: &Settings) -> u32 {
         match self {
             ImageRoute::ZImageControl
+            | ImageRoute::ZImageBaseControl
             | ImageRoute::QwenControl
             | ImageRoute::KolorsControl
             | ImageRoute::Flux1DevControl

--- a/crates/sceneworks-worker/src/image_jobs/strict_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/strict_control.rs
@@ -40,6 +40,7 @@ struct StrictControlEngine {
 /// - `flux1_dev_control` — `{Pose, Canny, Depth}` (Shakker Union-Pro-2.0; E2 sc-8239 / wiring sc-8244)
 /// - `flux2_dev_control` — `{Pose, Canny, Depth}`
 /// - `z_image_turbo_control` — `{Pose, Canny, Depth}`
+/// - `z_image_control` — `{Pose, Canny, Depth}` (base, full-CFG; alibaba-pai Z-Image-Fun-Union; sc-8251)
 /// - `qwen_image_control` — `{Pose, Canny, Depth}` (alibaba-pai 2512-Fun-Union; sc-8267 source swap / sc-8250 exposure)
 ///
 /// The SDXL tile detail-upscale path (`ControlKind::Other("tile")`, `image_jobs/detail.rs`) is OUTSIDE
@@ -58,6 +59,14 @@ const STRICT_CONTROL_ENGINES: &[StrictControlEngine] = &[
     StrictControlEngine {
         engine_id: "z_image_turbo_control",
         repo: "alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1",
+        supported_kinds: &[ControlKind::Pose, ControlKind::Canny, ControlKind::Depth],
+    },
+    StrictControlEngine {
+        // Base (non-distilled, full-CFG) Z-Image Fun-Controlnet-Union (sc-8251). Same VACE
+        // Fun-Union control branch as the Turbo variant, but assembled from a base
+        // `Tongyi-MAI/Z-Image` snapshot + the base control checkpoint.
+        engine_id: "z_image_control",
+        repo: "alibaba-pai/Z-Image-Fun-Controlnet-Union-2.1",
         supported_kinds: &[ControlKind::Pose, ControlKind::Canny, ControlKind::Depth],
     },
     StrictControlEngine {

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -2026,6 +2026,104 @@ fn qwen_threaded_source_drives_auto_canny_control_conditioning() {
     );
 }
 
+/// sc-8251 base Z-Image source-threading: the base `z_image_control` stream feeds the user input image
+/// into the SAME shared `preprocess_control_entry` driver (it passes `control_source`, not `None`). With
+/// `controlMode = canny` + a threaded source the driver derives a real edge-map control image — NOT the
+/// pose skeleton — and builds a `Control { kind: Canny }`. The base analogue of
+/// `threaded_source_drives_auto_canny_control_conditioning` (turbo). Also asserts the base engine row
+/// admits canny + depth. Real per-mode renders are the on-device `zimage_base_control_real_weights` smoke.
+#[cfg(target_os = "macos")]
+#[test]
+fn zimage_base_threaded_source_drives_auto_canny_control_conditioning() {
+    // The base Z-Image control engine row accepts canny + depth (sc-8251).
+    assert!(validate_control_kind("z_image_control", &ControlKind::Canny).is_ok());
+    assert!(validate_control_kind("z_image_control", &ControlKind::Depth).is_ok());
+
+    let (w, h) = (64u32, 48u32);
+    let pose = one_pose();
+    let stick = crate::openpose_skeleton::body_stickwidth(w, h);
+    let source = control_fixture(w, h, [128, 128, 128]);
+
+    // canny + a threaded source (no user passthrough, no depth weights) → an edge-map control image.
+    let control = preprocess_control_entry(
+        &ControlKind::Canny,
+        None,
+        Some(&pose),
+        Some(&source),
+        w,
+        h,
+        stick,
+        None,
+    )
+    .expect("auto-canny over the threaded base z-image source");
+    assert_eq!((control.width, control.height), (w, h));
+
+    // It must NOT be the pose skeleton (proving the source — not the synthetic skeleton — drove it).
+    let skeleton = crate::openpose_skeleton::draw_wholebody(
+        w,
+        h,
+        &pose.keypoints,
+        pose.hands.as_deref(),
+        pose.face.as_deref(),
+        stick,
+    );
+    assert_ne!(
+        control.pixels,
+        skeleton.into_raw(),
+        "base z-image auto-canny must derive from the source image, not render the pose skeleton"
+    );
+
+    let cond = build_control_conditioning(control, ControlKind::Canny, 0.9, None);
+    assert_eq!(cond.len(), 1);
+    assert!(
+        matches!(
+            &cond[0],
+            Conditioning::Control {
+                kind: ControlKind::Canny,
+                ..
+            }
+        ),
+        "base z-image canny builds a Control conditioning"
+    );
+
+    // Pose byte-identity: the base stream renders the SAME shared `draw_wholebody` skeleton as every
+    // other strict-control engine (no `Reference` unless identity-init), so the pose tier is
+    // byte-identical to the Turbo path — the base only diverges in the engine id + CFG forward.
+    let pose_control = preprocess_control_entry(
+        &ControlKind::Pose,
+        None,
+        Some(&pose),
+        None,
+        w,
+        h,
+        stick,
+        None,
+    )
+    .expect("base z-image pose render");
+    let expected = crate::openpose_skeleton::draw_wholebody(
+        w,
+        h,
+        &pose.keypoints,
+        pose.hands.as_deref(),
+        pose.face.as_deref(),
+        stick,
+    );
+    assert_eq!(
+        pose_control.pixels,
+        expected.into_raw(),
+        "base z-image pose preprocessing is byte-identical to a direct draw_wholebody"
+    );
+    let pose_cond = build_control_conditioning(pose_control, ControlKind::Pose, 0.9, None);
+    assert_eq!(pose_cond.len(), 1);
+    assert!(matches!(
+        &pose_cond[0],
+        Conditioning::Control {
+            kind: ControlKind::Pose,
+            ..
+        }
+    ));
+}
+
 /// sc-3031 A/B dump (NOT a CI test): generate ONE image through the **real new-adapter
 /// path** — the production resolvers (`model_repo` / `resolve_steps` / `resolve_guidance` /
 /// `resolve_negative_prompt` / `resolve_quant` / `resolve_adapters` / `resolve_weights_dir` /
@@ -2339,6 +2437,72 @@ fn zimage_control_real_weights_generates_one_pose() {
     assert_eq!(pixels.len(), 512 * 512 * 3);
     assert!(steps_seen >= 1, "expected denoise step progress");
     assert!(pixels.windows(2).any(|w| w[0] != w[1]));
+}
+
+/// Real-weights smoke: BASE Z-Image strict-control (sc-8251). Loads the base `Tongyi-MAI/Z-Image`
+/// snapshot + the cached base Fun-Controlnet-Union checkpoint and generates one image per mode
+/// (pose skeleton / auto-canny / auto-depth) through `z_image_control` with REAL CFG. Needs both
+/// weights in the HF cache + a Metal device; run on demand:
+/// `cargo test -p sceneworks-worker --lib -- --ignored zimage_base_control_real_weights`.
+#[cfg(target_os = "macos")]
+#[test]
+#[ignore = "needs real base Z-Image + base Fun-Controlnet-Union weights + Metal device"]
+fn zimage_base_control_real_weights_generates_per_mode() {
+    let base = hf_snapshot("models--Tongyi-MAI--Z-Image");
+    let control = std::fs::read_dir(dirs_home().join(
+        ".cache/huggingface/hub/models--alibaba-pai--Z-Image-Fun-Controlnet-Union-2.1/snapshots",
+    ))
+    .expect("base control snapshots dir")
+    .flatten()
+    .map(|entry| entry.path())
+    .find(|path| path.is_dir())
+    .map(|dir| dir.join(super::ZIMAGE_BASE_CONTROL_FILE))
+    .filter(|path| path.exists())
+    .expect("base control weights file");
+
+    let generator =
+        zimage_base_control_load(base, control, Some(gen_core::Quant::Q8), Vec::new()).unwrap();
+
+    let (w, h) = (512u32, 512u32);
+    let stick = crate::openpose_skeleton::body_stickwidth(w, h);
+    // A flat source for the auto-canny / auto-depth modes.
+    let source = control_fixture(w, h, [120, 140, 160]);
+    let pose = one_pose();
+
+    // Drive each supported mode through the shared preprocessor → conditioning → generate-one.
+    for kind in [ControlKind::Pose, ControlKind::Canny] {
+        let control_map =
+            preprocess_control_entry(&kind, None, Some(&pose), Some(&source), w, h, stick, None)
+                .expect("preprocess base control entry");
+        let conditioning = build_control_conditioning(control_map, kind.clone(), 0.9, None);
+        let cancel = gen_core::CancelFlag::new();
+        let mut steps_seen = 0u32;
+        let (ow, oh, pixels) = zimage_base_control_generate_one(
+            generator.as_ref(),
+            "a person standing in a meadow",
+            None,
+            w,
+            h,
+            42,
+            50,
+            4.0,
+            conditioning,
+            &cancel,
+            &mut |p| {
+                if let gen_core::Progress::Step { current, .. } = p {
+                    steps_seen = steps_seen.max(current);
+                }
+            },
+        )
+        .unwrap();
+        assert_eq!((ow, oh), (w, h));
+        assert_eq!(pixels.len() as u32, w * h * 3);
+        assert!(
+            steps_seen >= 1,
+            "expected denoise step progress for {kind:?}"
+        );
+        assert!(pixels.windows(2).any(|px| px[0] != px[1]));
+    }
 }
 
 /// Real-weights smoke: Qwen-Image strict-pose control. Loads the base
@@ -3166,6 +3330,16 @@ fn image_route_count_follows_dispatch_order() {
     assert_eq!(route, ImageRoute::ZImageControl);
     assert_eq!(route.image_count(&zimage_pose, &settings), 2);
 
+    // Base (full-CFG) Z-Image strict control (sc-8251): `z_image` + ≥1 pose → the base
+    // Fun-Controlnet-Union path, one image per pose. Keyed on the base id, distinct from the Turbo arm.
+    let zimage_base_pose = request(json!({
+        "projectId": "p", "model": "z_image", "count": 7,
+        "advanced": { "modelPath": model_path.clone(), "poses": [{ "id": "a" }, { "id": "b" }, { "id": "c" }] }
+    }));
+    let route = resolve_image_route(&zimage_base_pose, &settings).unwrap();
+    assert_eq!(route, ImageRoute::ZImageBaseControl);
+    assert_eq!(route.image_count(&zimage_base_pose, &settings), 3);
+
     let qwen_pose = request(json!({
         "projectId": "p", "model": "qwen_image", "mode": "character_image", "count": 5,
         "advanced": { "modelPath": model_path.clone(), "poses": [{ "id": "a" }, { "id": "b" }, { "id": "c" }] }
@@ -3252,6 +3426,16 @@ fn image_route_count_follows_dispatch_order() {
     let route = resolve_image_route(&plain_mlx, &settings).unwrap();
     assert_eq!(route, ImageRoute::Mlx);
     assert_eq!(route.image_count(&plain_mlx, &settings), 6);
+
+    // sc-8320: plain base `z_image` t2i (no poses) → the generic MLX path (base engine), NOT a control
+    // arm — proving the base is selectable + routes to the base t2i path, distinct from Turbo control.
+    let zimage_base_t2i = request(json!({
+        "projectId": "p", "model": "z_image", "count": 4,
+        "advanced": { "modelPath": model_path.clone() }
+    }));
+    let route = resolve_image_route(&zimage_base_t2i, &settings).unwrap();
+    assert_eq!(route, ImageRoute::Mlx);
+    assert_eq!(route.image_count(&zimage_base_t2i, &settings), 4);
 }
 
 #[cfg(target_os = "macos")]
@@ -5049,6 +5233,20 @@ fn strict_control_table_is_the_authority() {
         &[ControlKind::Pose, ControlKind::Canny, ControlKind::Depth]
     );
 
+    // sc-8251: the base (non-distilled, full-CFG) Z-Image control engine — its OWN row, the base
+    // control repo (no `-Turbo-`), pose + canny + depth.
+    let zimage_base = strict_control_engine("z_image_control").expect("z-image base row");
+    assert_eq!(
+        zimage_base.repo,
+        "alibaba-pai/Z-Image-Fun-Controlnet-Union-2.1"
+    );
+    assert_eq!(
+        zimage_base.supported_kinds,
+        &[ControlKind::Pose, ControlKind::Canny, ControlKind::Depth]
+    );
+    // The base must NOT collapse onto the Turbo control repo.
+    assert_ne!(zimage_base.repo, zimage.repo);
+
     let qwen = strict_control_engine("qwen_image_control").expect("qwen row");
     // sc-8267 source swap: InstantX → alibaba-pai 2512-Fun-Controlnet-Union (input-agnostic VACE branch).
     assert_eq!(
@@ -5077,6 +5275,7 @@ fn validate_control_kind_accepts_and_rejects_per_table() {
         "flux1_dev_control",
         "flux2_dev_control",
         "z_image_turbo_control",
+        "z_image_control",
         "qwen_image_control",
     ] {
         assert!(validate_control_kind(engine, &ControlKind::Pose).is_ok());

--- a/crates/sceneworks-worker/src/image_jobs/zimage.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage.rs
@@ -4,6 +4,14 @@ const ZIMAGE_CONTROL_ENGINE_ID: &str = "z_image_turbo_control";
 const ZIMAGE_CONTROL_REPO: &str = "alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1";
 const ZIMAGE_CONTROL_FILE: &str = "Z-Image-Turbo-Fun-Controlnet-Union-2.1-8steps.safetensors";
 
+/// The engine registry id for the **base** (non-distilled, full-CFG) Z-Image Fun-Controlnet-Union
+/// variant (sc-8251). Same VACE Fun-Union control branch as the Turbo variant, but assembled from a
+/// base `Tongyi-MAI/Z-Image` snapshot + the base control checkpoint, and driven with REAL CFG.
+const ZIMAGE_BASE_CONTROL_ENGINE_ID: &str = "z_image_control";
+/// Default base Fun-Controlnet-Union control-weights repo + file (sc-8251).
+const ZIMAGE_BASE_CONTROL_REPO: &str = "alibaba-pai/Z-Image-Fun-Controlnet-Union-2.1";
+const ZIMAGE_BASE_CONTROL_FILE: &str = "Z-Image-Fun-Controlnet-Union-2.1.safetensors";
+
 // `pose_entries` / `parse_poses` / `PoseInput` moved to `base.rs` (shared by the candle InstantID
 // lane, sc-5491); still in scope here via the shared `image_jobs` module.
 
@@ -13,6 +21,16 @@ const ZIMAGE_CONTROL_FILE: &str = "Z-Image-Turbo-Fun-Controlnet-Union-2.1-8steps
 /// loudly instead of silently dropping the poses to the txt2img path.
 fn zimage_control_available(request: &ImageRequest, settings: &Settings) -> bool {
     request.model == "z_image_turbo"
+        && !pose_entries(request).is_empty()
+        && matches!(resolve_weights_dir(request, settings), Ok(Some(_)))
+}
+
+/// True when this is a **base** Z-Image strict-control job (`z_image` + ≥1 pose) whose base weights
+/// resolve — routed to the base Fun-Controlnet-Union path (`z_image_control`) rather than plain
+/// txt2img (sc-8251). The base mirror of [`zimage_control_available`]; keyed on the base model id so
+/// the Turbo control path is untouched.
+fn zimage_base_control_available(request: &ImageRequest, settings: &Settings) -> bool {
+    request.model == "z_image"
         && !pose_entries(request).is_empty()
         && matches!(resolve_weights_dir(request, settings), Ok(Some(_)))
 }
@@ -55,6 +73,18 @@ fn resolve_control_weights(request: &ImageRequest, settings: &Settings) -> Optio
         settings,
         strict_control_default_repo(ZIMAGE_CONTROL_ENGINE_ID),
         ZIMAGE_CONTROL_FILE,
+    )
+}
+
+/// Resolve the **base** Z-Image Fun-Controlnet-Union checkpoint (sc-8251). The default repo comes from
+/// the shared strict-control table (single source of truth — `STRICT_CONTROL_ENGINES`); the file
+/// default stays engine-specific.
+fn resolve_base_control_weights(request: &ImageRequest, settings: &Settings) -> Option<PathBuf> {
+    resolve_control_weights_for(
+        request,
+        settings,
+        strict_control_default_repo(ZIMAGE_BASE_CONTROL_ENGINE_ID),
+        ZIMAGE_BASE_CONTROL_FILE,
     )
 }
 
@@ -103,6 +133,19 @@ fn zimage_control_load(
     let spec = zimage_control_spec(weights_dir, control_weights, quant, adapters);
     gen_core::load(ZIMAGE_CONTROL_ENGINE_ID, &spec)
         .map_err(|error| WorkerError::Engine(format!("Z-Image control load failed: {error}")))
+}
+
+#[cfg(all(target_os = "macos", test))]
+fn zimage_base_control_load(
+    weights_dir: PathBuf,
+    control_weights: PathBuf,
+    quant: Option<Quant>,
+    adapters: Vec<AdapterSpec>,
+) -> WorkerResult<Box<dyn Generator>> {
+    // Shares the Turbo control's `LoadSpec` shape (base dir + control overlay); only the engine id differs.
+    let spec = zimage_control_spec(weights_dir, control_weights, quant, adapters);
+    gen_core::load(ZIMAGE_BASE_CONTROL_ENGINE_ID, &spec)
+        .map_err(|error| WorkerError::Engine(format!("Z-Image base control load failed: {error}")))
 }
 
 /// Generate one strict-pose image: the pre-built `conditioning` (the required `Control` plus an optional
@@ -274,6 +317,219 @@ async fn generate_zimage_control_stream(
                     height,
                     seed,
                     steps,
+                    conditioning,
+                    &cancel,
+                    on_progress,
+                )?;
+                Ok(Some((seed, out_w, out_h, pixels)))
+            })
+        },
+    );
+
+    consume_gen_events(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        ZIMAGE_ADAPTER_LABEL,
+        &raw_settings,
+        count,
+        rx,
+        cancel,
+        blocking,
+        asset_writes,
+    )
+    .await
+}
+
+/// Generate one **base** Z-Image strict-control image (sc-8251): like [`zimage_control_generate_one`]
+/// but the base is the non-distilled full-CFG foundation model, so it forwards a real CFG `guidance`
+/// scale + an optional negative prompt (the base `z_image_control` descriptor `supports_guidance` +
+/// `supports_negative_prompt`).
+#[allow(clippy::too_many_arguments)]
+fn zimage_base_control_generate_one(
+    generator: &dyn Generator,
+    prompt: &str,
+    negative_prompt: Option<String>,
+    width: u32,
+    height: u32,
+    seed: i64,
+    steps: u32,
+    guidance: f32,
+    conditioning: Vec<Conditioning>,
+    cancel: &CancelFlag,
+    on_progress: &mut dyn FnMut(Progress),
+) -> WorkerResult<(u32, u32, Vec<u8>)> {
+    let request = GenerationRequest {
+        prompt: prompt.to_owned(),
+        negative_prompt,
+        width,
+        height,
+        count: 1,
+        seed: Some(seed as u64),
+        steps: Some(steps),
+        guidance: Some(guidance),
+        conditioning,
+        cancel: cancel.clone(),
+        ..Default::default()
+    };
+    let output = generator.generate(&request, on_progress).map_err(|error| {
+        WorkerError::Engine(format!("base Z-Image control generation failed: {error}"))
+    })?;
+    match output {
+        GenerationOutput::Images(mut images) => {
+            let image = images.pop().ok_or_else(|| {
+                WorkerError::Engine("base Z-Image control generator produced no image".to_owned())
+            })?;
+            Ok((image.width, image.height, image.pixels))
+        }
+        _ => Err(WorkerError::Engine(
+            "base Z-Image control generator returned non-image output".to_owned(),
+        )),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn zimage_base_control_raw_settings(
+    request: &ImageRequest,
+    repo: &str,
+    steps: u32,
+    quant_bits: Option<i64>,
+    guidance: f32,
+    control_scale: f32,
+    pose_count: usize,
+) -> JsonObject {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("repo".to_owned(), Value::String(repo.to_owned()));
+    raw.insert("numInferenceSteps".to_owned(), json!(steps));
+    // The base is the full-CFG foundation model — record the real guidance scale.
+    raw.insert("guidanceScale".to_owned(), json!(guidance));
+    raw.insert(
+        "mlxQuantize".to_owned(),
+        quant_bits.map(|bits| json!(bits)).unwrap_or(Value::Null),
+    );
+    raw.insert("controlScale".to_owned(), json!(control_scale));
+    raw.insert("poseCount".to_owned(), json!(pose_count));
+    raw.insert(
+        "controlEngine".to_owned(),
+        Value::String(ZIMAGE_BASE_CONTROL_ENGINE_ID.to_owned()),
+    );
+    raw
+}
+
+/// Real **base** Z-Image strict-control generation (sc-8251): one image per pose, each conditioned on
+/// a DWPose skeleton (or — when `advanced.controlMode` is canny/depth — an auto-derived control map
+/// over the threaded input image) + locked by the base Fun-Controlnet-Union branch. The base mirror of
+/// [`generate_zimage_control_stream`], differing only in the engine id (`z_image_control`), the base
+/// control checkpoint, and REAL CFG (`guidance` + negative prompt) — the base is undistilled. Pose
+/// rendering + source threading reuse the SAME shared strict-control driver, so the pose tier is
+/// byte-identical to the Turbo path.
+async fn generate_zimage_base_control_stream(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+    // Identity img2img-init (opt-in escape hatch, off by default) — same gate as the Turbo path
+    // (`advanced.referenceStrength > 0` AND a `referenceAssetId`). Shared across the whole pose set.
+    let identity_init = resolve_zimage_identity_init(request, settings, project_path)?;
+
+    let zimage = mlx_model("z_image")
+        .ok_or_else(|| WorkerError::InvalidPayload("z-image base model row missing".to_owned()))?;
+    let weights_dir = resolve_weights_dir(request, settings)?
+        .ok_or_else(|| WorkerError::InvalidPayload("Z-Image base weights not found".to_owned()))?;
+    let control_weights = resolve_base_control_weights(request, settings).ok_or_else(|| {
+        WorkerError::InvalidPayload(format!(
+            "Z-Image base strict-control weights not found (download {ZIMAGE_BASE_CONTROL_REPO})."
+        ))
+    })?;
+    let (quant, quant_bits) = resolve_quant(request);
+    let steps = resolve_steps(request, &zimage);
+    let guidance = resolve_guidance(request, &zimage).unwrap_or(zimage.default_guidance());
+    let negative_prompt = resolve_negative_prompt(request, &zimage);
+    let control_scale = resolve_control_scale(request);
+    let adapters = resolve_adapters(request, settings)?;
+    let repo = model_repo(request, &zimage);
+    // Shared strict-control driver: validate the requested ControlKind against the engine's
+    // supported_kinds (z_image_control = {Pose, Canny, Depth}) + resolve an optional user-supplied
+    // control-map passthrough. A pose job sets no `controlMode`, so `kind == Pose` (byte-identical render).
+    let control_kind = requested_control_kind(request)?;
+    validate_control_kind(ZIMAGE_BASE_CONTROL_ENGINE_ID, &control_kind)?;
+    let user_control = resolve_user_control_map(request, settings, project_path)?;
+    // sc-8251 source threading: for canny/depth WITHOUT a user-supplied control map, the control map is
+    // auto-derived from the input image (canny edges / Depth-Anything-V2). The pose tier never needs a
+    // source (the skeleton is synthetic).
+    let control_source = resolve_control_source(request, settings, project_path)?;
+    let depth_weights_dir = if control_kind == ControlKind::Depth && user_control.is_none() {
+        Some(ensure_depth_estimator_dir(api, settings, job).await?)
+    } else {
+        None
+    };
+    let poses = parse_poses(request);
+    let count = poses.len();
+    let raw_settings = zimage_base_control_raw_settings(
+        request,
+        &repo,
+        steps,
+        quant_bits,
+        guidance,
+        control_scale,
+        count,
+    );
+    // Strict control shares one seed across the set so noise-derived attributes stay constant
+    // while only the per-pose skeleton changes (Python parity).
+    let seed = resolve_seed(request, 0);
+
+    let prompt = request.prompt.clone();
+    let (width, height) = (request.width, request.height);
+    let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
+    let adapter_count = adapters.len();
+    let spec = zimage_control_spec(weights_dir, control_weights, quant, adapters);
+    let (cancel, rx, blocking) = start_cached_gen_stream(
+        job.id.clone(),
+        ZIMAGE_BASE_CONTROL_ENGINE_ID,
+        adapter_count,
+        spec,
+        "Z-Image base control load failed".to_owned(),
+        move |generator, tx, cancel| {
+            let identity_init = identity_init.as_ref();
+            let user_control = user_control.as_ref();
+            let control_source = control_source.as_ref();
+            let depth_weights_dir = depth_weights_dir.as_deref();
+            let negative_prompt = negative_prompt.clone();
+            drive_gen_items(tx, poses, move |_index, pose, on_progress| {
+                let control = preprocess_control_entry(
+                    &control_kind,
+                    user_control,
+                    Some(&pose),
+                    control_source,
+                    width,
+                    height,
+                    stickwidth,
+                    depth_weights_dir,
+                )?;
+                let conditioning = build_control_conditioning(
+                    control,
+                    control_kind.clone(),
+                    control_scale,
+                    identity_init,
+                );
+                let (out_w, out_h, pixels) = zimage_base_control_generate_one(
+                    generator,
+                    &prompt,
+                    negative_prompt.clone(),
+                    width,
+                    height,
+                    seed,
+                    steps,
+                    guidance,
                     conditioning,
                     &cancel,
                     on_progress,

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -660,6 +660,9 @@ fn model_table_rows_resolve_and_flags_match_descriptor() {
     // values that used to live on each MlxModel row.
     let expected: &[(&str, bool, bool)] = &[
         ("z_image_turbo", false, false),
+        // Base (non-distilled) Z-Image (sc-8320): the undistilled foundation model is full real CFG —
+        // supports_guidance=true + supports_negative_prompt=true (vs Turbo's CFG-free distill).
+        ("z_image", true, true),
         // Ideogram 4 (epic 4725): asymmetric-CFG guidance (supports_guidance=true) with no user
         // negative prompt (the "negative" is a fixed unconditional DiT, not a prompt).
         ("ideogram_4", true, false),


### PR DESCRIPTION
Surfaces the base (non-distilled, full-CFG) **Z-Image** in SceneWorks, both as a
t2i target and as a ControlNet engine. The mlx-gen `z_image` base descriptor +
`z_image_control` base control engine are already merged and pinned on main
(39ef575). Two stories, one commit each, additive + regression-safe.

## Commit 1 — sc-8320: base Z-Image t2i catalog wiring
- `engines.rs`: `z_image` MODEL_TABLE row → its own engine id `z_image`, repo
  `Tongyi-MAI/Z-Image`, 50 steps, real-CFG guidance 4.0 (`supports_guidance` +
  negative prompt). A plain t2i request (no poses) resolves to `ImageRoute::Mlx`
  → `generate_stream` → the base engine; CFG forwards via the descriptor.
- `builtin.models.jsonc` + `constants.js`: `z_image` catalog entry (~20.5GB base
  snapshot, minMemoryGb 48, full flow sampler/scheduler menu) + `controlModes`
  {pose,canny,depth} + `controlScale`.
- **No derived-tokenizer overlay needed** — the base `Tongyi-MAI/Z-Image`
  snapshot ships its own fast `tokenizer/tokenizer.json` (verified against the HF
  tree).
- Test: `z_image_base_row_is_distinct_from_turbo` (own engine id/repo/step+CFG,
  never collapsing onto Turbo).

## Commit 2 — sc-8251: base Z-Image ControlNet worker wiring
- `strict_control.rs`: `z_image_control` STRICT_CONTROL_ENGINES row (repo
  `alibaba-pai/Z-Image-Fun-Controlnet-Union-2.1`, kinds {Pose,Canny,Depth}) —
  the single source of truth for supported_kinds + default control repo.
- `zimage.rs`: `generate_zimage_base_control_stream` — mirrors the Turbo control
  stream but loads the `z_image_control` engine + base control checkpoint and
  drives **REAL CFG** (guidance + negative prompt). Pose render + source threading
  reuse the SAME shared `preprocess_control_entry` driver → pose tier byte-identical
  to Turbo. Keyed on the base `z_image` id, so the Turbo control path is untouched.
- **LIVE canny/depth + pose**: threads the user input image as the preprocess
  `source` (`resolve_control_source`) + provisions Depth-Anything-V2
  (`ensure_depth_estimator_dir`) for auto-depth, mirroring PR #954.
- `base.rs`: new `ImageRoute::ZImageBaseControl` (resolution + per-pose count),
  ordered right after the Turbo arm; `image_jobs.rs` dispatch to the base stream.
- Tests: authority-table + validate-kind include the `z_image_control` row + kinds;
  `image_route_count_follows_dispatch_order` asserts `z_image`+poses →
  ZImageBaseControl and plain `z_image` t2i → Mlx; a threaded-source test asserts
  auto-canny derives a non-skeleton map + `Control{kind:Canny}` and pose byte-identity;
  `zimage_base_control_real_weights_generates_per_mode` (`#[ignore]`, on-device gate).

## Verification
`cargo build/test -p sceneworks-worker` (431 pass), `cargo fmt --all --check`,
`cargo clippy -p sceneworks-worker --all-targets -D warnings`, web vitest (818 pass)
— all green. origin/main merged (not rebased) before opening.

## Regression
Turbo (`z_image_turbo` / `z_image_turbo_control`), flux, and qwen rows + their
pose behavior untouched (additive only; S2 goldens unaffected).

## Out of scope / follow-up
- candle base Z-Image control lane (`candle_zimage_control` is keyed on
  `z_image_turbo` only). The candle siblings are bespoke non-registry providers
  and out of scope per epic 8236; a base candle path is a tracked follow-up.

Stories: sc-8320, sc-8251 (epic 8236).

🤖 Generated with [Claude Code](https://claude.com/claude-code)