### PR TITLE
feat(worker): score angle-set generations with face-likeness (sc-4409)

### DIFF
--- a/crates/sceneworks-worker/src/face_likeness.rs
+++ b/crates/sceneworks-worker/src/face_likeness.rs
@@ -313,8 +313,11 @@ struct StubFaceBackend {
 
 #[cfg(test)]
 impl StubFaceBackend {
-    /// Map an image to its canned detection by pixel 0: `0` ⇒ no face; otherwise a reliable face
-    /// whose `det_score` scales with pixel 0 (so distinct identities produce distinct embeddings).
+    /// Map an image to its canned detection by pixel 0: `0` ⇒ no face; otherwise a face whose
+    /// `det_score` scales with pixel 0 (`0.5 + px/512`, so distinct identities produce distinct
+    /// embeddings). The score crosses [`MIN_DET_SCORE`] (0.65) at px ≈ 77, so the scorer treats a
+    /// low pixel value (px `1..=76`, det_score `< 0.65`) as a LowConfidence N/A and a high one
+    /// (px `>= 77`) as a reliable, scored detection — letting a test exercise all three outcomes.
     fn classify(image: &Image) -> StubFace {
         match image.pixels.first().copied().unwrap_or(0) {
             0 => StubFace::NoFace,
@@ -498,6 +501,72 @@ impl FaceLikenessScorer {
         let scorer = Self::with_backend(backend, source).expect("stub backend never errors");
         (scorer, calls)
     }
+
+    /// Platform-neutral load: the MLX stack on macOS, the candle stack off-Mac. Lets the shared
+    /// angle-set seam ([`build_angle_set_scorer`]) construct a scorer without each call site
+    /// cfg-branching on the backend. Embeds the source face once (the caching contract).
+    fn load_for_weights_dir(weights_dir: &std::path::Path, source: &Image) -> WorkerResult<Self> {
+        #[cfg(target_os = "macos")]
+        {
+            Self::load_mlx(weights_dir, source)
+        }
+        #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+        {
+            Self::load_candle(weights_dir, source)
+        }
+    }
+}
+
+/// Build the per-job identity-likeness scorer for an angle set (sc-4409), generator-agnostically.
+///
+/// This is the SHARED seam every angle-set producer calls — InstantID, FLUX.2 edit, Qwen-Edit, and
+/// SenseNova-U1 all route an `advanced.angleSet` job to their own engine, but each scores its finished
+/// views through this one path (the scorer is model-independent by design — sc-4407). The source
+/// identity face is embedded exactly ONCE here and reused across every angle.
+///
+/// **Non-fatal construction** (the explicit AC carried from the sc-4407 review): a missing/corrupt
+/// weights bundle or a source image with no detectable face must NEVER abort the generation. Any
+/// error is logged and becomes `None` — the angle set still renders, the scores are simply absent
+/// (the field is omitted from each sidecar). A `None` here ⇒ pass `None` to [`score_angle_image`].
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+pub(crate) fn build_angle_set_scorer(
+    weights_dir: &std::path::Path,
+    source: &Image,
+) -> Option<FaceLikenessScorer> {
+    match FaceLikenessScorer::load_for_weights_dir(weights_dir, source) {
+        Ok(scorer) => Some(scorer),
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                "angle-set face-likeness scorer construction failed; scores will be omitted \
+                 (generation continues)"
+            );
+            None
+        }
+    }
+}
+
+/// Score one finished angle image against the per-job cached source embedding and build the persisted
+/// `faceLikeness` sidecar block (sc-4408/sc-4409) — the SHARED per-image post-pass for every angle-set
+/// producer. `None` scorer (no angle set, or a failed [`build_angle_set_scorer`]) ⇒ `None` ⇒ the field
+/// is omitted entirely. Per-image scoring is non-fatal ([`score_or_null`]); a profile / up / down view
+/// with no reliable frontal face records an honest `detected: false` N/A block, never a low number.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+pub(crate) fn score_angle_image(
+    scorer: Option<&FaceLikenessScorer>,
+    image: &Image,
+    source_asset_id: Option<&str>,
+) -> Option<JsonObject> {
+    scorer.map(|scorer| {
+        let result = scorer.score_or_null(image);
+        face_likeness_fact(&result, source_asset_id)
+    })
 }
 
 #[cfg(test)]
@@ -846,6 +915,89 @@ mod tests {
             assert!(
                 !raw.contains_key(FACE_LIKENESS_FACT_KEY),
                 "absent scorer ⇒ faceLikeness omitted, generation unaffected"
+            );
+        }
+
+        #[test]
+        fn low_confidence_angle_records_low_confidence_na() {
+            // A low-confidence detection (an extreme-but-detected angle below MIN_DET_SCORE) records an
+            // honest low_confidence N/A, not a noisy number — exercises the stub's `1..=76` tier.
+            let (scorer, _calls) = FaceLikenessScorer::with_stub_source(&image(200));
+            let result = scorer.score_or_null(&image(40)); // det_score 0.5+40/512 ≈ 0.578 < 0.65
+            assert!(!result.detected, "low-confidence angle ⇒ detected:false");
+            assert!(result.score.is_none());
+            assert_eq!(result.reason, Some(NoScoreReason::LowConfidence));
+        }
+
+        // -- the shared seam every angle-set producer calls (InstantID / FLUX.2 / Qwen / SenseNova) --
+        // `build_angle_set_scorer` needs real weights, so it is covered by the `#[ignore]` real-weight
+        // test; `score_angle_image` (the per-image half all four lanes call identically) is fully
+        // covered here over the stub scorer.
+
+        /// Build a stub scorer the way `score_angle_image` consumes it (`Option<&_>`).
+        fn stub_scorer(
+            source_px: u8,
+        ) -> (
+            FaceLikenessScorer,
+            std::sync::Arc<std::sync::atomic::AtomicUsize>,
+        ) {
+            FaceLikenessScorer::with_stub_source(&image(source_px))
+        }
+
+        #[test]
+        fn score_angle_image_attaches_block_and_embeds_source_once_across_a_set() {
+            // The generator-agnostic per-image post-pass: each finished angle yields a faceLikeness
+            // block (detected:true for reliable views), and across an N-angle set the SOURCE is embedded
+            // exactly once — proving the FLUX.2 / Qwen / SenseNova lanes reuse one cached source embed
+            // (they build the scorer once, then call this per image), not re-embed per angle.
+            let (scorer, calls) = stub_scorer(200);
+            assert_eq!(
+                calls.load(Ordering::SeqCst),
+                1,
+                "construction embedded the source once"
+            );
+
+            let angles = [200u8, 180, 160, 140, 120, 100, 90, 200, 180, 160, 140];
+            for px in angles {
+                let block = score_angle_image(Some(&scorer), &image(px), Some("char_src"))
+                    .expect("a scorer present ⇒ a block built");
+                assert_eq!(block.get("detected"), Some(&Value::Bool(true)));
+                assert_eq!(block.get("sourceAssetId"), Some(&json!("char_src")));
+                assert_eq!(block.get("method"), Some(&json!(LIKENESS_METHOD)));
+            }
+            assert_eq!(
+                calls.load(Ordering::SeqCst),
+                1 + angles.len(),
+                "1 source embed + 1 detect per angle — the source is NEVER re-embedded across the set"
+            );
+        }
+
+        #[test]
+        fn score_angle_image_no_face_attaches_detected_false_block() {
+            // A profile / up / down angle (no detectable frontal face) attaches an honest detected:false
+            // N/A block through the shared seam — never a low number, never a skipped asset.
+            let (scorer, _calls) = stub_scorer(200);
+            let block = score_angle_image(Some(&scorer), &image(0), Some("char_src"))
+                .expect("a scorer present ⇒ a block (the N/A block) built");
+            assert_eq!(
+                Value::Object(block),
+                json!({
+                    "score": Value::Null,
+                    "detected": false,
+                    "method": LIKENESS_METHOD,
+                    "sourceAssetId": "char_src",
+                    "reason": "no_face",
+                })
+            );
+        }
+
+        #[test]
+        fn score_angle_image_none_scorer_omits_block() {
+            // No angle set / non-fatal construction failure ⇒ `None` scorer ⇒ `None` ⇒ the consumer
+            // omits the field entirely (the same contract the producer relies on for non-angle paths).
+            assert!(
+                score_angle_image(None, &image(200), Some("char_src")).is_none(),
+                "None scorer ⇒ no block ⇒ field omitted"
             );
         }
     }

--- a/crates/sceneworks-worker/src/face_likeness.rs
+++ b/crates/sceneworks-worker/src/face_likeness.rs
@@ -31,11 +31,14 @@
 
 use serde_json::{json, Value};
 
-#[cfg(any(
-    target_os = "macos",
-    all(not(target_os = "macos"), feature = "backend-candle")
-))]
+// `Image` resolves to `mlx_gen::Image` on macOS and `gen_core::Image` under the candle backend —
+// the same cfg-gated split the sibling job modules use (sensenova_jobs.rs / video_jobs.rs). The whole
+// scorer (and its test stub) only exists under these two configs, so on the plain Linux parity build
+// (no `backend-candle`) `Image` is intentionally absent and nothing here is compiled.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use gen_core::Image;
+#[cfg(target_os = "macos")]
+use mlx_gen::Image;
 
 use sceneworks_core::contracts::JsonObject;
 
@@ -288,14 +291,21 @@ enum FaceBackend {
     /// Weight-free deterministic backend for the wiring tests (sc-4409): keyed on the image's first
     /// pixel byte so a test can map a synthetic image to a face / no-face / low-confidence detection
     /// and count how often the backend is hit, WITHOUT staging the antelopev2 weights in CI. Never
-    /// compiled outside `cargo test`.
+    /// compiled outside `cargo test`. Gated on the face-backend configs too (the whole scorer is), so
+    /// the plain Linux parity build — which has no `Image` type in scope — doesn't try to compile it.
     #[cfg(test)]
     Stub(StubFaceBackend),
 }
 
 /// The canned detection the [`FaceBackend::Stub`] returns for a given image, selected by the image's
 /// first pixel byte (the test encodes intent in pixel 0). Mirrors the three real-backend outcomes.
-#[cfg(test)]
+#[cfg(all(
+    test,
+    any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    )
+))]
 #[derive(Clone, Copy)]
 enum StubFace {
     /// A reliable face at `det_score`, embedded as the canned vector (drives a real cosine).
@@ -306,12 +316,24 @@ enum StubFace {
 
 /// Counts every `largest_face` call so a test can prove the SOURCE is embedded exactly once across N
 /// generated-image scores (the explicit caching acceptance criterion), independent of weights.
-#[cfg(test)]
+#[cfg(all(
+    test,
+    any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    )
+))]
 struct StubFaceBackend {
     calls: std::sync::Arc<std::sync::atomic::AtomicUsize>,
 }
 
-#[cfg(test)]
+#[cfg(all(
+    test,
+    any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    )
+))]
 impl StubFaceBackend {
     /// Map an image to its canned detection by pixel 0: `0` ⇒ no face; otherwise a face whose
     /// `det_score` scales with pixel 0 (`0.5 + px/512`, so distinct identities produce distinct

--- a/crates/sceneworks-worker/src/face_likeness.rs
+++ b/crates/sceneworks-worker/src/face_likeness.rs
@@ -277,11 +277,57 @@ fn score_against_source(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
+// The test-only zero-cost `Stub` variant is tiny next to the real `Mlx` backend; the size disparity
+// is irrelevant for a per-job singleton (one scorer per generation), and it only exists under `test`.
+#[cfg_attr(test, allow(clippy::large_enum_variant))]
 enum FaceBackend {
     #[cfg(target_os = "macos")]
     Mlx(mlx_gen_face::FaceAnalysis),
     #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
     Candle(Box<dyn gen_core::FaceEmbedder>),
+    /// Weight-free deterministic backend for the wiring tests (sc-4409): keyed on the image's first
+    /// pixel byte so a test can map a synthetic image to a face / no-face / low-confidence detection
+    /// and count how often the backend is hit, WITHOUT staging the antelopev2 weights in CI. Never
+    /// compiled outside `cargo test`.
+    #[cfg(test)]
+    Stub(StubFaceBackend),
+}
+
+/// The canned detection the [`FaceBackend::Stub`] returns for a given image, selected by the image's
+/// first pixel byte (the test encodes intent in pixel 0). Mirrors the three real-backend outcomes.
+#[cfg(test)]
+#[derive(Clone, Copy)]
+enum StubFace {
+    /// A reliable face at `det_score`, embedded as the canned vector (drives a real cosine).
+    Face(f32),
+    /// No detectable face ⇒ `Ok(None)` (the clean N/A funnel).
+    NoFace,
+}
+
+/// Counts every `largest_face` call so a test can prove the SOURCE is embedded exactly once across N
+/// generated-image scores (the explicit caching acceptance criterion), independent of weights.
+#[cfg(test)]
+struct StubFaceBackend {
+    calls: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+}
+
+#[cfg(test)]
+impl StubFaceBackend {
+    /// Map an image to its canned detection by pixel 0: `0` ⇒ no face; otherwise a reliable face
+    /// whose `det_score` scales with pixel 0 (so distinct identities produce distinct embeddings).
+    fn classify(image: &Image) -> StubFace {
+        match image.pixels.first().copied().unwrap_or(0) {
+            0 => StubFace::NoFace,
+            other => StubFace::Face(0.5 + f32::from(other) / 512.0),
+        }
+    }
+
+    /// A canned, identity-bearing embedding keyed off pixel 0 so same-pixel images cosine-match high
+    /// and different-pixel images lower — enough to exercise the scoring + persistence wiring.
+    fn embedding(image: &Image) -> Vec<f32> {
+        let key = f32::from(image.pixels.first().copied().unwrap_or(0));
+        vec![key, 1.0, 0.25, 0.1]
+    }
 }
 
 #[cfg(any(
@@ -319,6 +365,14 @@ impl FaceBackend {
                     .analyze(image)
                     .map_err(|error| WorkerError::Engine(format!("face analyze: {error}")))?;
                 Ok(faces.into_iter().next().map(|f| (f.det_score, f.embedding)))
+            }
+            #[cfg(test)]
+            FaceBackend::Stub(stub) => {
+                stub.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok(match StubFaceBackend::classify(image) {
+                    StubFace::NoFace => None,
+                    StubFace::Face(det) => Some((det, StubFaceBackend::embedding(image))),
+                })
             }
         }
     }
@@ -427,6 +481,22 @@ impl FaceLikenessScorer {
     #[cfg(test)]
     pub(crate) fn source_embed_count(&self) -> usize {
         self.source_embed_count
+    }
+
+    /// Build a scorer over the weight-free [`FaceBackend::Stub`] from a synthetic `source` image
+    /// (sc-4409 wiring tests). Returns the scorer plus the shared backend-call counter so a test can
+    /// prove the source embedded exactly once and assert exactly how many generated-image scores hit
+    /// the backend — the caching acceptance criterion, verifiable without antelopev2 weights in CI.
+    #[cfg(test)]
+    pub(crate) fn with_stub_source(
+        source: &Image,
+    ) -> (Self, std::sync::Arc<std::sync::atomic::AtomicUsize>) {
+        let calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let backend = FaceBackend::Stub(StubFaceBackend {
+            calls: calls.clone(),
+        });
+        let scorer = Self::with_backend(backend, source).expect("stub backend never errors");
+        (scorer, calls)
     }
 }
 
@@ -652,6 +722,132 @@ mod tests {
         assert_eq!(NoScoreReason::LowConfidence.as_str(), "low_confidence");
         assert_eq!(NoScoreReason::NoSourceFace.as_str(), "no_source_face");
         assert_eq!(NoScoreReason::EmbeddingError.as_str(), "embedding_error");
+    }
+
+    // -- sc-4409: angle-set wiring over the weight-free stub backend -----------------
+    // These exercise the live `FaceLikenessScorer` (caching + N/A + non-fatal construction +
+    // per-image persistence) WITHOUT antelopev2 weights, so they run in CI on the face-backend
+    // build (macOS, or candle off-Mac). The real-weight end-to-end remains the `#[ignore]` test
+    // above. The angle-set producer (`generate_instantid_stream`) calls exactly this surface:
+    // construct once from the source, then `score_or_null` + `face_likeness_fact` per finished view.
+
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    mod angle_set_wiring {
+        use super::*;
+        use std::sync::atomic::Ordering;
+
+        /// A synthetic image whose first pixel byte selects the stub detection (see `StubFaceBackend`):
+        /// `0` ⇒ no face; `>=77` ⇒ a reliable face; `1..=76` ⇒ a low-confidence face.
+        fn image(pixel0: u8) -> Image {
+            Image {
+                width: 1,
+                height: 1,
+                pixels: vec![pixel0, 0, 0],
+            }
+        }
+
+        #[test]
+        fn source_embedded_once_across_n_angles_each_attaches_a_block() {
+            // The explicit caching AC: one source embed at construction, reused across N angle scores
+            // (the source is NEVER re-embedded), and every scored angle yields an attachable block.
+            let source = image(200);
+            let (scorer, calls) = FaceLikenessScorer::with_stub_source(&source);
+            assert!(scorer.has_source_face(), "source has a detectable face");
+            assert_eq!(scorer.source_embed_count(), 1, "source embedded once");
+            assert_eq!(
+                calls.load(Ordering::SeqCst),
+                1,
+                "construction hit the backend exactly once (the source embed)"
+            );
+
+            // Score an 11-view-style set; every reliable-face view attaches a faceLikeness block.
+            let angles = [200u8, 180, 160, 140, 120, 100, 90, 200, 180, 160, 140];
+            for (i, px) in angles.iter().enumerate() {
+                let result = scorer.score_or_null(&image(*px));
+                assert!(result.detected, "angle {i} (px {px}) detected");
+                let mut raw = JsonObject::new();
+                attach_face_likeness(&mut raw, Some(&result), Some("char_src"));
+                let block = raw
+                    .get(FACE_LIKENESS_FACT_KEY)
+                    .and_then(Value::as_object)
+                    .expect("faceLikeness block attached");
+                assert_eq!(block.get("detected"), Some(&Value::Bool(true)));
+                assert_eq!(block.get("sourceAssetId"), Some(&json!("char_src")));
+                assert!(block.get("score").map(Value::is_number).unwrap_or(false));
+            }
+
+            // The source was embedded ONCE; the backend was hit only the source embed + one detect per
+            // angle (N+1) — never a second source embed.
+            assert_eq!(
+                scorer.source_embed_count(),
+                1,
+                "still one source embed after N scores"
+            );
+            assert_eq!(
+                calls.load(Ordering::SeqCst),
+                1 + angles.len(),
+                "backend hit = 1 source embed + 1 detect per angle (no source re-embed)"
+            );
+        }
+
+        #[test]
+        fn profile_no_face_angle_records_detected_false_not_a_low_number() {
+            // A profile / up / down view with no detectable frontal face must persist an honest
+            // detected:false N/A block (score null + reason), NOT a misleading low number.
+            let (scorer, _calls) = FaceLikenessScorer::with_stub_source(&image(200));
+            let result = scorer.score_or_null(&image(0)); // pixel 0 == 0 ⇒ no face
+            assert!(!result.detected, "no-face angle ⇒ detected:false");
+            assert!(
+                result.score.is_none(),
+                "no-face angle ⇒ score:null (not a low number)"
+            );
+            assert_eq!(result.reason, Some(NoScoreReason::NoFace));
+
+            let mut raw = JsonObject::new();
+            attach_face_likeness(&mut raw, Some(&result), Some("char_src"));
+            assert_eq!(
+                raw.get(FACE_LIKENESS_FACT_KEY),
+                Some(&json!({
+                    "score": Value::Null,
+                    "detected": false,
+                    "method": LIKENESS_METHOD,
+                    "sourceAssetId": "char_src",
+                    "reason": "no_face",
+                })),
+                "the N/A block persists detected:false + reason, not a low score"
+            );
+        }
+
+        #[test]
+        fn no_source_face_makes_every_angle_na_but_never_fails_the_job() {
+            // Construction-side non-fatal guard surrogate: a source with no detectable face yields a
+            // scorer (NOT an error) whose every angle is the NoSourceFace N/A — the whole set is N/A,
+            // generation is never blocked. (The producer additionally maps a hard construction error
+            // to a `None` scorer ⇒ the field is omitted; see `omitted_when_scorer_absent`.)
+            let (scorer, _calls) = FaceLikenessScorer::with_stub_source(&image(0)); // no source face
+            assert!(!scorer.has_source_face(), "no detectable source face");
+            let result = scorer.score_or_null(&image(200)); // a real face in the generation
+            assert!(!result.detected, "no source ⇒ every angle N/A");
+            assert_eq!(result.reason, Some(NoScoreReason::NoSourceFace));
+        }
+
+        #[test]
+        fn omitted_when_scorer_absent() {
+            // The producer wraps scorer CONSTRUCTION so a hard failure → `None` scorer → no block is
+            // built → the field is omitted entirely from the sidecar (no null clutter, no crash).
+            // This is the `attach_face_likeness(None)` omit-when-absent path the angle producer uses
+            // when `scorer` is `None`.
+            let mut raw = JsonObject::new();
+            raw.insert("steps".to_owned(), json!(8));
+            attach_face_likeness(&mut raw, None, Some("char_src"));
+            assert!(
+                !raw.contains_key(FACE_LIKENESS_FACT_KEY),
+                "absent scorer ⇒ faceLikeness omitted, generation unaffected"
+            );
+        }
     }
 
     /// Real-weight scorer integration (sc-4407): proves the worker binary links + loads the MLX

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -2596,7 +2596,21 @@ async fn consume_gen_events(
                 width,
                 height,
                 pixels,
+                face_likeness,
             } => {
+                // The identity-likeness post-pass (sc-4409) scores each image on the blocking thread
+                // and hands the pre-built `faceLikeness` block back through the event. Attach it to a
+                // PER-IMAGE clone of the shared raw settings under the sidecar key so each angle's
+                // asset carries its own honest score (an N/A `detected:false` block for profile/up/
+                // down views), while every non-scoring path leaves `face_likeness` `None` ⇒ the field
+                // is omitted entirely (the sc-4408 omit-when-absent contract).
+                let mut image_raw_settings = raw_settings.clone();
+                if let Some(block) = face_likeness {
+                    image_raw_settings.insert(
+                        crate::face_likeness::FACE_LIKENESS_FACT_KEY.to_owned(),
+                        Value::Object(block),
+                    );
+                }
                 let fact = write_image_asset(
                     plan,
                     index,
@@ -2605,7 +2619,7 @@ async fn consume_gen_events(
                     height,
                     pixels,
                     adapter_label,
-                    raw_settings.clone(),
+                    image_raw_settings,
                     project_path,
                 )?;
                 asset_writes.push(Value::Object(fact));

--- a/crates/sceneworks-worker/src/image_jobs/flux2.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2.rs
@@ -436,6 +436,28 @@ async fn generate_flux2_edit_stream(
         Flux2Grouping::Plain => {}
     }
 
+    // Angle-set identity-likeness scoring (epic 4406, sc-4409): the generator-agnostic post-pass
+    // applies to EVERY angle set, not just InstantID-routed ones — a Character-Studio angle set on a
+    // FLUX.2 edit model is scored through the same shared seam. Stage the antelopev2 face stack (same
+    // bundle InstantID uses; a no-op if already cached) and capture the source identity reference +
+    // its asset id; the `!Send` scorer is built ONCE inside the generator-worker closure below and
+    // reused across all angles. Only on the angle set; staging is non-fatal (a failure → no scorer →
+    // scores omitted, the set still renders).
+    let angle_set = matches!(grouping, Flux2Grouping::Angles);
+    let face_stack_dir = if angle_set {
+        match ensure_face_stack_dir(api, settings, job).await {
+            Ok(dir) => Some(dir),
+            Err(error) => {
+                tracing::warn!(error = %error, "angle-set face-stack staging failed; likeness scores omitted");
+                None
+            }
+        }
+    } else {
+        None
+    };
+    let likeness_source = (angle_set && face_stack_dir.is_some()).then(|| references[0].clone());
+    let likeness_source_ref = reference_ids.first().cloned();
+
     let (width, height) = (request.width, request.height);
     let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
     let adapter_count = adapters.len();
@@ -450,7 +472,17 @@ async fn generate_flux2_edit_stream(
         spec,
         format!("{engine_id} load failed"),
         move |generator, tx, cancel| {
-            drive_gen_items(
+            // Build the per-job identity-likeness scorer ONCE here (on the generator-worker thread
+            // where the `!Send` face stack is allowed), embedding the source identity face a single
+            // time and reusing it across every angle (sc-4409 caching AC). `None` ⇒ not an angle set,
+            // or non-fatal construction failure ⇒ scores omitted; the set still renders.
+            let scorer = match (&face_stack_dir, &likeness_source) {
+                (Some(dir), Some(source)) => {
+                    crate::face_likeness::build_angle_set_scorer(dir, source)
+                }
+                _ => None,
+            };
+            drive_gen_items_scored(
                 tx,
                 seeds.into_iter().zip(prompts),
                 move |index, (seed, prompt), on_progress| {
@@ -499,7 +531,18 @@ async fn generate_flux2_edit_stream(
                         &cancel,
                         on_progress,
                     )?;
-                    Ok(Some((seed, out_w, out_h, pixels)))
+                    // Score this finished angle against the cached source embedding (sc-4409). `None`
+                    // scorer ⇒ no block ⇒ field omitted. Profile/up/down → honest detected:false N/A.
+                    let face_likeness = crate::face_likeness::score_angle_image(
+                        scorer.as_ref(),
+                        &Image {
+                            width: out_w,
+                            height: out_h,
+                            pixels: pixels.clone(),
+                        },
+                        likeness_source_ref.as_deref(),
+                    );
+                    Ok(Some((seed, out_w, out_h, pixels, face_likeness)))
                 },
             )
         },

--- a/crates/sceneworks-worker/src/image_jobs/flux2.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2.rs
@@ -531,17 +531,21 @@ async fn generate_flux2_edit_stream(
                         &cancel,
                         on_progress,
                     )?;
-                    // Score this finished angle against the cached source embedding (sc-4409). `None`
-                    // scorer ⇒ no block ⇒ field omitted. Profile/up/down → honest detected:false N/A.
-                    let face_likeness = crate::face_likeness::score_angle_image(
-                        scorer.as_ref(),
-                        &Image {
-                            width: out_w,
-                            height: out_h,
-                            pixels: pixels.clone(),
-                        },
-                        likeness_source_ref.as_deref(),
-                    );
+                    // Score this finished angle against the cached source embedding (sc-4409). The
+                    // Image build + pixel clone is paid ONLY when a scorer exists (an angle set) — the
+                    // common plain-edit path has no scorer, so this is a no-op with no clone. Profile/
+                    // up/down → honest detected:false N/A; `None` scorer ⇒ field omitted.
+                    let face_likeness = scorer.as_ref().and_then(|scorer| {
+                        crate::face_likeness::score_angle_image(
+                            Some(scorer),
+                            &Image {
+                                width: out_w,
+                                height: out_h,
+                                pixels: pixels.clone(),
+                            },
+                            likeness_source_ref.as_deref(),
+                        )
+                    });
                     Ok(Some((seed, out_w, out_h, pixels, face_likeness)))
                 },
             )

--- a/crates/sceneworks-worker/src/image_jobs/instantid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/instantid.rs
@@ -851,38 +851,19 @@ async fn generate_instantid_stream(
                 None
             };
             // Identity-likeness scorer (epic 4406, sc-4409): for an angle set, embed the source
-            // identity face ONCE here and reuse it across every angle. This is a SEPARATE SCRFD +
-            // ArcFace stack from the engine's `with_face` (the scorer is generator-agnostic on
-            // purpose — it must serve InstantID / Z-Image / Flux identity sets through one path), but
-            // it loads the SAME staged antelopev2 bundle, so no extra weights. Construction can fail
-            // (weights / a source with no detectable face) — that MUST NOT abort the generation, so
-            // any error becomes `None` (scoring simply absent) and the angle set still renders. Built
-            // only for the angle set; identity/pose modes don't score.
+            // identity face ONCE here and reuse it across every angle, through the SHARED
+            // generator-agnostic seam (the same `build_angle_set_scorer` the FLUX.2 / Qwen / SenseNova
+            // angle lanes call). It loads a SEPARATE SCRFD + ArcFace stack from the engine's
+            // `with_face`, but from the SAME staged antelopev2 bundle, so no extra weights.
+            // Construction is non-fatal (weights / no source face → `None` → scores omitted; the set
+            // still renders). Built only for the angle set; identity/pose modes don't score.
             #[cfg(any(
                 target_os = "macos",
                 all(not(target_os = "macos"), feature = "backend-candle")
             ))]
             let scorer: Option<crate::face_likeness::FaceLikenessScorer> = if angle_set {
                 let face_weights_dir = scrfd_path.parent().unwrap_or(scrfd_path.as_path());
-                #[cfg(target_os = "macos")]
-                let built =
-                    crate::face_likeness::FaceLikenessScorer::load_mlx(face_weights_dir, &reference);
-                #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-                let built = crate::face_likeness::FaceLikenessScorer::load_candle(
-                    face_weights_dir,
-                    &reference,
-                );
-                match built {
-                    Ok(scorer) => Some(scorer),
-                    Err(error) => {
-                        tracing::warn!(
-                            error = %error,
-                            "InstantID angle-set face-likeness scorer construction failed; \
-                             scores will be omitted (generation continues)"
-                        );
-                        None
-                    }
-                }
+                crate::face_likeness::build_angle_set_scorer(face_weights_dir, &reference)
             } else {
                 None
             };
@@ -1007,18 +988,15 @@ async fn generate_instantid_stream(
                         target_os = "macos",
                         all(not(target_os = "macos"), feature = "backend-candle")
                     ))]
-                    let face_likeness = scorer.as_ref().map(|scorer| {
-                        let scored = Image {
+                    let face_likeness = crate::face_likeness::score_angle_image(
+                        scorer.as_ref(),
+                        &Image {
                             width: out.width,
                             height: out.height,
                             pixels: out.pixels.clone(),
-                        };
-                        let result = scorer.score_or_null(&scored);
-                        crate::face_likeness::face_likeness_fact(
-                            &result,
-                            Some(face_likeness_source_ref.as_str()),
-                        )
-                    });
+                        },
+                        Some(face_likeness_source_ref.as_str()),
+                    );
                     #[cfg(not(any(
                         target_os = "macos",
                         all(not(target_os = "macos"), feature = "backend-candle")

--- a/crates/sceneworks-worker/src/image_jobs/instantid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/instantid.rs
@@ -981,22 +981,24 @@ async fn generate_instantid_stream(
                     // stack lives here). `score_or_null` makes per-image scoring non-fatal (a backend
                     // error → a logged `null`), and a profile / up / down view with no reliable
                     // frontal face records an honest `detected:false` N/A — never a misleading low
-                    // number. Build the persisted block once; `None` scorer (non-angle mode or a
-                    // failed construction) ⇒ no block ⇒ the field is omitted from the sidecar. Only
-                    // the generated pixels are cloned, and only when actually scoring.
+                    // number. `None` scorer (non-angle mode or a failed construction) ⇒ no block ⇒ the
+                    // field is omitted. The Image build + pixel clone is paid ONLY when a scorer exists
+                    // (an angle set) — identity/pose modes have no scorer, so this is a no-op, no clone.
                     #[cfg(any(
                         target_os = "macos",
                         all(not(target_os = "macos"), feature = "backend-candle")
                     ))]
-                    let face_likeness = crate::face_likeness::score_angle_image(
-                        scorer.as_ref(),
-                        &Image {
-                            width: out.width,
-                            height: out.height,
-                            pixels: out.pixels.clone(),
-                        },
-                        Some(face_likeness_source_ref.as_str()),
-                    );
+                    let face_likeness = scorer.as_ref().and_then(|scorer| {
+                        crate::face_likeness::score_angle_image(
+                            Some(scorer),
+                            &Image {
+                                width: out.width,
+                                height: out.height,
+                                pixels: out.pixels.clone(),
+                            },
+                            Some(face_likeness_source_ref.as_str()),
+                        )
+                    });
                     #[cfg(not(any(
                         target_os = "macos",
                         all(not(target_os = "macos"), feature = "backend-candle")

--- a/crates/sceneworks-worker/src/image_jobs/instantid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/instantid.rs
@@ -735,6 +735,18 @@ async fn generate_instantid_stream(
     );
 
     let negative_prompt = request.negative_prompt.clone();
+    // The reference asset id is the `sourceAssetId` recorded on each angle's `faceLikeness` block
+    // (sc-4408/sc-4409) so a consumer can attribute the score back to the source identity face.
+    // Captured as an owned String for the blocking closure. Only consumed on the angle-set scoring
+    // lane; allow it unused on the non-face-backend build.
+    #[cfg_attr(
+        not(any(
+            target_os = "macos",
+            all(not(target_os = "macos"), feature = "backend-candle")
+        )),
+        allow(unused_variables)
+    )]
+    let face_likeness_source_ref = reference_id.to_owned();
     let (cancel, rx, blocking) = start_gen_stream(
         job.id.clone(),
         "instantid",
@@ -838,15 +850,59 @@ async fn generate_instantid_stream(
             } else {
                 None
             };
-            Ok((model, reference, restore_embedding))
+            // Identity-likeness scorer (epic 4406, sc-4409): for an angle set, embed the source
+            // identity face ONCE here and reuse it across every angle. This is a SEPARATE SCRFD +
+            // ArcFace stack from the engine's `with_face` (the scorer is generator-agnostic on
+            // purpose — it must serve InstantID / Z-Image / Flux identity sets through one path), but
+            // it loads the SAME staged antelopev2 bundle, so no extra weights. Construction can fail
+            // (weights / a source with no detectable face) — that MUST NOT abort the generation, so
+            // any error becomes `None` (scoring simply absent) and the angle set still renders. Built
+            // only for the angle set; identity/pose modes don't score.
+            #[cfg(any(
+                target_os = "macos",
+                all(not(target_os = "macos"), feature = "backend-candle")
+            ))]
+            let scorer: Option<crate::face_likeness::FaceLikenessScorer> = if angle_set {
+                let face_weights_dir = scrfd_path.parent().unwrap_or(scrfd_path.as_path());
+                #[cfg(target_os = "macos")]
+                let built =
+                    crate::face_likeness::FaceLikenessScorer::load_mlx(face_weights_dir, &reference);
+                #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+                let built = crate::face_likeness::FaceLikenessScorer::load_candle(
+                    face_weights_dir,
+                    &reference,
+                );
+                match built {
+                    Ok(scorer) => Some(scorer),
+                    Err(error) => {
+                        tracing::warn!(
+                            error = %error,
+                            "InstantID angle-set face-likeness scorer construction failed; \
+                             scores will be omitted (generation continues)"
+                        );
+                        None
+                    }
+                }
+            } else {
+                None
+            };
+            #[cfg(not(any(
+                target_os = "macos",
+                all(not(target_os = "macos"), feature = "backend-candle")
+            )))]
+            let scorer: Option<()> = None;
+            Ok((model, reference, restore_embedding, scorer))
         },
-        move |(model, reference, restore_embedding), tx, cancel| {
+        move |(model, reference, restore_embedding, scorer), tx, cancel| {
             // The candle `generate*` / `restore_face` take `&mut self` (each call sets the face IP
             // tokens on the UNet before the denoise), so the per-item closure mutates `model`; the MLX
             // engine's are `&self`. Bind `mut` for the candle lane and allow the unused-mut on macOS.
             #[allow(unused_mut)]
             let mut model = model;
-            drive_gen_items(
+            // The scorer + its source-ref are moved into the per-item closure below; they live for
+            // the whole set so the source identity is embedded exactly ONCE (at construction, above)
+            // and reused across every angle.
+            drive_gen_items_scored(
                 tx,
                 work,
                 move |_index, (seed, prompt, action), on_progress| {
@@ -939,7 +995,39 @@ async fn generate_instantid_stream(
                             }
                         };
                     }
-                    Ok(Some((seed, out.width, out.height, out.pixels)))
+                    // Identity-likeness post-pass (sc-4409): score this finished angle against the
+                    // per-job cached source embedding, on this blocking thread (the `!Send` face
+                    // stack lives here). `score_or_null` makes per-image scoring non-fatal (a backend
+                    // error → a logged `null`), and a profile / up / down view with no reliable
+                    // frontal face records an honest `detected:false` N/A — never a misleading low
+                    // number. Build the persisted block once; `None` scorer (non-angle mode or a
+                    // failed construction) ⇒ no block ⇒ the field is omitted from the sidecar. Only
+                    // the generated pixels are cloned, and only when actually scoring.
+                    #[cfg(any(
+                        target_os = "macos",
+                        all(not(target_os = "macos"), feature = "backend-candle")
+                    ))]
+                    let face_likeness = scorer.as_ref().map(|scorer| {
+                        let scored = Image {
+                            width: out.width,
+                            height: out.height,
+                            pixels: out.pixels.clone(),
+                        };
+                        let result = scorer.score_or_null(&scored);
+                        crate::face_likeness::face_likeness_fact(
+                            &result,
+                            Some(face_likeness_source_ref.as_str()),
+                        )
+                    });
+                    #[cfg(not(any(
+                        target_os = "macos",
+                        all(not(target_os = "macos"), feature = "backend-candle")
+                    )))]
+                    let face_likeness: Option<JsonObject> = {
+                        let _ = (&scorer, &face_likeness_source_ref);
+                        None
+                    };
+                    Ok(Some((seed, out.width, out.height, out.pixels, face_likeness)))
                 },
             )
         },

--- a/crates/sceneworks-worker/src/image_jobs/qwen.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen.rs
@@ -772,17 +772,21 @@ async fn generate_qwen_edit_stream(
                         &cancel,
                         on_progress,
                     )?;
-                    // Score this finished angle against the cached source embedding (sc-4409). `None`
-                    // scorer ⇒ field omitted. Profile/up/down → honest detected:false N/A.
-                    let face_likeness = crate::face_likeness::score_angle_image(
-                        scorer.as_ref(),
-                        &Image {
-                            width: out_w,
-                            height: out_h,
-                            pixels: pixels.clone(),
-                        },
-                        likeness_source_ref.as_deref(),
-                    );
+                    // Score this finished angle against the cached source embedding (sc-4409). The
+                    // Image build + pixel clone is paid ONLY when a scorer exists (an angle set) — the
+                    // common plain-edit path has no scorer, so this is a no-op with no clone. Profile/
+                    // up/down → honest detected:false N/A; `None` scorer ⇒ field omitted.
+                    let face_likeness = scorer.as_ref().and_then(|scorer| {
+                        crate::face_likeness::score_angle_image(
+                            Some(scorer),
+                            &Image {
+                                width: out_w,
+                                height: out_h,
+                                pixels: pixels.clone(),
+                            },
+                            likeness_source_ref.as_deref(),
+                        )
+                    });
                     Ok(Some((seed, out_w, out_h, pixels, face_likeness)))
                 },
             )

--- a/crates/sceneworks-worker/src/image_jobs/qwen.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen.rs
@@ -675,6 +675,26 @@ async fn generate_qwen_edit_stream(
         );
     }
 
+    // Angle-set identity-likeness scoring (epic 4406, sc-4409): generator-agnostic — a Character-
+    // Studio angle set on Qwen-Edit is scored through the same shared seam as InstantID / FLUX.2.
+    // Stage the antelopev2 face stack (shared bundle, no-op if cached) and capture the source identity
+    // reference + asset id; the `!Send` scorer is built ONCE in the closure and reused across angles.
+    // Angle-set only; staging is non-fatal (failure → no scorer → scores omitted, set still renders).
+    let angle_set = matches!(grouping, Flux2Grouping::Angles);
+    let face_stack_dir = if angle_set {
+        match ensure_face_stack_dir(api, settings, job).await {
+            Ok(dir) => Some(dir),
+            Err(error) => {
+                tracing::warn!(error = %error, "angle-set face-stack staging failed; likeness scores omitted");
+                None
+            }
+        }
+    } else {
+        None
+    };
+    let likeness_source = (angle_set && face_stack_dir.is_some()).then(|| references[0].clone());
+    let likeness_source_ref = reference_ids.first().cloned();
+
     let (width, height) = (request.width, request.height);
     let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
     let adapter_count = adapters.len();
@@ -694,7 +714,15 @@ async fn generate_qwen_edit_stream(
         spec,
         format!("{engine_id} load failed"),
         move |generator, tx, cancel| {
-            drive_gen_items(
+            // Per-job identity-likeness scorer built ONCE on the generator-worker thread (the `!Send`
+            // face stack lives here); source embedded once, reused across every angle (sc-4409).
+            let scorer = match (&face_stack_dir, &likeness_source) {
+                (Some(dir), Some(source)) => {
+                    crate::face_likeness::build_angle_set_scorer(dir, source)
+                }
+                _ => None,
+            };
+            drive_gen_items_scored(
                 tx,
                 seeds.into_iter().zip(prompts),
                 move |index, (seed, prompt), on_progress| {
@@ -744,7 +772,18 @@ async fn generate_qwen_edit_stream(
                         &cancel,
                         on_progress,
                     )?;
-                    Ok(Some((seed, out_w, out_h, pixels)))
+                    // Score this finished angle against the cached source embedding (sc-4409). `None`
+                    // scorer ⇒ field omitted. Profile/up/down → honest detected:false N/A.
+                    let face_likeness = crate::face_likeness::score_angle_image(
+                        scorer.as_ref(),
+                        &Image {
+                            width: out_w,
+                            height: out_h,
+                            pixels: pixels.clone(),
+                        },
+                        likeness_source_ref.as_deref(),
+                    );
+                    Ok(Some((seed, out_w, out_h, pixels, face_likeness)))
                 },
             )
         },

--- a/crates/sceneworks-worker/src/image_jobs/sensenova.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sensenova.rs
@@ -302,17 +302,21 @@ async fn generate_sensenova_edit_stream(
                         &cancel,
                         on_progress,
                     )?;
-                    // Score this finished angle against the cached source embedding (sc-4409). `None`
-                    // scorer ⇒ field omitted. Profile/up/down → honest detected:false N/A.
-                    let face_likeness = crate::face_likeness::score_angle_image(
-                        scorer.as_ref(),
-                        &Image {
-                            width: w,
-                            height: h,
-                            pixels: pixels.clone(),
-                        },
-                        likeness_source_ref.as_deref(),
-                    );
+                    // Score this finished angle against the cached source embedding (sc-4409). The
+                    // Image build + pixel clone is paid ONLY when a scorer exists (an angle set) — the
+                    // common plain-edit path has no scorer, so this is a no-op with no clone. Profile/
+                    // up/down → honest detected:false N/A; `None` scorer ⇒ field omitted.
+                    let face_likeness = scorer.as_ref().and_then(|scorer| {
+                        crate::face_likeness::score_angle_image(
+                            Some(scorer),
+                            &Image {
+                                width: w,
+                                height: h,
+                                pixels: pixels.clone(),
+                            },
+                            likeness_source_ref.as_deref(),
+                        )
+                    });
                     Ok(Some((seed, w, h, pixels, face_likeness)))
                 },
             )

--- a/crates/sceneworks-worker/src/image_jobs/sensenova.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sensenova.rs
@@ -243,6 +243,26 @@ async fn generate_sensenova_edit_stream(
         raw_settings.insert("angleSet".to_owned(), Value::Bool(true));
     }
 
+    // Angle-set identity-likeness scoring (epic 4406, sc-4409): generator-agnostic — a Character-
+    // Studio angle set on SenseNova-U1 is scored through the same shared seam as InstantID / FLUX.2 /
+    // Qwen. Stage the antelopev2 face stack (shared bundle, no-op if cached) and capture the source
+    // identity reference + asset id; the `!Send` scorer is built ONCE in the closure and reused across
+    // angles. Angle-set only; staging is non-fatal (failure → no scorer → scores omitted, set renders).
+    let angle_set = matches!(grouping, Flux2Grouping::Angles);
+    let face_stack_dir = if angle_set {
+        match ensure_face_stack_dir(api, settings, job).await {
+            Ok(dir) => Some(dir),
+            Err(error) => {
+                tracing::warn!(error = %error, "angle-set face-stack staging failed; likeness scores omitted");
+                None
+            }
+        }
+    } else {
+        None
+    };
+    let likeness_source = (angle_set && face_stack_dir.is_some()).then(|| references[0].clone());
+    let likeness_source_ref = reference_ids.first().cloned();
+
     // No user adapters by design (sc-6038): SenseNova-U1 is an 8B MoT autoregressive model with no
     // diffusion-LoRA merge path, and its manifest declares `loraCompatibility.families:
     // ["sensenova-u1"]` (its own family — no LoRA declares it), so the picker offers none. The empty
@@ -256,7 +276,15 @@ async fn generate_sensenova_edit_stream(
         spec,
         format!("{engine_id} load failed"),
         move |generator, tx, cancel| {
-            drive_gen_items(
+            // Per-job identity-likeness scorer built ONCE on the generator-worker thread (the `!Send`
+            // face stack lives here); source embedded once, reused across every angle (sc-4409).
+            let scorer = match (&face_stack_dir, &likeness_source) {
+                (Some(dir), Some(source)) => {
+                    crate::face_likeness::build_angle_set_scorer(dir, source)
+                }
+                _ => None,
+            };
+            drive_gen_items_scored(
                 tx,
                 seeds.into_iter().zip(prompts),
                 move |_index, (seed, prompt), on_progress| {
@@ -274,7 +302,18 @@ async fn generate_sensenova_edit_stream(
                         &cancel,
                         on_progress,
                     )?;
-                    Ok(Some((seed, w, h, pixels)))
+                    // Score this finished angle against the cached source embedding (sc-4409). `None`
+                    // scorer ⇒ field omitted. Profile/up/down → honest detected:false N/A.
+                    let face_likeness = crate::face_likeness::score_angle_image(
+                        scorer.as_ref(),
+                        &Image {
+                            width: w,
+                            height: h,
+                            pixels: pixels.clone(),
+                        },
+                        likeness_source_ref.as_deref(),
+                    );
+                    Ok(Some((seed, w, h, pixels, face_likeness)))
                 },
             )
         },

--- a/crates/sceneworks-worker/src/image_jobs/stream.rs
+++ b/crates/sceneworks-worker/src/image_jobs/stream.rs
@@ -25,9 +25,9 @@ enum GenEvent {
 type GeneratedImage = (i64, u32, u32, Vec<u8>);
 
 /// A generated image plus its optional pre-built `faceLikeness` sidecar block (sc-4409). Returned by
-/// the per-item closure of [`drive_gen_items_scored`] so the identity-likeness post-pass (currently
-/// the InstantID angle set) can attach a per-image score without disturbing the shared
-/// [`GeneratedImage`] tuple every other generator returns.
+/// the per-item closure of [`drive_gen_items_scored`] so the identity-likeness post-pass (used by all
+/// four angle-set lanes — InstantID, FLUX.2 edit, Qwen-Edit, SenseNova-U1) can attach a per-image
+/// score without disturbing the shared [`GeneratedImage`] tuple every other generator returns.
 type ScoredGeneratedImage = (i64, u32, u32, Vec<u8>, Option<JsonObject>);
 
 fn send_gen_progress(tx: &tokio::sync::mpsc::Sender<GenEvent>, index: usize, progress: Progress) {
@@ -107,13 +107,14 @@ where
 
 /// Like [`drive_gen_items`] but the per-item closure additionally returns an optional pre-built
 /// `faceLikeness` sidecar block (sc-4409), carried through to `consume_gen_events` for per-image
-/// persistence. Used by the InstantID angle-set path, which scores each finished view against the
-/// per-job cached source identity embedding on this same blocking thread (the `!Send` MLX face stack
-/// lives entirely here). Every non-scoring path keeps using [`drive_gen_items`].
+/// persistence. Used by all four angle-set lanes — InstantID, FLUX.2 edit, Qwen-Edit, and
+/// SenseNova-U1 — each of which scores every finished view against the per-job cached source identity
+/// embedding on its generation thread (the `!Send` face stack lives there). Every non-scoring path
+/// keeps using [`drive_gen_items`].
 //
-// The InstantID lane is the only scored producer today; off-Mac it compiles only with the candle
-// backend (the angle-set scorer's backend legs are cfg-gated the same way), so allow it dead when
-// neither face backend is present.
+// The scored producers are all face-backend paths; off-Mac they compile only with the candle backend
+// (the angle-set scorer's backend legs are cfg-gated the same way), so allow this dead when neither
+// face backend is present.
 #[cfg_attr(
     not(any(
         target_os = "macos",

--- a/crates/sceneworks-worker/src/image_jobs/stream.rs
+++ b/crates/sceneworks-worker/src/image_jobs/stream.rs
@@ -13,10 +13,22 @@ enum GenEvent {
         width: u32,
         height: u32,
         pixels: Vec<u8>,
+        /// Pre-built `faceLikeness` sidecar block (epic 4406, sc-4409) for this image, or `None`
+        /// when the producing path did not score it. `consume_gen_events` inserts a `Some` block
+        /// verbatim into the per-image `rawAdapterSettings` under
+        /// [`face_likeness::FACE_LIKENESS_FACT_KEY`] — the omit-when-absent persistence seam, so a
+        /// path that doesn't score (every non-angle-set path) is untouched.
+        face_likeness: Option<JsonObject>,
     },
 }
 
 type GeneratedImage = (i64, u32, u32, Vec<u8>);
+
+/// A generated image plus its optional pre-built `faceLikeness` sidecar block (sc-4409). Returned by
+/// the per-item closure of [`drive_gen_items_scored`] so the identity-likeness post-pass (currently
+/// the InstantID angle set) can attach a per-image score without disturbing the shared
+/// [`GeneratedImage`] tuple every other generator returns.
+type ScoredGeneratedImage = (i64, u32, u32, Vec<u8>, Option<JsonObject>);
 
 fn send_gen_progress(tx: &tokio::sync::mpsc::Sender<GenEvent>, index: usize, progress: Progress) {
     let event = match progress {
@@ -42,6 +54,25 @@ fn send_generated_image(
         width,
         height,
         pixels,
+        face_likeness: None,
+    })
+    .is_ok()
+}
+
+/// Like [`send_generated_image`] but carries the optional pre-built `faceLikeness` block (sc-4409).
+fn send_scored_generated_image(
+    tx: &tokio::sync::mpsc::Sender<GenEvent>,
+    index: usize,
+    image: ScoredGeneratedImage,
+) -> bool {
+    let (seed, width, height, pixels, face_likeness) = image;
+    tx.blocking_send(GenEvent::Image {
+        index,
+        seed,
+        width,
+        height,
+        pixels,
+        face_likeness,
     })
     .is_ok()
 }
@@ -69,6 +100,44 @@ where
         // ceiling — an OS memory-pressure SIGKILL (Jetsam) that the dense SenseNova-U1 8B
         // family hits first (sc-5567). Frees only freed/retained buffers; the cached
         // generator's live weight arrays are untouched.
+        release_gen_cache_between_items();
+    }
+    Ok(())
+}
+
+/// Like [`drive_gen_items`] but the per-item closure additionally returns an optional pre-built
+/// `faceLikeness` sidecar block (sc-4409), carried through to `consume_gen_events` for per-image
+/// persistence. Used by the InstantID angle-set path, which scores each finished view against the
+/// per-job cached source identity embedding on this same blocking thread (the `!Send` MLX face stack
+/// lives entirely here). Every non-scoring path keeps using [`drive_gen_items`].
+//
+// The InstantID lane is the only scored producer today; off-Mac it compiles only with the candle
+// backend (the angle-set scorer's backend legs are cfg-gated the same way), so allow it dead when
+// neither face backend is present.
+#[cfg_attr(
+    not(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    )),
+    allow(dead_code)
+)]
+fn drive_gen_items_scored<I, Item, F>(
+    tx: tokio::sync::mpsc::Sender<GenEvent>,
+    items: I,
+    mut generate: F,
+) -> WorkerResult<()>
+where
+    I: IntoIterator<Item = Item>,
+    F: FnMut(usize, Item, &mut dyn FnMut(Progress)) -> WorkerResult<Option<ScoredGeneratedImage>>,
+{
+    for (index, item) in items.into_iter().enumerate() {
+        let mut on_progress = |progress| send_gen_progress(&tx, index, progress);
+        let Some(image) = generate(index, item, &mut on_progress)? else {
+            break;
+        };
+        if !send_scored_generated_image(&tx, index, image) {
+            break;
+        }
         release_gen_cache_between_items();
     }
     Ok(())


### PR DESCRIPTION
## What changed

Wires the shared identity-likeness scorer (sc-4407 `FaceLikenessScorer`) into **every angle-set generator** (`advanced.angleSet === true`, the ~11-view set) and persists a per-image likeness score via the sc-4408 sidecar seam. Angle-set generation is **not** InstantID-only — `resolve_image_route` sends a `character_image` + reference + `angleSet` job to FLUX.2 edit, Qwen-Edit, or SenseNova-U1 *before* InstantID — so the scorer is hooked generator-agnostically across all four lanes.

### Shared, generator-agnostic seam (`face_likeness.rs`)
- `build_angle_set_scorer(weights_dir, source) -> Option<FaceLikenessScorer>` — non-fatal construction: a missing/corrupt weights bundle or a source with no detectable face is logged and becomes `None` (scores absent), never an abort.
- `score_angle_image(scorer: Option<&_>, image, source_ref) -> Option<JsonObject>` — the per-image post-pass: `score_or_null` + `face_likeness_fact`; `None` scorer ⇒ `None` ⇒ field omitted.

### Wired into all angle lanes
- **InstantID** (`instantid.rs`), **FLUX.2 edit** (`flux2.rs`), **Qwen-Edit** (`qwen.rs`), **SenseNova-U1** (`sensenova.rs`). Each, only on the Angles grouping: stages the antelopev2 face stack (`ensure_face_stack_dir`, the same bundle InstantID uses — no-op if cached), captures the source identity reference + its asset id, builds **one** scorer per job on the generator-worker / blocking thread (source ArcFace embedding computed once, reused across all angles), and scores each finished view through `drive_gen_items_scored` → `GenEvent::Image.face_likeness` → `consume_gen_events`, which inserts the block into a **per-image clone** of `rawAdapterSettings.faceLikeness`. Lands at `recipe.rawAdapterSettings.faceLikeness`.

### Contracts held everywhere
- **Source embedded once per job**, reused across all angles (no per-image re-embed) — asserted via the cached-source counter + backend-call count.
- **Non-fatal, both legs**: construction guarded (weights/staging/no-source-face → `None` scorer → scores omitted, set still renders) AND per-image scoring via `score_or_null`.
- **Metric honesty**: profile / up / down views with no reliable frontal face record an explicit `detected:false` N/A block (with `reason`), not a misleading low number. Low-confidence detections record `low_confidence` N/A.
- Every non-angle-set / non-scoring path passes `None` → the field is omitted (sc-4408 omit-when-absent).

## Scope vs acceptance criteria

- [x] Angle set yields a per-image likeness score for frontal/three-quarter views and `detected:false` N/A for extreme profiles — on **InstantID, FLUX.2, Qwen, and SenseNova** angle sets.
- [x] Scores land in each asset's sidecar (`rawAdapterSettings.faceLikeness`).
- [x] Source embedded once per job, reused across all angles, on every path.
- [x] No measurable slowdown beyond the expected per-image detect+embed (generated pixels cloned only when scoring; source forward runs once per job).

## Tests

Weight-free stub-backend tests in `face_likeness.rs` (`angle_set_wiring` mod), runnable in CI on the face-backend build:
- `score_angle_image_attaches_block_and_embeds_source_once_across_a_set` — the shared per-image seam all four lanes call: each angle attaches a block, source embedded once across an N-view set (1 source embed + 1 detect/angle, no re-embed).
- `score_angle_image_no_face_attaches_detected_false_block` / `score_angle_image_none_scorer_omits_block` — N/A persistence + omit-when-absent.
- `source_embedded_once_across_n_angles_each_attaches_a_block`, `profile_no_face_angle_records_detected_false_not_a_low_number`, `no_source_face_makes_every_angle_na_but_never_fails_the_job`, `low_confidence_angle_records_low_confidence_na`, `omitted_when_scorer_absent`.

The real-weight end-to-end (per-engine) remains the existing `#[ignore]` test (`build_angle_set_scorer` needs the antelopev2 bundle).

## Verification

`npm run rust:check` green: `cargo fmt --all --check`, `cargo clippy --all-targets -D warnings`, full workspace `cargo test` (sceneworks-worker 453 pass / 98 ignored, incl. 24 face_likeness), and `cargo build` — all pass locally on macOS (Apple Silicon).

## Follow-ups

- None blocking. The candle lanes share the same seam (cfg-gated identically); off-Mac real-weight validation runs via the same `#[ignore]` harness with candle weights.