### PR TITLE
ci(macos-mlx): trigger worker lane on manifest-only changes (sc-8617)

### DIFF
--- a/.github/workflows/macos-mlx.yml
+++ b/.github/workflows/macos-mlx.yml
@@ -32,6 +32,12 @@ on:
     paths: &mlx_paths
       - "crates/**"
       - "apps/rust-worker/**"
+      # The builtin model catalog is include_str!'d into the worker (via
+      # sceneworks-core/builtin_manifests.rs) and read by the worker's
+      # `engines::tests::manifest_menu_is_subset_of_descriptor` drift guard, so a
+      # manifest-only edit can turn this suite red — gate on it (matches the
+      # windows-candle.yml / desktop-windows.yml filters). sc-8617.
+      - "config/manifests/**"
       - "Cargo.toml"
       - "Cargo.lock"
       - ".cargo/config.toml"


### PR DESCRIPTION
## Problem (sc-8617)

The **macos-mlx** lane's `paths:` filter (the shared `&mlx_paths` anchor) omitted `config/manifests/**`. The builtin model catalog (`config/manifests/builtin.models.jsonc`) is `include_str!`'d into the worker via `crates/sceneworks-core/src/builtin_manifests.rs`, and the worker test `engines::tests::manifest_menu_is_subset_of_descriptor` asserts against the embedded manifest.

Because the lane didn't watch `config/manifests/**`, a change touching **only** the manifest never triggered the worker test lane that validates it. A manifest regression slipped onto main and had to be caught via manual `workflow_dispatch`.

## Fix

Add `config/manifests/**` to the `&mlx_paths` anchor in `.github/workflows/macos-mlx.yml`. The entry sits inside the anchored list, so the `pull_request` trigger (which uses `*mlx_paths`) inherits it automatically — both push and PR triggers now fire on a manifest-only change. The existing entries are unchanged.

This mirrors the filters already present on `windows-candle.yml` and `desktop-windows.yml`, which gate on `config/manifests/**` for the same reason.

## Audit of other lanes that test/embed the manifest

- **`check.yml` (`parity` lane)** — runs `npm run rust:check` → `cargo test` (whole workspace, includes the worker drift guard). It has **no `paths:` filter** at all, so manifest-only changes already trigger it. No change needed.
- **`windows-candle.yml`** — already lists `config/manifests/**` (with an explanatory comment). No change needed.
- **`desktop-windows.yml`** — already lists `config/manifests/**`. No change needed.
- **`server-candle-linux.yml`** — `workflow_dispatch`-only, no path filter. No change needed.

So `macos-mlx.yml` was the only lane with the gap. CI-config only; no Rust/code changes.

## Lanes that will run on THIS PR (a `.github/workflows`-only change)

- **macos-mlx** — its paths include `.github/workflows/macos-mlx.yml` (the changed file) → runs.
- **Check** (web + parity jobs) — no path filter → runs.
- windows-candle / desktop-windows / server-candle-linux / release — will **not** trigger (their filters key on their own workflow file or are dispatch/tag-only).

Refs sc-8617.

🤖 Generated with [Claude Code](https://claude.com/claude-code)