### PR TITLE
fix(worker): generalize heartbeat keepalive to all long-inline job paths (sc-8390)

### DIFF
--- a/crates/sceneworks-worker/src/kps_jobs.rs
+++ b/crates/sceneworks-worker/src/kps_jobs.rs
@@ -40,8 +40,8 @@ use crate::image_jobs::ensure_face_stack_dir;
 use crate::image_jobs::ensure_scrfd_weights;
 use crate::image_jobs::load_reference_image;
 use crate::{
-    heartbeat, normalize_app_managed_cache_path, progress_payload, task_join_error, update_job,
-    ApiClient, Settings, WorkerError, WorkerResult,
+    heartbeat, normalize_app_managed_cache_path, progress_payload, run_blocking_with_heartbeat,
+    update_job, ApiClient, Settings, WorkerError, WorkerResult,
 };
 use sceneworks_core::contracts::{JobSnapshot, JobStatus, JsonObject, ProgressStage, WorkerStatus};
 use sceneworks_core::project_store::ProjectStore;
@@ -337,18 +337,27 @@ pub(crate) async fn run_kps_extract_job(
     )
     .await?;
 
-    let extraction = tokio::task::spawn_blocking(move || {
-        #[cfg(target_os = "macos")]
-        {
-            detect_largest_kps(&weights, &image)
-        }
-        #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-        {
-            detect_largest_kps_candle(&weights, &image)
-        }
-    })
-    .await
-    .map_err(|error| task_join_error("kps extraction task", error))??;
+    // Keep the worker heartbeat alive across the blocking SCRFD detect (cold weight load can run
+    // long) so a slow extraction never trips the API's 90s stale-sweep (sc-8390). Not cancelable.
+    let extraction = run_blocking_with_heartbeat(
+        api,
+        settings,
+        &job.id,
+        None,
+        "",
+        "kps extraction task",
+        tokio::task::spawn_blocking(move || {
+            #[cfg(target_os = "macos")]
+            {
+                detect_largest_kps(&weights, &image)
+            }
+            #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+            {
+                detect_largest_kps_candle(&weights, &image)
+            }
+        }),
+    )
+    .await?;
 
     let message = if extraction.detected {
         "Face landmarks extracted."

--- a/crates/sceneworks-worker/src/media_jobs.rs
+++ b/crates/sceneworks-worker/src/media_jobs.rs
@@ -594,11 +594,21 @@ async fn run_yolo11_person_detect(
     };
     let weights = crate::person_jobs::ensure_detector_weights(settings, &download_context).await?;
     let conf = confidence as f32;
-    let result = tokio::task::spawn_blocking(move || {
-        crate::person_jobs::detect_people_blocking(weights, frame_path, conf)
-    })
-    .await
-    .map_err(|error| task_join_error("person detect task", error))??;
+    // Keep the worker heartbeat alive across the blocking YOLO11 detect (cold weight load +
+    // inference) so a slow detection never trips the API's 90s stale-sweep (sc-8390). Not
+    // cancelable mid-inference.
+    let result = run_blocking_with_heartbeat(
+        api,
+        settings,
+        &job.id,
+        None,
+        "",
+        "person detect task",
+        tokio::task::spawn_blocking(move || {
+            crate::person_jobs::detect_people_blocking(weights, frame_path, conf)
+        }),
+    )
+    .await?;
     let boxes =
         crate::person_jobs::detections_to_json(&result.detections, result.width, result.height);
     Ok((boxes, result.device))

--- a/crates/sceneworks-worker/src/pose_jobs.rs
+++ b/crates/sceneworks-worker/src/pose_jobs.rs
@@ -42,7 +42,8 @@ use serde_json::{json, Value};
 use crate::openpose_skeleton::{body_stickwidth, draw_wholebody, Keypoint};
 use crate::{
     heartbeat, normalize_app_managed_cache_path, optional_payload_string, progress_payload,
-    task_join_error, update_job, ApiClient, Settings, WorkerError, WorkerResult,
+    run_blocking_with_heartbeat, task_join_error, update_job, ApiClient, Settings, WorkerError,
+    WorkerResult,
 };
 use sceneworks_core::contracts::{JobSnapshot, JobStatus, JsonObject, ProgressStage, WorkerStatus};
 use sceneworks_core::project_store::ProjectStore;
@@ -873,10 +874,18 @@ pub(crate) async fn run_pose_detect_job(
     )
     .await?;
     let image_paths: Vec<Option<PathBuf>> = resolved.iter().map(|s| s.path.clone()).collect();
-    let (raw, device) =
-        tokio::task::spawn_blocking(move || detect_batch(det_path, pose_path, image_paths))
-            .await
-            .map_err(|error| task_join_error("pose detection task", error))??;
+    // Keep the worker heartbeat alive across the blocking batch detect (cold RTMW/onnx load +
+    // multi-image inference can run long) so it never trips the API's 90s stale-sweep (sc-8390).
+    let (raw, device) = run_blocking_with_heartbeat(
+        api,
+        settings,
+        &job.id,
+        None,
+        "",
+        "pose detection task",
+        tokio::task::spawn_blocking(move || detect_batch(det_path, pose_path, image_paths)),
+    )
+    .await?;
 
     let out_dir = settings
         .data_dir

--- a/crates/sceneworks-worker/src/progress.rs
+++ b/crates/sceneworks-worker/src/progress.rs
@@ -55,6 +55,71 @@ pub(crate) async fn mark_job_canceled(
     Ok(())
 }
 
+/// Run a long, self-contained blocking `task` while keeping the worker's heartbeat alive (and,
+/// when given a `cancel` flag, honoring a user cancel). This is the SHARED keepalive every
+/// long-inline compute path should use: the Rust worker sends no periodic heartbeat on its own
+/// during a job, and posting job *progress* does NOT refresh the worker's `last_seen` (only a
+/// terminal status does), so without a `Busy` ping every `progress_report_interval` (5–15s) a job
+/// that runs silently past the API's worker-timeout (default 90s) gets swept to `interrupted`
+/// mid-flight — then the worker's next post is 409'd and the job looks "stuck" (sc-8200, sc-8390).
+///
+/// Before this existed the same `select!` was open-coded per handler, so new paths (LoRA training,
+/// VQA, pose/kps/person-detect) were missed — exactly the gap that hung a Krea2 LoRA run at a slow
+/// step-500 checkpoint save. Streaming consumers that already own an event loop
+/// (`training_jobs::consume_training_events`, caption/model/prompt/media/video) inline the same
+/// interval arm instead; this helper is for the single-blocking-task shape.
+///
+/// `task` must own all its work — it cannot report progress between ticks. The helper pings
+/// `WorkerStatus::Busy` every interval without posting any intermediate job status. When `cancel`
+/// is `Some`, it also polls the API for a user cancel and trips the flag; un-interruptible compute
+/// finishes its current op, then we post the terminal `Canceled` (`cancel_message`) and return
+/// `WorkerError::Canceled`. Pass `None` for paths with no cancelable work (heartbeat only).
+///
+/// Every consumer is a job handler gated behind `any(target_os = "macos", feature =
+/// "backend-candle")`, so on the plain-Linux parity build (neither) this is unused — allow
+/// dead_code there only, keeping real dead-code detection on the configs that do call it.
+#[cfg_attr(
+    all(not(target_os = "macos"), not(feature = "backend-candle")),
+    allow(dead_code)
+)]
+pub(crate) async fn run_blocking_with_heartbeat<R>(
+    api: &ApiClient,
+    settings: &Settings,
+    job_id: &str,
+    cancel: Option<gen_core::CancelFlag>,
+    cancel_message: &str,
+    task_label: &'static str,
+    mut task: tokio::task::JoinHandle<WorkerResult<R>>,
+) -> WorkerResult<R>
+where
+    R: Send + 'static,
+{
+    let mut canceled = false;
+    let mut interval = tokio::time::interval(progress_report_interval(settings));
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        tokio::select! {
+            result = &mut task => {
+                let value = result.map_err(|error| task_join_error(task_label, error))??;
+                if canceled {
+                    mark_job_canceled(api, job_id, cancel_message).await?;
+                    return Err(WorkerError::Canceled(cancel_message.to_owned()));
+                }
+                return Ok(value);
+            }
+            _ = interval.tick() => {
+                heartbeat(api, settings, WorkerStatus::Busy, Some(job_id)).await?;
+                if let Some(flag) = &cancel {
+                    if !canceled && cancel_requested_peek(api, job_id).await {
+                        flag.cancel();
+                        canceled = true;
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Check-only cancel poll (sc-5515): returns `true` when the user requested
 /// cancellation, WITHOUT posting any status. Unlike [`check_cancel`] this never
 /// writes the terminal `Canceled`. In-loop generation/training pollers that sit in

--- a/crates/sceneworks-worker/src/segment_jobs.rs
+++ b/crates/sceneworks-worker/src/segment_jobs.rs
@@ -29,9 +29,8 @@ use crate::person_segment_sam3::{
     ensure_segmenter_weights, segment_box_blocking, segment_points_blocking,
 };
 use crate::{
-    cancel_requested_peek, fresh_asset_id, heartbeat, mark_job_canceled, now_rfc3339,
-    progress_payload, progress_report_interval, task_join_error, update_job, ApiClient, Settings,
-    WorkerError, WorkerResult,
+    fresh_asset_id, heartbeat, now_rfc3339, progress_payload, run_blocking_with_heartbeat,
+    update_job, ApiClient, Settings, WorkerError, WorkerResult,
 };
 use sceneworks_core::contracts::{JobSnapshot, JobStatus, JsonObject, ProgressStage, WorkerStatus};
 use sceneworks_core::project_store::ProjectStore;
@@ -137,43 +136,6 @@ fn parse_points(payload: &JsonObject) -> WorkerResult<Option<Vec<(f32, f32, i32)
         out.push((x, y, label));
     }
     Ok(Some(out))
-}
-
-/// Heartbeat + cancel poll while the blocking segmentation task runs (mirrors
-/// `upscale_jobs::run_upscale_with_heartbeat`): keeps the worker live during the model load +
-/// inference and propagates a user cancel.
-async fn run_with_heartbeat<R>(
-    api: &ApiClient,
-    settings: &Settings,
-    job_id: &str,
-    cancel: CancelFlag,
-    mut task: tokio::task::JoinHandle<WorkerResult<R>>,
-) -> WorkerResult<R>
-where
-    R: Send + 'static,
-{
-    let mut canceled = false;
-    let mut interval = tokio::time::interval(progress_report_interval(settings));
-    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-    loop {
-        tokio::select! {
-            result = &mut task => {
-                let value = result.map_err(|error| task_join_error("smart-select task", error))??;
-                if canceled {
-                    mark_job_canceled(api, job_id, CANCEL_MESSAGE).await?;
-                    return Err(WorkerError::Canceled(CANCEL_MESSAGE.to_owned()));
-                }
-                return Ok(value);
-            }
-            _ = interval.tick() => {
-                heartbeat(api, settings, WorkerStatus::Busy, Some(job_id)).await?;
-                if !canceled && cancel_requested_peek(api, job_id).await {
-                    cancel.cancel();
-                    canceled = true;
-                }
-            }
-        }
-    }
 }
 
 pub(crate) async fn run_image_segment_job(
@@ -320,11 +282,13 @@ pub(crate) async fn run_image_segment_job(
     let cancel = CancelFlag::new();
     // Points → SAM3 tracker single-frame PVS (interactive clicks); box → SAM3 concept detector.
     let mask = if let Some(points) = points {
-        run_with_heartbeat(
+        run_blocking_with_heartbeat(
             api,
             settings,
             &job.id,
-            cancel.clone(),
+            Some(cancel.clone()),
+            CANCEL_MESSAGE,
+            "smart-select task",
             tokio::task::spawn_blocking(move || {
                 segment_points_blocking(model_path, source_image, points)
             }),
@@ -332,11 +296,13 @@ pub(crate) async fn run_image_segment_job(
         .await?
     } else {
         let box_xyxy = box_xyxy.expect("box prompt present when there are no points");
-        run_with_heartbeat(
+        run_blocking_with_heartbeat(
             api,
             settings,
             &job.id,
-            cancel.clone(),
+            Some(cancel.clone()),
+            CANCEL_MESSAGE,
+            "smart-select task",
             tokio::task::spawn_blocking(move || {
                 segment_box_blocking(
                     model_path,

--- a/crates/sceneworks-worker/src/sensenova_jobs.rs
+++ b/crates/sceneworks-worker/src/sensenova_jobs.rs
@@ -182,31 +182,41 @@ pub(crate) async fn run_vqa_job(
 
     let job_id = job.id.clone();
     let question_for_vqa = question.clone();
-    let answer = tokio::task::spawn_blocking(move || -> WorkerResult<String> {
-        emit_load_event("image_pipeline_load_start", &job_id, "sensenova_u1_8b", 0);
-        let (model, tokenizer) = load_sensenova_model(&weights_dir)?;
-        emit_load_event(
-            "image_pipeline_load_complete",
-            &job_id,
-            "sensenova_u1_8b",
-            0,
-        );
-        // ImageNet-normalized inside `vqa`; pass [3,H,W] in [0,1], 32-aligned, within the
-        // understanding pixel budget (default 768², `load_image_native` min 256²).
-        let pixel_values = image_to_chw01(&source, 256 * 256, max_image_pixels)?;
-        let answer = model
-            .vqa(
-                &tokenizer,
-                &question_for_vqa,
-                std::slice::from_ref(&pixel_values),
-                max_new_tokens,
-                Sampler::Greedy,
-            )
-            .map_err(|error| WorkerError::Engine(format!("SenseNova VQA failed: {error}")))?;
-        Ok(strip_reasoning(&answer))
-    })
-    .await
-    .map_err(|error| task_join_error("VQA task join", error))??;
+    // Keep the worker heartbeat alive across the blocking VLM load + generation (a cold
+    // SenseNova-U1 8B load + long answer easily exceeds the API's 90s stale-sweep) so the in-flight
+    // job is never falsely marked `interrupted` (sc-8390). Not cancelable mid-generation.
+    let answer = run_blocking_with_heartbeat(
+        api,
+        settings,
+        &job.id,
+        None,
+        "",
+        "VQA task join",
+        tokio::task::spawn_blocking(move || -> WorkerResult<String> {
+            emit_load_event("image_pipeline_load_start", &job_id, "sensenova_u1_8b", 0);
+            let (model, tokenizer) = load_sensenova_model(&weights_dir)?;
+            emit_load_event(
+                "image_pipeline_load_complete",
+                &job_id,
+                "sensenova_u1_8b",
+                0,
+            );
+            // ImageNet-normalized inside `vqa`; pass [3,H,W] in [0,1], 32-aligned, within the
+            // understanding pixel budget (default 768², `load_image_native` min 256²).
+            let pixel_values = image_to_chw01(&source, 256 * 256, max_image_pixels)?;
+            let answer = model
+                .vqa(
+                    &tokenizer,
+                    &question_for_vqa,
+                    std::slice::from_ref(&pixel_values),
+                    max_new_tokens,
+                    Sampler::Greedy,
+                )
+                .map_err(|error| WorkerError::Engine(format!("SenseNova VQA failed: {error}")))?;
+            Ok(strip_reasoning(&answer))
+        }),
+    )
+    .await?;
 
     let result = json!({
         "answer": answer,
@@ -334,32 +344,42 @@ pub(crate) async fn run_vqa_job(
 
     let job_id = job.id.clone();
     let question_for_vqa = question.clone();
-    let answer = tokio::task::spawn_blocking(move || -> WorkerResult<String> {
-        emit_load_event("image_pipeline_load_start", &job_id, "sensenova_u1_8b", 0);
-        let (model, tokenizer) = load_understanding(&weights_dir)
-            .map_err(|error| WorkerError::Engine(format!("SenseNova-U1 load: {error}")))?;
-        emit_load_event(
-            "image_pipeline_load_complete",
-            &job_id,
-            "sensenova_u1_8b",
-            0,
-        );
-        // ImageNet-normalized inside `vqa`; pass [3,H,W] in [0,1], 32-aligned, within the
-        // understanding pixel budget (default 768², min 256²).
-        let pixel_values = image_to_chw01_candle(&source, 256 * 256, max_image_pixels)?;
-        let answer = model
-            .vqa(
-                &tokenizer,
-                &question_for_vqa,
-                std::slice::from_ref(&pixel_values),
-                max_new_tokens,
-                Sampler::Greedy,
-            )
-            .map_err(|error| WorkerError::Engine(format!("SenseNova VQA failed: {error}")))?;
-        Ok(strip_reasoning(&answer))
-    })
-    .await
-    .map_err(|error| task_join_error("VQA task join", error))??;
+    // Keep the worker heartbeat alive across the blocking VLM load + generation (a cold
+    // SenseNova-U1 8B load + long answer easily exceeds the API's 90s stale-sweep) so the in-flight
+    // job is never falsely marked `interrupted` (sc-8390). Not cancelable mid-generation.
+    let answer = run_blocking_with_heartbeat(
+        api,
+        settings,
+        &job.id,
+        None,
+        "",
+        "VQA task join",
+        tokio::task::spawn_blocking(move || -> WorkerResult<String> {
+            emit_load_event("image_pipeline_load_start", &job_id, "sensenova_u1_8b", 0);
+            let (model, tokenizer) = load_understanding(&weights_dir)
+                .map_err(|error| WorkerError::Engine(format!("SenseNova-U1 load: {error}")))?;
+            emit_load_event(
+                "image_pipeline_load_complete",
+                &job_id,
+                "sensenova_u1_8b",
+                0,
+            );
+            // ImageNet-normalized inside `vqa`; pass [3,H,W] in [0,1], 32-aligned, within the
+            // understanding pixel budget (default 768², min 256²).
+            let pixel_values = image_to_chw01_candle(&source, 256 * 256, max_image_pixels)?;
+            let answer = model
+                .vqa(
+                    &tokenizer,
+                    &question_for_vqa,
+                    std::slice::from_ref(&pixel_values),
+                    max_new_tokens,
+                    Sampler::Greedy,
+                )
+                .map_err(|error| WorkerError::Engine(format!("SenseNova VQA failed: {error}")))?;
+            Ok(strip_reasoning(&answer))
+        }),
+    )
+    .await?;
 
     let result = json!({
         "answer": answer,
@@ -544,7 +564,7 @@ pub(crate) async fn run_interleave_job(
     // images come back as Send `Image`s for asset writing on the async side.
     let job_id = job.id.clone();
     let prompt_for_gen = prompt.clone();
-    let (generated_text, images) =
+    let interleave_task =
         tokio::task::spawn_blocking(move || -> WorkerResult<(String, Vec<Image>)> {
             emit_load_event("image_pipeline_load_start", &job_id, "sensenova_u1_8b", 0);
             let (model, tokenizer) = load_sensenova_model(&weights_dir)?;
@@ -598,9 +618,20 @@ pub(crate) async fn run_interleave_job(
                 })?);
             }
             Ok((out.text, decoded))
-        })
-        .await
-        .map_err(|error| task_join_error("interleave task join", error))??;
+        });
+    // Keep the worker heartbeat alive across the blocking VLM load + interleave rollout (cold 8B
+    // load + multi-image generation easily exceeds the API's 90s stale-sweep) so the in-flight job
+    // is never falsely marked `interrupted` (sc-8390). Not cancelable mid-rollout.
+    let (generated_text, images) = run_blocking_with_heartbeat(
+        api,
+        settings,
+        &job.id,
+        None,
+        "",
+        "interleave task join",
+        interleave_task,
+    )
+    .await?;
 
     update_job(
         api,
@@ -778,7 +809,7 @@ pub(crate) async fn run_interleave_job(
 
     let job_id = job.id.clone();
     let prompt_for_gen = prompt.clone();
-    let (generated_text, images) =
+    let interleave_task =
         tokio::task::spawn_blocking(move || -> WorkerResult<(String, Vec<Image>)> {
             emit_load_event("image_pipeline_load_start", &job_id, "sensenova_u1_8b", 0);
             let (model, tokenizer) = load_understanding(&weights_dir)
@@ -836,9 +867,20 @@ pub(crate) async fn run_interleave_job(
                 })?);
             }
             Ok((out.text, decoded))
-        })
-        .await
-        .map_err(|error| task_join_error("interleave task join", error))??;
+        });
+    // Keep the worker heartbeat alive across the blocking VLM load + interleave rollout (cold 8B
+    // load + multi-image generation easily exceeds the API's 90s stale-sweep) so the in-flight job
+    // is never falsely marked `interrupted` (sc-8390). Not cancelable mid-rollout.
+    let (generated_text, images) = run_blocking_with_heartbeat(
+        api,
+        settings,
+        &job.id,
+        None,
+        "",
+        "interleave task join",
+        interleave_task,
+    )
+    .await?;
 
     update_job(
         api,

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -790,7 +790,30 @@ async fn consume_training_events(
     let mut latest_step: u32 = 0;
     let mut latest_samples: Vec<Value> = Vec::new();
 
-    while let Some(event) = rx.recv().await {
+    let mut heartbeat_interval = tokio::time::interval(progress_report_interval(settings));
+    heartbeat_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        let event = tokio::select! {
+            maybe_event = rx.recv() => match maybe_event {
+                Some(event) => event,
+                None => break,
+            },
+            _ = heartbeat_interval.tick() => {
+                // Keep the worker's heartbeat alive during long silent gaps between engine events
+                // — e.g. a slow checkpoint disk-write + preview-sampling pass for a large model
+                // (Krea2). Heartbeats otherwise ride only on incoming progress events (below), so a
+                // quiet stretch past the API's 90s worker-timeout lets the stale-sweep mark this
+                // still-running job `interrupted`, and the next progress post is then 409'd
+                // (sc-8390; same class as the inline-upscale sc-8200). Also poll cancel here so a
+                // cancel requested during such a gap is honored without awaiting the next event.
+                heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+                if !canceled && cancel_requested_peek(api, &job.id).await {
+                    begin_training_cancel(api, &job.id, &cancel, backend).await;
+                    canceled = true;
+                }
+                continue;
+            }
+        };
         if canceled {
             continue; // drain remaining events so the blocking sender never blocks.
         }

--- a/crates/sceneworks-worker/src/upscale_jobs.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs.rs
@@ -675,6 +675,11 @@ pub(crate) async fn upscale_image_in_memory(
     }
 }
 
+/// Upscale-specific keepalive. The generic [`crate::run_blocking_with_heartbeat`] covers the same
+/// "heartbeat + cancel-poll while a blocking task runs" need for every other path (sc-8390); this
+/// one stays bespoke only because it ALSO posts an intermediate `Running`/"Canceling image upscale."
+/// update the instant a cancel is observed, so the UI acknowledges the cancel while the long
+/// diffusion finishes rather than appearing frozen until it flips terminal. Keep them in sync.
 async fn run_upscale_with_heartbeat<R>(
     api: &ApiClient,
     settings: &Settings,


### PR DESCRIPTION
## Symptom (user-reported, on-device)
An overnight **Krea2 LoRA training** job hung at `Saved checkpoint at step 500.` for hours. Worker log:
```
MLX-WORKER ERROR utility_job_failed jobId=job_… error=API 409 Conflict: {"detail":"Job job_… is already interrupted; terminal jobs cannot be updated."}
API DEBUG api_error status=409 detail=Job job_… is already interrupted; terminal jobs cannot be updated.
```
plus later `404 File not found` when the UI tried to load the (never-written) output artifact.

## Root cause — same class as #938 / sc-8200, different path
The Rust worker sends **no** periodic heartbeat on its own during a job; long jobs stay alive only by a per-path keepalive that pings `WorkerStatus::Busy` every `progress_report_interval` (5–15s). Posting job *progress* does **not** refresh the worker's `last_seen` (only a terminal status does), so the keepalive is the sole thing holding off the API stale-sweep (`SCENEWORKS_WORKER_TIMEOUT_SECONDS`, default **90s** → `jobs_store::mark_stale_workers_interrupted`).

`training_jobs::consume_training_events` heartbeats **only** as a side-effect of receiving an engine progress event; its loop was `while let Some(event) = rx.recv().await` with no interval arm. The post-checkpoint disk-write + preview-sampling pass for a large model (Krea2) goes silent >90s → stale-sweep marks the in-flight `lora_train` job `interrupted` → next progress post is 409'd → work lost. Identical mechanism to the inline-upscale fix in #938, just a path that never got a keepalive.

## Why it keeps recurring
The keepalive was open-coded as ~9 divergent local copies. There was **no single shared helper**, so new long-inline paths were a fresh chance to forget it. Paths that had **no** keepalive at all: `training_jobs` (this bug), `sensenova_jobs` (VQA/interleave), `kps_jobs`, `pose_jobs`, `person_jobs`/PersonDetect.

## Change
- **New shared helper** `progress::run_blocking_with_heartbeat` — heartbeat every 5–15s + optional cancel-poll, for the single-blocking-task shape.
- **training (the bug):** `consume_training_events` now uses `tokio::select!` with an interval arm that heartbeats + polls cancel during silent gaps between engine events.
- **Wrapped through the shared helper:** SenseNova VQA + interleave (cold 8B VLM load + generation), KpsExtract, PoseDetect, PersonDetect.
- **Migrated:** `segment_jobs` off its local `run_with_heartbeat` onto the shared helper (identical behavior; removes a copy).
- `upscale_jobs` keeps its bespoke wrapper (it *also* posts an intermediate "Canceling…" update); the intentional divergence is now documented.

## Validation
- `npm run rust:check` (fmt + clippy `-D warnings` + test + build) — green.
- `cargo check -p sceneworks-worker` (default) and `--no-default-features --features backend-candle --all-targets` (parity config) — green.
- `cargo test -p sceneworks-worker --lib` — **455 passed**.
- **Remaining on-device gate:** a real long-running training run on a Mac (e.g. the Krea2 LoRA that triggered this) completing past a slow checkpoint without a spurious `interrupted`/409. Can't run in a worktree (needs Mac + dataset + licensed weights).

## Relations
- Same defect class as #938 (sc-8200, inline SeedVR2 upscale). Epic 4811. Story sc-8390.

🤖 Generated with [Claude Code](https://claude.com/claude-code)