### PR TITLE
fix(lora): accept ai-toolkit Krea LoKr — canonical krea_2 family + UI vocabulary (sc-8393 / sc-8394)

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -32,8 +32,9 @@ use sceneworks_core::jobs_store::{
     RetryJob, RouteDecision, StaleSweep, UnsupportedReason, WorkerHeartbeat, JOB_STATUSES,
 };
 use sceneworks_core::lora_family::{
-    apply_model_manifest_defaults, detect_lora_family, detect_model_family, first_safetensors_path,
-    read_safetensors_header, reconcile_detected_family, SafetensorsHeaderError,
+    apply_model_manifest_defaults, canonical_lora_family, detect_lora_family, detect_model_family,
+    first_safetensors_path, read_safetensors_header, reconcile_detected_family,
+    SafetensorsHeaderError,
 };
 use sceneworks_core::lora_url::{lora_source_url_file_stem, parse_lora_source_url, LoraUrlError};
 use sceneworks_core::project_store::{
@@ -1690,7 +1691,11 @@ fn validate_lora_family(models: &[Value], family: &str) -> Result<String, ApiErr
 }
 
 fn normalize_lora_family(family: &str) -> String {
-    family.trim().to_ascii_lowercase().replace('_', "-")
+    // Delegate to the shared canonical resolver so the API agrees with the worker
+    // and the catalog on one token per family (Krea 2's `krea2`/`krea-2`/`krea_2`
+    // all become `krea_2`). Applied symmetrically to every family string the API
+    // compares, so membership tests stay consistent (see `validate_lora_specs_for_model`).
+    canonical_lora_family(family)
 }
 
 fn known_lora_families(models: &[Value]) -> Vec<String> {

--- a/apps/rust-api/src/loras.rs
+++ b/apps/rust-api/src/loras.rs
@@ -6,6 +6,10 @@ pub(crate) async fn list_loras(
 ) -> Result<Json<Vec<Value>>, ApiError> {
     let mut items = lora_catalog(&state, query.project_id.as_deref()).await?;
     if let Some(model_family) = query.model_family {
+        // `lora_families` returns canonical tokens, so canonicalize the raw query
+        // param too — otherwise a `?model_family=krea-2` filter would miss a stored
+        // `krea_2` LoRA.
+        let model_family = normalize_lora_family(&model_family);
         items.retain(|item| {
             lora_families(item)
                 .iter()
@@ -1068,28 +1072,25 @@ pub(crate) fn reconcile_lora_family(
     detected: Option<String>,
     context: &str,
 ) -> Result<Option<String>, ApiError> {
-    match (supplied, detected) {
-        (Some(supplied), Some(detected)) => {
-            if supplied == detected {
-                Ok(Some(supplied))
-            } else {
-                Err(ApiError::bad_request(format!(
-                    "LoRA file appears to be a {detected} model, but family was declared as {supplied}. Re-import with family {detected} or pick a different file."
-                )))
-            }
-        }
-        (None, Some(detected)) => Ok(Some(detected)),
-        (Some(supplied), None) => {
-            tracing::info!(
-                event = "lora_import_architecture_inconclusive",
-                context = %context,
-                family = %supplied,
-                "LoRA import: architecture detection inconclusive; accepting supplied family"
-            );
-            Ok(Some(supplied))
-        }
-        (None, None) => Ok(None),
+    // Log the inconclusive case (a supplied family with no confident detection)
+    // before delegating, so the operational signal is preserved.
+    if let (Some(supplied), None) = (&supplied, &detected) {
+        tracing::info!(
+            event = "lora_import_architecture_inconclusive",
+            context = %context,
+            family = %supplied,
+            "LoRA import: architecture detection inconclusive; accepting supplied family"
+        );
     }
+    // Shared policy + canonicalization: spelling variants of one family (Krea 2's
+    // `krea2`/`krea-2`/`krea_2`) reconcile instead of being rejected, and the result
+    // is the canonical stored token.
+    reconcile_detected_family(supplied, detected).map_err(|mismatch| {
+        ApiError::bad_request(format!(
+            "LoRA file appears to be a {} model, but family was declared as {}. Re-import with family {} or pick a different file.",
+            mismatch.detected, mismatch.supplied, mismatch.detected
+        ))
+    })
 }
 
 pub(crate) fn lora_is_installed(path: &FsPath) -> bool {

--- a/apps/web/src/presetUtils.js
+++ b/apps/web/src/presetUtils.js
@@ -94,7 +94,11 @@ export function modelLoraFamilies(model) {
 }
 
 export function normalizeLoraFamily(family) {
-  return String(family ?? "").trim().toLowerCase().replaceAll("_", "-");
+  const normalized = String(family ?? "").trim().toLowerCase().replaceAll("_", "-");
+  // Mirror the backend's canonical resolver: the separator-less `krea2` (ostris
+  // ai-toolkit's `ss_base_model_version`) means the same family as `krea-2`/`krea_2`,
+  // which the `_`->`-` step alone can't unify. Explicit alias, not a blind strip.
+  return normalized === "krea2" ? "krea-2" : normalized;
 }
 
 export function normalizeFamilies(values) {

--- a/apps/web/src/presetUtils.test.jsx
+++ b/apps/web/src/presetUtils.test.jsx
@@ -7,6 +7,7 @@ import {
   editModelForAsset,
   finiteNumberOrUndefined,
   loraWeight,
+  normalizeLoraFamily,
   presetMatchesModel,
   presetNameTaken,
   slugifyPresetId,
@@ -17,6 +18,20 @@ const ltx = { id: "ltx_2_3", family: "ltx-video" };
 const ltxEros = { id: "ltx_2_3_eros", family: "ltx-video" };
 const sdxl = { id: "sdxl", family: "sdxl" };
 const catalog = [ltx, ltxEros, sdxl];
+
+describe("normalizeLoraFamily", () => {
+  it("collapses every Krea 2 spelling variant to the UI's krea-2 token", () => {
+    for (const variant of ["krea_2", "krea-2", "krea2", "KREA2", " Krea_2 "]) {
+      expect(normalizeLoraFamily(variant)).toBe("krea-2");
+    }
+  });
+
+  it("lower-cases and hyphenates other families, leaving unrelated tokens intact", () => {
+    expect(normalizeLoraFamily("Z_Image")).toBe("z-image");
+    expect(normalizeLoraFamily("wan-video")).toBe("wan-video");
+    expect(normalizeLoraFamily("")).toBe("");
+  });
+});
 
 describe("presetMatchesModel", () => {
   it("matches when the preset pins no model", () => {

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -2,7 +2,13 @@ import React, { useEffect, useState } from "react";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
 import { terminalStatuses } from "../constants.js";
 import { hasPresentCredential, loadCredentials, serverToken } from "../credentials.js";
-import { extractFamilies, modelLoraFamilies, presetLoraId, presetLoras } from "../presetUtils.js";
+import {
+  extractFamilies,
+  modelLoraFamilies,
+  normalizeLoraFamily,
+  presetLoraId,
+  presetLoras,
+} from "../presetUtils.js";
 import { useAppContext } from "../context/AppContext.js";
 import { DEFAULT_MAC_CAPABILITIES, macModelBlock } from "../macGating.js";
 import { apiFetch } from "../api.js";
@@ -519,8 +525,13 @@ export function ModelManagerScreen() {
       });
       const loraId = job?.payload?.loraId;
       const resolvedFamily = job?.payload?.manifestEntry?.family;
+      // Show the detected family in the same normalized vocabulary the dropdown
+      // uses (e.g. the backend's canonical `krea_2` displays as `krea-2`), so the
+      // note never names a token the manual selector doesn't list.
       const detectionNote =
-        !importForm.family && resolvedFamily ? ` Detected family: ${resolvedFamily}.` : "";
+        !importForm.family && resolvedFamily
+          ? ` Detected family: ${normalizeLoraFamily(resolvedFamily)}.`
+          : "";
       setImportForm((current) => ({ ...current, sourceUrl: "", file: null, secondaryFile: null, name: "" }));
       // Force a re-mount so choosing the same file again still emits a change event.
       setFileInputKey((current) => current + 1);
@@ -557,7 +568,9 @@ export function ModelManagerScreen() {
       const modelId = job?.payload?.modelId;
       const resolvedFamily = job?.payload?.manifestEntry?.family;
       const detectionNote =
-        !modelImportForm.family && resolvedFamily ? ` Detected family: ${resolvedFamily}.` : "";
+        !modelImportForm.family && resolvedFamily
+          ? ` Detected family: ${normalizeLoraFamily(resolvedFamily)}.`
+          : "";
       setModelImportForm((current) => ({ ...current, sourceUrl: "", file: null, name: "" }));
       setModelFileInputKey((current) => current + 1);
       setModelImportMessage({

--- a/crates/sceneworks-core/src/lora_family.rs
+++ b/crates/sceneworks-core/src/lora_family.rs
@@ -197,12 +197,20 @@ pub fn reconcile_detected_family(
     detected: Option<String>,
 ) -> Result<Option<String>, FamilyMismatch> {
     match (supplied, detected) {
-        (Some(supplied), Some(detected)) if supplied != detected => {
-            Err(FamilyMismatch { supplied, detected })
+        (Some(supplied), Some(detected)) => {
+            // Compare on the canonical family token, not the raw string, so spelling
+            // variants of one family agree: a user-supplied `krea-2` (the UI's hyphen
+            // form) against a detected `krea_2` (the catalog/trainer token), or
+            // ai-toolkit's separator-less `krea2`. Store the canonical token so the
+            // recorded family matches `loraCompatibility.families` exactly.
+            if canonical_lora_family(&supplied) == canonical_lora_family(&detected) {
+                Ok(Some(canonical_lora_family(&detected)))
+            } else {
+                Err(FamilyMismatch { supplied, detected })
+            }
         }
-        (Some(supplied), Some(_)) => Ok(Some(supplied)),
-        (None, Some(detected)) => Ok(Some(detected)),
-        (Some(supplied), None) => Ok(Some(supplied)),
+        (None, Some(detected)) => Ok(Some(canonical_lora_family(&detected))),
+        (Some(supplied), None) => Ok(Some(canonical_lora_family(&supplied))),
         (None, None) => Ok(None),
     }
 }
@@ -375,7 +383,32 @@ pub fn model_capabilities_for_type_and_family(model_type: &str, family: &str) ->
 }
 
 fn normalize_model_family(family: &str) -> String {
-    family.trim().to_ascii_lowercase().replace('_', "-")
+    let normalized = family.trim().to_ascii_lowercase().replace('_', "-");
+    // Collapse spelling variants the `_`→`-` step alone can't unify. ostris
+    // ai-toolkit bakes Krea 2's base id into trained files as the separator-less
+    // `krea2` (`ss_base_model_version: "krea2"`), which is the same family as
+    // `krea-2` / `krea_2`. Kept an explicit alias, not a blind separator-strip —
+    // a blind strip could merge unrelated families.
+    match normalized.as_str() {
+        "krea2" => "krea-2".to_owned(),
+        _ => normalized,
+    }
+}
+
+/// The canonical *stored* LoRA-family token for any spelling of a family.
+///
+/// Detection, the catalog manifests, and the trainers agree on one token per
+/// family; only Krea 2 has variants in the wild — `krea2` (ai-toolkit's
+/// `ss_base_model_version`), `krea-2` (the UI's hyphen form), and `krea_2` (the
+/// catalog token) — all of which resolve to the catalog token `krea_2`. Every
+/// other family already stores its `normalize_model_family` form, so this returns
+/// that (lower-cased, `_`→`-`) unchanged for them.
+pub fn canonical_lora_family(family: &str) -> String {
+    let normalized = normalize_model_family(family);
+    match normalized.as_str() {
+        "krea-2" => "krea_2".to_owned(),
+        _ => normalized,
+    }
 }
 
 fn read_diffusers_model_index_family(dir: &Path) -> Option<String> {
@@ -2288,6 +2321,47 @@ mod tests {
                 supplied: "z-image".to_owned(),
                 detected: "qwen-image".to_owned(),
             }
+        );
+    }
+
+    #[test]
+    fn canonical_lora_family_collapses_krea_spelling_variants() {
+        for variant in ["krea_2", "krea-2", "krea2", "KREA2", " Krea-2 "] {
+            assert_eq!(
+                canonical_lora_family(variant),
+                "krea_2",
+                "{variant:?} should canonicalize to krea_2"
+            );
+        }
+        // Unrelated families keep their normalized (hyphen) stored token.
+        assert_eq!(canonical_lora_family("z_image"), "z-image");
+        assert_eq!(canonical_lora_family("Wan-Video"), "wan-video");
+        assert_eq!(canonical_lora_family("flux2"), "flux2");
+    }
+
+    #[test]
+    fn reconcile_detected_family_unifies_krea_spelling_variants() {
+        // The reported bug: a UI-supplied `krea-2` (or ai-toolkit's `krea2`) against a
+        // detected `krea_2` must reconcile to the canonical `krea_2`, not be rejected.
+        for supplied in ["krea-2", "krea2", "KREA_2"] {
+            assert_eq!(
+                reconcile_detected_family(Some(supplied.to_owned()), Some("krea_2".to_owned()))
+                    .unwrap()
+                    .as_deref(),
+                Some("krea_2"),
+                "supplied {supplied:?} vs detected krea_2 should resolve to krea_2"
+            );
+        }
+        // A supplied-only krea variant (detection inconclusive) is canonicalized too.
+        assert_eq!(
+            reconcile_detected_family(Some("krea-2".to_owned()), None)
+                .unwrap()
+                .as_deref(),
+            Some("krea_2")
+        );
+        // A genuine cross-family conflict still errors, reporting the raw inputs.
+        assert!(
+            reconcile_detected_family(Some("flux".to_owned()), Some("krea_2".to_owned())).is_err()
         );
     }
 

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -1717,32 +1717,30 @@ pub(crate) async fn run_lora_import_job(
         }
     };
     let supplied_family = optional_payload_string(&job.payload, "family").map(str::to_owned);
-    let resolved_family = match (supplied_family, detected_family) {
-        (Some(supplied), Some(detected)) => {
-            if supplied != detected {
-                return fail_job(
-                    api,
-                    &job.id,
-                    "LoRA import failed.",
-                    Some(format!(
-                        "LoRA file appears to be a {detected} model, but family was declared as {supplied}. Re-import with family {detected} or pick a different file."
-                    )),
-                )
-                .await;
-            }
-            Some(supplied)
+    if let (Some(supplied), None) = (&supplied_family, &detected_family) {
+        tracing::info!(
+            event = "lora_import_architecture_inconclusive",
+            jobId = %job.id,
+            family = %supplied,
+            "LoRA import: architecture detection inconclusive; accepting supplied family"
+        );
+    }
+    // Shared reconcile policy + canonicalization (krea2/krea-2/krea_2 → krea_2),
+    // matching the API pre-flight so a manual family override agrees with detection.
+    let resolved_family = match reconcile_detected_family(supplied_family, detected_family) {
+        Ok(family) => family,
+        Err(mismatch) => {
+            return fail_job(
+                api,
+                &job.id,
+                "LoRA import failed.",
+                Some(format!(
+                    "LoRA file appears to be a {} model, but family was declared as {}. Re-import with family {} or pick a different file.",
+                    mismatch.detected, mismatch.supplied, mismatch.detected
+                )),
+            )
+            .await;
         }
-        (None, Some(detected)) => Some(detected),
-        (Some(supplied), None) => {
-            tracing::info!(
-                event = "lora_import_architecture_inconclusive",
-                jobId = %job.id,
-                family = %supplied,
-                "LoRA import: architecture detection inconclusive; accepting supplied family"
-            );
-            Some(supplied)
-        }
-        (None, None) => None,
     };
 
     write_lora_install_marker(&target_dir, &job.payload, &job.id).await?;


### PR DESCRIPTION
## Why
Importing an ostris **ai-toolkit Krea 2 LoKr** (`realism_engine_krea2_v2.safetensors`) failed: the import was rejected with *"Re-import with family krea_2"* — a token the importer dropdown can't even offer. Root cause: the Krea family is stored/detected as `krea_2`, but the stack normalized to the hyphen form `krea-2` and compared **raw** in three places, and the separator-less `krea2` (ai-toolkit's `ss_base_model_version`) fell through entirely.

This PR fixes the **import + UI** halves (epic 7565). The generation-time *load* matcher is a separate mlx-gen PR (sc-8395) — see below.

## What

**sc-8393 — canonical `krea_2` resolver (core/api/worker)**
- `sceneworks-core`: new `canonical_lora_family` (`krea2`/`krea-2`/`krea_2` → `krea_2`; other families unchanged) + `normalize_model_family` collapses `krea2`; `reconcile_detected_family` compares **and returns** the canonical token.
- `rust-api`: `normalize_lora_family` delegates to the core resolver (unifies validate / known-families / membership on `krea_2`); `list_loras` canonicalizes the `?model_family=` query param; `reconcile_lora_family` delegates to core (de-dups the 2nd raw-compare copy).
- `worker`: the LoRA-import inline reconcile delegates to `reconcile_detected_family` (de-dups the 3rd copy).

**sc-8394 — importer family vocabulary (web)**
- The detected-family note runs through `normalizeLoraFamily` (LoRA + model paths), so it never names a token the dropdown lacks.
- `normalizeLoraFamily` mirrors the backend, collapsing `krea2` → `krea-2`.

## Tests
- core: 69 `lora_family` tests (+2 new canonical/reconcile krea-variant cases).
- api: 19 `lora` tests (incl. the prior sc-8185 krea case).
- web: full suite (823) green; new `normalizeLoraFamily` krea-variant cases.
- `cargo fmt --all --check` + clippy clean; merged latest `origin/main`.

## Follow-up (not in this PR)
- **mlx-gen sc-8395** (separate PR): strip the `diffusion_model.` prefix on the third-party-LoKr apply path so the file actually *loads* at generation. Real-weight validated on macOS (applies + renders coherently). candle-gen needs no change.
- After that merges: bump the worker's mlx-gen pin.

Stories: sc-8393, sc-8394 (epic 7565).

🤖 Generated with [Claude Code](https://claude.com/claude-code)