### PR TITLE
fix(worker): restrict sana_sprint_1600m manifest menu to descriptor-honored set (sc-8490)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2699,13 +2699,15 @@
       },
       "limits": {
         // 32× DC-AE divisor → W×H must be multiples of 32 (descriptor RES_MULTIPLE). Native 1024².
-        // Sprint's native loop is the SCM few-step sampler ("default"); the curated flow menu still
-        // resolves the unified-framework knobs (epic 7114). The engines.rs drift guard checks this list
-        // is a subset of the descriptor's curated_sampler_names()/curated_scheduler_names().
+        // Sprint's native loop is the SCM/TrigFlow few-step consistency sampler — a DEDICATED loop, NOT
+        // a curated epic-7114 `Solver`. Unlike base SANA, the Sprint descriptor (`sprint_descriptor()`
+        // in mlx-gen-sana) advertises ONLY the engine-default sentinel for both axes (and NO guidance
+        // methods — CFG-free embedded-scalar guidance). The engines.rs drift guard requires this list to
+        // be a SUBSET of the descriptor's honored set, so it must be exactly ["default"].
         "resolutions": ["1024x1024", "1152x896", "896x1152", "1216x832", "832x1216"],
         "count": [1, 2, 4],
-        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
-        "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
+        "samplers": ["default"],
+        "schedulers": ["default"]
       },
       "loraCompatibility": {
         // No SANA LoRA wired yet (the engine descriptor reports supports_lora: false). Family reserved


### PR DESCRIPTION
## Regression

The `nax-worker` CI lane (`macos-mlx.yml` → "Worker tests incl. the NAX 16-bit SDPA guard", i.e. `cargo test -p sceneworks-worker`) went **RED on main** after #990 (sc-8490 Phase B, commit `63b5985`) surfaced the SANA-Sprint model.

`engines::tests::manifest_menu_is_subset_of_descriptor` panicked with 15 violations:

```
sana_sprint_1600m: mlx samplers "euler","euler_ancestral","heun","dpmpp_2m","dpmpp_sde","uni_pc","lcm","ddim" not honored (advertised: ["default"])
sana_sprint_1600m: mlx schedulers "normal","simple","karras","exponential","sgm_uniform","beta","ddim_uniform" not honored (advertised: ["default"])
```

## Root cause

The new `sana_sprint_1600m` builtin.models entry copied **base SANA**'s full unified-flow (epic 7114) sampler/scheduler menu. But SANA-Sprint is a CFG-free **SCM/TrigFlow few-step** distillation: its gen-core descriptor (`sprint_descriptor()` in `mlx-gen-sana`, pinned rev `bdf3233`) advertises a **dedicated** loop, honoring only the engine-default sentinel — `samplers: ["default"]`, `schedulers: ["default"]`, `supported_guidance_methods: []`.

The `manifest_menu_is_subset_of_descriptor` drift guard requires the manifest's advertised menu to be a **subset** of what the engine descriptor honors, so the entry advertising 15 extra names reddened the lane.

## Fix

Pure manifest-data fix: restrict the `sana_sprint_1600m` `limits.samplers`/`limits.schedulers` to exactly `["default"]`, matching `sprint_descriptor()`. (No guidance methods were advertised, so the guidance axis is already correct.) Everything else about the entry is intact.

Base `sana_1600m` is **untouched** — its descriptor legitimately honors the full curated flow menu.

The test was neither weakened nor skipped.

## Verification

- Reproduced the exact 15-violation failure on the pre-fix manifest, then confirmed `manifest_menu_is_subset_of_descriptor` passes after the fix (`cargo test -p sceneworks-worker`, default features → MLX backend, macOS — same as the nax-worker lane).
- Full `cargo test -p sceneworks-worker`: 471 + 1 passed, 0 failed.

This un-reds the `nax-worker` lane on main.

Relates to sc-8490 (epic 8485).

🤖 Generated with [Claude Code](https://claude.com/claude-code)