### PR TITLE
chore(web): calibrate face-likeness threshold bands + frontal-only doc (sc-4414)

### DIFF
--- a/apps/web/src/faceLikeness.js
+++ b/apps/web/src/faceLikeness.js
@@ -1,0 +1,117 @@
+// Face-likeness band constants + classifier — the SINGLE SOURCE OF TRUTH for the
+// identity-likeness UI (epic 4406). The frontend badge (sc-4413) imports `classifyLikeness`
+// and `LIKENESS_BANDS` from here; do NOT duplicate the cut-points anywhere else.
+//
+// The backend scorer (crates/sceneworks-worker/src/face_likeness.rs) writes a per-asset
+// `recipe.rawAdapterSettings.faceLikeness = { score, detected, method, sourceAssetId, reason? }`
+// where `score` is an ArcFace antelopev2 cosine in [-1, 1] (effectively [0, 1] for face pairs).
+// This module turns that block into one of four UI states.
+//
+// The metric, the frontal-only limitation, the N/A behaviour, the band rationale, and the
+// antelopev2 non-commercial licensing note are all documented in docs/face-likeness.md.
+
+// The recognition method string the backend stamps on every faceLikeness block
+// (`LIKENESS_METHOD` in face_likeness.rs). Kept here so the frontend can assert/label the
+// metric without hard-coding the literal at the call site.
+export const LIKENESS_METHOD = "arcface_antelopev2";
+
+// The band labels. `na` is NOT a likeness tier — it is the explicit "no detectable frontal
+// face" outcome (detected:false, score:null), surfaced so the badge never renders a missing
+// score as a low quality number. See docs/face-likeness.md § "Why profiles return N/A".
+export const LIKENESS_BAND = Object.freeze({
+  STRONG: "strong",
+  MODERATE: "moderate",
+  WEAK: "weak",
+  NA: "na",
+});
+
+// The calibrated cosine cut-points (epic 4406, sc-4414). Anchored to recorded antelopev2
+// ArcFace baselines — NOT invented numbers. Full rationale in docs/face-likeness.md.
+//
+//   strong   : score >= STRONG_MIN            (solid frontal identity)
+//   moderate : MODERATE_MIN <= score < STRONG_MIN  (recognizable, with drift)
+//   weak     : score < MODERATE_MIN           (clear drift / wrong person)
+//
+// STRONG_MIN = 0.80 — the floor that captures every solidly-recognizable anchor: InstantID
+//   frontal ~0.876 and its 9-angle pack 0.81–0.89, PuLID-FLUX photoreal 0.8016, and the upper
+//   end of the InstantID face-restore range (~0.83). It deliberately excludes the PuLID
+//   id_weight=0.8 case (0.7422, which "visually drifts") — that should read as moderate, not
+//   strong.
+// MODERATE_MIN = 0.55 — the floor below which results are clear drift. It sits just below the
+//   closest anchor above it, PuLID id_weight=0.6 (0.5689, "drifts further") — that borderline
+//   case stays moderate — while putting the soft-identity backbones (FLUX.2-klein angle-set mean
+//   ~0.52) and the InstantID landmark-disabled collapse (~0.15) into weak. Everything in
+//   [0.55, 0.80) — the pose tier (~0.71), the lower face-restore edge (~0.74), Qwen-Edit
+//   Lightning angle mean (~0.62) — is "recognizable but drifting", i.e. moderate.
+export const STRONG_MIN = 0.8;
+export const MODERATE_MIN = 0.55;
+
+// Ordered descriptors for the bands (the frontend badge maps these to label/colour/tooltip).
+// The order is highest-to-lowest confidence; `na` is appended as the non-tier outcome.
+export const LIKENESS_BANDS = Object.freeze([
+  {
+    band: LIKENESS_BAND.STRONG,
+    label: "Strong likeness",
+    min: STRONG_MIN,
+    max: 1,
+    description: "Frontal identity solidly matches the reference.",
+  },
+  {
+    band: LIKENESS_BAND.MODERATE,
+    label: "Moderate likeness",
+    min: MODERATE_MIN,
+    max: STRONG_MIN,
+    description: "Recognizable as the same person, with some identity drift.",
+  },
+  {
+    band: LIKENESS_BAND.WEAK,
+    label: "Weak likeness",
+    min: -1,
+    max: MODERATE_MIN,
+    description: "Clear identity drift — likely not a confident match.",
+  },
+  {
+    band: LIKENESS_BAND.NA,
+    label: "No frontal face",
+    min: null,
+    max: null,
+    description:
+      "No detectable frontal face to score (e.g. a profile, extreme angle, or full-body pose). " +
+      "This is not a low likeness — it is the absence of a measurable frontal identity signal.",
+  },
+]);
+
+// Map a faceLikeness block (or a bare cosine) to a band. This is the EXACT mapping sc-4413's
+// badge needs:
+//   - detected:false / score:null  -> "na"  (the honest no-frontal-face outcome)
+//   - score >= STRONG_MIN          -> "strong"
+//   - score >= MODERATE_MIN        -> "moderate"
+//   - otherwise                    -> "weak"
+//
+// Accepts either the persisted block `{ score, detected, ... }` or a raw number. A missing/
+// null/non-finite score, or an explicit detected:false, is "na" — never silently coerced to a
+// weak score. (Detection honesty is enforced in the backend scorer; this guard keeps the UI
+// honest even if a block arrives without `detected`.)
+export function classifyLikeness(input) {
+  const score = typeof input === "number" ? input : input?.score;
+  const detected = typeof input === "number" ? true : input?.detected;
+
+  if (detected === false) {
+    return LIKENESS_BAND.NA;
+  }
+  if (typeof score !== "number" || !Number.isFinite(score)) {
+    return LIKENESS_BAND.NA;
+  }
+  if (score >= STRONG_MIN) {
+    return LIKENESS_BAND.STRONG;
+  }
+  if (score >= MODERATE_MIN) {
+    return LIKENESS_BAND.MODERATE;
+  }
+  return LIKENESS_BAND.WEAK;
+}
+
+// The descriptor (label/min/max/description) for a band id, for the badge to render.
+export function likenessBand(band) {
+  return LIKENESS_BANDS.find((entry) => entry.band === band) ?? null;
+}

--- a/apps/web/src/faceLikeness.test.js
+++ b/apps/web/src/faceLikeness.test.js
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  LIKENESS_BAND,
+  LIKENESS_BANDS,
+  LIKENESS_METHOD,
+  MODERATE_MIN,
+  STRONG_MIN,
+  classifyLikeness,
+  likenessBand,
+} from "./faceLikeness.js";
+
+// Face-likeness band calibration + classifier (epic 4406, sc-4414). These pin the calibrated
+// cut-points to the recorded antelopev2 ArcFace baselines and prove the classifier maps each
+// outcome (incl. the explicit N/A) the way the sc-4413 badge consumes it.
+describe("face-likeness band calibration (sc-4414)", () => {
+  it("exposes the method string the backend stamps", () => {
+    expect(LIKENESS_METHOD).toBe("arcface_antelopev2");
+  });
+
+  it("cut-points are the calibrated edges (strong>=0.80, moderate>=0.55)", () => {
+    expect(STRONG_MIN).toBe(0.8);
+    expect(MODERATE_MIN).toBe(0.55);
+    expect(MODERATE_MIN).toBeLessThan(STRONG_MIN);
+  });
+
+  // -- the classifier mapping the badge (sc-4413) consumes ------------------------------
+  describe("classifyLikeness", () => {
+    it("classifies solid frontal identity as strong", () => {
+      // Recorded anchors that MUST land in strong: InstantID frontal ~0.876, its angle pack
+      // 0.81–0.89, PuLID-FLUX photoreal 0.8016, upper face-restore ~0.83.
+      for (const score of [0.876, 0.81, 0.89, 0.8016, 0.83, STRONG_MIN, 1]) {
+        expect(classifyLikeness(score), `${score} should be strong`).toBe(LIKENESS_BAND.STRONG);
+      }
+    });
+
+    it("classifies recognizable-but-drifting as moderate", () => {
+      // The [0.55, 0.80) band: pose tier ~0.71, lower face-restore ~0.74, PuLID iw0.8 drift
+      // 0.7422, Qwen-Edit Lightning angle mean ~0.62, PuLID iw0.6 borderline drift 0.5689
+      // (the closest anchor above the floor — 0.55 sits just below it), and the floor itself.
+      for (const score of [0.71, 0.74, 0.7422, 0.62, 0.5689, MODERATE_MIN]) {
+        expect(classifyLikeness(score), `${score} should be moderate`).toBe(LIKENESS_BAND.MODERATE);
+      }
+    });
+
+    it("classifies clear drift / collapse as weak", () => {
+      // Below the moderate floor: FLUX.2-klein angle mean ~0.52 (soft-identity backbone),
+      // InstantID landmark-disabled collapse ~0.15, and outright non-matches.
+      for (const score of [0.52, 0.15, 0, -0.3]) {
+        expect(classifyLikeness(score), `${score} should be weak`).toBe(LIKENESS_BAND.WEAK);
+      }
+    });
+
+    it("treats a detected:false block as N/A, never a low number", () => {
+      // The honesty linchpin (mirrors the backend scorer): a profile / no-face generation is
+      // detected:false / score:null -> N/A, NOT weak.
+      expect(
+        classifyLikeness({ score: null, detected: false, method: LIKENESS_METHOD, reason: "no_face" }),
+      ).toBe(LIKENESS_BAND.NA);
+      expect(classifyLikeness({ score: null, detected: false, reason: "low_confidence" })).toBe(
+        LIKENESS_BAND.NA,
+      );
+    });
+
+    it("treats a missing / non-finite score as N/A", () => {
+      expect(classifyLikeness(undefined)).toBe(LIKENESS_BAND.NA);
+      expect(classifyLikeness(null)).toBe(LIKENESS_BAND.NA);
+      expect(classifyLikeness({})).toBe(LIKENESS_BAND.NA);
+      expect(classifyLikeness(Number.NaN)).toBe(LIKENESS_BAND.NA);
+      expect(classifyLikeness({ score: Number.NaN, detected: true })).toBe(LIKENESS_BAND.NA);
+    });
+
+    it("classifies a scored block (detected:true) by its cosine", () => {
+      expect(classifyLikeness({ score: 0.876, detected: true })).toBe(LIKENESS_BAND.STRONG);
+      expect(classifyLikeness({ score: 0.71, detected: true })).toBe(LIKENESS_BAND.MODERATE);
+      expect(classifyLikeness({ score: 0.2, detected: true })).toBe(LIKENESS_BAND.WEAK);
+    });
+  });
+
+  describe("band descriptors", () => {
+    it("has a descriptor for every band incl. the N/A non-tier", () => {
+      for (const band of Object.values(LIKENESS_BAND)) {
+        const descriptor = likenessBand(band);
+        expect(descriptor, `${band} must have a descriptor`).toBeTruthy();
+        expect(descriptor.label).toBeTruthy();
+        expect(descriptor.description).toBeTruthy();
+      }
+    });
+
+    it("the scored bands tile [-1, 1] contiguously at the cut-points", () => {
+      const strong = LIKENESS_BANDS.find((b) => b.band === LIKENESS_BAND.STRONG);
+      const moderate = LIKENESS_BANDS.find((b) => b.band === LIKENESS_BAND.MODERATE);
+      const weak = LIKENESS_BANDS.find((b) => b.band === LIKENESS_BAND.WEAK);
+      expect(strong.min).toBe(STRONG_MIN);
+      expect(moderate.max).toBe(STRONG_MIN);
+      expect(moderate.min).toBe(MODERATE_MIN);
+      expect(weak.max).toBe(MODERATE_MIN);
+    });
+  });
+});

--- a/docs/face-likeness.md
+++ b/docs/face-likeness.md
@@ -1,0 +1,149 @@
+# Face likeness (identity-likeness score)
+
+The **face-likeness score** is the identity-confidence signal SceneWorks attaches to character
+generations across Character Studio (Angles / Poses) and Image Studio ("With Character"). It
+answers one narrow question: *does the frontal face in this generated image match the reference
+person?* It is **not** a general image-quality, aesthetics, or prompt-adherence score, and must
+never be presented as one.
+
+- **Epic:** 4406 (generator-agnostic native ArcFace identity score).
+- **Backend scorer:** `crates/sceneworks-worker/src/face_likeness.rs` (sc-4407).
+- **Persisted shape:** `recipe.rawAdapterSettings.faceLikeness` (sc-4408).
+- **Shared band constants + classifier (single source of truth):** `apps/web/src/faceLikeness.js`
+  (sc-4414). The frontend badge (sc-4413) imports `classifyLikeness` / `LIKENESS_BANDS` from it —
+  the cut-points are defined once, there.
+
+## What the metric is
+
+The score is the **cosine similarity between two ArcFace face embeddings** — one of the reference
+("source") face and one of the largest detected face in the generated image. Both faces are found
+with SCRFD and embedded with ArcFace from the InsightFace **antelopev2** pack (`glintr100`), the
+same SCRFD + ArcFace stack the InstantID / keypoint / dataset-face paths already provision
+(`mlx-gen-face` on macOS, `candle-gen-face` off-Mac — no new weights). The embeddings are
+L2-normalized, so the cosine lives in `[-1, 1]`; for real face pairs it is effectively `[0, 1]`.
+
+The source face is embedded **once per job** and cached; each generated image re-embeds only
+itself and dots against the cached source. Scoring is **non-fatal** — a failure is logged and
+recorded as `null`, never blocking a generation.
+
+The persisted block:
+
+```json
+{
+  "score": 0.876,
+  "detected": true,
+  "method": "arcface_antelopev2",
+  "sourceAssetId": "asset_…"
+}
+```
+
+…or, when there is no measurable frontal identity:
+
+```json
+{
+  "score": null,
+  "detected": false,
+  "method": "arcface_antelopev2",
+  "sourceAssetId": "asset_…",
+  "reason": "no_face"
+}
+```
+
+## Frontal-identity only — the load-bearing limitation
+
+ArcFace is a **frontal face-recognition** model. The embedding is only meaningful when SCRFD
+detects a reasonably frontal face with enough confidence (the scorer's `MIN_DET_SCORE = 0.65`,
+mirroring the keypoint-extract confidence floor). The score therefore measures *frontal-identity
+match*, not "how good the picture is".
+
+Consequences a reader must keep in mind:
+
+- A **high** score means the frontal face is recognizably the reference person. It says nothing
+  about pose accuracy, composition, hands, background, or style.
+- A **low** score (a real, detected cosine below the bands) means a frontal face *was* found but
+  it is **drifting toward a different person**.
+- A **missing** score (N/A) means there was **no detectable frontal face to compare** — see below.
+
+### Why profiles, up/down, and full-body poses return N/A
+
+A left/right profile, a strong up/down tilt, an occluded face, or a full-body / turned pose
+legitimately has **no detectable frontal face**. In that case the scorer returns an explicit
+**`detected: false`, `score: null`** result with a `reason`
+(`no_face` | `low_confidence` | `no_source_face` | `embedding_error`) — **not** a low number.
+
+This is deliberate and is the single most important thing not to misread:
+
+> A profile shot is **N/A**, not "0.2". The absence of a frontal-identity signal is *not* evidence
+> of poor likeness. Rendering N/A as a low score would punish exactly the angles a character set is
+> *supposed* to produce (profiles, looking up/down), and would be dishonest.
+
+The UI must surface N/A as its own neutral state ("No frontal face to score" / "—"), distinct
+from a weak likeness. The classifier in `apps/web/src/faceLikeness.js` enforces this: any
+`detected: false` or non-finite score maps to the `na` band, never to `weak`.
+
+## The bands
+
+`classifyLikeness(scoreOrBlock)` maps a cosine to one of four states:
+
+| Band         | Condition                       | Meaning                                                  |
+| ------------ | ------------------------------- | -------------------------------------------------------- |
+| **strong**   | `score >= 0.80`                 | Frontal identity solidly matches the reference.          |
+| **moderate** | `0.55 <= score < 0.80`          | Recognizable as the same person, with some drift.        |
+| **weak**     | `score < 0.55`                  | Clear identity drift — likely not a confident match.     |
+| **na**       | `detected:false` / `score:null` | No detectable frontal face to score (not a low number).  |
+
+Cut-points: `STRONG_MIN = 0.80`, `MODERATE_MIN = 0.55` (defined in `apps/web/src/faceLikeness.js`).
+
+### Rationale — why these edges (anchored to recorded baselines)
+
+The edges are calibrated against **recorded antelopev2 ArcFace cosines** measured on this stack
+(InstantID and PuLID-FLUX spikes, epic 4406 surfaces), not invented round numbers:
+
+| Generation / condition                              | Recorded cosine | Source                |
+| --------------------------------------------------- | --------------- | --------------------- |
+| InstantID frontal identity (E2E, "STRONG")          | ~0.876          | sc-2009               |
+| InstantID 9-angle pack (all angles hold)            | 0.81 – 0.89     | sc-2009               |
+| InstantID three-quarter                             | ~0.875          | sc-2009               |
+| InstantID with face-restore pass                    | ~0.74 → 0.83    | epic 4406 baselines   |
+| InstantID pose tier                                 | ~0.71           | epic 4406 baselines   |
+| InstantID, landmark ControlNet disabled (collapse)  | ~0.15           | sc-2009               |
+| PuLID-FLUX photoreal preset (iw=1.0, sc=4)          | 0.8016          | sc-2012               |
+| PuLID-FLUX iw=0.8 (visually drifts)                 | 0.7422          | sc-2012               |
+| PuLID-FLUX iw=0.6 (drifts further)                  | 0.5689          | sc-2012               |
+| Qwen-Edit Lightning angle-set mean                  | ~0.62           | sc-2003               |
+| FLUX.2-klein angle-set mean                         | ~0.52           | sc-2003               |
+
+**`STRONG_MIN = 0.80`** — the floor that captures every result a viewer reads as unmistakably the
+same person: InstantID frontal (~0.876) and its full angle pack (0.81–0.89), PuLID-FLUX photoreal
+(0.8016), and the top of the InstantID face-restore range (~0.83). It deliberately sits **just
+above** the PuLID iw=0.8 case (0.7422) that the spike described as *visually drifting* — that
+result should read as **moderate**, not strong. Confidence: **high.**
+
+**`MODERATE_MIN = 0.55`** — the floor below which results are *clear* drift. It sits just below
+the closest anchor above it, PuLID iw=0.6 (0.5689, "drifts further") — that borderline result
+stays **moderate** — while the soft-identity backbones (FLUX.2-klein ~0.52) and the
+landmark-disabled collapse (~0.15) fall into **weak**. Everything in `[0.55, 0.80)` — the pose
+tier (~0.71), the lower face-restore edge (~0.74), PuLID iw=0.8 drift (0.7422), Qwen-Edit
+Lightning (~0.62), PuLID iw=0.6 (0.5689) — is "recognizable but drifting", i.e. **moderate**.
+Confidence: **medium-high**;
+the 0.50–0.60 region is genuinely fuzzy across generators, so this edge is the more debatable of
+the two. If the badge later proves too lenient or too harsh in this band, this is the knob to
+revisit (and it lives in one place).
+
+## Licensing note — antelopev2 (ArcFace / SCRFD) is non-commercial
+
+The face detection + recognition models here come from the InsightFace **antelopev2** pack, which
+is licensed for **non-commercial / research use only**. SceneWorks is an **open-source,
+non-commercial project** (PolyForm Noncommercial for its own code), so this is in-scope and
+acceptable — the same posture under which the project already ships non-commercial model weights.
+
+Precedent and posture:
+
+- SceneWorks downloads weights under the **user's own license acceptance** and does not redistribute
+  the antelopev2 pack; the non-commercial obligation falls on the end user.
+- The project already ships strictly more-restrictive non-commercial weights (e.g. FLUX.1-dev under
+  the BFL Non-Commercial License), and accepted the revenue-gated Stability AI Community License as
+  non-blocking — so a non-commercial face pack is well within the established licensing posture.
+- This is **not legal advice**. It is recorded here so that anyone evaluating a *commercial* fork of
+  SceneWorks knows antelopev2 is a commercial blocker (InsightFace sells a separate commercial
+  license) and that the likeness feature depends on it.


### PR DESCRIPTION
## sc-4414 — Calibrate likeness threshold bands + document frontal-face limitation

Decides and documents the strong/moderate/weak cosine cut-points for the identity-likeness UI (epic 4406), grounded in recorded antelopev2 ArcFace baselines — not invented numbers — and ships the bands as a single shared, frontend-importable source of truth that the sc-4413 badge will consume.

### Chosen cut-points + rationale

| Band | Condition | Meaning |
| --- | --- | --- |
| **strong** | `score >= 0.80` | Frontal identity solidly matches the reference |
| **moderate** | `0.55 <= score < 0.80` | Recognizable as the same person, with drift |
| **weak** | `score < 0.55` | Clear identity drift — likely not a confident match |
| **na** | `detected:false` / `score:null` | No detectable frontal face (NOT a low number) |

- **`STRONG_MIN = 0.80`** captures every solidly-recognizable anchor — InstantID frontal ~0.876 and its 9-angle pack 0.81–0.89, PuLID-FLUX photoreal 0.8016, upper InstantID face-restore ~0.83 — and sits just above the PuLID iw=0.8 case (0.7422) the spike called "visually drifts" (→ moderate, not strong). **Confidence: high.**
- **`MODERATE_MIN = 0.55`** sits just below the closest anchor above it (PuLID iw=0.6, 0.5689, "drifts further" — a borderline result that stays moderate) while putting the soft-identity backbones (FLUX.2-klein ~0.52) and the landmark-disabled collapse (~0.15) into weak. The `[0.55, 0.80)` band holds the pose tier (~0.71), lower face-restore (~0.74), Qwen-Edit Lightning (~0.62). **Confidence: medium-high** — the 0.50–0.60 region is genuinely fuzzy across generators; this is the edge to revisit if the badge proves too lenient/harsh, and it lives in exactly one place.

Baselines sourced from the recorded InstantID (sc-2009) and PuLID-FLUX (sc-2012) spikes plus the epic-4406 surface baselines (full table in the doc).

### Where the constants live (single source of truth)
`apps/web/src/faceLikeness.js` — `STRONG_MIN`, `MODERATE_MIN`, `LIKENESS_BAND`, `LIKENESS_BANDS`, `LIKENESS_METHOD` (`arcface_antelopev2`, matching the backend `LIKENESS_METHOD`), plus the `classifyLikeness()` classifier (cosine **or** the persisted `faceLikeness` block → band) and `likenessBand()` descriptor lookup. sc-4413 imports `classifyLikeness` / `LIKENESS_BANDS` directly — no duplication. The web app is JS (not TS), so this is a `.js` module alongside the existing `constants.js`.

### Doc
`docs/face-likeness.md`: what the metric is (ArcFace antelopev2 cosine = frontal-identity confidence, **not** image quality), the frontal-only limitation, why profiles / up-down / full-body poses return **N/A** (`detected:false`, not a low number), the band definitions + per-edge rationale with the baseline table, and the **antelopev2 ArcFace/SCRFD non-commercial licensing note** (SceneWorks is already non-commercial; FLUX.1-dev NC + Stability AI Community License precedent; antelopev2 is a commercial-fork blocker).

### Tests
- `apps/web/src/faceLikeness.test.js` (new, 10 cases): classifier maps each recorded anchor to its band, the explicit N/A path for `detected:false` / missing / non-finite scores, cut-points pinned to the baselines, contiguous band tiling, descriptor coverage incl. the N/A non-tier.
- Full web vitest: **833 passing** (48 files). eslint: **0 errors** (pre-existing warnings only, none in the new files). `vite build`: green. No Rust touched → `rust:check` N/A.

### Acceptance
- ✅ Band cut-points committed as shared, frontend-importable constants with documented rationale.
- ✅ Doc explains the frontal-face limitation + N/A behaviour so the number isn't misread as quality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)