### PR TITLE
feat(worker): score Image Studio "With Character" generations (sc-4411)

### DIFF
--- a/crates/sceneworks-worker/src/face_likeness.rs
+++ b/crates/sceneworks-worker/src/face_likeness.rs
@@ -1089,6 +1089,113 @@ mod tests {
                 "a full-body / turned pose persists detected:false + reason, not a low score"
             );
         }
+
+        // -- sc-4411: the SAME shared seam carries Image Studio "With Character" (plain) scoring -------
+        // The PLAIN With-Character generation (`character_image` + a `referenceAssetId`, no angle/pose)
+        // routes to its identity generator (Z-Image identity init, Flux IP-adapter, InstantID identity,
+        // PuLID, Kolors IP, SenseNova / FLUX.2 / Qwen plain edit) and scores each finished image through
+        // `build_face_likeness_scorer` + `score_generated_image` — the IDENTICAL seam the angle/pose
+        // lanes use, no fork. These assert the sc-4411 ACs over the weight-free stub (generator-
+        // agnostic): a block is attached vs the reference, the source is embedded once across N images,
+        // CHANGING the reference changes the scored source, and a non-frontal result is an honest N/A.
+
+        #[test]
+        fn with_character_attaches_block_and_embeds_source_once_across_n_images() {
+            // A With-Character generation produces N regular images "with" the character; each attaches a
+            // faceLikeness block vs the chosen reference, and across the N-image batch the SOURCE is
+            // embedded exactly once (the per-job scorer is built once from the reference, then reused).
+            let (scorer, calls) = stub_scorer(200);
+            assert_eq!(
+                calls.load(Ordering::SeqCst),
+                1,
+                "construction embedded the reference source once"
+            );
+            // Distinct per-image seeds ⇒ distinct generations, but all "with" the one character.
+            let generated = [200u8, 150, 120, 90, 80];
+            for px in generated {
+                let block = score_generated_image(Some(&scorer), &image(px), Some("char_ref_1"))
+                    .expect("a scorer present ⇒ a block built");
+                assert_eq!(block.get("detected"), Some(&Value::Bool(true)));
+                assert_eq!(
+                    block.get("sourceAssetId"),
+                    Some(&json!("char_ref_1")),
+                    "the block attributes the score to the chosen reference asset"
+                );
+                assert!(block.get("score").map(Value::is_number).unwrap_or(false));
+            }
+            assert_eq!(
+                calls.load(Ordering::SeqCst),
+                1 + generated.len(),
+                "1 source embed + 1 detect per image — the source is NEVER re-embedded across the batch"
+            );
+            assert_eq!(scorer.source_embed_count(), 1, "still one source embed");
+        }
+
+        #[test]
+        fn changing_the_reference_asset_changes_the_scored_source() {
+            // The explicit AC: changing the reference asset changes the source the score is computed
+            // against. Two scorers built from DIFFERENT reference faces (the per-job source is the
+            // current `referenceAssetId`, never cached across jobs) score the SAME generated image to
+            // different cosines — same-identity high, different-identity lower.
+            let generated = image(200); // a generation matching reference A's identity (pixel 200)
+            let (scorer_a, _) = FaceLikenessScorer::with_stub_source(&image(200)); // reference A
+            let (scorer_b, _) = FaceLikenessScorer::with_stub_source(&image(80)); // reference B (changed)
+
+            let a = scorer_a.score_or_null(&generated);
+            let b = scorer_b.score_or_null(&generated);
+            let (sa, sb) = (a.score.expect("A scored"), b.score.expect("B scored"));
+            assert!(
+                sa > sb,
+                "same reference (A) cosine {sa} exceeds the changed reference (B) cosine {sb} — \
+                 the source IS derived from the current reference asset"
+            );
+
+            // And the persisted block records WHICH reference each score was computed against.
+            let block_a =
+                score_generated_image(Some(&scorer_a), &generated, Some("ref_a")).expect("block A");
+            let block_b =
+                score_generated_image(Some(&scorer_b), &generated, Some("ref_b")).expect("block B");
+            assert_eq!(block_a.get("sourceAssetId"), Some(&json!("ref_a")));
+            assert_eq!(block_b.get("sourceAssetId"), Some(&json!("ref_b")));
+        }
+
+        #[test]
+        fn with_character_non_frontal_result_is_na_per_metric_honesty() {
+            // The AC's metric-honesty rule: a non-frontal / no-face With-Character result returns N/A
+            // (detected:false, score:null + reason) through the shared seam — never a misleading low
+            // number. (pixel 0 ⇒ the stub's no-face funnel.)
+            let (scorer, _calls) = stub_scorer(200);
+            let block = score_generated_image(Some(&scorer), &image(0), Some("char_ref_1"))
+                .expect("a scorer present ⇒ the N/A block built");
+            assert_eq!(
+                Value::Object(block),
+                json!({
+                    "score": Value::Null,
+                    "detected": false,
+                    "method": LIKENESS_METHOD,
+                    "sourceAssetId": "char_ref_1",
+                    "reason": "no_face",
+                }),
+                "a non-frontal With-Character result is an honest N/A, not a low score"
+            );
+        }
+
+        #[test]
+        fn with_character_non_fatal_when_reference_has_no_face() {
+            // Non-fatal construction surrogate (the sc-4407 contract carried to sc-4411): a reference
+            // image with no detectable face yields a scorer (NOT an error) whose every generated image
+            // is the NoSourceFace N/A — the With-Character generation still renders, scores just absent.
+            let (scorer, _calls) = FaceLikenessScorer::with_stub_source(&image(0)); // no face in ref
+            assert!(!scorer.has_source_face(), "no detectable reference face");
+            let result = scorer.score_or_null(&image(200));
+            assert!(!result.detected, "no reference face ⇒ every image N/A");
+            assert_eq!(result.reason, Some(NoScoreReason::NoSourceFace));
+            // And the producer's `None`-scorer path (a hard construction failure) omits the field.
+            assert!(
+                score_generated_image(None, &image(200), Some("char_ref_1")).is_none(),
+                "a failed scorer construction ⇒ no block ⇒ field omitted (generation unaffected)"
+            );
+        }
     }
 
     /// Real-weight scorer integration (sc-4407): proves the worker binary links + loads the MLX

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -1306,6 +1306,48 @@ pub(crate) fn resolve_control_identity_source(
     }
 }
 
+/// The source identity reference (decoded image + its asset id) an Image Studio "With Character"
+/// (`character_image`) generation scores each finished image against (epic 4406, sc-4411), or `None`
+/// when the job is not a plain character image with a reference face.
+///
+/// This is the GENERAL With-Character case — a regular `character_image` generation against a
+/// `referenceAssetId` (the character reference shown in the Image Studio reference thumbnail), NOT an
+/// angle set (`advanced.angleSet`) and NOT a pose-library set (`advanced.poses`). Those two are ALSO
+/// `character_image` jobs but are already scored by sc-4409 (angles) / sc-4410 (poses) through the same
+/// shared seam; this resolver deliberately returns `None` for them so the plain case never
+/// double-attaches or conflicts on an angle/pose job. The gate is therefore:
+/// `mode == "character_image"` AND a non-empty `referenceAssetId` AND no angle/pose grouping.
+///
+/// The asset id returned is the CURRENT job's `referenceAssetId`, so changing the reference asset
+/// changes the source the score is computed against (an explicit sc-4411 acceptance criterion) — the
+/// source is never cached across jobs or hardcoded.
+///
+/// Decoding is non-fatal (the sc-4407 contract): a reference that fails to load logs and yields `None`
+/// (scores omitted, the generation still runs) — scoring NEVER aborts a generation. The source image is
+/// decoded here ONCE and handed to the per-job scorer, which embeds it ONCE (the caching AC).
+///
+/// Lives in `base.rs` (compiled under BOTH the macOS routes and the off-Mac candle-control lanes) so the
+/// candle siblings can resolve it identically.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+pub(crate) fn resolve_character_image_likeness_source(
+    request: &ImageRequest,
+    settings: &Settings,
+    project_path: &Path,
+) -> Option<(Image, String)> {
+    if request.mode != "character_image" {
+        return None;
+    }
+    // Angle / pose sets are already scored by sc-4409 / sc-4410 through the same shared seam; this is
+    // the PLAIN With-Character path only, so exclude both groupings to avoid double-attaching.
+    if !pose_entries(request).is_empty() || advanced::flag(&request.advanced, "angleSet") {
+        return None;
+    }
+    resolve_control_identity_source(request, settings, project_path)
+}
+
 /// img2img (Remix) strength for a plain Ideogram 4 edit with no mask — mirrors the sdxl/z-image 0.6
 /// edit default and the engine's `DEFAULT_IMG2IMG_STRENGTH`. Shared by the macOS MLX edit path and the
 /// candle in-lane edit (sc-6598), so it compiles off-Mac under `backend-candle` too.
@@ -1885,6 +1927,30 @@ async fn generate_stream(
     if let Some(pid) = pid_weights {
         spec = spec.with_pid(pid.checkpoint, pid.gemma);
     }
+
+    // Identity-likeness scoring (epic 4406, sc-4411 plain With-Character): the generic MLX lane serves
+    // the remaining With-Character identity generators — Z-Image identity-init (`referenceAssetId` ⇒
+    // img2img init), the FLUX.1 XLabs IP-Adapter, and the Kolors IP-Adapter-Plus reference — all of
+    // which carry a character `referenceAssetId`. Score every output against that reference face through
+    // the SHARED generator-agnostic seam, but ONLY for an Image Studio "With Character"
+    // (`character_image`) generation; a z-image / kolors `edit_image` job (its source is `sourceAssetId`,
+    // not an identity reference) is excluded by `resolve_character_image_likeness_source` (mode gate),
+    // which also resolves the CURRENT job's reference (so changing it changes the scored source) and is
+    // non-fatal. The `!Send` scorer is built ONCE inside the closure and reused across the N outputs.
+    let likeness_source = resolve_character_image_likeness_source(request, settings, project_path);
+    let face_stack_dir = match &likeness_source {
+        Some(_) => match ensure_face_stack_dir(api, settings, job).await {
+            Ok(dir) => Some(dir),
+            Err(error) => {
+                tracing::warn!(error = %error, "character_image face-stack staging failed; likeness scores omitted");
+                None
+            }
+        },
+        None => None,
+    };
+    // Keep the source only if the face stack staged (otherwise no scorer can be built).
+    let likeness_source = face_stack_dir.as_ref().and(likeness_source);
+
     let (cancel, rx, blocking) = start_cached_gen_stream(
         job.id.clone(),
         engine_id,
@@ -1892,7 +1958,17 @@ async fn generate_stream(
         spec,
         format!("{engine_id} load failed"),
         move |generator, tx, cancel| {
-            drive_gen_items(tx, seeds, move |_index, seed, on_progress| {
+            // Per-job identity-likeness scorer built ONCE on the generator-worker thread (the `!Send`
+            // face stack lives here); source embedded once, reused across every output (sc-4411). `None`
+            // ⇒ not a With-Character generation, or non-fatal staging/construction failure ⇒ omitted.
+            let scorer = match (&face_stack_dir, &likeness_source) {
+                (Some(dir), Some((source, _))) => {
+                    crate::face_likeness::build_face_likeness_scorer(dir, source)
+                }
+                _ => None,
+            };
+            let likeness_source_ref = likeness_source.as_ref().map(|(_, id)| id.clone());
+            drive_gen_items_scored(tx, seeds, move |_index, seed, on_progress| {
                 let render = |seed: i64, on_progress: &mut dyn FnMut(Progress)| {
                     generate_one(
                         generator,
@@ -1950,7 +2026,22 @@ async fn generate_stream(
                         }
                     }
                 }
-                Ok(Some((final_seed, out_w, out_h, pixels)))
+                // Score this finished image against the cached source embedding (sc-4411). Image build +
+                // pixel clone is paid ONLY when a scorer exists (a With-Character generation) — a plain
+                // t2i / edit job has no scorer, so this is a no-op with no clone. Non-frontal → honest
+                // detected:false N/A; `None` scorer ⇒ field omitted.
+                let face_likeness = scorer.as_ref().and_then(|scorer| {
+                    crate::face_likeness::score_generated_image(
+                        Some(scorer),
+                        &Image {
+                            width: out_w,
+                            height: out_h,
+                            pixels: pixels.clone(),
+                        },
+                        likeness_source_ref.as_deref(),
+                    )
+                });
+                Ok(Some((final_seed, out_w, out_h, pixels, face_likeness)))
             })
         },
     );

--- a/crates/sceneworks-worker/src/image_jobs/flux2.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2.rs
@@ -436,28 +436,39 @@ async fn generate_flux2_edit_stream(
         Flux2Grouping::Plain => {}
     }
 
-    // Character-set identity-likeness scoring (epic 4406, sc-4409 angles / sc-4410 poses): the
-    // generator-agnostic post-pass applies to EVERY character set, not just InstantID-routed ones — a
-    // Character-Studio angle set OR a pose-library set on a FLUX.2 edit model is scored through the same
-    // shared seam. The FLUX.2 edit pose tier produces the FINAL image directly (no face-restore pass on
-    // this lane), so scoring the generated image scores what the user sees (sc-4410). Stage the
+    // Identity-likeness scoring (epic 4406, sc-4409 angles / sc-4410 poses / sc-4411 plain
+    // With-Character): the generator-agnostic post-pass applies to EVERY character_image generation, not
+    // just InstantID-routed ones — a Character-Studio angle set, a pose-library set, OR a plain
+    // With-Character generation on a FLUX.2 edit model is scored through the same shared seam. The FLUX.2
+    // edit path produces the FINAL image directly (no face-restore pass on this lane), so scoring the
+    // generated image scores what the user sees. The PLAIN case (sc-4411) is scored only when this is a
+    // `character_image` job with a character `referenceAssetId` (NOT an `edit_image` job, whose `Plain`
+    // grouping also lands here but carries the `sourceAssetId`, not an identity reference). The angle +
+    // pose sets keep their existing scoring; this just adds the plain `character_image` case so the
+    // common With-Character generation is scored too — `score_likeness` covers all three. Stage the
     // antelopev2 face stack (same bundle InstantID uses; a no-op if already cached) and capture the
     // source identity reference + its asset id; the `!Send` scorer is built ONCE inside the
-    // generator-worker closure below and reused across all angles / poses. On the angle + pose sets;
-    // staging is non-fatal (a failure → no scorer → scores omitted, the set still renders).
+    // generator-worker closure below and reused across all outputs. Staging is non-fatal (a failure → no
+    // scorer → scores omitted, the generation still renders).
     let character_set = matches!(grouping, Flux2Grouping::Angles | Flux2Grouping::Poses(_));
-    let face_stack_dir = if character_set {
+    // Plain With-Character: a `character_image` job (so NOT an `edit_image`) whose `Plain` grouping is the
+    // general subject-variation case (sc-4411). For this lane the scored reference is `references[0]` —
+    // for a character_image job that IS the `referenceAssetId` (it is first in `flux2_edit_reference_ids`).
+    let plain_with_character =
+        matches!(grouping, Flux2Grouping::Plain) && request.mode == "character_image";
+    let score_likeness = character_set || plain_with_character;
+    let face_stack_dir = if score_likeness {
         match ensure_face_stack_dir(api, settings, job).await {
             Ok(dir) => Some(dir),
             Err(error) => {
-                tracing::warn!(error = %error, "character-set face-stack staging failed; likeness scores omitted");
+                tracing::warn!(error = %error, "character_image face-stack staging failed; likeness scores omitted");
                 None
             }
         }
     } else {
         None
     };
-    let likeness_source = (character_set && face_stack_dir.is_some()).then(|| references[0].clone());
+    let likeness_source = (score_likeness && face_stack_dir.is_some()).then(|| references[0].clone());
     let likeness_source_ref = reference_ids.first().cloned();
 
     let (width, height) = (request.width, request.height);
@@ -533,11 +544,11 @@ async fn generate_flux2_edit_stream(
                         &cancel,
                         on_progress,
                     )?;
-                    // Score this finished angle / pose against the cached source embedding (sc-4409/
-                    // sc-4410). The Image build + pixel clone is paid ONLY when a scorer exists (an
-                    // angle or pose set) — the common plain-edit path has no scorer, so this is a no-op
-                    // with no clone. Profile / up / down / full-body → honest detected:false N/A; `None`
-                    // scorer ⇒ field omitted.
+                    // Score this finished image against the cached source embedding (sc-4409 angles /
+                    // sc-4410 poses / sc-4411 plain With-Character). The Image build + pixel clone is paid
+                    // ONLY when a scorer exists (a character_image generation) — a plain `edit_image` job
+                    // has no scorer, so this is a no-op with no clone. Profile / up / down / full-body →
+                    // honest detected:false N/A; `None` scorer ⇒ field omitted.
                     let face_likeness = scorer.as_ref().and_then(|scorer| {
                         crate::face_likeness::score_generated_image(
                             Some(scorer),

--- a/crates/sceneworks-worker/src/image_jobs/flux_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux_ipadapter.rs
@@ -268,12 +268,16 @@ async fn generate_candle_flux_ipadapter_stream(
 
     // Identity-likeness scoring (epic 4406, sc-4411 plain With-Character): the candle FLUX XLabs
     // IP-Adapter lane is the With-Character route for a FLUX.1 model — score every output against the
-    // reference face through the SHARED generator-agnostic seam, but only for an Image Studio "With
-    // Character" (`character_image`) generation. Stage the antelopev2 SCRFD + ArcFace bundle; the `!Send`
-    // scorer is built ONCE inside the load closure and reused across the N outputs (source embedded
-    // once). The source is the CURRENT job's `referenceAssetId`. Staging is non-fatal (failure → scores
-    // omitted, generation still renders).
-    let score_likeness = request.mode == "character_image";
+    // reference face through the SHARED generator-agnostic seam. Eligibility goes through
+    // `resolve_character_image_likeness_source` (the SAME gate the macOS lanes use), so the angle/pose/
+    // edit exclusion is explicit and self-contained here — NOT dependent on dispatch order (an angle/pose
+    // job is excluded by the helper even if it ever reached this lane, so it can never be double-scored).
+    // The helper's decode is ignored: the already-decoded `reference` (this lane's generation input, the
+    // current job's `referenceAssetId`) is the scorer source, so there is no second decode. Stage the
+    // antelopev2 SCRFD + ArcFace bundle; the `!Send` scorer is built ONCE inside the load closure and
+    // reused across the N outputs (source embedded once). Staging is non-fatal (failure → scores omitted).
+    let score_likeness =
+        resolve_character_image_likeness_source(request, settings, project_path).is_some();
     let face_stack_dir = if score_likeness {
         match ensure_face_stack_dir(api, settings, job).await {
             Ok(dir) => Some(dir),

--- a/crates/sceneworks-worker/src/image_jobs/flux_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux_ipadapter.rs
@@ -266,6 +266,28 @@ async fn generate_candle_flux_ipadapter_stream(
     )?;
     let (adapter_file, encoder_dir) = ensure_flux_ipadapter_weights(api, settings, job).await?;
 
+    // Identity-likeness scoring (epic 4406, sc-4411 plain With-Character): the candle FLUX XLabs
+    // IP-Adapter lane is the With-Character route for a FLUX.1 model — score every output against the
+    // reference face through the SHARED generator-agnostic seam, but only for an Image Studio "With
+    // Character" (`character_image`) generation. Stage the antelopev2 SCRFD + ArcFace bundle; the `!Send`
+    // scorer is built ONCE inside the load closure and reused across the N outputs (source embedded
+    // once). The source is the CURRENT job's `referenceAssetId`. Staging is non-fatal (failure → scores
+    // omitted, generation still renders).
+    let score_likeness = request.mode == "character_image";
+    let face_stack_dir = if score_likeness {
+        match ensure_face_stack_dir(api, settings, job).await {
+            Ok(dir) => Some(dir),
+            Err(error) => {
+                tracing::warn!(error = %error, "character_image face-stack staging failed; likeness scores omitted");
+                None
+            }
+        }
+    } else {
+        None
+    };
+    let likeness_source = face_stack_dir.as_ref().map(|_| reference.clone());
+    let likeness_source_ref = reference_id.to_owned();
+
     let steps = flux_ipadapter_steps(request);
     let guidance = flux_ipadapter_guidance(request);
     let ip_scale = advanced::f32_clamped(
@@ -304,12 +326,21 @@ async fn generate_candle_flux_ipadapter_stream(
             let model = IpAdapterFlux::load(&paths).map_err(|error| {
                 WorkerError::Engine(format!("FLUX IP-Adapter load failed: {error}"))
             })?;
-            Ok((model, reference))
+            // Per-job identity-likeness scorer built ONCE here (`!Send` face stack on the blocking
+            // thread); source embedded once, reused across every output (sc-4411). `None` ⇒ non-fatal
+            // staging / construction failure ⇒ scores omitted.
+            let scorer = match (&face_stack_dir, &likeness_source) {
+                (Some(dir), Some(source)) => {
+                    crate::face_likeness::build_face_likeness_scorer(dir, source)
+                }
+                _ => None,
+            };
+            Ok((model, reference, scorer))
         },
-        move |(model, reference), tx, cancel| {
+        move |(model, reference, scorer), tx, cancel| {
             // `IpAdapterFlux::generate` takes `&self` (the IP tokens live in a per-call injector, not on
             // the DiT), so — unlike the SDXL/Kolors lanes — the per-item closure needs no `mut model`.
-            drive_gen_items(tx, work, move |_index, (seed, prompt), on_progress| {
+            drive_gen_items_scored(tx, work, move |_index, (seed, prompt), on_progress| {
                 if cancel.is_cancelled() {
                     return Ok(None);
                 }
@@ -332,7 +363,20 @@ async fn generate_candle_flux_ipadapter_stream(
                         )));
                     }
                 };
-                Ok(Some((seed, out.width, out.height, out.pixels)))
+                // Score this finished image against the cached source embedding (sc-4411). Clone paid
+                // ONLY when a scorer exists; non-frontal → honest detected:false N/A; `None` ⇒ omitted.
+                let face_likeness = scorer.as_ref().and_then(|scorer| {
+                    crate::face_likeness::score_generated_image(
+                        Some(scorer),
+                        &Image {
+                            width: out.width,
+                            height: out.height,
+                            pixels: out.pixels.clone(),
+                        },
+                        Some(likeness_source_ref.as_str()),
+                    )
+                });
+                Ok(Some((seed, out.width, out.height, out.pixels, face_likeness)))
             })
         },
     );

--- a/crates/sceneworks-worker/src/image_jobs/instantid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/instantid.rs
@@ -735,10 +735,11 @@ async fn generate_instantid_stream(
     );
 
     let negative_prompt = request.negative_prompt.clone();
-    // The reference asset id is the `sourceAssetId` recorded on each angle / pose `faceLikeness` block
-    // (sc-4408/sc-4409/sc-4410) so a consumer can attribute the score back to the source identity face.
-    // Captured as an owned String for the blocking closure. Only consumed on the angle/pose-set scoring
-    // lane; allow it unused on the non-face-backend build.
+    // The reference asset id is the `sourceAssetId` recorded on each `faceLikeness` block
+    // (sc-4408/sc-4409/sc-4410/sc-4411) so a consumer can attribute the score back to the source
+    // identity face. Captured as an owned String for the blocking closure. Consumed on every InstantID
+    // mode now (single identity / angle / pose all score, sc-4411); allow it unused on the
+    // non-face-backend build.
     #[cfg_attr(
         not(any(
             target_os = "macos",
@@ -850,22 +851,24 @@ async fn generate_instantid_stream(
             } else {
                 None
             };
-            // Identity-likeness scorer (epic 4406, sc-4409 angles / sc-4410 poses): for an angle set
-            // OR a pose set, embed the source identity face ONCE here and reuse it across every angle /
-            // pose, through the SHARED generator-agnostic seam (the same `build_face_likeness_scorer`
-            // the FLUX.2 / Qwen / SenseNova lanes call). It loads a SEPARATE SCRFD + ArcFace stack from
-            // the engine's `with_face`, but from the SAME staged antelopev2 bundle, so no extra weights.
-            // Construction is non-fatal (weights / no source face → `None` → scores omitted; the set
-            // still renders). Built for angle + pose sets; single identity doesn't score.
+            // Identity-likeness scorer (epic 4406, sc-4409 angles / sc-4410 poses / sc-4411 plain
+            // With-Character): for EVERY InstantID character_image job — single identity (the plain
+            // With-Character generation, sc-4411), an angle set, OR a pose set — embed the source
+            // identity face ONCE here and reuse it across every output image, through the SHARED
+            // generator-agnostic seam (the same `build_face_likeness_scorer` the FLUX.2 / Qwen /
+            // SenseNova lanes call). It loads a SEPARATE SCRFD + ArcFace stack from the engine's
+            // `with_face`, but from the SAME staged antelopev2 bundle, so no extra weights. All three
+            // modes carry the character `referenceAssetId` (InstantID requires a reference face), so the
+            // scorer is always built — the plain identity case is the general With-Character scoring
+            // sc-4411 wires. Construction is non-fatal (weights / no source face → `None` → scores
+            // omitted; generation still renders).
             #[cfg(any(
                 target_os = "macos",
                 all(not(target_os = "macos"), feature = "backend-candle")
             ))]
-            let scorer: Option<crate::face_likeness::FaceLikenessScorer> = if angle_set || pose_set {
+            let scorer: Option<crate::face_likeness::FaceLikenessScorer> = {
                 let face_weights_dir = scrfd_path.parent().unwrap_or(scrfd_path.as_path());
                 crate::face_likeness::build_face_likeness_scorer(face_weights_dir, &reference)
-            } else {
-                None
             };
             #[cfg(not(any(
                 target_os = "macos",
@@ -976,17 +979,16 @@ async fn generate_instantid_stream(
                             }
                         };
                     }
-                    // Identity-likeness post-pass (sc-4409 angles / sc-4410 poses): score this finished
-                    // image against the per-job cached source embedding, on this blocking thread (the
-                    // `!Send` face stack lives here). CRITICAL ordering (sc-4410): this runs AFTER the
-                    // optional face-restore re-render above, so `out` is the FINAL post-restore image —
-                    // the score reflects exactly what the user sees. `score_or_null` makes per-image
-                    // scoring non-fatal (a backend error → a logged `null`), and a full-body / turned /
-                    // profile pose with no reliable frontal face records an honest `detected:false` N/A —
-                    // never a misleading low number. `None` scorer (single identity, or a failed
-                    // construction) ⇒ no block ⇒ the field is omitted. The Image build + pixel clone is
-                    // paid ONLY when a scorer exists (an angle or pose set) — single identity has no
-                    // scorer, so this is a no-op, no clone.
+                    // Identity-likeness post-pass (sc-4409 angles / sc-4410 poses / sc-4411 plain
+                    // With-Character): score this finished image against the per-job cached source
+                    // embedding, on this blocking thread (the `!Send` face stack lives here). CRITICAL
+                    // ordering (sc-4410): this runs AFTER the optional face-restore re-render above, so
+                    // `out` is the FINAL post-restore image — the score reflects exactly what the user
+                    // sees. `score_or_null` makes per-image scoring non-fatal (a backend error → a
+                    // logged `null`), and a full-body / turned / profile result with no reliable frontal
+                    // face records an honest `detected:false` N/A — never a misleading low number. `None`
+                    // scorer (a failed construction) ⇒ no block ⇒ the field is omitted. The Image build +
+                    // pixel clone is paid ONLY when a scorer exists.
                     #[cfg(any(
                         target_os = "macos",
                         all(not(target_os = "macos"), feature = "backend-candle")

--- a/crates/sceneworks-worker/src/image_jobs/kolors_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/kolors_ipadapter.rs
@@ -235,6 +235,27 @@ async fn generate_candle_kolors_ipadapter_stream(
     )?;
     let ip_adapter = ensure_kolors_ipadapter_weights(api, settings, job).await?;
 
+    // Identity-likeness scoring (epic 4406, sc-4411 plain With-Character): the candle Kolors IP-Adapter
+    // lane is the With-Character route for a Kolors model — score every output against the reference face
+    // through the SHARED generator-agnostic seam, but only for an Image Studio "With Character"
+    // (`character_image`) generation. Stage the antelopev2 SCRFD + ArcFace bundle; the `!Send` scorer is
+    // built ONCE inside the load closure and reused across the N outputs (source embedded once). The
+    // source is the CURRENT job's `referenceAssetId`. Staging is non-fatal (failure → scores omitted).
+    let score_likeness = request.mode == "character_image";
+    let face_stack_dir = if score_likeness {
+        match ensure_face_stack_dir(api, settings, job).await {
+            Ok(dir) => Some(dir),
+            Err(error) => {
+                tracing::warn!(error = %error, "character_image face-stack staging failed; likeness scores omitted");
+                None
+            }
+        }
+    } else {
+        None
+    };
+    let likeness_source = face_stack_dir.as_ref().map(|_| reference.clone());
+    let likeness_source_ref = reference_id.to_owned();
+
     let steps = kolors_ipadapter_steps(request);
     let guidance = kolors_ipadapter_guidance(request);
     let ip_scale = advanced::f32_clamped(
@@ -294,13 +315,22 @@ async fn generate_candle_kolors_ipadapter_stream(
             let model = IpAdapterKolors::load(&paths).map_err(|error| {
                 WorkerError::Engine(format!("Kolors IP-Adapter load failed: {error}"))
             })?;
-            Ok((model, reference))
+            // Per-job identity-likeness scorer built ONCE here (`!Send` face stack on the blocking
+            // thread); source embedded once, reused across every output (sc-4411). `None` ⇒ non-fatal
+            // staging / construction failure ⇒ scores omitted.
+            let scorer = match (&face_stack_dir, &likeness_source) {
+                (Some(dir), Some(source)) => {
+                    crate::face_likeness::build_face_likeness_scorer(dir, source)
+                }
+                _ => None,
+            };
+            Ok((model, reference, scorer))
         },
-        move |(model, reference), tx, cancel| {
+        move |(model, reference, scorer), tx, cancel| {
             // `IpAdapterKolors::generate` takes `&mut self` (it sets the IP image tokens on the UNet
             // before the denoise), so the per-item closure mutates `model`.
             let mut model = model;
-            drive_gen_items(tx, work, move |_index, (seed, prompt), on_progress| {
+            drive_gen_items_scored(tx, work, move |_index, (seed, prompt), on_progress| {
                 if cancel.is_cancelled() {
                     return Ok(None);
                 }
@@ -326,7 +356,20 @@ async fn generate_candle_kolors_ipadapter_stream(
                         )));
                     }
                 };
-                Ok(Some((seed, out.width, out.height, out.pixels)))
+                // Score this finished image against the cached source embedding (sc-4411). Clone paid
+                // ONLY when a scorer exists; non-frontal → honest detected:false N/A; `None` ⇒ omitted.
+                let face_likeness = scorer.as_ref().and_then(|scorer| {
+                    crate::face_likeness::score_generated_image(
+                        Some(scorer),
+                        &Image {
+                            width: out.width,
+                            height: out.height,
+                            pixels: out.pixels.clone(),
+                        },
+                        Some(likeness_source_ref.as_str()),
+                    )
+                });
+                Ok(Some((seed, out.width, out.height, out.pixels, face_likeness)))
             })
         },
     );

--- a/crates/sceneworks-worker/src/image_jobs/kolors_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/kolors_ipadapter.rs
@@ -237,11 +237,16 @@ async fn generate_candle_kolors_ipadapter_stream(
 
     // Identity-likeness scoring (epic 4406, sc-4411 plain With-Character): the candle Kolors IP-Adapter
     // lane is the With-Character route for a Kolors model — score every output against the reference face
-    // through the SHARED generator-agnostic seam, but only for an Image Studio "With Character"
-    // (`character_image`) generation. Stage the antelopev2 SCRFD + ArcFace bundle; the `!Send` scorer is
-    // built ONCE inside the load closure and reused across the N outputs (source embedded once). The
-    // source is the CURRENT job's `referenceAssetId`. Staging is non-fatal (failure → scores omitted).
-    let score_likeness = request.mode == "character_image";
+    // through the SHARED generator-agnostic seam. Eligibility goes through `resolve_character_image_
+    // likeness_source` (the SAME gate the macOS lanes use), so the angle/pose/edit exclusion is explicit
+    // and self-contained here — NOT dependent on dispatch order (an angle/pose job is excluded by the
+    // helper even if it ever reached this lane, so it can never be double-scored). The helper's decode is
+    // ignored: the already-decoded `reference` (this lane's generation input, the current job's
+    // `referenceAssetId`) is the scorer source, so there is no second decode. Stage the antelopev2 SCRFD +
+    // ArcFace bundle; the `!Send` scorer is built ONCE inside the load closure and reused across the N
+    // outputs (source embedded once). Staging is non-fatal (failure → scores omitted).
+    let score_likeness =
+        resolve_character_image_likeness_source(request, settings, project_path).is_some();
     let face_stack_dir = if score_likeness {
         match ensure_face_stack_dir(api, settings, job).await {
             Ok(dir) => Some(dir),

--- a/crates/sceneworks-worker/src/image_jobs/pulid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/pulid.rs
@@ -403,6 +403,25 @@ async fn generate_pulid_flux_stream(
     let (width, height) = (request.width, request.height);
     let prompt = request.prompt.clone();
 
+    // Identity-likeness scoring (epic 4406, sc-4411 plain With-Character): PuLID-FLUX serves only the
+    // single-identity `character_image` path (one identity image per seed, no angle/pose grouping), so
+    // it is always a With-Character generation — score every output against the reference face through
+    // the SHARED generator-agnostic seam (the same `build_face_likeness_scorer` InstantID / FLUX.2 /
+    // Qwen / SenseNova use). Stage the antelopev2 face stack (shared bundle, no-op if cached); the
+    // `!Send` scorer is built ONCE inside the generator-worker closure and reused across the N outputs
+    // (source embedded once — the caching AC). The source is the CURRENT job's `referenceAssetId`, so
+    // changing the reference changes the scored source. Staging is non-fatal (failure → no scorer →
+    // scores omitted, generation still renders).
+    let face_stack_dir = match ensure_face_stack_dir(api, settings, job).await {
+        Ok(dir) => Some(dir),
+        Err(error) => {
+            tracing::warn!(error = %error, "PuLID-FLUX face-stack staging failed; likeness scores omitted");
+            None
+        }
+    };
+    let likeness_source = face_stack_dir.as_ref().map(|_| reference.clone());
+    let likeness_source_ref = reference_id.to_owned();
+
     let spec = load_spec(flux_base, quant, Vec::new(), None);
     let (cancel, rx, blocking) = start_cached_gen_stream(
         job.id.clone(),
@@ -411,7 +430,15 @@ async fn generate_pulid_flux_stream(
         spec,
         format!("{PULID_ENGINE_ID} load failed"),
         move |generator, tx, cancel| {
-            drive_gen_items(tx, seeds, move |_index, seed, on_progress| {
+            // Per-job identity-likeness scorer built ONCE on the generator-worker thread (the `!Send`
+            // face stack lives here); source embedded once, reused across every output (sc-4411).
+            let scorer = match (&face_stack_dir, &likeness_source) {
+                (Some(dir), Some(source)) => {
+                    crate::face_likeness::build_face_likeness_scorer(dir, source)
+                }
+                _ => None,
+            };
+            drive_gen_items_scored(tx, seeds, move |_index, seed, on_progress| {
                 if cancel.is_cancelled() {
                     return Ok(None);
                 }
@@ -452,7 +479,22 @@ async fn generate_pulid_flux_stream(
                         let image = images.pop().ok_or_else(|| {
                             WorkerError::Engine("PuLID-FLUX produced no image".to_owned())
                         })?;
-                        Ok(Some((seed, image.width, image.height, image.pixels)))
+                        // Score this finished image against the cached source embedding (sc-4411). The
+                        // Image build + pixel clone is paid ONLY when a scorer exists; a non-frontal /
+                        // no-face result records an honest detected:false N/A, `None` scorer ⇒ field
+                        // omitted.
+                        let face_likeness = scorer.as_ref().and_then(|scorer| {
+                            crate::face_likeness::score_generated_image(
+                                Some(scorer),
+                                &Image {
+                                    width: image.width,
+                                    height: image.height,
+                                    pixels: image.pixels.clone(),
+                                },
+                                Some(likeness_source_ref.as_str()),
+                            )
+                        });
+                        Ok(Some((seed, image.width, image.height, image.pixels, face_likeness)))
                     }
                     _ => Err(WorkerError::Engine(
                         "PuLID-FLUX returned non-image output".to_owned(),

--- a/crates/sceneworks-worker/src/image_jobs/pulid_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/pulid_candle.rs
@@ -274,19 +274,28 @@ async fn generate_candle_pulid_stream(
     let (adapter, eva, face_dir) = ensure_pulid_candle_weights(api, settings, job).await?;
 
     // Identity-likeness scoring (epic 4406, sc-4411 plain With-Character): the candle PuLID-FLUX lane
-    // serves only the single-identity `character_image` path (one identity image per seed), so it is
-    // always a With-Character generation — score every output against the reference face through the
-    // SHARED generator-agnostic seam. Stage the antelopev2 SCRFD + ArcFace bundle (the same one the
-    // scorer's candle leg loads; distinct from PuLID's own BiSeNet `face_dir`); the `!Send` scorer is
-    // built ONCE inside the load closure and reused across the N outputs (source embedded once — the
-    // caching AC). The source is the CURRENT job's `referenceAssetId`. Staging is non-fatal (failure →
-    // no scorer → scores omitted, generation still renders).
-    let face_stack_dir = match ensure_face_stack_dir(api, settings, job).await {
-        Ok(dir) => Some(dir),
-        Err(error) => {
-            tracing::warn!(error = %error, "PuLID-FLUX face-stack staging failed; likeness scores omitted");
-            None
+    // serves the single-identity `character_image` path (one identity image per seed) and has no
+    // angle/pose tier — score every output against the reference face through the SHARED generator-
+    // agnostic seam. Eligibility goes through `resolve_character_image_likeness_source` (the SAME gate the
+    // macOS lanes use), so the angle/pose/edit exclusion is explicit and self-contained here — NOT
+    // dependent on dispatch order. The helper's decode is ignored: the already-decoded `reference` (this
+    // lane's generation input, the current job's `referenceAssetId`) is the scorer source, so there is no
+    // second decode. Stage the antelopev2 SCRFD + ArcFace bundle (the same one the scorer's candle leg
+    // loads; distinct from PuLID's own BiSeNet `face_dir`); the `!Send` scorer is built ONCE inside the
+    // load closure and reused across the N outputs (source embedded once — the caching AC). Staging is
+    // non-fatal (failure → no scorer → scores omitted, generation still renders).
+    let score_likeness =
+        resolve_character_image_likeness_source(request, settings, project_path).is_some();
+    let face_stack_dir = if score_likeness {
+        match ensure_face_stack_dir(api, settings, job).await {
+            Ok(dir) => Some(dir),
+            Err(error) => {
+                tracing::warn!(error = %error, "PuLID-FLUX face-stack staging failed; likeness scores omitted");
+                None
+            }
         }
+    } else {
+        None
     };
     let likeness_source = face_stack_dir.as_ref().map(|_| reference.clone());
     let likeness_source_ref = reference_id.to_owned();

--- a/crates/sceneworks-worker/src/image_jobs/pulid_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/pulid_candle.rs
@@ -273,6 +273,24 @@ async fn generate_candle_pulid_stream(
     )?;
     let (adapter, eva, face_dir) = ensure_pulid_candle_weights(api, settings, job).await?;
 
+    // Identity-likeness scoring (epic 4406, sc-4411 plain With-Character): the candle PuLID-FLUX lane
+    // serves only the single-identity `character_image` path (one identity image per seed), so it is
+    // always a With-Character generation — score every output against the reference face through the
+    // SHARED generator-agnostic seam. Stage the antelopev2 SCRFD + ArcFace bundle (the same one the
+    // scorer's candle leg loads; distinct from PuLID's own BiSeNet `face_dir`); the `!Send` scorer is
+    // built ONCE inside the load closure and reused across the N outputs (source embedded once — the
+    // caching AC). The source is the CURRENT job's `referenceAssetId`. Staging is non-fatal (failure →
+    // no scorer → scores omitted, generation still renders).
+    let face_stack_dir = match ensure_face_stack_dir(api, settings, job).await {
+        Ok(dir) => Some(dir),
+        Err(error) => {
+            tracing::warn!(error = %error, "PuLID-FLUX face-stack staging failed; likeness scores omitted");
+            None
+        }
+    };
+    let likeness_source = face_stack_dir.as_ref().map(|_| reference.clone());
+    let likeness_source_ref = reference_id.to_owned();
+
     let steps = pulid_candle_steps(request);
     let guidance = pulid_candle_guidance(request);
     let id_weight = pulid_candle_id_weight(request);
@@ -329,10 +347,20 @@ async fn generate_candle_pulid_stream(
             let model = PulidFlux::load(&paths).map_err(|error| {
                 WorkerError::Engine(format!("PuLID-FLUX load failed: {error}"))
             })?;
-            Ok((model, reference))
+            // Build the per-job identity-likeness scorer ONCE here (on the blocking thread where the
+            // `!Send` face stack is allowed), embedding the source identity face a single time and
+            // reusing it across every output (sc-4411 caching AC). `None` ⇒ non-fatal staging /
+            // construction failure ⇒ scores omitted; the generation still renders.
+            let scorer = match (&face_stack_dir, &likeness_source) {
+                (Some(dir), Some(source)) => {
+                    crate::face_likeness::build_face_likeness_scorer(dir, source)
+                }
+                _ => None,
+            };
+            Ok((model, reference, scorer))
         },
-        move |(model, reference), tx, cancel| {
-            drive_gen_items(tx, work, move |_index, (seed, prompt), on_progress| {
+        move |(model, reference, scorer), tx, cancel| {
+            drive_gen_items_scored(tx, work, move |_index, (seed, prompt), on_progress| {
                 if cancel.is_cancelled() {
                     return Ok(None);
                 }
@@ -357,7 +385,21 @@ async fn generate_candle_pulid_stream(
                         )));
                     }
                 };
-                Ok(Some((seed, out.width, out.height, out.pixels)))
+                // Score this finished image against the cached source embedding (sc-4411). The Image
+                // build + pixel clone is paid ONLY when a scorer exists; a non-frontal / no-face result
+                // records an honest detected:false N/A, `None` scorer ⇒ field omitted.
+                let face_likeness = scorer.as_ref().and_then(|scorer| {
+                    crate::face_likeness::score_generated_image(
+                        Some(scorer),
+                        &Image {
+                            width: out.width,
+                            height: out.height,
+                            pixels: out.pixels.clone(),
+                        },
+                        Some(likeness_source_ref.as_str()),
+                    )
+                });
+                Ok(Some((seed, out.width, out.height, out.pixels, face_likeness)))
             })
         },
     );

--- a/crates/sceneworks-worker/src/image_jobs/qwen.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen.rs
@@ -718,27 +718,35 @@ async fn generate_qwen_edit_stream(
         );
     }
 
-    // Character-set identity-likeness scoring (epic 4406, sc-4409 angles / sc-4410 poses): generator-
-    // agnostic — a Character-Studio angle set OR a pose-library set on Qwen-Edit is scored through the
-    // same shared seam as InstantID / FLUX.2. The Qwen edit pose tier produces the FINAL image directly
-    // (no face-restore pass on this lane), so scoring the generated image scores what the user sees
-    // (sc-4410). Stage the antelopev2 face stack (shared bundle, no-op if cached) and capture the source
-    // identity reference + asset id; the `!Send` scorer is built ONCE in the closure and reused across
-    // angles / poses. On the angle + pose sets; staging is non-fatal (failure → no scorer → scores
-    // omitted, set still renders).
+    // Identity-likeness scoring (epic 4406, sc-4409 angles / sc-4410 poses / sc-4411 plain
+    // With-Character): generator-agnostic — a Character-Studio angle set, a pose-library set, OR a plain
+    // With-Character generation on Qwen-Edit is scored through the same shared seam as InstantID /
+    // FLUX.2. The Qwen edit path produces the FINAL image directly (no face-restore pass on this lane),
+    // so scoring the generated image scores what the user sees. The PLAIN case (sc-4411) is scored only
+    // when this is a `character_image` job with a character `referenceAssetId` (NOT an `edit_image` job,
+    // whose `Plain` grouping also lands here but carries `sourceAssetId`, not an identity reference).
+    // Stage the antelopev2 face stack (shared bundle, no-op if cached) and capture the source identity
+    // reference + asset id; the `!Send` scorer is built ONCE in the closure and reused across all
+    // outputs. Staging is non-fatal (failure → no scorer → scores omitted, generation still renders).
     let character_set = matches!(grouping, Flux2Grouping::Angles | Flux2Grouping::Poses(_));
-    let face_stack_dir = if character_set {
+    // Plain With-Character (sc-4411): a `character_image` job (so NOT an `edit_image`) whose `Plain`
+    // grouping is the general subject-variation case. The scored reference is `references[0]` — for a
+    // character_image job that IS the `referenceAssetId` (first in `flux2_edit_reference_ids`).
+    let plain_with_character =
+        matches!(grouping, Flux2Grouping::Plain) && request.mode == "character_image";
+    let score_likeness = character_set || plain_with_character;
+    let face_stack_dir = if score_likeness {
         match ensure_face_stack_dir(api, settings, job).await {
             Ok(dir) => Some(dir),
             Err(error) => {
-                tracing::warn!(error = %error, "character-set face-stack staging failed; likeness scores omitted");
+                tracing::warn!(error = %error, "character_image face-stack staging failed; likeness scores omitted");
                 None
             }
         }
     } else {
         None
     };
-    let likeness_source = (character_set && face_stack_dir.is_some()).then(|| references[0].clone());
+    let likeness_source = (score_likeness && face_stack_dir.is_some()).then(|| references[0].clone());
     let likeness_source_ref = reference_ids.first().cloned();
 
     let (width, height) = (request.width, request.height);
@@ -819,11 +827,11 @@ async fn generate_qwen_edit_stream(
                         &cancel,
                         on_progress,
                     )?;
-                    // Score this finished angle / pose against the cached source embedding (sc-4409/
-                    // sc-4410). The Image build + pixel clone is paid ONLY when a scorer exists (an
-                    // angle or pose set) — the common plain-edit path has no scorer, so this is a no-op
-                    // with no clone. Profile / up / down / full-body → honest detected:false N/A; `None`
-                    // scorer ⇒ field omitted.
+                    // Score this finished image against the cached source embedding (sc-4409 angles /
+                    // sc-4410 poses / sc-4411 plain With-Character). The Image build + pixel clone is paid
+                    // ONLY when a scorer exists (a character_image generation) — a plain `edit_image` job
+                    // has no scorer, so this is a no-op with no clone. Profile / up / down / full-body →
+                    // honest detected:false N/A; `None` scorer ⇒ field omitted.
                     let face_likeness = scorer.as_ref().and_then(|scorer| {
                         crate::face_likeness::score_generated_image(
                             Some(scorer),

--- a/crates/sceneworks-worker/src/image_jobs/sdxl.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl.rs
@@ -385,6 +385,34 @@ async fn generate_sdxl_advanced_stream(
         .collect();
     let total = seeds.len();
 
+    // Identity-likeness scoring (epic 4406, sc-4411 plain With-Character): the SDXL IP-Adapter sub-mode
+    // (`SdxlSubMode::Ip`) is the With-Character route for an SDXL-family model — score every output
+    // against the reference face through the SHARED generator-agnostic seam, but only for an Image Studio
+    // "With Character" (`character_image`) generation (an Edit/Inpaint/Outpaint job has no identity
+    // reference; a non-character reference job records no identity score). `resolve_character_image_
+    // likeness_source` resolves the CURRENT job's `referenceAssetId` (so changing the reference changes
+    // the scored source) and is non-fatal (a decode failure → `None` → scores omitted). Decoding the
+    // source here is independent of the conditioning Reference above, so the existing IP path is
+    // untouched. The `!Send` scorer is built ONCE inside the closure and reused across the N outputs.
+    let likeness =
+        matches!(sub_mode, SdxlSubMode::Ip).then(|| {
+            resolve_character_image_likeness_source(request, settings, project_path)
+        });
+    let face_stack_dir = match likeness {
+        Some(Some(_)) => match ensure_face_stack_dir(api, settings, job).await {
+            Ok(dir) => Some(dir),
+            Err(error) => {
+                tracing::warn!(error = %error, "character_image face-stack staging failed; likeness scores omitted");
+                None
+            }
+        },
+        _ => None,
+    };
+    let likeness_source = match (&face_stack_dir, likeness.flatten()) {
+        (Some(_), Some((image, asset_id))) => Some((image, asset_id)),
+        _ => None,
+    };
+
     let prompt = request.prompt.clone();
     let negative_prompt = negative_prompt.clone();
     let adapter_count = adapters.len();
@@ -396,7 +424,17 @@ async fn generate_sdxl_advanced_stream(
         spec,
         "sdxl advanced load failed".to_owned(),
         move |generator, tx, cancel| {
-            drive_gen_items(tx, seeds, move |_index, seed, on_progress| {
+            // Per-job identity-likeness scorer built ONCE on the generator-worker thread (the `!Send`
+            // face stack lives here); source embedded once, reused across every output (sc-4411). `None`
+            // ⇒ not an IP character_image job, or non-fatal staging/construction failure ⇒ scores omitted.
+            let scorer = match (&face_stack_dir, &likeness_source) {
+                (Some(dir), Some((source, _))) => {
+                    crate::face_likeness::build_face_likeness_scorer(dir, source)
+                }
+                _ => None,
+            };
+            let likeness_source_ref = likeness_source.as_ref().map(|(_, id)| id.clone());
+            drive_gen_items_scored(tx, seeds, move |_index, seed, on_progress| {
                 let (out_w, out_h, pixels) = sdxl_advanced_generate_one(
                     generator,
                     &prompt,
@@ -410,7 +448,21 @@ async fn generate_sdxl_advanced_stream(
                     &cancel,
                     on_progress,
                 )?;
-                Ok(Some((seed, out_w, out_h, pixels)))
+                // Score this finished image against the cached source embedding (sc-4411). Clone paid
+                // ONLY when a scorer exists (an IP character_image job); non-frontal → honest
+                // detected:false N/A; `None` scorer ⇒ field omitted.
+                let face_likeness = scorer.as_ref().and_then(|scorer| {
+                    crate::face_likeness::score_generated_image(
+                        Some(scorer),
+                        &Image {
+                            width: out_w,
+                            height: out_h,
+                            pixels: pixels.clone(),
+                        },
+                        likeness_source_ref.as_deref(),
+                    )
+                });
+                Ok(Some((seed, out_w, out_h, pixels, face_likeness)))
             })
         },
     );

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
@@ -240,13 +240,17 @@ async fn generate_candle_sdxl_ipadapter_stream(
 
     // Identity-likeness scoring (epic 4406, sc-4411 plain With-Character): the candle SDXL IP-Adapter
     // lane is the With-Character route for an SDXL-family model — score every output against the
-    // reference face through the SHARED generator-agnostic seam, but only for an Image Studio "With
-    // Character" (`character_image`) generation (a non-character reference job records no identity score).
-    // Stage the antelopev2 SCRFD + ArcFace bundle (the scorer's candle leg loads it); the `!Send` scorer
-    // is built ONCE inside the load closure and reused across the N outputs (source embedded once — the
-    // caching AC). The source is the CURRENT job's `referenceAssetId`. Staging is non-fatal (failure → no
-    // scorer → scores omitted, generation still renders).
-    let score_likeness = request.mode == "character_image";
+    // reference face through the SHARED generator-agnostic seam. Eligibility goes through
+    // `resolve_character_image_likeness_source` (the SAME gate the macOS lanes use), so the angle/pose/
+    // edit exclusion is explicit and self-contained here — NOT dependent on dispatch order (an angle/pose
+    // job is excluded by the helper even if it ever reached this lane, so it can never be double-scored).
+    // The helper's decode is ignored: the already-decoded `reference` (this lane's generation input, the
+    // current job's `referenceAssetId`) is the scorer source, so there is no second decode. Stage the
+    // antelopev2 SCRFD + ArcFace bundle (the scorer's candle leg loads it); the `!Send` scorer is built
+    // ONCE inside the load closure and reused across the N outputs (source embedded once — the caching
+    // AC). Staging is non-fatal (failure → no scorer → scores omitted, generation still renders).
+    let score_likeness =
+        resolve_character_image_likeness_source(request, settings, project_path).is_some();
     let face_stack_dir = if score_likeness {
         match ensure_face_stack_dir(api, settings, job).await {
             Ok(dir) => Some(dir),

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
@@ -238,6 +238,29 @@ async fn generate_candle_sdxl_ipadapter_stream(
     )?;
     let (ip_bundle, image_encoder) = ensure_sdxl_ipadapter_weights(api, settings, job).await?;
 
+    // Identity-likeness scoring (epic 4406, sc-4411 plain With-Character): the candle SDXL IP-Adapter
+    // lane is the With-Character route for an SDXL-family model — score every output against the
+    // reference face through the SHARED generator-agnostic seam, but only for an Image Studio "With
+    // Character" (`character_image`) generation (a non-character reference job records no identity score).
+    // Stage the antelopev2 SCRFD + ArcFace bundle (the scorer's candle leg loads it); the `!Send` scorer
+    // is built ONCE inside the load closure and reused across the N outputs (source embedded once — the
+    // caching AC). The source is the CURRENT job's `referenceAssetId`. Staging is non-fatal (failure → no
+    // scorer → scores omitted, generation still renders).
+    let score_likeness = request.mode == "character_image";
+    let face_stack_dir = if score_likeness {
+        match ensure_face_stack_dir(api, settings, job).await {
+            Ok(dir) => Some(dir),
+            Err(error) => {
+                tracing::warn!(error = %error, "character_image face-stack staging failed; likeness scores omitted");
+                None
+            }
+        }
+    } else {
+        None
+    };
+    let likeness_source = face_stack_dir.as_ref().map(|_| reference.clone());
+    let likeness_source_ref = reference_id.to_owned();
+
     let steps = sdxl_ipadapter_steps(request);
     let guidance = sdxl_ipadapter_guidance(request);
     let ip_scale = advanced::f32_clamped(
@@ -300,13 +323,22 @@ async fn generate_candle_sdxl_ipadapter_stream(
             let model = IpAdapterSdxl::load(&paths).map_err(|error| {
                 WorkerError::Engine(format!("SDXL IP-Adapter load failed: {error}"))
             })?;
-            Ok((model, reference))
+            // Per-job identity-likeness scorer built ONCE here (on the blocking thread where the `!Send`
+            // face stack is allowed); source embedded once, reused across every output (sc-4411 caching
+            // AC). `None` ⇒ non-fatal staging / construction failure ⇒ scores omitted.
+            let scorer = match (&face_stack_dir, &likeness_source) {
+                (Some(dir), Some(source)) => {
+                    crate::face_likeness::build_face_likeness_scorer(dir, source)
+                }
+                _ => None,
+            };
+            Ok((model, reference, scorer))
         },
-        move |(model, reference), tx, cancel| {
+        move |(model, reference, scorer), tx, cancel| {
             // `IpAdapterSdxl::generate` takes `&mut self` (it sets the IP image tokens on the UNet before
             // the denoise), so the per-item closure mutates `model`.
             let mut model = model;
-            drive_gen_items(tx, work, move |_index, (seed, prompt), on_progress| {
+            drive_gen_items_scored(tx, work, move |_index, (seed, prompt), on_progress| {
                 if cancel.is_cancelled() {
                     return Ok(None);
                 }
@@ -332,7 +364,21 @@ async fn generate_candle_sdxl_ipadapter_stream(
                         )));
                     }
                 };
-                Ok(Some((seed, out.width, out.height, out.pixels)))
+                // Score this finished image against the cached source embedding (sc-4411). Image build +
+                // pixel clone paid ONLY when a scorer exists; non-frontal → honest detected:false N/A;
+                // `None` scorer ⇒ field omitted.
+                let face_likeness = scorer.as_ref().and_then(|scorer| {
+                    crate::face_likeness::score_generated_image(
+                        Some(scorer),
+                        &Image {
+                            width: out.width,
+                            height: out.height,
+                            pixels: out.pixels.clone(),
+                        },
+                        Some(likeness_source_ref.as_str()),
+                    )
+                });
+                Ok(Some((seed, out.width, out.height, out.pixels, face_likeness)))
             })
         },
     );

--- a/crates/sceneworks-worker/src/image_jobs/sensenova.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sensenova.rs
@@ -243,24 +243,34 @@ async fn generate_sensenova_edit_stream(
         raw_settings.insert("angleSet".to_owned(), Value::Bool(true));
     }
 
-    // Angle-set identity-likeness scoring (epic 4406, sc-4409): generator-agnostic — a Character-
-    // Studio angle set on SenseNova-U1 is scored through the same shared seam as InstantID / FLUX.2 /
-    // Qwen. Stage the antelopev2 face stack (shared bundle, no-op if cached) and capture the source
-    // identity reference + asset id; the `!Send` scorer is built ONCE in the closure and reused across
-    // angles. Angle-set only; staging is non-fatal (failure → no scorer → scores omitted, set renders).
+    // Identity-likeness scoring (epic 4406, sc-4409 angles / sc-4411 plain With-Character): generator-
+    // agnostic — a Character-Studio angle set OR a plain With-Character generation on SenseNova-U1 is
+    // scored through the same shared seam as InstantID / FLUX.2 / Qwen (SenseNova has no pose tier). The
+    // PLAIN case (sc-4411) is scored only when this is a `character_image` job with a character
+    // `referenceAssetId` (NOT an `edit_image` job, whose `Plain` grouping also lands here but carries
+    // `sourceAssetId`, not an identity reference). Stage the antelopev2 face stack (shared bundle, no-op
+    // if cached) and capture the source identity reference + asset id; the `!Send` scorer is built ONCE
+    // in the closure and reused across all outputs. Staging is non-fatal (failure → no scorer → scores
+    // omitted, generation still renders).
     let angle_set = matches!(grouping, Flux2Grouping::Angles);
-    let face_stack_dir = if angle_set {
+    // Plain With-Character (sc-4411): a `character_image` job (so NOT an `edit_image`) whose `Plain`
+    // grouping is the general subject-variation case. The scored reference is `references[0]` — for a
+    // character_image job that IS the `referenceAssetId` (first in `qwen_edit_reference_ids`).
+    let plain_with_character =
+        matches!(grouping, Flux2Grouping::Plain) && request.mode == "character_image";
+    let score_likeness = angle_set || plain_with_character;
+    let face_stack_dir = if score_likeness {
         match ensure_face_stack_dir(api, settings, job).await {
             Ok(dir) => Some(dir),
             Err(error) => {
-                tracing::warn!(error = %error, "angle-set face-stack staging failed; likeness scores omitted");
+                tracing::warn!(error = %error, "character_image face-stack staging failed; likeness scores omitted");
                 None
             }
         }
     } else {
         None
     };
-    let likeness_source = (angle_set && face_stack_dir.is_some()).then(|| references[0].clone());
+    let likeness_source = (score_likeness && face_stack_dir.is_some()).then(|| references[0].clone());
     let likeness_source_ref = reference_ids.first().cloned();
 
     // No user adapters by design (sc-6038): SenseNova-U1 is an 8B MoT autoregressive model with no
@@ -302,10 +312,11 @@ async fn generate_sensenova_edit_stream(
                         &cancel,
                         on_progress,
                     )?;
-                    // Score this finished angle against the cached source embedding (sc-4409). The
-                    // Image build + pixel clone is paid ONLY when a scorer exists (an angle set) — the
-                    // common plain-edit path has no scorer, so this is a no-op with no clone. Profile/
-                    // up/down → honest detected:false N/A; `None` scorer ⇒ field omitted.
+                    // Score this finished image against the cached source embedding (sc-4409 angles /
+                    // sc-4411 plain With-Character). The Image build + pixel clone is paid ONLY when a
+                    // scorer exists (a character_image generation) — a plain `edit_image` job has no
+                    // scorer, so this is a no-op with no clone. Profile / up / down → honest
+                    // detected:false N/A; `None` scorer ⇒ field omitted.
                     let face_likeness = scorer.as_ref().and_then(|scorer| {
                         crate::face_likeness::score_generated_image(
                             Some(scorer),

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -3533,6 +3533,75 @@ fn should_fit_edit_source_only_for_off_aspect_edit_image() {
     }))));
 }
 
+/// sc-4411: the With-Character likeness-source resolver gates scoring to a PLAIN `character_image`
+/// generation with a character `referenceAssetId`, and EXCLUDES angle sets / pose sets (already scored
+/// by sc-4409/4410 through the same seam) and non-character modes — the no-double-attach guard. Here the
+/// asset can't decode (empty temp data dir), so the positive plain case returns `None` via the non-fatal
+/// decode path; the assertions key on the gate (the decode-vs-gate distinction is exercised by the
+/// reference-presence cases). Decode of a real asset is covered by the sc-4410 control-source tests.
+#[cfg(target_os = "macos")]
+#[test]
+fn character_image_likeness_source_gates_to_plain_with_character() {
+    let dir = tempfile::tempdir().unwrap();
+    let project_path = dir.path();
+    let mut settings = Settings::from_env();
+    settings.data_dir = dir.path().to_path_buf();
+
+    // A non-character mode (text_to_image / edit_image) is NEVER a With-Character generation: excluded
+    // BEFORE any decode, even with a referenceAssetId present.
+    for mode in ["text_to_image", "edit_image"] {
+        let req = request(json!({
+            "projectId": "p", "model": "instantid_realvisxl", "mode": mode,
+            "referenceAssetId": "ref",
+        }));
+        assert!(
+            resolve_character_image_likeness_source(&req, &settings, project_path).is_none(),
+            "mode {mode} is not a With-Character generation ⇒ no likeness source",
+        );
+    }
+
+    // An angle set (sc-4409) and a pose set (sc-4410) are character_image jobs but are ALREADY scored
+    // through the same seam — the plain resolver must exclude them so the plain case never double-attaches.
+    let angle = request(json!({
+        "projectId": "p", "model": "instantid_realvisxl", "mode": "character_image",
+        "referenceAssetId": "ref", "advanced": { "angleSet": true }
+    }));
+    assert!(
+        resolve_character_image_likeness_source(&angle, &settings, project_path).is_none(),
+        "an angle set is scored by sc-4409 ⇒ the plain resolver excludes it (no double-attach)",
+    );
+    let pose = request(json!({
+        "projectId": "p", "model": "instantid_realvisxl", "mode": "character_image",
+        "referenceAssetId": "ref", "advanced": { "poses": [{ "id": "a" }] }
+    }));
+    assert!(
+        resolve_character_image_likeness_source(&pose, &settings, project_path).is_none(),
+        "a pose set is scored by sc-4410 ⇒ the plain resolver excludes it (no double-attach)",
+    );
+
+    // A plain character_image with NO reference returns None at the reference filter (an honest no-source,
+    // not an error) — distinguishing the reference gate from the mode/grouping gates above.
+    let no_ref = request(json!({
+        "projectId": "p", "model": "instantid_realvisxl", "mode": "character_image",
+    }));
+    assert!(
+        resolve_character_image_likeness_source(&no_ref, &settings, project_path).is_none(),
+        "a character_image with no referenceAssetId has no identity source",
+    );
+
+    // The PLAIN With-Character case (character_image + reference, no angle/pose) passes the gate and
+    // reaches the (non-fatal) decode; the asset is absent here, so it resolves to None WITHOUT panicking
+    // — scoring never aborts a generation (the sc-4407 non-fatal contract).
+    let plain = request(json!({
+        "projectId": "p", "model": "instantid_realvisxl", "mode": "character_image",
+        "referenceAssetId": "missing-asset",
+    }));
+    assert!(
+        resolve_character_image_likeness_source(&plain, &settings, project_path).is_none(),
+        "a missing reference decodes to None (non-fatal), never a panic",
+    );
+}
+
 #[cfg(target_os = "macos")]
 #[test]
 fn contain_box_centers_the_contained_rect() {


### PR DESCRIPTION
## What

Wires the shared, generator-agnostic face-likeness scorer (sc-4407) into the **plain Image Studio "With Character"** path — a regular `character_image` generation against a `referenceAssetId` (no angle set, no pose set). This is the general subject-variation case that complements the already-scored Character Studio **Angles** (sc-4409) and **Poses** (sc-4410), reusing the IDENTICAL seam — no parallel mechanism.

For a With-Character job the per-job scorer is built ONCE from the current `referenceAssetId` source face (embedded once, reused across the N generated images), each finished image attaches a `faceLikeness` block to its sidecar (`GenEvent::Image.face_likeness` → `drive_gen_items_scored` → `consume_gen_events` at `recipe.rawAdapterSettings.faceLikeness`). Non-frontal / no-face results record an honest `detected:false` N/A per the metric-honesty rule. Construction and per-image scoring are non-fatal (failure → field omitted, generation still renders); the hot-path pixel clone is gated behind `scorer.is_some()`.

The source is derived from the **current** job's `referenceAssetId` each job (never cached across jobs / hardcoded), so changing the reference asset changes the source the score is computed against.

## Routes wired (both platforms)

| Route | Platform | Change |
|---|---|---|
| InstantID identity mode | macOS MLX + candle | scorer now built for plain identity too (was angle/pose only) |
| FLUX.2 edit plain `character_image` | macOS | new `plain_with_character` gate arm |
| Qwen-Edit plain `character_image` | macOS | new `plain_with_character` gate arm |
| SenseNova plain `character_image` | macOS | new `plain_with_character` gate arm |
| PuLID-FLUX | macOS MLX + candle | always a With-Character route; switched to scored driver |
| SDXL IP-Adapter | macOS (`SdxlSubMode::Ip`) + candle | scored, gated to `character_image` |
| Kolors IP-Adapter | candle | scored, gated to `character_image` |
| FLUX XLabs IP-Adapter | candle | scored, gated to `character_image` |
| Generic MLX lane (Z-Image identity init, FLUX.1 XLabs IP, Kolors IP) | macOS | scored via the new resolver |

A new shared `resolve_character_image_likeness_source` (base.rs, dual-platform cfg) resolves the plain With-Character source: `mode == character_image` AND a `referenceAssetId` AND **not** an angle/pose grouping.

## Plain vs angle/pose (no double-attach)

Angle and pose sets are also `character_image` jobs but are already scored by sc-4409/4410 through the same seam. The plain resolver **excludes** them (and excludes non-character / `edit_image` jobs, whose `Plain` grouping carries `sourceAssetId`, not an identity reference), so the plain case never double-attaches or conflicts on an angle/pose job. In the FLUX.2/Qwen/SenseNova lanes the existing angle/pose scoring is untouched; a `plain_with_character` arm is OR'd into the gate.

## Scope vs AC

- ✅ A With-Character generation produces a likeness score vs the chosen reference asset, persisted to the result's sidecar.
- ✅ Changing the reference asset changes the source the score is computed against.
- ✅ Non-frontal results return N/A per the metric-honesty rule.
- ✅ Generator-agnostic across the routed identity generators (Z-Image identity init, Flux IP-adapter, InstantID, PuLID, Kolors IP, SDXL IP, and the FLUX.2/Qwen/SenseNova plain edit lanes).

## Tests

- `character_image_likeness_source_gates_to_plain_with_character` — gating: excludes text/edit modes + angle/pose sets, plain-with-no-reference → None, plain reaches the non-fatal decode (missing asset → None, no panic).
- Stub-backed seam tests (weight-free, run in CI on the face-backend build): block attached vs the reference; source embedded once across N images; **changing the reference changes the scored source/cosine**; non-frontal → `detected:false` N/A; non-fatal when the reference has no face. Covers non-InstantID routes (the seam is shared).
- Real-weight end-to-end remains the existing `#[ignore]` test.

## Build verification

- macOS: `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, worker lib tests — all green.
- candle: `cargo clippy -p sceneworks-worker --no-default-features --features backend-candle --all-targets -- -D warnings` + `cargo check ... --all-targets` — green.
- **cfg-superset audit** (the macOS-host candle check does NOT compile the not-macOS candle-IP/PuLID modules): every symbol the candle-side wiring references — `ensure_face_stack_dir`, `crate::face_likeness::{build_face_likeness_scorer, score_generated_image, FaceLikenessScorer}`, `drive_gen_items_scored`, `Image` — is defined under `any(macos, all(not(macos), backend-candle))` (or always-compiled), a strict superset of the candle modules' `all(not(macos), backend-candle)`. Cross-compile to `x86_64-unknown-linux-gnu` blocked by the absent CUDA/`x86_64-linux-gnu-gcc` host toolchain; relied on the cfg audit + CI parity lane.

## Follow-ups

- Off-Mac Z-Image **identity-init** for `character_image` has no bespoke candle lane today (only `zimage_edit_candle`, which is `edit_image`-only), so it is out of this story's reach on the candle side — a pre-existing routing gap, not introduced here.

sc-4411

🤖 Generated with [Claude Code](https://claude.com/claude-code)