### PR TITLE
fix(desktop): stop orphaning candle worker children on app close (Windows)

### DIFF
--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -1339,10 +1339,18 @@ pub fn begin_shutdown(app: &AppHandle) -> bool {
         if let Some(child) = mlx_worker {
             let _ = child.kill();
         }
-        // Windows-only (candle is Windows); None elsewhere. The Windows shutdown
-        // path force-kills (no SIGTERM grace above), and the worker also honours the
-        // parent-death watchdog, so this is the belt to that suspenders.
+        // Windows-only (candle is Windows); None elsewhere. The candle `auto` worker
+        // is a supervisor that spawns one child per GPU plus a CPU child;
+        // CommandChild::kill() (TerminateProcess) reaps ONLY the supervisor and
+        // orphans those children — the exact leak that left N worker processes
+        // running after every quit. Tree-kill the whole group by PID instead
+        // (taskkill /T /F, the same reap path `reap_stale_sidecars` uses). The
+        // worker's parent-death watchdog is the belt to this suspenders for the
+        // force-quit/crash path that skips this teardown entirely.
         if let Some(child) = candle_worker {
+            #[cfg(windows)]
+            kill_pid(child.pid());
+            #[cfg(not(windows))]
             let _ = child.kill();
         }
         if let Some(child) = api_child {

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -477,24 +477,24 @@ pub async fn run_worker() -> Result<(), Box<dyn std::error::Error>> {
             "SceneWorks Rust worker defaulting HF_HOME"
         );
     }
-    #[cfg(unix)]
-    {
-        tokio::select! {
-            result = sceneworks_worker::run() => result?,
-            _ = parent_death(parent_pid_to_watch()) => {
-                tracing::info!(
-                    event = "worker_parent_gone",
-                    "SceneWorks Rust worker: watched parent process gone, exiting"
-                );
-            }
+    // Race the worker against the parent-death watchdog on every platform. The
+    // desktop sets SCENEWORKS_PARENT_PID to its own PID; a force-quit/crash skips
+    // the shell's graceful teardown, and a graceful quit on Windows TerminateProcess-
+    // kills only the `auto` supervisor — never its per-GPU/CPU children. Without this
+    // watchdog those children orphan, holding multi-GB CUDA contexts and a jobs.db
+    // handle until the next launch reaps them (and the reap only knows the supervisor
+    // PID, so the children accumulated unbounded). Unset (server/Docker) -> the
+    // watchdog future stays pending and never fires.
+    tokio::select! {
+        result = sceneworks_worker::run() => result?,
+        _ = parent_death(parent_pid_to_watch()) => {
+            tracing::info!(
+                event = "worker_parent_gone",
+                "SceneWorks Rust worker: watched parent process gone, exiting"
+            );
         }
-        Ok(())
     }
-    #[cfg(not(unix))]
-    {
-        sceneworks_worker::run().await?;
-        Ok(())
-    }
+    Ok(())
 }
 
 /// Spawns the utility worker loop ([`sceneworks_worker::run_worker_loop`]) as a
@@ -560,14 +560,12 @@ impl InProcessUtilityWorker {
 }
 
 /// Poll cadence for the parent-death watchdog (see [`shutdown_signal`]).
-#[cfg(unix)]
 const PARENT_POLL_INTERVAL: Duration = Duration::from_secs(3);
 
 /// The parent PID this process should watch, parsed from `SCENEWORKS_PARENT_PID`.
 /// `None` when the var is unset/blank/unparseable or `<= 1`: a value of 0 or 1
 /// (init/launchd) means "already reparented or no real parent", so the watchdog
 /// must not fire. Server/Docker deployments leave the var unset.
-#[cfg(unix)]
 fn parent_pid_to_watch() -> Option<i32> {
     let pid: i64 = std::env::var("SCENEWORKS_PARENT_PID")
         .ok()?
@@ -589,10 +587,28 @@ fn pid_alive(pid: i32) -> bool {
     }
 }
 
+/// True while `pid` names a live process. The workspace forbids `unsafe`, so we
+/// can't `OpenProcess`/`WaitForSingleObject` directly; instead we shell out to
+/// `tasklist` (the same liveness probe the desktop shell uses to reap sidecars).
+/// `tasklist /FO CSV` quotes every field, so a live PID appears as `"<pid>"` in a
+/// data row while the no-match case prints only an `INFO:` banner — anchoring on
+/// the quoted PID is locale-proof and immune to the digits colliding with another
+/// column. A probe we can't even launch is treated as "alive" so a transient
+/// failure never makes the worker self-terminate spuriously.
+#[cfg(windows)]
+fn pid_alive(pid: i32) -> bool {
+    let Ok(output) = std::process::Command::new("tasklist")
+        .args(["/FI", &format!("PID eq {pid}"), "/FO", "CSV", "/NH"])
+        .output()
+    else {
+        return true;
+    };
+    String::from_utf8_lossy(&output.stdout).contains(&format!("\"{pid}\""))
+}
+
 /// Resolves once the watched parent process disappears, polling every
 /// [`PARENT_POLL_INTERVAL`]. With no parent to watch (`None`) it stays pending
 /// forever, so the `select!` branch in [`shutdown_signal`] never fires.
-#[cfg(unix)]
 async fn parent_death(parent_pid: Option<i32>) {
     let Some(parent_pid) = parent_pid else {
         std::future::pending::<()>().await;
@@ -624,14 +640,10 @@ async fn shutdown_signal() {
     // Parent-death watchdog: when launched as a desktop sidecar the Tauri shell
     // sets SCENEWORKS_PARENT_PID to its own PID. A force-quit/crash skips the
     // shell's graceful teardown (`begin_shutdown`), so without this the API
-    // orphans to launchd (PPID=1) — holding its OS-assigned port and a jobs.db
-    // handle until the next launch reaps it. Unset (server/Docker) -> the future
-    // stays pending and this branch never fires.
-    #[cfg(unix)]
+    // orphans (reparented to PID 1 / the Windows session) — holding its
+    // OS-assigned port and a jobs.db handle until the next launch reaps it. Unset
+    // (server/Docker) -> the future stays pending and this branch never fires.
     let parent_gone = parent_death(parent_pid_to_watch());
-
-    #[cfg(not(unix))]
-    let parent_gone = std::future::pending::<()>();
 
     tokio::select! {
         _ = ctrl_c => {}

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -9135,8 +9135,50 @@ async fn parent_death_resolves_when_watched_parent_exits() {
     .expect("watchdog did not resolve after the parent exited");
 }
 
+/// The Windows analogue: the parent-death watchdog is no longer unix-only (the
+/// candle `auto` supervisor's per-GPU children orphaned on every quit because
+/// `run_worker`/`shutdown_signal` never raced it off-unix). Spawn a dummy parent,
+/// confirm `pid_alive` (a `tasklist` probe) tracks it, kill it, and assert the
+/// watchdog then resolves.
+#[cfg(windows)]
+#[tokio::test]
+async fn parent_death_resolves_when_watched_parent_exits_windows() {
+    // `ping -n 30` lives ~30s and spawns no children to orphan; its stdout is
+    // discarded so it doesn't bleed into the test output.
+    let mut parent = std::process::Command::new("ping")
+        .args(["-n", "30", "127.0.0.1"])
+        .stdout(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn dummy parent");
+    let pid = parent.id() as i32;
+
+    assert!(
+        super::pid_alive(pid),
+        "freshly spawned parent reads as dead"
+    );
+    // Still alive -> the watchdog must not resolve within a poll cycle.
+    assert!(
+        tokio::time::timeout(Duration::from_millis(500), super::parent_death(Some(pid)))
+            .await
+            .is_err(),
+        "watchdog resolved while the parent was still alive"
+    );
+
+    parent.kill().expect("kill dummy parent");
+    parent.wait().expect("reap dummy parent");
+    assert!(!super::pid_alive(pid), "reaped parent still reads as alive");
+
+    // Now gone -> the watchdog resolves on its next check.
+    tokio::time::timeout(
+        super::PARENT_POLL_INTERVAL + Duration::from_secs(5),
+        super::parent_death(Some(pid)),
+    )
+    .await
+    .expect("watchdog did not resolve after the parent exited");
+}
+
 /// No configured parent (server/Docker) -> the watchdog future never resolves.
-#[cfg(unix)]
+/// Cross-platform: the watchdog is now wired on Windows too.
 #[tokio::test]
 async fn parent_death_never_fires_without_a_parent_pid() {
     assert!(
@@ -9147,8 +9189,8 @@ async fn parent_death_never_fires_without_a_parent_pid() {
     );
 }
 
-/// PIDs of 0 or 1 (and unset/garbage) yield no parent to watch.
-#[cfg(unix)]
+/// PIDs of 0 or 1 (and unset/garbage) yield no parent to watch. Cross-platform:
+/// the parser backs the watchdog on every OS now.
 #[test]
 fn parent_pid_to_watch_rejects_init_and_invalid_values() {
     use std::env;


### PR DESCRIPTION
## Problem
Closing the SceneWorks desktop app left **3 `sceneworks-api` processes running** on this 2-GPU box. The candle `auto` worker is a *supervisor* that spawns one child per GPU + a CPU utility child (= 3 on a 2-GPU machine), and nothing reaped those children on quit.

## Root cause (two gaps, both Windows-only)
1. **Parent-death watchdog was `#[cfg(unix)]`-only.** The watchdog is the codebase's documented self-terminate mechanism (a worker exits when `SCENEWORKS_PARENT_PID` disappears). On Windows both `run_worker()` and the API's `shutdown_signal()` replaced it with a `std::future::pending` no-op — so an orphaned worker could *never* notice the desktop was gone. The next-launch reap only knows the supervisor PID, so the grandchildren accumulated unbounded.
2. **`begin_shutdown` killed only the supervisor.** It force-killed the candle worker with `CommandChild::kill()` (TerminateProcess on a single PID), reaping the supervisor and orphaning its per-GPU/CPU children.

## Fix
- Wire the parent-death watchdog on **every platform**. Windows liveness uses a `tasklist` probe — the workspace forbids `unsafe`, so this mirrors the existing nix-based unix probe and the desktop's own reap path (no new dependency).
- `begin_shutdown` now **tree-kills** the candle supervisor by PID (`taskkill /T /F`, the same path `reap_stale_sidecars` uses), so the whole group dies instantly on a graceful quit.

Graceful quit → instant tree-kill of supervisor + children. Force-quit/crash (skips teardown) → each worker self-terminates within one poll interval via the watchdog.

## Tests
- New `parent_death_resolves_when_watched_parent_exits_windows` exercises the real `tasklist` → watchdog-resolution path.
- Broadened the two platform-agnostic watchdog tests to run on Windows.
- All 3 pass on the RTX PRO 6000 box; `cargo check` + `clippy` + `fmt` clean on both `sceneworks-rust-api` and `sceneworks-desktop`.

## Validation status
Unit-tested on real Windows/CUDA hardware. Full desktop-app E2E (launch → close → confirm 0 leftover `sceneworks-api.exe`) is a manual follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)