### PR TITLE
feat(worker): SANA-Sprint catalog wiring + pin bump (sc-8490, Phase B)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -520,7 +520,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -586,7 +586,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -601,7 +601,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -614,7 +614,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -626,7 +626,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -643,7 +643,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -669,7 +669,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -684,7 +684,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -701,7 +701,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -719,7 +719,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -730,7 +730,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -743,7 +743,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -754,7 +754,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -767,7 +767,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=89621997fde1fe45c4966336fc907fd9bdbb7992#89621997fde1fe45c4966336fc907fd9bdbb7992"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -3472,7 +3472,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3485,7 +3485,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
 dependencies = [
  "image",
  "inventory",
@@ -3499,7 +3499,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
 dependencies = [
  "image",
  "inventory",
@@ -3513,7 +3513,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3526,7 +3526,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3537,7 +3537,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3546,7 +3546,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3555,7 +3555,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3568,7 +3568,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3581,7 +3581,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3594,7 +3594,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3606,7 +3606,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3616,7 +3616,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
 dependencies = [
  "image",
  "inventory",
@@ -3629,7 +3629,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
 dependencies = [
  "image",
  "inventory",
@@ -3643,7 +3643,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
 dependencies = [
  "image",
  "inventory",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
 dependencies = [
  "image",
  "inventory",
@@ -3669,7 +3669,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3680,7 +3680,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3692,7 +3692,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3703,7 +3703,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3712,7 +3712,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3721,7 +3721,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3731,7 +3731,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3743,7 +3743,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
 dependencies = [
  "image",
  "inventory",
@@ -3758,7 +3758,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
 dependencies = [
  "image",
  "inventory",
@@ -3772,7 +3772,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3783,7 +3783,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3795,7 +3795,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3806,7 +3806,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
 dependencies = [
  "image",
  "inventory",
@@ -3820,7 +3820,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
 dependencies = [
  "image",
  "inventory",
@@ -5511,7 +5511,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=875cf7f82230408e39e08c59df41dbf73ecc1da1#875cf7f82230408e39e08c59df41dbf73ecc1da1"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
 dependencies = [
  "core-llm",
  "inventory",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0da70db886d0e515baba417651f42cfdbe5c1acf#0da70db886d0e515baba417651f42cfdbe5c1acf"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0da70db886d0e515baba417651f42cfdbe5c1acf#0da70db886d0e515baba417651f42cfdbe5c1acf"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0da70db886d0e515baba417651f42cfdbe5c1acf#0da70db886d0e515baba417651f42cfdbe5c1acf"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0da70db886d0e515baba417651f42cfdbe5c1acf#0da70db886d0e515baba417651f42cfdbe5c1acf"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0da70db886d0e515baba417651f42cfdbe5c1acf#0da70db886d0e515baba417651f42cfdbe5c1acf"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0da70db886d0e515baba417651f42cfdbe5c1acf#0da70db886d0e515baba417651f42cfdbe5c1acf"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -520,7 +520,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0da70db886d0e515baba417651f42cfdbe5c1acf#0da70db886d0e515baba417651f42cfdbe5c1acf"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0da70db886d0e515baba417651f42cfdbe5c1acf#0da70db886d0e515baba417651f42cfdbe5c1acf"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0da70db886d0e515baba417651f42cfdbe5c1acf#0da70db886d0e515baba417651f42cfdbe5c1acf"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0da70db886d0e515baba417651f42cfdbe5c1acf#0da70db886d0e515baba417651f42cfdbe5c1acf"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0da70db886d0e515baba417651f42cfdbe5c1acf#0da70db886d0e515baba417651f42cfdbe5c1acf"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -586,7 +586,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0da70db886d0e515baba417651f42cfdbe5c1acf#0da70db886d0e515baba417651f42cfdbe5c1acf"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -601,7 +601,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0da70db886d0e515baba417651f42cfdbe5c1acf#0da70db886d0e515baba417651f42cfdbe5c1acf"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -614,7 +614,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0da70db886d0e515baba417651f42cfdbe5c1acf#0da70db886d0e515baba417651f42cfdbe5c1acf"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -626,7 +626,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0da70db886d0e515baba417651f42cfdbe5c1acf#0da70db886d0e515baba417651f42cfdbe5c1acf"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -643,7 +643,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0da70db886d0e515baba417651f42cfdbe5c1acf#0da70db886d0e515baba417651f42cfdbe5c1acf"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0da70db886d0e515baba417651f42cfdbe5c1acf#0da70db886d0e515baba417651f42cfdbe5c1acf"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -669,7 +669,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0da70db886d0e515baba417651f42cfdbe5c1acf#0da70db886d0e515baba417651f42cfdbe5c1acf"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -684,7 +684,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0da70db886d0e515baba417651f42cfdbe5c1acf#0da70db886d0e515baba417651f42cfdbe5c1acf"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -701,7 +701,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0da70db886d0e515baba417651f42cfdbe5c1acf#0da70db886d0e515baba417651f42cfdbe5c1acf"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -719,7 +719,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0da70db886d0e515baba417651f42cfdbe5c1acf#0da70db886d0e515baba417651f42cfdbe5c1acf"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -730,7 +730,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0da70db886d0e515baba417651f42cfdbe5c1acf#0da70db886d0e515baba417651f42cfdbe5c1acf"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -743,7 +743,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0da70db886d0e515baba417651f42cfdbe5c1acf#0da70db886d0e515baba417651f42cfdbe5c1acf"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -754,7 +754,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0da70db886d0e515baba417651f42cfdbe5c1acf#0da70db886d0e515baba417651f42cfdbe5c1acf"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -767,7 +767,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d4b159f561215f87095f45752a509bc8a4eb3dea#d4b159f561215f87095f45752a509bc8a4eb3dea"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0da70db886d0e515baba417651f42cfdbe5c1acf#0da70db886d0e515baba417651f42cfdbe5c1acf"
 dependencies = [
  "candle-core",
  "candle-gen",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2640,6 +2640,102 @@
       }
     },
     {
+      "id": "sana_sprint_1600m",
+      // SANA-Sprint 1.6B 1024px (epic 8485 / sc-8490) — NVIDIA's few-step distillation of SANA, ported
+      // natively to mlx-gen (engine id `sana_sprint_1600m`). SAME 1.6B Linear-DiT trunk (ReLU linear
+      // attention + Mix-FFN + NoPE) + gemma-2-2b-it Complex-Human-Instruction (CHI) caption encoder
+      // (SceneWorks/gemma-2-2b-it, reused — NOT duplicated) + 32× DC-AE (f32) decoder as base SANA. The
+      // distillation is CFG-FREE: a guidance scalar is folded into the trunk via a guidance-embedding
+      // (no negative-prompt second pass) and sampled by the SCM (continuous-time consistency / trigflow)
+      // sampler, so it runs in ~2 steps. Native MLX only (mlx-gen-sana, no torch/candle backend) →
+      // macOnly. `adapter` is the asset stamp (mirrors mlx_<family>). Worker routing through
+      // engines::MODEL_TABLE / the gen_core registry + the MLX_ROUTED_MODELS gate (jobs_store.rs) lands in
+      // this story (sc-8490 Phase B).
+      //
+      // NVIDIA non-commercial: SANA-Sprint is distributed under the NVIDIA Open Model License / NSCLv1
+      // (research & evaluation, non-commercial). The re-hosted `SceneWorks/Sana_Sprint_1.6B_1024px_mlx`
+      // mirror carries the upstream LICENSE + NOTICE + attribution (the Krea/Ideogram re-host precedent —
+      // OK to ship gated-with-notice). SceneWorks's overall non-commercial posture covers this;
+      // generations are for non-commercial use only.
+      "autoDownload": false,
+      "name": "SANA-Sprint 1.6B",
+      "family": "sana",
+      "type": "image",
+      "adapter": "mlx_sana",
+      "capabilities": ["text_to_image"],
+      "macOnly": true,
+      "downloads": [
+        {
+          // Pre-converted MLX snapshot on the SceneWorks HF org (sc-8490): ONE
+          // `SanaPipeline::new_sprint`-loadable root — `transformer/` (the Linear-DiT trunk, Sprint
+          // weights), `vae/` (the 32× DC-AE f32 decoder), and `text_encoder/` (the gemma-2-2b-it CHI
+          // caption encoder — `gemma-2-2b-it.safetensors` + `tokenizer.json`, sourced from the
+          // SceneWorks/gemma-2-2b-it mirror so the TE weights are NOT duplicated as a separate catalog
+          // dependency). Un-gated (the mirror carries the NVIDIA non-commercial NOTICE). Dense bf16 (no
+          // quant subdir). estimatedSizeBytes is a PLACEHOLDER (the 1.6B DiT + ~2.6B gemma TE + DC-AE)
+          // refined once the real pull is measured.
+          "provider": "huggingface",
+          "repo": "SceneWorks/Sana_Sprint_1.6B_1024px_mlx",
+          "files": ["transformer/*", "vae/*", "text_encoder/*"],
+          "platforms": ["macos"],
+          "estimatedSizeBytes": 9500000000
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/SceneWorks/Sana_Sprint_1.6B_1024px_mlx"
+      },
+      "defaults": {
+        // SANA-Sprint reference defaults: the SCM few-step loop (continuous-time consistency), 2 steps,
+        // CFG-free (the guidance scalar is a trunk embedding, not a true-CFG second pass — so no negative
+        // prompt). The flow-match time-shift carries over as the orthogonal schedulerShift knob (epic
+        // 7114).
+        "resolution": "1024x1024",
+        "steps": 2,
+        "guidanceScale": 4.5,
+        "count": 1,
+        "sampler": "default",
+        "scheduler": "default",
+        "schedulerShift": 3.0
+      },
+      "limits": {
+        // 32× DC-AE divisor → W×H must be multiples of 32 (descriptor RES_MULTIPLE). Native 1024².
+        // Sprint's native loop is the SCM few-step sampler ("default"); the curated flow menu still
+        // resolves the unified-framework knobs (epic 7114). The engines.rs drift guard checks this list
+        // is a subset of the descriptor's curated_sampler_names()/curated_scheduler_names().
+        "resolutions": ["1024x1024", "1152x896", "896x1152", "1216x832", "832x1216"],
+        "count": [1, 2, 4],
+        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+        "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
+      },
+      "loraCompatibility": {
+        // No SANA LoRA wired yet (the engine descriptor reports supports_lora: false). Family reserved
+        // for when/if adapters are added.
+        "families": ["sana"],
+        "types": []
+      },
+      "mlx": {
+        // Dense bf16 snapshot (no runtime quant — the 2-bit SANA quant is NOT ported). minMemoryGb 24:
+        // the 1.6B Linear-DiT trunk + the ~2.6B gemma TE + DC-AE decode, a comfortably small footprint.
+        "minMemoryGb": 24,
+        "repo": "SceneWorks/Sana_Sprint_1.6B_1024px_mlx"
+      },
+      "licenseUrl": "https://huggingface.co/Efficient-Large-Model/Sana_Sprint_1.6B_1024px",
+      "ui": {
+        "label": "SANA-Sprint 1.6B",
+        "description": "NVIDIA SANA-Sprint 1.6B — the few-step distillation of SANA, ported natively to MLX (Apple Silicon only). The same 1.6B linear-attention transformer (deep compression 32× DC-AE autoencoder + a gemma-2 instruction text encoder) as base SANA, distilled for ~2-step CFG-free generation via a continuous-time consistency (SCM) sampler and a guidance-embedding trunk — so it generates a 1024×1024 image in a couple of steps with no negative prompt. Dense bf16 (no quantization). Distributed under the NVIDIA Open Model License (non-commercial): generations are for non-commercial / research use only. The SceneWorks mirror is un-gated and carries the upstream license + notice. Runs comfortably on a 24 GB-class Mac.",
+        "recommendedFor": ["text_to_image"],
+        "promptGuide": {
+          "title": "SANA Prompt Guide",
+          "path": "/prompt-guides/sana.md",
+          "sources": [
+            { "label": "SANA-Sprint model card (NVIDIA)", "url": "https://huggingface.co/Efficient-Large-Model/Sana_Sprint_1.6B_1024px" },
+            { "label": "SANA project page", "url": "https://nvlabs.github.io/Sana/" },
+            { "label": "SANA-Sprint paper (few-step distillation)", "url": "https://arxiv.org/abs/2503.09641" }
+          ]
+        }
+      }
+    },
+    {
       "id": "sdxl",
       "recommended": true,
       "name": "Stable Diffusion XL",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3640,6 +3640,11 @@ const MLX_ROUTED_MODELS: &[&str] = &[
     // (no torch backend). True-CFG text-to-image only (20 steps / guidance 4.5); `edit_image` has no
     // source/reference path, so it's rejected (mirrors Krea/SD3.5/Lens).
     "sana_1600m",
+    // SANA-Sprint 1.6B (epic 8485 / sc-8490): the CFG-free few-step (default 2-step, SCM sampler +
+    // guidance-embed trunk) SANA distillation — same `mlx-gen-sana` engine (adapter `mlx_sana`) over the
+    // un-gated `SceneWorks/Sana_Sprint_1.6B_1024px_mlx` MLX snapshot. macOS-only (no torch backend).
+    // Text-to-image only; `edit_image` has no source/reference path, so it's rejected (mirrors base SANA).
+    "sana_sprint_1600m",
 ];
 
 /// Epic 3018 routing — does this image job belong on the in-process Rust MLX
@@ -3704,7 +3709,7 @@ fn image_request_mlx_eligible(model: &str, payload: &Map<String, Value>) -> bool
         "boogu_image" | "boogu_image_turbo" | "boogu_image_edit" => boogu_mlx_eligible(payload),
         "krea_2_turbo" => krea_mlx_eligible(payload),
         "sd3_5_large" | "sd3_5_large_turbo" | "sd3_5_medium" => sd3_5_mlx_eligible(payload),
-        "sana_1600m" => sana_mlx_eligible(payload),
+        "sana_1600m" | "sana_sprint_1600m" => sana_mlx_eligible(payload),
         // Every model in MLX_ROUTED_MODELS must have an arm.
         _ => false,
     }
@@ -5081,8 +5086,9 @@ fn sd3_5_mlx_eligible(payload: &Map<String, Value>) -> bool {
     payload.get("mode").and_then(Value::as_str) != Some("edit_image")
 }
 
-/// SANA 1600M (epic 8485 / sc-8489) MLX-eligibility. The native `mlx-gen-sana` engine serves the
-/// **text-to-image** surface only (true-CFG, 20 steps / guidance 4.5); the base SANA checkpoint has no
+/// SANA 1600M (epic 8485 / sc-8489) + SANA-Sprint (sc-8490) MLX-eligibility. The native `mlx-gen-sana`
+/// engine serves the **text-to-image** surface only — base SANA (true-CFG, 20 steps / guidance 4.5) and
+/// the CFG-free few-step Sprint distillation (default 2 steps) share this gate; neither checkpoint has
 /// img2img/control conditioning, so an `edit_image` request is rejected (the same defensive shape
 /// Krea / SD3.5 / Lens reject). This keeps `model_mac_support`'s `features.edit` false (it probes with
 /// `mode: edit_image`). macOS-only (the catalog flags `macOnly`); off-Mac no `mlx` worker registers so

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -419,7 +419,20 @@ sceneworks-core = { path = "../sceneworks-core" }
 # candle pin below moves `185fe4a0` -> `8962199` IN LOCKSTEP (candle-gen sc-8489: re-pins candle-gen's own
 # gen-core b6538cb -> 875cf7f, byte-identical — candle links no sana crate and compiles UNCHANGED) so
 # `--features backend-candle --target all` resolves the SINGLE gen-core rev 875cf7f.
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
+# Bumped `875cf7f` -> `bdf3233` (epic 8485, sc-8490 Phase B): re-pin to mlx-gen main HEAD to surface the
+# native MLX SANA-**Sprint** few-step model in the worker. bdf3233 = SANA-Sprint Phase A (mlx-gen #617):
+# the SCM (trigflow / continuous-time consistency) sampler + the guidance-embed trunk path +
+# `SanaPipeline::new_sprint` + the in-crate `sana_sprint_1600m` gen-core `Generator` adapter, all ADDED
+# inside the already-linked `mlx-gen-sana` provider crate (no new dep / force-linker needed — the existing
+# `use mlx_gen_sana as _;` already covers Sprint's `register_generators!` registration). `git diff
+# 875cf7f..bdf3233 -- gen-core/ gen-core-testkit/` is EMPTY — gen-core BYTE-IDENTICAL (the range only ADDS
+# Sprint code to the sana provider crate), mlx-rs unchanged (38e1cc1), so the worker's import surface is
+# unchanged and the DEFAULT skew gate stays single-rev/green at bdf3233. The candle pin below moves
+# `8962199` -> `d4b159f` IN LOCKSTEP (candle-gen sc-8490 PR #187: re-pins candle-gen's own gen-core
+# 875cf7f -> bdf3233, byte-identical — candle links no sana crate and compiles UNCHANGED) so
+# `--features backend-candle --target all` resolves the SINGLE gen-core rev bdf3233. (Pins to the
+# candle-gen PR-branch head for now; flip to the squash-merged candle-gen main SHA once #187 lands.)
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -764,7 +777,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -780,23 +793,23 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f8223
 # exactly this rev, so the worker MUST match (a different rev would compile pmetal-mlx-sys twice). This
 # rebuilds MLX from source. Paired with mlx-llm `6c052ba` below (mlx-llm#45 carries the same fork pin).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
 # Krea 2 Turbo (native MLX, Krea 2 Community License; epic 7565, sc-7572). Same git rev as mlx-gen.
 # Self-registers `krea_2_turbo` (Qwen3-VL-4B TE + 28-block single-stream DiT + Qwen-Image VAE; CFG-free
 # rectified-flow few-step) via inventory only when force-linked (`use mlx_gen_krea as _;` in
 # image_jobs.rs). Loads the packed Q8/Q4 turnkey subdir (krea_model_subdir; the loader auto-detects the
 # packed quant, so the resolved `spec.quantize` is a no-op on it). Depends on mlx-gen-qwen-image for the
 # shared `AutoencoderKLQwenImage` VAE.
-mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
+mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
 # Stable Diffusion 3.5 provider (native MLX, Stability AI Community License; epic 7841, sc-7871). Same
 # git rev as mlx-gen so MLX builds once. Self-registers `sd3_5_large` (true-CFG, 28 steps / guidance 3.5)
 # + `sd3_5_large_turbo` (ADD-distilled few-step, CFG-off) + `sd3_5_medium` (MMDiT-X, true-CFG, 40 steps /
@@ -804,7 +817,7 @@ mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7
 # (`use mlx_gen_sd3 as _;` in image_jobs.rs). All three carry a `sd3_5_*_quant` converter. Reuses the SDXL
 # CLIP encoder (×2), the FLUX T5-XXL encoder, and the Z-Image 16-ch VAE — its `quantize_sd3_dir` converter
 # is wired in model_jobs.rs for the `sd3_5_{large,large_turbo,medium}_quant` install-time conversions.
-mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
+mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
 # SANA 1600M provider (native MLX, NVIDIA non-commercial license; epic 8485, sc-8489). Same git rev as
 # mlx-gen so MLX builds once. Self-registers `sana_1600m` (Image/t2i, true-CFG, 32× DC-AE divisor,
 # mac_only) via `register_generators!` into the gen-core inventory — surfaces only when force-linked
@@ -812,59 +825,59 @@ mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f
 # conditioning (sc-8488); the `SanaPipeline` composes SanaTextEncoder -> SanaTransformer (Linear DiT) ->
 # DC-AE f32 decoder and exposes the `from_snapshot`/`from_weights` weight-load entrypoints the generic
 # generator-cache load path drives.
-mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
+mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
 # CLIP ViT-L/14 image embedder for the Dataset Doctor analysis job (epic 6529 P2, sc-6535).
 # Self-registers `clip_vit_l14` (gen_core::ImageEmbedder) via inventory only when force-linked
 # (`use mlx_gen_clip as _;` in dataset_analysis_jobs.rs). Reuses mlx-gen-sdxl's CLIP body → same rev.
-mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
+mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -873,19 +886,19 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
 # Depth Anything V2 (DINOv2 ViT-S/14 + DPT) native-MLX monocular depth estimator (epic 8236,
 # sc-8242). A plain utility crate (NOT a self-registering generation provider): an arbitrary RGB
 # image → a normalized single-channel depth control image, the AUTO depth source for the
 # Fun-Controlnet-Union depth tier (`ControlKind::Depth`) — sibling of the CPU canny/pose
 # preprocessors, but neural so it is macOS-gated (MLX). Consumed by the worker `depth` module /
 # the shared strict-control driver (sc-8243). Same mlx-rs pin as every other mlx-gen crate.
-mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
+mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -894,7 +907,7 @@ mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -902,7 +915,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -913,7 +926,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875c
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -924,7 +937,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -946,7 +959,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7
 # a Metal large-tensor limit, not precision). New `VAE_SAFE_DECODE_EDGE_PX=1536` forces decode tiling on
 # a CORRECTNESS cap independent of the memory budget (image + video), so a 2048² upscale that fits memory
 # still tiles. Real-weight 1024→2048 pixel-cosine vs the mflux reference 0.9524 → 0.9974.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -957,7 +970,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
 # The unified LLM engine (epic 7153, sc-7158): the macOS `prompt_refine` job now runs through
 # mlx-llm's generic `mlx-llama` provider (a `core_llm::TextLlm`) resolved model-first via
 # `gen_core::core_llm::load_for_model`, RETIRING the bespoke `mlx-gen-prompt-refine` hand-rolled
@@ -989,7 +1002,7 @@ mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "7041411f395e43
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875cf7f82230408e39e08c59df41dbf73ecc1da1" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -1266,15 +1279,15 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "875c
 # THIS worker's unified lock; gen-core stays e9682318 (== this worker's mlx pin), so the gen-core skew gate
 # still resolves the SINGLE rev e9682318 on `--features backend-candle --target all`. ALL candle-gen-* rev
 # lines move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1282,17 +1295,17 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1302,7 +1315,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1310,21 +1323,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1333,17 +1346,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1352,7 +1365,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1374,7 +1387,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "bf99e5b4
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1383,12 +1396,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1396,7 +1409,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1405,7 +1418,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1413,7 +1426,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1427,7 +1440,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1454,7 +1467,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "89621997fde1fe45c4966336fc907fd9bdbb7992", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -430,8 +430,8 @@ sceneworks-core = { path = "../sceneworks-core" }
 # unchanged and the DEFAULT skew gate stays single-rev/green at bdf3233. The candle pin below moves
 # `8962199` -> `0da70db` IN LOCKSTEP (candle-gen sc-8490 PR #187: re-pins candle-gen's own gen-core
 # 875cf7f -> bdf3233, byte-identical — candle links no sana crate and compiles UNCHANGED) so
-# `--features backend-candle --target all` resolves the SINGLE gen-core rev bdf3233. (Pins to the
-# candle-gen PR-branch head for now; flip to the squash-merged candle-gen main SHA once #187 lands.)
+# `--features backend-candle --target all` resolves the SINGLE gen-core rev bdf3233. (Candle-gen is
+# pinned to the squash-merged candle-gen main SHA 0da70db from PR #187.)
 sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -428,7 +428,7 @@ sceneworks-core = { path = "../sceneworks-core" }
 # 875cf7f..bdf3233 -- gen-core/ gen-core-testkit/` is EMPTY — gen-core BYTE-IDENTICAL (the range only ADDS
 # Sprint code to the sana provider crate), mlx-rs unchanged (38e1cc1), so the worker's import surface is
 # unchanged and the DEFAULT skew gate stays single-rev/green at bdf3233. The candle pin below moves
-# `8962199` -> `d4b159f` IN LOCKSTEP (candle-gen sc-8490 PR #187: re-pins candle-gen's own gen-core
+# `8962199` -> `0da70db` IN LOCKSTEP (candle-gen sc-8490 PR #187: re-pins candle-gen's own gen-core
 # 875cf7f -> bdf3233, byte-identical — candle links no sana crate and compiles UNCHANGED) so
 # `--features backend-candle --target all` resolves the SINGLE gen-core rev bdf3233. (Pins to the
 # candle-gen PR-branch head for now; flip to the squash-merged candle-gen main SHA once #187 lands.)
@@ -1279,15 +1279,15 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3
 # THIS worker's unified lock; gen-core stays e9682318 (== this worker's mlx pin), so the gen-core skew gate
 # still resolves the SINGLE rev e9682318 on `--features backend-candle --target all`. ALL candle-gen-* rev
 # lines move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0da70db886d0e515baba417651f42cfdbe5c1acf", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0da70db886d0e515baba417651f42cfdbe5c1acf", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0da70db886d0e515baba417651f42cfdbe5c1acf", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0da70db886d0e515baba417651f42cfdbe5c1acf", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0da70db886d0e515baba417651f42cfdbe5c1acf", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1295,17 +1295,17 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0da70db886d0e515baba417651f42cfdbe5c1acf", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0da70db886d0e515baba417651f42cfdbe5c1acf", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0da70db886d0e515baba417651f42cfdbe5c1acf", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1315,7 +1315,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0da70db886d0e515baba417651f42cfdbe5c1acf", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1323,21 +1323,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0da70db886d0e515baba417651f42cfdbe5c1acf", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0da70db886d0e515baba417651f42cfdbe5c1acf", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0da70db886d0e515baba417651f42cfdbe5c1acf", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0da70db886d0e515baba417651f42cfdbe5c1acf", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1346,17 +1346,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0da70db886d0e515baba417651f42cfdbe5c1acf", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0da70db886d0e515baba417651f42cfdbe5c1acf", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0da70db886d0e515baba417651f42cfdbe5c1acf", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1365,7 +1365,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0da70db886d0e515baba417651f42cfdbe5c1acf", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1387,7 +1387,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "bf99e5b4
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0da70db886d0e515baba417651f42cfdbe5c1acf", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1396,12 +1396,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0da70db886d0e515baba417651f42cfdbe5c1acf", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0da70db886d0e515baba417651f42cfdbe5c1acf", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1409,7 +1409,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b15
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0da70db886d0e515baba417651f42cfdbe5c1acf", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1418,7 +1418,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0da70db886d0e515baba417651f42cfdbe5c1acf", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1426,7 +1426,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0da70db886d0e515baba417651f42cfdbe5c1acf", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1440,7 +1440,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0da70db886d0e515baba417651f42cfdbe5c1acf", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1467,7 +1467,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d4b159f561215f87095f45752a509bc8a4eb3dea", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0da70db886d0e515baba417651f42cfdbe5c1acf", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -492,6 +492,24 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
         default_guidance: 4.5,
         adapter_label: "mlx_sana",
     },
+    // SANA-Sprint 1.6B 1024px (epic 8485 / sc-8490) — the few-step distillation of SANA over the SAME
+    // Linear-DiT trunk + gemma-2-2b-it CHI encoder + 32× DC-AE decoder, ported natively to mlx-gen (engine
+    // id `sana_sprint_1600m`, registered by `SanaPipeline::new_sprint` via the shared force-link). Sprint
+    // is CFG-FREE: a guidance scalar is folded into the trunk via a guidance-embedding (no negative-prompt
+    // second pass) and sampled by the SCM (continuous-time consistency / trigflow) sampler — so it runs in
+    // ~2 steps (the `sana_sprint_1600m` descriptor advertises NO supports_true_cfg / supports_negative).
+    // Loads the un-gated `SceneWorks/Sana_Sprint_1.6B_1024px_mlx` MLX snapshot (same transformer/ vae/
+    // text_encoder/ layout as base SANA; the text_encoder/ bundles the SceneWorks/gemma-2-2b-it TE so it is
+    // NOT duplicated). Dense bf16 (no quant). 32× DC-AE divisor → width/height multiples of 32. NVIDIA
+    // non-commercial (NSCLv1) — the re-host carries the upstream LICENSE + NOTICE.
+    ModelRow {
+        sceneworks_id: "sana_sprint_1600m",
+        engine_id: "sana_sprint_1600m",
+        default_repo: "SceneWorks/Sana_Sprint_1.6B_1024px_mlx",
+        default_steps: 2,
+        default_guidance: 4.5,
+        adapter_label: "mlx_sana",
+    },
 ];
 
 /// The mlx-gen registry ids of the video generators this worker serves (the engine ids

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -740,6 +740,12 @@ fn model_table_rows_resolve_and_flags_match_descriptor() {
         // SANA 1600M (epic 8485 / sc-8489): true-CFG Linear-DiT — supports_guidance=true +
         // supports_negative_prompt=true (the `sana_1600m` descriptor advertises supports_true_cfg).
         ("sana_1600m", true, true),
+        // SANA-Sprint 1.6B (epic 8485 / sc-8490): the CFG-free few-step distillation — the guidance
+        // scalar is folded into the trunk via a guidance-embedding (supports_guidance=true) but there is
+        // no cond/uncond combine, so the descriptor advertises supports_true_cfg=false +
+        // supports_negative_prompt=false (the distilled-turbo "guidance is an embedding, no negative"
+        // shape; cf. boogu_image_turbo's CFG-free-without-negative pattern).
+        ("sana_sprint_1600m", true, false),
     ];
     // Every row is covered by the expectation table (no row added without a flag pair here).
     assert_eq!(MODEL_TABLE.len(), expected.len());
@@ -959,6 +965,105 @@ fn sana_manifest_entry_gates_correctly() {
     assert!(
         desc.contains("NVIDIA") && desc.to_lowercase().contains("non-commercial"),
         "sana UI description carries the NVIDIA non-commercial notice"
+    );
+}
+
+/// sc-8490: the SANA-Sprint builtin entry gates exactly like base SANA — `sana` family, text_to_image
+/// only (CFG-free few-step distillation, no edit/reference surface), un-gated `SceneWorks/*` MLX
+/// re-host carrying the NVIDIA non-commercial notice, dense bf16 (no mlx.quantize), and the SANA LoRA
+/// family reserved. The few-step default (2 steps) is asserted so a manifest drift to the base 20-step
+/// loop fails CI. Descriptor-derived guidance/negative/backend flags are covered by
+/// `model_table_rows_resolve_and_flags_match_descriptor`.
+#[test]
+fn sana_sprint_manifest_entry_gates_correctly() {
+    use sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS;
+    use sceneworks_core::jsonc::strip_jsonc_comments;
+
+    let raw = BUILTIN_MANIFESTS
+        .iter()
+        .find(|(name, _)| *name == "builtin.models.jsonc")
+        .map(|(_, contents)| *contents)
+        .expect("builtin.models.jsonc present");
+    let manifest: Value =
+        serde_json::from_str(&strip_jsonc_comments(raw)).expect("builtin models parses as JSON");
+    let models = manifest
+        .get("models")
+        .and_then(Value::as_array)
+        .expect("models array");
+    let entry = models
+        .iter()
+        .find(|m| m.get("id").and_then(Value::as_str) == Some("sana_sprint_1600m"))
+        .expect("sana_sprint_1600m present in builtin.models.jsonc");
+
+    assert_eq!(
+        entry.get("family").and_then(Value::as_str),
+        Some("sana"),
+        "sana-sprint family"
+    );
+    // Capability gate: text_to_image ONLY — edit/reference are rejected (Sprint is plain few-step t2i).
+    let caps: Vec<&str> = entry
+        .get("capabilities")
+        .and_then(Value::as_array)
+        .map(|a| a.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_default();
+    assert_eq!(caps, vec!["text_to_image"], "sana-sprint capabilities");
+    // UN-gated SceneWorks/* MLX re-host (the mirror carries the NVIDIA non-commercial NOTICE) — no `gated`.
+    assert_ne!(
+        entry.get("gated").and_then(Value::as_bool),
+        Some(true),
+        "sana-sprint is un-gated (re-host carries the notice)"
+    );
+    let repo = entry
+        .get("downloads")
+        .and_then(Value::as_array)
+        .and_then(|d| d.first())
+        .and_then(|d| d.get("repo"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    assert_eq!(
+        repo, "SceneWorks/Sana_Sprint_1.6B_1024px_mlx",
+        "sana-sprint downloads from the un-gated SceneWorks/* MLX mirror, got {repo:?}"
+    );
+    // Few-step distillation: default steps = 2 (a drift to base SANA's 20-step loop fails here).
+    assert_eq!(
+        entry
+            .get("defaults")
+            .and_then(|d| d.get("steps"))
+            .and_then(Value::as_u64),
+        Some(2),
+        "sana-sprint is a few-step (2-step) distillation"
+    );
+    // Dense bf16: NO `mlx.quantize`.
+    let mlx = entry.get("mlx").expect("sana-sprint mlx block");
+    assert!(
+        mlx.get("quantize").is_none(),
+        "sana-sprint ships dense bf16 — no mlx.quantize"
+    );
+    assert!(
+        mlx.get("minMemoryGb").and_then(Value::as_u64).is_some(),
+        "sana-sprint mlx.minMemoryGb present"
+    );
+    // sana LoRA family declared (reserved; no SANA LoRA wired yet).
+    let lora_families: Vec<&str> = entry
+        .get("loraCompatibility")
+        .and_then(|c| c.get("families"))
+        .and_then(Value::as_array)
+        .map(|a| a.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_default();
+    assert_eq!(
+        lora_families,
+        vec!["sana"],
+        "sana-sprint loraCompatibility.families"
+    );
+    // NVIDIA non-commercial notice surfaced in the UI description (the gated-with-notice carrier).
+    let desc = entry
+        .get("ui")
+        .and_then(|u| u.get("description"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    assert!(
+        desc.contains("NVIDIA") && desc.to_lowercase().contains("non-commercial"),
+        "sana-sprint UI description carries the NVIDIA non-commercial notice"
     );
 }
 


### PR DESCRIPTION
## Summary
Phase B of sc-8490 (SANA-Sprint): SceneWorks-side catalog wiring + the mlx-gen/candle-gen pin bump that surfaces the native-MLX **SANA-Sprint** few-step model in the worker. SANA-Sprint Phase A (the engine) is already on mlx-gen main (HEAD `bdf3233`).

## Pin bumps
- **mlx-gen** `875cf7f` -> `bdf3233` (main HEAD). bdf3233 = SANA-Sprint Phase A (#617): the SCM (continuous-time consistency / trigflow) sampler + the guidance-embed trunk path + `SanaPipeline::new_sprint` + the in-crate `sana_sprint_1600m` gen-core `Generator` adapter, **all added inside the already-linked `mlx-gen-sana` crate** — so no new worker dependency or force-linker is needed (the existing `use mlx_gen_sana as _;` already covers Sprint's `register_generators!` registration). `git diff 875cf7f..bdf3233 -- gen-core/` is **EMPTY** (gen-core byte-identical).
- **candle-gen** `8962199` -> `d4b159f` **IN LOCKSTEP** (companion candle-gen PR **https://github.com/SceneWorks/candle-gen/pull/187** re-pins candle-gen's own gen-core 875cf7f -> bdf3233, byte-identical). Keeps the worker's `--features backend-candle --target all` gen-core skew gate on a **single** gen-core rev (`bdf3233`).
  - Pinned to the candle-gen PR-branch head for now; the coordinator re-pins to the squash-merged candle-gen main SHA after #187 merges.
- All ~30 mlx-gen + ~25 candle-gen dep entries bumped consistently across `crates/sceneworks-worker/Cargo.toml` + root `Cargo.lock`; no `875cf7f` / `8962199` rev remnant on any dep line (historical bump comments preserved).

## Catalog wiring
- **builtin.models.jsonc** — new `sana_sprint_1600m` entry mirroring `sana_1600m`: un-gated `SceneWorks/Sana_Sprint_1.6B_1024px_mlx` MLX mirror (same `transformer/` `vae/` `text_encoder/` layout; the `text_encoder/` bundles the SceneWorks/gemma-2-2b-it TE so it is **not** duplicated), `capabilities: ["text_to_image"]`, `macOnly`, dense bf16 (no `mlx.quantize`), **few-step default (2 steps), CFG-free**, NVIDIA non-commercial (NSCLv1) NOTICE carried in the UI description.
- **engines.rs MODEL_TABLE** — `sana_sprint_1600m` row (engine id `sana_sprint_1600m`, adapter `mlx_sana`, 2 steps / guidance 4.5).
- **jobs_store.rs** — added to `MLX_ROUTED_MODELS`, the dispatch `match` arm (`"sana_1600m" | "sana_sprint_1600m" => sana_mlx_eligible`), sharing base SANA's eligibility gate (text-to-image only; `edit_image` rejected).

## Tests
- `sana_sprint_manifest_entry_gates_correctly` — family `sana`, capabilities text_to_image only, un-gated, repo `SceneWorks/Sana_Sprint_1.6B_1024px_mlx`, NVIDIA non-commercial notice, dense bf16, **2-step few-step default**, LoRA family reserved.
- `model_table_rows_resolve_and_flags_match_descriptor` — extended with `("sana_sprint_1600m", true, false)`: the row resolves through the gen-core registry with `supports_guidance=true` + `supports_negative_prompt=false` (the CFG-free embedded-guidance shape; no cond/uncond combine).

## Checks (all green)
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- worker tests (sana manifest + descriptor-flag-drift) + `sceneworks-core` tests
- candle parity lane: `cargo check -p sceneworks-worker --no-default-features --features backend-candle --all-targets`
- `scripts/check-gen-core-skew.sh` → "OK: exactly one sceneworks-gen-core … bdf3233"
- No contract types or web touched → rust-api regen / vitest not required.

## HF mirror
`SceneWorks/Sana_Sprint_1.6B_1024px_mlx` is wired in the catalog; the actual MLX-snapshot upload is a separate provisioning step (no creds attempted here).

Companion candle-gen PR: https://github.com/SceneWorks/candle-gen/pull/187

Refs sc-8490.

🤖 Generated with [Claude Code](https://claude.com/claude-code)