### PR TITLE
feat(worker): off-Mac candle Z-Image identity-init lane for "With Character" (sc-8409)

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3981,6 +3981,17 @@ fn image_job_is_candle_eligible(job: &JobSnapshot) -> bool {
     {
         return true;
     }
+    // Z-Image identity-init for Image Studio "With Character" (sc-8409, epic 4406): a `z_image_turbo`
+    // `character_image` job with a `referenceAssetId` + `advanced.referenceStrength > 0` is the bespoke
+    // candle `ZImageEdit` identity-init lane (`generate_candle_zimage_identity_stream`), NOT txt2img — the
+    // `image_request_candle_eligible` gate below rejects any `referenceAssetId`, so without this the job
+    // falls back to torch/MLX (off-Mac: plain txt2img, dropping the reference — the pre-existing gap this
+    // story closes). Branch it out first; disjoint from the Z-Image edit lane above (`edit_image` +
+    // `sourceAssetId`) and the strict-pose control lane below (`advanced.poses`, which this gate excludes).
+    // Mirrors the worker's `zimage_identity_candle_available`.
+    if model == "z_image_turbo" && zimage_identity_candle_eligible(&job.payload) {
+        return true;
+    }
     // Ideogram 4 img2img / Remix + mask inpaint / outpaint edit (sc-6598, epic 6561): an ideogram-family
     // `edit_image` job with a source image runs the candle `candle-gen-ideogram` edit path. Unlike the
     // other families above, Ideogram has no bespoke edit stream — it's the SAME engine for T2I and edit,
@@ -4659,6 +4670,66 @@ fn zimage_control_candle_eligible(payload: &Map<String, Value>) -> bool {
         .and_then(|advanced| advanced.get("poses"))
         .and_then(Value::as_array)
         .is_some_and(|poses| !poses.is_empty())
+}
+
+/// Z-Image identity-init (Image Studio "With Character") candle-routing conditions (sc-8409, epic 4406).
+/// The candle `ZImageEdit` engine seeds the Turbo denoise from the chosen character `referenceAssetId`
+/// latents (identity img2img) for a `character_image` job with `advanced.referenceStrength > 0`, that is
+/// NOT an angle set (`advanced.angleSet`) and NOT a pose-library set (`advanced.poses`) — those are
+/// `character_image` too but route to (and score on) their own candle lanes (InstantID angle/pose, the
+/// Z-Image strict-control lane). The model gate (`z_image_turbo`) is applied at the call site. The
+/// `referenceStrength > 0` engage condition mirrors the macOS `zimage_identity_strength` gate (zimage.rs,
+/// sc-3146) EXACTLY, so candle routes the identity init precisely when the MLX generic lane runs it — a
+/// With-Character job without a positive `referenceStrength` stays plain txt2img on both backends. Mirrors
+/// the worker's `zimage_identity_candle_available` (minus the local weight-resolve check). Candle-only —
+/// macOS keeps the MLX `z_image_turbo` generic-lane identity img2img (`resolve_zimage_identity_init`).
+fn zimage_identity_candle_eligible(payload: &Map<String, Value>) -> bool {
+    if payload.get("mode").and_then(Value::as_str) != Some("character_image") {
+        return false;
+    }
+    // A non-empty referenceAssetId is the identity source.
+    let has_reference = payload
+        .get("referenceAssetId")
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.trim().is_empty());
+    if !has_reference {
+        return false;
+    }
+    // referenceStrength > 0 engages the identity init (parity with `zimage_identity_strength`); without a
+    // positive strength the With-Character job stays plain txt2img.
+    let reference_strength = payload
+        .get("advanced")
+        .and_then(Value::as_object)
+        .and_then(|advanced| advanced.get("referenceStrength"))
+        .and_then(|value| value.as_f64().or_else(|| value.as_str()?.trim().parse().ok()))
+        .unwrap_or(0.0);
+    if reference_strength <= 0.0 {
+        return false;
+    }
+    // Angle / pose sets are `character_image` too but route to their own lanes — exclude both so this
+    // plain With-Character gate never steals them (the worker sits this lane BEFORE the strict-control
+    // lane). Mirrors the worker's `resolve_character_image_likeness_source` exclusions.
+    let angle_set = match payload
+        .get("advanced")
+        .and_then(Value::as_object)
+        .and_then(|advanced| advanced.get("angleSet"))
+    {
+        Some(Value::Bool(value)) => *value,
+        Some(Value::Number(number)) => number.as_f64().is_some_and(|value| value != 0.0),
+        Some(Value::String(value)) => !value.is_empty(),
+        Some(Value::Array(value)) => !value.is_empty(),
+        _ => false,
+    };
+    if angle_set {
+        return false;
+    }
+    let has_poses = payload
+        .get("advanced")
+        .and_then(Value::as_object)
+        .and_then(|advanced| advanced.get("poses"))
+        .and_then(Value::as_array)
+        .is_some_and(|poses| !poses.is_empty());
+    !has_poses
 }
 
 /// FLUX.2-dev strict-pose Fun-Controlnet-Union candle-routing conditions (sc-7736, epic 6564). The candle
@@ -7554,6 +7625,59 @@ mod candle_routing_tests {
         // A z_image_turbo strict-pose job (advanced.poses, not edit_image) is the control lane, not edit.
         assert!(!zimage_edit_candle_eligible(&object(json!({
             "model": "z_image_turbo", "advanced": { "poses": [{}] }
+        }))));
+    }
+
+    #[test]
+    fn zimage_identity_with_character_jobs_route_to_candle() {
+        // Z-Image identity-init "With Character" jobs (sc-8409): a `z_image_turbo` `character_image` job
+        // with a `referenceAssetId` + `advanced.referenceStrength > 0` routes to the bespoke candle
+        // `ZImageEdit` identity lane via the new branch, NOT the txt2img `image_request_candle_eligible`
+        // gate (which rejects any `referenceAssetId`). Without this the off-Mac job fell through to plain
+        // txt2img, dropping the reference (no identity, no score).
+        let with_character = json!({
+            "model": "z_image_turbo",
+            "mode": "character_image",
+            "referenceAssetId": "asset_1",
+            "advanced": { "referenceStrength": 0.6 }
+        });
+        assert!(zimage_identity_candle_eligible(&object(with_character.clone())));
+        assert!(image_job_is_candle_eligible(&image_generate_job(
+            with_character
+        )));
+        // A numeric-string referenceStrength engages too (the web sends strings).
+        assert!(zimage_identity_candle_eligible(&object(json!({
+            "model": "z_image_turbo", "mode": "character_image",
+            "referenceAssetId": "asset_1", "advanced": { "referenceStrength": "0.45" }
+        }))));
+
+        // No referenceStrength (or <= 0) → stays plain txt2img on both backends (parity), NOT this lane.
+        assert!(!zimage_identity_candle_eligible(&object(json!({
+            "model": "z_image_turbo", "mode": "character_image", "referenceAssetId": "asset_1"
+        }))));
+        assert!(!zimage_identity_candle_eligible(&object(json!({
+            "model": "z_image_turbo", "mode": "character_image",
+            "referenceAssetId": "asset_1", "advanced": { "referenceStrength": 0.0 }
+        }))));
+        // No reference face → no identity source → not this lane.
+        assert!(!zimage_identity_candle_eligible(&object(json!({
+            "model": "z_image_turbo", "mode": "character_image",
+            "advanced": { "referenceStrength": 0.6 }
+        }))));
+        // Non-character mode → not this lane (an `edit_image` job is the edit lane, sc-6595).
+        assert!(!zimage_identity_candle_eligible(&object(json!({
+            "model": "z_image_turbo", "mode": "edit_image",
+            "referenceAssetId": "asset_1", "advanced": { "referenceStrength": 0.6 }
+        }))));
+        // Angle set + pose set are `character_image` too but route to their own lanes — excluded here so
+        // this plain With-Character gate never steals them.
+        assert!(!zimage_identity_candle_eligible(&object(json!({
+            "model": "z_image_turbo", "mode": "character_image", "referenceAssetId": "asset_1",
+            "advanced": { "referenceStrength": 0.6, "angleSet": true }
+        }))));
+        assert!(!zimage_identity_candle_eligible(&object(json!({
+            "model": "z_image_turbo", "mode": "character_image", "referenceAssetId": "asset_1",
+            "advanced": { "referenceStrength": 0.6, "poses": [{ "id": "a" }] }
         }))));
     }
 

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -4701,7 +4701,11 @@ fn zimage_identity_candle_eligible(payload: &Map<String, Value>) -> bool {
         .get("advanced")
         .and_then(Value::as_object)
         .and_then(|advanced| advanced.get("referenceStrength"))
-        .and_then(|value| value.as_f64().or_else(|| value.as_str()?.trim().parse().ok()))
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
         .unwrap_or(0.0);
     if reference_strength <= 0.0 {
         return false;
@@ -7641,7 +7645,9 @@ mod candle_routing_tests {
             "referenceAssetId": "asset_1",
             "advanced": { "referenceStrength": 0.6 }
         });
-        assert!(zimage_identity_candle_eligible(&object(with_character.clone())));
+        assert!(zimage_identity_candle_eligible(&object(
+            with_character.clone()
+        )));
         assert!(image_job_is_candle_eligible(&image_generate_job(
             with_character
         )));

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -685,6 +685,29 @@ pub(crate) async fn run_image_generate_job(
         )
         .await?;
         true
+    } else if settings.backend_candle_enabled && zimage_identity_candle_available(&request, settings)
+    {
+        // Z-Image identity-init for Image Studio "With Character" (sc-8409, epic 4406) — checked BEFORE
+        // `is_candle_engine` because `z_image_turbo` IS a candle txt2img id, so without this a
+        // `character_image` + `referenceAssetId` (+ `referenceStrength > 0`) job would be caught by the
+        // txt2img branch and silently drop the reference (carrying no identity, hence no score — the gap
+        // this story closes). The off-Mac sibling of the macOS generic lane's Z-Image identity img2img
+        // (`resolve_zimage_identity_init`); reuses the candle `ZImageEdit` engine with the identity
+        // `referenceAssetId` as the source-latent init + wires the sc-4411 face-likeness scorer. Disjoint
+        // from the Z-Image edit lane above (that one is `edit_image` + `sourceAssetId`) and the strict-pose
+        // control lane below (that one is `advanced.poses`, which this gate excludes). Mirrors the router's
+        // `zimage_identity_candle_eligible`.
+        generate_candle_zimage_identity_stream(
+            api,
+            settings,
+            job,
+            &plan,
+            &project_path,
+            backend,
+            &mut asset_writes,
+        )
+        .await?;
+        true
     } else if settings.backend_candle_enabled && sdxl_ipadapter_available(&request, settings) {
         // SDXL IP-Adapter-Plus reference conditioning (sc-5488) — checked BEFORE `is_candle_engine`
         // because `sdxl`/`realvisxl` ARE candle txt2img ids, so without this a reference job would be
@@ -1591,6 +1614,13 @@ include!("image_jobs/flux2_control_candle.rs");
 // is a bespoke provider.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 include!("image_jobs/zimage_edit_candle.rs");
+// Z-Image identity-init for Image Studio "With Character" — the Windows/CUDA candle lane ONLY (sc-8409,
+// epic 4406). macOS keeps the MLX `z_image_turbo` generic-lane identity img2img (`generate_stream` ⇒
+// `resolve_zimage_identity_init`); off-Mac this bespoke lane reuses the candle `ZImageEdit` engine with
+// the identity `referenceAssetId` as the source-latent init + wires the sc-4411 face-likeness scorer.
+// Reuses the sibling `zimage_edit_candle.rs` base/steps helpers, so it is included right after it.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+include!("image_jobs/zimage_identity_candle.rs");
 // PuLID-FLUX face identity — the Windows/CUDA candle lane ONLY (sc-5492). macOS keeps the
 // inventory-registered `pulid_flux` MLX generator (image_jobs/pulid.rs); the candle `PulidFlux` is a
 // bespoke provider, so this file is candle-gated and distinct from the macOS route.

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -685,7 +685,8 @@ pub(crate) async fn run_image_generate_job(
         )
         .await?;
         true
-    } else if settings.backend_candle_enabled && zimage_identity_candle_available(&request, settings)
+    } else if settings.backend_candle_enabled
+        && zimage_identity_candle_available(&request, settings)
     {
         // Z-Image identity-init for Image Studio "With Character" (sc-8409, epic 4406) — checked BEFORE
         // `is_candle_engine` because `z_image_turbo` IS a candle txt2img id, so without this a

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -2385,6 +2385,52 @@ fn zimage_identity_strength_gate_and_clamp() {
     );
 }
 
+/// The candle Z-Image identity-init engage gate + clamp (sc-8409): the off-Mac sibling of
+/// `zimage_identity_strength_gate_and_clamp`, exercising `zimage_identity_candle_strength` — the gate the
+/// candle "With Character" lane (`zimage_identity_candle_available`) keys on. Must agree with the macOS
+/// `zimage_identity_strength` semantics verbatim (engage iff `referenceStrength > 0` AND a non-empty
+/// `referenceAssetId`; strength forwarded with no inversion, clamped to [0.05, 1.0]) so candle runs the
+/// identity init precisely when the MLX generic lane does.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn zimage_identity_candle_strength_gate_and_clamp() {
+    let with = |adv: Value, asset: Value| {
+        let mut payload = json!({
+            "projectId": "p", "model": "z_image_turbo", "mode": "character_image", "prompt": "a knight"
+        });
+        let obj = payload.as_object_mut().unwrap();
+        obj.insert("advanced".to_owned(), adv);
+        if !asset.is_null() {
+            obj.insert("referenceAssetId".to_owned(), asset);
+        }
+        zimage_identity_candle_strength(&request(payload))
+    };
+
+    // Not engaged → None: no referenceStrength; == 0 (parity: requires > 0); > 0 but no/blank asset.
+    assert_eq!(with(json!({}), json!("ref_1")), None);
+    assert_eq!(with(json!({ "referenceStrength": 0.0 }), json!("ref_1")), None);
+    assert_eq!(with(json!({ "referenceStrength": 0.6 }), Value::Null), None);
+    assert_eq!(with(json!({ "referenceStrength": 0.6 }), json!("   ")), None);
+
+    // Engaged: strength forwarded verbatim (no inversion) and clamped to [0.05, 1.0].
+    assert_eq!(
+        with(json!({ "referenceStrength": 0.6 }), json!("ref_1")),
+        Some(0.6)
+    );
+    assert_eq!(
+        with(json!({ "referenceStrength": "0.45" }), json!("ref_1")),
+        Some(0.45)
+    );
+    assert_eq!(
+        with(json!({ "referenceStrength": 1.8 }), json!("ref_1")),
+        Some(1.0)
+    );
+    assert_eq!(
+        with(json!({ "referenceStrength": 0.01 }), json!("ref_1")),
+        Some(0.05)
+    );
+}
+
 /// Real-weights smoke: Z-Image strict-pose ControlNet. Loads the base
 /// `Tongyi-MAI/Z-Image-Turbo` snapshot + the cached Fun-Controlnet-Union checkpoint,
 /// renders a DWPose skeleton, and generates one pose image. Needs both in the HF

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -2408,9 +2408,15 @@ fn zimage_identity_candle_strength_gate_and_clamp() {
 
     // Not engaged → None: no referenceStrength; == 0 (parity: requires > 0); > 0 but no/blank asset.
     assert_eq!(with(json!({}), json!("ref_1")), None);
-    assert_eq!(with(json!({ "referenceStrength": 0.0 }), json!("ref_1")), None);
+    assert_eq!(
+        with(json!({ "referenceStrength": 0.0 }), json!("ref_1")),
+        None
+    );
     assert_eq!(with(json!({ "referenceStrength": 0.6 }), Value::Null), None);
-    assert_eq!(with(json!({ "referenceStrength": 0.6 }), json!("   ")), None);
+    assert_eq!(
+        with(json!({ "referenceStrength": 0.6 }), json!("   ")),
+        None
+    );
 
     // Engaged: strength forwarded verbatim (no inversion) and clamped to [0.05, 1.0].
     assert_eq!(

--- a/crates/sceneworks-worker/src/image_jobs/zimage_identity_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage_identity_candle.rs
@@ -1,0 +1,287 @@
+// Candle (Windows/CUDA) Z-Image identity-init route for Image Studio "With Character" (sc-8409, epic
+// 4406) — the off-Mac sibling of the macOS MLX generic lane's Z-Image identity img2img path
+// (`resolve_zimage_identity_init` in zimage.rs, sc-3146). A `character_image` job with a chosen
+// `referenceAssetId` (and `advanced.referenceStrength > 0`) seeds the Z-Image-Turbo denoise FROM the
+// reference latents — carrying the character's identity into the variation — instead of falling through
+// to plain txt2img (which drops the reference entirely, the pre-existing gap this story closes).
+//
+// **Why a bespoke lane.** `z_image_turbo` IS a candle txt2img id, so without this a With-Character job
+// would be caught by the generic `generate_candle_stream` (txt2img) branch and silently drop the
+// reference. The candle `zimage_edit_candle` lane is `edit_image`-only (`sourceAssetId`), so it does not
+// cover the identity-init shape (`character_image` + `referenceAssetId`). This reuses the SAME candle
+// `ZImageEdit` engine the edit lane drives (the Turbo DiT + a strength-derived source-latent init) — the
+// only difference from the edit lane is the source-keying (the identity `referenceAssetId` instead of the
+// edit `sourceAssetId`) and the `character_image` mode gate.
+//
+// **Parity with macOS.** The engage condition mirrors the macOS `zimage_identity_strength` gate EXACTLY
+// (`advanced.referenceStrength > 0` AND a non-empty `referenceAssetId`), so candle runs identity img2img
+// precisely when the MLX generic lane does — a With-Character job WITHOUT a positive `referenceStrength`
+// stays plain txt2img on both backends.
+//
+// **Face-likeness scoring (sc-4411 seam).** Once the route exists, each finished image is scored against
+// the chosen reference face through the SHARED generator-agnostic seam (`build_face_likeness_scorer` +
+// `score_generated_image`, source resolved by `resolve_character_image_likeness_source`), exactly as the
+// macOS generic lane and the other identity lanes do — source embedded ONCE, reused across the N images,
+// non-fatal, the hot-path pixel clone gated behind `scorer.is_some()`, non-frontal → honest N/A.
+//
+// `include!`d into the `image_jobs` module (carrying the candle cfg), so it shares that module's imports
+// (`ImageRequest`/`Settings`/`WorkerResult`/`advanced`/`load_reference_image`/`fit_engine_image`/
+// `resolve_character_image_likeness_source`/`ensure_face_stack_dir`/`ZImageEdit`/`drive_gen_items_scored`/
+// `score_generated_image`/`consume_gen_events`/`resolve_seed`/`Image`/… all in scope). It also reuses the
+// edit lane's `resolve_zimage_edit_candle_base` / `zimage_edit_candle_steps` helpers (same engine, same
+// base snapshot resolution) — both live in the sibling `zimage_edit_candle.rs` include.
+
+/// The adapter/engine id recorded on candle Z-Image identity-init assets + telemetry (distinct from the
+/// txt2img `candle_z_image`, the `candle_zimage_edit`, and the `candle_zimage_control` lanes).
+const ZIMAGE_IDENTITY_CANDLE_ENGINE: &str = "candle_zimage_identity";
+
+/// Model ids the candle Z-Image identity-init route accepts: only `z_image_turbo` (the With-Character
+/// target — the candle z-image engine is the distilled Turbo). The dedicated `z_image_edit` id is an
+/// edit-mode id (handled by `zimage_edit_candle`), not a character target.
+fn is_zimage_identity_candle_model(model: &str) -> bool {
+    model == "z_image_turbo"
+}
+
+/// The clamped identity img2img-init strength for a candle Z-Image With-Character job, or `None` when the
+/// identity init does NOT engage. `Some(strength)` iff `advanced.referenceStrength > 0` AND a non-empty
+/// `referenceAssetId` is present — the EXACT engage gate of the macOS `zimage_identity_strength`
+/// (zimage.rs, sc-3146), so candle runs identity img2img precisely when the MLX generic lane does.
+///
+/// `strength` is the user value clamped to `[0.05, 1.0]` and carries the mflux `image_strength`
+/// convention **verbatim** (no numeric inversion): higher strength → later denoise start
+/// (`init_time_step`) → output stays closer to the reference. Pure (request only) so the parity-sensitive
+/// gate + clamp are unit-testable without asset I/O. (Deliberately duplicates the macOS helper, which
+/// lives in the macOS-only `zimage.rs` include — the same per-lane-helper pattern the candle siblings use,
+/// kept in lockstep by the shared parity comment.)
+fn zimage_identity_candle_strength(request: &ImageRequest) -> Option<f32> {
+    let strength = request
+        .advanced
+        .get("referenceStrength")
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .filter(|strength| *strength > 0.0)?;
+    let has_asset = request
+        .reference_asset_id
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|id| !id.is_empty());
+    has_asset.then(|| (strength as f32).clamp(0.05, 1.0))
+}
+
+/// True when this is a candle-eligible Z-Image identity-init job: a `z_image_turbo` Image Studio
+/// "With Character" generation (`mode == "character_image"`) with a chosen `referenceAssetId` and a
+/// positive `referenceStrength`, that is NOT an angle set / pose-library set (those are already routed to
+/// their own lanes — the candle InstantID angle/pose paths and the Z-Image strict-control lane — and
+/// scored there), and whose Turbo base resolves locally. Mirrors `jobs_store::zimage_identity_candle_\
+/// eligible` (minus the local weight-resolve check) so the worker and router agree.
+fn zimage_identity_candle_available(request: &ImageRequest, settings: &Settings) -> bool {
+    is_zimage_identity_candle_model(&request.model)
+        && request.mode == "character_image"
+        && zimage_identity_candle_strength(request).is_some()
+        // Angle / pose sets are `character_image` too, but route to (and score on) their own lanes —
+        // exclude both so this plain With-Character lane never steals them (it sits BEFORE the Z-Image
+        // strict-control lane in the dispatch). Mirrors `resolve_character_image_likeness_source`.
+        && pose_entries(request).is_empty()
+        && !advanced::flag(&request.advanced, "angleSet")
+        && matches!(
+            resolve_zimage_edit_candle_base(request, settings),
+            Ok(Some(_))
+        )
+}
+
+/// Flat telemetry recorded on candle Z-Image identity-init assets. No guidance — Z-Image-Turbo is
+/// guidance-distilled. Mirrors `zimage_edit_candle_raw_settings`, keyed to the `character_image` mode +
+/// the identity engine id (so the sidecar attributes the route distinctly from the edit lane).
+fn zimage_identity_candle_raw_settings(
+    request: &ImageRequest,
+    repo: &str,
+    steps: u32,
+    strength: f32,
+) -> JsonObject {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("repo".to_owned(), Value::String(repo.to_owned()));
+    raw.insert("numInferenceSteps".to_owned(), json!(steps));
+    // Verbatim mflux `image_strength` (higher ⇒ closer to the reference) — the same key the recipe
+    // records for the identity init on the MLX side.
+    raw.insert("referenceStrength".to_owned(), json!(strength));
+    raw.insert(
+        "mode".to_owned(),
+        Value::String("character_image".to_owned()),
+    );
+    raw.insert(
+        "identityEngine".to_owned(),
+        Value::String(ZIMAGE_IDENTITY_CANDLE_ENGINE.to_owned()),
+    );
+    raw
+}
+
+/// Real candle Z-Image identity-init generation: resolve the reference + base on the async side, fit the
+/// reference to the render size (honoring `fit_mode`), then load `ZImageEdit` once + generate each image
+/// on the blocking thread, seeding the denoise from the reference latents at `referenceStrength`.
+/// `request.count` images, each its own seed, all carrying the same character identity. Z-Image-Turbo is
+/// distilled (no CFG / negative prompt), so the request carries no guidance. Each finished image is scored
+/// against the reference face through the shared sc-4411 seam (the `!Send` scorer built ONCE on the
+/// generator thread, source embedded once, reused across the N images; non-fatal; the pixel clone gated
+/// behind `scorer.is_some()`). Reuses [`drive_gen_items_scored`] + [`consume_gen_events`].
+async fn generate_candle_zimage_identity_stream(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+    let base = resolve_zimage_edit_candle_base(request, settings)?.ok_or_else(|| {
+        WorkerError::InvalidPayload("Z-Image base (Z-Image-Turbo) weights not found".to_owned())
+    })?;
+
+    let (width, height) = (request.width, request.height);
+    // The identity init strength engages this lane (the dispatch gate guarantees `Some`); resolve it
+    // again here as the source of truth for the engine + the recipe.
+    let strength = zimage_identity_candle_strength(request).ok_or_else(|| {
+        WorkerError::InvalidPayload(
+            "Z-Image identity init requires a referenceAssetId + referenceStrength > 0".to_owned(),
+        )
+    })?;
+    // Identity img2img source = the chosen character `referenceAssetId` (the reference shown in the Image
+    // Studio thumbnail), fit to the render geometry honoring `fit_mode` (the provider also resizes
+    // internally, but pre-fitting avoids stretching an off-aspect reference). Guaranteed non-empty by the
+    // strength gate above.
+    let reference_id = request
+        .reference_asset_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .expect("zimage_identity_candle_strength guarantees a non-empty referenceAssetId")
+        .to_owned();
+    let source = load_reference_image(
+        &settings.data_dir,
+        &request.project_id,
+        &reference_id,
+        project_path,
+    )?;
+    let source = fit_engine_image(source, width, height, &request.fit_mode)?;
+
+    let steps = zimage_edit_candle_steps(request);
+    let repo = request
+        .model_manifest_entry
+        .get("repo")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(ZIMAGE_EDIT_CANDLE_DEFAULT_REPO)
+        .to_owned();
+    let raw_settings = zimage_identity_candle_raw_settings(request, &repo, steps, strength);
+
+    // Identity-likeness scoring (sc-4411): resolve the source identity (the CURRENT job's
+    // `referenceAssetId`, so changing it changes the scored source) + stage the antelopev2 face stack
+    // (the same bundle InstantID uses; a no-op if cached). The dispatch gate guarantees a plain
+    // With-Character job, so `resolve_character_image_likeness_source` resolves the same reference the
+    // img2img init uses (decoded raw, not fit — better for face detection). All non-fatal: a missing
+    // reference / staging failure → no scorer → scores omitted, the generation still renders.
+    let likeness_source = resolve_character_image_likeness_source(request, settings, project_path);
+    let face_stack_dir = match &likeness_source {
+        Some(_) => match ensure_face_stack_dir(api, settings, job).await {
+            Ok(dir) => Some(dir),
+            Err(error) => {
+                tracing::warn!(error = %error, "With-Character (z-image identity) face-stack staging failed; likeness scores omitted");
+                None
+            }
+        },
+        None => None,
+    };
+    // Keep the source only if the face stack staged (otherwise no scorer can be built).
+    let likeness_source = face_stack_dir.as_ref().and(likeness_source);
+
+    // Per-image work items: (seed, prompt) — `request.count` identity-init renders of the same reference.
+    let work: Vec<(i64, String)> = (0..request.count as usize)
+        .map(|index| (resolve_seed(request, index), request.prompt.clone()))
+        .collect();
+    let total = work.len();
+
+    let (cancel, rx, blocking) = start_gen_stream(
+        job.id.clone(),
+        "zimage_identity",
+        0,
+        move || {
+            let model = ZImageEdit::load(&ZImageEditPaths { base }).map_err(|error| {
+                WorkerError::Engine(format!("Z-Image identity load failed: {error}"))
+            })?;
+            Ok((model, source))
+        },
+        move |(model, source), tx, cancel| {
+            // Per-job identity-likeness scorer built ONCE on the generator-worker thread (the `!Send`
+            // face stack lives here); source embedded once, reused across every output (sc-4411). `None`
+            // ⇒ non-fatal staging/construction failure ⇒ scores omitted.
+            let scorer = match (&face_stack_dir, &likeness_source) {
+                (Some(dir), Some((source, _))) => {
+                    crate::face_likeness::build_face_likeness_scorer(dir, source)
+                }
+                _ => None,
+            };
+            let likeness_source_ref = likeness_source.as_ref().map(|(_, id)| id.clone());
+            drive_gen_items_scored(tx, work, move |_index, (seed, prompt), on_progress| {
+                if cancel.is_cancelled() {
+                    return Ok(None);
+                }
+                let req = ZImageEditRequest {
+                    prompt,
+                    width,
+                    height,
+                    steps: steps as usize,
+                    strength,
+                    seed: seed as u64,
+                    cancel: cancel.clone(),
+                };
+                let out = match model.generate(&req, &source, &mut *on_progress) {
+                    Ok(out) => out,
+                    Err(_) if cancel.is_cancelled() => return Ok(None),
+                    Err(error) => {
+                        return Err(WorkerError::Engine(format!(
+                            "Z-Image identity generation failed: {error}"
+                        )));
+                    }
+                };
+                let (out_w, out_h, pixels) = (out.width, out.height, out.pixels);
+                // Score this finished image against the cached source embedding (sc-4411). Image build +
+                // pixel clone is paid ONLY when a scorer exists (a With-Character generation); non-frontal
+                // → honest detected:false N/A; `None` scorer ⇒ field omitted.
+                let face_likeness = scorer.as_ref().and_then(|scorer| {
+                    crate::face_likeness::score_generated_image(
+                        Some(scorer),
+                        &Image {
+                            width: out_w,
+                            height: out_h,
+                            pixels: pixels.clone(),
+                        },
+                        likeness_source_ref.as_deref(),
+                    )
+                });
+                Ok(Some((seed, out_w, out_h, pixels, face_likeness)))
+            })
+        },
+    );
+
+    consume_gen_events(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        ZIMAGE_IDENTITY_CANDLE_ENGINE,
+        &raw_settings,
+        total,
+        rx,
+        cancel,
+        blocking,
+        asset_writes,
+    )
+    .await
+}


### PR DESCRIPTION
## What

Closes the off-Mac (candle) routing gap discovered during [sc-4411](https://app.shortcut.com/trefry/story/4411): an Image Studio **"With Character"** job on Z-Image (`mode == "character_image"` + `referenceAssetId`) had **no bespoke candle identity-init lane**. `zimage_edit_candle` is `edit_image`-only (`sourceAssetId`), so a Z-Image With-Character job fell through to the generic candle **txt2img** lane and silently dropped the reference — no identity conditioning, and (downstream) no identity source to score.

Implements [sc-8409](https://app.shortcut.com/trefry/story/8409): add the candle Z-Image identity-init route (the off-Mac sibling of the macOS MLX generic lane's `resolve_zimage_identity_init`) and wire the shared face-likeness scorer into it.

## How

- **New `image_jobs/zimage_identity_candle.rs`** — reuses the candle `ZImageEdit` engine with the character `referenceAssetId` as the strength-derived source-latent init. The engage gate mirrors the macOS `zimage_identity_strength` **exactly** (`advanced.referenceStrength > 0` AND a non-empty `referenceAssetId`), excludes angle/pose sets (which route to — and score on — their own lanes), so candle runs identity img2img **precisely when the MLX generic lane does**. A With-Character job without a positive `referenceStrength` stays plain txt2img on both backends (parity).
- **Face-likeness scoring (sc-4411 seam)** — each finished image is scored against the chosen reference face through the identical generator-agnostic seam every other identity lane uses (`resolve_character_image_likeness_source` + `build_face_likeness_scorer` + `score_generated_image` over `drive_gen_items_scored`): source embedded **once**, reused across the N images, non-fatal, the hot-path pixel clone gated behind `scorer.is_some()`, non-frontal → honest `detected:false` N/A.
- **Worker dispatch** — branched before `is_candle_engine` (so a `z_image_turbo` character job isn't caught by the txt2img branch), grouped with the Z-Image lanes; disjoint from the edit lane (`edit_image`) and the strict-pose control lane (`advanced.poses`, which this gate excludes).
- **Router** — `zimage_identity_candle_eligible` + a branch in `image_job_is_candle_eligible` before the generic gate (which rejects any `referenceAssetId`), mirroring the worker gate so router and worker agree.

## Acceptance

- ✅ An off-Mac (candle) Z-Image "With Character" generation performs identity img2img against the chosen `referenceAssetId` (parity with macOS — same engage condition).
- ✅ The result carries a face-likeness score vs that reference in its sidecar (honest N/A for non-frontal).

## Scope note

Faithful to the story's "mirror the macOS MLX Z-Image identity-init behavior / parity with macOS": the lane engages exactly on the macOS `referenceStrength > 0` condition. The narrower no-`referenceStrength` case (macOS generic lane: plain txt2img, still scored) is the broader generic-lane behavior, not the identity-init route this story scopes; it is unchanged here (no regression — that shape was already not candle-eligible).

## Verification

- candle `cargo clippy -p sceneworks-worker --features backend-candle --all-targets -- -D warnings` → clean (CUDA cap=120 box).
- `cargo check -p sceneworks-core` → clean (the router change compiles cross-platform; macOS worker is untouched — the new file + dispatch branch are candle-cfg'd).
- New tests pass: router routing (`zimage_identity_with_character_jobs_route_to_candle`) + worker strength-gate parity/clamp (`zimage_identity_candle_strength_gate_and_clamp`). Full `candle_routing_tests` module (46) green.
- Real-weight GPU round-trip not run here (needs the staged Z-Image-Turbo + antelopev2 bundles); the engine + scorer seam are the same ones already GPU-validated by the edit lane (sc-6595) and the sc-4411 scorer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)