### PR TITLE
chore(release): 0.4.0

### DIFF
--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sceneworks/desktop",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sceneworks/desktop",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sceneworks/desktop",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "SceneWorks desktop shell (Tauri).",
   "scripts": {
     "dev": "tauri dev",

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SceneWorks",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "identifier": "net.trefry.sceneworks",
   "build": {
     "frontendDist": "ui",

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sceneworks/web",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sceneworks/web",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "konva": "^9.3.22",
         "react": "18.3.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sceneworks/web",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite --host 0.0.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sceneworks",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Local AI image and video generation studio runtime skeleton.",
   "license": "SEE LICENSE IN LICENSE",
   "scripts": {


### PR DESCRIPTION
Release bump to **0.4.0** (from 0.3.0). Bumps all four manifests + lockfiles in lockstep via \`npm version\` → \`sync-version.mjs\`:

- root \`package.json\`
- \`apps/web/package.json\` (+ lock)
- \`apps/desktop/package.json\` (+ lock)
- \`apps/desktop/tauri.conf.json\` (artifact-critical: names the bundled .app / DMG)

After merge, tagging the merge commit \`v0.4.0\` and pushing the tag fires \`.github/workflows/release.yml\` on the self-hosted \`nax\` runner → builds/signs/notarizes the macOS DMG and creates a **draft** GitHub release to review and publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)