### PR TITLE
feat(worker): surface SANA 1600M native MLX (sc-8489, Phase B2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -520,7 +520,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -586,7 +586,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -601,7 +601,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -614,7 +614,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -626,7 +626,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -643,7 +643,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -669,7 +669,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -684,7 +684,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -701,7 +701,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -719,7 +719,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -730,7 +730,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -743,7 +743,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -754,7 +754,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -767,7 +767,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=185fe4a0ffa40af87fc6678848ab591e7c5c3446#185fe4a0ffa40af87fc6678848ab591e7c5c3446"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -3472,7 +3472,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac#b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3485,7 +3485,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac#b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
 dependencies = [
  "image",
  "inventory",
@@ -3499,7 +3499,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac#b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
 dependencies = [
  "image",
  "inventory",
@@ -3513,7 +3513,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac#b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3526,7 +3526,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac#b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3537,7 +3537,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac#b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3546,7 +3546,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac#b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3555,7 +3555,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac#b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3568,7 +3568,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac#b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3581,7 +3581,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac#b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3594,7 +3594,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac#b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3606,7 +3606,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac#b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3616,7 +3616,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac#b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
 dependencies = [
  "image",
  "inventory",
@@ -3629,7 +3629,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac#b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
 dependencies = [
  "image",
  "inventory",
@@ -3643,7 +3643,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac#b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
 dependencies = [
  "image",
  "inventory",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac#b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
 dependencies = [
  "image",
  "inventory",
@@ -3669,7 +3669,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac#b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3680,7 +3680,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac#b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3692,7 +3692,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac#b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3703,7 +3703,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac#b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3712,16 +3712,26 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac#b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
 ]
 
 [[package]]
+name = "mlx-gen-sana"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
+dependencies = [
+ "mlx-gen",
+ "mlx-gen-pid",
+ "pmetal-mlx-rs",
+]
+
+[[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac#b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3733,7 +3743,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac#b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
 dependencies = [
  "image",
  "inventory",
@@ -3748,7 +3758,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac#b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
 dependencies = [
  "image",
  "inventory",
@@ -3762,7 +3772,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac#b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3773,7 +3783,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac#b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3785,7 +3795,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac#b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3796,7 +3806,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac#b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
 dependencies = [
  "image",
  "inventory",
@@ -3810,7 +3820,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac#b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
 dependencies = [
  "image",
  "inventory",
@@ -5501,7 +5511,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac#b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
 dependencies = [
  "core-llm",
  "inventory",
@@ -5615,6 +5625,7 @@ dependencies = [
  "mlx-gen-qwen-image",
  "mlx-gen-sam2",
  "mlx-gen-sam3",
+ "mlx-gen-sana",
  "mlx-gen-scail2",
  "mlx-gen-sd3",
  "mlx-gen-sdxl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -520,7 +520,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -586,7 +586,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -601,7 +601,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -614,7 +614,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -626,7 +626,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -643,7 +643,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -669,7 +669,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -684,7 +684,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -701,7 +701,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -719,7 +719,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -730,7 +730,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -743,7 +743,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -754,7 +754,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -767,7 +767,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e14d3beec45c04a93a0215ca4ba3ac93ac89d539#e14d3beec45c04a93a0215ca4ba3ac93ac89d539"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
 dependencies = [
  "candle-core",
  "candle-gen",

--- a/apps/web/public/prompt-guides/sana.md
+++ b/apps/web/public/prompt-guides/sana.md
@@ -1,0 +1,42 @@
+# SANA Prompt Guide
+
+## Best For
+
+Fast, efficient 1024×1024 text-to-image. SANA 1600M is NVIDIA's Linear-DiT model — a 1.6B linear-attention transformer paired with a deep-compression 32× DC-AE autoencoder and a Gemma-2 instruction text encoder. It uses **real classifier-free guidance** (positive *and* negative prompt) and renders quickly with a comfortably small memory footprint.
+
+Distributed under the NVIDIA Open Model License (non-commercial / research use only).
+
+## Prompt Shape
+
+SANA's text encoder is the Gemma-2 instruction model run over a Complex-Human-Instruction (CHI) wrapper, so it responds well to fluent, natural-language descriptions rather than tag lists. Write a sentence or two describing the finished image:
+
+`subject + setting + visual details + style + composition + lighting`
+
+Use the positive prompt to describe what you want and the negative prompt to push away what you don't. Recommended defaults: **~20 steps at guidance 4.5**.
+
+## Build The Prompt
+
+### Subject
+
+Describe the subject as if captioning a finished photo — type, action, position, distinguishing features.
+
+Good: `a red fox curled asleep on a mossy log in a misty forest`
+
+### Setting And Details
+
+Add the environment, materials, and any small details you want emphasized. SANA follows descriptive language closely.
+
+### Style And Lighting
+
+Name the medium (photo, oil painting, 3D render), the mood, and the lighting (golden hour, soft studio light, dramatic rim light).
+
+## Settings
+
+- **Steps**: ~20 (the diffusers reference default). More steps add little once the image converges.
+- **Guidance**: ~4.5. Lower for more natural/varied results, higher for stricter prompt adherence.
+- **Resolution**: native 1024×1024; width and height must be multiples of 32 (the DC-AE compression factor).
+- **Negative prompt**: supported — use it to remove unwanted elements or artifacts.
+
+## Notes
+
+SANA ships dense (bf16); there is no quantized variant. Generations are for non-commercial use only.

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2544,6 +2544,102 @@
       }
     },
     {
+      "id": "sana_1600m",
+      // SANA 1600M 1024px (epic 8485 / sc-8489) — NVIDIA's efficient Linear-DiT text-to-image model,
+      // ported natively to mlx-gen (engine id `sana_1600m`). A 1.6B Linear-DiT trunk (ReLU linear
+      // attention + Mix-FFN + NoPE) conditioned by a gemma-2-2b-it Complex-Human-Instruction (CHI)
+      // caption encoder (reused from the PiD epic 7840 — SceneWorks/gemma-2-2b-it) + the deeply-
+      // compressed 32× DC-AE (f32) decoder. Native MLX only (mlx-gen-sana, no torch/candle backend) →
+      // macOnly. True-CFG text-to-image (20 steps / guidance 4.5). `adapter` is the asset stamp
+      // (mirrors mlx_<family>). Worker routing through engines::MODEL_TABLE / the gen_core registry +
+      // the MLX_ROUTED_MODELS gate (jobs_store.rs) lands in this same story (sc-8489 Phase B2).
+      //
+      // NVIDIA non-commercial: SANA-1.6B is distributed under the NVIDIA Open Model License /
+      // NSCLv1 (research & evaluation, non-commercial). The re-hosted `SceneWorks/Sana_1600M_1024px_mlx`
+      // mirror carries the upstream LICENSE + NOTICE + attribution (the Krea/Ideogram re-host
+      // precedent — OK to ship gated-with-notice). SceneWorks's overall non-commercial posture covers
+      // this; generations are for non-commercial use only.
+      "autoDownload": false,
+      "name": "SANA 1600M",
+      "family": "sana",
+      "type": "image",
+      "adapter": "mlx_sana",
+      "capabilities": ["text_to_image"],
+      "macOnly": true,
+      "downloads": [
+        {
+          // Pre-converted MLX snapshot on the SceneWorks HF org (sc-8489): ONE
+          // `SanaPipeline::from_snapshot`-loadable root — `transformer/` (the Linear-DiT trunk),
+          // `vae/` (the 32× DC-AE f32 decoder), and `text_encoder/` (the gemma-2-2b-it CHI caption
+          // encoder — `gemma-2-2b-it.safetensors` + `tokenizer.json`, sourced from the
+          // SceneWorks/gemma-2-2b-it mirror so the TE weights are NOT duplicated as a separate
+          // catalog dependency). Un-gated (the mirror carries the NVIDIA non-commercial NOTICE).
+          // Dense bf16 (no quant subdir — the 2-bit SANA quant is intentionally NOT ported).
+          // estimatedSizeBytes is a PLACEHOLDER (the 1.6B DiT + ~2.6B gemma TE + DC-AE) refined once
+          // the real pull is measured.
+          "provider": "huggingface",
+          "repo": "SceneWorks/Sana_1600M_1024px_mlx",
+          "files": ["transformer/*", "vae/*", "text_encoder/*"],
+          "platforms": ["macos"],
+          "estimatedSizeBytes": 9500000000
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/SceneWorks/Sana_1600M_1024px_mlx"
+      },
+      "defaults": {
+        // diffusers `SanaPipeline` reference defaults: flow-match Euler with a static time-shift of
+        // 3.0, 20 steps, true CFG 4.5 (negative-prompt capable). The shift is the orthogonal
+        // schedulerShift knob (epic 7114) rather than a scheduler choice.
+        "resolution": "1024x1024",
+        "steps": 20,
+        "guidanceScale": 4.5,
+        "count": 1,
+        "sampler": "euler",
+        "scheduler": "default",
+        "schedulerShift": 3.0
+      },
+      "limits": {
+        // 32× DC-AE divisor → W×H must be multiples of 32 (descriptor RES_MULTIPLE). Native 1024².
+        // SANA routes the per-generation sampler/scheduler knobs through the unified flow framework
+        // (epic 7114), so it advertises the full curated flow menu. "default" is the native
+        // flow-match Euler loop. The `sana_1600m` descriptor advertises curated_sampler_names()/
+        // curated_scheduler_names(); the engines.rs drift guard checks this list is a subset.
+        "resolutions": ["1024x1024", "1152x896", "896x1152", "1216x832", "832x1216"],
+        "count": [1, 2, 4],
+        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+        "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
+      },
+      "loraCompatibility": {
+        // No SANA LoRA wired yet (the engine descriptor reports supports_lora: false). Family
+        // reserved for when/if adapters are added.
+        "families": ["sana"],
+        "types": []
+      },
+      "mlx": {
+        // Dense bf16 snapshot (no runtime quant — the 2-bit SANA quant is NOT ported; the load path
+        // rejects a quantize override). minMemoryGb 24: the 1.6B Linear-DiT trunk + the ~2.6B gemma
+        // TE + DC-AE decode, a comfortably small footprint relative to the SD3.5 / Boogu flagships.
+        "minMemoryGb": 24,
+        "repo": "SceneWorks/Sana_1600M_1024px_mlx"
+      },
+      "licenseUrl": "https://huggingface.co/Efficient-Large-Model/Sana_1600M_1024px",
+      "ui": {
+        "label": "SANA 1600M",
+        "description": "NVIDIA SANA 1600M — an efficient Linear-DiT text-to-image model, ported natively to MLX (Apple Silicon only). A 1.6B linear-attention transformer (deep compression 32× DC-AE autoencoder + a gemma-2 instruction text encoder) for fast 1024×1024 generation with true classifier-free guidance and negative prompts. Runs ~20 steps at guidance 4.5 (flow-match Euler, shift 3.0). Dense bf16 (no quantization). Distributed under the NVIDIA Open Model License (non-commercial): generations are for non-commercial / research use only. The SceneWorks mirror is un-gated and carries the upstream license + notice. Runs comfortably on a 24 GB-class Mac.",
+        "recommendedFor": ["text_to_image"],
+        "promptGuide": {
+          "title": "SANA Prompt Guide",
+          "path": "/prompt-guides/sana.md",
+          "sources": [
+            { "label": "SANA model card (NVIDIA)", "url": "https://huggingface.co/Efficient-Large-Model/Sana_1600M_1024px" },
+            { "label": "SANA project page", "url": "https://nvlabs.github.io/Sana/" },
+            { "label": "SANA paper (Linear DiT + DC-AE)", "url": "https://arxiv.org/abs/2410.10629" }
+          ]
+        }
+      }
+    },
+    {
       "id": "sdxl",
       "recommended": true,
       "name": "Stable Diffusion XL",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3635,6 +3635,11 @@ const MLX_ROUTED_MODELS: &[&str] = &[
     "sd3_5_large",
     "sd3_5_large_turbo",
     "sd3_5_medium",
+    // SANA 1600M (epic 8485 / sc-8489): native `mlx-gen-sana` text-to-image engine (adapter
+    // `mlx_sana`) over the un-gated `SceneWorks/Sana_1600M_1024px_mlx` MLX snapshot. macOS-only
+    // (no torch backend). True-CFG text-to-image only (20 steps / guidance 4.5); `edit_image` has no
+    // source/reference path, so it's rejected (mirrors Krea/SD3.5/Lens).
+    "sana_1600m",
 ];
 
 /// Epic 3018 routing — does this image job belong on the in-process Rust MLX
@@ -3699,6 +3704,7 @@ fn image_request_mlx_eligible(model: &str, payload: &Map<String, Value>) -> bool
         "boogu_image" | "boogu_image_turbo" | "boogu_image_edit" => boogu_mlx_eligible(payload),
         "krea_2_turbo" => krea_mlx_eligible(payload),
         "sd3_5_large" | "sd3_5_large_turbo" | "sd3_5_medium" => sd3_5_mlx_eligible(payload),
+        "sana_1600m" => sana_mlx_eligible(payload),
         // Every model in MLX_ROUTED_MODELS must have an arm.
         _ => false,
     }
@@ -5072,6 +5078,16 @@ fn krea_mlx_eligible(payload: &Map<String, Value>) -> bool {
 /// `model_mac_support`'s `features.edit` false for all three (it probes with `mode: edit_image`).
 /// macOS-only (the catalog flags `macOnly`); off-Mac no `mlx` worker registers so nothing defers.
 fn sd3_5_mlx_eligible(payload: &Map<String, Value>) -> bool {
+    payload.get("mode").and_then(Value::as_str) != Some("edit_image")
+}
+
+/// SANA 1600M (epic 8485 / sc-8489) MLX-eligibility. The native `mlx-gen-sana` engine serves the
+/// **text-to-image** surface only (true-CFG, 20 steps / guidance 4.5); the base SANA checkpoint has no
+/// img2img/control conditioning, so an `edit_image` request is rejected (the same defensive shape
+/// Krea / SD3.5 / Lens reject). This keeps `model_mac_support`'s `features.edit` false (it probes with
+/// `mode: edit_image`). macOS-only (the catalog flags `macOnly`); off-Mac no `mlx` worker registers so
+/// nothing defers.
+fn sana_mlx_eligible(payload: &Map<String, Value>) -> bool {
     payload.get("mode").and_then(Value::as_str) != Some("edit_image")
 }
 

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -416,7 +416,7 @@ sceneworks-core = { path = "../sceneworks-core" }
 # b6538cb..875cf7f -- gen-core/ gen-core-testkit/` is EMPTY — gen-core BYTE-IDENTICAL (the range only ADDS
 # the sana provider crate), mlx-rs unchanged (38e1cc1 — MLX core does not rebuild beyond the new crate), so
 # the worker's import surface is unchanged and the DEFAULT skew gate stays single-rev/green at 875cf7f. The
-# candle pin below moves `185fe4a0` -> `e14d3be` IN LOCKSTEP (candle-gen sc-8489: re-pins candle-gen's own
+# candle pin below moves `185fe4a0` -> `8962199` IN LOCKSTEP (candle-gen sc-8489: re-pins candle-gen's own
 # gen-core b6538cb -> 875cf7f, byte-identical — candle links no sana crate and compiles UNCHANGED) so
 # `--features backend-candle --target all` resolves the SINGLE gen-core rev 875cf7f.
 sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
@@ -1266,15 +1266,15 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875c
 # THIS worker's unified lock; gen-core stays e9682318 (== this worker's mlx pin), so the gen-core skew gate
 # still resolves the SINGLE rev e9682318 on `--features backend-candle --target all`. ALL candle-gen-* rev
 # lines move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1282,17 +1282,17 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1302,7 +1302,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1310,21 +1310,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1333,17 +1333,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1352,7 +1352,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1374,7 +1374,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "bf99e5b4
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1383,12 +1383,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1396,7 +1396,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1405,7 +1405,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1413,7 +1413,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1427,7 +1427,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1454,7 +1454,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -407,7 +407,19 @@ sceneworks-core = { path = "../sceneworks-core" }
 # mlx-gen-krea (gen-core BYTE-IDENTICAL); candle re-pins its gen-core in lockstep so both skew lanes
 # resolve the SINGLE rev 1ebc7a7 (verified: default + `--features backend-candle`, worker + rust-api).
 # The backend-candle BUILD stays red on the pre-existing sc-8177 candle-llm/core-llm blocker (orthogonal).
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac" }
+# Bumped `b6538cb` -> `875cf7f` (epic 8485, sc-8489 Phase B2): re-pin to mlx-gen main HEAD to surface the
+# native MLX SANA model in the worker. 875cf7f = SANA Phase A (end-to-end native t2i `SanaPipeline` —
+# DC-AE f32 decoder + Linear DiT trunk + gemma-2 CHI text conditioning, mlx-gen #612-#615) + Phase B
+# (in-crate gen-core `Generator` adapter + `register_generators!` registration of `sana_1600m`, mlx-gen
+# #616). The new `mlx-gen-sana` provider crate is added to the macOS block below + force-linked via
+# `use mlx_gen_sana as _;` in image_jobs.rs so its inventory registration survives linker GC. `git diff
+# b6538cb..875cf7f -- gen-core/ gen-core-testkit/` is EMPTY — gen-core BYTE-IDENTICAL (the range only ADDS
+# the sana provider crate), mlx-rs unchanged (38e1cc1 — MLX core does not rebuild beyond the new crate), so
+# the worker's import surface is unchanged and the DEFAULT skew gate stays single-rev/green at 875cf7f. The
+# candle pin below moves `185fe4a0` -> `e14d3be` IN LOCKSTEP (candle-gen sc-8489: re-pins candle-gen's own
+# gen-core b6538cb -> 875cf7f, byte-identical — candle links no sana crate and compiles UNCHANGED) so
+# `--features backend-candle --target all` resolves the SINGLE gen-core rev 875cf7f.
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -752,7 +764,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -768,23 +780,23 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538cb4c4b
 # exactly this rev, so the worker MUST match (a different rev would compile pmetal-mlx-sys twice). This
 # rebuilds MLX from source. Paired with mlx-llm `6c052ba` below (mlx-llm#45 carries the same fork pin).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
 # Krea 2 Turbo (native MLX, Krea 2 Community License; epic 7565, sc-7572). Same git rev as mlx-gen.
 # Self-registers `krea_2_turbo` (Qwen3-VL-4B TE + 28-block single-stream DiT + Qwen-Image VAE; CFG-free
 # rectified-flow few-step) via inventory only when force-linked (`use mlx_gen_krea as _;` in
 # image_jobs.rs). Loads the packed Q8/Q4 turnkey subdir (krea_model_subdir; the loader auto-detects the
 # packed quant, so the resolved `spec.quantize` is a no-op on it). Depends on mlx-gen-qwen-image for the
 # shared `AutoencoderKLQwenImage` VAE.
-mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac" }
+mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
 # Stable Diffusion 3.5 provider (native MLX, Stability AI Community License; epic 7841, sc-7871). Same
 # git rev as mlx-gen so MLX builds once. Self-registers `sd3_5_large` (true-CFG, 28 steps / guidance 3.5)
 # + `sd3_5_large_turbo` (ADD-distilled few-step, CFG-off) + `sd3_5_medium` (MMDiT-X, true-CFG, 40 steps /
@@ -792,59 +804,67 @@ mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538c
 # (`use mlx_gen_sd3 as _;` in image_jobs.rs). All three carry a `sd3_5_*_quant` converter. Reuses the SDXL
 # CLIP encoder (×2), the FLUX T5-XXL encoder, and the Z-Image 16-ch VAE — its `quantize_sd3_dir` converter
 # is wired in model_jobs.rs for the `sd3_5_{large,large_turbo,medium}_quant` install-time conversions.
-mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac" }
+mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
+# SANA 1600M provider (native MLX, NVIDIA non-commercial license; epic 8485, sc-8489). Same git rev as
+# mlx-gen so MLX builds once. Self-registers `sana_1600m` (Image/t2i, true-CFG, 32× DC-AE divisor,
+# mac_only) via `register_generators!` into the gen-core inventory — surfaces only when force-linked
+# (`use mlx_gen_sana as _;` in image_jobs.rs). Reuses the PiD gemma-2-2b-it CHI caption encoder for text
+# conditioning (sc-8488); the `SanaPipeline` composes SanaTextEncoder -> SanaTransformer (Linear DiT) ->
+# DC-AE f32 decoder and exposes the `from_snapshot`/`from_weights` weight-load entrypoints the generic
+# generator-cache load path drives.
+mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
 # CLIP ViT-L/14 image embedder for the Dataset Doctor analysis job (epic 6529 P2, sc-6535).
 # Self-registers `clip_vit_l14` (gen_core::ImageEmbedder) via inventory only when force-linked
 # (`use mlx_gen_clip as _;` in dataset_analysis_jobs.rs). Reuses mlx-gen-sdxl's CLIP body → same rev.
-mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac" }
+mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -853,19 +873,19 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538c
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
 # Depth Anything V2 (DINOv2 ViT-S/14 + DPT) native-MLX monocular depth estimator (epic 8236,
 # sc-8242). A plain utility crate (NOT a self-registering generation provider): an arbitrary RGB
 # image → a normalized single-channel depth control image, the AUTO depth source for the
 # Fun-Controlnet-Union depth tier (`ControlKind::Depth`) — sibling of the CPU canny/pose
 # preprocessors, but neural so it is macOS-gated (MLX). Consumed by the worker `depth` module /
 # the shared strict-control driver (sc-8243). Same mlx-rs pin as every other mlx-gen crate.
-mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac" }
+mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -874,7 +894,7 @@ mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -882,7 +902,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -893,7 +913,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b653
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -904,7 +924,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -926,7 +946,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538c
 # a Metal large-tensor limit, not precision). New `VAE_SAFE_DECODE_EDGE_PX=1536` forces decode tiling on
 # a CORRECTNESS cap independent of the memory budget (image + video), so a 2048² upscale that fits memory
 # still tiles. Real-weight 1024→2048 pixel-cosine vs the mflux reference 0.9524 → 0.9974.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -937,7 +957,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b65
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
 # The unified LLM engine (epic 7153, sc-7158): the macOS `prompt_refine` job now runs through
 # mlx-llm's generic `mlx-llama` provider (a `core_llm::TextLlm`) resolved model-first via
 # `gen_core::core_llm::load_for_model`, RETIRING the bespoke `mlx-gen-prompt-refine` hand-rolled
@@ -969,7 +989,7 @@ mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "7041411f395e43
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b6538cb4c4b3a9c70ac8e0db73084fb3ccb6eeac" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -1246,15 +1266,15 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b653
 # THIS worker's unified lock; gen-core stays e9682318 (== this worker's mlx pin), so the gen-core skew gate
 # still resolves the SINGLE rev e9682318 on `--features backend-candle --target all`. ALL candle-gen-* rev
 # lines move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1262,17 +1282,17 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1282,7 +1302,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1290,21 +1310,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1313,17 +1333,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1332,7 +1352,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1354,7 +1374,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "bf99e5b4
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1363,12 +1383,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1376,7 +1396,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1385,7 +1405,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1393,7 +1413,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1407,7 +1427,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1434,7 +1454,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "185fe4a0ffa40af87fc6678848ab591e7c5c3446", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e14d3beec45c04a93a0215ca4ba3ac93ac89d539", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -474,6 +474,24 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
         default_guidance: 5.0,
         adapter_label: "mlx_sd3",
     },
+    // SANA 1600M 1024px (epic 8485 / sc-8489) — native MLX, NVIDIA non-commercial. NVIDIA's efficient
+    // Linear-DiT (ReLU linear-attn + Mix-FFN + NoPE) 1.6B trunk + a gemma-2-2b-it CHI caption encoder +
+    // the 32× DC-AE (f32) decoder. True-CFG text-to-image: 20 steps / guidance 4.5 + negative prompt
+    // (the `sana_1600m` descriptor advertises supports_guidance + supports_negative + supports_true_cfg).
+    // Loads the un-gated `SceneWorks/Sana_1600M_1024px_mlx` MLX snapshot (transformer/ vae/ text_encoder/,
+    // the latter bundling the SceneWorks/gemma-2-2b-it TE so the load path resolves one snapshot dir —
+    // SanaTextEncoder::from_snapshot reads `<dir>/text_encoder/gemma-2-2b-it.safetensors` + tokenizer.json).
+    // Generator self-registers via the shared force-link (`use mlx_gen_sana as _;` in image_jobs.rs);
+    // reaches the generic MODEL_TABLE / `generate_stream` path. No runtime quant (the 2-bit quant is NOT
+    // ported); ships dense bf16. 32× DC-AE divisor → width/height must be multiples of 32.
+    ModelRow {
+        sceneworks_id: "sana_1600m",
+        engine_id: "sana_1600m",
+        default_repo: "SceneWorks/Sana_1600M_1024px_mlx",
+        default_steps: 20,
+        default_guidance: 4.5,
+        adapter_label: "mlx_sana",
+    },
 ];
 
 /// The mlx-gen registry ids of the video generators this worker serves (the engine ids
@@ -573,9 +591,14 @@ impl ResolvedModel {
     }
     /// Whether the engine advertises any on-the-fly Q4/Q8 quantization (descriptor-derived). The
     /// candle SDXL / sc-5096 families advertise none (dense only); Lens advertises Q4/Q8 (sc-5126).
-    /// Candle-lane-only: the MLX path always resolves quant unconditionally, so this gate is unused
-    /// on macOS.
-    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    /// Used on BOTH lanes: the candle lane has always gated quant on this; the MLX lane gates on it
+    /// too as of sc-8489 so SANA (the lone generic-MLX family with `supported_quants: &[]`, whose
+    /// `load` rejects any quant) loads dense, while every pre-existing family (all Q4/Q8) is
+    /// unaffected.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
     pub fn supports_quant(&self) -> bool {
         !self.descriptor.capabilities.supported_quants.is_empty()
     }

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -66,6 +66,12 @@ use mlx_gen_krea as _;
 // generator registered". All three reach the generic MODEL_TABLE / `generate_stream` path.
 #[cfg(target_os = "macos")]
 use mlx_gen_sd3 as _;
+// SANA 1600M (epic 8485 / sc-8489) — force-link so `register_generators!` registers `sana_1600m`
+// (Image/t2i, true-CFG, 32× DC-AE divisor, mac_only) into the gen-core inventory; else linker GC drops
+// its `ModelRegistration` and `gen_core::load("sana_1600m")` returns "no generator registered". Reaches
+// the generic MODEL_TABLE / `generate_stream` path like the other registry families.
+#[cfg(target_os = "macos")]
+use mlx_gen_sana as _;
 // Lens / Lens-Turbo (epic 3164 engine / sc-5105) — an inventory-registered `Generator` under the ids
 // `lens` + `lens_turbo`, reached through the generic MODEL_TABLE / `generate_stream` path. Force-link
 // or the linker GCs its `ModelRegistration` and `gen_core::load("lens_turbo")` returns "no generator

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -1728,7 +1728,17 @@ async fn generate_stream(
     } else {
         model.backend()
     };
-    let (quant, quant_bits) = resolve_quant(request);
+    // Descriptor-gated quant (mirrors the candle lane below): the generic MLX families all advertise
+    // Q4/Q8 (`supported_quants`) and tolerate the Q8 default (a real quant on a dense convert, a no-op on
+    // an already-packed turnkey). SANA (sc-8489) is the lone exception — its descriptor advertises
+    // `supported_quants: &[]` and its `load` REJECTS any `spec.quantize`, so resolve no quant for it and
+    // let it load dense bf16. Every pre-existing family keeps `supports_quant() == true`, so their
+    // resolved quant is byte-identical.
+    let (quant, quant_bits) = if model.supports_quant() {
+        resolve_quant(request)
+    } else {
+        (None, None)
+    };
     let steps = resolve_steps(request, &model);
     let guidance = resolve_guidance(request, &model);
     let (sampler, scheduler, scheduler_shift) = read_advanced_sampling_knobs(&request.advanced);

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -737,6 +737,9 @@ fn model_table_rows_resolve_and_flags_match_descriptor() {
         // supports_guidance=true + supports_negative_prompt=true (the `sd3_5_medium` descriptor advertises
         // supports_true_cfg, same as Large; only the transformer + step/guidance recipe differ).
         ("sd3_5_medium", true, true),
+        // SANA 1600M (epic 8485 / sc-8489): true-CFG Linear-DiT — supports_guidance=true +
+        // supports_negative_prompt=true (the `sana_1600m` descriptor advertises supports_true_cfg).
+        ("sana_1600m", true, true),
     ];
     // Every row is covered by the expectation table (no row added without a flag pair here).
     assert_eq!(MODEL_TABLE.len(), expected.len());
@@ -861,6 +864,102 @@ fn sd3_5_manifest_entries_gate_correctly() {
             "{id} loraCompatibility.families"
         );
     }
+}
+
+/// sc-8489 (SANA Phase B2): the SANA builtin-manifest entry gates correctly at the catalog layer —
+/// family `sana`, `capabilities == ["text_to_image"]` only (edit/reference rejected), the UN-gated
+/// `SceneWorks/Sana_1600M_1024px_mlx` MLX re-host (NOT gated — the mirror carries the NVIDIA
+/// non-commercial NOTICE), dense bf16 (NO `mlx.quantize` — the load path rejects a quant), the
+/// `mlx.minMemoryGb` memory-eligibility lever, the sana LoRA family, and the NVIDIA non-commercial
+/// notice surfaced in the UI description. Parses the embedded builtin manifest (the exact bytes
+/// shipped) so manifest drift on any of these levers fails CI without a real download. The
+/// descriptor-derived guidance/negative/backend surface is covered by
+/// `model_table_rows_resolve_and_flags_match_descriptor`.
+#[test]
+fn sana_manifest_entry_gates_correctly() {
+    use sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS;
+    use sceneworks_core::jsonc::strip_jsonc_comments;
+
+    let raw = BUILTIN_MANIFESTS
+        .iter()
+        .find(|(name, _)| *name == "builtin.models.jsonc")
+        .map(|(_, contents)| *contents)
+        .expect("builtin.models.jsonc present");
+    let manifest: Value =
+        serde_json::from_str(&strip_jsonc_comments(raw)).expect("builtin models parses as JSON");
+    let models = manifest
+        .get("models")
+        .and_then(Value::as_array)
+        .expect("models array");
+    let entry = models
+        .iter()
+        .find(|m| m.get("id").and_then(Value::as_str) == Some("sana_1600m"))
+        .expect("sana_1600m present in builtin.models.jsonc");
+
+    assert_eq!(
+        entry.get("family").and_then(Value::as_str),
+        Some("sana"),
+        "sana family"
+    );
+    // Capability gate: text_to_image ONLY — edit/reference are rejected (base SANA is plain t2i).
+    let caps: Vec<&str> = entry
+        .get("capabilities")
+        .and_then(Value::as_array)
+        .map(|a| a.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_default();
+    assert_eq!(caps, vec!["text_to_image"], "sana capabilities");
+    // UN-gated SceneWorks/* MLX re-host (the mirror carries the NVIDIA non-commercial NOTICE; OK to
+    // ship un-gated with notice, the Krea/Boogu precedent) — so NO `gated: true`.
+    assert_ne!(
+        entry.get("gated").and_then(Value::as_bool),
+        Some(true),
+        "sana is un-gated (re-host carries the notice)"
+    );
+    let repo = entry
+        .get("downloads")
+        .and_then(Value::as_array)
+        .and_then(|d| d.first())
+        .and_then(|d| d.get("repo"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    assert_eq!(
+        repo, "SceneWorks/Sana_1600M_1024px_mlx",
+        "sana downloads from the un-gated SceneWorks/* MLX mirror, got {repo:?}"
+    );
+    // Dense bf16: NO `mlx.quantize` (the SANA `load` rejects any `spec.quantize`; the worker resolves
+    // no quant for it via the `supports_quant()` gate). minMemoryGb drives the admit/hide gate.
+    let mlx = entry.get("mlx").expect("sana mlx block");
+    assert!(
+        mlx.get("quantize").is_none(),
+        "sana ships dense bf16 — no mlx.quantize"
+    );
+    assert!(
+        mlx.get("minMemoryGb").and_then(Value::as_u64).is_some(),
+        "sana mlx.minMemoryGb present"
+    );
+    // sana LoRA family declared (reserved; no SANA LoRA wired yet) — an empty list would match every
+    // LoRA (sc-1927).
+    let lora_families: Vec<&str> = entry
+        .get("loraCompatibility")
+        .and_then(|c| c.get("families"))
+        .and_then(Value::as_array)
+        .map(|a| a.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_default();
+    assert_eq!(
+        lora_families,
+        vec!["sana"],
+        "sana loraCompatibility.families"
+    );
+    // NVIDIA non-commercial notice surfaced in the UI description (the gated-with-notice carrier).
+    let desc = entry
+        .get("ui")
+        .and_then(|u| u.get("description"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    assert!(
+        desc.contains("NVIDIA") && desc.to_lowercase().contains("non-commercial"),
+        "sana UI description carries the NVIDIA non-commercial notice"
+    );
 }
 
 /// sc-3513: the worker's `JobType::ImageEdit` dispatch arm delegates to


### PR DESCRIPTION
## sc-8489 Phase B2 — surface SANA 1600M in the SceneWorks worker

The mlx-gen side is merged to mlx-gen main: **Phase A** (`mlx_gen_sana::SanaPipeline` — DC-AE f32 decoder + Linear-DiT trunk + gemma-2 CHI text conditioning, end-to-end native t2i) and **Phase B** (in-crate gen-core `Generator` adapter + `register_generators!` registration of `sana_1600m`). This PR pins, depends on, link-forces, and catalogs/provisions it in the worker.

### Pin bump (lockstep)
- **mlx-gen / sceneworks-gen-core** `b6538cb` → `875cf7f` (mlx-gen main HEAD = SANA Phase A #615 + Phase B #616). `git diff b6538cb..875cf7f -- gen-core/ gen-core-testkit/` is **EMPTY** (gen-core BYTE-IDENTICAL — the range only ADDS the `mlx-gen-sana` provider crate). mlx-rs unchanged (`38e1cc1`), so MLX core does not rebuild beyond the new crate.
- **candle-gen** `185fe4a0` → `e14d3be` **IN LOCKSTEP** (candle-gen branch `michaeltrefry1818/sc-8489/candle-gen-core-875cf7f`, rev `e14d3be`, re-pins candle-gen's own gen-core `b6538cb` → `875cf7f`, byte-identical — candle links no sana crate and compiles UNCHANGED). This keeps the `--features backend-candle --target all` skew gate at a **SINGLE** gen-core rev. Verified: `check-gen-core-skew.sh` = one rev (`875cf7f`).

### Dependency + link-forcer
- `mlx-gen-sana` added to the worker macOS dep block (same git rev).
- `use mlx_gen_sana as _;` in `image_jobs.rs` so `register_generators!` registers `sana_1600m` into the gen-core inventory (survives linker GC).

### builtin.models.jsonc entry + mirror id + NOTICE
- `sana_1600m` entry: un-gated `SceneWorks/Sana_1600M_1024px_mlx` MLX mirror (downloads `transformer/ vae/ text_encoder/`; the `text_encoder/` bundles the `SceneWorks/gemma-2-2b-it` TE per the PiD epic — TE weights are **not** duplicated as a separate catalog dep). Dense bf16 (no `mlx.quantize`). NVIDIA non-commercial **NOTICE** carried in `ui.description` + `licenseUrl` (the Krea/Ideogram gated-with-notice re-host precedent; OK to ship un-gated-with-notice).
- `/prompt-guides/sana.md`.

### Provisioning / gen-core contract wiring
- `engines::MODEL_TABLE` row (`sana_1600m`, 20 steps / guidance 4.5, adapter `mlx_sana`) + `MLX_ROUTED_MODELS` + `sana_mlx_eligible` arm (t2i only; `edit_image` rejected).
- The generic `resolve_weights_dir` snapshot path drives `SanaPipeline::from_snapshot` (snapshot root = transformer/vae/text_encoder) — no special case needed (the sd3 pattern).
- **Quant gate:** the MLX-path quant is now gated on `model.supports_quant()` (mirrors the candle lane). SANA is the lone generic-MLX family with `supported_quants: &[]` and a `load` that **rejects** any `spec.quantize`, so it loads dense; every pre-existing MLX family advertises Q4/Q8, so its resolved quant is **byte-identical**.

### Tests run
- `cargo fmt --all -- --check` ✅
- `cargo clippy -p sceneworks-worker -p sceneworks-core --all-targets -- -D warnings` ✅ (default lane)
- `cargo clippy -p sceneworks-worker --no-default-features --features backend-candle --all-targets -- -D warnings` ✅ (candle parity lane)
- `cargo test -p sceneworks-worker` (model-table + new `sana_manifest_entry_gates_correctly`) ✅ and `-p sceneworks-core` (routing) ✅
- `scripts/check-gen-core-skew.sh` ✅ single gen-core rev `875cf7f`
- No rust-api contract types or web TS touched → no contract regen / vitest needed.

### HF upload status
The code is **complete** and wired against `SceneWorks/Sana_1600M_1024px_mlx` regardless of upload state. The actual weight upload (convert the SANA-1.6B diffusers snapshot → MLX `transformer/ vae/ text_encoder/` layout with the gemma TE bundled, strip gating, ship the NVIDIA LICENSE/NOTICE) is **not** attempted in this headless session and is tracked separately.

Companion candle-gen lockstep PR: `SceneWorks/candle-gen` branch `michaeltrefry1818/sc-8489/candle-gen-core-875cf7f`.

Links sc-8489.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
