### PR TITLE
fix(catalog): add missing model dependencies so Model Manager can install them (sc-8613)

### DIFF
--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -9789,25 +9789,38 @@ fn builtin_manifest_registers_the_wan_vace_fun_model() {
         "expose only the validated VACE mode"
     );
 
-    // Download = the diffusers conversion (loadable), never the raw VideoX-Fun upstream.
-    let download = model["downloads"]
-        .as_array()
-        .and_then(|downloads| downloads.first())
-        .expect("a download entry");
-    assert_eq!(download["provider"], "huggingface");
-    assert_eq!(download["repo"], "linoyts/Wan2.2-VACE-Fun-14B-diffusers");
-    assert_ne!(
-        download["repo"], "alibaba-pai/Wan2.2-VACE-Fun-A14B",
-        "must not point at the raw VideoX-Fun repo (it does not load via diffusers/native)"
+    // Per-platform download split (sc-8613): macOS pulls the native MLX VACE-Fun checkpoint;
+    // Windows/Linux pull the DIFFERENT candle Wan2.1-VACE-14B diffusers tree the candle `wan_vace`
+    // provider reads (CANDLE_WAN_VACE_REPO). Both are diffusers-loadable conversions, never the raw
+    // VideoX-Fun upstream. Every OS must have exactly one install path.
+    let downloads = model["downloads"].as_array().expect("downloads array");
+    let download_for = |os: &str| {
+        downloads
+            .iter()
+            .find(|download| {
+                download["platforms"]
+                    .as_array()
+                    .map(|platforms| platforms.iter().any(|p| p.as_str() == Some(os)))
+                    .unwrap_or(false)
+            })
+            .unwrap_or_else(|| panic!("a download covering {os}"))
+    };
+    let macos = download_for("macos");
+    assert_eq!(macos["provider"], "huggingface");
+    assert_eq!(macos["repo"], "linoyts/Wan2.2-VACE-Fun-14B-diffusers");
+    let windows = download_for("windows");
+    assert_eq!(windows["repo"], "Wan-AI/Wan2.1-VACE-14B-diffusers");
+    assert_eq!(
+        download_for("linux")["repo"],
+        "Wan-AI/Wan2.1-VACE-14B-diffusers",
+        "Linux rides the same candle checkpoint as Windows"
     );
-    let platforms: Vec<&str> = download["platforms"]
-        .as_array()
-        .expect("platforms array")
-        .iter()
-        .filter_map(Value::as_str)
-        .collect();
-    for os in ["macos", "windows", "linux"] {
-        assert!(platforms.contains(&os), "download should cover {os}");
+    for download in downloads {
+        assert_eq!(download["provider"], "huggingface");
+        assert_ne!(
+            download["repo"], "alibaba-pai/Wan2.2-VACE-Fun-A14B",
+            "must not point at the raw VideoX-Fun repo (it does not load via diffusers/native)"
+        );
     }
 
     // Native-only: an MLX block, and NO Torch GGUF quantization variants.

--- a/apps/web/public/prompt-guides/clip-vit-l14.md
+++ b/apps/web/public/prompt-guides/clip-vit-l14.md
@@ -1,0 +1,13 @@
+# CLIP ViT-L/14 (image embedder)
+
+CLIP ViT-L/14 is OpenAI's image encoder. SceneWorks uses it as a small utility dependency — **it does not generate images or video, and there is nothing to prompt.** Dataset Doctor embeds each training image with it to measure dataset quality: near-duplicate detection, diversity/coverage, and caption↔image alignment.
+
+## Installation
+
+The native worker (MLX on macOS, candle on Windows/CUDA) resolves this model from the shared Hugging Face cache and does **not** auto-download it. Install it once from the **Models** screen; it downloads into the shared Hugging Face cache, so other tools reuse it.
+
+If Dataset Doctor reports that the "CLIP embedder model path snapshot is not cached," this is the model to install.
+
+## Practical Notes
+
+There are no settings — the embedder runs automatically as part of dataset analysis. Once it is installed, re-run the dataset analysis and the embedding-based findings (duplicates, diversity, alignment) will populate.

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1556,6 +1556,66 @@
       }
     },
     {
+      "id": "krea_2_raw",
+      // Krea 2 Raw (epic 7565 P3, sc-8613) — the UNDISTILLED 12B single-stream DiT that Krea 2 LoRAs
+      // train on; the trained adapter applies back at Krea 2 Turbo inference by family match (the Lens /
+      // Z-Image train-on-base → infer-on-Turbo pattern). This is a training-base DEPENDENCY, not an
+      // inference model: there is no `krea_2_raw` generator (only `krea_2_turbo` is routed), so it is
+      // `utility` (empty capabilities) and never appears in the Image Studio picker. The id MUST equal
+      // the training target's `base_model` (`krea_2_raw`, core training.rs) — the Training UI matches
+      // the base by `item.id === target.baseModel` (TrainingStudio.jsx) and offers this for download
+      // when it's missing.
+      //
+      // Cataloging it lets Model Manager install the base into the HF cache the trainer reads via
+      // `training_base_model_installed` (apps/rust-api training.rs) — closing the "Base model
+      // 'krea_2_raw' is not installed. Install it from the model catalog" dead-end (the bare repo was
+      // never catalogued, unlike every other trainable family's base). macOS-gated for now: `krea_lora`
+      // is MLX-only today (CANDLE_ROUTED_TRAINING_KERNELS excludes it; MLX_ONLY_TRAINING_KERNELS includes
+      // it), so the windows/linux `krea/Krea-2-Raw` download + candle trainer routing land with sc-8614.
+      // Ungated public diffusers tree, Krea 2 Community License (non-commercial).
+      "autoDownload": false,
+      "name": "Krea 2 Raw (LoRA training base)",
+      "family": "krea_2",
+      "type": "utility",
+      "adapter": "mlx_krea",
+      "capabilities": [],
+      "downloads": [
+        {
+          "provider": "huggingface",
+          "repo": "krea/Krea-2-Raw",
+          "files": [],
+          "platforms": ["macos"],
+          "estimatedSizeBytes": 40000000000
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/krea/Krea-2-Raw"
+      },
+      "defaults": {},
+      "limits": {},
+      "loraCompatibility": {
+        // A LoRA trained here records `family: krea_2` / `baseModel: krea_2_raw` and applies at Krea 2
+        // Turbo inference (family match, no base-model gating — lora_family.rs). Mirrors the Krea 2 Turbo
+        // entry's `families: [krea_2]`.
+        "families": ["krea_2"],
+        "types": ["character", "style"]
+      },
+      "licenseUrl": "https://www.krea.ai/krea-2-licensing",
+      "ui": {
+        "label": "Krea 2 Raw (training base)",
+        "description": "Undistilled Krea 2 12B DiT — the LoRA training base for Krea 2 (epic 7565). Train a LoRA here and it applies at Krea 2 Turbo inference; this is not a generation model itself. Native MLX (Apple Silicon) training only today (~40 GB download). Krea 2 Community License (non-commercial).",
+        "recommendedFor": [],
+        "promptGuide": {
+          "title": "Krea 2 Prompt Guide",
+          "path": "/prompt-guides/krea-2.md",
+          "sources": [
+            { "label": "Krea 2 (Hugging Face)", "url": "https://huggingface.co/krea" },
+            { "label": "Krea 2 Raw model card", "url": "https://huggingface.co/krea/Krea-2-Raw" }
+          ]
+        }
+      }
+    },
+    {
       "id": "flux2_klein_9b",
       "name": "FLUX.2 [klein] 9B",
       "family": "flux2-klein",
@@ -3781,11 +3841,27 @@
       "capabilities": ["replace_person"],
       "downloads": [
         {
+          // macOS: the native MLX dual-expert VACE-Fun checkpoint (mlx-gen-wan "wan2_2_vace_fun_14b").
           "provider": "huggingface",
           "repo": "linoyts/Wan2.2-VACE-Fun-14B-diffusers",
           "files": [],
-          "platforms": ["macos", "windows", "linux"],
+          "platforms": ["macos"],
           "estimatedSizeBytes": 81200000000
+        },
+        {
+          // Windows/Linux candle (sc-8613): the candle `wan_vace` provider serves replace_person off a
+          // DIFFERENT, single-expert checkpoint — `Wan-AI/Wan2.1-VACE-14B-diffusers` (transformer/ +
+          // text_encoder/ + vae/ + tokenizer/), matching the provider's `WanVaceConfig::vace_14b` dims
+          // (dim 5120, 40 layers). The candle worker resolves this repo by string from the HF cache
+          // (`CANDLE_WAN_VACE_REPO`, video_jobs.rs; overridable via SCENEWORKS_CANDLE_WAN_VACE_DIR),
+          // independent of `paths.model`. Without this entry the off-Mac VACE lane dead-ended with no
+          // way to install the snapshot. Per-OS `install_state` reads the retained download's repo
+          // (models.rs), so macOS still resolves the MLX checkpoint above.
+          "provider": "huggingface",
+          "repo": "Wan-AI/Wan2.1-VACE-14B-diffusers",
+          "files": [],
+          "platforms": ["windows", "linux"],
+          "estimatedSizeBytes": 50000000000
         }
       ],
       "paths": {
@@ -4385,6 +4461,48 @@
             { "label": "JoyCaption project (GitHub)", "url": "https://github.com/fpgaminer/joycaption" }
           ]
         }
+      }
+    },
+    {
+      // CLIP ViT-L/14 image embedder (sc-8613) — the canonical OpenAI CLIP encoder the Dataset Doctor
+      // CLIP analysis (`dataset_analysis` job, epic 6529) uses for image embeddings (near-duplicate
+      // clustering, diversity/coverage, aesthetic, caption↔image alignment). The native worker resolves
+      // it by REPO STRING (`dataset_analysis_jobs::CLIP_EMBEDDER_MODEL`) via
+      // `resolve_app_managed_model_dir` → `huggingface_snapshot_dir`, which only RESOLVES an
+      // already-cached snapshot (no auto-download — the JoyCaption seam). Without a catalog entry the
+      // job dead-ended with "CLIP embedder model path snapshot is not cached for
+      // openai/clip-vit-large-patch14" and no UI to install it. Cataloging it lets Model Manager pull
+      // the snapshot into the HF cache the worker reads. (Also the encoder the macOS FLUX.1 IP-Adapter
+      // image path resolves — `resolve_flux_ip_adapter_dir` — so this entry serves both consumers.)
+      // Runs on macOS (MLX) and Windows/CUDA (candle) — not platform-gated. Stock repo pulled as-is.
+      "id": "clip_vit_l14",
+      "autoDownload": false,
+      "name": "CLIP ViT-L/14 (image embedder)",
+      "family": "clip",
+      "type": "utility",
+      "adapter": "clip",
+      "capabilities": [],
+      "downloads": [
+        {
+          "provider": "huggingface",
+          "repo": "openai/clip-vit-large-patch14",
+          "files": [],
+          "estimatedSizeBytes": 7000000000
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/openai/clip-vit-large-patch14"
+      },
+      "defaults": {},
+      "limits": {},
+      "loraCompatibility": {
+        "families": [],
+        "types": []
+      },
+      "ui": {
+        "label": "CLIP ViT-L/14 (image embedder)",
+        "description": "OpenAI CLIP ViT-L/14 image encoder used by Dataset Doctor to embed training-dataset images for near-duplicate, diversity, and caption-alignment analysis. A small utility dependency — not a generation model. Runs in-process on the native worker (MLX on macOS, candle on Windows/CUDA).",
+        "recommendedFor": ["dataset_analysis"]
       }
     },
     {

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -4502,7 +4502,14 @@
       "ui": {
         "label": "CLIP ViT-L/14 (image embedder)",
         "description": "OpenAI CLIP ViT-L/14 image encoder used by Dataset Doctor to embed training-dataset images for near-duplicate, diversity, and caption-alignment analysis. A small utility dependency — not a generation model. Runs in-process on the native worker (MLX on macOS, candle on Windows/CUDA).",
-        "recommendedFor": ["dataset_analysis"]
+        "recommendedFor": ["dataset_analysis"],
+        "promptGuide": {
+          "title": "CLIP ViT-L/14 (image embedder)",
+          "path": "/prompt-guides/clip-vit-l14.md",
+          "sources": [
+            { "label": "openai/clip-vit-large-patch14 model card", "url": "https://huggingface.co/openai/clip-vit-large-patch14" }
+          ]
+        }
       }
     },
     {


### PR DESCRIPTION
## Problem

Several features resolve a model by Hugging Face repo string through a **cache-only resolver** (`resolve_app_managed_model_dir` / `huggingface_snapshot_dir` / `candle_video_snapshot_dir` / `training_base_model_installed`) — these only *resolve an already-installed* snapshot; they do **not** auto-download. The model must therefore be in `config/manifests/builtin.models.jsonc` so the Model Manager can install it. Three models were referenced but **not catalogued**, dead-ending the feature with no UI path to install the dependency. Two were user-reported; the third was found in the same audit.

| Model | Feature | Resolver | Error |
|---|---|---|---|
| `openai/clip-vit-large-patch14` | Dataset Doctor CLIP analysis (`dataset_analysis`); also macOS FLUX IP-Adapter encoder | `resolve_app_managed_model_dir` (`dataset_analysis_jobs.rs:25,98`) | "CLIP embedder model path snapshot is not cached for openai/clip-vit-large-patch14." |
| `krea/Krea-2-Raw` | Krea 2 LoRA training base (`krea_2_raw_lora`, `training.rs:1236`) | `training_base_model_installed` (`training.rs:1481`) | "Base model 'krea_2_raw' is not installed. Install it from the model catalog…" |
| `Wan-AI/Wan2.1-VACE-14B-diffusers` | off-Mac **candle** Wan-VACE `replace_person` (sc-5494) | `resolve_candle_wan_vace_model_dir` (`CANDLE_WAN_VACE_REPO`, `video_jobs.rs:2946`) | candle video snapshot not found |

Every *other* trainable family's base repo is catalogued (z-image/lens/sdxl/kolors/sd3.5/wan/ltx) — Krea Raw was the lone miss.

## Change (additive, manifest-only)

1. **CLIP** — new `type: "utility"` entry `clip_vit_l14` → `openai/clip-vit-large-patch14` (whole repo). Mirrors the JoyCaption utility entry.
2. **Krea 2 Raw** — new `type: "utility"` entry with **`id: "krea_2_raw"`** (must equal `target.baseModel`; the Training UI matches the base by `item.id === target.baseModel`, `TrainingStudio.jsx:499`) → `krea/Krea-2-Raw`, `loraCompatibility.families: ["krea_2"]`, **macOS-gated** (off-Mac Krea training isn't wired yet — see follow-up).
3. **candle Wan2.1-VACE-14B** — split the existing `wan_2_2_vace_fun_14b` download by platform: MLX `linoyts/Wan2.2-VACE-Fun-14B-diffusers` → `["macos"]`; new candle `Wan-AI/Wan2.1-VACE-14B-diffusers` → `["windows","linux"]` (the `krea_2_turbo` two-download pattern). The candle worker resolves the repo from the HF cache independently of `paths.model`; per-OS `install_state` reads the retained download repo (`models.rs:1004`).

## Validation

- JSONC parses (string-aware `//` strip + strict JSON, mirroring `serde_json`); all three entries present with correct repos/platforms; no duplicate ids (56 models total).
- The `engines.rs` sampler/scheduler **drift guard skips** these entries (no engine descriptor for utility ids — `engines.rs:935`); no catalog-count snapshot test exists.
- `estimatedSizeBytes` are conservative fallbacks; the live HF size query overrides them.

## Follow-up

[sc-8614](https://app.shortcut.com/trefry/story/8614) — wire the off-Mac **candle Krea LoRA trainer** into routing. `krea_lora` is currently MLX-only (`CANDLE_ROUTED_TRAINING_KERNELS` excludes it; `MLX_ONLY_TRAINING_KERNELS` includes it), so a Windows/Linux user still can't train Krea even with the base installed. That story also adds the windows/linux `krea/Krea-2-Raw` download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)