### PR TITLE
feat(worker): shared generator-agnostic face-likeness scorer (sc-4407)

### DIFF
--- a/apps/worker/scene_worker/face_likeness_adapters.py
+++ b/apps/worker/scene_worker/face_likeness_adapters.py
@@ -1,0 +1,220 @@
+"""Shared, generator-agnostic face-likeness scorer (epic 4406, sc-4407).
+
+The Windows/Linux InsightFace counterpart of the macOS/CUDA native scorer
+(``crates/sceneworks-worker/src/face_likeness.rs``). Given a **source face image** (embedded
+ONCE per job) and any number of **generated images**, it returns an identity-likeness result
+by cosine-comparing antelopev2 ArcFace embeddings of the largest detected face in each.
+
+Model-independent on purpose: NOT coupled to the InstantID adapter. InstantID, Z-Image
+identity, and Flux IP-adapter generations all produce a finished image, and this scorer runs
+as a post-pass over that image — so it serves every identity generator through one path. It
+reuses the antelopev2 FaceAnalysis app InstantID already provisions
+(``instantid_adapter._ensure_antelopev2``), so no new weights.
+
+Result honesty (drives the design): ArcFace is a frontal-identity signal only. A profile /
+extreme-angle / no-face generation legitimately has no detectable frontal face — that is an
+explicit ``detected: false`` / ``score: None`` result carrying a ``reason``, NOT a misleading
+low number. Kept byte-identical in shape to the Rust scorer so both platforms produce the same
+``{ score, detected, method, sourceRef, reason? }`` result.
+
+Source-embed caching (an explicit acceptance criterion): ``FaceLikenessScorer`` embeds the
+source face exactly once at construction and stores the L2-normalized vector. Every ``score``
+call re-embeds only the *generated* image — never the source again.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+from typing import Any, Optional
+
+# The recognition method surfaced on every result. Stable string the asset sidecar (sc-4408)
+# and the UI bands (sc-4414) key off — the same antelopev2 ArcFace stack on both platforms.
+LIKENESS_METHOD = "arcface_antelopev2"
+
+# SCRFD detection-confidence floor below which a detection is treated as "no reliable frontal
+# face". Mirrors the Rust ``MIN_DET_SCORE`` (and the kps-extract ``LOW_CONF_THRESH``): below it
+# the face is an unreliable extreme profile / poor framing, so the scorer returns an explicit
+# N/A rather than a noisy number.
+MIN_DET_SCORE = 0.65
+
+# N/A reason strings — must match the Rust ``NoScoreReason::as_str`` values exactly.
+REASON_NO_FACE = "no_face"
+REASON_LOW_CONFIDENCE = "low_confidence"
+REASON_NO_SOURCE_FACE = "no_source_face"
+REASON_EMBEDDING_ERROR = "embedding_error"
+
+# SCRFD detector input (square), matches the macOS native path + InstantID.
+DET_SIZE = (640, 640)
+
+
+def face_likeness_backend_available() -> bool:
+    """True when InsightFace + onnxruntime + OpenCV are importable (the SCRFD/ArcFace path)."""
+    return all(
+        importlib.util.find_spec(mod) is not None
+        for mod in ("insightface", "onnxruntime", "cv2")
+    )
+
+
+def _l2_normalized(vec: Any) -> Optional[Any]:
+    """L2-normalize a raw ArcFace embedding. ``None`` for an empty / zero-norm vector."""
+    import numpy as np
+
+    arr = np.asarray(vec, dtype=np.float64).ravel()
+    if arr.size == 0:
+        return None
+    norm = float(np.linalg.norm(arr))
+    if norm == 0.0 or not math.isfinite(norm):
+        return None
+    return arr / norm
+
+
+def _cosine(a: Any, b: Any) -> Optional[float]:
+    """Cosine of two already-L2-normalized vectors (a plain dot). ``None`` on a length mismatch."""
+    import numpy as np
+
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    if a.size == 0 or a.size != b.size:
+        return None
+    return float(np.dot(a, b))
+
+
+def _largest_face(app: Any, pil_image: Any) -> Optional[Any]:
+    """Detect the largest face in a PIL RGB image via the antelopev2 app. ``None`` if no face."""
+    import cv2
+    import numpy as np
+
+    bgr = cv2.cvtColor(np.array(pil_image.convert("RGB")), cv2.COLOR_RGB2BGR)
+    faces = app.get(bgr)
+    if not faces:
+        return None
+    return sorted(
+        faces, key=lambda f: (f.bbox[2] - f.bbox[0]) * (f.bbox[3] - f.bbox[1])
+    )[-1]
+
+
+def _face_app(settings: Any) -> Any:
+    """Load the antelopev2 FaceAnalysis app (CPU EP), reusing InstantID's provisioning."""
+    from insightface.app import FaceAnalysis
+
+    from .instantid_adapter import _ensure_antelopev2
+
+    root = _ensure_antelopev2()
+    app = FaceAnalysis(
+        name="antelopev2", root=str(root), providers=["CPUExecutionProvider"]
+    )
+    app.prepare(ctx_id=0, det_size=DET_SIZE)
+    return app
+
+
+def score_result(
+    source_normalized: Optional[Any],
+    generated_face: Optional[Any],
+    source_ref: Optional[str],
+) -> dict[str, Any]:
+    """The pure scoring decision (no IO) — the N/A policy, shared by every caller + unit-tested.
+
+    ``source_normalized`` is the cached L2-normalized source embedding (``None`` ⇒ no source
+    face). ``generated_face`` is the largest detected face of the generated image (an object
+    with ``.det_score`` + ``.normed_embedding`` / ``.embedding``), or ``None`` when SCRFD found
+    no face. Returns the acceptance result shape.
+    """
+    if source_normalized is None:
+        return _na(REASON_NO_SOURCE_FACE, source_ref)
+    if generated_face is None:
+        return _na(REASON_NO_FACE, source_ref)
+
+    det_score = float(getattr(generated_face, "det_score", 0.0))
+    if det_score < MIN_DET_SCORE:
+        return _na(REASON_LOW_CONFIDENCE, source_ref)
+
+    # Prefer insightface's own normed_embedding; fall back to normalizing the raw embedding.
+    normed = getattr(generated_face, "normed_embedding", None)
+    if normed is not None:
+        gen_normalized = _l2_normalized(normed)
+    else:
+        gen_normalized = _l2_normalized(getattr(generated_face, "embedding", []))
+    if gen_normalized is None:
+        return _na(REASON_EMBEDDING_ERROR, source_ref)
+
+    score = _cosine(source_normalized, gen_normalized)
+    if score is None:
+        return _na(REASON_EMBEDDING_ERROR, source_ref)
+    return {
+        "score": score,
+        "detected": True,
+        "method": LIKENESS_METHOD,
+        "sourceRef": source_ref,
+    }
+
+
+def _na(reason: str, source_ref: Optional[str]) -> dict[str, Any]:
+    """An N/A result — ``detected: False``, ``score: None``, carrying the reason."""
+    return {
+        "score": None,
+        "detected": False,
+        "method": LIKENESS_METHOD,
+        "sourceRef": source_ref,
+        "reason": reason,
+    }
+
+
+class FaceLikenessScorer:
+    """Generator-agnostic identity-likeness scorer (sc-4407). Construct once per job from the
+    source face image — the source embedding is computed ONCE here and cached — then call
+    :meth:`score` for each generated image. The source is never re-embedded.
+    """
+
+    def __init__(self, app: Any, source_image: Any, source_ref: Optional[str] = None) -> None:
+        self._app = app
+        self._source_ref = source_ref
+        self._source_embed_count = 0
+        face = _largest_face(app, source_image)
+        self._source_embed_count = 1
+        if face is None:
+            self._source_normalized = None
+        else:
+            normed = getattr(face, "normed_embedding", None)
+            self._source_normalized = (
+                _l2_normalized(normed)
+                if normed is not None
+                else _l2_normalized(getattr(face, "embedding", []))
+            )
+
+    @classmethod
+    def load(
+        cls, settings: Any, source_image: Any, source_ref: Optional[str] = None
+    ) -> "FaceLikenessScorer":
+        """Load the antelopev2 app + embed the source face once."""
+        return cls(_face_app(settings), source_image, source_ref)
+
+    @property
+    def has_source_face(self) -> bool:
+        """``False`` ⇒ the whole job is N/A (no detectable source face) — never an error."""
+        return self._source_normalized is not None
+
+    @property
+    def source_embed_count(self) -> int:
+        """How many times the source was embedded (always <= 1). For the caching test."""
+        return self._source_embed_count
+
+    def score(self, generated_image: Any) -> dict[str, Any]:
+        """Score one generated image against the CACHED source embedding. Re-embeds only the
+        generated image — never the source. Returns the acceptance result shape (an N/A dict for
+        the no-face / low-confidence / no-source-face cases, never raising for those)."""
+        face = _largest_face(self._app, generated_image)
+        return score_result(self._source_normalized, face, self._source_ref)
+
+    def score_or_null(self, generated_image: Any) -> dict[str, Any]:
+        """Score one generated image, turning any backend error into a logged ``null`` result —
+        the "scoring errors are non-fatal; never block a generation" acceptance criterion."""
+        try:
+            return self.score(generated_image)
+        except Exception as error:  # noqa: BLE001 — non-fatal by contract
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "face-likeness scoring failed; recording null: %s", error
+            )
+            return _na(REASON_EMBEDDING_ERROR, self._source_ref)

--- a/crates/sceneworks-worker/src/face_likeness.rs
+++ b/crates/sceneworks-worker/src/face_likeness.rs
@@ -1,0 +1,607 @@
+//! Shared, generator-agnostic face-likeness scorer (epic 4406, sc-4407).
+//!
+//! The backbone identity-likeness component every surface in epic 4406 calls — Character Studio
+//! Angles (sc-4409) / Poses (sc-4410) and Image Studio "With Character" (sc-4411) — plus the
+//! stretch compare-two-images tool (sc-4415). Given a **source face image** (embedded ONCE per job)
+//! and any number of **generated images**, it returns an identity-likeness result by cosine-comparing
+//! ArcFace embeddings of the largest detected face in each.
+//!
+//! It is **model-independent on purpose**: it is NOT coupled to the InstantID adapter. InstantID,
+//! Z-Image identity, and Flux IP-adapter generations all produce a finished image, and this scorer
+//! runs as a post-pass over that image — so it serves every identity generator through one path. It
+//! reuses the same SCRFD + ArcFace (antelopev2 `glintr100`) stack the InstantID / kps / dataset-face
+//! paths already provision (`mlx-gen-face` on macOS, `candle-gen-face` off-Mac), so no new weights.
+//!
+//! ## Result honesty (drives the whole design)
+//! ArcFace is a **frontal-identity** signal only. A profile / extreme-angle / no-face generation
+//! legitimately has no detectable frontal face — that is an explicit `detected: false`, `score: null`
+//! result carrying a `reason`, NOT a misleading low number. The downstream UI (sc-4413) frames the
+//! score as frontal-identity confidence, so the N/A state must be a first-class outcome, not an error.
+//!
+//! ## Source-embed caching (an explicit acceptance criterion)
+//! [`FaceLikenessScorer`] embeds the source face exactly once at construction and stores the L2-
+//! normalized vector. Every subsequent [`score`](FaceLikenessScorer::score) call re-embeds only the
+//! *generated* image and dots it against the cached source — never the source again. A job that scores
+//! N generated images runs the source recognition forward once, not N times.
+//!
+//! ## Non-fatal
+//! Scoring never fails a generation. The backend embedding legs surface errors, but the intended
+//! caller wraps each [`score`](FaceLikenessScorer::score) so a hard error becomes a logged `null`
+//! result (see [`score_or_null`]); a *no-face* generation is already a clean `detected: false`.
+
+use serde_json::{json, Value};
+
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+use gen_core::Image;
+
+use sceneworks_core::contracts::JsonObject;
+
+// `WorkerResult` / `WorkerError` are re-exported from the crate root (`error::*`); the backend legs
+// surface model failures through them, the same as every other worker face path.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+use crate::{WorkerError, WorkerResult};
+
+/// The recognition method surfaced on every result. Stable string the asset sidecar (sc-4408) and the
+/// UI bands (sc-4414) key off — the same antelopev2 ArcFace stack on both platforms.
+pub(crate) const LIKENESS_METHOD: &str = "arcface_antelopev2";
+
+/// SCRFD detection-confidence floor below which a detection is treated as "no reliable frontal face".
+/// Mirrors the kps-extract `LOW_CONF_THRESH` (0.65): below it, the captured face is an unreliable
+/// extreme profile / poor framing, so the scorer returns an explicit N/A rather than a noisy number.
+pub(crate) const MIN_DET_SCORE: f32 = 0.65;
+
+// ---------------------------------------------------------------------------
+// Pure scoring core — no GPU, no IO, no cfg gating. Always compiled + unit-tested
+// (so the cosine / caching / N-A contract is verified on every platform incl. CI).
+// ---------------------------------------------------------------------------
+
+/// Why a generated image produced no likeness score. Serialized in `camelCase` snake string on the
+/// result `reason` field so the UI can phrase the N/A precisely (vs. a bare `null`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum NoScoreReason {
+    /// SCRFD found no face at all in the generated image.
+    NoFace,
+    /// A face was found but below [`MIN_DET_SCORE`] — an unreliable extreme-angle / profile detection.
+    LowConfidence,
+    /// The source face could not be embedded (no detectable source face). The whole job is N/A.
+    NoSourceFace,
+    /// The embedding forward errored (non-fatal: logged + surfaced as `null`, never blocks a gen).
+    EmbeddingError,
+}
+
+impl NoScoreReason {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            NoScoreReason::NoFace => "no_face",
+            NoScoreReason::LowConfidence => "low_confidence",
+            NoScoreReason::NoSourceFace => "no_source_face",
+            NoScoreReason::EmbeddingError => "embedding_error",
+        }
+    }
+}
+
+/// One identity-likeness outcome for a single generated image. The acceptance result shape:
+/// `{ score: f32|null, detected: bool, method, sourceRef }` (+ a `reason` on the N/A branch).
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct LikenessResult {
+    /// Cosine similarity in `[-1, 1]` (ArcFace cosines are effectively `[0, 1]` for same/other faces).
+    /// `None` ⇒ N/A (see `reason`); never a misleading low number.
+    pub score: Option<f64>,
+    /// Whether a reliable frontal face was detected in the generated image AND scored.
+    pub detected: bool,
+    /// Why there is no score, when `score` is `None`. `None` on a scored result.
+    pub reason: Option<NoScoreReason>,
+}
+
+impl LikenessResult {
+    /// A scored result (a reliable face was detected + cosine-compared).
+    fn scored(score: f64) -> Self {
+        Self {
+            score: Some(score),
+            detected: true,
+            reason: None,
+        }
+    }
+
+    /// An N/A result — `detected: false`, `score: null`, carrying the reason.
+    fn na(reason: NoScoreReason) -> Self {
+        Self {
+            score: None,
+            detected: false,
+            reason: Some(reason),
+        }
+    }
+
+    /// Serialize to the acceptance result object. `source_ref` is the caller's stable id for the
+    /// source face (e.g. the reference asset id) so a consumer can attribute the score.
+    pub(crate) fn to_json(&self, source_ref: Option<&str>) -> JsonObject {
+        let mut object = JsonObject::new();
+        object.insert(
+            "score".to_owned(),
+            match self.score {
+                Some(score) => json!(score),
+                None => Value::Null,
+            },
+        );
+        object.insert("detected".to_owned(), Value::Bool(self.detected));
+        object.insert("method".to_owned(), json!(LIKENESS_METHOD));
+        object.insert(
+            "sourceRef".to_owned(),
+            match source_ref {
+                Some(id) => json!(id),
+                None => Value::Null,
+            },
+        );
+        if let Some(reason) = self.reason {
+            object.insert("reason".to_owned(), json!(reason.as_str()));
+        }
+        object
+    }
+}
+
+/// L2-normalize a raw ArcFace embedding. `None` for an empty or zero-norm vector (so callers can treat
+/// "no usable embedding" explicitly). Identical contract to the dataset-face / lora-eval normalizers.
+fn l2_normalized(v: &[f32]) -> Option<Vec<f32>> {
+    if v.is_empty() {
+        return None;
+    }
+    let norm = v
+        .iter()
+        .map(|x| f64::from(*x) * f64::from(*x))
+        .sum::<f64>()
+        .sqrt();
+    if norm == 0.0 {
+        return None;
+    }
+    Some(v.iter().map(|x| (f64::from(*x) / norm) as f32).collect())
+}
+
+/// Cosine of two already-L2-normalized vectors (a plain dot product). `None` on a length mismatch
+/// (defensive — a length mismatch means the two embeddings are not comparable).
+fn cosine_normalized(a: &[f32], b: &[f32]) -> Option<f64> {
+    if a.len() != b.len() || a.is_empty() {
+        return None;
+    }
+    Some(
+        a.iter()
+            .zip(b)
+            .map(|(x, y)| f64::from(*x) * f64::from(*y))
+            .sum(),
+    )
+}
+
+/// The pure scoring decision, shared by both backends + fully unit-tested without weights. Given the
+/// cached (already-normalized) source embedding and the generated image's largest detection — its
+/// detection score + raw embedding, or `None` when SCRFD found no face — produce the [`LikenessResult`].
+///
+/// This is where the N/A policy lives: no generated face ⇒ `NoFace`; a face below [`MIN_DET_SCORE`] ⇒
+/// `LowConfidence`; an un-normalizable embedding ⇒ `EmbeddingError`; otherwise the cosine score.
+fn score_against_source(
+    source_normalized: &[f32],
+    generated: Option<(f32, &[f32])>,
+) -> LikenessResult {
+    let Some((det_score, raw_embedding)) = generated else {
+        return LikenessResult::na(NoScoreReason::NoFace);
+    };
+    if det_score < MIN_DET_SCORE {
+        return LikenessResult::na(NoScoreReason::LowConfidence);
+    }
+    let Some(generated_normalized) = l2_normalized(raw_embedding) else {
+        return LikenessResult::na(NoScoreReason::EmbeddingError);
+    };
+    match cosine_normalized(source_normalized, &generated_normalized) {
+        Some(score) => LikenessResult::scored(score),
+        None => LikenessResult::na(NoScoreReason::EmbeddingError),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The shared scorer — caches the source embedding once, scores N generated images.
+// Backend legs (MLX on macOS, candle off-Mac) feed the same pure core above.
+// ---------------------------------------------------------------------------
+
+/// The loaded SCRFD + ArcFace backend, abstracted so the [`FaceLikenessScorer`] is backend-agnostic.
+/// MLX on macOS (`mlx-gen-face`), candle off-Mac (`candle-gen-face`); both produce the same
+/// `(det_score, raw 512-d embedding)` for the largest detected face — or `None` when there is no face.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+enum FaceBackend {
+    #[cfg(target_os = "macos")]
+    Mlx(mlx_gen_face::FaceAnalysis),
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    Candle(Box<dyn gen_core::FaceEmbedder>),
+}
+
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+impl FaceBackend {
+    /// Detect + embed the largest face of `image`. `Ok(None)` ⇒ no detectable face (a clean N/A,
+    /// not an error); `Err` ⇒ a real failure (weights / forward). MLX embeds only the largest
+    /// detection (`detect` then `embed`, one recognition forward); candle's `largest_face` errors on
+    /// no face, so it is mapped to `Ok(None)`.
+    fn largest_face(&self, image: &Image) -> WorkerResult<Option<(f32, Vec<f32>)>> {
+        match self {
+            #[cfg(target_os = "macos")]
+            FaceBackend::Mlx(analysis) => {
+                let (h, w) = (image.height as usize, image.width as usize);
+                let dets = analysis
+                    .detect(&image.pixels, h, w)
+                    .map_err(|error| WorkerError::Engine(format!("face detect: {error}")))?;
+                // `detect` returns largest-first; embed just `[0]` (one recognition forward).
+                let Some(det) = dets.first() else {
+                    return Ok(None);
+                };
+                let face = analysis
+                    .embed(&image.pixels, h, w, det)
+                    .map_err(|error| WorkerError::Engine(format!("face embed: {error}")))?;
+                Ok(Some((face.det_score, face.embedding)))
+            }
+            #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+            FaceBackend::Candle(analysis) => {
+                // candle `analyze` returns every face largest-first with embeddings; take `[0]`.
+                // (`largest_face` *errors* on no face — `analyze` returns an empty list instead, the
+                // clean N/A funnel both other worker face paths rely on.)
+                let faces = analysis
+                    .analyze(image)
+                    .map_err(|error| WorkerError::Engine(format!("face analyze: {error}")))?;
+                Ok(faces.into_iter().next().map(|f| (f.det_score, f.embedding)))
+            }
+        }
+    }
+}
+
+/// The generator-agnostic identity-likeness scorer (sc-4407). Construct it once per job from the loaded
+/// face stack + the source face image — the source embedding is computed ONCE here and cached — then
+/// call [`score`](Self::score) for each generated image. The source is never re-embedded.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+pub(crate) struct FaceLikenessScorer {
+    backend: FaceBackend,
+    /// The cached, L2-normalized source embedding. `None` ⇒ no detectable source face: every `score`
+    /// call short-circuits to an N/A result (`NoSourceFace`) — the whole job is N/A, but never an error.
+    source_normalized: Option<Vec<f32>>,
+    /// Count of source embeddings actually computed (always ≤ 1). Lets a test assert the source is
+    /// embedded exactly once across N `score` calls — the explicit caching acceptance criterion.
+    source_embed_count: usize,
+}
+
+#[cfg(target_os = "macos")]
+impl FaceLikenessScorer {
+    /// Load the MLX SCRFD + ArcFace stack from `weights_dir` (the same converted bundle InstantID /
+    /// kps / dataset-face provision) and embed the source face once. Runs `!Send` MLX work — call
+    /// inside `spawn_blocking`.
+    pub(crate) fn load_mlx(weights_dir: &std::path::Path, source: &Image) -> WorkerResult<Self> {
+        use mlx_gen::weights::Weights;
+        let scrfd = Weights::from_file(weights_dir.join(crate::image_jobs::INSTANTID_SCRFD_FILE))
+            .map_err(|error| WorkerError::Engine(format!("SCRFD weights: {error}")))?;
+        let arcface =
+            Weights::from_file(weights_dir.join(crate::image_jobs::INSTANTID_ARCFACE_FILE))
+                .map_err(|error| WorkerError::Engine(format!("ArcFace weights: {error}")))?;
+        let analysis = mlx_gen_face::FaceAnalysis::load(&scrfd, &arcface)
+            .map_err(|error| WorkerError::Engine(format!("face stack load: {error}")))?;
+        Self::with_backend(FaceBackend::Mlx(analysis), source)
+    }
+}
+
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+impl FaceLikenessScorer {
+    /// Load the candle SCRFD + ArcFace stack from `weights_dir` and embed the source face once.
+    pub(crate) fn load_candle(weights_dir: &std::path::Path, source: &Image) -> WorkerResult<Self> {
+        let analysis = candle_gen_face::load(weights_dir)
+            .map_err(|error| WorkerError::Engine(format!("face stack load: {error}")))?;
+        Self::with_backend(FaceBackend::Candle(Box::new(analysis)), source)
+    }
+}
+
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+impl FaceLikenessScorer {
+    /// Build the scorer from an already-loaded backend, embedding + caching the source face exactly
+    /// once. A source with no detectable face is NOT an error — it yields a scorer whose every `score`
+    /// returns the `NoSourceFace` N/A (the whole job is N/A, but generation is never blocked).
+    fn with_backend(backend: FaceBackend, source: &Image) -> WorkerResult<Self> {
+        let (source_normalized, source_embed_count) = match backend.largest_face(source)? {
+            Some((_det_score, raw)) => (l2_normalized(&raw), 1),
+            None => (None, 1),
+        };
+        Ok(Self {
+            backend,
+            source_normalized,
+            source_embed_count,
+        })
+    }
+
+    /// Score one generated image against the CACHED source embedding. Re-embeds only the generated
+    /// image — never the source. Returns an N/A [`LikenessResult`] (not an `Err`) for the no-face /
+    /// low-confidence / no-source-face cases; `Err` only for a genuine backend failure (which the
+    /// caller turns into a logged `null` — see [`score_or_null`]). Runs `!Send` work; call inside
+    /// `spawn_blocking`.
+    pub(crate) fn score(&self, generated: &Image) -> WorkerResult<LikenessResult> {
+        let Some(source_normalized) = self.source_normalized.as_deref() else {
+            return Ok(LikenessResult::na(NoScoreReason::NoSourceFace));
+        };
+        let largest = self.backend.largest_face(generated)?;
+        let generated = largest
+            .as_ref()
+            .map(|(det_score, raw)| (*det_score, raw.as_slice()));
+        Ok(score_against_source(source_normalized, generated))
+    }
+
+    /// Score one generated image, turning a backend error into a logged `null` result — the
+    /// "scoring errors are non-fatal; never block a generation" acceptance criterion. Use this from a
+    /// generation post-pass; use [`score`](Self::score) when the caller wants to handle the error.
+    pub(crate) fn score_or_null(&self, generated: &Image) -> LikenessResult {
+        match self.score(generated) {
+            Ok(result) => result,
+            Err(error) => {
+                tracing::warn!(error = %error, "face-likeness scoring failed; recording null");
+                LikenessResult::na(NoScoreReason::EmbeddingError)
+            }
+        }
+    }
+
+    /// Whether the source face embedded — `false` ⇒ the whole job is N/A (no source face).
+    pub(crate) fn has_source_face(&self) -> bool {
+        self.source_normalized.is_some()
+    }
+
+    /// How many times the source was embedded (always ≤ 1). For the caching acceptance test.
+    #[cfg(test)]
+    pub(crate) fn source_embed_count(&self) -> usize {
+        self.source_embed_count
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // `l2_normalized` casts back to f32, so round-tripped components carry only ~1e-7 precision —
+    // an f32-appropriate tolerance, not f64 epsilon.
+    fn approx(a: f64, b: f64) -> bool {
+        (a - b).abs() < 1e-5
+    }
+
+    // -- pure cosine / normalization -------------------------------------------------
+
+    #[test]
+    fn l2_normalize_unit_and_degenerate() {
+        let n = l2_normalized(&[3.0, 4.0]).expect("non-zero");
+        assert!(approx(f64::from(n[0]), 0.6) && approx(f64::from(n[1]), 0.8));
+        assert!(l2_normalized(&[]).is_none(), "empty ⇒ None");
+        assert!(l2_normalized(&[0.0, 0.0]).is_none(), "zero-norm ⇒ None");
+    }
+
+    #[test]
+    fn cosine_is_dot_of_normalized() {
+        // Identical direction ⇒ 1.0; orthogonal ⇒ 0.0; opposite ⇒ -1.0.
+        let a = l2_normalized(&[1.0, 1.0]).unwrap();
+        assert!(approx(cosine_normalized(&a, &a).unwrap(), 1.0));
+        let x = l2_normalized(&[1.0, 0.0]).unwrap();
+        let y = l2_normalized(&[0.0, 1.0]).unwrap();
+        assert!(approx(cosine_normalized(&x, &y).unwrap(), 0.0));
+        let neg = l2_normalized(&[-1.0, 0.0]).unwrap();
+        assert!(approx(cosine_normalized(&x, &neg).unwrap(), -1.0));
+    }
+
+    #[test]
+    fn cosine_length_mismatch_is_none() {
+        assert!(cosine_normalized(&[1.0, 0.0], &[1.0, 0.0, 0.0]).is_none());
+        assert!(cosine_normalized(&[], &[]).is_none());
+    }
+
+    // -- the N/A decision (the result-honesty acceptance) ---------------------------
+
+    #[test]
+    fn same_identity_scores_high() {
+        // A source embedding and a near-identical generated embedding ⇒ a high cosine, detected.
+        let source = l2_normalized(&[1.0, 0.2, 0.1, 0.05]).unwrap();
+        let generated_raw = [0.98, 0.21, 0.11, 0.04];
+        let result = score_against_source(&source, Some((0.95, &generated_raw)));
+        assert!(result.detected);
+        let score = result.score.expect("scored");
+        assert!(score > 0.99, "same-identity cosine should be high: {score}");
+        assert!(result.reason.is_none());
+    }
+
+    #[test]
+    fn different_identity_scores_low() {
+        // A nearly-orthogonal generated embedding ⇒ a low (near-zero) cosine — still detected (a face
+        // WAS found), just not a match. This is a real low score, NOT the N/A branch.
+        let source = l2_normalized(&[1.0, 0.0, 0.0, 0.0]).unwrap();
+        let generated_raw = [0.02, 1.0, 0.0, 0.0];
+        let result = score_against_source(&source, Some((0.92, &generated_raw)));
+        assert!(result.detected);
+        let score = result.score.expect("scored");
+        assert!(
+            score < 0.1,
+            "different-identity cosine should be low: {score}"
+        );
+    }
+
+    #[test]
+    fn no_generated_face_is_na_not_a_low_score() {
+        // The honesty linchpin: a generation with no detectable face must be detected:false /
+        // score:null with reason no_face — NEVER a misleading low number.
+        let source = l2_normalized(&[1.0, 0.0]).unwrap();
+        let result = score_against_source(&source, None);
+        assert!(!result.detected);
+        assert!(result.score.is_none());
+        assert_eq!(result.reason, Some(NoScoreReason::NoFace));
+    }
+
+    #[test]
+    fn low_confidence_detection_is_na() {
+        // A face below MIN_DET_SCORE (extreme profile) ⇒ N/A low_confidence, not a noisy score.
+        let source = l2_normalized(&[1.0, 0.0]).unwrap();
+        let generated_raw = [1.0, 0.0];
+        let result = score_against_source(&source, Some((MIN_DET_SCORE - 0.01, &generated_raw)));
+        assert!(!result.detected);
+        assert!(result.score.is_none());
+        assert_eq!(result.reason, Some(NoScoreReason::LowConfidence));
+    }
+
+    #[test]
+    fn at_threshold_is_scored() {
+        // Exactly at the floor counts as a reliable detection (>= is the boundary).
+        let source = l2_normalized(&[1.0, 0.0]).unwrap();
+        let generated_raw = [1.0, 0.0];
+        let result = score_against_source(&source, Some((MIN_DET_SCORE, &generated_raw)));
+        assert!(result.detected);
+        assert!(approx(result.score.unwrap(), 1.0));
+    }
+
+    #[test]
+    fn unnormalizable_generated_embedding_is_embedding_error() {
+        let source = l2_normalized(&[1.0, 0.0]).unwrap();
+        let zero = [0.0f32, 0.0];
+        let result = score_against_source(&source, Some((0.9, &zero)));
+        assert_eq!(result.reason, Some(NoScoreReason::EmbeddingError));
+        assert!(result.score.is_none());
+    }
+
+    // -- result serialization (the acceptance result shape) -------------------------
+
+    #[test]
+    fn scored_result_json_shape() {
+        let result = LikenessResult::scored(0.873);
+        let json = Value::Object(result.to_json(Some("asset_123")));
+        assert_eq!(
+            json,
+            json!({
+                "score": 0.873,
+                "detected": true,
+                "method": "arcface_antelopev2",
+                "sourceRef": "asset_123",
+            })
+        );
+    }
+
+    #[test]
+    fn na_result_json_shape_carries_reason_and_null_score() {
+        let result = LikenessResult::na(NoScoreReason::NoFace);
+        let json = Value::Object(result.to_json(Some("asset_123")));
+        assert_eq!(
+            json,
+            json!({
+                "score": Value::Null,
+                "detected": false,
+                "method": "arcface_antelopev2",
+                "sourceRef": "asset_123",
+                "reason": "no_face",
+            })
+        );
+    }
+
+    #[test]
+    fn na_reason_strings_are_stable() {
+        assert_eq!(NoScoreReason::NoFace.as_str(), "no_face");
+        assert_eq!(NoScoreReason::LowConfidence.as_str(), "low_confidence");
+        assert_eq!(NoScoreReason::NoSourceFace.as_str(), "no_source_face");
+        assert_eq!(NoScoreReason::EmbeddingError.as_str(), "embedding_error");
+    }
+
+    /// Real-weight scorer integration (sc-4407): proves the worker binary links + loads the MLX
+    /// `FaceAnalysis` and that the SHARED scorer (a) scores a same-identity pair high (≈ the recorded
+    /// InstantID ArcFace baselines), (b) scores a different-identity pair low, (c) returns
+    /// `detected: false` for a no-face image, and — the explicit caching AC — (d) embeds the SOURCE
+    /// face exactly ONCE across N generated-image `score` calls. `#[ignore]` per convention (weights
+    /// live outside CI). Run on a Mac with the bundle staged + Metal:
+    ///   SCENEWORKS_INSTANTID_WEIGHTS=/path/to/instantid-mlx \
+    ///   SCENEWORKS_TEST_FACE=/path/to/personA.png \
+    ///   SCENEWORKS_TEST_FACE_B=/path/to/personB.png \
+    ///     cargo test -p sceneworks-worker --lib -- --ignored face_likeness_real_weights --nocapture
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "real-weight: needs the SceneWorks/instantid-mlx SCRFD+ArcFace bundle + Metal + face photos"]
+    fn face_likeness_real_weights_scores_and_caches_source_once() {
+        use std::path::PathBuf;
+        let home = std::env::var("HOME").expect("HOME");
+        let bundle = std::env::var("SCENEWORKS_INSTANTID_WEIGHTS")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| {
+                PathBuf::from(&home)
+                    .join("Library/Application Support/SceneWorks/data/cache/instantid-mlx")
+            });
+
+        let load = |path: &str| -> Image {
+            let decoded = image::open(path)
+                .unwrap_or_else(|e| panic!("face {path}: {e}"))
+                .to_rgb8();
+            Image {
+                width: decoded.width(),
+                height: decoded.height(),
+                pixels: decoded.into_raw(),
+            }
+        };
+
+        let face_a =
+            std::env::var("SCENEWORKS_TEST_FACE").expect("set SCENEWORKS_TEST_FACE to person A");
+        let source = load(&face_a);
+        let scorer = FaceLikenessScorer::load_mlx(&bundle, &source).expect("scorer loads");
+        assert!(scorer.has_source_face(), "source has a detectable face");
+        assert_eq!(scorer.source_embed_count(), 1, "source embedded once");
+
+        // (a) same identity (source vs itself) scores high — ≈ the recorded InstantID baselines.
+        let same = scorer.score(&source).expect("score runs");
+        assert!(same.detected, "same-identity detected");
+        let same_score = same.score.expect("same-identity scored");
+        assert!(
+            same_score > 0.8,
+            "same-identity cosine ≈ InstantID baseline (>0.8): {same_score}"
+        );
+
+        // (d) caching: after N score() calls the SOURCE is still embedded exactly once.
+        for _ in 0..3 {
+            let _ = scorer.score(&source).expect("score runs");
+        }
+        assert_eq!(
+            scorer.source_embed_count(),
+            1,
+            "source embedded ONCE across N generated-image scores"
+        );
+
+        // (b) different identity scores low (if a second photo is supplied).
+        if let Ok(face_b) = std::env::var("SCENEWORKS_TEST_FACE_B") {
+            let other = load(&face_b);
+            let diff = scorer.score(&other).expect("score runs");
+            if diff.detected {
+                let diff_score = diff.score.expect("different-identity scored");
+                assert!(
+                    diff_score < same_score,
+                    "different identity {diff_score} below same identity {same_score}"
+                );
+            }
+        }
+
+        // (c) a no-face image (synthetic gradient) returns detected:false / score:null.
+        let mut gradient = image::RgbImage::new(128, 128);
+        for (x, y, px) in gradient.enumerate_pixels_mut() {
+            *px = image::Rgb([(x * 2) as u8, (y * 2) as u8, 96]);
+        }
+        let gradient = Image {
+            width: gradient.width(),
+            height: gradient.height(),
+            pixels: gradient.into_raw(),
+        };
+        let none = scorer.score(&gradient).expect("score runs");
+        assert!(!none.detected, "no-face ⇒ detected:false");
+        assert!(none.score.is_none(), "no-face ⇒ score:null");
+        assert_eq!(none.reason, Some(NoScoreReason::NoFace));
+        println!("face-likeness ok: same={same_score:.4}");
+    }
+}

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -111,6 +111,13 @@ mod dataset_analysis_jobs;
 use dataset_analysis_jobs::*;
 mod face_analysis_jobs;
 use face_analysis_jobs::*;
+// sc-4407 — the shared, generator-agnostic face-likeness scorer (epic 4406): the backbone identity-
+// likeness component the Angles (sc-4409) / Poses (sc-4410) / With-Character (sc-4411) surfaces call as
+// a post-pass over a finished generation. Its public seam (`FaceLikenessScorer`) has no production
+// caller YET — the consuming surfaces are separate stories — so allow the unused seam here; the pure
+// scoring core is exercised by the module's unit tests and the seam by the ignored real-weight test.
+#[allow(dead_code)]
+mod face_likeness;
 mod prompt_refine_jobs;
 use prompt_refine_jobs::*;
 mod downloads;

--- a/tests/test_face_likeness_adapters.py
+++ b/tests/test_face_likeness_adapters.py
@@ -1,0 +1,163 @@
+"""Unit tests for the shared face-likeness scorer adapter (epic 4406, sc-4407).
+
+Cover the pure cosine / N-A scoring policy (kept in parity with the Rust
+``face_likeness::score_against_source``), the backend-availability gate, and the
+``FaceLikenessScorer`` caching contract with a fake antelopev2 app so coverage needs neither
+the onnx weights nor a GPU. Only numpy is required (light-dep, runs in the CI parity lane).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from scene_worker import face_likeness_adapters as fa
+
+np = pytest.importorskip("numpy")
+
+
+def _face(det_score: float, embedding):
+    """A fake insightface ``Face``: a det_score + a raw embedding (no normed_embedding, so the
+    scorer normalizes the raw vector — exercising the same path as the Rust core)."""
+    return SimpleNamespace(
+        det_score=det_score,
+        embedding=np.asarray(embedding, dtype=np.float32),
+        bbox=[0.0, 0.0, 100.0, 100.0],
+    )
+
+
+def test_backend_available_reflects_optional_deps(monkeypatch):
+    monkeypatch.setattr(fa.importlib.util, "find_spec", lambda _name: object())
+    assert fa.face_likeness_backend_available() is True
+    monkeypatch.setattr(
+        fa.importlib.util,
+        "find_spec",
+        lambda name: None if name == "insightface" else object(),
+    )
+    assert fa.face_likeness_backend_available() is False
+
+
+def test_same_identity_scores_high():
+    source = fa._l2_normalized([1.0, 0.2, 0.1, 0.05])
+    gen = _face(0.95, [0.98, 0.21, 0.11, 0.04])
+    result = fa.score_result(source, gen, "asset_a")
+    assert result["detected"] is True
+    assert result["score"] > 0.99
+    assert result["method"] == "arcface_antelopev2"
+    assert result["sourceRef"] == "asset_a"
+    assert "reason" not in result
+
+
+def test_different_identity_scores_low():
+    # A nearly-orthogonal embedding ⇒ a real low score — still detected (a face WAS found).
+    source = fa._l2_normalized([1.0, 0.0, 0.0, 0.0])
+    gen = _face(0.92, [0.02, 1.0, 0.0, 0.0])
+    result = fa.score_result(source, gen, "asset_a")
+    assert result["detected"] is True
+    assert result["score"] < 0.1
+
+
+def test_no_generated_face_is_na_not_a_low_score():
+    # The honesty linchpin: no detectable face ⇒ detected:False / score:None / reason no_face,
+    # NEVER a misleading low number.
+    source = fa._l2_normalized([1.0, 0.0])
+    result = fa.score_result(source, None, "asset_a")
+    assert result["detected"] is False
+    assert result["score"] is None
+    assert result["reason"] == "no_face"
+
+
+def test_low_confidence_detection_is_na():
+    source = fa._l2_normalized([1.0, 0.0])
+    gen = _face(fa.MIN_DET_SCORE - 0.01, [1.0, 0.0])
+    result = fa.score_result(source, gen, "asset_a")
+    assert result["detected"] is False
+    assert result["score"] is None
+    assert result["reason"] == "low_confidence"
+
+
+def test_at_threshold_is_scored():
+    source = fa._l2_normalized([1.0, 0.0])
+    gen = _face(fa.MIN_DET_SCORE, [1.0, 0.0])
+    result = fa.score_result(source, gen, "asset_a")
+    assert result["detected"] is True
+    assert result["score"] == pytest.approx(1.0, abs=1e-5)
+
+
+def test_no_source_face_is_na():
+    gen = _face(0.95, [1.0, 0.0])
+    result = fa.score_result(None, gen, "asset_a")
+    assert result["detected"] is False
+    assert result["score"] is None
+    assert result["reason"] == "no_source_face"
+
+
+def test_normed_embedding_is_preferred_when_present():
+    source = fa._l2_normalized([1.0, 0.0])
+    # normed_embedding already unit-length and pointing the same way ⇒ cosine 1.0.
+    gen = SimpleNamespace(
+        det_score=0.9,
+        normed_embedding=np.asarray([1.0, 0.0], dtype=np.float32),
+        embedding=np.asarray([5.0, 5.0], dtype=np.float32),  # ignored when normed present
+    )
+    result = fa.score_result(source, gen, None)
+    assert result["score"] == pytest.approx(1.0, abs=1e-5)
+    assert result["sourceRef"] is None
+
+
+def test_scorer_embeds_source_once_across_n_scores(monkeypatch):
+    """The explicit caching AC: the SOURCE is embedded exactly once, then reused across N
+    generated-image scores. A fake app counts how many largest-face detections it runs."""
+    calls = {"n": 0}
+    source_face = _face(0.99, [1.0, 0.0, 0.0])
+    gen_face = _face(0.9, [0.9, 0.1, 0.0])
+
+    def fake_largest(_app, image):
+        calls["n"] += 1
+        # First call (construction) embeds the source; subsequent calls are the generated images.
+        return source_face if image == "SOURCE" else gen_face
+
+    monkeypatch.setattr(fa, "_largest_face", fake_largest)
+
+    scorer = fa.FaceLikenessScorer(app=object(), source_image="SOURCE", source_ref="asset_a")
+    assert scorer.has_source_face is True
+    assert scorer.source_embed_count == 1
+    assert calls["n"] == 1  # source embedded once at construction
+
+    for _ in range(3):
+        result = scorer.score("GEN")
+        assert result["detected"] is True
+
+    # The source was embedded exactly once; the 3 extra detections are the generated images only.
+    assert scorer.source_embed_count == 1
+    assert calls["n"] == 4  # 1 source + 3 generated, NOT 1 + 3*2 (no source re-embed)
+
+
+def test_scorer_no_source_face_is_na_for_every_score(monkeypatch):
+    monkeypatch.setattr(fa, "_largest_face", lambda _app, _img: None)
+    scorer = fa.FaceLikenessScorer(app=object(), source_image="SOURCE", source_ref="asset_a")
+    assert scorer.has_source_face is False
+    assert scorer.source_embed_count == 1
+    result = scorer.score("GEN")
+    assert result["detected"] is False
+    assert result["reason"] == "no_source_face"
+
+
+def test_score_or_null_swallows_backend_error(monkeypatch):
+    source_face = _face(0.99, [1.0, 0.0])
+    seq = iter([source_face])
+
+    def fake_largest(_app, image):
+        # Source embeds fine; the generated-image detection raises (a backend failure).
+        nxt = next(seq, None)
+        if nxt is not None:
+            return nxt
+        raise RuntimeError("simulated onnxruntime failure")
+
+    monkeypatch.setattr(fa, "_largest_face", fake_largest)
+    scorer = fa.FaceLikenessScorer(app=object(), source_image="SOURCE")
+    result = scorer.score_or_null("GEN")
+    assert result["detected"] is False
+    assert result["score"] is None
+    assert result["reason"] == "embedding_error"


### PR DESCRIPTION
## What & why

Builds the **backbone identity-likeness scorer** for epic 4406 (sc-4407). Given a **source face image** (embedded once per job, cached) and any number of **generated images**, it cosine-compares antelopev2 ArcFace embeddings of the largest detected face in each and returns the acceptance result shape:

```
{ score: f32|null, detected: bool, method: "arcface_antelopev2", sourceRef: <id>, reason?: <str> }
```

It is **generator-agnostic by design** — it runs as a post-pass over a *finished* generation, so InstantID, Z-Image identity, and Flux IP-adapter generations all flow through one path. It is **not** coupled to the InstantID adapter.

## Where it lives

- `crates/sceneworks-worker/src/face_likeness.rs` — the shared `FaceLikenessScorer` (+ pure scoring core). Native Rust `mlx-gen-face` (SCRFD + ArcFace) on macOS (zero-Python, epic 3482); `candle-gen-face` off-Mac. Reuses the same SCRFD+ArcFace bundle InstantID / kps / dataset-face already provision (no new weights).
- `apps/worker/scene_worker/face_likeness_adapters.py` — the Win/Linux InsightFace equivalent, **byte-identical result shape** + the same source-embed-once caching contract.

## How source-embed caching works (explicit AC)

`FaceLikenessScorer` embeds the source face **exactly once** at construction and stores the L2-normalized vector. Every `score()` call re-embeds only the *generated* image and dots it against the cached source — the source recognition forward runs once per job, not once per generated image. A `source_embed_count` counter backs the caching test on both platforms.

## Honest N/A handling (drives the design)

ArcFace is a frontal-identity signal only. No-face / low-confidence (`det_score < 0.65`) / no-source-face / embedding-error all return `detected:false`, `score:null` with a precise `reason` — **never a misleading low number**. Scoring errors are non-fatal: `score_or_null` logs and returns null, never blocking a generation.

## Scope vs acceptance criteria

- [x] SCRFD detect + ArcFace embed source once (cached) + each generated image; cosine compare — **Mac (MLX) + Win/Linux (InsightFace)**
- [x] Result shape `{ score, detected, method, sourceRef }` + `reason` on N/A
- [x] No-frontal-face / low-confidence ⇒ `detected:false`, `score:null` + reason (no misleading low score)
- [x] Decoupled from the InstantID adapter
- [x] Scoring errors non-fatal (log + null)
- [x] Source embedding computed once and reused across N generated images
- [x] Runs on the Mac MLX worker with no venv

## Tests

- **Rust (12 unit, platform-agnostic so they run in CI parity):** L2/cosine math, same-identity-high, different-identity-low, no-face ⇒ N/A, low-confidence ⇒ N/A, at-threshold ⇒ scored, unnormalizable ⇒ embedding-error, JSON result shapes, stable reason strings.
- **Rust (1 ignored real-weight, macOS):** loads the real MLX SCRFD+ArcFace stack and asserts same-identity scores high (≈ recorded InstantID baselines), different-identity lower, no-face ⇒ `detected:false`, and **source embedded exactly once across N `score()` calls**.
- **Python (11 unit, light-dep/numpy-only ⇒ CI parity):** the same matrix incl. the source-embed-once caching assertion and `score_or_null` swallowing a backend error.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy -p sceneworks-worker --all-targets -- -D warnings` clean
- `cargo build --workspace --exclude sceneworks-desktop` clean
- `cargo test -p sceneworks-worker --lib` → 441 passed, 98 ignored
- Python: `pytest tests/test_face_likeness_adapters.py` → 11 passed (+ existing kps tests still green)

Full `npm run rust:check`'s `cargo build` includes `sceneworks-desktop`, which needs sidecar staging in a fresh worktree; this change touches only `sceneworks-worker` (built green above) — no desktop code paths affected.

## Follow-ups (separate stories, not in scope here)

- sc-4409 / sc-4410 / sc-4411 wire the scorer into the Angles / Poses / With-Character generation post-passes (this is why the public seam currently has no production caller — flagged `#[allow(dead_code)]` with a pointer).
- sc-4408 persists the score into the asset sidecar `rawAdapterSettings.faceLikeness`.
- sc-4415 the stretch compare-two-images tool.

Relates to epic 4406 / sc-4407.

🤖 Generated with [Claude Code](https://claude.com/claude-code)