### PR TITLE
chore(worker): persist face-likeness in asset sidecar (sc-4408)

### DIFF
--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -4149,6 +4149,74 @@ mod tests {
         assert_eq!(asset["lineage"]["jobId"], json!("job-1"));
     }
 
+    /// sc-4408: a scored generation's `rawAdapterSettings.faceLikeness` block (attached worker-side by
+    /// `attach_face_likeness`) survives verbatim through `build_image_sidecar_parts` into
+    /// `recipe.rawAdapterSettings` — the persistence pathway the scoring surfaces (4409/4410/4411) rely
+    /// on. The omit-when-absent contract is covered too: no `faceLikeness` key in ⇒ none out.
+    #[test]
+    fn build_image_sidecar_carries_face_likeness_when_present_and_omits_when_absent() {
+        let base_fact = |raw: Value| {
+            json!({
+                "assetId": "asset_fl",
+                "mediaPath": "assets/images/genset_x/img_0001.png",
+                "mimeType": "image/png",
+                "width": 1024,
+                "height": 1024,
+                "mode": "character_image",
+                "model": "z_image_turbo",
+                "adapter": "z_image_diffusers",
+                "prompt": "portrait",
+                "loras": [],
+                "rawAdapterSettings": raw,
+            })
+        };
+
+        // Present: the detected:true block (and a detected:false N/A block) passes through verbatim.
+        let scored = json!({
+            "faceLikeness": {
+                "score": 0.873,
+                "detected": true,
+                "method": "arcface_antelopev2",
+                "sourceAssetId": "asset_source_fixture",
+            }
+        });
+        let asset = build_generated_asset_sidecar(
+            "project-1",
+            "job-1",
+            "genset_x",
+            &base_fact(scored.clone()),
+        );
+        assert_eq!(asset["recipe"]["rawAdapterSettings"], scored);
+        assert_eq!(
+            asset["recipe"]["rawAdapterSettings"]["faceLikeness"]["detected"],
+            json!(true)
+        );
+
+        let na = json!({
+            "faceLikeness": {
+                "score": Value::Null,
+                "detected": false,
+                "method": "arcface_antelopev2",
+                "sourceAssetId": "asset_source_fixture",
+                "reason": "no_face",
+            }
+        });
+        let asset_na =
+            build_generated_asset_sidecar("project-1", "job-1", "genset_x", &base_fact(na.clone()));
+        assert_eq!(asset_na["recipe"]["rawAdapterSettings"], na);
+
+        // Absent: no faceLikeness key in rawAdapterSettings ⇒ none in the sidecar (clean, no crash).
+        let asset_absent =
+            build_generated_asset_sidecar("project-1", "job-1", "genset_x", &base_fact(json!({})));
+        assert_eq!(asset_absent["recipe"]["rawAdapterSettings"], json!({}));
+        assert!(
+            asset_absent["recipe"]["rawAdapterSettings"]
+                .get("faceLikeness")
+                .is_none(),
+            "absent score ⇒ faceLikeness omitted from sidecar"
+        );
+    }
+
     /// sc-5721 (CORE-002→F): `persist_generated_asset` joins the worker-supplied
     /// `mediaPath` into the project tree and `create_dir_all`/`write`s a sidecar there,
     /// so a traversal or absolute path must be rejected before any filesystem write —

--- a/crates/sceneworks-worker/src/face_likeness.rs
+++ b/crates/sceneworks-worker/src/face_likeness.rs
@@ -145,6 +145,70 @@ impl LikenessResult {
     }
 }
 
+/// The `rawAdapterSettings` key the likeness block lands under in a generated asset's sidecar
+/// (sc-4408). `build_image_sidecar_parts` passes `rawAdapterSettings` through verbatim into
+/// `recipe.rawAdapterSettings`, so attaching the block here is the whole persistence pathway.
+pub(crate) const FACE_LIKENESS_FACT_KEY: &str = "faceLikeness";
+
+/// Build the `faceLikeness` fact block for a generated asset's `rawAdapterSettings` (sc-4408).
+///
+/// This is the carrier seam the scoring surfaces (sc-4409 Angles / sc-4410 Poses / sc-4411
+/// With-Character) attach to each scored asset — NOT the pure scorer (that is sc-4407's
+/// [`LikenessResult`]). The persisted shape matches the asset-sidecar contract:
+/// `{ score, detected, method, sourceAssetId }` (+ a `reason` on the N/A branch). It maps the
+/// scorer's `sourceRef` to the sidecar's `sourceAssetId` field name.
+///
+/// A scored result carries the cosine `score` + `detected: true`; an N/A result carries
+/// `score: null`, `detected: false` and the `reason`, so a profile / no-face generation persists an
+/// honest `detected: false` block rather than a misleading low number (the sc-4407 result-honesty
+/// contract, carried intact into the sidecar).
+pub(crate) fn face_likeness_fact(
+    result: &LikenessResult,
+    source_asset_id: Option<&str>,
+) -> JsonObject {
+    let mut object = JsonObject::new();
+    object.insert(
+        "score".to_owned(),
+        match result.score {
+            Some(score) => json!(score),
+            None => Value::Null,
+        },
+    );
+    object.insert("detected".to_owned(), Value::Bool(result.detected));
+    object.insert("method".to_owned(), json!(LIKENESS_METHOD));
+    object.insert(
+        "sourceAssetId".to_owned(),
+        match source_asset_id {
+            Some(id) => json!(id),
+            None => Value::Null,
+        },
+    );
+    if let Some(reason) = result.reason {
+        object.insert("reason".to_owned(), json!(reason.as_str()));
+    }
+    object
+}
+
+/// Attach a face-likeness result to a generated asset's `rawAdapterSettings` under
+/// [`FACE_LIKENESS_FACT_KEY`] (sc-4408). The omit-when-absent seam: a `None` result (scoring was
+/// skipped / not applicable / hard-failed before a [`LikenessResult`] was produced) leaves
+/// `rawAdapterSettings` untouched, so the field is OMITTED entirely from the sidecar — no `null`
+/// clutter, no crash. A `Some(result)` writes the [`face_likeness_fact`] block (including the
+/// explicit `detected: false` N/A block). The scoring surfaces call this once per generated asset
+/// just before [`write_image_asset`](crate::image_jobs::write_image_asset) builds its fact.
+pub(crate) fn attach_face_likeness(
+    raw_settings: &mut JsonObject,
+    result: Option<&LikenessResult>,
+    source_asset_id: Option<&str>,
+) {
+    if let Some(result) = result {
+        raw_settings.insert(
+            FACE_LIKENESS_FACT_KEY.to_owned(),
+            Value::Object(face_likeness_fact(result, source_asset_id)),
+        );
+    }
+}
+
 /// L2-normalize a raw ArcFace embedding. `None` for an empty or zero-norm vector (so callers can treat
 /// "no usable embedding" explicitly). Identical contract to the dataset-face / lora-eval normalizers.
 fn l2_normalized(v: &[f32]) -> Option<Vec<f32>> {
@@ -505,6 +569,81 @@ mod tests {
                 "reason": "no_face",
             })
         );
+    }
+
+    // -- sc-4408 carrier: faceLikeness → rawAdapterSettings persistence seam --------
+
+    #[test]
+    fn face_likeness_fact_scored_shape_uses_source_asset_id() {
+        // The sidecar contract field is `sourceAssetId` (sc-4407's scorer emits `sourceRef`); the
+        // carrier maps it. A scored result is the full `{score, detected, method, sourceAssetId}`.
+        let fact = face_likeness_fact(&LikenessResult::scored(0.873), Some("asset_src1"));
+        assert_eq!(
+            Value::Object(fact),
+            json!({
+                "score": 0.873,
+                "detected": true,
+                "method": "arcface_antelopev2",
+                "sourceAssetId": "asset_src1",
+            })
+        );
+    }
+
+    #[test]
+    fn face_likeness_fact_na_block_carries_detected_false_and_reason() {
+        // An N/A generation persists an explicit detected:false block (with reason), NOT a low number.
+        let fact = face_likeness_fact(
+            &LikenessResult::na(NoScoreReason::NoFace),
+            Some("asset_src1"),
+        );
+        assert_eq!(
+            Value::Object(fact),
+            json!({
+                "score": Value::Null,
+                "detected": false,
+                "method": "arcface_antelopev2",
+                "sourceAssetId": "asset_src1",
+                "reason": "no_face",
+            })
+        );
+    }
+
+    #[test]
+    fn attach_face_likeness_writes_block_into_raw_settings() {
+        // The end-to-end persistence pathway: attaching a scored result puts the `faceLikeness` block
+        // into `rawAdapterSettings` (which `build_image_sidecar_parts` passes through verbatim) while
+        // leaving any pre-existing settings intact.
+        let mut raw = JsonObject::new();
+        raw.insert("steps".to_owned(), json!(8));
+        attach_face_likeness(
+            &mut raw,
+            Some(&LikenessResult::scored(0.91)),
+            Some("asset_src1"),
+        );
+        assert_eq!(raw.get("steps"), Some(&json!(8)));
+        assert_eq!(
+            raw.get(FACE_LIKENESS_FACT_KEY),
+            Some(&json!({
+                "score": 0.91,
+                "detected": true,
+                "method": "arcface_antelopev2",
+                "sourceAssetId": "asset_src1",
+            }))
+        );
+    }
+
+    #[test]
+    fn attach_face_likeness_omits_field_when_absent() {
+        // The omit-when-absent contract: a None result (scoring skipped/failed) leaves
+        // rawAdapterSettings untouched — the field is omitted entirely, no null clutter, no crash.
+        let mut raw = JsonObject::new();
+        raw.insert("steps".to_owned(), json!(8));
+        attach_face_likeness(&mut raw, None, Some("asset_src1"));
+        assert!(
+            !raw.contains_key(FACE_LIKENESS_FACT_KEY),
+            "absent score ⇒ faceLikeness omitted"
+        );
+        assert_eq!(raw.get("steps"), Some(&json!(8)));
     }
 
     #[test]

--- a/tests/fixtures/rust_migration_contracts/sidecars/asset-image.sceneworks.json
+++ b/tests/fixtures/rust_migration_contracts/sidecars/asset-image.sceneworks.json
@@ -39,7 +39,14 @@
       "characterConditioningActive": false,
       "characterConditioningNote": "Character metadata is recorded, but adapter-level character conditioning is not active in this build."
     },
-    "rawAdapterSettings": {}
+    "rawAdapterSettings": {
+      "faceLikeness": {
+        "score": 0.873,
+        "detected": true,
+        "method": "arcface_antelopev2",
+        "sourceAssetId": "asset_source_fixture"
+      }
+    }
   },
   "lineage": {
     "parents": [],


### PR DESCRIPTION
## What changed (sc-4408)

Carrier seam to persist the sc-4407 face-likeness scorer result from worker → asset sidecar so the frontend (sc-4413/4414) can read it. **This story is the persistence pathway + serialization only** — the scoring surfaces sc-4409 (Angles) / sc-4410 (Poses) / sc-4411 (With-Character) are the production callers that populate it.

- **`face_likeness_fact(result, source_asset_id)`** (`crates/sceneworks-worker/src/face_likeness.rs`): builds the persisted block matching the asset-sidecar contract `{ score, detected, method, sourceAssetId }` (+ `reason` on the N/A branch). Maps the sc-4407 scorer's `sourceRef` → the sidecar's `sourceAssetId` field name per the contract.
- **`attach_face_likeness(raw_settings, result, source_asset_id)`**: the omit-when-absent seam. `Some(result)` writes the `faceLikeness` block into a generated asset's `rawAdapterSettings` (including the explicit `detected:false` N/A block, with `reason`); `None` (scoring skipped / failed before a result) leaves `rawAdapterSettings` untouched, so the field is **omitted entirely** — no `null` clutter, no crash.
- **No `project_store.rs` wiring change**: `build_image_sidecar_parts()` already copies `rawAdapterSettings` verbatim into `recipe.rawAdapterSettings`, so the block lands at `recipe.rawAdapterSettings.faceLikeness` through the existing passthrough.

## Where it lands in the sidecar

`asset.recipe.rawAdapterSettings.faceLikeness = { score, detected, method, sourceAssetId, [reason] }`

## Scope vs acceptance criteria

- ✅ Worker reports likeness as a per-asset fact under `rawAdapterSettings.faceLikeness`.
- ✅ Persisted via the existing `build_image_sidecar_parts()` passthrough.
- ✅ Sidecar JSON contains the likeness block (or explicit `detected:false` block) after a scored fact — proven end-to-end by a `build_image_sidecar_parts` test.
- ✅ Absent score serializes cleanly (field omitted, no crash).
- ✅ Migration-contract fixture updated; round-trip green.
- Did NOT wire the actual generation flows (that is sc-4409/4410/4411) — but the seam is real and end-to-end testable, not stubbed.

## Tests (all green)

- worker `face_likeness`: carrier shape uses `sourceAssetId`; `detected:false`+`reason` N/A block; `attach` writes block into raw settings; `attach` omits field when absent.
- core `project_store`: `build_image_sidecar_carries_face_likeness_when_present_and_omits_when_absent` (scored + N/A pass through verbatim; absent ⇒ omitted).
- `contract_roundtrip` round-trip over the updated `asset-image.sceneworks.json` fixture.
- `npm run rust:check` (fmt --check + clippy + test + build): **clean, exit 0**.

## Snapshot updates

- Updated `tests/fixtures/rust_migration_contracts/sidecars/asset-image.sceneworks.json` to carry a `faceLikeness` block under `rawAdapterSettings`.
- **`tests/fixtures/rust_api_contract_snapshots/snapshots.json` unchanged**: the live-API parity harness exercises upload/preset/test-job paths only; no production caller emits a `faceLikeness` fact yet, and `rawAdapterSettings` is freeform passthrough, so the public API surface does not change. Will be regenerated when a scoring surface (sc-4409/4410/4411) lands a real generation flow.

## Follow-ups

- sc-4409 / sc-4410 / sc-4411 call `attach_face_likeness` from their generation post-pass (the real producers). When the first lands, regen `snapshots.json` via `UPDATE_SNAPSHOTS=1` if a scored generation enters the parity harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)