### PR TITLE
feat: wire off-Mac candle Krea LoRA trainer end-to-end (sc-8614)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -254,3 +254,6 @@ __marimo__/
 
 # macOS
 .DS_Store
+
+# Local Windows build convenience script (loads vcvars + NVCC_CCBIN, runs tauri build)
+build.bat

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1569,9 +1569,11 @@
       // Cataloging it lets Model Manager install the base into the HF cache the trainer reads via
       // `training_base_model_installed` (apps/rust-api training.rs) — closing the "Base model
       // 'krea_2_raw' is not installed. Install it from the model catalog" dead-end (the bare repo was
-      // never catalogued, unlike every other trainable family's base). macOS-gated for now: `krea_lora`
-      // is MLX-only today (CANDLE_ROUTED_TRAINING_KERNELS excludes it; MLX_ONLY_TRAINING_KERNELS includes
-      // it), so the windows/linux `krea/Krea-2-Raw` download + candle trainer routing land with sc-8614.
+      // never catalogued, unlike every other trainable family's base). Cross-platform as of sc-8614:
+      // `krea_lora` now also routes to the candle (Windows/Linux CUDA) trainer
+      // (CANDLE_ROUTED_TRAINING_KERNELS includes it; MLX_ONLY_TRAINING_KERNELS keeps it off torch), and
+      // BOTH the MLX and candle trainers read the same `krea/Krea-2-Raw` diffusers tree — so a single
+      // whole-repo download serves every platform (no MLX-turnkey vs candle split like Krea 2 Turbo).
       // Ungated public diffusers tree, Krea 2 Community License (non-commercial).
       "autoDownload": false,
       "name": "Krea 2 Raw (LoRA training base)",
@@ -1584,7 +1586,7 @@
           "provider": "huggingface",
           "repo": "krea/Krea-2-Raw",
           "files": [],
-          "platforms": ["macos"],
+          "platforms": ["macos", "windows", "linux"],
           "estimatedSizeBytes": 40000000000
         }
       ],
@@ -1603,7 +1605,7 @@
       "licenseUrl": "https://www.krea.ai/krea-2-licensing",
       "ui": {
         "label": "Krea 2 Raw (training base)",
-        "description": "Undistilled Krea 2 12B DiT — the LoRA training base for Krea 2 (epic 7565). Train a LoRA here and it applies at Krea 2 Turbo inference; this is not a generation model itself. Native MLX (Apple Silicon) training only today (~40 GB download). Krea 2 Community License (non-commercial).",
+        "description": "Undistilled Krea 2 12B DiT — the LoRA training base for Krea 2 (epic 7565). Train a LoRA here and it applies at Krea 2 Turbo inference; this is not a generation model itself. Trains on Apple Silicon (native MLX) or Windows/Linux NVIDIA (candle/CUDA) (~40 GB download). Krea 2 Community License (non-commercial).",
         "recommendedFor": [],
         "promptGuide": {
           "title": "Krea 2 Prompt Guide",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -5305,12 +5305,15 @@ fn training_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
 
 /// SceneWorks training kernels with a native candle trainer that needs no base-model disambiguation
 /// (sc-7817, epic 5164) — the off-Mac twin of [`MLX_ROUTED_TRAINING_KERNELS`]. The candle registry
-/// holds trainers for `sdxl`, `z_image_turbo`, `lens`, and the Wan **A14B T2V** MoE
-/// (`wan2_2_t2v_14b`); the first three map straight from kernel, while `wan_moe_lora` is base-model
-/// gated (handled in [`training_job_is_candle_eligible`]). The dense Wan 5B + the I2V A14B have no
-/// candle trainer yet (sc-5167 follow-ups) and Kolors/LTX none at all — those kernels stay on the
-/// Python torch worker off-Mac.
-const CANDLE_ROUTED_TRAINING_KERNELS: &[&str] = &["z_image_lora", "sdxl_lora", "lens_lora"];
+/// holds trainers for `sdxl`, `z_image_turbo`, `lens`, `krea_2_raw` (the Krea 2 Raw 12B DiT, epic
+/// 7565 P4 — sc-8614 wires it here), and the Wan **A14B T2V** MoE (`wan2_2_t2v_14b`); the first four
+/// map straight from kernel, while `wan_moe_lora` is base-model gated (handled in
+/// [`training_job_is_candle_eligible`]). UNLIKE the torch families (z-image/sdxl/lens/wan), Krea has
+/// NO torch trainer — it is in BOTH this set and [`MLX_ONLY_TRAINING_KERNELS`] (Rust-only: mlx OR
+/// candle, never torch). The dense Wan 5B + the I2V A14B have no candle trainer yet (sc-5167
+/// follow-ups) and Kolors/LTX none at all — those kernels stay on the Python torch worker off-Mac.
+const CANDLE_ROUTED_TRAINING_KERNELS: &[&str] =
+    &["z_image_lora", "sdxl_lora", "lens_lora", "krea_lora"];
 
 /// Epic 5164 / sc-7817 routing — does this `lora_train` job belong on the candle (Windows/CUDA +
 /// Linux/NVIDIA) worker (vs the Python torch worker)? The training sibling of
@@ -5436,16 +5439,18 @@ fn video_upscale_job_is_candle_eligible(job: &JobSnapshot) -> bool {
     video_upscale_job_is_mlx_eligible(job)
 }
 
-/// Training kernels with NO non-Rust fallback — only the in-process Rust mlx worker
-/// can run them. `ltx_mlx_lora` was Apple-Silicon-only MLX-Python; epic 3039 (sc-3049)
-/// retired that Python trainer, leaving the native Rust LTX trainer as the sole path,
-/// so a non-mlx worker must refuse the job (leaving it queued for the mlx worker)
-/// rather than claim it and fail with "no training kernel". The torch families
-/// (z-image/sdxl/wan) keep their Python trainer as the Windows path + Mac fallback, so
-/// they are deliberately NOT listed here. `krea_lora` (epic 7565 P3) is MLX-native with
-/// no torch trainer — like LTX — so it is listed here (the candle Krea trainer is sc P4).
-/// `sd3_lora` (epic 7841 T3 sc-7884) is likewise MLX-native with no torch trainer — the
-/// off-Mac/candle SD3.5 trainer is epic 7982 — so it is listed here too.
+/// Training kernels with NO **torch** fallback — only a Rust worker can run them, so a torch worker
+/// must refuse the job (leaving it queued for a Rust worker) rather than claim it and fail with "no
+/// training kernel". `ltx_mlx_lora` was Apple-Silicon-only MLX-Python; epic 3039 (sc-3049) retired
+/// that Python trainer, leaving the native Rust LTX trainer as the sole path. The torch families
+/// (z-image/sdxl/wan) keep their Python trainer as the Windows path + Mac fallback, so they are
+/// deliberately NOT listed here. `krea_lora` (epic 7565) is Rust-native with no torch trainer — but
+/// UNLIKE LTX/SD3 it now ALSO has a candle trainer (sc-8614, P4), so it is the one member that runs
+/// on EITHER Rust backend (mlx in-process on Mac, candle off-Mac); the [`worker_supports_job`] gate
+/// exempts a candle worker for a `krea_lora` job it is candle-eligible for (it is also in
+/// [`CANDLE_ROUTED_TRAINING_KERNELS`]), while torch is still refused. `sd3_lora` (epic 7841 T3
+/// sc-7884) is MLX-native with no torch trainer and no candle trainer yet (the off-Mac/candle SD3.5
+/// trainer is epic 7982), so — like LTX — only an mlx worker runs it today.
 const MLX_ONLY_TRAINING_KERNELS: &[&str] = &["ltx_mlx_lora", "krea_lora", "sd3_lora"];
 
 /// Whether this `lora_train` job targets a kernel with no non-Rust fallback (see
@@ -5482,9 +5487,15 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
         return false;
     }
     // Epic 3039 (sc-3049): a training kernel with no torch fallback (the retired Python
-    // MLX LTX trainer) runs only on the mlx worker — a non-mlx worker must refuse it
-    // (leaving it queued for the mlx worker) instead of claiming it and failing.
-    if !worker.gpu_id.eq_ignore_ascii_case("mlx") && training_kernel_is_mlx_only(job) {
+    // MLX LTX trainer) runs only on a Rust worker — a non-mlx worker must refuse it
+    // (leaving it queued for the mlx worker) instead of claiming it and failing. The
+    // exception (sc-8614): `krea_lora` is no-torch-fallback AND has a candle trainer, so a
+    // candle worker it is candle-eligible for must NOT be refused here (the candle training
+    // gate below admits it); only torch (and any non-candle non-mlx worker) still defers.
+    if !worker.gpu_id.eq_ignore_ascii_case("mlx")
+        && training_kernel_is_mlx_only(job)
+        && !(worker_is_candle(worker) && training_job_is_candle_eligible(job))
+    {
         return false;
     }
     // Epic 3018/3041 + sc-3036: the in-process MLX worker (gpu_id "mlx") serves a fixed

--- a/crates/sceneworks-core/src/training.rs
+++ b/crates/sceneworks-core/src/training.rs
@@ -1214,11 +1214,13 @@ fn lens_turbo_lora_target() -> TrainingTarget {
 /// time by **family match, no base-model gating** (`lora_family.rs` gates only `wan-video`). The
 /// Turbo manifest declares `loraCompatibility.families: [krea_2]`.
 ///
-/// Native MLX, **Apple-Silicon only**: the `krea_lora` kernel runs the in-process `mlx-gen-krea`
-/// Rust trainer (a functional-autograd flow-match velocity loop on the single-stream DiT). There is
-/// no torch Krea trainer, so — like the LTX MLX video target — the job has no non-Rust fallback
-/// (`MLX_ONLY_TRAINING_KERNELS` keeps it queued for the mlx worker) and the target is Mac-gated in
-/// the UI via `MacTrainingSupport::supported_kernels`.
+/// Rust-native, **no torch trainer** — but NOT Apple-Silicon-only (sc-8614): the `krea_lora` kernel
+/// runs the in-process `mlx-gen-krea` trainer on Apple Silicon AND the `candle-gen-krea` trainer on
+/// Windows/Linux NVIDIA (a functional-autograd flow-match velocity loop on the single-stream DiT).
+/// There is no torch path, so `MLX_ONLY_TRAINING_KERNELS` keeps it off the torch worker while
+/// `CANDLE_ROUTED_TRAINING_KERNELS` admits it on candle. The `appleSiliconOnly`/`requiresBackend`
+/// mlx-only markers are therefore omitted (matching the candle-capable z-image/lens targets);
+/// `MacTrainingSupport::supported_kernels` already lists `krea_lora` and is inert off-Mac.
 ///
 /// `base_model_repo` points the plan's `baseModelPath` at the ungated public `krea/Krea-2-Raw`
 /// diffusers tree (Krea 2 Community License), independent of the served `krea_2_turbo` model. The
@@ -1278,9 +1280,7 @@ fn krea_raw_lora_target() -> TrainingTarget {
                 "sampleGuidanceScale": 3.5,
                 "qualityPreset": "balanced",
                 "outputScope": "project",
-                "requestedGpu": "auto",
-                // Native MLX trainer (surfaced for the UI; Apple-Silicon only).
-                "backend": "mlx"
+                "requestedGpu": "auto"
             })),
             extra: ExtraFields::new(),
         },
@@ -1296,17 +1296,14 @@ fn krea_raw_lora_target() -> TrainingTarget {
             "networkTypes": ["lora", "lokr"],
             "lrSchedulers": ["constant", "linear", "cosine"],
             "qualityPresets": ["speed", "balanced", "quality"],
-            "outputScopes": ["project", "global"],
-            // Native MLX trainer — no torch Krea path (mirrors the LTX MLX target).
-            "requiresBackend": "mlx",
-            "appleSiliconOnly": true
+            "outputScopes": ["project", "global"]
+            // No `requiresBackend`/`appleSiliconOnly` markers: a Rust trainer runs on BOTH backends
+            // (mlx on Apple Silicon, candle on Windows/Linux NVIDIA — sc-8614), no torch path.
         })),
         ui: object(json!({
             "label": "Krea 2 LoRA",
-            "description": "Train an image LoRA for Krea 2 (Qwen3-VL-4B text encoder + Qwen-Image VAE). Trains on the undistilled Krea 2 Raw base and applies to Krea 2 Turbo. Apple Silicon only (native MLX).",
+            "description": "Train an image LoRA for Krea 2 (Qwen3-VL-4B text encoder + Qwen-Image VAE). Trains on the undistilled Krea 2 Raw base and applies to Krea 2 Turbo. Apple Silicon (native MLX) or Windows/Linux NVIDIA (candle/CUDA).",
             "recommendedFor": ["character", "style"],
-            "appleSiliconOnly": true,
-            "backend": "mlx",
             "datasetModality": "image"
         })),
         extra: ExtraFields::new(),

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -3689,12 +3689,15 @@ fn candle_training_caps() -> Vec<WorkerCapability> {
 
 #[test]
 fn candle_worker_claims_candle_native_training_kernels() {
-    // The four families with a candle trainer (sdxl / z_image / lens / Wan A14B T2V) route to the
-    // candle worker off-Mac. Each in its own store so the claim is unambiguous.
+    // The five families with a candle trainer (sdxl / z_image / lens / Krea 2 Raw / Wan A14B T2V)
+    // route to the candle worker off-Mac. `krea_lora` is no-torch-fallback (MLX_ONLY) yet candle
+    // claims it (sc-8614) — the gate exempts a candle-eligible job from the mlx-only refusal. Each in
+    // its own store so the claim is unambiguous.
     let cases: &[(&str, &str, &str)] = &[
         ("sdxl_lora", "sdxl", "lora"),
         ("z_image_lora", "z_image_turbo", "lokr"),
         ("lens_lora", "lens", "lora"),
+        ("krea_lora", "krea_2_raw", "lokr"),
         ("wan_moe_lora", "wan_2_2_t2v_14b", "lora"),
     ];
     for (kernel, base_model, network_type) in cases {
@@ -3815,11 +3818,41 @@ fn ltx_training_is_mlx_worker_only_with_no_torch_fallback() {
 }
 
 #[test]
-fn krea_training_is_mlx_worker_only_with_no_torch_fallback() {
-    let store = store("mlx-training-krea-only");
-    // Krea 2 (epic 7565 P3, sc-7578) trains on the native `mlx-gen-krea` trainer and has no
-    // torch path, so — like LTX — a torch worker must NOT claim a `krea_lora` job; it stays
-    // queued for the mlx worker (the candle Krea trainer is the separate P4 path).
+fn krea_training_has_no_torch_fallback_but_runs_on_either_rust_backend() {
+    let store = store("training-krea-no-torch");
+    // Krea 2 (epic 7565) trains on a native Rust trainer and has NO torch path, so — like LTX — a
+    // torch worker must NOT claim a `krea_lora` job. UNLIKE LTX it is Rust-only on BOTH backends:
+    // the mlx worker (Mac) and, since sc-8614, the candle worker (off-Mac) each run it.
+    register_gpu_worker(&store, "worker-torch", "mps", training_caps());
+    let job = store
+        .create_job(mlx_training_job(
+            "krea_lora",
+            "krea_2_raw",
+            "lora",
+            false,
+            "auto",
+        ))
+        .expect("job creates");
+
+    // Torch defers (no Krea torch trainer).
+    assert!(store
+        .claim_next_job("worker-torch")
+        .expect("torch claim ok")
+        .is_none());
+
+    // The candle worker claims it off-Mac (sc-8614): no-torch-fallback no longer means mlx-only.
+    register_gpu_worker(&store, "worker-candle", "0", candle_training_caps());
+    let claimed = store
+        .claim_next_job("worker-candle")
+        .expect("candle claim ok")
+        .expect("candle claims the Krea training job");
+    assert_eq!(claimed.id, job.id);
+}
+
+#[test]
+fn krea_training_runs_on_the_mlx_worker() {
+    let store = store("mlx-training-krea");
+    // On Mac the mlx worker is Krea's home (the off-Mac candle path is covered separately).
     register_gpu_worker(&store, "worker-torch", "mps", training_caps());
     let job = store
         .create_job(mlx_training_job(
@@ -3836,7 +3869,6 @@ fn krea_training_is_mlx_worker_only_with_no_torch_fallback() {
         .expect("torch claim ok")
         .is_none());
 
-    // The mlx worker is the only home for it.
     register_gpu_worker(&store, "worker-mlx", "mlx", training_caps());
     let claimed = store
         .claim_next_job("worker-mlx")

--- a/crates/sceneworks-core/tests/training_contracts.rs
+++ b/crates/sceneworks-core/tests/training_contracts.rs
@@ -299,9 +299,10 @@ fn builtin_registry_exposes_kolors_target() {
 
 #[test]
 fn builtin_registry_exposes_krea_target() {
-    // Krea 2 (epic 7565 P3) trains on the undistilled `krea/Krea-2-Raw` 12B single-stream
-    // DiT via the native `mlx-gen-krea` `krea_lora` kernel and applies at Krea 2 Turbo
-    // inference (family `krea_2`, no base-model gating). Native MLX, Apple-Silicon only.
+    // Krea 2 (epic 7565) trains on the undistilled `krea/Krea-2-Raw` 12B single-stream
+    // DiT via the `krea_lora` kernel and applies at Krea 2 Turbo inference (family `krea_2`,
+    // no base-model gating). Rust-native on BOTH backends — mlx (Apple Silicon) + candle
+    // (Windows/Linux NVIDIA, sc-8614) — no torch path.
     let registry = builtin_training_targets();
     let target = registry
         .targets
@@ -327,11 +328,11 @@ fn builtin_registry_exposes_krea_target() {
         target.limits.get("networkTypes"),
         Some(&serde_json::json!(["lora", "lokr"]))
     );
-    // No torch Krea trainer — Apple-Silicon/MLX-only, like the LTX video target.
-    assert_eq!(
-        target.limits.get("appleSiliconOnly"),
-        Some(&serde_json::Value::Bool(true))
-    );
+    // No torch Krea trainer, but Rust-native on BOTH backends (mlx + candle, sc-8614) — so it is
+    // NOT Apple-Silicon-only: the `appleSiliconOnly`/`requiresBackend` mlx-only markers are gone
+    // (matching the candle-capable z-image/lens targets; routing is enforced by the worker tables).
+    assert_eq!(target.limits.get("appleSiliconOnly"), None);
+    assert_eq!(target.limits.get("requiresBackend"), None);
 }
 
 #[test]

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -18,10 +18,11 @@
 //! sc-7884 (engine trainer sc-7883/7885), native-MLX/Apple-Silicon only. The dry-run validator is
 //! cross-platform. The real run executes in-process on the macOS
 //! MLX engine OR — the off-Mac cutover (sc-7817, epic 5164) — on the candle Windows/CUDA + Linux
-//! engine, for the four families with a candle trainer (`sdxl`/`z_image_turbo`/`lens`/the Wan A14B
-//! **T2V** `wan2_2_t2v_14b`). The Python torch trainer stays the fallback for everything off-Mac
-//! with no candle trainer (Kolors, LTX, the dense Wan 5B, the Wan I2V A14B) and the cross-platform
-//! default until candle is the default off-Mac worker.
+//! engine, for the five families with a candle trainer (`sdxl`/`z_image_turbo`/`lens`/the Krea 2 Raw
+//! 12B DiT `krea_2_raw` (sc-8614)/the Wan A14B **T2V** `wan2_2_t2v_14b`). The Python torch trainer
+//! has no Krea path at all (Krea is Rust-only — mlx or candle); it stays the fallback for everything
+//! else off-Mac with no candle trainer (Kolors, LTX, the dense Wan 5B, the Wan I2V A14B) and the
+//! cross-platform default until candle is the default off-Mac worker.
 
 use super::*;
 use sceneworks_core::training::{TrainingPlan, TRAINING_PLAN_VERSION};
@@ -63,12 +64,15 @@ use mlx_gen_z_image as _;
 // training cutover (sc-7817, epic 5164). Each self-registers a `backend = "candle"` `Trainer` into
 // the SAME gen_core registry the mlx crates use, so `gen_core::load_trainer(id, …)` resolves the
 // candle trainer by id with no candle-specific dispatch (exactly like the inference path). These
-// four crates are already linked for inference under `backend-candle`; the trainer `inventory::
+// crates are already linked for inference under `backend-candle`; the trainer `inventory::
 // submit!` is NOT behind a separate feature, so re-stating the dependency here is purely explicit.
-// Only the four families with a candle trainer are anchored: `sdxl`, `z_image_turbo`, `lens`, and
-// the Wan **A14B T2V** MoE (`wan2_2_t2v_14b`). The dense Wan 5B + the I2V A14B have no candle
-// trainer yet (sc-5167 follow-ups) and Kolors/LTX none at all — those kernels stay on the Python
-// torch worker off-Mac (`jobs_store::training_job_is_candle_eligible` keeps them from routing here).
+// Only the five families with a candle trainer are anchored: `sdxl`, `z_image_turbo`, `lens`, the
+// Krea 2 Raw 12B DiT (`krea_2_raw`, epic 7565 P4 — sc-8614), and the Wan **A14B T2V** MoE
+// (`wan2_2_t2v_14b`). The dense Wan 5B + the I2V A14B have no candle trainer yet (sc-5167
+// follow-ups) and Kolors/LTX none at all — those kernels stay on the Python torch worker off-Mac
+// (`jobs_store::training_job_is_candle_eligible` keeps them from routing here).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+use candle_gen_krea as _;
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_lens as _;
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
@@ -511,13 +515,17 @@ fn map_training_config(config: &sceneworks_core::training::TrainingConfig) -> Tr
 /// got checkpointing in sc-5246, and the Wan A14B trainer needs it too). Scoped to exactly the
 /// candle-trainable big-DiT families: Z-Image and the Wan A14B **T2V** MoE — the same set
 /// `jobs_store::training_job_is_candle_eligible` gates the MoE to (only `wan_2_2_t2v_14b` has a candle
-/// trainer; the I2V A14B / dense 5B stay on torch). SDXL's smaller U-Net fits a dense backward (the
-/// `candle_sdxl_real_weights` smoke trains it with checkpointing off) and Lens is small, so neither is
-/// forced — both honor the plan's value.
+/// trainer; the I2V A14B / dense 5B stay on torch). Krea 2 Raw is a 12B DiT (epic 7565 P4, sc-8614) —
+/// the same dense-backward OOM class, so it is forced too (the sc-7900 big-DiT backstop). SDXL's
+/// smaller U-Net fits a dense backward (the `candle_sdxl_real_weights` smoke trains it with
+/// checkpointing off) and Lens is small, so neither is forced — both honor the plan's value.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 fn candle_requires_gradient_checkpointing(plan: &TrainingPlan) -> bool {
     match plan.target.kernel.as_str() {
         "z_image_lora" => true,
+        // Krea 2 Raw is a 12B DiT — a dense backward materializes ~another model of frozen-weight
+        // grads on candle and OOMs, so force checkpointing on (sc-8614 / sc-7900 backstop).
+        "krea_lora" => true,
         "wan_moe_lora" => plan.target.base_model == "wan_2_2_t2v_14b",
         _ => false,
     }
@@ -529,7 +537,7 @@ fn candle_requires_gradient_checkpointing(plan: &TrainingPlan) -> bool {
 /// cross-platform "Gradient Checkpointing" UI box ON, but the user can turn it OFF — harmless on the
 /// macOS MLX path (bf16 alone fits) yet a guaranteed OOM on candle for these families — and a thin /
 /// legacy submit that omits the key leaves the worker's `map_training_config` default (`false`) in
-/// force. Forcing it here makes a real off-Mac Z-Image / Wan A14B-T2V run impossible to configure
+/// force. Forcing it here makes a real off-Mac Z-Image / Krea Raw / Wan A14B-T2V run impossible to configure
 /// into a dense-backward OOM. On macOS this is the identity (the MLX path tolerates a dense bf16
 /// backward), so the mapped config passes through unchanged.
 #[cfg(target_os = "macos")]
@@ -2297,7 +2305,7 @@ mod tests {
     ///
     /// `gradient_checkpointing` matters per-family on candle: UNLIKE MLX/torch, candle's matmul
     /// backward materializes a gradient for the FROZEN base weight too, so a dense backward over a
-    /// multi-billion-param DiT (Z-Image, Wan) OOMs even at 512² on a 96 GB card — checkpointing
+    /// multi-billion-param DiT (Z-Image, Krea Raw 12B, Wan) OOMs even at 512² on a 96 GB card — checkpointing
     /// (sc-5246) recomputes activations and avoids retaining those frozen-weight grads. SDXL's smaller
     /// U-Net fits dense; Z-Image needs checkpointing on. (A real training job carries this from its
     /// preset; the smoke sets it explicitly per family.)
@@ -2473,5 +2481,28 @@ mod tests {
     fn candle_lens_real_weights_trains_a_lora_step() {
         let snapshot = candle_hf_snapshot("models--microsoft--Lens", "transformer");
         candle_real_weights_smoke("lens", &snapshot, 64, true, "candle_lens_smoke.safetensors");
+    }
+
+    /// sc-8614 — the candle Krea 2 training smoke. Loads `load_trainer("krea_2_raw", …)` from the
+    /// installed `krea/Krea-2-Raw` diffusers snapshot (`transformer/ text_encoder/ vae/`) and trains
+    /// two LoRA micro-steps at 256² with **gradient checkpointing ON** — REQUIRED on candle: the Raw
+    /// 12B DiT's dense backward OOMs because candle materializes a grad for the frozen base weight too
+    /// (the Z-Image/Wan-14B finding). The adapter records `family: krea_2` and applies at Krea 2 Turbo
+    /// inference (family match, no base-model gating). Needs the `krea/Krea-2-Raw` base model
+    /// installed (the sibling catalog story sc-8613 ships the off-Mac download). Run on demand on the
+    /// RTX box (one smoke per GPU):
+    /// `cargo test -p sceneworks-worker --lib --features backend-candle -- --ignored candle_krea_real_weights --nocapture`.
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    #[test]
+    #[ignore = "needs real krea/Krea-2-Raw weights + a CUDA device; run one smoke per GPU (12B DiT)"]
+    fn candle_krea_real_weights_trains_a_lora_step() {
+        let snapshot = candle_hf_snapshot("models--krea--Krea-2-Raw", "transformer");
+        candle_real_weights_smoke(
+            "krea_2_raw",
+            &snapshot,
+            256,
+            true,
+            "candle_krea_smoke.safetensors",
+        );
     }
 }

--- a/tests/fixtures/rust_migration_contracts/training/preset-registry.json
+++ b/tests/fixtures/rust_migration_contracts/training/preset-registry.json
@@ -702,7 +702,6 @@
         "seed": 42,
         "optimizer": "adamw8bit",
         "advanced": {
-          "backend": "mlx",
           "cacheLatents": true,
           "cacheTextEmbeddings": true,
           "gradientCheckpointing": true,
@@ -755,7 +754,6 @@
         "seed": 42,
         "optimizer": "adamw8bit",
         "advanced": {
-          "backend": "mlx",
           "cacheLatents": true,
           "cacheTextEmbeddings": true,
           "gradientCheckpointing": true,
@@ -807,7 +805,6 @@
         "seed": 42,
         "optimizer": "adamw8bit",
         "advanced": {
-          "backend": "mlx",
           "cacheLatents": true,
           "cacheTextEmbeddings": true,
           "gradientCheckpointing": true,

--- a/tests/fixtures/rust_migration_contracts/training/target-registry.json
+++ b/tests/fixtures/rust_migration_contracts/training/target-registry.json
@@ -419,7 +419,6 @@
         "seed": 42,
         "optimizer": "adamw8bit",
         "advanced": {
-          "backend": "mlx",
           "cacheLatents": true,
           "cacheTextEmbeddings": true,
           "gradientCheckpointing": true,
@@ -449,7 +448,6 @@
           1,
           128
         ],
-        "appleSiliconOnly": true,
         "batchSize": [
           1,
           4
@@ -483,7 +481,6 @@
           4,
           128
         ],
-        "requiresBackend": "mlx",
         "resolutions": [
           768,
           1024,
@@ -495,10 +492,8 @@
         ]
       },
       "ui": {
-        "appleSiliconOnly": true,
-        "backend": "mlx",
         "datasetModality": "image",
-        "description": "Train an image LoRA for Krea 2 (Qwen3-VL-4B text encoder + Qwen-Image VAE). Trains on the undistilled Krea 2 Raw base and applies to Krea 2 Turbo. Apple Silicon only (native MLX).",
+        "description": "Train an image LoRA for Krea 2 (Qwen3-VL-4B text encoder + Qwen-Image VAE). Trains on the undistilled Krea 2 Raw base and applies to Krea 2 Turbo. Apple Silicon (native MLX) or Windows/Linux NVIDIA (candle/CUDA).",
         "label": "Krea 2 LoRA",
         "recommendedFor": [
           "character",


### PR DESCRIPTION
## Story
[sc-8614](https://app.shortcut.com/trefry/story/8614) — Wire off-Mac candle Krea LoRA trainer into routing (epic 7565). `krea_lora` was Rust-native but MLX-only, so Windows/Linux could not train Krea. Builds on the sibling catalog story [sc-8613/#992](https://github.com/SceneWorks/SceneWorks/pull/992) which catalogued `krea_2_raw` macOS-only.

## Changes
**Routing (`jobs_store.rs`)**
- Add `krea_lora` to `CANDLE_ROUTED_TRAINING_KERNELS`.
- Exempt a candle worker from the `MLX_ONLY` refusal when the job is candle-eligible; **torch still defers** (Krea has no torch trainer). `MLX_ONLY_TRAINING_KERNELS` now means "no *torch* fallback" — Krea is the first member that runs on **either** Rust backend (mlx on Mac, candle off-Mac).

**Worker (`training_jobs.rs`)**
- Force-link `candle_gen_krea` (the sc-7817 cutover pattern).
- Force gradient checkpointing for `krea_lora` (12B DiT → the sc-7900 big-DiT backstop).
- Add an `#[ignore]`d candle Krea real-weight smoke for GPU-val.

**Catalog (task 4)** — extend the `krea_2_raw` download to `["macos","windows","linux"]`. A single whole-repo `krea/Krea-2-Raw` download serves both the MLX and candle trainers (no MLX-turnkey/candle split like Krea 2 Turbo).

**Training target / UI (task 5)** — drop the `appleSiliconOnly` / `requiresBackend` / `backend` mlx-only markers from the `krea_2_raw_lora` target (now matching the candle-capable z-image/lens targets); description → "Apple Silicon (native MLX) or Windows/Linux NVIDIA (candle/CUDA)". `MacTrainingSupport.supported_kernels` already lists `krea_lora` and is inert off-Mac, so the target is **offered (not stranded) on Windows**. Regenerated target + preset fixtures.

## Verification
- `cargo test -p sceneworks-core` — jobs_store (127) + training_contracts (32) green, incl. new `krea_training_has_no_torch_fallback_but_runs_on_either_rust_backend` and candle-claims (now 5 families).
- `cargo test --no-run -p sceneworks-worker --features backend-candle` — compiles clean (`candle_gen_krea` linked) via VS2022 MSVC 14.44.
- `node scripts/check-scaffold.mjs` — passes.

## Follow-up
**Task 6 (GPU-val)** is the remaining acceptance: train a Krea LoRA on Raw → apply at Krea 2 Turbo on the candle Windows/CUDA lane. Now unblocked (base model is Windows-installable via the catalog change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)