### PR TITLE
feat(models): SD3.5 family (Large/Turbo/Medium) pre-built bf16/Q8/Q4 tiers + generalized quant-matrix builder/resolver (sc-8513)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2341,32 +2341,36 @@
       "macOnly": false,
       "downloads": [
         {
-          // Gated repo (Stability AI Community License — non-commercial / <$1M-rev commercial OK;
-          // requires HF license acknowledgement + token). The repo ships the diffusers tree
-          // (transformer/ + the three text encoders + VAE + tokenizers) AND single-file checkpoints;
-          // the native converter reads ONLY the diffusers subdirs, so include just those (+
-          // model_index.json). estimatedSizeBytes is a PLACEHOLDER (the diffusers subset of the
-          // gated repo) — refine in E7/S3 once the real pull is measured.
+          // SceneWorks pre-built MLX quant-matrix turnkey (sc-8513, epic 8506): a public/ungated
+          // re-host of stabilityai/stable-diffusion-3.5-large under the Stability AI Community
+          // License (LICENSE.md + "Powered by Stability AI" NOTICE travel with the weights — no HF
+          // token or license-click needed). Per-tier subdirs, each a complete from_snapshot tree
+          // (packed/dense transformer/ + the dense triple text encoder + tokenizers + 16-ch VAE):
+          // q4/ (default), q8/, bf16/. Replaces the old gated diffusers download + install-time Q8
+          // convert: the worker loads the chosen tier's subdir directly (standard_tier_subdir).
+          // Only the MMDiT transformer is quantized; the text encoders + VAE are reused dense in
+          // every tier (so the tiers differ only in transformer precision). q8/ + bf16/ are
+          // separate entries (tier selection: sc-8508/8509). Sizes are the measured on-disk totals.
           "provider": "huggingface",
-          "repo": "stabilityai/stable-diffusion-3.5-large",
-          "files": [
-            "model_index.json",
-            "transformer/*",
-            "text_encoder/*",
-            "text_encoder_2/*",
-            "text_encoder_3/*",
-            "tokenizer/*",
-            "tokenizer_2/*",
-            "tokenizer_3/*",
-            "vae/*",
-            "scheduler/*"
-          ],
-          "estimatedSizeBytes": 20500000000
+          "repo": "SceneWorks/sd3.5-large-mlx",
+          "files": ["q4/*"],
+          "estimatedSizeBytes": 27212570624
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/sd3.5-large-mlx",
+          "files": ["q8/*"],
+          "estimatedSizeBytes": 31248461824
+        },
+        {
+          // bf16/ — the dense diffusers tree (sharded transformer), the max-fidelity tier.
+          // Selectable via per-variant tracking (sc-8508/8509).
+          "provider": "huggingface",
+          "repo": "SceneWorks/sd3.5-large-mlx",
+          "files": ["bf16/*"],
+          "estimatedSizeBytes": 38789746688
         }
       ],
-      "paths": {
-        "model": "${HF_CACHE}/stabilityai/stable-diffusion-3.5-large"
-      },
       "defaults": {
         // SD3.5 Large reference defaults: flow-match Euler with a time-shift of 3.0, ~28 steps,
         // true classifier-free guidance 3.5 (negative-prompt capable). The shift is the orthogonal
@@ -2398,23 +2402,20 @@
         "types": ["style", "enhance", "character"]
       },
       "mlx": {
-        // 8B MMDiT + triple text encoder (CLIP-L + CLIP-G + ~4.7B T5-XXL) + 16-ch VAE. Converted to
-        // a packed MLX dir at install (mlx.requiresConversion + the `sd3_5_large_quant` converter,
-        // REGISTERED IN S2/S3 — this entry only declares it). minMemoryGb 64 — E7 profiled the real
-        // OS peak memory footprint at ~59 GB Q8 (MLX Metal-wired memory, not RSS, dominated by the
-        // T5-XXL TE + activations); 64 leaves headroom over that measured peak.
+        // 8B MMDiT + triple text encoder (CLIP-L + CLIP-G + ~4.7B T5-XXL) + 16-ch VAE. Now ships as
+        // a SceneWorks pre-built turnkey (sc-8513) — no install-time convert. q4/ is the default
+        // tier (`quantize: 4`); q8/ + bf16/ are hosted and selectable (sc-8508/8509). Only the MMDiT
+        // is quantized; the dense T5-XXL TE + VAE dominate the footprint in every tier, so minMemoryGb
+        // stays 64 (E7 profiled the real OS peak at ~59 GB; the q4 transformer trims a few GB but the
+        // dense-TE floor is unchanged).
         "minMemoryGb": 64,
-        "quantize": 8,
-        "requiresConversion": true,
-        "converter": "sd3_5_large_quant",
-        "convertSourceRepo": "stabilityai/stable-diffusion-3.5-large"
+        "quantize": 4
       },
-      "gated": true,
-      "credentialHost": "huggingface.co",
-      "licenseUrl": "https://huggingface.co/stabilityai/stable-diffusion-3.5-large",
+      "gated": false,
+      "licenseUrl": "https://huggingface.co/SceneWorks/sd3.5-large-mlx/blob/main/LICENSE.md",
       "ui": {
         "label": "Stable Diffusion 3.5 Large",
-        "description": "Stability AI Stable Diffusion 3.5 Large — the 8B multimodal diffusion transformer (MMDiT) flagship, ported natively to MLX (Apple Silicon only). Triple text encoder (CLIP-L + CLIP-G + T5-XXL) for strong prompt adherence and in-image text; true classifier-free guidance with negative prompts. Runs ~28 steps at guidance 3.5 (flow-match Euler, shift 3.0); native 1024×1024. Distributed under the Stability AI Community License (gated): accept the license at huggingface.co/stabilityai/stable-diffusion-3.5-large and add a Hugging Face token under Settings → Service credentials before downloading. Pre-quantized to Q8 at install.",
+        "description": "Stability AI Stable Diffusion 3.5 Large — the 8B multimodal diffusion transformer (MMDiT) flagship, ported natively to MLX (Apple Silicon only). Triple text encoder (CLIP-L + CLIP-G + T5-XXL) for strong prompt adherence and in-image text; true classifier-free guidance with negative prompts. Runs ~28 steps at guidance 3.5 (flow-match Euler, shift 3.0); native 1024×1024. Pre-built and hosted by SceneWorks (Q4 default; Q8 + bf16 also available) — downloads ready-to-run with no install-time conversion or gated download. Distributed under the Stability AI Community License; SceneWorks hosts a public, ungated re-host (Powered by Stability AI), so no Hugging Face token or license acceptance is needed before downloading.",
         "recommendedFor": ["text_to_image", "style_variations"],
         "promptGuide": {
           "title": "Stable Diffusion 3.5 Prompt Guide",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2450,28 +2450,31 @@
       "macOnly": false,
       "downloads": [
         {
-          // Gated repo (Stability AI Community License; HF license-ack + token required). Diffusers
-          // subset only; estimatedSizeBytes is a PLACEHOLDER (refine in E7/S3).
+          // SceneWorks pre-built MLX quant-matrix turnkey (sc-8513, epic 8506): public/ungated
+          // re-host of stabilityai/stable-diffusion-3.5-large-turbo under the Stability AI Community
+          // License (LICENSE.md + "Powered by Stability AI" NOTICE travel with the weights). Per-tier
+          // subdirs q4/ (default) + q8/ + bf16/, each a complete from_snapshot tree (packed/dense
+          // transformer/ + the dense triple TE + tokenizers + 16-ch VAE — only the MMDiT is
+          // quantized). Replaces the gated download + install-time convert. Sizes = measured on-disk.
           "provider": "huggingface",
-          "repo": "stabilityai/stable-diffusion-3.5-large-turbo",
-          "files": [
-            "model_index.json",
-            "transformer/*",
-            "text_encoder/*",
-            "text_encoder_2/*",
-            "text_encoder_3/*",
-            "tokenizer/*",
-            "tokenizer_2/*",
-            "tokenizer_3/*",
-            "vae/*",
-            "scheduler/*"
-          ],
-          "estimatedSizeBytes": 20500000000
+          "repo": "SceneWorks/sd3.5-large-turbo-mlx",
+          "files": ["q4/*"],
+          "estimatedSizeBytes": 27212570624
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/sd3.5-large-turbo-mlx",
+          "files": ["q8/*"],
+          "estimatedSizeBytes": 31239405568
+        },
+        {
+          // bf16/ — the dense diffusers tree (sharded transformer), max-fidelity tier (sc-8508/8509).
+          "provider": "huggingface",
+          "repo": "SceneWorks/sd3.5-large-turbo-mlx",
+          "files": ["bf16/*"],
+          "estimatedSizeBytes": 38789746688
         }
       ],
-      "paths": {
-        "model": "${HF_CACHE}/stabilityai/stable-diffusion-3.5-large-turbo"
-      },
       "defaults": {
         // Turbo: ADD-distilled few-step (4), CFG-free (guidanceScale ~1.0 — the turbo path runs no
         // unconditional branch, so the negative prompt is inert). Flow-match Euler, shift 3.0.
@@ -2497,22 +2500,18 @@
         "types": ["style", "enhance", "character"]
       },
       "mlx": {
-        // Same footprint as Large (same backbone weights, few-step schedule). Converted to a packed
-        // MLX dir at install (`sd3_5_large_turbo_quant` converter, REGISTERED IN S2/S3). minMemoryGb 64
-        // — E7 measured the same ~59 GB Q8 OS peak footprint as Large (identical backbone); 64 with
-        // headroom.
+        // Same footprint as Large (same backbone weights, few-step schedule). Now ships as a
+        // SceneWorks pre-built turnkey (sc-8513) — no install-time convert. q4/ default
+        // (`quantize: 4`); q8/ + bf16/ hosted + selectable (sc-8508/8509). Only the MMDiT is
+        // quantized; the dense T5-XXL TE + VAE dominate every tier, so minMemoryGb stays 64.
         "minMemoryGb": 64,
-        "quantize": 8,
-        "requiresConversion": true,
-        "converter": "sd3_5_large_turbo_quant",
-        "convertSourceRepo": "stabilityai/stable-diffusion-3.5-large-turbo"
+        "quantize": 4
       },
-      "gated": true,
-      "credentialHost": "huggingface.co",
-      "licenseUrl": "https://huggingface.co/stabilityai/stable-diffusion-3.5-large-turbo",
+      "gated": false,
+      "licenseUrl": "https://huggingface.co/SceneWorks/sd3.5-large-turbo-mlx/blob/main/LICENSE.md",
       "ui": {
         "label": "Stable Diffusion 3.5 Large Turbo",
-        "description": "Stable Diffusion 3.5 Large Turbo — the few-step (~4), CFG-free distilled variant of SD3.5 Large: the same 8B multimodal diffusion transformer with a triple text encoder, distilled (ADD) for much faster renders, native MLX (Apple Silicon). Best for fast iteration at flagship quality; native 1024×1024. Runs CFG-free (the negative prompt is inert). Distributed under the Stability AI Community License (gated): accept the license at huggingface.co/stabilityai/stable-diffusion-3.5-large-turbo and add a Hugging Face token under Settings → Service credentials before downloading. Pre-quantized to Q8 at install.",
+        "description": "Stable Diffusion 3.5 Large Turbo — the few-step (~4), CFG-free distilled variant of SD3.5 Large: the same 8B multimodal diffusion transformer with a triple text encoder, distilled (ADD) for much faster renders, native MLX (Apple Silicon). Best for fast iteration at flagship quality; native 1024×1024. Runs CFG-free (the negative prompt is inert). Pre-built and hosted by SceneWorks (Q4 default; Q8 + bf16 also available) — downloads ready-to-run with no install-time conversion or gated download. Distributed under the Stability AI Community License; SceneWorks hosts a public, ungated re-host (Powered by Stability AI), so no Hugging Face token or license acceptance is needed before downloading.",
         "recommendedFor": ["text_to_image", "style_variations"],
         "promptGuide": {
           "title": "Stable Diffusion 3.5 Prompt Guide",
@@ -2541,29 +2540,32 @@
       "macOnly": false,
       "downloads": [
         {
-          // Gated repo (Stability AI Community License; HF license-ack + token required). Diffusers
-          // subset only; estimatedSizeBytes is a PLACEHOLDER (the smaller 2.5B backbone — refine in
-          // E7/S3).
+          // SceneWorks pre-built MLX quant-matrix turnkey (sc-8513, epic 8506): public/ungated
+          // re-host of stabilityai/stable-diffusion-3.5-medium under the Stability AI Community
+          // License (LICENSE.md + "Powered by Stability AI" NOTICE travel with the weights). Per-tier
+          // subdirs q4/ (default) + q8/ + bf16/, each a complete from_snapshot tree (packed/dense
+          // transformer/ + the dense triple TE + tokenizers + 16-ch VAE — only the 2.5B MMDiT-X is
+          // quantized). Replaces the gated download + install-time convert. Sizes = measured on-disk
+          // (the dense T5-XXL TE dominates even the small backbone, so the tiers are close in size).
           "provider": "huggingface",
-          "repo": "stabilityai/stable-diffusion-3.5-medium",
-          "files": [
-            "model_index.json",
-            "transformer/*",
-            "text_encoder/*",
-            "text_encoder_2/*",
-            "text_encoder_3/*",
-            "tokenizer/*",
-            "tokenizer_2/*",
-            "tokenizer_3/*",
-            "vae/*",
-            "scheduler/*"
-          ],
-          "estimatedSizeBytes": 12000000000
+          "repo": "SceneWorks/sd3.5-medium-mlx",
+          "files": ["q4/*"],
+          "estimatedSizeBytes": 24213819392
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/sd3.5-medium-mlx",
+          "files": ["q8/*"],
+          "estimatedSizeBytes": 25334730752
+        },
+        {
+          // bf16/ — the dense diffusers tree, max-fidelity tier (sc-8508/8509).
+          "provider": "huggingface",
+          "repo": "SceneWorks/sd3.5-medium-mlx",
+          "files": ["bf16/*"],
+          "estimatedSizeBytes": 27436347392
         }
       ],
-      "paths": {
-        "model": "${HF_CACHE}/stabilityai/stable-diffusion-3.5-medium"
-      },
       "defaults": {
         // SD3.5 Medium reference defaults: flow-match Euler, shift 3.0, ~40 steps, true CFG ~4.5
         // (the Medium MMDiT-X benefits from a few more steps + slightly higher guidance than Large).
@@ -2595,18 +2597,19 @@
         // the 2.5B backbone, so the earlier ~16 GB estimate was badly understated). 56 covers the
         // measured Q8 peak plus headroom while staying below Large/Turbo's 64 so Medium remains the
         // lightest SD3.5 tier without admitting a machine that would OOM.
+        // The 2.5B MMDiT-X now ships as a SceneWorks pre-built turnkey (sc-8513) — no install-time
+        // convert. q4/ default (`quantize: 4`); q8/ + bf16/ hosted + selectable (sc-8508/8509). Only
+        // the MMDiT-X is quantized; the dense T5-XXL TE + VAE dominate every tier (so the tiers are
+        // close in size), keeping the real Q8 OS peak ~52 GB — minMemoryGb stays 56 (the lightest
+        // SD3.5 tier, below Large/Turbo's 64).
         "minMemoryGb": 56,
-        "quantize": 8,
-        "requiresConversion": true,
-        "converter": "sd3_5_medium_quant",
-        "convertSourceRepo": "stabilityai/stable-diffusion-3.5-medium"
+        "quantize": 4
       },
-      "gated": true,
-      "credentialHost": "huggingface.co",
-      "licenseUrl": "https://huggingface.co/stabilityai/stable-diffusion-3.5-medium",
+      "gated": false,
+      "licenseUrl": "https://huggingface.co/SceneWorks/sd3.5-medium-mlx/blob/main/LICENSE.md",
       "ui": {
         "label": "Stable Diffusion 3.5 Medium",
-        "description": "Stability AI Stable Diffusion 3.5 Medium — the 2.5B MMDiT-X (dual-attention) mid-tier of the SD3.5 family, ported natively to MLX (Apple Silicon only). Same triple text encoder (CLIP-L + CLIP-G + T5-XXL) and true CFG as Large, with a smaller transformer that renders up to 1440×1440 and a lighter memory footprint. Runs ~40 steps at guidance 4.5 (flow-match Euler, shift 3.0). Distributed under the Stability AI Community License (gated): accept the license at huggingface.co/stabilityai/stable-diffusion-3.5-medium and add a Hugging Face token under Settings → Service credentials before downloading. Pre-quantized to Q8 at install.",
+        "description": "Stability AI Stable Diffusion 3.5 Medium — the 2.5B MMDiT-X (dual-attention) mid-tier of the SD3.5 family, ported natively to MLX (Apple Silicon only). Same triple text encoder (CLIP-L + CLIP-G + T5-XXL) and true CFG as Large, with a smaller transformer that renders up to 1440×1440 and a lighter memory footprint. Runs ~40 steps at guidance 4.5 (flow-match Euler, shift 3.0). Pre-built and hosted by SceneWorks (Q4 default; Q8 + bf16 also available) — downloads ready-to-run with no install-time conversion or gated download. Distributed under the Stability AI Community License; SceneWorks hosts a public, ungated re-host (Powered by Stability AI), so no Hugging Face token or license acceptance is needed before downloading.",
         "recommendedFor": ["text_to_image", "style_variations"],
         "promptGuide": {
           "title": "Stable Diffusion 3.5 Prompt Guide",

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -441,7 +441,9 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
     ModelRow {
         sceneworks_id: "sd3_5_large",
         engine_id: "sd3_5_large",
-        default_repo: "stabilityai/stable-diffusion-3.5-large",
+        // SceneWorks pre-built quant-matrix turnkey (sc-8513): standard_tier_subdir points the engine
+        // at the chosen tier subdir (q4 default / q8 / bf16). Re-host of the gated Stability source.
+        default_repo: "SceneWorks/sd3.5-large-mlx",
         default_steps: 28,
         default_guidance: 3.5,
         adapter_label: "mlx_sd3",

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -456,7 +456,9 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
     ModelRow {
         sceneworks_id: "sd3_5_large_turbo",
         engine_id: "sd3_5_large_turbo",
-        default_repo: "stabilityai/stable-diffusion-3.5-large-turbo",
+        // SceneWorks pre-built quant-matrix turnkey (sc-8513): q4 default / q8 / bf16 via
+        // standard_tier_subdir. Re-host of the gated Stability source.
+        default_repo: "SceneWorks/sd3.5-large-turbo-mlx",
         default_steps: 4,
         default_guidance: 0.0,
         adapter_label: "mlx_sd3",
@@ -471,7 +473,9 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
     ModelRow {
         sceneworks_id: "sd3_5_medium",
         engine_id: "sd3_5_medium",
-        default_repo: "stabilityai/stable-diffusion-3.5-medium",
+        // SceneWorks pre-built quant-matrix turnkey (sc-8513): q4 default / q8 / bf16 via
+        // standard_tier_subdir. Re-host of the gated Stability source.
+        default_repo: "SceneWorks/sd3.5-medium-mlx",
         default_steps: 40,
         default_guidance: 5.0,
         adapter_label: "mlx_sd3",

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -244,13 +244,69 @@ pub(crate) fn resolve_weights_dir(
     if request.model == "krea_2_turbo" {
         return Ok(snapshot.map(|root| krea_model_subdir(&root, request)));
     }
-    // FLUX.2-dev (sc-8513, epic 8506) now ships as a SceneWorks pre-quantized turnkey with packed
-    // `q4/` (default) + `q8/` self-contained subdirs (replacing the install-time convert); point the
-    // engine at the chosen quant's subdir rather than the repo root.
-    if request.model == "flux2_dev" {
-        return Ok(snapshot.map(|root| flux2_dev_model_subdir(&root, request)));
+    // Catalog-wide quant-matrix models (sc-8513, epic 8506) ship as SceneWorks pre-quantized
+    // turnkeys with self-contained `q4/` (default) + `q8/` + `bf16/` subdirs (replacing any
+    // install-time convert); point the engine at the chosen tier's subdir rather than the repo root.
+    // FLUX.2-dev was the pilot; the rollout registers each model in [`STANDARD_TIER_MODELS`].
+    if STANDARD_TIER_MODELS.contains(&request.model.as_str()) {
+        return Ok(snapshot.map(|root| standard_tier_subdir(&root, request)));
     }
     Ok(snapshot)
+}
+
+/// Models that ship the standard SceneWorks quant-matrix turnkey layout: self-contained `q4/`
+/// (manifest default) + `q8/` + `bf16/` subdirs, each a complete `from_snapshot`-loadable tree
+/// (packed or dense `transformer/` + the dense text encoder(s)/VAE/tokenizer). Registering a model
+/// here routes it through [`standard_tier_subdir`] (sc-8513, epic 8506) — the generalization of the
+/// FLUX.2-dev pilot's bespoke resolver. Legacy turnkeys with non-standard defaults/variants
+/// (Ideogram q4-only, Krea q8-default, Boogu per-variant + on-demand bf16) keep their own resolvers
+/// above.
+const STANDARD_TIER_MODELS: &[&str] = &[
+    "flux2_dev",
+    "sd3_5_large",
+    "sd3_5_large_turbo",
+    "sd3_5_medium",
+];
+
+/// Pick the engine-complete tier subdir of a standard SceneWorks quant-matrix turnkey `root`:
+/// `bf16/` when the request opts out of quantization (`advanced.mlxQuantize <= 0` / "none"), `q8/`
+/// when it opts into Q8 (`> 4`), else the default `q4/`. Falls back through q4 → q8 → bf16 → `root`
+/// so a partially-downloaded turnkey surfaces as a load error rather than a silent half-load.
+///
+/// Tier presence is filename-agnostic: a tier is "present" when its `transformer/` holds any
+/// `*.safetensors` (packed single-file OR a `*-00001-of-*.safetensors` shard) or a `*.index.json`
+/// (dense sharded). This covers every backbone regardless of its packed filename
+/// (`diffusion_pytorch_model.safetensors`, `model.safetensors`, …), so a new model needs only a
+/// [`STANDARD_TIER_MODELS`] entry, no bespoke resolver.
+fn standard_tier_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
+    let bits = request
+        .advanced
+        .get("mlxQuantize")
+        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()));
+    let present = |name: &str| -> Option<PathBuf> {
+        let dir = root.join(name);
+        let transformer = dir.join("transformer");
+        let Ok(entries) = std::fs::read_dir(&transformer) else {
+            return None;
+        };
+        let has_weights = entries.flatten().any(|entry| {
+            let file = entry.file_name();
+            let name = file.to_string_lossy();
+            name.ends_with(".safetensors") || name.ends_with(".index.json")
+        });
+        has_weights.then_some(dir)
+    };
+    // bits<=0 (advanced.mlxQuantize: 0 / "none") → bf16; bits>4 → q8; else the q4 default.
+    let preferred = match bits {
+        Some(b) if b <= 0 => "bf16",
+        Some(b) if b > 4 => "q8",
+        _ => "q4",
+    };
+    present(preferred)
+        .or_else(|| present("q4"))
+        .or_else(|| present("q8"))
+        .or_else(|| present("bf16"))
+        .unwrap_or_else(|| root.to_path_buf())
 }
 
 /// Pick the engine-complete packed subdir of an Ideogram 4 turnkey `root`: `q8/` when the request
@@ -277,39 +333,6 @@ fn ideogram_model_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
     }
     present("q4")
         .or_else(|| present("q8"))
-        .unwrap_or_else(|| root.to_path_buf())
-}
-
-/// Pick the engine-complete packed subdir of a FLUX.2-dev SceneWorks turnkey `root`: `q8/` when the
-/// request opts into Q8 (`advanced.mlxQuantize: 8`) AND it is downloaded, else the default `q4/`.
-/// Falls back to whichever subdir is present, then `root` (a partially-downloaded bundle surfaces as
-/// a load error rather than a silent half-load). FLUX.2-dev's packed transformer file is
-/// `diffusion_pytorch_model.safetensors` (vs Ideogram's `model.safetensors`). sc-8513 / epic 8506.
-fn flux2_dev_model_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
-    let bits = request
-        .advanced
-        .get("mlxQuantize")
-        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()));
-    // Tier presence: q4/q8 ship a single packed transformer file; bf16 is the dense diffusers tree
-    // (SHARDED → no single file, only the `.index.json`). Accept either shape.
-    let present = |name: &str| -> Option<PathBuf> {
-        let dir = root.join(name);
-        let packed = dir.join("transformer/diffusion_pytorch_model.safetensors").is_file();
-        let sharded = dir
-            .join("transformer/diffusion_pytorch_model.safetensors.index.json")
-            .is_file();
-        (packed || sharded).then_some(dir)
-    };
-    // bits<=0 (advanced.mlxQuantize: 0 / "none") → bf16; bits>4 → q8; else the q4 default.
-    let preferred = match bits {
-        Some(b) if b <= 0 => "bf16",
-        Some(b) if b > 4 => "q8",
-        _ => "q4",
-    };
-    present(preferred)
-        .or_else(|| present("q4"))
-        .or_else(|| present("q8"))
-        .or_else(|| present("bf16"))
         .unwrap_or_else(|| root.to_path_buf())
 }
 
@@ -3029,5 +3052,75 @@ mod candle_label_tests {
         ] {
             assert!(!is_candle_engine(model), "{model} must not be a candle engine");
         }
+    }
+}
+
+#[cfg(test)]
+mod standard_tier_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn request(advanced: serde_json::Value) -> ImageRequest {
+        ImageRequest::from_payload(
+            json!({ "model": "sd3_5_large", "advanced": advanced })
+                .as_object()
+                .unwrap(),
+        )
+    }
+
+    /// Write a minimal present `<tier>/transformer/<file>` so [`standard_tier_subdir`]'s
+    /// filename-agnostic probe sees the tier as downloaded.
+    fn seed_tier(root: &Path, tier: &str, file: &str) {
+        let dir = root.join(tier).join("transformer");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join(file), b"x").unwrap();
+    }
+
+    #[test]
+    fn defaults_to_q4_and_honors_quantize_selection() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        // Packed q4/q8 single-file + dense sharded bf16 (only the index.json shape).
+        seed_tier(root, "q4", "diffusion_pytorch_model.safetensors");
+        seed_tier(root, "q8", "diffusion_pytorch_model.safetensors");
+        seed_tier(root, "bf16", "diffusion_pytorch_model.safetensors.index.json");
+
+        // No selection → q4 default.
+        assert_eq!(
+            standard_tier_subdir(root, &request(json!({}))),
+            root.join("q4")
+        );
+        // mlxQuantize 8 → q8; 0/"none" → bf16; numeric-string accepted.
+        assert_eq!(
+            standard_tier_subdir(root, &request(json!({ "mlxQuantize": 8 }))),
+            root.join("q8")
+        );
+        assert_eq!(
+            standard_tier_subdir(root, &request(json!({ "mlxQuantize": 0 }))),
+            root.join("bf16")
+        );
+        assert_eq!(
+            standard_tier_subdir(root, &request(json!({ "mlxQuantize": "8" }))),
+            root.join("q8")
+        );
+    }
+
+    #[test]
+    fn falls_back_when_preferred_tier_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        // Only q4 downloaded: a q8/bf16 request still resolves to the present q4 rather than a
+        // half-empty subdir, so a partial turnkey surfaces as a load error, not a silent half-load.
+        seed_tier(root, "q4", "diffusion_pytorch_model.safetensors");
+        assert_eq!(
+            standard_tier_subdir(root, &request(json!({ "mlxQuantize": 8 }))),
+            root.join("q4")
+        );
+        // Nothing present → the repo root (engine surfaces the missing-weights error).
+        let empty = tempfile::tempdir().unwrap();
+        assert_eq!(
+            standard_tier_subdir(empty.path(), &request(json!({}))),
+            empty.path().to_path_buf()
+        );
     }
 }

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -1351,6 +1351,67 @@ fn flux2_dev_bf16_real_weights_loads_and_generates() {
     );
 }
 
+/// On-device verify of a hosted SceneWorks SD3.5 quant-matrix tier (sc-8513, epic 8506): load the
+/// DOWNLOADED tier subdir through the real worker `load_engine` seam and render a non-degenerate
+/// frame — proving the hosted artifact (download → load → generate) works end to end. Point
+/// `SCENEWORKS_SD3_DIR` at the downloaded tier subdir (e.g. the `q4/` of
+/// `SceneWorks/sd3.5-large-mlx`); `SCENEWORKS_SD3_ENGINE` selects the variant engine
+/// (`sd3_5_large` default / `sd3_5_large_turbo` / `sd3_5_medium`); `SCENEWORKS_SD3_QUANT`
+/// (`q4` default / `q8` / `bf16`) sets the load hint (a no-op on the already-packed q4/q8 weights;
+/// `bf16` loads dense via `Quant::None`). Small size/steps by default to fit a 128 GB box; the dense
+/// T5-XXL TE dominates the footprint. Run on demand:
+/// `SCENEWORKS_SD3_DIR=… cargo test -p sceneworks-worker --release --lib -- --ignored sd3_5_hosted_tier_real_weights`.
+#[cfg(target_os = "macos")]
+#[test]
+#[ignore = "needs a downloaded SceneWorks SD3.5 tier dir + a high-memory Metal device"]
+fn sd3_5_hosted_tier_real_weights_generates_one_image() {
+    let dir = std::path::PathBuf::from(
+        std::env::var("SCENEWORKS_SD3_DIR").expect("set SCENEWORKS_SD3_DIR to a downloaded tier dir"),
+    );
+    let engine = std::env::var("SCENEWORKS_SD3_ENGINE").unwrap_or_else(|_| "sd3_5_large".to_owned());
+    let quant = match std::env::var("SCENEWORKS_SD3_QUANT").as_deref() {
+        Ok("bf16") => None,
+        Ok("q8") => Some(gen_core::Quant::Q8),
+        _ => Some(gen_core::Quant::Q4),
+    };
+    let size: u32 = std::env::var("SCENEWORKS_SD3_SIZE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(512);
+    let steps: u32 = std::env::var("SCENEWORKS_SD3_STEPS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(8);
+    eprintln!("[sd3-verify] loading {engine} from {} ({quant:?})…", dir.display());
+    let generator = load_engine(&engine, dir, quant, Vec::new(), None).unwrap();
+    eprintln!("[sd3-verify] LOADED — generating {size}²/{steps}…");
+    let request = GenerationRequest {
+        prompt: "a serene mountain lake at dawn".into(),
+        width: size,
+        height: size,
+        count: 1,
+        seed: Some(42),
+        steps: Some(steps),
+        guidance: Some(3.5),
+        ..Default::default()
+    };
+    let img = match generator.generate(&request, &mut |_| {}).unwrap() {
+        GenerationOutput::Images(mut v) => v.remove(0),
+        other => panic!("expected Images, got {other:?}"),
+    };
+    eprintln!("[sd3-verify] GENERATED {}x{}", img.width, img.height);
+    assert_eq!((img.width, img.height), (size, size), "output dimensions");
+    assert_eq!(
+        img.pixels.len(),
+        (size * size * 3) as usize,
+        "RGB8 pixel count"
+    );
+    assert!(
+        img.pixels.windows(2).any(|w| w[0] != w[1]),
+        "render is flat (degenerate)"
+    );
+}
+
 /// Real-weights smoke (sc-5923): FLUX.2-dev EDIT through the worker `flux2_dev_edit` engine path
 /// (the `flux2_edit_engine_id("flux2_dev")` variant, sc-5919/5922). Loads the SAME converted Q4 dev
 /// snapshot, then renders with a single `Conditioning::Reference` AND with a 2-image

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -1366,9 +1366,11 @@ fn flux2_dev_bf16_real_weights_loads_and_generates() {
 #[ignore = "needs a downloaded SceneWorks SD3.5 tier dir + a high-memory Metal device"]
 fn sd3_5_hosted_tier_real_weights_generates_one_image() {
     let dir = std::path::PathBuf::from(
-        std::env::var("SCENEWORKS_SD3_DIR").expect("set SCENEWORKS_SD3_DIR to a downloaded tier dir"),
+        std::env::var("SCENEWORKS_SD3_DIR")
+            .expect("set SCENEWORKS_SD3_DIR to a downloaded tier dir"),
     );
-    let engine = std::env::var("SCENEWORKS_SD3_ENGINE").unwrap_or_else(|_| "sd3_5_large".to_owned());
+    let engine =
+        std::env::var("SCENEWORKS_SD3_ENGINE").unwrap_or_else(|_| "sd3_5_large".to_owned());
     let quant = match std::env::var("SCENEWORKS_SD3_QUANT").as_deref() {
         Ok("bf16") => None,
         Ok("q8") => Some(gen_core::Quant::Q8),
@@ -1382,9 +1384,15 @@ fn sd3_5_hosted_tier_real_weights_generates_one_image() {
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(8);
-    eprintln!("[sd3-verify] loading {engine} from {} ({quant:?})…", dir.display());
+    eprintln!(
+        "[sd3-verify] loading {engine} from {} ({quant:?})…",
+        dir.display()
+    );
     let generator = load_engine(&engine, dir, quant, Vec::new(), None).unwrap();
     eprintln!("[sd3-verify] LOADED — generating {size}²/{steps}…");
+    // Large/Medium are true-CFG; the distilled Turbo bakes guidance in and REJECTS a guidance value
+    // (CFG off), so omit it there.
+    let guidance = (!engine.contains("turbo")).then_some(3.5);
     let request = GenerationRequest {
         prompt: "a serene mountain lake at dawn".into(),
         width: size,
@@ -1392,7 +1400,7 @@ fn sd3_5_hosted_tier_real_weights_generates_one_image() {
         count: 1,
         seed: Some(42),
         steps: Some(steps),
-        guidance: Some(3.5),
+        guidance,
         ..Default::default()
     };
     let img = match generator.generate(&request, &mut |_| {}).unwrap() {

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -2364,3 +2364,153 @@ mod hardlink_tests {
         );
     }
 }
+
+/// Offline quant-matrix tier builder (sc-8513, epic 8506) — the generalization of the FLUX.2-dev
+/// pilot's one-off builder into a per-converter dispatch over the SAME production `ConvertPlan`
+/// converters, so each hosted tier is byte-equivalent to the install-time output.
+///
+/// Produces ONE complete, HF-uploadable turnkey subdir (`q4/`, `q8/`, or `bf16/`) from a cached
+/// dense diffusers source:
+/// - `q4`/`q8`: run the production converter (packs `transformer/`, symlinks the dense TE/VAE/
+///   tokenizer through), then dereference those symlinks into real files (HF upload does not follow
+///   cache blob symlinks across a move).
+/// - `bf16`: mirror the dense diffusers tree as-is (no quantize) — the dense backbone IS the bf16
+///   tier.
+///
+/// `#[ignore]`: needs the cached dense source snapshot + Metal. Run ONE tier at a time (bounds the
+/// transformer quantize disk peak), e.g.:
+/// ```text
+/// SC8513_CONVERTER=sd3_5_large_quant SC8513_BITS=4 \
+///   SC8513_SRC="$HOME/.cache/huggingface/hub/models--stabilityai--stable-diffusion-3.5-large/snapshots/<rev>" \
+///   SC8513_OUT="$HOME/sc8513/sd3.5-large-mlx" \
+///   cargo test -p sceneworks-worker --release tier_builder::build_tier -- --ignored --nocapture
+/// ```
+/// `SC8513_BITS<=0` builds the bf16 tier. New architectures: add a `SC8513_CONVERTER` arm mapping to
+/// the model's production converter + its dense-reuse subdir list.
+#[cfg(all(test, target_os = "macos"))]
+mod tier_builder {
+    use super::*;
+    use std::path::{Path, PathBuf};
+
+    fn env_path(key: &str) -> PathBuf {
+        PathBuf::from(std::env::var(key).unwrap_or_else(|_| panic!("set {key}")))
+    }
+
+    /// Recursively copy `src` → `dst`, resolving any symlink (incl. HF-cache blob symlinks) to its
+    /// real bytes so the output is a self-contained tree of real files.
+    fn copy_tree_deref(src: &Path, dst: &Path) {
+        if src.is_dir() {
+            std::fs::create_dir_all(dst).unwrap();
+            for entry in std::fs::read_dir(src).unwrap() {
+                let entry = entry.unwrap();
+                copy_tree_deref(&entry.path(), &dst.join(entry.file_name()));
+            }
+        } else {
+            let real = std::fs::canonicalize(src).unwrap();
+            std::fs::copy(&real, dst).unwrap();
+        }
+    }
+
+    /// Replace every symlink under `dir` (the dense TE/VAE/tokenizer the converter borrowed from the
+    /// source) with a real copy of its canonical target, in place.
+    fn deref_symlinks(dir: &Path) {
+        for entry in std::fs::read_dir(dir).unwrap() {
+            let path = entry.unwrap().path();
+            let ty = std::fs::symlink_metadata(&path).unwrap().file_type();
+            if ty.is_symlink() {
+                let real = std::fs::canonicalize(&path).unwrap();
+                std::fs::remove_file(&path).unwrap();
+                if real.is_dir() {
+                    copy_tree_deref(&real, &path);
+                } else {
+                    std::fs::copy(&real, &path).unwrap();
+                }
+            } else if ty.is_dir() {
+                deref_symlinks(&path);
+            }
+        }
+    }
+
+    /// The diffusers subdirs a converter reuses DENSE (also the extra bf16-mirror set beyond
+    /// `transformer/`). `scheduler` is optional metadata and skipped when absent.
+    fn dense_subs(converter: &str) -> &'static [&'static str] {
+        match converter {
+            "sd3_5_large_quant" | "sd3_5_large_turbo_quant" | "sd3_5_medium_quant" => &[
+                "text_encoder",
+                "text_encoder_2",
+                "text_encoder_3",
+                "tokenizer",
+                "tokenizer_2",
+                "tokenizer_3",
+                "vae",
+                "scheduler",
+                "model_index.json",
+            ],
+            "flux2_dev_quant" => &["text_encoder", "vae", "tokenizer", "model_index.json"],
+            other => panic!("unknown SC8513_CONVERTER {other}"),
+        }
+    }
+
+    #[test]
+    #[ignore = "real-weight: cached dense source snapshot + Metal"]
+    fn build_tier() {
+        let converter = std::env::var("SC8513_CONVERTER").expect("set SC8513_CONVERTER");
+        let bits: i32 = std::env::var("SC8513_BITS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(4);
+        let group_size: i32 = std::env::var("SC8513_GROUP")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(64);
+        let src = env_path("SC8513_SRC");
+        let out_root = env_path("SC8513_OUT");
+        let tier = if bits <= 0 {
+            "bf16".to_owned()
+        } else {
+            format!("q{bits}")
+        };
+        let out = out_root.join(&tier);
+        let _ = std::fs::remove_dir_all(&out);
+        std::fs::create_dir_all(&out).unwrap();
+        eprintln!(
+            "[sc-8513] {converter} {tier} (bits {bits}, group {group_size}) {} -> {}",
+            src.display(),
+            out.display()
+        );
+
+        if bits <= 0 {
+            // bf16: the dense backbone IS the tier — mirror transformer + the dense-reuse subdirs.
+            copy_tree_deref(&src.join("transformer"), &out.join("transformer"));
+            eprintln!("[sc-8513]   bf16 transformer mirrored");
+            for sub in dense_subs(&converter) {
+                let s = src.join(sub);
+                if !s.exists() {
+                    assert_eq!(*sub, "scheduler", "bf16 source missing required `{sub}`");
+                    continue;
+                }
+                copy_tree_deref(&s, &out.join(sub));
+                eprintln!("[sc-8513]   bf16 {sub} mirrored");
+            }
+        } else {
+            // q4/q8: production converter packs transformer/ + symlinks dense parts; then realize.
+            let result = match converter.as_str() {
+                "sd3_5_large_quant" => {
+                    convert_sd3_prequant(&src, &out, Sd3Variant::Large, bits, group_size)
+                }
+                "sd3_5_large_turbo_quant" => {
+                    convert_sd3_prequant(&src, &out, Sd3Variant::LargeTurbo, bits, group_size)
+                }
+                "sd3_5_medium_quant" => {
+                    convert_sd3_prequant(&src, &out, Sd3Variant::Medium, bits, group_size)
+                }
+                "flux2_dev_quant" => convert_flux2_dev_prequant(&src, &out, bits, group_size),
+                other => panic!("unknown SC8513_CONVERTER {other}"),
+            };
+            result.unwrap_or_else(|error| panic!("production convert failed: {error}"));
+            eprintln!("[sc-8513]   transformer packed; dereferencing dense symlinks");
+            deref_symlinks(&out);
+        }
+        eprintln!("[sc-8513] DONE {tier} at {}", out.display());
+    }
+}

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -825,28 +825,39 @@ fn sd3_5_manifest_entries_gate_correctly() {
             .map(|a| a.iter().filter_map(Value::as_str).collect())
             .unwrap_or_default();
         assert_eq!(caps, vec!["text_to_image"], "{id} capabilities");
-        // Gated stabilityai/* download (Stability AI Community License); HF credential host.
+        // UN-gated SceneWorks MLX re-host (sc-8513, epic 8506): the pre-built quant-matrix turnkey
+        // carries the Stability AI Community License + "Powered by Stability AI" NOTICE, so no HF
+        // credential host / license-click. (Was the gated stabilityai/* source + install-time convert.)
         assert_eq!(
             entry.get("gated").and_then(Value::as_bool),
-            Some(true),
+            Some(false),
             "{id} gated"
         );
         assert_eq!(
-            entry.get("credentialHost").and_then(Value::as_str),
-            Some("huggingface.co"),
-            "{id} credentialHost"
+            entry.get("credentialHost"),
+            None,
+            "{id} credentialHost (dropped on re-host)"
         );
-        let repo = entry
+        // Every tier download is the SceneWorks re-host (q4 default + q8 + bf16), and the default
+        // (first) entry is q4.
+        let downloads = entry
             .get("downloads")
             .and_then(Value::as_array)
-            .and_then(|d| d.first())
-            .and_then(|d| d.get("repo"))
-            .and_then(Value::as_str)
-            .unwrap_or("");
-        assert!(
-            repo.starts_with("stabilityai/stable-diffusion-3.5"),
-            "{id} downloads from the gated stabilityai/* repo (no re-host), got {repo:?}"
-        );
+            .unwrap_or_else(|| panic!("{id} downloads array"));
+        for dl in downloads {
+            let repo = dl.get("repo").and_then(Value::as_str).unwrap_or("");
+            assert!(
+                repo.starts_with("SceneWorks/sd3.5-"),
+                "{id} tier downloads from the SceneWorks re-host, got {repo:?}"
+            );
+        }
+        let first_files: Vec<&str> = downloads
+            .first()
+            .and_then(|d| d.get("files"))
+            .and_then(Value::as_array)
+            .map(|a| a.iter().filter_map(Value::as_str).collect())
+            .unwrap_or_default();
+        assert_eq!(first_files, vec!["q4/*"], "{id} default tier is q4");
         // Per-tier memory-eligibility gate (drives the Studio admit/hide-by-available-memory).
         assert_eq!(
             entry


### PR DESCRIPTION
## Summary
Resumes the catalog-wide quant-matrix rollout (epic 8506) after the FLUX.2-dev pilot ([#997](https://github.com/SceneWorks/SceneWorks/pull/997)). Generalizes the pilot's bespoke machinery into reusable, data-driven infrastructure, then brings the **entire SD3.5 family** onto the matrix.

### Generalized machinery (each future model is now data + ops, not a refactor)
- **Worker resolver** (`image_jobs/base.rs`): the one-off `flux2_dev_model_subdir` → a data-driven `standard_tier_subdir` + `STANDARD_TIER_MODELS` registry. Tier presence is filename-agnostic (scans `<tier>/transformer/` for any `*.safetensors` packed/shard OR `*.index.json` dense-sharded), so a new model needs only a registry entry. flux2_dev migrated onto it. Selection unchanged (bits≤0→bf16, >4→q8, else q4 default; fallback q4→q8→bf16→root). +2 unit tests.
- **Offline tier-builder** (`model_jobs.rs`, `tier_builder` test module): a per-converter dispatch over the **same production `ConvertPlan` converters** (byte-equivalent to install-time). q4/q8 run the production converter then dereference its dense symlinks into real files (HF upload needs real files); bf16 mirrors the dense source. New arch = one match arm.

### SD3.5 family → SceneWorks HF (public/ungated)
`SceneWorks/sd3.5-large-mlx`, `sd3.5-large-turbo-mlx`, `sd3.5-medium-mlx` — each with **bf16/Q8/Q4** turnkey subdirs (3 models × 3 tiers = 9 hosted artifacts). Only the MMDiT is quantized; the dense triple TE (CLIP-L + CLIP-G + T5-XXL) + 16-ch VAE are reused in every tier. Stability AI Community License + "Powered by Stability AI" NOTICE travel with the weights; `extra_gated_*` keys stripped (Community License permits redistribution — matches the FLUX.2/Krea re-host precedent).
- **Manifest**: per-tier downloads (q4 default + q8 + bf16, **real measured on-disk sizes**); dropped `mlx.requiresConversion`/`converter`/`convertSourceRepo` + the gated source download; `gated:false`; `licenseUrl` → re-host. `default_repo` → the SceneWorks repos.
- **Removes** the gated diffusers download + install-time Q8 convert for every user.

### Verification
- On-device: the hosted **q4** tier of each variant loads through the real worker engine and generates a non-degenerate 512² image (`sd3_5_hosted_tier_real_weights…`). Large/Medium true-CFG; the distilled Turbo runs CFG-free (verify omits guidance there). q8 = same packed format/load path as the proven q4 (by construction); bf16 = dense (same loader, exercised by FLUX.2-dev's bf16 verify).
- Gates green locally: `cargo fmt --all --check`, `cargo clippy -p sceneworks-worker --all-targets -D warnings`, candle parity (`--no-default-features -F backend-candle --all-targets`), engines manifest-parse tests, 3× on-device q4 gen.

### Notes
- Per-variant tier **selection** (exposing q8/bf16 to users) is sc-8508/8509; until then the q4 default auto-pulls, same interim state as the FLUX.2-dev pilot.
- Remaining sc-8513 work: roll the same loop to the rest of the catalog (~40 models), tracked on the story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)