### PR TITLE
fix(desktop): macOS Metal startup preflight — actionable message when MLX can't get a GPU (sc-8411)

### DIFF
--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -1426,6 +1426,42 @@ fn cuda_preflight() -> Result<(), String> {
     evaluate_nvidia_preflight(Some(&stdout))
 }
 
+/// Apple-Silicon Metal preflight (sc-8411): the macOS counterpart of the Windows
+/// `cuda_preflight`. The desktop crate doesn't link MLX, so probe by re-launching the
+/// bundled `sceneworks-api` sidecar in its one-shot `SCENEWORKS_GPU_CHECK=1` mode — a
+/// tiny MLX op (1-element astype + eval) that fails exactly as a real job would if this
+/// machine can't acquire a Metal GPU (a headless/SSH session, a wedged GPU). Running it
+/// as the same sidecar binary means the probe sees the identical spawn context the
+/// worker will. `Ok(())` when usable; `Err(message)` is the sidecar's user-facing reason
+/// (relayed verbatim onto the setup screen), or a fallback if the probe produced none.
+#[cfg(target_os = "macos")]
+async fn metal_preflight(app: &AppHandle) -> Result<(), String> {
+    let output = app
+        .shell()
+        .sidecar("sceneworks-api")
+        .map_err(|error| format!("locate api for GPU check: {error}"))?
+        .env("SCENEWORKS_GPU_CHECK", "1")
+        .output()
+        .await
+        .map_err(|error| format!("run GPU check: {error}"))?;
+    if output.status.code() == Some(0) {
+        return Ok(());
+    }
+    let message = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    if message.is_empty() {
+        // The probe died before printing its reason (e.g. an unexpected crash / signal).
+        // Surface a usable fallback rather than a blank error.
+        return Err(
+            "SceneWorks can't initialize the Metal GPU on this Mac. It requires \
+                    Apple Silicon with GPU access; running over SSH or in a headless \
+                    session is not supported. Try opening SceneWorks on the Mac itself, \
+                    or reboot and reopen."
+                .to_owned(),
+        );
+    }
+    Err(message)
+}
+
 async fn run_startup(app: AppHandle) {
     // Provide the builtin model catalog the rust-api/worker expect before they
     // start, so Model Manager is populated and native video resources resolve.
@@ -1461,6 +1497,17 @@ async fn run_startup(app: AppHandle) {
             format!("GPU runtime download failed: {error}"),
             true,
         );
+        return;
+    }
+    // Apple-Silicon Metal preflight (sc-8411): fail fast with a clear, actionable
+    // message on the setup screen if this Mac can't acquire a Metal GPU (a headless/SSH
+    // session, a wedged GPU), BEFORE spawning the worker and loading a multi-GB model —
+    // the macOS counterpart of the Windows `cuda_preflight` above. Without it the first
+    // GPU op fails deep inside a model load with a raw MLX C++ assertion (and a leaked
+    // CI build path). The setup page renders this `error` event.
+    #[cfg(target_os = "macos")]
+    if let Err(error) = metal_preflight(&app).await {
+        emit(&app, "error", error, true);
         return;
     }
     // No Python venv on ANY platform: macOS went MLX-only (epic 3482, sc-3492/sc-3493)

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -440,6 +440,17 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 /// Run this binary as a standalone worker process instead of the HTTP API.
+/// Apple-Silicon Metal preflight (sc-8411). Dispatched from `main` when
+/// `SCENEWORKS_GPU_CHECK=1`: a one-shot probe that the desktop spawns at startup —
+/// the macOS counterpart of the Windows `nvidia-smi` `cuda_preflight`. Reuses this
+/// binary because it already links MLX (the desktop crate does not), and runs the
+/// probe in the SAME process/spawn context the real worker uses, so it faithfully
+/// predicts whether the worker can acquire a Metal GPU. `Ok(())` when usable;
+/// `Err(message)` is the user-facing reason the desktop relays onto the setup screen.
+pub fn gpu_check() -> Result<(), String> {
+    sceneworks_worker::metal_preflight()
+}
+
 /// Dispatched from `main` when `SCENEWORKS_WORKER_ONLY=1`; the desktop app uses
 /// it to launch the Apple-Silicon MLX GPU worker (`SCENEWORKS_GPU_ID=mlx`,
 /// sc-3289) as a crash-isolated sibling of the API process — reusing this binary

--- a/apps/rust-api/src/main.rs
+++ b/apps/rust-api/src/main.rs
@@ -4,6 +4,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // GPU worker — the Apple-Silicon MLX worker (sc-3289) — by setting
     // SCENEWORKS_WORKER_ONLY=1. The binary already links the mlx-gen engine, so
     // reusing it avoids bundling a second multi-hundred-MB sidecar.
+    // One-shot Metal preflight (sc-8411): the desktop re-launches this binary with
+    // SCENEWORKS_GPU_CHECK=1 at startup to verify a usable Metal GPU before spawning
+    // the long-running worker. Print the user-facing reason to stdout (the desktop
+    // relays it onto the setup screen) and exit non-zero on failure, rather than
+    // returning Err (whose Debug print would be noise). Checked before WORKER_ONLY so
+    // the probe never starts a worker loop.
+    if std::env::var("SCENEWORKS_GPU_CHECK").is_ok_and(|value| value.trim() == "1") {
+        match sceneworks_rust_api::gpu_check() {
+            Ok(()) => std::process::exit(0),
+            Err(message) => {
+                println!("{message}");
+                std::process::exit(1);
+            }
+        }
+    }
     if std::env::var("SCENEWORKS_WORKER_ONLY").is_ok_and(|value| value.trim() == "1") {
         return sceneworks_rust_api::run_worker().await;
     }

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -305,6 +305,8 @@ mod progress;
 pub(crate) use progress::*;
 mod util;
 pub use util::*;
+mod preflight;
+pub use preflight::*;
 
 const INSTALL_MARKER: &str = ".sceneworks-download-complete.json";
 const DEFAULT_API_URL: &str = "http://localhost:8000";

--- a/crates/sceneworks-worker/src/preflight.rs
+++ b/crates/sceneworks-worker/src/preflight.rs
@@ -1,0 +1,46 @@
+//! Startup hardware preflight (sc-8411).
+//!
+//! On Apple Silicon the generation worker is MLX-only: every job eventually casts a
+//! tensor on the Metal GPU. If MLX can't materialize a default Metal device+stream —
+//! a headless / no-window-server session (SSH, a LaunchDaemon), or a transient GPU
+//! wedge — the FIRST GPU op fails deep inside a model load with a raw MLX C++
+//! assertion (`expected a non-empty mlx_stream`), which also leaks the CI build path
+//! baked into MLX's compiled `__FILE__`. The desktop runs [`metal_preflight`] as a
+//! one-shot at startup (via the `SCENEWORKS_GPU_CHECK=1` sidecar mode) so an
+//! unusable-GPU machine gets a clear, actionable message on the setup screen BEFORE
+//! any model load — the macOS counterpart of the Windows `nvidia-smi` `cuda_preflight`.
+
+/// User-facing message when MLX can't acquire a Metal GPU. Authored here (next to the
+/// MLX knowledge) and printed to stdout by the `SCENEWORKS_GPU_CHECK=1` probe so the
+/// desktop can relay it verbatim onto the setup screen.
+#[cfg(target_os = "macos")]
+const METAL_UNAVAILABLE: &str = "SceneWorks can't initialize the Metal GPU on this Mac. \
+It requires Apple Silicon with GPU access — running over SSH or in a headless session \
+(no logged-in graphical session) is not supported. Try opening SceneWorks normally on \
+the Mac itself, or reboot and reopen.";
+
+/// Verify this process can acquire a usable Metal GPU by running the smallest MLX op
+/// that forces default-device + default-stream acquisition: a 1-element `astype` +
+/// `eval` — the exact op that fails in the field. `Ok(())` when the GPU is usable;
+/// `Err(message)` is the user-facing reason (with the underlying MLX error appended
+/// for the logs).
+#[cfg(target_os = "macos")]
+pub fn metal_preflight() -> Result<(), String> {
+    let probe = mlx_rs::Array::from_slice(&[1.0f32], &[1])
+        .as_dtype(mlx_rs::Dtype::Float16)
+        .and_then(|array| array.eval());
+    match probe {
+        Ok(()) => Ok(()),
+        Err(error) => Err(format!(
+            "{METAL_UNAVAILABLE}\n\nUnderlying MLX error: {error}"
+        )),
+    }
+}
+
+/// Off-Mac the desktop uses its own CUDA preflight (`nvidia-smi`); there is no MLX to
+/// probe, so this is a no-op. Present on all targets so the `SCENEWORKS_GPU_CHECK`
+/// dispatch in the shared binary compiles everywhere.
+#[cfg(not(target_os = "macos"))]
+pub fn metal_preflight() -> Result<(), String> {
+    Ok(())
+}


### PR DESCRIPTION
## Why

A user hit this generating with FLUX.2-klein:

```
flux2_klein_9b load failed: backend op failed: "expected a non-empty mlx_stream at /Users/michael/actions-runner-sceneworks/.../mlx/c/ops.cpp:456" at .../mlx-rs/src/ops/conversion.rs:58:9
```

Two problems in one message:

1. **Leaked build path** — `/Users/michael/actions-runner-sceneworks/...` is `__FILE__` baked into MLX's compiled C++ assertion at build time on the CI runner. It is **not** a path on the user's disk and can't be stripped. Cosmetic, but it makes errors look broken.
2. **Real failure** — `expected a non-empty mlx_stream`, thrown from `as_dtype` (`mlx_astype`) during klein weight load. mlx-rs filled in `Stream::default()` → `Stream::new()`, which is only valid "if dev is valid." An empty stream means **MLX could not materialize a default Metal GPU device** at the moment of the first GPU op — a headless/SSH session (no window-server), or a transient GPU wedge. The astype is just the first op that touches the GPU, so that's where it surfaced.

There was a Windows `cuda_preflight()` that fails fast with a clear requirement message, but **no macOS/Metal equivalent** — so an unusable-GPU Mac got a raw C++ assertion deep inside a job instead of an actionable message at startup.

## What

Add a startup Metal preflight, mirroring the Windows path so the verdict lands on the setup screen **before any model load**.

The wrinkle: `apps/desktop` doesn't link MLX (only `sceneworks-core`), so unlike the Windows `nvidia-smi` probe it can't check in-process. The probe runs where MLX is linked — the bundled `sceneworks-api` sidecar — in the **same spawn context** the real worker uses, so it faithfully predicts whether the worker can get Metal.

- **`crates/sceneworks-worker/src/preflight.rs`** (new) — `metal_preflight()` runs the smallest MLX op (1-element `as_dtype(Float16)` + `eval`, the exact astype that fails) and maps any error to a user-facing message. No-op off-Mac so the dispatch compiles on all targets and the candle/Linux parity lane never touches MLX.
- **`apps/rust-api`** — `gpu_check()` wrapper + a `SCENEWORKS_GPU_CHECK=1` one-shot branch in `main` (prints the reason to stdout, `exit(0/1)`), checked before `WORKER_ONLY` so the probe never starts a worker loop.
- **`apps/desktop/src/setup.rs`** — `metal_preflight(&app)` spawns the sidecar in check mode during `run_startup`; on failure emits the message to the setup screen and aborts — same slot/UX as `cuda_preflight`.

## Notes for reviewers

- **No separate arch/OS pre-gate.** The bundle is arm64-only (can't launch on Intel) and `minimumSystemVersion: 26.2` blocks old-OS launch at Launch Services — so a pre-gate could never fire; it'd be dead code. The live probe is the only check that catches the real failure (headless/wedged GPU).
- The leaked `__FILE__` path is **not** fixable here (it's compiled into MLX's C++); this PR's value is replacing the raw assertion with an actionable startup message.
- **Runtime not yet exercised** — `cargo check` proves it compiles; actually running the probe needs a full `cargo build` of `sceneworks-api`. The failure-path AC needs a headless/wedged-GPU machine to reproduce.

## Test plan

- [x] `cargo check -p sceneworks-rust-api` (worker + preflight + gpu_check + main) — clean
- [x] `cargo check -p sceneworks-desktop` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p sceneworks-rust-api -p sceneworks-desktop --all-targets -- -D warnings` — clean
- [ ] Runtime probe on a healthy Mac (exit 0) — needs full binary build
- [ ] Failure-path message on a headless/no-GPU context — needs repro hardware

Shortcut: [sc-8411](https://app.shortcut.com/trefry/story/8411)

🤖 Generated with [Claude Code](https://claude.com/claude-code)