### PR TITLE
feat(worker): candle backend wiring for Stable Diffusion 3.5 (sc-7880)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4678df3c4abb51f22b7575f0962dd11657e4a202#4678df3c4abb51f22b7575f0962dd11657e4a202"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4678df3c4abb51f22b7575f0962dd11657e4a202#4678df3c4abb51f22b7575f0962dd11657e4a202"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4678df3c4abb51f22b7575f0962dd11657e4a202#4678df3c4abb51f22b7575f0962dd11657e4a202"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4678df3c4abb51f22b7575f0962dd11657e4a202#4678df3c4abb51f22b7575f0962dd11657e4a202"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4678df3c4abb51f22b7575f0962dd11657e4a202#4678df3c4abb51f22b7575f0962dd11657e4a202"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4678df3c4abb51f22b7575f0962dd11657e4a202#4678df3c4abb51f22b7575f0962dd11657e4a202"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -520,7 +520,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4678df3c4abb51f22b7575f0962dd11657e4a202#4678df3c4abb51f22b7575f0962dd11657e4a202"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4678df3c4abb51f22b7575f0962dd11657e4a202#4678df3c4abb51f22b7575f0962dd11657e4a202"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4678df3c4abb51f22b7575f0962dd11657e4a202#4678df3c4abb51f22b7575f0962dd11657e4a202"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4678df3c4abb51f22b7575f0962dd11657e4a202#4678df3c4abb51f22b7575f0962dd11657e4a202"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4678df3c4abb51f22b7575f0962dd11657e4a202#4678df3c4abb51f22b7575f0962dd11657e4a202"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -586,7 +586,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4678df3c4abb51f22b7575f0962dd11657e4a202#4678df3c4abb51f22b7575f0962dd11657e4a202"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -601,7 +601,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4678df3c4abb51f22b7575f0962dd11657e4a202#4678df3c4abb51f22b7575f0962dd11657e4a202"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -614,7 +614,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4678df3c4abb51f22b7575f0962dd11657e4a202#4678df3c4abb51f22b7575f0962dd11657e4a202"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -626,7 +626,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4678df3c4abb51f22b7575f0962dd11657e4a202#4678df3c4abb51f22b7575f0962dd11657e4a202"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -643,7 +643,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4678df3c4abb51f22b7575f0962dd11657e4a202#4678df3c4abb51f22b7575f0962dd11657e4a202"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4678df3c4abb51f22b7575f0962dd11657e4a202#4678df3c4abb51f22b7575f0962dd11657e4a202"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -669,7 +669,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4678df3c4abb51f22b7575f0962dd11657e4a202#4678df3c4abb51f22b7575f0962dd11657e4a202"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -682,9 +682,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "candle-gen-sd3"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
+dependencies = [
+ "candle-core",
+ "candle-gen",
+ "candle-nn",
+ "candle-transformers",
+ "inventory",
+ "rand 0.9.4",
+ "rand_distr 0.5.1",
+ "safetensors 0.7.0",
+ "serde_json",
+ "tokenizers 0.22.2",
+]
+
+[[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4678df3c4abb51f22b7575f0962dd11657e4a202#4678df3c4abb51f22b7575f0962dd11657e4a202"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -702,7 +719,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4678df3c4abb51f22b7575f0962dd11657e4a202#4678df3c4abb51f22b7575f0962dd11657e4a202"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -713,7 +730,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4678df3c4abb51f22b7575f0962dd11657e4a202#4678df3c4abb51f22b7575f0962dd11657e4a202"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -726,7 +743,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4678df3c4abb51f22b7575f0962dd11657e4a202#4678df3c4abb51f22b7575f0962dd11657e4a202"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -737,7 +754,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4678df3c4abb51f22b7575f0962dd11657e4a202#4678df3c4abb51f22b7575f0962dd11657e4a202"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -750,7 +767,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4678df3c4abb51f22b7575f0962dd11657e4a202#4678df3c4abb51f22b7575f0962dd11657e4a202"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -5565,6 +5582,7 @@ dependencies = [
  "candle-gen-qwen-image",
  "candle-gen-sam3",
  "candle-gen-scail2",
+ "candle-gen-sd3",
  "candle-gen-sdxl",
  "candle-gen-seedvr2",
  "candle-gen-sensenova",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2256,14 +2256,14 @@
       // Stable Diffusion 3.5 Large (epic 7841 / S1 sc-7870) — Stability AI's 8B MMDiT flagship,
       // ported natively to mlx-gen (engine id `sd3_5_large`, E5 — real-weight validated, coherent
       // 1024²). Triple text-encoder aggregator (CLIP-L + CLIP-G + T5-XXL) feeding a multimodal
-      // diffusion transformer (NO RoPE) + the 16-channel SD3.5 VAE. No torch backend → native MLX
-      // only (macOnly initially; off-Mac/candle is epic 7982). `adapter` is the asset stamp
+      // diffusion transformer (NO RoPE) + the 16-channel SD3.5 VAE. Native MLX on Mac; off-Mac the
+      // candle `candle-gen-sd3` provider serves it (sc-7880, epic 7982). `adapter` is the asset stamp
       // (mirrors mlx_<family>). Worker routing through engines::MODEL_TABLE / the gen_core registry
-      // lands in S2 (sc-7871) — until then this entry is downloadable/catalog-visible but not yet a
-      // Studio picker (mirrors the Boogu sc-6399 staging).
+      // landed in S2 (sc-7871). macOnly is now a no-op label (mirroring krea/flux2_dev): availability is
+      // driven by the routing tables (`MLX_ROUTED_MODELS` / `CANDLE_ROUTED_MODELS`), not this flag.
       "adapter": "mlx_sd3",
       "capabilities": ["text_to_image"],
-      "macOnly": true,
+      "macOnly": false,
       "downloads": [
         {
           // Gated repo (Stability AI Community License — non-commercial / <$1M-rev commercial OK;
@@ -2365,11 +2365,13 @@
       "type": "image",
       // Stable Diffusion 3.5 Large Turbo (epic 7841 / S1 sc-7870) — the ADD-distilled few-step,
       // CFG-free sibling of SD3.5 Large: same 8B MMDiT + triple TE + 16-ch VAE, rendered in ~4 steps
-      // with guidance off. Native MLX only (engine id `sd3_5_large_turbo`, E6 — in flight). Worker
-      // routing lands in S2 (sc-7871).
+      // with guidance off. Native MLX on Mac (engine id `sd3_5_large_turbo`); off-Mac the candle
+      // `candle-gen-sd3` provider serves it (sc-7880, epic 7982). Worker routing landed in S2 (sc-7871).
+      // macOnly is now a no-op label (mirroring krea/flux2_dev): availability is driven by the routing
+      // tables (`MLX_ROUTED_MODELS` / `CANDLE_ROUTED_MODELS`), not this flag.
       "adapter": "mlx_sd3",
       "capabilities": ["text_to_image"],
-      "macOnly": true,
+      "macOnly": false,
       "downloads": [
         {
           // Gated repo (Stability AI Community License; HF license-ack + token required). Diffusers
@@ -2454,11 +2456,13 @@
       "type": "image",
       // Stable Diffusion 3.5 Medium (epic 7841 / S1 sc-7870) — the 2.5B MMDiT-X (dual-attention)
       // mid-tier: same triple text encoder + 16-ch VAE, a smaller transformer that renders up to
-      // 1440². Native MLX only (engine id `sd3_5_medium` — forward M2 in flight, pipeline M3 later).
-      // Worker routing lands in S2 (sc-7871).
+      // 1440². Native MLX on Mac (engine id `sd3_5_medium`); off-Mac the candle `candle-gen-sd3`
+      // provider serves it (sc-7880, epic 7982). Worker routing landed in S2 (sc-7871). macOnly is now a
+      // no-op label (mirroring krea/flux2_dev): availability is driven by the routing tables
+      // (`MLX_ROUTED_MODELS` / `CANDLE_ROUTED_MODELS`), not this flag.
       "adapter": "mlx_sd3",
       "capabilities": ["text_to_image"],
-      "macOnly": true,
+      "macOnly": false,
       "downloads": [
         {
           // Gated repo (Stability AI Community License; HF license-ack + token required). Diffusers

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3872,6 +3872,17 @@ const CANDLE_ROUTED_MODELS: &[&str] = &[
     // `krea/Krea-2-Turbo`, the boogu pattern). This id is also in `MLX_ROUTED_MODELS`; mirror
     // `krea_mlx_eligible`.
     "krea_2_turbo",
+    // Stable Diffusion 3.5 (sc-7880, epic 7982): the candle `candle-gen-sd3` provider serves
+    // `sd3_5_large` (8B MMDiT, true-CFG), `sd3_5_large_turbo` (ADD-distilled few-step, CFG-free), and
+    // `sd3_5_medium` (2.5B MMDiT-X dual-attention). All three are pure **txt2img** on candle — the
+    // generic `image_request_candle_eligible` gate accepts the plain shape and rejects edit / reference /
+    // mask / pose / LoRA (the descriptor advertises `supports_lora: false`). The provider DOES advertise
+    // Q4/Q8 (sc-7879), so an explicit quant request stays on the candle lane (listed in
+    // `CANDLE_QUANT_MODELS` below). The MODEL_TABLE rows + manifest entries are the MLX twin (sc-7871);
+    // these ids are also in `MLX_ROUTED_MODELS` (the macOS native engine); mirror `sd3_5_mlx_eligible`.
+    "sd3_5_large",
+    "sd3_5_large_turbo",
+    "sd3_5_medium",
 ];
 
 /// The candle image families that advertise on-the-fly Q4/Q8 quant AND LoRA/LoKr adapters — Lens /
@@ -3880,6 +3891,14 @@ const CANDLE_ROUTED_MODELS: &[&str] = &[
 /// into the `LoadSpec` (descriptor-gated, see `ResolvedModel::supports_quant`/`supports_adapters`).
 /// Every other candle family advertises neither, so a LoRA/quant request there still defers to torch.
 const CANDLE_QUANT_LORA_MODELS: &[&str] = &["lens", "lens_turbo"];
+
+/// The candle image families that advertise on-the-fly Q4/Q8 quant but NOT inference LoRA — Stable
+/// Diffusion 3.5 (sc-7880): the `candle-gen-sd3` descriptor advertises `supported_quants: [Q4, Q8]`
+/// with `supports_lora: false`. For these an explicit quant request stays on the candle lane (the
+/// worker's `generate_candle_stream` resolves it descriptor-side via `model.supports_quant()`), but a
+/// LoRA still defers to the Python torch worker. `CANDLE_QUANT_LORA_MODELS` (Lens) is the superset that
+/// also keeps LoRAs on candle; these two lists are disjoint and the gate consults both.
+const CANDLE_QUANT_MODELS: &[&str] = &["sd3_5_large", "sd3_5_large_turbo", "sd3_5_medium"];
 
 /// Whether `worker` is the candle (Windows/CUDA) SDXL worker — identified by the `candle` marker
 /// capability it self-advertises (`gpu::with_candle_capabilities`), mirroring the `nvidia` marker
@@ -4110,11 +4129,13 @@ fn image_request_candle_eligible(model: &str, payload: &Map<String, Value>) -> b
     {
         return false;
     }
-    // Lens / Lens-Turbo advertise Q4/Q8 + LoRA/LoKr, so a quant request or a LoRA stays on the candle
-    // lane for them; every other candle family advertises neither and defers those to torch.
-    let supports_quant_lora = CANDLE_QUANT_LORA_MODELS.contains(&model);
+    // Lens / Lens-Turbo advertise Q4/Q8 + LoRA/LoKr, so a quant request OR a LoRA stays on the candle
+    // lane for them. SD3.5 (sc-7880) advertises Q4/Q8 but NOT inference LoRA, so a quant request stays
+    // on candle while a LoRA still defers. Every other candle family advertises neither and defers both.
+    let supports_lora = CANDLE_QUANT_LORA_MODELS.contains(&model);
+    let supports_quant = supports_lora || CANDLE_QUANT_MODELS.contains(&model);
     // LoRAs: not in the candle lane unless the family advertises adapters (Lens).
-    if !supports_quant_lora
+    if !supports_lora
         && payload
             .get("loras")
             .and_then(Value::as_array)
@@ -4135,8 +4156,8 @@ fn image_request_candle_eligible(model: &str, payload: &Map<String, Value>) -> b
     // On-the-fly quantization (`advanced.mlxQuantize` > 0) → torch UNLESS the family advertises quant.
     // The sc-3675/sc-5096 candle providers advertise `supported_quants: &[]` (dense bf16/fp16 only), so
     // an explicit quant request can't be honored — route to Python rather than silently running dense
-    // (sc-5099). Lens advertises Q4/Q8, so its quant request stays here (sc-5126).
-    if !supports_quant_lora && candle_request_wants_quant(payload) {
+    // (sc-5099). Lens (sc-5126) + SD3.5 (sc-7880) advertise Q4/Q8, so their quant requests stay here.
+    if !supports_quant && candle_request_wants_quant(payload) {
         return false;
     }
     true
@@ -6335,6 +6356,50 @@ mod candle_routing_tests {
         ];
         for model in ["lens", "lens_turbo"] {
             for case in &cases {
+                assert!(
+                    !image_request_candle_eligible(model, &object(case.clone())),
+                    "{model} conditioning shape must fall back to torch: {case}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn sd3_5_quant_stays_on_candle_but_lora_and_conditioning_defer() {
+        // sc-7880 (epic 7982): the candle SD3.5 descriptor advertises supported_quants: [Q4, Q8] but
+        // supports_lora: false, so — unlike Lens — an explicit quant request stays on the candle lane
+        // while a LoRA (and every conditioning shape) still defers to the Python torch worker.
+        for model in ["sd3_5_large", "sd3_5_large_turbo", "sd3_5_medium"] {
+            // Plain txt2img is eligible.
+            assert!(
+                image_request_candle_eligible(model, &object(json!({ "prompt": "a misty fjord" }))),
+                "{model} plain txt2img should be candle-eligible"
+            );
+            // Q8 / Q4 requests stay on candle (descriptor-gated quant, resolved worker-side).
+            for bits in [8, 4] {
+                assert!(
+                    image_request_candle_eligible(
+                        model,
+                        &object(json!({ "advanced": { "mlxQuantize": bits } }))
+                    ),
+                    "{model} Q{bits} request should stay on candle"
+                );
+            }
+            // A LoRA defers (SD3.5 has no inference-LoRA candle path yet).
+            assert!(
+                !image_request_candle_eligible(
+                    model,
+                    &object(json!({ "loras": [{ "name": "x", "path": "/x.safetensors" }] }))
+                ),
+                "{model} with a LoRA must fall back to torch"
+            );
+            // Every conditioning shape defers (txt2img only).
+            for case in [
+                json!({ "mode": "edit_image", "sourceAssetId": "a" }),
+                json!({ "referenceAssetId": "a" }),
+                json!({ "maskAssetId": "m" }),
+                json!({ "advanced": { "poses": [{ "id": "pose_1" }] } }),
+            ] {
                 assert!(
                     !image_request_candle_eligible(model, &object(case.clone())),
                     "{model} conditioning shape must fall back to torch: {case}"

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -474,6 +474,9 @@ backend-candle = [
     "dep:candle-gen-flux",
     "dep:candle-gen-flux2",
     "dep:candle-gen-qwen-image",
+    # sc-7880 (epic 7982): the candle Stable Diffusion 3.5 provider (`sd3_5_large` / `sd3_5_large_turbo`
+    # / `sd3_5_medium`). Pure T2I; Q4/Q8 quant, no inference LoRA. Windows/CUDA sibling of mlx-gen-sd3.
+    "dep:candle-gen-sd3",
     # sc-6596 (epic 6561): the candle Ideogram 4 image provider (`ideogram_4` + `ideogram_4_turbo`).
     "dep:candle-gen-ideogram",
     # sc-5484 (epic 3692): the candle Chroma image provider (chroma1_hd / chroma1_base / chroma1_flash).
@@ -1243,25 +1246,33 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b653
 # THIS worker's unified lock; gen-core stays e9682318 (== this worker's mlx pin), so the gen-core skew gate
 # still resolves the SINGLE rev e9682318 on `--features backend-candle --target all`. ALL candle-gen-* rev
 # lines move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4678df3c4abb51f22b7575f0962dd11657e4a202", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4678df3c4abb51f22b7575f0962dd11657e4a202", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4678df3c4abb51f22b7575f0962dd11657e4a202", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4678df3c4abb51f22b7575f0962dd11657e4a202", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4678df3c4abb51f22b7575f0962dd11657e4a202", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
+# Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
+# Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
+# few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
+# CLIP-G + T5-XXL) + 16-ch VAE; advertises Q4/Q8 (sc-7879), no LoRA at inference. Force-linked in
+# `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
+# gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
+# `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4678df3c4abb51f22b7575f0962dd11657e4a202", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4678df3c4abb51f22b7575f0962dd11657e4a202", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1271,7 +1282,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4678df3c4abb51f22b7575f0962dd11657e4a202", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1279,21 +1290,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4678df3c4abb51f22b7575f0962dd11657e4a202", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4678df3c4abb51f22b7575f0962dd11657e4a202", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4678df3c4abb51f22b7575f0962dd11657e4a202", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4678df3c4abb51f22b7575f0962dd11657e4a202", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1302,17 +1313,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4678df3c4abb51f22b7575f0962dd11657e4a202", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4678df3c4abb51f22b7575f0962dd11657e4a202", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4678df3c4abb51f22b7575f0962dd11657e4a202", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1321,7 +1332,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4678df3c4abb51f22b7575f0962dd11657e4a202", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1343,7 +1354,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "bf99e5b4
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4678df3c4abb51f22b7575f0962dd11657e4a202", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1352,12 +1363,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4678df3c4abb51f22b7575f0962dd11657e4a202", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4678df3c4abb51f22b7575f0962dd11657e4a202", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1365,7 +1376,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4678d
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4678df3c4abb51f22b7575f0962dd11657e4a202", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1374,7 +1385,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4678df3c4abb51f22b7575f0962dd11657e4a202", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1382,7 +1393,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4678df3c4abb51f22b7575f0962dd11657e4a202", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1396,7 +1407,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4678df3c4abb51f22b7575f0962dd11657e4a202", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1423,7 +1434,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4678df3c4abb51f22b7575f0962dd11657e4a202", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -114,6 +114,12 @@ use candle_gen_flux as _;
 use candle_gen_flux2 as _;
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_qwen_image as _;
+// Candle Stable Diffusion 3.5 (sc-7880, epic 7982): `sd3_5_large` / `sd3_5_large_turbo` / `sd3_5_medium`
+// self-register into the shared gen_core inventory; the `as _;` keeps the MSVC release linker from GC-ing
+// the `inventory::submit!` registrations (else `gen_core::load("sd3_5_large")` returns "no generator
+// registered"). The Windows/CUDA sibling of the `mlx_gen_sd3` anchor above. Pure txt2img; Q4/Q8 quant.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+use candle_gen_sd3 as _;
 // Candle Ideogram 4 (sc-6596, epic 6561): `ideogram_4` + `ideogram_4_turbo` self-register into the
 // shared gen_core inventory; `as _;` keeps the MSVC release linker from GC-ing the registrations.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -2123,6 +2123,14 @@ fn is_candle_engine(model: &str) -> bool {
             // candle-readable, so the candle lane loads bf16 from the ungated public `krea/Krea-2-Turbo`
             // snapshot root (no subdir). No edit/reference/control shapes.
             | "krea_2_turbo"
+            // Stable Diffusion 3.5 (sc-7880, epic 7982): Large / Large Turbo / Medium all ride the generic
+            // candle txt2img lane (the `candle-gen-sd3` provider). `generate_candle_stream` resolves Q4/Q8
+            // from the descriptor + manifest (`mlx.quantize` 8) — the dense MMDiT folds to Q4_0/Q8_0 at
+            // load (sc-7879). Pure txt2img; no edit/reference/control/LoRA candle path (those defer to
+            // torch via `image_request_candle_eligible`).
+            | "sd3_5_large"
+            | "sd3_5_large_turbo"
+            | "sd3_5_medium"
     )
 }
 
@@ -2147,6 +2155,8 @@ fn candle_adapter_label(model: &str) -> &'static str {
         "ideogram_4" | "ideogram_4_turbo" => "candle_ideogram",
         "boogu_image" | "boogu_image_turbo" | "boogu_image_edit" => "candle_boogu",
         "krea_2_turbo" => "candle_krea",
+        // Stable Diffusion 3.5 (sc-7880): Large / Large Turbo / Medium share the candle SD3.5 engine.
+        "sd3_5_large" | "sd3_5_large_turbo" | "sd3_5_medium" => "candle_sd3",
         // sdxl / realvisxl share the candle "sdxl" engine.
         _ => CANDLE_ADAPTER,
     }
@@ -2903,11 +2913,19 @@ mod candle_label_tests {
             "boogu_image",
             "boogu_image_turbo",
             "boogu_image_edit",
+            // SD3.5 (sc-7880): Large / Large Turbo / Medium carry the `candle_sd3` stamp.
+            "sd3_5_large",
+            "sd3_5_large_turbo",
+            "sd3_5_medium",
             "sdxl",
             "realvisxl",
         ] {
             assert!(candle_adapter_label(model).starts_with("candle_"));
         }
+        // SD3.5 (sc-7880): the candle asset stamp.
+        assert_eq!(candle_adapter_label("sd3_5_large"), "candle_sd3");
+        assert_eq!(candle_adapter_label("sd3_5_large_turbo"), "candle_sd3");
+        assert_eq!(candle_adapter_label("sd3_5_medium"), "candle_sd3");
     }
 
     #[test]
@@ -2943,6 +2961,10 @@ mod candle_label_tests {
             "boogu_image_edit",
             // Krea 2 Turbo (sc-7581): pure txt2img on the generic candle lane.
             "krea_2_turbo",
+            // SD3.5 (sc-7880): Large / Large Turbo / Medium ride the generic candle txt2img lane.
+            "sd3_5_large",
+            "sd3_5_large_turbo",
+            "sd3_5_medium",
         ] {
             assert!(is_candle_engine(model), "{model} should be a candle engine");
         }

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -757,14 +757,15 @@ fn model_table_rows_resolve_and_flags_match_descriptor() {
 }
 
 /// sc-7875 (SD3.5 S6, MLX-path validation boundary): the three SD3.5 builtin-manifest entries gate
-/// correctly at the catalog layer — `macOnly: true` (picker hidden off-Mac), `capabilities ==
-/// ["text_to_image"]` only (edit/reference rejected), the family `sd3`, the gated stabilityai/* download
-/// with `gated: true` + `credentialHost: huggingface.co`, and the per-tier `mlx.minMemoryGb`
-/// (Large/Turbo 64, Medium 16) that drives the memory-eligibility gate. Parses the embedded builtin
-/// manifest (the exact bytes shipped) so manifest drift on any of these eligibility levers fails CI
-/// without a real download. (The descriptor-derived guidance/negative/backend surface is covered by
-/// `model_table_rows_resolve_and_flags_match_descriptor`; the credential-host derivation by the
-/// rust-api `gated_credential_tests`; this is the catalog-eligibility counterpart.)
+/// correctly at the catalog layer — `macOnly: false` (cross-platform now that the candle off-Mac lane
+/// is wired, sc-7880/epic 7982; availability is driven by the routing tables, not this flag),
+/// `capabilities == ["text_to_image"]` only (edit/reference rejected), the family `sd3`, the gated
+/// stabilityai/* download with `gated: true` + `credentialHost: huggingface.co`, and the per-tier
+/// `mlx.minMemoryGb` (Large/Turbo 64, Medium 56) that drives the memory-eligibility gate. Parses the
+/// embedded builtin manifest (the exact bytes shipped) so manifest drift on any of these eligibility
+/// levers fails CI without a real download. (The descriptor-derived guidance/negative/backend surface
+/// is covered by `model_table_rows_resolve_and_flags_match_descriptor`; the credential-host derivation
+/// by the rust-api `gated_credential_tests`; this is the catalog-eligibility counterpart.)
 #[test]
 fn sd3_5_manifest_entries_gate_correctly() {
     use sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS;
@@ -800,11 +801,12 @@ fn sd3_5_manifest_entries_gate_correctly() {
             Some("sd3"),
             "{id} family"
         );
-        // Mac-only: the native MLX SD3.5 port has no off-Mac/candle lane (epic 7982), so the picker is
-        // hidden off-Mac.
+        // Cross-platform: the candle off-Mac lane is now wired (sc-7880, epic 7982), so `macOnly` is a
+        // no-op label flipped to false (mirroring krea/flux2_dev) — availability is driven by the
+        // routing tables (`MLX_ROUTED_MODELS` / `CANDLE_ROUTED_MODELS`), not this flag.
         assert_eq!(
             entry.get("macOnly").and_then(Value::as_bool),
-            Some(true),
+            Some(false),
             "{id} macOnly"
         );
         // Capability gate: text_to_image ONLY — edit/reference are rejected (no img2img/inpaint path).


### PR DESCRIPTION
## SD3.5 C5b — worker candle wiring (sc-7880, epic 7982)

Wires the candle (Windows/CUDA) backend for **SD3.5 Large / Large Turbo / Medium** — the off-Mac sibling of the MLX `mlx-gen-sd3` engines already shipped in this worker. The just-landed `candle-gen-sd3` crate (canonical engine ids `sd3_5_large` / `sd3_5_large_turbo` / `sd3_5_medium`, matching `mlx-gen-sd3` + the MODEL_TABLE) self-registers into the shared gen_core inventory, so SD3.5 jobs route to the candle worker off-Mac instead of failing `candle_unsupported`. Pure txt2img; Q4/Q8 quant (sc-7879), no inference LoRA.

### The edits
1. **Cargo deps** (`crates/sceneworks-worker/Cargo.toml`): add `candle-gen-sd3` (dep + `backend-candle` feature entry), pinned to candle-gen rev **185fe4a**. **Lockstep:** bump EVERY existing `candle-gen-*` pin to the same 185fe4a so all candle-gen-* crates resolve at one candle-gen rev. gen-core / mlx-gen pins unchanged. `Cargo.lock` refreshed.
2. **Force-link anchor** (`src/image_jobs.rs`): `use candle_gen_sd3 as _;` (under `cfg(all(not(target_os="macos"), feature="backend-candle"))`) — keeps the MSVC release linker from GC-ing the `inventory::submit!` registrations.
3. **Router** (`crates/sceneworks-core/src/jobs_store.rs`): add the three ids to `CANDLE_ROUTED_MODELS`; add a quant-only `CANDLE_QUANT_MODELS` list (SD3.5 advertises Q4/Q8 but `supports_lora: false`) so an explicit quant request stays on candle while LoRA + every conditioning shape (edit/reference/mask/pose) defers to torch. The `image_request_candle_eligible` gate splits the old `supports_quant_lora` into separate `supports_quant` (Lens ∪ SD3.5) / `supports_lora` (Lens) flags.
4. **Worker generate lane** (`src/image_jobs/base.rs`): add the ids to `is_candle_engine` (generic candle txt2img lane) + `candle_adapter_label` (`candle_sd3` stamp) so the worker actually serves the jobs the router hands it.
5. **Manifest** (`config/manifests/builtin.models.jsonc`): flip `macOnly` true → false on all three SD3.5 entries (mirroring krea/flux2_dev — a no-op label now that availability is driven by the routing tables) so SD3.5 is eligible off-Mac.

### Lockstep / gen-core skew
- candle-gen **185fe4a** pins `sceneworks-gen-core` at **b6538cb** — **IDENTICAL** to the worker's mlx-gen pin (verified against candle-gen `Cargo.toml` @185fe4a).
- **24** `candle-gen-*` pins bumped to 185fe4a (23 existing + new sd3). `Cargo.lock` confirms a SINGLE candle-gen rev (185fe4a) and a SINGLE gen-core/mlx-gen rev (b6538cb), so `--features backend-candle --target all` resolves one gen-core rev — the skew gate stays green. No gen-core re-pin needed.

### Validation (local)
- `cargo check -p sceneworks-worker --features backend-candle` — green.
- `cargo clippy -p sceneworks-worker --features backend-candle --all-targets -- -D warnings` — green.
- Worker candle tests: `is_candle_engine_covers_only_the_wired_txt2img_families`, `candle_image_adapter_labels_are_per_family`, and the **`manifest_menu_is_subset_of_descriptor` drift guard** (SD3.5 manifest menu ⊆ candle descriptor's curated samplers/schedulers — no reconciliation needed) all pass.
- `cargo test -p sceneworks-core` routing: 47 candle routing tests + new `sd3_5_quant_stays_on_candle_but_lora_and_conditioning_defer` + existing `sd3_5_text_to_image_routes_to_mlx` — green. `cargo fmt --check` clean.

### CI must confirm
The **windows-candle** lane runs the full CUDA build + test (the heavy link is deferred to CI per the story).

### Caveat
Gated SD3.5 weights are unavailable locally (no HF token) — **real-weight e2e is C6 (sc-7881)**. This PR is logic/driver-free wiring + build only.

sc-7880

🤖 Generated with [Claude Code](https://claude.com/claude-code)