### PR TITLE
feat(web): control-mode picker gated by per-backbone control modes (sc-8245)

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -21,6 +21,7 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "globals": "^17.6.0",
         "jsdom": "27.3.0",
+        "json5": "^2.2.3",
         "vite": "6.4.2",
         "vitest": "4.1.8"
       }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,6 +24,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "globals": "^17.6.0",
     "jsdom": "27.3.0",
+    "json5": "^2.2.3",
     "vite": "6.4.2",
     "vitest": "4.1.8"
   }

--- a/apps/web/src/components/ControlPanel.jsx
+++ b/apps/web/src/components/ControlPanel.jsx
@@ -1,0 +1,137 @@
+import React from "react";
+import { PoseLibraryPicker } from "./PoseLibraryPicker.jsx";
+import { ImageEditSourcePickerField } from "./AssetPicker.jsx";
+
+// Strict-control panel for the text-to-image studios (epic 8236, sc-8245). One picker gated by the
+// selected backbone's supported control modes (`ui.controlModes`, mirrored from the manifest /
+// STRICT_CONTROL_ENGINES `supported_kinds`), plus the per-mode conditioning input and the control-scale
+// slider. The parent owns all state and the request wiring; this component is presentational + controlled:
+//
+//   * Pose  → the existing PoseLibraryPicker (`ui.poseLibrary`); the parent maps the selected pose ids to
+//     `advanced.poses` exactly as the InstantID pose flow does — this never reinvents it.
+//   * Canny / depth → a generic control-image upload (the reused ImageEditSourcePickerField, which already
+//     supports upload via `importAsset`) plus a preprocess-vs-use-as-is toggle:
+//       - preprocess (derive): the worker auto-derives the canny/depth map FROM the uploaded image; the
+//         parent sends the asset id as the request `sourceAssetId`.
+//       - use-as-is (passthrough): the user-supplied map is fed verbatim; the parent sends the asset id as
+//         `advanced.controlImage`.
+//     The toggle only changes WHICH request field carries the asset id (see ImageStudio.submit), matching
+//     the worker's strict_control.rs distinction (resolve_user_control_map vs resolve_control_source).
+//   * Control scale → a slider bound to `controlScale` (range/default from `ui.controlScale`), sent as
+//     `advanced.controlScale`.
+//
+// `supportedModes` is the canonical-ordered, gated list (modelEligibility.supportedControlModes). When it
+// is empty the parent hides the panel entirely; this component assumes at least one mode.
+const MODE_LABELS = { pose: "Pose", canny: "Canny", depth: "Depth" };
+
+export function ControlPanel({
+  supportedModes,
+  controlMode,
+  onControlModeChange,
+  // Pose
+  selectedPoseIds,
+  onTogglePose,
+  onClearPoses,
+  loadUserPoses,
+  poseBlockText,
+  // Canny / depth control image
+  controlImageAssetId,
+  onControlImageChange,
+  controlImagePassthrough,
+  onControlImagePassthroughChange,
+  controlImageAssets,
+  importAsset,
+  projectId,
+  characters,
+  // Control scale
+  controlScaleConfig,
+  controlScale,
+  onControlScaleChange,
+}) {
+  const modes = Array.isArray(supportedModes) ? supportedModes : [];
+  if (!modes.length) {
+    return null;
+  }
+  const activeMode = modes.includes(controlMode) ? controlMode : modes[0];
+  const scaleCfg = controlScaleConfig ?? {};
+
+  return (
+    <div className="control-panel">
+      <div className="control-panel-head">
+        <span className="control-panel-label">Structure control</span>
+        <span className="muted">Lock the output's pose, edges, or depth to a reference.</span>
+      </div>
+
+      <div className="control-mode-tabs" role="tablist" aria-label="Control type">
+        {modes.map((mode) => (
+          <button
+            aria-pressed={mode === activeMode}
+            className={mode === activeMode ? "control-mode-tab active" : "control-mode-tab"}
+            key={mode}
+            onClick={() => onControlModeChange?.(mode)}
+            role="tab"
+            type="button"
+          >
+            {MODE_LABELS[mode] ?? mode}
+          </button>
+        ))}
+      </div>
+
+      {activeMode === "pose" ? (
+        poseBlockText ? (
+          <p className="mac-gating-note">{poseBlockText}</p>
+        ) : (
+          <div className="control-pose-section">
+            <PoseLibraryPicker
+              loadUserPoses={loadUserPoses}
+              onClear={onClearPoses}
+              onToggle={onTogglePose}
+              selectedIds={selectedPoseIds}
+            />
+            <p className="muted">Selecting poses generates one image per pose (overrides Variations).</p>
+          </div>
+        )
+      ) : (
+        <div className="control-image-section">
+          <ImageEditSourcePickerField
+            assets={controlImageAssets}
+            buttonLabel="Select image"
+            characters={characters}
+            emptyLabel={`No ${activeMode} control image selected`}
+            importAsset={importAsset}
+            label={activeMode === "canny" ? "Edge/canny source" : "Depth source"}
+            onChange={onControlImageChange}
+            projectId={projectId}
+            value={controlImageAssetId}
+          />
+          <label className="checkline">
+            <input
+              checked={Boolean(controlImagePassthrough)}
+              onChange={(event) => onControlImagePassthroughChange?.(event.target.checked)}
+              type="checkbox"
+            />
+            Use this image as the control map directly (skip preprocessing)
+          </label>
+          <p className="muted">
+            {controlImagePassthrough
+              ? `Your image is fed in verbatim as the ${activeMode} map — supply an already-prepared ${activeMode} map.`
+              : `The worker auto-derives the ${activeMode} map from your image before generating.`}
+          </p>
+        </div>
+      )}
+
+      <label className="reference-strength control-scale">
+        {scaleCfg.label ?? "Control strength"}
+        <input
+          max={scaleCfg.max ?? 2}
+          min={scaleCfg.min ?? 0}
+          onChange={(event) => onControlScaleChange?.(Number(event.target.value))}
+          step={scaleCfg.step ?? 0.05}
+          type="range"
+          value={controlScale}
+        />
+        <span>{Number(controlScale).toFixed(2)}</span>
+      </label>
+    </div>
+  );
+}

--- a/apps/web/src/components/ControlPanel.test.jsx
+++ b/apps/web/src/components/ControlPanel.test.jsx
@@ -1,0 +1,145 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ControlPanel } from "./ControlPanel.jsx";
+
+// The pose picker pulls the library over the API; stub it so the panel test stays focused on the mode
+// gating + the canny/depth upload toggle. The picker itself is covered by PoseLibraryPicker tests.
+vi.mock("../poseLibrary.js", () => ({
+  usePoseLibrary: () => ({
+    poses: [{ id: "p1", label: "Standing", category: "Basics", keypoints: [], preview: "p1.png" }],
+    categories: ["Basics"],
+    loading: false,
+    error: null,
+  }),
+  useUserPoseLoader: () => () => Promise.resolve([]),
+}));
+// The source picker opens a modal on click; for the panel test we only need its presence/label and the
+// onChange seam, so stub it to a lightweight control surfacing the same props.
+vi.mock("./AssetPicker.jsx", () => ({
+  ImageEditSourcePickerField: ({ label }) => <div data-testid="control-image-picker">{label}</div>,
+}));
+
+describe("ControlPanel (sc-8245 gating + toggle)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  async function render(ui) {
+    await act(async () => root.render(ui));
+  }
+
+  const tabLabels = () =>
+    [...container.querySelectorAll(".control-mode-tab")].map((b) => b.textContent.trim());
+
+  const tabByLabel = (label) =>
+    [...container.querySelectorAll(".control-mode-tab")].find((b) => b.textContent.trim() === label);
+
+  function baseProps(overrides = {}) {
+    return {
+      supportedModes: ["pose", "canny", "depth"],
+      controlMode: "pose",
+      onControlModeChange: vi.fn(),
+      selectedPoseIds: [],
+      onTogglePose: vi.fn(),
+      onClearPoses: vi.fn(),
+      loadUserPoses: vi.fn(),
+      poseBlockText: null,
+      controlImageAssetId: "",
+      onControlImageChange: vi.fn(),
+      controlImagePassthrough: false,
+      onControlImagePassthroughChange: vi.fn(),
+      controlImageAssets: [],
+      importAsset: vi.fn(),
+      projectId: "proj_1",
+      characters: [],
+      controlScaleConfig: { label: "Control strength", default: 0.9, min: 0, max: 2, step: 0.05 },
+      controlScale: 0.9,
+      onControlScaleChange: vi.fn(),
+      ...overrides,
+    };
+  }
+
+  it("shows all three tabs when the backbone supports pose+canny+depth", async () => {
+    await render(<ControlPanel {...baseProps()} />);
+    expect(tabLabels()).toEqual(["Pose", "Canny", "Depth"]);
+  });
+
+  it("shows only the pose tab for a pose-only backbone", async () => {
+    await render(<ControlPanel {...baseProps({ supportedModes: ["pose"], controlMode: "pose" })} />);
+    expect(tabLabels()).toEqual(["Pose"]);
+  });
+
+  it("renders nothing when the backbone supports no control modes", async () => {
+    await render(<ControlPanel {...baseProps({ supportedModes: [] })} />);
+    expect(container.querySelector(".control-panel")).toBeNull();
+  });
+
+  it("pose mode shows the pose library, not the control-image upload", async () => {
+    await render(<ControlPanel {...baseProps({ controlMode: "pose" })} />);
+    expect(container.querySelector(".pose-library")).not.toBeNull();
+    expect(container.querySelector('[data-testid="control-image-picker"]')).toBeNull();
+  });
+
+  it("canny/depth mode shows the control-image upload + the preprocess toggle", async () => {
+    await render(<ControlPanel {...baseProps({ controlMode: "canny" })} />);
+    expect(container.querySelector('[data-testid="control-image-picker"]')).not.toBeNull();
+    const toggle = container.querySelector('input[type="checkbox"]');
+    expect(toggle).not.toBeNull();
+    expect(toggle.checked).toBe(false); // preprocess (derive) by default
+  });
+
+  it("the preprocess/use-as-is toggle reports its checked state", async () => {
+    const onControlImagePassthroughChange = vi.fn();
+    await render(
+      <ControlPanel
+        {...baseProps({ controlMode: "depth", onControlImagePassthroughChange })}
+      />,
+    );
+    const toggle = container.querySelector('input[type="checkbox"]');
+    await act(async () => {
+      // A click toggles the (unchecked) box → React fires onChange with checked=true.
+      toggle.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(onControlImagePassthroughChange).toHaveBeenCalledWith(true);
+  });
+
+  it("falls back to the first supported mode when the active pick is unsupported", async () => {
+    // controlMode is a stranded "canny" but the backbone only supports pose → pose renders.
+    await render(<ControlPanel {...baseProps({ supportedModes: ["pose"], controlMode: "canny" })} />);
+    expect(tabLabels()).toEqual(["Pose"]);
+    expect(container.querySelector(".pose-library")).not.toBeNull();
+  });
+
+  it("clicking a mode tab calls onControlModeChange", async () => {
+    const onControlModeChange = vi.fn();
+    await render(<ControlPanel {...baseProps({ onControlModeChange })} />);
+    await act(async () => {
+      tabByLabel("Depth").dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(onControlModeChange).toHaveBeenCalledWith("depth");
+  });
+
+  it("binds the control-scale slider to controlScale + its config range", async () => {
+    await render(<ControlPanel {...baseProps({ controlScale: 1.25 })} />);
+    const slider = container.querySelector('input[type="range"]');
+    expect(slider).not.toBeNull();
+    expect(slider.value).toBe("1.25");
+    expect(slider.min).toBe("0");
+    expect(slider.max).toBe("2");
+    expect(slider.step).toBe("0.05");
+  });
+});

--- a/apps/web/src/controlModesParity.test.js
+++ b/apps/web/src/controlModesParity.test.js
@@ -1,0 +1,73 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import JSON5 from "json5";
+import { describe, expect, it } from "vitest";
+import { fallbackModels } from "./constants.js";
+
+// Manifest ↔ constants parity for strict-control modes (sc-8245, folded in from the sc-8244 review).
+//
+// The web control panel gates the pose/canny/depth picker off the selected model's `ui.controlModes`
+// (and binds the scale slider to `ui.controlScale`). At runtime those come from the live catalog —
+// itself seeded from `config/manifests/builtin.models.jsonc` — but `apps/web/src/constants.js`
+// (`fallbackModels`) carries a HAND-MIRRORED copy used before the catalog loads (and in tests). Nothing
+// stops that mirror from silently drifting from the manifest. This test is the guard: for every backbone
+// the manifest advertises strict control on AND that also appears in `fallbackModels`, the mirror's
+// `controlModes` + `controlScale` must match the manifest exactly. A manifest change that isn't mirrored
+// (or a mirror typo) fails here instead of shipping a picker that offers the wrong modes / scale defaults.
+const HERE = dirname(fileURLToPath(import.meta.url));
+const MANIFEST_PATH = resolve(HERE, "../../../config/manifests/builtin.models.jsonc");
+
+function loadManifestModels() {
+  const raw = readFileSync(MANIFEST_PATH, "utf8");
+  const parsed = JSON5.parse(raw);
+  const models = Array.isArray(parsed) ? parsed : parsed.models;
+  expect(Array.isArray(models), "manifest must expose a models array").toBe(true);
+  return models;
+}
+
+describe("controlModes ↔ manifest parity (sc-8245)", () => {
+  const manifestModels = loadManifestModels();
+  const manifestById = new Map(manifestModels.map((model) => [model.id, model]));
+
+  // The manifest backbones that advertise strict control — the authority the picker gates on.
+  const manifestControlModels = manifestModels.filter(
+    (model) => Array.isArray(model?.ui?.controlModes) && model.ui.controlModes.length > 0,
+  );
+
+  it("the manifest advertises strict control on the five Fun-Union backbones", () => {
+    const ids = manifestControlModels.map((model) => model.id).sort();
+    expect(ids).toEqual(["flux2_dev", "flux_dev", "qwen_image", "z_image", "z_image_turbo"]);
+  });
+
+  it.each(
+    fallbackModels
+      .filter((model) => Array.isArray(model?.ui?.controlModes) && model.ui.controlModes.length > 0)
+      .map((model) => [model.id, model]),
+  )("constants.js %s mirrors the manifest controlModes + controlScale", (id, fallback) => {
+    const manifest = manifestById.get(id);
+    expect(manifest, `${id} must exist in the manifest`).toBeTruthy();
+    // controlModes must match exactly, including order (the picker renders in this order).
+    expect(fallback.ui.controlModes).toEqual(manifest.ui.controlModes);
+    // controlScale (label/default/min/max/step) is the slider config — it must match too.
+    expect(fallback.ui.controlScale).toEqual(manifest.ui.controlScale);
+  });
+
+  it("every manifest control backbone present in fallbackModels mirrors controlModes", () => {
+    // The reverse guard: a manifest control backbone that fallbackModels DOES carry (by id) but with a
+    // missing/empty controlModes would silently drop the picker — catch that drift too. Backbones absent
+    // from the seed list (e.g. flux2_dev, which loads from the live catalog) are intentionally skipped.
+    for (const manifest of manifestControlModels) {
+      const fallback = fallbackModels.find((model) => model.id === manifest.id);
+      if (!fallback) {
+        continue;
+      }
+      expect(fallback.ui?.controlModes, `${manifest.id} controlModes must be mirrored`).toEqual(
+        manifest.ui.controlModes,
+      );
+      expect(fallback.ui?.controlScale, `${manifest.id} controlScale must be mirrored`).toEqual(
+        manifest.ui.controlScale,
+      );
+    }
+  });
+});

--- a/apps/web/src/modelEligibility.js
+++ b/apps/web/src/modelEligibility.js
@@ -114,6 +114,25 @@ export function poseModelUsable(model, caps) {
   return !macModelBlock(model, caps) && Boolean(model?.ui?.poseLibrary);
 }
 
+// Strict-control modes the selected backbone advertises (sc-8245). The single source of truth is the
+// model's `ui.controlModes` — mirrored into constants.js from the manifest (the worker's
+// STRICT_CONTROL_ENGINES `supported_kinds`). Canonical-ordered (pose, canny, depth) and de-duplicated so
+// the picker renders deterministically regardless of manifest ordering; unknown modes are dropped (the
+// worker only admits pose/canny/depth). Empty array ⇒ the backbone supports no strict control and the
+// panel hides. Pure (model in → modes out), so the picker and its gate share exactly one notion of
+// "supported_kinds".
+export const CONTROL_MODE_ORDER = ["pose", "canny", "depth"];
+
+export function supportedControlModes(model) {
+  const declared = Array.isArray(model?.ui?.controlModes) ? model.ui.controlModes : [];
+  const present = new Set(
+    declared
+      .filter((mode) => typeof mode === "string")
+      .map((mode) => mode.trim().toLowerCase()),
+  );
+  return CONTROL_MODE_ORDER.filter((mode) => present.has(mode));
+}
+
 // Character Studio needs Angles OR Poses support.
 export function characterModelUsable(model, caps) {
   return angleModelUsable(model, caps) || poseModelUsable(model, caps);

--- a/apps/web/src/modelEligibility.test.js
+++ b/apps/web/src/modelEligibility.test.js
@@ -8,6 +8,7 @@ import {
   hasUsableModelFor,
   imageModelUsable,
   poseModelUsable,
+  supportedControlModes,
   videoModelUsable,
   visionCaptionModelUsable,
 } from "./modelEligibility.js";
@@ -110,6 +111,28 @@ describe("modelEligibility predicates", () => {
     ]);
     // On Windows the predicate rejects it, so there is no offer (feature stays hidden).
     expect(downloadOffersFor([missing], visionCaptionModelUsable, { ...caps, platform: "windows" })).toEqual([]);
+  });
+
+  it("supportedControlModes gates on ui.controlModes, canonical-ordered + deduped", () => {
+    // A backbone advertising all three → all three, canonical order regardless of declared order.
+    expect(supportedControlModes({ ui: { controlModes: ["depth", "pose", "canny"] } })).toEqual([
+      "pose",
+      "canny",
+      "depth",
+    ]);
+    // Pose-only backbone → only pose (the picker would show a single tab).
+    expect(supportedControlModes({ ui: { controlModes: ["pose"] } })).toEqual(["pose"]);
+    // Canny+depth (no pose) → exactly those, in canonical order.
+    expect(supportedControlModes({ ui: { controlModes: ["depth", "canny"] } })).toEqual(["canny", "depth"]);
+    // Unknown modes are dropped (the worker only admits pose/canny/depth); dupes collapse.
+    expect(supportedControlModes({ ui: { controlModes: ["pose", "POSE", "scribble", "canny"] } })).toEqual([
+      "pose",
+      "canny",
+    ]);
+    // No controlModes / no ui → empty (the panel hides).
+    expect(supportedControlModes({ ui: {} })).toEqual([]);
+    expect(supportedControlModes({})).toEqual([]);
+    expect(supportedControlModes(null)).toEqual([]);
   });
 
   it("downloadOffersFor prefers recommended, falls back to any eligible, skips installed", () => {

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -95,7 +95,13 @@ import {
 } from "./generationStudio.jsx";
 import { useAppContext } from "../context/AppContext.js";
 import { ModelAvailabilityGate } from "../components/ModelAvailabilityGate.jsx";
-import { downloadOffersFor, imageModelUsable, visionCaptionModelUsable } from "../modelEligibility.js";
+import {
+  downloadOffersFor,
+  imageModelUsable,
+  supportedControlModes,
+  visionCaptionModelUsable,
+} from "../modelEligibility.js";
+import { ControlPanel } from "../components/ControlPanel.jsx";
 import { pidToggleVisible } from "../pidEligibility.js";
 import { PROMPT_REFINE_MODEL_ID, VISION_CAPTION_MODEL_ID, VISION_CAPTION_MODEL_REPO } from "../constants.js";
 import { pickClosestResolution } from "../resolutionMatch.js";
@@ -398,6 +404,16 @@ export function ImageStudio() {
   // Pose library: selected pose ids. When non-empty, the job carries advanced.poses
   // (one image per pose) instead of the normal variations count. Transient (not saved).
   const [selectedPoseIds, setSelectedPoseIds] = useState([]);
+  // Strict-control panel (epic 8236, sc-8245). The selected control type (pose / canny / depth),
+  // gated to the backbone's `ui.controlModes`. Pose reuses `selectedPoseIds`; canny/depth use a
+  // control-image asset + a preprocess-vs-passthrough toggle. `controlScale` (advanced.controlScale)
+  // is the control-lock strength. All reset to the model's defaults on model change (below).
+  const [controlMode, setControlMode] = useState(saved.controlMode ?? "pose");
+  const [controlImageAssetId, setControlImageAssetId] = useState("");
+  // false = preprocess (worker auto-derives the map from the image → request.sourceAssetId);
+  // true = use-as-is (the user-supplied map passes through verbatim → advanced.controlImage).
+  const [controlImagePassthrough, setControlImagePassthrough] = useState(false);
+  const [controlScale, setControlScale] = useState(saved.controlScale ?? null);
   // Configurable sampler / scheduler (epic 1753). Restored from per-workspace
   // settings; reset to the selected model's manifest defaults whenever the
   // model changes.
@@ -625,6 +641,19 @@ export function ImageStudio() {
   const viewAngles = Array.isArray(selectedModel?.ui?.viewAngles) ? selectedModel.ui.viewAngles : null;
   // Whether the model supports the OpenPose pose library (InstantID).
   const poseLibrary = Boolean(selectedModel?.ui?.poseLibrary);
+  // Strict-control modes the selected backbone advertises (sc-8245) — canonical-ordered, gated to
+  // `ui.controlModes` (the manifest / STRICT_CONTROL_ENGINES `supported_kinds`). Empty ⇒ no strict
+  // control ⇒ the panel hides. The control panel surfaces only in text-to-image mode (its conditioning
+  // is its own input image / pose, distinct from the edit / character source).
+  const controlModes = useMemo(() => supportedControlModes(selectedModel), [selectedModel]);
+  const controlScaleConfig = selectedModel?.ui?.controlScale ?? null;
+  // The control type actually in effect: the user's pick when the backbone still supports it, else the
+  // first supported mode. Decouples the gating (derived) from the raw state so a backbone switch that
+  // strands an unsupported pick degrades gracefully even before the reset effect runs.
+  const activeControlMode = controlModes.includes(controlMode) ? controlMode : (controlModes[0] ?? null);
+  const showControlPanel = mode === "text_to_image" && controlModes.length > 0;
+  const effectiveControlScale =
+    typeof controlScale === "number" ? controlScale : controlScaleConfig?.default ?? 0.9;
   // Whether the model exposes its built-in prompt upsampler ("Enhance prompt" toggle) — FLUX.2-dev.
   const promptEnhance = Boolean(selectedModel?.ui?.promptEnhance);
   // Whether the model ships a packed default + a hosted full-precision bf16 build, exposing the
@@ -699,6 +728,14 @@ export function ImageStudio() {
     setTrueCfgScale(typeof ui.variationStrength?.default === "number" ? ui.variationStrength.default : 4.0);
     setViewAngle("");
     setSelectedPoseIds([]);
+    // Re-gate the strict-control panel to the new backbone: snap the control type to a supported mode
+    // (an unsupported pick — e.g. canny on a pose-only backbone — resets to the first supported one),
+    // reset the control-scale to the model's manifest default, and clear a stale control image.
+    const nextModes = supportedControlModes(imageModels.find((item) => item.id === model));
+    setControlMode((current) => (nextModes.includes(current) ? current : nextModes[0] ?? "pose"));
+    setControlScale(typeof ui.controlScale?.default === "number" ? ui.controlScale.default : null);
+    setControlImageAssetId("");
+    setControlImagePassthrough(false);
   }, [model]);
   // Approved reference images for the selected character (the IP-Adapter identity
   // source). Resolve the full asset from the catalog so thumbnails render even when
@@ -1266,11 +1303,28 @@ export function ImageStudio() {
     setSubmitting(true);
     try {
       // Pose library: when poses are selected, the job emits one image per pose
-      // (advanced.poses) instead of `count` variations.
+      // (advanced.poses) instead of `count` variations. Two pose surfaces share this payload:
+      //   * character_image — InstantID pose set (needs an approved reference).
+      //   * text_to_image — the strict-control panel's pose mode (sc-8245): a Fun-Union backbone
+      //     conditions each render on the selected library skeleton; no reference needed.
+      const usePosePayload =
+        (mode === "character_image" && referenceAssetId && poseLibrary) ||
+        (showControlPanel && activeControlMode === "pose");
       const posePayload =
-        mode === "character_image" && referenceAssetId && poseLibrary && selectedPoseIds.length
+        usePosePayload && selectedPoseIds.length
           ? selectedPoseIds.map((id) => poseById[id]).filter(Boolean).map((pose) => ({ id: pose.id, keypoints: pose.keypoints }))
           : [];
+      // Strict-control conditioning (sc-8245). Active only for a text-to-image control backbone.
+      // Pose flows through `posePayload` above; canny/depth carry the control type + the uploaded
+      // control image, routed by the preprocess-vs-passthrough toggle:
+      //   * preprocess (derive) → request `sourceAssetId` (the worker auto-derives the map).
+      //   * use-as-is (passthrough) → `advanced.controlImage` (the map is fed verbatim).
+      const controlActive = showControlPanel && Boolean(activeControlMode);
+      const controlIsImageMode = controlActive && activeControlMode !== "pose";
+      const controlPreprocessSourceId =
+        controlIsImageMode && !controlImagePassthrough && controlImageAssetId ? controlImageAssetId : null;
+      const controlPassthroughId =
+        controlIsImageMode && controlImagePassthrough && controlImageAssetId ? controlImageAssetId : null;
       // Resolve the prompt + structured-caption payload. Structured models (Ideogram 4) are
       // JSON-caption-only: raw plain text is out-of-distribution and renders the "Image blocked by
       // safety filter" placeholder (sc-6307/sc-6501). So a structured model ALWAYS sends a JSON
@@ -1337,7 +1391,13 @@ export function ImageStudio() {
         characterLookId: mode === "character_image" ? characterLookId || null : null,
         // edit_image: a single source image, except for a multi-reference model (sc-6211,
         // FLUX.2-dev) whose source picker is replaced by the multi-image reference picker below.
-        sourceAssetId: mode === "edit_image" && !multiReference ? sourceAssetId || null : null,
+        // text_to_image strict-control (sc-8245): canny/depth in preprocess (derive) mode send the
+        // uploaded control image here as the source the worker auto-derives the map FROM
+        // (strict_control.rs `resolve_control_source`). Passthrough mode uses `advanced.controlImage`.
+        sourceAssetId:
+          mode === "edit_image" && !multiReference
+            ? sourceAssetId || null
+            : controlPreprocessSourceId,
         // Multi-reference edit (sc-6211): the plural reference set the FLUX.2-dev edit conditions on.
         // Only sent in edit_image mode for a multiReference model; the worker routes a non-empty list
         // to Conditioning::MultiReference (one image ⇒ a normal single-reference edit).
@@ -1446,6 +1506,15 @@ export function ImageStudio() {
           // Pose library (InstantID) — one image per selected pose; faceRestore toggles
           // the full-body face-restoration pass.
           ...(posePayload.length ? { poses: posePayload, faceRestore } : {}),
+          // Strict-control conditioning (epic 8236, sc-8245). The control type the worker's shared
+          // strict-control driver reads (strict_control.rs `requested_control_kind`). Pose is the
+          // engine default (omitted → byte-preserved), so only non-pose modes ride the payload. The
+          // control-lock strength (`advanced.controlScale`) is sent whenever the panel is active.
+          ...(controlActive && activeControlMode !== "pose" ? { controlMode: activeControlMode } : {}),
+          // Use-as-is passthrough: a pre-made canny/depth map fed verbatim
+          // (strict_control.rs `resolve_user_control_map`). Derive mode uses request.sourceAssetId.
+          ...(controlPassthroughId ? { controlImage: controlPassthroughId } : {}),
+          ...(controlActive ? { controlScale: effectiveControlScale } : {}),
         },
       });
       onLocalJobCreated?.(job);
@@ -1833,6 +1902,41 @@ export function ImageStudio() {
                 )}
               </>
             ) : null}
+          </div>
+        ) : null}
+
+        {/* Strict-control panel (epic 8236, sc-8245): pose / canny / depth structure lock for the
+            text-to-image backbones whose `ui.controlModes` advertises it. Hidden when the backbone
+            supports no strict control. Pose reuses the library picker (one image per pose); canny/depth
+            take an uploaded control image + a preprocess-vs-use-as-is toggle. The request wiring lives in
+            submit() — controlMode / sourceAssetId|advanced.controlImage / advanced.controlScale. */}
+        {showControlPanel ? (
+          <div className="studio-source-band">
+            <ControlPanel
+              supportedModes={controlModes}
+              controlMode={activeControlMode}
+              onControlModeChange={setControlMode}
+              selectedPoseIds={selectedPoseIds}
+              onTogglePose={(id) =>
+                setSelectedPoseIds((ids) =>
+                  ids.includes(id) ? ids.filter((value) => value !== id) : [...ids, id],
+                )
+              }
+              onClearPoses={() => setSelectedPoseIds([])}
+              loadUserPoses={loadUserPoses}
+              poseBlockText={macPoseBlock ? macPoseBlock.text : null}
+              controlImageAssetId={controlImageAssetId}
+              onControlImageChange={setControlImageAssetId}
+              controlImagePassthrough={controlImagePassthrough}
+              onControlImagePassthroughChange={setControlImagePassthrough}
+              controlImageAssets={editImageAssets}
+              importAsset={importAsset}
+              projectId={activeProject?.id}
+              characters={characters}
+              controlScaleConfig={controlScaleConfig}
+              controlScale={effectiveControlScale}
+              onControlScaleChange={setControlScale}
+            />
           </div>
         ) : null}
 

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -1251,3 +1251,140 @@ describe("ImageStudio PiD decoder toggle (sc-7851)", () => {
     expect(createImageJob.mock.calls[1][0].advanced.usePid).toBe(true);
   });
 });
+
+describe("ImageStudio strict-control panel (epic 8236, sc-8245)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <ImageStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  // A Fun-Union backbone advertising all three control modes (mirrors the manifest controlModes/
+  // controlScale). The pose-only fixture omits canny/depth so the picker gates to a single tab.
+  const FULL_CONTROL = {
+    ...Z_IMAGE,
+    id: "flux2_dev",
+    name: "FLUX.2-dev",
+    family: "flux2",
+    ui: {
+      poseLibrary: true,
+      controlModes: ["pose", "canny", "depth"],
+      controlScale: { label: "Control strength", default: 0.75, min: 0, max: 2, step: 0.05 },
+    },
+  };
+  const POSE_ONLY = {
+    ...Z_IMAGE,
+    id: "pose_only",
+    name: "Pose Only",
+    family: "pose",
+    ui: {
+      poseLibrary: true,
+      controlModes: ["pose"],
+      controlScale: { label: "Control strength", default: 0.9, min: 0, max: 2, step: 0.05 },
+    },
+  };
+  const NO_CONTROL = { ...Z_IMAGE, id: "plain", name: "Plain", family: "plain", ui: {} };
+
+  const controlTabs = () =>
+    [...container.querySelectorAll(".control-mode-tab")].map((b) => b.textContent.trim());
+  const controlTabByLabel = (label) =>
+    [...container.querySelectorAll(".control-mode-tab")].find((b) => b.textContent.trim() === label);
+  const generate = async () =>
+    click([...container.querySelectorAll("button")].find((b) => b.textContent === "Generate"));
+
+  it("gates the picker to the backbone's supported modes (all three)", async () => {
+    await render(baseContext({ imageModels: [FULL_CONTROL] }));
+    expect(controlTabs()).toEqual(["Pose", "Canny", "Depth"]);
+  });
+
+  it("shows only the pose tab for a pose-only backbone", async () => {
+    await render(baseContext({ imageModels: [POSE_ONLY] }));
+    expect(controlTabs()).toEqual(["Pose"]);
+  });
+
+  it("hides the panel entirely for a backbone with no control modes", async () => {
+    await render(baseContext({ imageModels: [NO_CONTROL] }));
+    expect(container.querySelector(".control-panel")).toBeNull();
+  });
+
+  it("re-gates and resets an unsupported mode when the backbone switches", async () => {
+    await render(baseContext({ imageModels: [FULL_CONTROL, POSE_ONLY] }));
+    // Pick canny on the multi-mode backbone.
+    await click(controlTabByLabel("Canny"));
+    expect(controlTabByLabel("Canny").getAttribute("aria-pressed")).toBe("true");
+    // Switch to the pose-only backbone → canny is gone, only pose remains, and pose is active.
+    await act(async () => setSelect(field(container, "Model"), "pose_only"));
+    await act(async () => {});
+    expect(controlTabs()).toEqual(["Pose"]);
+    expect(controlTabByLabel("Pose").getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("canny preprocess (derive) sends the control image as sourceAssetId + controlMode/controlScale", async () => {
+    const createImageJob = vi.fn(async () => ({ id: "job-1" }));
+    const plate = { id: "ctrl-plate", projectId: "project_1", type: "image", displayName: "Plate", status: {} };
+    await render(baseContext({ createImageJob, imageModels: [FULL_CONTROL], assets: [plate] }));
+    await click(controlTabByLabel("Canny"));
+    // Open the control-image picker and double-click the asset to confirm it.
+    await click(
+      [...container.querySelectorAll(".asset-picker-head button")].find((b) => b.textContent === "Select image"),
+    );
+    const card = [...container.querySelectorAll(".asset-picker-card")].find((b) =>
+      b.textContent.includes("Plate"),
+    );
+    await act(async () => card.dispatchEvent(new window.MouseEvent("dblclick", { bubbles: true })));
+
+    await generate();
+    const payload = createImageJob.mock.calls[0][0];
+    // Derive mode → the asset rides as the source the worker auto-derives from; NOT advanced.controlImage.
+    expect(payload.sourceAssetId).toBe("ctrl-plate");
+    expect(payload.advanced.controlMode).toBe("canny");
+    expect(payload.advanced).not.toHaveProperty("controlImage");
+    expect(payload.advanced.controlScale).toBe(0.75);
+  });
+
+  it("use-as-is passthrough sends the control image as advanced.controlImage, not sourceAssetId", async () => {
+    const createImageJob = vi.fn(async () => ({ id: "job-1" }));
+    const plate = { id: "ctrl-plate", projectId: "project_1", type: "image", displayName: "Plate", status: {} };
+    await render(baseContext({ createImageJob, imageModels: [FULL_CONTROL], assets: [plate] }));
+    await click(controlTabByLabel("Depth"));
+    await click(
+      [...container.querySelectorAll(".asset-picker-head button")].find((b) => b.textContent === "Select image"),
+    );
+    const card = [...container.querySelectorAll(".asset-picker-card")].find((b) =>
+      b.textContent.includes("Plate"),
+    );
+    await act(async () => card.dispatchEvent(new window.MouseEvent("dblclick", { bubbles: true })));
+    // Flip the preprocess toggle ON → use-as-is passthrough.
+    const toggle = [...container.querySelectorAll(".control-image-section input[type='checkbox']")][0];
+    await act(async () => toggle.dispatchEvent(new window.MouseEvent("click", { bubbles: true })));
+
+    await generate();
+    const payload = createImageJob.mock.calls[0][0];
+    expect(payload.advanced.controlImage).toBe("ctrl-plate");
+    expect(payload.sourceAssetId).toBeNull();
+    expect(payload.advanced.controlMode).toBe("depth");
+    expect(payload.advanced.controlScale).toBe(0.75);
+  });
+});

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2093,6 +2093,64 @@ label {
   border-radius: var(--r-md);
 }
 
+/* Strict-control panel (epic 8236, sc-8245): pose / canny / depth structure lock. Reuses the
+   .studio-source-band shell, .reference-strength slider, .checkline toggle, and .asset-picker-field /
+   .pose-library inner surfaces; only the mode tabs + section spacing are panel-specific. */
+.control-panel {
+  display: grid;
+  gap: 12px;
+}
+
+.control-panel-head {
+  display: grid;
+  gap: 2px;
+}
+
+.control-panel-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.control-mode-tabs {
+  display: inline-flex;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  padding: 3px;
+  gap: 2px;
+  flex-wrap: wrap;
+  width: fit-content;
+}
+
+.control-mode-tab {
+  min-height: 28px;
+  padding: 0 14px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 12.5px;
+  font-weight: 500;
+  box-shadow: none;
+}
+
+.control-mode-tab:hover:not(.active) {
+  color: var(--text);
+}
+
+.control-mode-tab.active {
+  background: var(--surface);
+  color: var(--text);
+  box-shadow: var(--shadow-sm);
+}
+
+.control-image-section,
+.control-pose-section {
+  display: grid;
+  gap: 8px;
+}
+
 .character-reference-picker {
   display: grid;
   gap: 10px;


### PR DESCRIPTION
## What

Adds the web **strict-control panel** to the Image Studio text-to-image flow (epic 8236, sc-8245): a **pose / canny / depth picker gated by the selected backbone's supported control modes**, uniform across flux_dev / flux2_dev / z_image_turbo / z_image / qwen_image.

## Gating

- The picker reads `selectedModel.ui.controlModes` via `modelEligibility.supportedControlModes()` (canonical-ordered `pose,canny,depth`, deduped, unknown-dropped) — the single source of truth mirrored from `config/manifests/builtin.models.jsonc` (the worker's `STRICT_CONTROL_ENGINES` `supported_kinds`).
- Only supported modes render; the whole panel **hides** when the backbone supports none, and only in `text_to_image` mode.
- Switching backbone **re-gates**: an unsupported current pick (e.g. canny on a pose-only backbone) snaps to the first supported mode, control scale resets to the new manifest default, and any stale control image clears.

## Inputs

- **Pose** → reuses the existing `PoseLibraryPicker` (one image per pose, via the shared pose payload).
- **Canny / depth** → generic control-image upload (`ImageEditSourcePickerField`) + a **preprocess vs use-as-is** toggle.
- **Control scale** → slider bound to `controlScale`, range/default from the model's `ui.controlScale`.

## Request wiring (matches `crates/sceneworks-worker/src/image_jobs/strict_control.rs`)

- `controlMode` → `advanced.controlMode` (worker `requested_control_kind`).
- **preprocess (derive)** → the uploaded image rides as request `sourceAssetId`; the worker auto-derives the map (`resolve_control_source`).
- **use-as-is (passthrough)** → `advanced.controlImage`, fed verbatim (`resolve_user_control_map`).
- `advanced.controlScale` sent whenever the panel is active.

`advanced` is an open `JsonObject` and `sourceAssetId` is already contracted, so **no rust-api snapshot change**.

## Parity test (folded from sc-8244 review)

`apps/web/src/controlModesParity.test.js` asserts `constants.js` `controlModes` + `controlScale` match `builtin.models.jsonc` for every control backbone, so the hand-mirrored web copy can't silently drift.

## Tests

- New component tests (`ControlPanel.test.jsx`): gating to supported modes, pose-only single tab, hidden when none, preprocess toggle, scale-slider binding.
- New integration tests (`ImageStudio.test.jsx`): gating, backbone-switch reset, derive→`sourceAssetId` and passthrough→`advanced.controlImage` routing.
- `modelEligibility.test.js`: `supportedControlModes` canonical-order/dedup/drop.
- Full web suite: **845 passed (49 files)**; lint **0 errors** (warnings all pre-existing, unrelated files).

Closes sc-8245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)