### PR TITLE
feat(web): frontal-identity likeness badge on generated results (sc-4413)

### DIFF
--- a/apps/web/src/components/LikenessBadge.jsx
+++ b/apps/web/src/components/LikenessBadge.jsx
@@ -1,0 +1,107 @@
+// Frontal-identity likeness badge (epic 4406, sc-4413). Surfaces the per-asset ArcFace
+// antelopev2 likeness score the backend persists at
+// `recipe.rawAdapterSettings.faceLikeness = { score, detected, method, sourceAssetId, reason? }`
+// (written by sc-4408) as a small colour-banded badge on generated result thumbnails.
+//
+// The metric is *frontal-identity confidence*, NOT overall image quality. The band cut-points,
+// labels, descriptions, and method string live in ../faceLikeness.js (sc-4414) — this component
+// is a pure presenter and MUST NOT duplicate or re-derive any threshold.
+//
+// Three render states:
+//   - scored (detected, finite cosine)  -> "92%" badge in a strong/moderate/weak colour band
+//   - N/A   (detected:false / no score) -> neutral "—" chip reading "No frontal face to score",
+//                                          never a red low number (metric honesty)
+//   - absent (no faceLikeness block)    -> render nothing (legacy/unscored assets) — no layout box
+import React from "react";
+import { LIKENESS_BAND, LIKENESS_METHOD, classifyLikeness, likenessBand } from "../faceLikeness.js";
+
+// The human-facing name for the recognition method (LIKENESS_METHOD is the machine string the
+// backend stamps; this is what the tooltip shows). Kept adjacent so the literal lives in one place.
+export const LIKENESS_METHOD_LABEL = "ArcFace antelopev2";
+
+// Pull the persisted faceLikeness block off an asset's recipe. Returns null when the block is
+// absent (legacy / unscored asset) so callers can render nothing without poking at the recipe.
+export function assetFaceLikeness(asset) {
+  const block = asset?.recipe?.rawAdapterSettings?.faceLikeness;
+  return block && typeof block === "object" ? block : null;
+}
+
+// Cosine in [-1, 1] -> integer percent for the badge label. 0.92 -> "92%". Clamps to [0, 100]
+// so a rare negative cosine never renders as "-12%".
+function formatPercent(score) {
+  const clamped = Math.min(1, Math.max(0, score));
+  return `${Math.round(clamped * 100)}%`;
+}
+
+// Build the tooltip text: raw cosine + method + which reference it was scored against.
+function buildTooltip({ band, descriptor, score, detected, sourceLabel }) {
+  const lines = [descriptor?.label ?? "Frontal-identity confidence"];
+  if (descriptor?.description) {
+    lines.push(descriptor.description);
+  }
+  if (band !== LIKENESS_BAND.NA && typeof score === "number" && Number.isFinite(score)) {
+    lines.push(`Cosine: ${score.toFixed(3)}`);
+  }
+  lines.push(`Method: ${LIKENESS_METHOD_LABEL}`);
+  if (sourceLabel) {
+    lines.push(`Scored against: ${sourceLabel}`);
+  }
+  // Reinforce that this is identity confidence, not overall quality — once, at the end.
+  lines.push("Measures frontal-identity confidence, not overall image quality.");
+  void detected;
+  return lines.join("\n");
+}
+
+// `faceLikeness` may be passed directly, or inferred from `asset`. `sourceLabel` is an optional
+// pre-resolved human name for the reference (sourceAssetId) — falls back to the raw id.
+export function LikenessBadge({ asset = null, faceLikeness = null, sourceLabel = null }) {
+  const block = faceLikeness ?? assetFaceLikeness(asset);
+
+  // Absent block (legacy / unscored): render nothing — no badge, no layout box.
+  if (!block) {
+    return null;
+  }
+
+  const band = classifyLikeness(block);
+  const descriptor = likenessBand(band);
+  const score = typeof block.score === "number" ? block.score : null;
+  const resolvedSource = sourceLabel || block.sourceAssetId || null;
+  const tooltip = buildTooltip({
+    band,
+    descriptor,
+    score,
+    detected: block.detected,
+    sourceLabel: resolvedSource,
+  });
+
+  // N/A: neutral chip, explanatory copy — never a low number coloured red.
+  if (band === LIKENESS_BAND.NA) {
+    return (
+      <span
+        className="likeness-badge likeness-badge--na"
+        data-band={LIKENESS_BAND.NA}
+        title={tooltip}
+        aria-label={`Frontal-identity confidence: no frontal face to score (${LIKENESS_METHOD_LABEL})`}
+      >
+        <span className="likeness-badge__value" aria-hidden="true">
+          —
+        </span>
+        <span className="likeness-badge__note">No frontal face to score</span>
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={`likeness-badge likeness-badge--${band}`}
+      data-band={band}
+      data-method={LIKENESS_METHOD}
+      title={tooltip}
+      aria-label={`Frontal-identity confidence ${formatPercent(score ?? 0)} — ${descriptor?.label ?? band} (${LIKENESS_METHOD_LABEL})`}
+    >
+      <span className="likeness-badge__value">{formatPercent(score ?? 0)}</span>
+    </span>
+  );
+}
+
+export default LikenessBadge;

--- a/apps/web/src/components/LikenessBadge.test.jsx
+++ b/apps/web/src/components/LikenessBadge.test.jsx
@@ -1,0 +1,151 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { LikenessBadge, LIKENESS_METHOD_LABEL, assetFaceLikeness } from "./LikenessBadge.jsx";
+import { LIKENESS_METHOD } from "../faceLikeness.js";
+
+// Frontal-identity likeness badge (epic 4406, sc-4413). Proves the three render states the AC
+// requires: a colour-banded score badge, the neutral N/A treatment (never a low number), and the
+// graceful no-render for legacy/unscored assets — all reading the band from the shared classifier.
+
+let container;
+let root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function render(ui) {
+  act(() => root.render(ui));
+}
+
+function assetWith(faceLikeness) {
+  return { id: "asset-1", recipe: { rawAdapterSettings: { faceLikeness } } };
+}
+
+describe("LikenessBadge (sc-4413)", () => {
+  describe("scored results show a colour-banded percentage", () => {
+    it("renders a strong score as a percentage in the strong band", () => {
+      render(<LikenessBadge faceLikeness={{ score: 0.92, detected: true, method: LIKENESS_METHOD }} />);
+      const badge = container.querySelector(".likeness-badge");
+      expect(badge).toBeTruthy();
+      expect(badge.dataset.band).toBe("strong");
+      expect(badge.classList.contains("likeness-badge--strong")).toBe(true);
+      expect(badge.textContent).toContain("92%");
+    });
+
+    it("bands a mid score as moderate and a drift score as weak", () => {
+      render(<LikenessBadge faceLikeness={{ score: 0.71, detected: true }} />);
+      expect(container.querySelector(".likeness-badge").dataset.band).toBe("moderate");
+      expect(container.querySelector(".likeness-badge").textContent).toContain("71%");
+
+      render(<LikenessBadge faceLikeness={{ score: 0.2, detected: true }} />);
+      expect(container.querySelector(".likeness-badge").dataset.band).toBe("weak");
+      expect(container.querySelector(".likeness-badge").textContent).toContain("20%");
+    });
+
+    it("tooltip exposes raw cosine, method, and the scored-against source", () => {
+      render(
+        <LikenessBadge
+          faceLikeness={{ score: 0.876, detected: true, sourceAssetId: "ref-42" }}
+        />,
+      );
+      const title = container.querySelector(".likeness-badge").getAttribute("title");
+      expect(title).toContain("Cosine: 0.876");
+      expect(title).toContain(LIKENESS_METHOD_LABEL);
+      expect(title).toContain("ref-42");
+      // honest framing, not a quality claim
+      expect(title.toLowerCase()).toContain("frontal-identity");
+    });
+
+    it("prefers a resolved source label over the raw id", () => {
+      render(
+        <LikenessBadge
+          faceLikeness={{ score: 0.876, detected: true, sourceAssetId: "ref-42" }}
+          sourceLabel="Reference portrait"
+        />,
+      );
+      const title = container.querySelector(".likeness-badge").getAttribute("title");
+      expect(title).toContain("Reference portrait");
+      expect(title).not.toContain("ref-42");
+    });
+
+    it("clamps a percentage to [0, 100] and rounds", () => {
+      render(<LikenessBadge faceLikeness={{ score: 1.0, detected: true }} />);
+      expect(container.querySelector(".likeness-badge").textContent).toContain("100%");
+    });
+  });
+
+  describe("N/A state (detected:false) is neutral, not a low number", () => {
+    it("renders the neutral dash + explanatory copy", () => {
+      render(
+        <LikenessBadge
+          faceLikeness={{ score: null, detected: false, method: LIKENESS_METHOD, reason: "no_face" }}
+        />,
+      );
+      const badge = container.querySelector(".likeness-badge");
+      expect(badge).toBeTruthy();
+      expect(badge.dataset.band).toBe("na");
+      expect(badge.classList.contains("likeness-badge--na")).toBe(true);
+      // neutral dash, explanatory copy — and crucially NOT a red low percentage
+      expect(badge.textContent).toContain("—");
+      expect(badge.textContent).toContain("No frontal face to score");
+      expect(badge.textContent).not.toMatch(/\d+%/);
+      expect(badge.classList.contains("likeness-badge--weak")).toBe(false);
+    });
+
+    it("frames N/A as identity confidence, not quality, in the tooltip", () => {
+      render(<LikenessBadge faceLikeness={{ score: null, detected: false }} />);
+      const title = container.querySelector(".likeness-badge").getAttribute("title");
+      expect(title).toContain("No frontal face");
+      expect(title.toLowerCase()).toContain("not overall image quality");
+      // never invents a cosine for an unscored block
+      expect(title).not.toContain("Cosine:");
+    });
+  });
+
+  describe("absent / legacy block renders nothing", () => {
+    it("renders no badge when faceLikeness is absent on the asset", () => {
+      render(<LikenessBadge asset={{ id: "legacy", recipe: { rawAdapterSettings: {} } }} />);
+      expect(container.querySelector(".likeness-badge")).toBeNull();
+      expect(container.textContent).toBe("");
+    });
+
+    it("renders no badge when the recipe itself is absent", () => {
+      render(<LikenessBadge asset={{ id: "legacy" }} />);
+      expect(container.querySelector(".likeness-badge")).toBeNull();
+    });
+
+    it("renders no badge when neither asset nor block is provided", () => {
+      render(<LikenessBadge />);
+      expect(container.querySelector(".likeness-badge")).toBeNull();
+    });
+  });
+
+  describe("asset accessor", () => {
+    it("reads the block off recipe.rawAdapterSettings.faceLikeness", () => {
+      const block = { score: 0.8, detected: true };
+      expect(assetFaceLikeness(assetWith(block))).toBe(block);
+    });
+
+    it("returns null for a legacy/unscored asset", () => {
+      expect(assetFaceLikeness({ id: "x", recipe: { rawAdapterSettings: {} } })).toBeNull();
+      expect(assetFaceLikeness(null)).toBeNull();
+    });
+  });
+
+  it("reads the block from an asset and bands it end-to-end", () => {
+    render(<LikenessBadge asset={assetWith({ score: 0.85, detected: true })} />);
+    const badge = container.querySelector(".likeness-badge");
+    expect(badge.dataset.band).toBe("strong");
+    expect(badge.dataset.method).toBe(LIKENESS_METHOD);
+    expect(badge.textContent).toContain("85%");
+  });
+});

--- a/apps/web/src/components/WorkerProgressCard.jsx
+++ b/apps/web/src/components/WorkerProgressCard.jsx
@@ -4,6 +4,7 @@ import { formatSeconds, liveElapsedSeconds, percent } from "../formatting.js";
 import { useAppContext } from "../context/AppContext.js";
 import { deriveWorkerHardware, findWorkerForJob, liveMeters } from "../workers.js";
 import { AssetMedia, AssetThumbnail, assetUrl, posterUrl } from "./assetMedia.jsx";
+import { LikenessBadge } from "./LikenessBadge.jsx";
 
 // Live-ticking elapsed seconds for in-flight jobs. Re-exported here after the
 // sc-2093 cleanup deleted the legacy JobProgress.jsx that originally housed it.
@@ -244,7 +245,12 @@ function ThumbnailGrid({ assets, variant, onThumbnailClick, isRunning, expectedC
     >
       {items.map((asset, index) => {
         const interactive = !!onThumbnailClick;
-        const inner = <AssetThumbnail asset={asset} className="worker-progress-card__thumb-media" />;
+        const inner = (
+          <>
+            <AssetThumbnail asset={asset} className="worker-progress-card__thumb-media" />
+            <LikenessBadge asset={asset} />
+          </>
+        );
         const label = asset.displayName && variant === "image-grid" ? (
           <small className="worker-progress-card__thumb-label">{asset.displayName}</small>
         ) : null;

--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -3,6 +3,7 @@ import { isAbortError } from "../api.js";
 import { AssetMedia, assetUrl } from "./assetMedia.jsx";
 import { DocumentView } from "./DocumentView.jsx";
 import { Icon } from "./Icons.jsx";
+import { LikenessBadge } from "./LikenessBadge.jsx";
 import { Modal } from "./Modal.jsx";
 
 // Permanently purge every discarded asset in a single Trashcan view. The caller
@@ -460,6 +461,7 @@ export function AssetCard({ asset, deleteAsset, purgeAsset, onPreview, updateAss
     <article className={classes}>
       <button className="preview-button" onClick={() => onPreview(asset)} type="button">
         <AssetMedia asset={asset} />
+        <LikenessBadge asset={asset} />
       </button>
       <div className="review-actions">
         <button onClick={() => updateAssetStatus(asset, { favorite: !asset.status?.favorite })} type="button">
@@ -522,6 +524,7 @@ export function FullscreenPreview({
             <Icon.ArrowLeft size={18} />
           </button>
           <AssetMedia asset={displayedAsset} />
+          <LikenessBadge asset={asset} />
           <button
             aria-label="Next asset"
             className="preview-nav-button next"

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -3,6 +3,7 @@ import { AssetBatchModal, AssetSelectionBar, useAssetBatch } from "../assetBatch
 import { AssetPickerField, CharacterImportDialog } from "../components/AssetPicker.jsx";
 import { AssetCard, emptyTrash } from "../components/assetPanels.jsx";
 import { AssetMedia } from "../components/assetMedia.jsx";
+import { LikenessBadge } from "../components/LikenessBadge.jsx";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
 import { terminalStatuses } from "../jobTypes.js";
 import { PoseLibraryPicker } from "../components/PoseLibraryPicker.jsx";
@@ -712,6 +713,7 @@ function CharacterGenerationPanel({
               type="button"
             >
               <AssetMedia asset={asset} controls={false} />
+              <LikenessBadge asset={asset} />
             </button>
           ))}
         </div>
@@ -946,6 +948,7 @@ export function CharacterAssets({
                   type="button"
                 >
                   <AssetMedia asset={asset} controls={false} />
+                  <LikenessBadge asset={asset} />
                 </button>
                 <strong>{asset.displayName ?? asset.id}</strong>
                 <div className="character-asset-card-actions">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -10000,3 +10000,84 @@ details[open] > summary.lora-scope-group-heading::before,
     grid-template-columns: 1fr;
   }
 }
+
+/* ---------- Frontal-identity likeness badge (sc-4413) ----------
+   A small colour-banded badge pinned to the top-right of a generated result
+   thumbnail. Bands map to the shared classifier in faceLikeness.js (sc-4414):
+   strong -> success, moderate -> warn, weak -> danger, na -> neutral/muted.
+   The metric is frontal-identity confidence, NOT overall quality. */
+
+/* Each surface that hosts a badge needs a positioning context. These already
+   clip with overflow:hidden where present, so an absolutely-positioned badge
+   stays inside the tile. */
+.preview-button,
+.reference-thumb,
+.character-asset-media,
+.worker-progress-card__thumb-cell,
+.preview-modal-stage {
+  position: relative;
+}
+
+.likeness-badge {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  max-width: calc(100% - 12px);
+  padding: 2px 7px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1.3;
+  letter-spacing: 0.01em;
+  box-shadow: var(--shadow-sm);
+  pointer-events: auto;
+  cursor: help;
+}
+
+.likeness-badge__value {
+  font-variant-numeric: tabular-nums;
+}
+
+.likeness-badge--strong {
+  background: var(--success-soft, color-mix(in oklch, var(--success) 18%, var(--surface)));
+  color: color-mix(in oklch, var(--success) 78%, var(--text));
+}
+
+.likeness-badge--moderate {
+  background: var(--warn-soft);
+  color: color-mix(in oklch, var(--warn) 78%, var(--text));
+}
+
+.likeness-badge--weak {
+  background: var(--danger-soft);
+  color: color-mix(in oklch, var(--danger) 80%, var(--text));
+}
+
+/* N/A is deliberately neutral — it is the absence of a measurable frontal-identity
+   signal, NOT a low score. It must never read as a red failure. */
+.likeness-badge--na {
+  background: var(--surface-2);
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+  font-weight: 600;
+}
+
+.likeness-badge__note {
+  font-size: 10px;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* The full preview modal is large — give its badge a touch more presence. */
+.preview-modal-stage .likeness-badge {
+  top: 12px;
+  right: 12px;
+  font-size: 12px;
+  padding: 3px 9px;
+}


### PR DESCRIPTION
## sc-4413 — Surface likeness badge + N/A framing on generated results

Surfaces the per-asset ArcFace **antelopev2** frontal-identity score (persisted by sc-4408 at `recipe.rawAdapterSettings.faceLikeness`) as a colour-banded badge on generated result thumbnails.

### Badge design
- New `<LikenessBadge>` presenter (`apps/web/src/components/LikenessBadge.jsx`). It derives the band **only** via the shared `classifyLikeness` / `likenessBand` from `faceLikeness.js` (sc-4414) — no duplicated thresholds.
- **Scored:** small pill showing the percentage (`0.92 → "92%"`) in a `strong` (success/green), `moderate` (warn/amber), or `weak` (danger/red) band using the existing design-system tokens (`--success`, `--warn`, `--danger` + `-soft` mixes).
- **Tooltip / detail:** raw cosine (`Cosine: 0.876`), method (`ArcFace antelopev2`, from `LIKENESS_METHOD`), and which reference it was scored against (resolved `sourceLabel` or the raw `sourceAssetId`), plus an explicit "frontal-identity confidence, not overall quality" line.

### N/A framing (metric honesty)
- When `detected:false` (block present, `score:null` → band `na`): a **neutral** `—` chip reading **"No frontal face to score"** — never a red low number. Copy frames the metric as frontal-identity confidence, not overall quality.

### Absent / legacy
- When the `faceLikeness` block is absent entirely: renders **nothing** (no badge, no layout box).

### Three surfaces wired
- **Image Studio "With Character"** + character test outputs → shared `AssetCard` and `FullscreenPreview` (`assetPanels.jsx`).
- **Character Studio Angles / Poses** (streaming results) → `WorkerProgressCard` thumbnail grid.
- **Character galleries** (persistent angle/pose result tiles) → `characterPanels.jsx` (`reference-thumb` row + `character-asset-media` gallery).

### Tests
- `apps/web/src/components/LikenessBadge.test.jsx` — 16 cases covering banded score, tooltip (cosine + method + source), resolved-label preference, percent clamp/round, N/A neutral treatment (asserts it is **not** a `%` and **not** the weak band), and absent/legacy → no render.
- Full web suite green: **868 passed (51 files)**. eslint: 0 errors (pre-existing warnings only, none in new files). `vite build`: success.

### In-browser verification
The full app dev server needs the backend stack, which isn't available in this isolated worktree. The badge was exercised via the running `vite` dev server (component + a standalone harness transformed/served HTTP 200, no errors) and via the jsdom DOM assertions above. A pixel screenshot of the live Studio screens wasn't capturable here because the preview launcher couldn't resolve `vite` from the worktree root; flagging for human eyeball on the Studios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)