### PR TITLE
feat(character): on-demand "compare image to another" likeness tool (sc-4415)

### DIFF
--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -47,6 +47,23 @@ pub(crate) struct PromptRefineRequest {
     pub(crate) caption_style: Option<String>,
 }
 
+/// On-demand "compare image to another" likeness request (epic 4406, sc-4415). Scores a CANDIDATE
+/// asset against a SOURCE identity reference asset (both project assets) through the shared
+/// SCRFD+ArcFace face-likeness scorer in the worker. The handler enqueues a `face_likeness_compare`
+/// job; the client reads the result (`{ score, detected, method, sourceRef, reason? }`) from the
+/// completed job.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct FaceLikenessCompareRequest {
+    /// Project owning both assets (so the worker can resolve each asset's `file.path`).
+    pub(crate) project_id: String,
+    /// The SOURCE identity reference asset (an approved character Reference Asset). Its face is
+    /// embedded once and the candidate is scored against it.
+    pub(crate) source_asset_id: String,
+    /// The CANDIDATE asset (any image the user picked) whose face is compared to the source.
+    pub(crate) candidate_asset_id: String,
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct AssetsQuery {

--- a/apps/rust-api/src/face_likeness.rs
+++ b/apps/rust-api/src/face_likeness.rs
@@ -1,0 +1,97 @@
+use super::*;
+
+/// Enqueue a `face_likeness_compare` job (epic 4406, sc-4415): score a CANDIDATE asset against a
+/// SOURCE identity reference asset through the shared SCRFD+ArcFace face-likeness scorer in the worker.
+/// GPU-routed (`auto`) like `dataset_face_analysis` — the native face stack lives on the GPU worker.
+/// The client reads the result (`{ score, detected, method, sourceRef, reason? }`) from the completed
+/// job. NOT a generation post-pass: it compares two already-existing assets on demand.
+///
+/// The handler validates the request and confirms both assets resolve on disk inside the project
+/// (mirroring the prompt-refine vision-task resolution) so a garbled id fails fast as a 400 rather than
+/// dispatching a doomed job; the worker independently re-confines each path before opening it
+/// (defence-in-depth, epic 4484).
+pub(crate) async fn create_face_likeness_compare_job(
+    State(state): State<AppState>,
+    ApiJson(payload): ApiJson<FaceLikenessCompareRequest>,
+) -> Result<(StatusCode, Json<JobSnapshot>), ApiError> {
+    let project_id = payload.project_id.trim();
+    let source_asset_id = payload.source_asset_id.trim();
+    let candidate_asset_id = payload.candidate_asset_id.trim();
+    if project_id.is_empty() {
+        return Err(ApiError::bad_request("projectId is required"));
+    }
+    if source_asset_id.is_empty() {
+        return Err(ApiError::bad_request("sourceAssetId is required"));
+    }
+    if candidate_asset_id.is_empty() {
+        return Err(ApiError::bad_request("candidateAssetId is required"));
+    }
+
+    // Resolve both assets to confined on-disk paths up front so an invalid id is a clean 400 (the
+    // worker re-resolves + re-confines independently; this is fail-fast UX, not the sole guard).
+    let project_path = project_path_for_id(state.clone(), project_id).await?;
+    resolve_project_asset_path(state.clone(), project_id, source_asset_id, &project_path).await?;
+    resolve_project_asset_path(state.clone(), project_id, candidate_asset_id, &project_path)
+        .await?;
+
+    let mut job_payload = JsonObject::new();
+    job_payload.insert("projectId".to_owned(), Value::String(project_id.to_owned()));
+    job_payload.insert(
+        "sourceAssetId".to_owned(),
+        Value::String(source_asset_id.to_owned()),
+    );
+    job_payload.insert(
+        "candidateAssetId".to_owned(),
+        Value::String(candidate_asset_id.to_owned()),
+    );
+
+    let job = create_generation_job(
+        state,
+        JobType::FaceLikenessCompare,
+        Some(project_id.to_owned()),
+        None,
+        job_payload,
+        "auto".to_owned(),
+    )
+    .await?;
+    Ok((StatusCode::CREATED, Json(job)))
+}
+
+/// Resolve a project asset id to an absolute, project-confined on-disk path. Mirrors the worker's
+/// `load_reference_image` / the prompt-refine `resolve_image_caption_path`: read the asset record's
+/// relative `file.path`, join it under the project directory using only `Normal` components (rejecting
+/// `..`/absolute traversal), and confirm the file exists. Returns a 400 for a missing/garbled record or
+/// a path that escapes the project root.
+async fn resolve_project_asset_path(
+    state: AppState,
+    project_id: &str,
+    asset_id: &str,
+    project_path: &std::path::Path,
+) -> Result<(), ApiError> {
+    let project_id_owned = project_id.to_owned();
+    let asset_id_owned = asset_id.to_owned();
+    let asset = project_call(state, move |store| {
+        store.get_asset(&project_id_owned, &asset_id_owned)
+    })
+    .await?;
+    let rel = asset
+        .get("file")
+        .and_then(|file| file.get("path"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| ApiError::bad_request("Asset has no file path"))?;
+    let mut path = project_path.to_path_buf();
+    for component in std::path::Path::new(rel).components() {
+        match component {
+            std::path::Component::Normal(value) => path.push(value),
+            _ => {
+                return Err(ApiError::bad_request(
+                    "Asset path must stay inside the project directory",
+                ))
+            }
+        }
+    }
+    if !path.exists() {
+        return Err(ApiError::bad_request("Asset image not found on disk"));
+    }
+    Ok(())
+}

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -105,6 +105,10 @@ mod preferences;
 use preferences::*;
 mod prompts;
 use prompts::*;
+// On-demand "compare image to another" likeness tool (epic 4406, sc-4415): enqueues a
+// `face_likeness_compare` job scoring a candidate asset against a source identity reference asset.
+mod face_likeness;
+use face_likeness::*;
 mod poses;
 use poses::*;
 mod keypoints;
@@ -898,6 +902,10 @@ pub(crate) fn create_app_with_state(
         .route("/api/v1/image/interleave/jobs", post(create_interleave_job))
         .route("/api/v1/video/jobs", post(create_video_job))
         .route("/api/v1/prompts/refine", post(create_prompt_refine_job))
+        .route(
+            "/api/v1/face-likeness/compare",
+            post(create_face_likeness_compare_job),
+        )
         .route("/api/v1/poses", post(create_poses))
         .route("/api/v1/poses/sources", post(create_pose_sources))
         .route(

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1560,6 +1560,45 @@ export function App() {
     [token],
   );
 
+  // On-demand "compare image to another" likeness (epic 4406, sc-4415): score a CANDIDATE asset
+  // against a SOURCE identity reference asset through the shared SCRFD+ArcFace scorer in the worker.
+  // Same poll-to-completion contract as the refine/describe runners, but `/face-likeness/compare`
+  // enqueues the GPU-routed `face_likeness_compare` job and returns the full result object
+  // (`{ score, detected, method, sourceRef, reason? }`) so the caller can render the band + N/A framing
+  // via `classifyLikeness` / `LikenessBadge`. Non-fatal end to end: a no-face / non-frontal candidate
+  // is an honest detected:false result (NOT an error); only a hard failure throws.
+  const compareFaceLikeness = useCallback(
+    async ({ sourceAssetId, candidateAssetId, projectId, signal }) => {
+      const created = await apiFetch("/api/v1/face-likeness/compare", token, {
+        method: "POST",
+        signal,
+        body: JSON.stringify({ sourceAssetId, candidateAssetId, projectId }),
+      });
+      const jobId = created?.id;
+      if (!jobId) {
+        throw new Error("Could not start the likeness compare.");
+      }
+      const deadline = Date.now() + 180000;
+      while (Date.now() < deadline) {
+        await abortableDelay(1000, signal);
+        const job = await apiFetch(`/api/v1/jobs/${jobId}`, token, { signal });
+        if (job.status === "completed") {
+          // A completed compare always carries a result block (a detected:false N/A is a valid,
+          // non-error outcome). Surface the whole block so the UI can band/N-A it.
+          if (!job.result) {
+            throw new Error("Likeness compare returned no result.");
+          }
+          return job.result;
+        }
+        if (job.status === "failed" || job.status === "canceled" || job.status === "interrupted") {
+          throw new Error(job.message || job.error || "Likeness compare failed.");
+        }
+      }
+      throw new Error("Likeness compare timed out. Is the worker running?");
+    },
+    [token],
+  );
+
   const createVqaJob = useCallback(
     async (asset, question, maxNewTokens) => {
       if (!activeProject) {
@@ -1947,6 +1986,7 @@ export function App() {
     magicPrompt,
     imageCaption,
     imageDescribe,
+    compareFaceLikeness,
     latestVideoAssets,
     recentImageAssets,
     recentVideoAssets,
@@ -2045,7 +2085,7 @@ export function App() {
     updateAssetStatus, updateAssetTags, latestImageAssets,
     jobs, jobAction, createVqaJob, createInterleaveJob, createPlaceholderJob, filteredJobs,
     jobPrompt, setJobPrompt, projectFilter, setProjectFilter, projects, visibleWorkers, workersById,
-    createVideoJob, createVideoUpscaleJob, createImageJob, refinePrompt, magicPrompt, imageCaption, imageDescribe, latestVideoAssets, recentImageAssets,
+    createVideoJob, createVideoUpscaleJob, createImageJob, refinePrompt, magicPrompt, imageCaption, imageDescribe, compareFaceLikeness, latestVideoAssets, recentImageAssets,
     recentVideoAssets, videoLocalJobs, imageLocalJobs, documentLocalJobs, studioLaunch,
     rememberLocalGenerationJob, personTracks, personReadiness, createPersonDetectionJob,
     createPersonTrackJob, saveTrackCorrections, imageModels, videoModels, models, macCapabilities,

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -61,6 +61,7 @@ export function CharacterStudio() {
     updateCharacterLora,
     detachCharacterLora,
     createCharacterTestJob,
+    compareFaceLikeness,
     createImageJob,
     createModelDownloadJob,
     importAsset,
@@ -655,7 +656,9 @@ export function CharacterStudio() {
             >
               <CharacterAssets
                 addCharacterReference={addCharacterReference}
+                approvedReferences={approvedReferences}
                 assets={assets}
+                compareFaceLikeness={compareFaceLikeness}
                 deleteAsset={deleteAsset}
                 importAsset={importAsset}
                 onPreview={onPreview}

--- a/apps/web/src/screens/LikenessCompare.test.jsx
+++ b/apps/web/src/screens/LikenessCompare.test.jsx
@@ -1,0 +1,142 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { LikenessCompare } from "./characterPanels.jsx";
+
+// On-demand "compare image to another" likeness UI (epic 4406, sc-4415). Covers the compare states:
+// scored (a banded percentage), N/A (the honest no-frontal-face chip, not a low number), error
+// (inline failure), and absent (no approved Reference Asset → nothing to compare against).
+
+function click(el) {
+  el.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+}
+
+const APPROVED_REFS = [
+  { assetId: "ref_a", asset: { id: "ref_a", displayName: "Hero front" } },
+  { assetId: "ref_b", asset: { id: "ref_b", displayName: "Hero profile" } },
+];
+const CANDIDATE = { id: "asset_candidate", type: "image", displayName: "Test render" };
+
+describe("LikenessCompare", () => {
+  let container;
+  let root;
+
+  async function clickAndSettle(el) {
+    await act(async () => {
+      click(el);
+      await new Promise((r) => setTimeout(r, 0));
+    });
+  }
+
+  function render(node) {
+    act(() => {
+      root.render(node);
+    });
+  }
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("renders nothing when the character has no approved reference (no source identity)", () => {
+    render(
+      <LikenessCompare
+        approvedReferences={[]}
+        candidateAsset={CANDIDATE}
+        compareFaceLikeness={vi.fn()}
+        projectId="proj_1"
+      />,
+    );
+    expect(container.textContent).toBe("");
+  });
+
+  it("scores a candidate and renders a banded percentage from the shared scorer result", async () => {
+    const compareFaceLikeness = vi.fn().mockResolvedValue({
+      score: 0.91,
+      detected: true,
+      method: "arcface_antelopev2",
+      sourceRef: "ref_a",
+    });
+    render(
+      <LikenessCompare
+        approvedReferences={APPROVED_REFS}
+        candidateAsset={CANDIDATE}
+        compareFaceLikeness={compareFaceLikeness}
+        projectId="proj_1"
+      />,
+    );
+    // Open the control, then run the compare.
+    await clickAndSettle(container.querySelector(".likeness-compare-toggle"));
+    const compareButton = [...container.querySelectorAll("button")].find(
+      (b) => b.textContent === "Compare",
+    );
+    await clickAndSettle(compareButton);
+
+    // The runner is called with the selected source + the candidate + the project.
+    expect(compareFaceLikeness).toHaveBeenCalledWith({
+      sourceAssetId: "ref_a",
+      candidateAssetId: "asset_candidate",
+      projectId: "proj_1",
+    });
+    // A strong score renders the percentage badge (91%), not an N/A chip.
+    expect(container.textContent).toContain("91%");
+  });
+
+  it("renders the honest N/A chip for a no-face candidate, not a low number", async () => {
+    const compareFaceLikeness = vi.fn().mockResolvedValue({
+      score: null,
+      detected: false,
+      method: "arcface_antelopev2",
+      sourceRef: "ref_a",
+      reason: "no_face",
+    });
+    render(
+      <LikenessCompare
+        approvedReferences={APPROVED_REFS}
+        candidateAsset={CANDIDATE}
+        compareFaceLikeness={compareFaceLikeness}
+        projectId="proj_1"
+      />,
+    );
+    await clickAndSettle(container.querySelector(".likeness-compare-toggle"));
+    const compareButton = [...container.querySelectorAll("button")].find(
+      (b) => b.textContent === "Compare",
+    );
+    await clickAndSettle(compareButton);
+
+    // The N/A badge renders a neutral em-dash chip + the "No frontal face" copy, never a 0% number.
+    expect(container.textContent).toContain("—");
+    expect(container.textContent).not.toContain("0%");
+  });
+
+  it("surfaces an inline error when the compare fails, without crashing", async () => {
+    const compareFaceLikeness = vi.fn().mockRejectedValue(new Error("Worker offline"));
+    render(
+      <LikenessCompare
+        approvedReferences={APPROVED_REFS}
+        candidateAsset={CANDIDATE}
+        compareFaceLikeness={compareFaceLikeness}
+        projectId="proj_1"
+      />,
+    );
+    await clickAndSettle(container.querySelector(".likeness-compare-toggle"));
+    const compareButton = [...container.querySelectorAll("button")].find(
+      (b) => b.textContent === "Compare",
+    );
+    await clickAndSettle(compareButton);
+
+    const alert = container.querySelector("[role='alert']");
+    expect(alert).not.toBeNull();
+    expect(alert.textContent).toContain("Worker offline");
+  });
+});

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -815,12 +815,133 @@ export function CharacterAngleSet({ angleModel, angleModels, ...props }) {
 // character (recipe.normalizedSettings.characterId) or referencing it
 // (metadata.characterReferences). Reads the full project asset list, so character outputs
 // persist beyond the transient "recent generations" window (sc-2076).
+// On-demand "compare image to another" likeness control (epic 4406, sc-4415). Lives on each Character
+// Studio asset card: the user picks one of the character's APPROVED Reference Assets (the SOURCE
+// identity face) and compares the card's image (the CANDIDATE) against it, seeing the face-likeness
+// score with the SAME band + N/A framing as the rest of the epic (via `LikenessBadge`). Reuses the
+// shared worker scorer through `compareFaceLikeness` — no new scoring here. Non-fatal: a no-face /
+// non-frontal candidate is an honest N/A result (rendered by the badge), and a hard failure surfaces an
+// inline error, never crashing the panel.
+export function LikenessCompare({ candidateAsset, approvedReferences = [], projectId, compareFaceLikeness }) {
+  const [open, setOpen] = React.useState(false);
+  // Default the source to the first approved reference (the primary identity face).
+  const [sourceAssetId, setSourceAssetId] = React.useState(approvedReferences[0]?.assetId ?? "");
+  // "idle" | "running" | "done" | "error"
+  const [status, setStatus] = React.useState("idle");
+  const [result, setResult] = React.useState(null);
+  const [errorMessage, setErrorMessage] = React.useState("");
+
+  React.useEffect(() => {
+    // Keep a valid default selected as the approved set changes (or clear when none remain).
+    setSourceAssetId((current) => {
+      if (current && approvedReferences.some((reference) => reference.assetId === current)) {
+        return current;
+      }
+      return approvedReferences[0]?.assetId ?? "";
+    });
+  }, [approvedReferences]);
+
+  const sourceReference = approvedReferences.find((reference) => reference.assetId === sourceAssetId);
+  const sourceLabel = sourceReference?.asset?.displayName ?? sourceReference?.assetId ?? null;
+  const canCompare =
+    typeof compareFaceLikeness === "function" &&
+    !!projectId &&
+    !!candidateAsset?.id &&
+    !!sourceAssetId &&
+    status !== "running";
+
+  async function runCompare() {
+    if (!canCompare) {
+      return;
+    }
+    setStatus("running");
+    setResult(null);
+    setErrorMessage("");
+    try {
+      const block = await compareFaceLikeness({
+        sourceAssetId,
+        candidateAssetId: candidateAsset.id,
+        projectId,
+      });
+      setResult(block);
+      setStatus("done");
+    } catch (error) {
+      setErrorMessage(error?.message || "Likeness compare failed.");
+      setStatus("error");
+    }
+  }
+
+  if (!approvedReferences.length) {
+    // No approved Reference Asset to compare against — there is no source identity yet.
+    return null;
+  }
+
+  if (!open) {
+    return (
+      <button
+        className="likeness-compare-toggle"
+        onClick={() => setOpen(true)}
+        type="button"
+      >
+        Compare likeness
+      </button>
+    );
+  }
+
+  return (
+    <div className="likeness-compare">
+      <label className="likeness-compare-source">
+        <span>Compare to reference</span>
+        <select
+          aria-label="Reference asset to compare against"
+          disabled={status === "running"}
+          onChange={(event) => setSourceAssetId(event.target.value)}
+          value={sourceAssetId}
+        >
+          {approvedReferences.map((reference) => (
+            <option key={reference.assetId} value={reference.assetId}>
+              {reference.asset?.displayName ?? reference.assetId}
+            </option>
+          ))}
+        </select>
+      </label>
+      <div className="likeness-compare-actions">
+        <button disabled={!canCompare} onClick={runCompare} type="button">
+          {status === "running" ? "Comparing…" : "Compare"}
+        </button>
+        <button className="secondary-action" onClick={() => setOpen(false)} type="button">
+          Close
+        </button>
+      </div>
+      {status === "running" ? (
+        <p className="likeness-compare-status muted" role="status">
+          Scoring face likeness…
+        </p>
+      ) : null}
+      {status === "error" ? (
+        <p className="likeness-compare-status inline-warning" role="alert">
+          {errorMessage}
+        </p>
+      ) : null}
+      {status === "done" && result ? (
+        <div className="likeness-compare-result">
+          {/* The compare result carries the SAME shape the badge bands (score/detected/reason); a
+              no-face / non-frontal candidate renders the honest N/A chip, not a low number. */}
+          <LikenessBadge faceLikeness={result} sourceLabel={sourceLabel} />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 export function CharacterAssets({
   selectedCharacter,
   assets = [],
+  approvedReferences = [],
   projectId,
   importAsset,
   addCharacterReference,
+  compareFaceLikeness,
   onPreview,
   deleteAsset,
   purgeAsset,
@@ -967,6 +1088,16 @@ export function CharacterAssets({
                     </button>
                   )}
                 </div>
+                {/* sc-4415: compare this image (candidate) to an approved Reference Asset (source)
+                    identity face. Only meaningful for still images and outside the Trashcan view. */}
+                {!showingTrash && asset.type === "image" ? (
+                  <LikenessCompare
+                    approvedReferences={approvedReferences}
+                    candidateAsset={asset}
+                    compareFaceLikeness={compareFaceLikeness}
+                    projectId={projectId}
+                  />
+                ) : null}
               </article>
             </div>
           ))}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2221,6 +2221,54 @@ label {
   line-height: 1.2;
 }
 
+/* On-demand "compare image to another" likeness control on each asset card (sc-4415). */
+.likeness-compare-toggle {
+  margin-top: 6px;
+  padding: 4px 10px;
+  font-size: 12px;
+  line-height: 1.2;
+}
+
+.likeness-compare {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.likeness-compare-source {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 12px;
+}
+
+.likeness-compare-source select {
+  font-size: 12px;
+  padding: 3px 6px;
+}
+
+.likeness-compare-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.likeness-compare-actions button {
+  padding: 4px 10px;
+  font-size: 12px;
+  line-height: 1.2;
+}
+
+.likeness-compare-status {
+  font-size: 12px;
+  margin: 0;
+}
+
+.likeness-compare-result {
+  display: flex;
+}
+
 .character-section > .segmented-control {
   margin-bottom: 12px;
 }

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -278,6 +278,13 @@ string_enum! {
         // embedding + its frame fraction → the face sidecar. GPU-routed like dataset_analysis (the
         // native SCRFD+ArcFace stack), served by the Rust/MLX worker.
         DatasetFaceAnalysis => "dataset_face_analysis",
+        // On-demand identity-likeness compare of two existing assets (epic 4406, sc-4415): a SOURCE
+        // identity reference asset + a CANDIDATE asset, scored through the shared SCRFD+ArcFace
+        // face-likeness scorer (face_likeness.rs) and returned as the standard
+        // `{ score, detected, method, sourceRef, reason? }` result. NOT a generation post-pass — it
+        // compares two already-existing images on demand. GPU-routed like dataset_face_analysis (the
+        // native SCRFD+ArcFace stack); served by the Rust/MLX worker (MLX on Mac, candle off-Mac).
+        FaceLikenessCompare => "face_likeness_compare",
         PromptRefine => "prompt_refine",
     }
 }
@@ -415,6 +422,12 @@ string_enum! {
         // like `kps_extract`, not registry-derived (the `FaceEmbedder` has no gen-core registry); a
         // `dataset_face_analysis` job stays queued rather than mis-claimed where the stack isn't linked.
         DatasetFaceAnalysis => "dataset_face_analysis",
+        // On-demand face-likeness compare (epic 4406, sc-4415). Advertised by a worker that links the
+        // native SCRFD+ArcFace face stack (`mlx-gen-face` on Mac / `candle-gen-face` on the candle
+        // lane) — gpu.rs-hardcoded like `dataset_face_analysis` (the `FaceEmbedder` has no gen-core
+        // registry, so it isn't in `registry_capabilities`); a `face_likeness_compare` job stays queued
+        // rather than mis-claimed where the stack isn't linked.
+        FaceLikenessCompare => "face_likeness_compare",
         // Real (non-dry-run) LoRA training execution. Advertised separately from
         // `LoraTrain` (dry-run plan validation, which needs no inference backend)
         // so a real run only routes to a worker that can actually train. See

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -1711,6 +1711,13 @@ fn derive_job_title(job_type: &JobType, payload: &Map<String, Value>) -> Option<
                 .to_owned();
             Some(format!("Dataset Face Analysis — {subject}"))
         }
+        JobType::FaceLikenessCompare => {
+            // sc-4415: compare a candidate asset to a source identity reference. The candidate is the
+            // user-facing subject of the row; fall back to a plain label when the payload omits it.
+            let subject =
+                first_str(payload, &["candidateName", "candidateAssetId"]).unwrap_or("(image)");
+            Some(format!("Compare Likeness — {subject}"))
+        }
         JobType::ImageGenerate
         | JobType::ImageEdit
         | JobType::ImageVqa
@@ -2304,7 +2311,11 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
         // sc-6538: dataset_face_analysis runs the native SCRFD+ArcFace stack (mlx-gen-face) in the Rust
         // worker — not a Python-torch gap. Gated by the worker's capability advertisement, so it queues
         // rather than enforce-fails here.
-        | JobType::DatasetFaceAnalysis => Ok(()),
+        | JobType::DatasetFaceAnalysis
+        // sc-4415: face_likeness_compare runs the same native SCRFD+ArcFace stack to score two existing
+        // assets on demand — a native Rust/MLX job, not a Python-torch gap. Gated by the worker's
+        // capability advertisement, so it queues rather than enforce-fails here.
+        | JobType::FaceLikenessCompare => Ok(()),
 
         // Forward-compat: an unrecognized job type isn't a known Python-torch gap, so don't
         // enforce-fail it (it would otherwise break a newer job type this build doesn't model).
@@ -2547,6 +2558,8 @@ pub fn candle_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
         | JobType::DatasetUpscale
         // sc-6538: dataset_face_analysis on the candle lane (candle-gen-face) routes by capability too.
         | JobType::DatasetFaceAnalysis
+        // sc-4415: face_likeness_compare on the candle lane (candle-gen-face) routes by capability too.
+        | JobType::FaceLikenessCompare
         | JobType::Unknown(_) => Ok(()),
     }
 }
@@ -5752,6 +5765,7 @@ fn job_requires_gpu(job_type: &JobType) -> bool {
             | JobType::DatasetAnalysis
             | JobType::DatasetUpscale
             | JobType::DatasetFaceAnalysis
+            | JobType::FaceLikenessCompare
     )
 }
 

--- a/crates/sceneworks-worker/src/face_likeness.rs
+++ b/crates/sceneworks-worker/src/face_likeness.rs
@@ -524,6 +524,20 @@ impl FaceLikenessScorer {
         (scorer, calls)
     }
 
+    /// Platform-neutral load for the on-demand compare tool (sc-4415): the MLX stack on macOS, the
+    /// candle stack off-Mac, embedding + caching the SOURCE face once. Unlike
+    /// [`build_face_likeness_scorer`] (the generation post-pass seam, which swallows a construction
+    /// error into a `None` scorer so a gen never aborts), this surfaces a hard weights/backend error to
+    /// the caller so a standalone compare JOB fails loudly rather than silently returning N/A — while a
+    /// source image with NO detectable face still yields a scorer whose `score` is the honest
+    /// `NoSourceFace` N/A (not an error). The exact same shared scorer, no new algorithm.
+    pub(crate) fn load_for_compare(
+        weights_dir: &std::path::Path,
+        source: &Image,
+    ) -> WorkerResult<Self> {
+        Self::load_for_weights_dir(weights_dir, source)
+    }
+
     /// Platform-neutral load: the MLX stack on macOS, the candle stack off-Mac. Lets the shared
     /// angle-set seam ([`build_face_likeness_scorer`]) construct a scorer without each call site
     /// cfg-branching on the backend. Embeds the source face once (the caching contract).

--- a/crates/sceneworks-worker/src/face_likeness_compare_jobs.rs
+++ b/crates/sceneworks-worker/src/face_likeness_compare_jobs.rs
@@ -1,0 +1,431 @@
+//! On-demand identity-likeness compare of two existing assets (epic 4406, sc-4415).
+//!
+//! The "compare image to another" tool behind Character Studio Assets: given a SOURCE identity
+//! reference asset (the approved Reference Asset that carries the character's face) and a CANDIDATE
+//! asset (any image the user picked from the character's assets), score the candidate's face against
+//! the source identity and return the standard face-likeness result. This is NOT a generation
+//! post-pass — both images already exist on disk; the job loads them, runs the SHARED
+//! [`crate::face_likeness::FaceLikenessScorer`] (the same SCRFD + ArcFace scorer every other epic-4406
+//! surface uses — NO new scoring algorithm), and returns the result.
+//!
+//! Generator-agnostic + cross-platform: MLX on macOS (`mlx-gen-face`), candle off-Mac with
+//! `--features backend-candle` (`candle-gen-face`); on a platform with neither, a precise unsupported
+//! error. GPU-routed like `dataset_face_analysis` (the native face stack lives on the GPU worker).
+//!
+//! ## Result honesty (carried intact from sc-4407)
+//! ArcFace is a frontal-identity signal only. A non-frontal / no-face CANDIDATE returns an explicit
+//! `detected: false`, `score: null` result carrying a `reason` — an honest N/A, NOT a misleading low
+//! number. A SOURCE reference with no detectable face yields the same N/A (`no_source_face`).
+//!
+//! ## Non-fatal
+//! Scoring errors never crash the worker: a backend forward failure becomes a logged N/A result via
+//! [`crate::face_likeness::FaceLikenessScorer::score_or_null`], and a missing/garbled asset is a clean
+//! `InvalidPayload` the dispatcher turns into a failed job (never a panic).
+
+use std::path::PathBuf;
+
+// `Image` resolves to `mlx_gen::Image` on macOS and `gen_core::Image` under the candle backend — the
+// same cfg-gated split the scorer (face_likeness.rs) and sibling job modules use. The whole module
+// only exists under these two configs; on the plain Linux parity build (no `backend-candle`) `Image`
+// is intentionally absent and only the unsupported stub at the bottom is compiled.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+use gen_core::Image;
+#[cfg(target_os = "macos")]
+use mlx_gen::Image;
+
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+use crate::face_likeness::FaceLikenessScorer;
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+use crate::image_jobs::load_reference_image;
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+use crate::{
+    heartbeat, progress_payload, run_blocking_with_heartbeat, update_job, ApiClient, Settings,
+    WorkerError, WorkerResult,
+};
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+use sceneworks_core::contracts::{JobSnapshot, JobStatus, JsonObject, ProgressStage, WorkerStatus};
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+use sceneworks_core::project_store::ProjectStore;
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+use serde_json::Value;
+
+/// Resolve `sourceAssetId` + `candidateAssetId` (both in the same project) to decoded RGB images.
+/// Mirrors the `kps_extract` / reference-asset resolution: read each asset record, confine its
+/// `file.path` to the project directory ([`load_reference_image`] routes through `safe_project_path`),
+/// and decode. A missing/garbled asset id is a clean `InvalidPayload`, never a panic.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn load_compare_images(settings: &Settings, job: &JobSnapshot) -> WorkerResult<(Image, Image)> {
+    let payload = &job.payload;
+    let project_id = payload
+        .get("projectId")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .or(job.project_id.as_deref())
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload(
+                "face likeness compare needs a projectId to resolve its assets".to_owned(),
+            )
+        })?;
+    let source_asset_id = required_asset_id(payload, "sourceAssetId")?;
+    let candidate_asset_id = required_asset_id(payload, "candidateAssetId")?;
+
+    let store = ProjectStore::new(settings.data_dir.clone(), "worker");
+    let project_path = store
+        .get_project(project_id)
+        .map(|p| PathBuf::from(p.path))
+        .map_err(|error| {
+            WorkerError::InvalidPayload(format!(
+                "face likeness compare project {project_id}: {error}"
+            ))
+        })?;
+
+    let source = load_reference_image(
+        &settings.data_dir,
+        project_id,
+        source_asset_id,
+        &project_path,
+    )?;
+    let candidate = load_reference_image(
+        &settings.data_dir,
+        project_id,
+        candidate_asset_id,
+        &project_path,
+    )?;
+    Ok((source, candidate))
+}
+
+/// Read a required, non-empty asset id from the payload, or a precise `InvalidPayload`.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn required_asset_id<'a>(payload: &'a JsonObject, field: &str) -> WorkerResult<&'a str> {
+    payload
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload(format!("face likeness compare needs a {field}"))
+        })
+}
+
+/// Build the scorer from the SOURCE face, score the CANDIDATE, and return the standard result object
+/// (`{ score, detected, method, sourceRef, reason? }`). Reuses the SHARED scorer — no new algorithm.
+/// `source_ref` is stamped on the result so the UI can attribute the score to the chosen reference.
+/// Runs the `!Send` MLX/candle work; call inside `spawn_blocking`. Non-fatal: a backend forward
+/// failure becomes a logged N/A result (`score_or_null`), never an `Err` that fails the job.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn compare(
+    weights_dir: &std::path::Path,
+    source: &Image,
+    candidate: &Image,
+    source_ref: &str,
+) -> WorkerResult<JsonObject> {
+    let scorer = FaceLikenessScorer::load_for_compare(weights_dir, source)?;
+    Ok(compare_with_scorer(&scorer, candidate, source_ref))
+}
+
+/// Score the CANDIDATE against an already-constructed scorer and shape the standard result object. The
+/// JSON-producing half of [`compare`], factored out so the wiring tests exercise the exact same path
+/// over the weight-free stub scorer (no antelopev2 weights in CI). Non-fatal: a backend forward
+/// failure becomes a logged N/A via `score_or_null`, never an `Err`.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn compare_with_scorer(
+    scorer: &FaceLikenessScorer,
+    candidate: &Image,
+    source_ref: &str,
+) -> JsonObject {
+    scorer.score_or_null(candidate).to_json(Some(source_ref))
+}
+
+/// Run a `face_likeness_compare` job: load the SOURCE reference + CANDIDATE assets, score the
+/// candidate's face against the source identity through the shared scorer, and return the result.
+/// MLX on Mac, candle off-Mac — the result shape is backend-identical.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+pub(crate) async fn run_face_likeness_compare_job(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+) -> WorkerResult<()> {
+    heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+    update_job(
+        api,
+        &job.id,
+        progress_payload(
+            JobStatus::Preparing,
+            ProgressStage::Preparing,
+            0.1,
+            "Preparing face scorer.",
+            None,
+            None,
+            None,
+        ),
+    )
+    .await?;
+
+    let (source, candidate) = load_compare_images(settings, job)?;
+    let source_ref = required_asset_id(&job.payload, "sourceAssetId")?.to_owned();
+
+    // Stage the SCRFD + ArcFace bundle (download-on-first-use; a prior InstantID / kps / dataset-face
+    // run leaves it cached). The same dir the candle stack loads and the MLX path joins file names in.
+    let weights_dir = crate::image_jobs::ensure_face_stack_dir(api, settings, job).await?;
+
+    update_job(
+        api,
+        &job.id,
+        progress_payload(
+            JobStatus::Running,
+            ProgressStage::Running,
+            0.5,
+            "Comparing faces.",
+            None,
+            None,
+            None,
+        ),
+    )
+    .await?;
+
+    // Keep the worker heartbeat alive across the blocking face stack load + two forwards (a cold weight
+    // load can run long) so a slow compare never trips the API's 90s stale-sweep (sc-8390). Not
+    // cancelable. A hard error here (e.g. missing weights) propagates and fails the job — but the
+    // *scoring* itself is non-fatal (an N/A result, never an error).
+    let result = run_blocking_with_heartbeat(
+        api,
+        settings,
+        &job.id,
+        None,
+        "",
+        "face likeness compare task",
+        tokio::task::spawn_blocking(move || {
+            compare(&weights_dir, &source, &candidate, &source_ref)
+        }),
+    )
+    .await?;
+
+    let detected = result
+        .get("detected")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let message = if detected {
+        "Face likeness computed."
+    } else {
+        "No comparable frontal face detected."
+    };
+    update_job(
+        api,
+        &job.id,
+        progress_payload(
+            JobStatus::Completed,
+            ProgressStage::Completed,
+            1.0,
+            message,
+            None,
+            Some(result),
+            None,
+        ),
+    )
+    .await?;
+    Ok(())
+}
+
+#[cfg(all(
+    test,
+    any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    )
+))]
+mod tests {
+    use super::*;
+    use crate::face_likeness::FaceLikenessScorer;
+    use serde_json::json;
+
+    /// A synthetic image whose first pixel byte selects the weight-free stub detection (see the scorer's
+    /// `StubFaceBackend`): `0` ⇒ no face; `>=77` ⇒ a reliable face; `1..=76` ⇒ a low-confidence face.
+    fn image(pixel0: u8) -> Image {
+        Image {
+            width: 1,
+            height: 1,
+            pixels: vec![pixel0, 0, 0],
+        }
+    }
+
+    #[test]
+    fn same_identity_candidate_scores_high_and_attributes_the_source() {
+        // The compare's happy path: a candidate matching the SOURCE identity (same stub pixel) scores a
+        // high cosine, detected:true, with the result attributed to the chosen reference asset id.
+        let (scorer, _calls) = FaceLikenessScorer::with_stub_source(&image(200));
+        let result = compare_with_scorer(&scorer, &image(200), "ref_src_1");
+        assert_eq!(result.get("detected"), Some(&Value::Bool(true)));
+        assert_eq!(result.get("sourceRef"), Some(&json!("ref_src_1")));
+        assert_eq!(
+            result.get("method"),
+            Some(&json!("arcface_antelopev2")),
+            "reuses the shared scorer's method (no new algorithm)"
+        );
+        let score = result
+            .get("score")
+            .and_then(Value::as_f64)
+            .expect("a detected candidate carries a numeric score");
+        assert!(score > 0.9, "same-identity cosine should be high: {score}");
+    }
+
+    #[test]
+    fn no_face_candidate_is_na_not_a_low_number() {
+        // The honesty linchpin: a non-frontal / no-face CANDIDATE (stub pixel 0) is an explicit
+        // detected:false / score:null N/A carrying a reason — NEVER a misleading low number.
+        let (scorer, _calls) = FaceLikenessScorer::with_stub_source(&image(200));
+        let result = compare_with_scorer(&scorer, &image(0), "ref_src_1");
+        assert_eq!(
+            Value::Object(result),
+            json!({
+                "score": Value::Null,
+                "detected": false,
+                "method": "arcface_antelopev2",
+                "sourceRef": "ref_src_1",
+                "reason": "no_face",
+            }),
+            "a no-face candidate is an honest N/A, not a low score"
+        );
+    }
+
+    #[test]
+    fn low_confidence_candidate_is_na() {
+        // An extreme-but-detected candidate below the detection floor (stub pixel 40 ⇒ det_score ≈ 0.578
+        // < 0.65) records an honest low_confidence N/A, not a noisy number.
+        let (scorer, _calls) = FaceLikenessScorer::with_stub_source(&image(200));
+        let result = compare_with_scorer(&scorer, &image(40), "ref_src_1");
+        assert_eq!(result.get("detected"), Some(&Value::Bool(false)));
+        assert_eq!(result.get("score"), Some(&Value::Null));
+        assert_eq!(result.get("reason"), Some(&json!("low_confidence")));
+    }
+
+    #[test]
+    fn source_with_no_face_makes_every_compare_na_never_a_crash() {
+        // Non-fatal end-to-end: a SOURCE reference with no detectable face yields a scorer (NOT an
+        // error) whose every candidate compare is the honest NoSourceFace N/A — the compare never
+        // crashes the worker, it just reports there is no comparable source identity.
+        let (scorer, _calls) = FaceLikenessScorer::with_stub_source(&image(0));
+        let result = compare_with_scorer(&scorer, &image(200), "ref_src_1");
+        assert_eq!(result.get("detected"), Some(&Value::Bool(false)));
+        assert_eq!(result.get("reason"), Some(&json!("no_source_face")));
+    }
+
+    #[test]
+    fn required_asset_id_rejects_missing_and_blank() {
+        // The payload-validation guard: a missing or blank asset id is a clean InvalidPayload (which the
+        // dispatcher turns into a failed job), never a panic.
+        let mut payload = JsonObject::new();
+        assert!(required_asset_id(&payload, "sourceAssetId").is_err());
+        payload.insert("sourceAssetId".to_owned(), json!("   "));
+        assert!(required_asset_id(&payload, "sourceAssetId").is_err());
+        payload.insert("sourceAssetId".to_owned(), json!("asset_42"));
+        assert_eq!(
+            required_asset_id(&payload, "sourceAssetId").unwrap(),
+            "asset_42"
+        );
+    }
+
+    /// Real-weight worker integration (sc-4415): proves the worker binary links + loads the MLX face
+    /// stack and that the on-demand compare (a) scores a same-identity pair high and (b) returns an
+    /// honest N/A for a no-face candidate — through the SAME shared scorer the rest of epic 4406 uses.
+    /// `#[ignore]` per convention (weights live outside CI). Run on a Mac with the bundle staged + Metal:
+    ///   SCENEWORKS_INSTANTID_WEIGHTS=/path/to/instantid-mlx \
+    ///   SCENEWORKS_TEST_FACE=/path/to/personA.png \
+    ///     cargo test -p sceneworks-worker --lib -- --ignored face_likeness_compare_real_weights --nocapture
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "real-weight: needs the SceneWorks/instantid-mlx SCRFD+ArcFace bundle + Metal + a face photo"]
+    fn face_likeness_compare_real_weights_scores_and_reports_na() {
+        use std::path::PathBuf;
+        let home = std::env::var("HOME").expect("HOME");
+        let bundle = std::env::var("SCENEWORKS_INSTANTID_WEIGHTS")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| {
+                PathBuf::from(&home)
+                    .join("Library/Application Support/SceneWorks/data/cache/instantid-mlx")
+            });
+        let face_path = std::env::var("SCENEWORKS_TEST_FACE")
+            .expect("set SCENEWORKS_TEST_FACE to a face photo");
+        let decoded = image::open(&face_path)
+            .unwrap_or_else(|e| panic!("face {face_path}: {e}"))
+            .to_rgb8();
+        let source = Image {
+            width: decoded.width(),
+            height: decoded.height(),
+            pixels: decoded.into_raw(),
+        };
+
+        // (a) same-identity compare (source vs itself) scores high + detected.
+        let same = compare(&bundle, &source, &source, "ref_src_1").expect("compare runs");
+        assert_eq!(same.get("detected"), Some(&Value::Bool(true)));
+        let score = same.get("score").and_then(Value::as_f64).expect("scored");
+        assert!(
+            score > 0.8,
+            "same-identity cosine ≈ baseline (>0.8): {score}"
+        );
+
+        // (b) a no-face candidate (synthetic gradient) is an honest detected:false N/A.
+        let mut gradient = image::RgbImage::new(128, 128);
+        for (x, y, px) in gradient.enumerate_pixels_mut() {
+            *px = image::Rgb([(x * 2) as u8, (y * 2) as u8, 96]);
+        }
+        let gradient = Image {
+            width: gradient.width(),
+            height: gradient.height(),
+            pixels: gradient.into_raw(),
+        };
+        let none = compare(&bundle, &source, &gradient, "ref_src_1").expect("compare runs");
+        assert_eq!(none.get("detected"), Some(&Value::Bool(false)));
+        assert_eq!(none.get("score"), Some(&Value::Null));
+        println!("face-likeness compare ok: same={score:.4}");
+    }
+}
+
+/// Plain-Linux parity build (no MLX, no candle): the native SCRFD + ArcFace face stack is unavailable,
+/// so the compare cannot run. Return a precise unsupported error rather than failing to compile or
+/// silently mis-handling the job — mirrors `run_dataset_face_analysis_job`.
+#[cfg(not(any(target_os = "macos", feature = "backend-candle")))]
+pub(crate) async fn run_face_likeness_compare_job(
+    _api: &crate::ApiClient,
+    _settings: &crate::Settings,
+    _job: &sceneworks_core::contracts::JobSnapshot,
+) -> crate::WorkerResult<()> {
+    Err(crate::WorkerError::InvalidPayload(
+        "Face likeness compare (SCRFD + ArcFace) needs the macOS MLX backend or the candle backend \
+         (build with --features backend-candle)."
+            .to_owned(),
+    ))
+}

--- a/crates/sceneworks-worker/src/face_likeness_compare_jobs.rs
+++ b/crates/sceneworks-worker/src/face_likeness_compare_jobs.rs
@@ -22,6 +22,15 @@
 //! [`crate::face_likeness::FaceLikenessScorer::score_or_null`], and a missing/garbled asset is a clean
 //! `InvalidPayload` the dispatcher turns into a failed job (never a panic).
 
+// `PathBuf` is used only by `load_compare_images` (and the macOS real-weight test), both of which exist
+// only under the face-stack configs — so gate the import to the SAME cfg as its use sites. On the plain
+// Linux parity build (no `backend-candle`) only the unsupported stub at the bottom compiles, and it uses
+// fully-qualified paths with no top-level imports; an ungated `PathBuf` would be an unused-import error
+// there under `-D warnings` (the cfg trap that broke the parity lane).
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 use std::path::PathBuf;
 
 // `Image` resolves to `mlx_gen::Image` on macOS and `gen_core::Image` under the candle backend — the

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -123,6 +123,16 @@ fn with_candle_capabilities(mut gpu: DiscoveredGpu, settings: &Settings) -> Disc
             {
                 gpu.capabilities.push(WorkerCapability::DatasetFaceAnalysis);
             }
+            // On-demand face-likeness compare (sc-4415): the off-Mac sibling of the macOS face stack —
+            // the candle SCRFD/ArcFace stack scores a candidate asset against a source identity
+            // reference. A job-type capability (not a generation modality), so it isn't in
+            // `registry_capabilities`; advertise it explicitly, like dataset_face_analysis.
+            if !gpu
+                .capabilities
+                .contains(&WorkerCapability::FaceLikenessCompare)
+            {
+                gpu.capabilities.push(WorkerCapability::FaceLikenessCompare);
+            }
             // DWPose whole-body pose detection (sc-5496, epic 5482): the off-Mac sibling of the macOS
             // `ort`/CoreML path (sc-3487) — the same RTMW detector via `pose_jobs::run_pose_detect_job`
             // with the CUDA execution provider, serving `pose_detect` for the Pose Library "create from
@@ -591,6 +601,13 @@ pub(crate) fn mlx_gpu(settings: &Settings) -> DiscoveredGpu {
         // `FaceEmbedder` stack has no gen-core registry, so it isn't in `registry_capabilities`;
         // advertised here so a `dataset_face_analysis` job routes to the Mac worker by construction.
         WorkerCapability::DatasetFaceAnalysis,
+        // On-demand face-likeness compare (epic 4406, sc-4415): scores a CANDIDATE asset against a
+        // SOURCE identity reference through the same native SCRFD+ArcFace stack
+        // (`face_likeness_compare_jobs::run_face_likeness_compare_job`). Hardcoded like
+        // DatasetFaceAnalysis — the `FaceEmbedder` stack has no gen-core registry, so it isn't in
+        // `registry_capabilities`; advertised here so the Character Studio Assets compare tool routes
+        // to the Mac worker by construction.
+        WorkerCapability::FaceLikenessCompare,
         // Real-ESRGAN image upscaling (epic 3482, sc-3489): RRDBNet x2/x4 via
         // onnxruntime/CoreML, served in-process by `upscale_jobs::run_image_upscale_job`.
         // Replaces the Python torch Real-ESRGAN path so the Image Editor upscale tool

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -118,6 +118,11 @@ use face_analysis_jobs::*;
 // scoring core is exercised by the module's unit tests and the seam by the ignored real-weight test.
 #[allow(dead_code)]
 mod face_likeness;
+// sc-4415 — on-demand "compare image to another" likeness tool (epic 4406): scores a CANDIDATE asset
+// against a SOURCE identity reference asset through the shared `face_likeness` scorer. Lives in
+// Character Studio Assets; routed as the `face_likeness_compare` job type.
+mod face_likeness_compare_jobs;
+use face_likeness_compare_jobs::*;
 mod prompt_refine_jobs;
 use prompt_refine_jobs::*;
 mod downloads;
@@ -734,6 +739,14 @@ async fn run_utility_job(
         JobType::DatasetFaceAnalysis => run_dataset_face_analysis_job(api, settings, &job)
             .await
             .map_err(|error| ("Dataset face analysis failed.", error)),
+        // On-demand "compare image to another" likeness tool (sc-4415): scores a CANDIDATE asset
+        // against a SOURCE identity reference asset through the shared SCRFD+ArcFace scorer. MLX on Mac,
+        // candle off-Mac; off both the handler returns a precise unsupported error. Like the
+        // dataset-face pass, the job-type capability is gpu.rs-hardcoded (the face stack has no gen-core
+        // registry), so a job stays queued rather than mis-claimed where the stack isn't linked.
+        JobType::FaceLikenessCompare => run_face_likeness_compare_job(api, settings, &job)
+            .await
+            .map_err(|error| ("Face likeness compare failed.", error)),
         // Native candle prompt refinement (epic 5095, sc-5525; consolidated onto candle-llm in sc-7404):
         // routes `prompt_refine` to the candle `core_llm::TextLlm` provider (candle-llama, resolved
         // model-first). The candle worker advertises `prompt_refine` only when `backend_candle_enabled`

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -629,6 +629,9 @@ fn mlx_gpu_capability_set_matches_expected_full_set() {
         // gen-core registry for FaceEmbedder), so DatasetFaceAnalysis is advertised on Mac like
         // KpsExtract.
         WorkerCapability::DatasetFaceAnalysis,
+        // sc-4415: on-demand face-likeness compare — same hardcoded-in-mlx_gpu native face stack as
+        // DatasetFaceAnalysis (no gen-core registry for FaceEmbedder), advertised on Mac like KpsExtract.
+        WorkerCapability::FaceLikenessCompare,
         WorkerCapability::ImageUpscale,
         // sc-6539: Dataset Doctor one-tap upscale — reuses the Real-ESRGAN engine, advertised
         // wherever image_upscale is.


### PR DESCRIPTION
## sc-4415 — General "compare image to another" likeness tool

Adds a general face-likeness compare in **Character Studio → Assets**: the user selects any character asset (the CANDIDATE) and compares it against one of that character's approved **Reference Assets** (the SOURCE identity face), seeing the face-likeness score with the same strong/moderate/weak band + N/A framing as the rest of epic 4406. It compares two already-existing assets on demand — NOT a generation post-pass.

### Worker compare task (both platforms)
- New `face_likeness_compare` job type in `crates/sceneworks-worker/src/face_likeness_compare_jobs.rs`: resolves a `sourceAssetId` + `candidateAssetId` to pixels via `load_reference_image` (project-confined), constructs the **shared** `FaceLikenessScorer` from the source face (new `load_for_compare` seam in `face_likeness.rs`), scores the candidate, and returns the standard `{ score, detected, method, sourceRef, reason? }` result.
- **Reuses the sc-4407 scorer — no new scoring algorithm.**
- MLX on macOS (`mlx-gen-face`), candle off-Mac (`candle-gen-face`), cfg-gated identically to `face_analysis_jobs.rs`; plain-Linux returns a precise unsupported error.
- **Non-fatal end to end:** a no-face / non-frontal candidate is an honest `detected:false` N/A (never a low number); a source with no face yields `no_source_face`; a missing/garbled asset is a clean `InvalidPayload`, never a panic.
- GPU-routed + advertised like `dataset_face_analysis`: `gpu.rs` hardcodes the capability on both the macOS and candle lanes; `jobs_store` classifiers, `job_requires_gpu`, and `derive_job_title` updated.

### Contract
- `FaceLikenessCompare` added to the `JobType` + `WorkerCapability` string enums (`contracts.rs`).
- **Contract snapshot unaffected:** the snapshot's worker capability arrays carry model-manifest vocab (`character_image`, `edit_image`, …), not GPU job-type capabilities, so the new value never appears there — no regen needed.

### API
- `POST /api/v1/face-likeness/compare` (`FaceLikenessCompareRequest`) validates the request, resolves + confines both asset paths up front (fail-fast 400), and enqueues the GPU-routed job; the worker re-confines independently (defence-in-depth).

### Character Studio Assets UI
- `App.compareFaceLikeness` runner (poll-to-completion, returns the full result block).
- `CharacterStudio` passes it + `approvedReferences` to `CharacterAssets`.
- New `LikenessCompare` control on each asset card: pick an approved Reference Asset → Compare → renders the score via the shared `classifyLikeness` / `LikenessBadge` (same N/A + frontal-only framing). Hidden when the character has no approved reference.

### Tests
- **Worker:** unit tests over the weight-free stub scorer (same-id high / no-face N/A / low-confidence N/A / no-source-face non-fatal / payload validation) + an `#[ignore]` real-weight integration test.
- **Web:** vitest for the compare UI states (scored, N/A, error, absent).

### Build verification
- macOS `rust:check`: `cargo fmt --all --check`, clippy (`-D warnings`), worker+core+rust-api tests, build — all green.
- candle: `cargo check -p sceneworks-worker --no-default-features --features backend-candle --all-targets` + clippy — green (cfg-superset audit handled via the established gating).
- web: vitest (872 passed) + eslint (clean on touched files) + `vite build` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)