### PR TITLE
chore(catalog): real SANA mirror sizes in builtin.models (sc-8604, sc-8607)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2635,13 +2635,13 @@
           // SceneWorks/gemma-2-2b-it mirror so the TE weights are NOT duplicated as a separate
           // catalog dependency). Un-gated (the mirror carries the NVIDIA non-commercial NOTICE).
           // Dense bf16 (no quant subdir — the 2-bit SANA quant is intentionally NOT ported).
-          // estimatedSizeBytes is a PLACEHOLDER (the 1.6B DiT + ~2.6B gemma TE + DC-AE) refined once
-          // the real pull is measured.
+          // estimatedSizeBytes is the measured mirror total (transformer F16 3.21GB + DC-AE F32
+          // 1.25GB + merged gemma-2-2b-it TE BF16 5.23GB + license/notice), sc-8604.
           "provider": "huggingface",
           "repo": "SceneWorks/Sana_1600M_1024px_mlx",
           "files": ["transformer/*", "vae/*", "text_encoder/*"],
           "platforms": ["macos"],
-          "estimatedSizeBytes": 9500000000
+          "estimatedSizeBytes": 9704269924
         }
       ],
       "paths": {
@@ -2732,13 +2732,13 @@
           // caption encoder — `gemma-2-2b-it.safetensors` + `tokenizer.json`, sourced from the
           // SceneWorks/gemma-2-2b-it mirror so the TE weights are NOT duplicated as a separate catalog
           // dependency). Un-gated (the mirror carries the NVIDIA non-commercial NOTICE). Dense bf16 (no
-          // quant subdir). estimatedSizeBytes is a PLACEHOLDER (the 1.6B DiT + ~2.6B gemma TE + DC-AE)
-          // refined once the real pull is measured.
+          // quant subdir). estimatedSizeBytes is the measured mirror total (transformer BF16 3.22GB +
+          // DC-AE F32 1.25GB + merged gemma-2-2b-it TE BF16 5.23GB + license/notice), sc-8607.
           "provider": "huggingface",
           "repo": "SceneWorks/Sana_Sprint_1.6B_1024px_mlx",
           "files": ["transformer/*", "vae/*", "text_encoder/*"],
           "platforms": ["macos"],
-          "estimatedSizeBytes": 9500000000
+          "estimatedSizeBytes": 9715830101
         }
       ],
       "paths": {


### PR DESCRIPTION
## What

The `sana_1600m` and `sana_sprint_1600m` catalog entries shipped with a
placeholder `estimatedSizeBytes` (9,500,000,000) pending the real mirror pull.
The SANA MLX mirrors have now been provisioned on the SceneWorks HF org, so this
sets the measured totals:

| Entry | Mirror | estimatedSizeBytes |
|---|---|---|
| `sana_1600m` | `SceneWorks/Sana_1600M_1024px_mlx` | 9,704,269,924 |
| `sana_sprint_1600m` | `SceneWorks/Sana_Sprint_1.6B_1024px_mlx` | 9,715,830,101 |

Each mirror = transformer safetensors (base F16 ~3.21GB / Sprint BF16 ~3.22GB) +
DC-AE f32c32 VAE (F32, 1.25GB) + the bundled gemma-2-2b-it CHI text encoder
(BF16, 5.23GB, merged single-file from `SceneWorks/gemma-2-2b-it`). Both mirrors
are public + un-gated (`gated: false`) and carry the NVIDIA Open Model License +
NOTICE. `minMemoryGb` (24) was a deliberate value and is unchanged.

## Provisioning + validation (this PR is just the size refresh)

- Mirrors built as a dtype-preserving repackage of the gated NVIDIA diffusers
  checkpoints into the `SanaPipeline::from_snapshot` layout (`transformer/`,
  `vae/`, `text_encoder/`). The base transformer needed a header-level key rename
  (`pos_embed`→`patch_embed`, `adaln_single`→`time_embed`, `ff.*_conv.conv`→
  `ff.conv_*`); Sprint needed only the `ff` rename. No torch/diffusers, no dtype
  cast.
- Validated on Apple Silicon by running the previously-`#[ignore]`d real-weight
  e2e tests in `mlx-gen-sana` against the local snapshots:
  `real_weight_1024_e2e` (base) and `real_weight_sprint_1024_e2e` (Sprint) both
  pass — real 1024² generations, finite + non-degenerate output.

## Note

This change touches only `config/manifests/`, so the macos-mlx CI lane won't
auto-trigger (tracked as sc-8617); the coordinator will validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)