### PR TITLE
feat: raise per-job LoRA limit (user-pick 2→4, total 3→5)

### DIFF
--- a/apps/rust-api/src/recipe_presets.rs
+++ b/apps/rust-api/src/recipe_presets.rs
@@ -882,9 +882,9 @@ pub(crate) fn normalize_recipe_preset_loras(object: &mut JsonObject) -> Result<(
     let items = loras
         .as_array_mut()
         .ok_or_else(|| ApiError::bad_request("Recipe preset loras must be an array"))?;
-    if items.len() > 3 {
+    if items.len() > 5 {
         return Err(ApiError::bad_request(
-            "Recipe presets can include at most 3 LoRAs",
+            "Recipe presets can include at most 5 LoRAs",
         ));
     }
     for item in items {

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -7498,7 +7498,9 @@ async fn recipe_preset_crud_routes_persist_global_and_project_presets() {
                 { "id": "style_one" },
                 { "id": "style_two" },
                 { "id": "style_three" },
-                { "id": "style_four" }
+                { "id": "style_four" },
+                { "id": "style_five" },
+                { "id": "style_six" }
             ]
         }),
     )
@@ -7506,7 +7508,7 @@ async fn recipe_preset_crud_routes_persist_global_and_project_presets() {
     assert_eq!(bad_status, StatusCode::BAD_REQUEST);
     assert_eq!(
         bad_error["detail"],
-        "Recipe presets can include at most 3 LoRAs"
+        "Recipe presets can include at most 5 LoRAs"
     );
 
     let (bad_status, bad_error) = request(

--- a/apps/web/src/components/LoraPickerField.jsx
+++ b/apps/web/src/components/LoraPickerField.jsx
@@ -3,7 +3,7 @@ import { loraMatchesModel, loraWeight, serializeLora } from "../presetUtils.js";
 
 // Keep in sync with the worker guard (lora_adapters.MAX_JOB_LORAS) and the Rust
 // recipe-preset normalizer — generation rejects more than this many LoRAs per job.
-const MAX_JOB_LORAS = 3;
+const MAX_JOB_LORAS = 5;
 
 // Family-filtered LoRA selection shared by the Character Studio Angle Set + Pose
 // Library panels (sc-2223). Mirrors the Image/Video Studio behaviour without

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -6735,7 +6735,7 @@ describe("SceneWorks app shell", () => {
     expect(container.querySelector(".worker-progress-card.completed")).toBeNull();
   });
 
-  it("submits compatible image LoRAs while capping simple user selections at two", async () => {
+  it("submits compatible image LoRAs while capping simple user selections at four", async () => {
     const createImageJob = vi.fn();
     root = createRoot(container);
     await act(async () => {
@@ -6754,6 +6754,8 @@ describe("SceneWorks app shell", () => {
             { id: "global_style", name: "Global Style", family: "z-image", scope: "global" },
             { id: "project_mira", name: "Project Mira", family: "z-image", scope: "project", files: ["mira.safetensors"] },
             { id: "third_user", name: "Third User", family: "z-image", scope: "global" },
+            { id: "fourth_user", name: "Fourth User", family: "z-image", scope: "global" },
+            { id: "fifth_user", name: "Fifth User", family: "z-image", scope: "global" },
             { id: "qwen_only", name: "Qwen Only", family: "qwen-image", scope: "global" },
             { id: "missing_lora", name: "Missing LoRA", family: "z-image", scope: "global", installState: "missing" },
           ],
@@ -6781,9 +6783,13 @@ describe("SceneWorks app shell", () => {
       checkboxes[0].click();
       checkboxes[1].click();
       checkboxes[2].click();
+      checkboxes[3].click();
+      checkboxes[4].click();
     });
 
-    expect(checkboxes[3].disabled).toBe(true);
+    // built_in is scope "builtin" and doesn't count toward the user cap, so four
+    // user LoRAs are selected here; the fifth user LoRA is disabled at the cap.
+    expect(checkboxes[5].disabled).toBe(true);
 
     await act(async () => {
       container.querySelector('.lora-picker .checkline input[type="checkbox"]').click();
@@ -6802,6 +6808,8 @@ describe("SceneWorks app shell", () => {
           expect.objectContaining({ id: "built_in", scope: "builtin", weight: 0.6 }),
           expect.objectContaining({ id: "global_style", scope: "global" }),
           expect.objectContaining({ id: "project_mira", scope: "project", files: ["mira.safetensors"] }),
+          expect.objectContaining({ id: "third_user", scope: "global" }),
+          expect.objectContaining({ id: "fourth_user", scope: "global" }),
         ],
       }),
     );

--- a/apps/web/src/screens/PresetManagerScreen.jsx
+++ b/apps/web/src/screens/PresetManagerScreen.jsx
@@ -210,7 +210,7 @@ export function PresetManagerScreen() {
     }
     setForm((current) => {
       const hasLora = current.loras.some((lora) => lora.id === id);
-      if (hasLora || current.loras.length >= 3) {
+      if (hasLora || current.loras.length >= 5) {
         return current;
       }
       const source = loras.find((lora) => lora.id === id);
@@ -749,7 +749,7 @@ export function PresetManagerScreen() {
             {renderSection({
               step: "6",
               title: "Style stack",
-              help: `Up to 3 LoRAs layered with this preset. Compatible with ${selectedModel?.name ?? "the chosen model"}.`,
+              help: `Up to 5 LoRAs layered with this preset. Compatible with ${selectedModel?.name ?? "the chosen model"}.`,
               optional: true,
               children: (
                 <section aria-label="Preset LoRAs">
@@ -806,7 +806,7 @@ export function PresetManagerScreen() {
                       </div>
                     ) : null}
 
-                    {form.loras.length < 3 ? (
+                    {form.loras.length < 5 ? (
                       showLoraPicker ? (
                         <div className="lora-picker-panel">
                           <strong>Pick a LoRA</strong>

--- a/apps/web/src/screens/generationStudio.jsx
+++ b/apps/web/src/screens/generationStudio.jsx
@@ -256,7 +256,7 @@ export function useGenerationStudio({
       }
       const selected = ids.map((id) => compatibleLoras.find((item) => item.id === id)).filter(Boolean);
       const userCount = selected.filter((item) => item.scope !== "builtin").length;
-      if (lora.scope !== "builtin" && userCount >= 2) {
+      if (lora.scope !== "builtin" && userCount >= 4) {
         return ids;
       }
       return [...ids, lora.id];
@@ -337,7 +337,7 @@ export function LoraPickerSection({
         <div className="lora-choice-list">
           {compatibleLoras.map((lora) => {
             const checked = selectedLoraIds.includes(lora.id);
-            const userLimitReached = lora.scope !== "builtin" && !checked && userSelectedLoraCount >= 2;
+            const userLimitReached = lora.scope !== "builtin" && !checked && userSelectedLoraCount >= 4;
             const weight = effectiveLoraWeight(lora);
             return (
               <div className="lora-choice-item" key={lora.id}>

--- a/apps/worker/scene_worker/lora_adapters.py
+++ b/apps/worker/scene_worker/lora_adapters.py
@@ -14,7 +14,7 @@ from .hf_cache import huggingface_cache_roots, huggingface_repo_cache_path
 
 # Keep in sync with packages/schemas/recipe-preset.schema.json and the Rust
 # normalize_recipe_preset_loras API guard.
-MAX_JOB_LORAS = 3
+MAX_JOB_LORAS = 5
 
 
 @dataclass(frozen=True)

--- a/crates/sceneworks-core/src/lora_family.rs
+++ b/crates/sceneworks-core/src/lora_family.rs
@@ -1130,7 +1130,7 @@ fn collect_tensor_keys(header: &Value) -> Vec<String> {
 
 /// Maximum LoRAs per job (matches the worker's `MAX_JOB_LORAS` / Python
 /// `normalize_lora_specs`).
-pub const MAX_JOB_LORAS: usize = 3;
+pub const MAX_JOB_LORAS: usize = 5;
 
 /// Architecture families a model can load LoRAs from *in addition to* its own
 /// (Python `EXTRA_COMPATIBLE_LORA_FAMILIES`). Chroma is FLUX.1-derived and shares

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -294,7 +294,7 @@ const CANDLE_ADAPTER: &str = "candle_sdxl";
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
-const MAX_JOB_LORAS: usize = 3;
+const MAX_JOB_LORAS: usize = 5;
 
 // The engine dispatch table + its `ModelRow`/`mlx_model` join moved to the all-targets
 // `engines` module (sc-3723); the two descriptor-duplicating flags it used to carry

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -1610,9 +1610,9 @@ pub(crate) async fn run_video_upscale_job(
 #[cfg(target_os = "macos")]
 const WAN_ADAPTER: &str = "mlx_wan";
 
-/// At most 3 user LoRAs per job (mirrors the image path's `MAX_JOB_LORAS`).
+/// At most 5 user LoRAs per job (mirrors the image path's `MAX_JOB_LORAS`).
 #[cfg(target_os = "macos")]
-const MAX_JOB_LORAS: usize = 3;
+const MAX_JOB_LORAS: usize = 5;
 
 /// Raw-settings recorded on a real MLX Wan asset: the request's `advanced` knobs plus
 /// the real-inference markers (mirrors the image `mlx_raw_settings`). Also records the
@@ -3310,7 +3310,7 @@ fn candle_scail2_raw_settings(request: &VideoRequest, lightning: bool) -> Value 
 
 /// Max LoRAs per candle SCAIL-2 job (matches the macOS `MAX_JOB_LORAS`).
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-const CANDLE_SCAIL2_MAX_LORAS: usize = 3;
+const CANDLE_SCAIL2_MAX_LORAS: usize = 5;
 
 /// The lightx2v lightning step-distill recipe (sc-6838, the candle sibling of the MLX sc-5684/5700
 /// recipe): 8 steps, CFG off, scheduler shift 1.

--- a/packages/schemas/recipe-preset.schema.json
+++ b/packages/schemas/recipe-preset.schema.json
@@ -47,7 +47,7 @@
           },
           "loras": {
             "type": "array",
-            "maxItems": 3,
+            "maxItems": 5,
             "items": {
               "type": "object",
               "required": ["id"],
@@ -69,7 +69,7 @@
           "builtInLoras": {
             "description": "Deprecated legacy alias for loras. The API accepts this field on read and write migration paths, but API-managed manifest writes normalize it to loras.",
             "type": "array",
-            "maxItems": 3,
+            "maxItems": 5,
             "items": {
               "oneOf": [
                 { "type": "string", "pattern": "^[a-z0-9][a-z0-9_-]*$" },

--- a/tests/test_worker_lora_adapters.py
+++ b/tests/test_worker_lora_adapters.py
@@ -506,8 +506,8 @@ def test_lora_specs_fail_before_inference_for_missing_or_excess_loras(tmp_path):
     with pytest.raises(RuntimeError, match=r"LoRA empty has no \.safetensors file"):
         normalize_lora_specs([{"id": "empty", "installedPath": str(empty_dir)}])
 
-    many = [{"id": f"lora_{index}", "installedPath": str(missing)} for index in range(4)]
-    with pytest.raises(RuntimeError, match="at most 3 LoRAs"):
+    many = [{"id": f"lora_{index}", "installedPath": str(missing)} for index in range(6)]
+    with pytest.raises(RuntimeError, match="at most 5 LoRAs"):
         normalize_lora_specs(many)
 
 


### PR DESCRIPTION
## What

Lifts the per-job LoRA limit globally across all studios.

The codebase enforced **two distinct limits**, scattered across ~8 surfaces with no shared constant:

| Limit | Where | Before → After |
|---|---|---|
| **User-pick cap** (counts only *non-builtin* LoRAs) | Image/Video Studio picker | **2 → 4** |
| **Total job cap** | worker (MLX + candle), recipe-preset API + schema, Character Studio, Preset Manager, Python test stub | **3 → 5** |

## Why

The user-facing limit in Image/Video Studio was 2 user LoRAs. This raises it to 4. The total job cap stays **one above** the user-pick cap — preserving headroom for a builtin acceleration LoRA alongside a full user stack. (Builtin LoRAs ride free in the picker but still count toward the backend total, so capping the total at exactly 4 would reject "4 user LoRAs + 1 builtin"; 5 keeps that working.)

## Surfaces changed

- `apps/web` — `generationStudio.jsx` (Image/Video picker, 2 spots), `LoraPickerField.jsx` (Character Studio), `PresetManagerScreen.jsx` (guard + picker visibility + help text)
- `crates/sceneworks-worker` — `image_jobs.rs`, `video_jobs.rs` (macOS MLX `MAX_JOB_LORAS` + candle `CANDLE_SCAIL2_MAX_LORAS`)
- `crates/sceneworks-core` — `lora_family.rs`
- `apps/rust-api` — `recipe_presets.rs` normalizer + message, matching assertion in `tests.rs`
- `packages/schemas/recipe-preset.schema.json` — `maxItems` on `loras` and deprecated `builtInLoras`
- `apps/worker/scene_worker/lora_adapters.py` (test-only legacy) + `tests/test_worker_lora_adapters.py`

## Reviewer notes

- There is **no single shared constant** for this cap — `sceneworks-core::lora_family::MAX_JOB_LORAS` is defined but unused/doc-only. All surfaces above must move in lockstep.
- Verified locally: `cargo fmt --check` clean on all three touched crates; schema JSON parses.
- Not run locally (run in CI parity): the Python worker test (no worker venv present) and web ESLint/build (worktree `node_modules` missing `@eslint/js`). Python test range/regex were updated to the new cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)