### PR TITLE
feat(depth): off-Mac candle depth auto-estimation via candle-gen-depth (sc-8413)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,6 +491,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "candle-gen-depth"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=725190c5a0dcf55f6657ca4becbb242b3f606fe0#725190c5a0dcf55f6657ca4becbb242b3f606fe0"
+dependencies = [
+ "candle-core",
+ "candle-gen",
+ "candle-nn",
+]
+
+[[package]]
 name = "candle-gen-face"
 version = "0.0.0"
 source = "git+https://github.com/michaeltrefry/candle-gen?rev=725190c5a0dcf55f6657ca4becbb242b3f606fe0#725190c5a0dcf55f6657ca4becbb242b3f606fe0"
@@ -5578,6 +5588,7 @@ dependencies = [
  "candle-gen-boogu",
  "candle-gen-chroma",
  "candle-gen-clip",
+ "candle-gen-depth",
  "candle-gen-face",
  "candle-gen-flux",
  "candle-gen-flux2",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -574,6 +574,13 @@ backend-candle = [
     # utility segmenter (NOT inventory-registered), called directly from `person_segment_sam3_candle.rs`
     # (`Sam3VideoModel::propagate("person")`). Retires the off-Mac `maskState = "missing"` box-only path.
     "dep:candle-gen-sam3",
+    # sc-8413 (epic 8236): the candle Depth Anything V2 monocular depth estimator — the Windows/CUDA
+    # sibling of `mlx-gen-depth`, providing the off-Mac auto depth-map preprocessor for `ControlKind::Depth`.
+    # A bespoke utility preprocessor (NOT inventory-registered, like candle-gen-face/sam3), called directly
+    # from `depth.rs`'s non-mac `depth_control_image` (`DepthAnythingV2::estimate_control_rgb8`). Replaces
+    # the off-Mac "automatic depth estimation is macOS-only" error. The control-lane routing that calls it
+    # is the separate sc-8304.
+    "dep:candle-gen-depth",
     # sc-5496 (epic 5482): DWPose pose detection off-Mac via the `ort` (onnxruntime) crate with the CUDA
     # execution provider — the Windows/Linux sibling of the macOS sc-3487 `ort`/CoreML path; `zip` unpacks
     # the openmmlab weight bundles. Both are Mac-non-optional but off-Mac optional + candle-gated (declared
@@ -1492,6 +1499,17 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
 candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "725190c5a0dcf55f6657ca4becbb242b3f606fe0", features = ["cuda"], optional = true }
+# Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
+# Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
+# `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
+# `DepthAnythingV2::from_dir` / `estimate_control_rgb8` DIRECTLY to auto-estimate the `ControlKind::Depth`
+# control image (the off-Mac path previously errored "automatic depth estimation is macOS-only"). The model
+# is the ungated ~100 MB `depth-anything/Depth-Anything-V2-Small-hf` checkpoint, resolved/cached via the
+# worker's existing HF-snapshot mechanism. Same git rev as every candle-gen provider above — candle-gen-depth
+# re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
+# still resolves ONE candle-gen / gen-core build (725190c5 pins the gen-core rev matching the worker's mlx
+# pin; no skew). The control-lane routing that drives this is the separate sc-8304.
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "725190c5a0dcf55f6657ca4becbb242b3f606fe0", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/depth.rs
+++ b/crates/sceneworks-worker/src/depth.rs
@@ -1,27 +1,41 @@
-//! Depth-map preprocessor for the Fun-Controlnet-Union depth head (epic 8236, sc-8242).
-//! A native-MLX model-agnostic preprocessor — sibling of [`crate::canny`] /
+//! Depth-map preprocessor for the Fun-Controlnet-Union depth head (epic 8236, sc-8242 mac /
+//! sc-8413 candle). A model-agnostic preprocessor — sibling of [`crate::canny`] /
 //! `openpose_skeleton`: an arbitrary input image → a depth control image for
 //! `ControlKind::Depth`.
 //!
-//! Unlike canny/pose (pure raster, cross-platform), depth needs real neural inference,
-//! so it is **macOS-gated** and runs the native-MLX [`mlx_gen_depth`] port of Depth
-//! Anything V2 (DINOv2 ViT-S/14 + DPT). The model is the **Small** variant
-//! (`depth-anything/Depth-Anything-V2-Small-hf`, apache-2.0, ungated) — favoring
-//! speed/size for a preprocessing tier.
+//! Unlike canny/pose (pure raster, cross-platform), depth needs real neural inference, so it runs
+//! a from-scratch Depth Anything V2 port (DINOv2 ViT-S/14 + DPT) on whichever backend the build
+//! selects:
+//! - **macOS** — the native-MLX [`mlx_gen_depth`] port (sc-8242);
+//! - **off-Mac + `backend-candle`** — the candle/CUDA `candle_gen_depth` sibling (sc-8413), so
+//!   `ControlKind::Depth` auto-estimates on Windows/Linux instead of erroring "macOS-only".
+//!
+//! Both load the **Small** variant (`depth-anything/Depth-Anything-V2-Small-hf`, apache-2.0,
+//! ungated) — favoring speed/size for a preprocessing tier — from a snapshot dir holding
+//! `model.safetensors`, and expose the same [`depth_control_image`] entry point.
 //!
 //! Output contract: an [`image::RgbImage`], the same type the pose preprocessor's
 //! `draw_wholebody` and the canny preprocessor return and the `ControlKind::Depth` path
 //! consumes — a single-channel depth map min/max-normalized to `[0,255]` and broadcast
 //! across the three RGB channels (near = bright, the standard ControlNet depth
 //! convention), at the input image's dimensions.
+//!
+//! The control-lane routing that drives [`depth_control_image`] off-Mac (the shared candle
+//! strict-control driver) is the separate sc-8304; this module only provides the estimation entry
+//! point so that PR can call it.
 
 /// The Hugging Face repo for the default depth estimator: Depth Anything V2 **Small**
 /// (apache-2.0, ungated — ships standard `model.safetensors`; no re-host needed). The
 /// `-hf` (transformers) mirror is the safetensors-bearing one (the base
 /// `depth-anything/Depth-Anything-V2-Small` ships only a `.pth`).
+///
+/// Always available (the strict-control weight-resolution + smoke tests reference it on every
+/// platform); only the estimation function is backend-gated.
 pub const DEPTH_ANYTHING_V2_SMALL_REPO: &str = "depth-anything/Depth-Anything-V2-Small-hf";
 
-/// The single weight file the estimator loads from its snapshot dir.
+/// The single weight file the estimator loads from its snapshot dir. (Both the MLX and candle
+/// loaders read every `*.safetensors` in the dir; the published Small checkpoint ships exactly
+/// this one file.)
 pub const DEPTH_ANYTHING_V2_FILE: &str = "model.safetensors";
 
 /// Estimate a depth control image from an arbitrary RGB input, loading the Depth Anything V2
@@ -29,7 +43,7 @@ pub const DEPTH_ANYTHING_V2_FILE: &str = "model.safetensors";
 ///
 /// `img` is the source RGB image; the returned [`image::RgbImage`] is the normalized
 /// grayscale-broadcast depth map at the SAME dimensions, drop-in for the `ControlKind::Depth`
-/// path (the sibling of `canny::canny_control_image_default`). macOS-only (MLX inference).
+/// path (the sibling of `canny::canny_control_image_default`). macOS path: MLX inference.
 #[cfg(target_os = "macos")]
 pub fn depth_control_image(
     img: &image::RgbImage,
@@ -46,4 +60,90 @@ pub fn depth_control_image(
     image::RgbImage::from_raw(w, h, control).ok_or_else(|| {
         WorkerError::Engine("depth estimator returned a mis-sized control buffer".to_owned())
     })
+}
+
+/// Off-Mac (Windows/Linux) candle/CUDA depth auto-estimation — the sibling of the macOS MLX path
+/// above, backed by the from-scratch `candle_gen_depth` Depth Anything V2 port (sc-8413, the
+/// Windows/CUDA twin of `mlx-gen-depth`).
+///
+/// Identical signature + contract to the macOS function: `img` is the source RGB image,
+/// `weights_dir` is the Depth-Anything-V2-Small snapshot dir holding `model.safetensors`, and the
+/// returned [`image::RgbImage`] is the normalized grayscale-broadcast depth control map at the SAME
+/// dimensions. `DepthAnythingV2::from_dir` runs on the build's default candle device (CUDA when
+/// built+available, else CPU); `estimate_control_rgb8` returns the `w·h·3` RGB control buffer.
+///
+/// Replaces the prior off-Mac "automatic depth estimation is macOS-only" error so the candle
+/// strict-control driver (sc-8304) can auto-estimate `ControlKind::Depth`.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+pub fn depth_control_image(
+    img: &image::RgbImage,
+    weights_dir: &std::path::Path,
+) -> crate::WorkerResult<image::RgbImage> {
+    use crate::WorkerError;
+
+    let model = candle_gen_depth::DepthAnythingV2::from_dir(weights_dir)
+        .map_err(|error| WorkerError::Engine(format!("depth estimator load: {error}")))?;
+    let (w, h) = (img.width(), img.height());
+    let control = model
+        .estimate_control_rgb8(img.as_raw(), w, h)
+        .map_err(|error| WorkerError::Engine(format!("depth estimate: {error}")))?;
+    image::RgbImage::from_raw(w, h, control).ok_or_else(|| {
+        WorkerError::Engine("depth estimator returned a mis-sized control buffer".to_owned())
+    })
+}
+
+#[cfg(all(test, not(target_os = "macos"), feature = "backend-candle"))]
+mod candle_tests {
+    //! Off-Mac candle depth-path tests (sc-8413).
+    //!
+    //! - [`constants_point_at_ungated_small`] always runs (no weights / no GPU): it pins the weight
+    //!   source the strict-control resolver + this estimator agree on.
+    //! - [`estimates_depth_control_at_input_dims`] is a real-weight smoke gated on
+    //!   `SCENEWORKS_DEPTH_ANYTHING_V2` (the same env var the strict-control depth smokes use); it
+    //!   skips when unset/missing so the candle-worker CI lane (which BUILDS the cuda feature but has
+    //!   no GPU and no cached weights) stays green. `DepthAnythingV2::from_dir` falls back to the CPU
+    //!   device when no GPU is present, so it CAN run in CI once the ~100 MB Small checkpoint is
+    //!   cached and the env var is set; otherwise the coordinator's local CUDA build runs it.
+    use super::*;
+
+    #[test]
+    fn constants_point_at_ungated_small() {
+        assert_eq!(
+            DEPTH_ANYTHING_V2_SMALL_REPO,
+            "depth-anything/Depth-Anything-V2-Small-hf"
+        );
+        assert_eq!(DEPTH_ANYTHING_V2_FILE, "model.safetensors");
+    }
+
+    #[test]
+    fn estimates_depth_control_at_input_dims() {
+        let Ok(dir) = std::env::var("SCENEWORKS_DEPTH_ANYTHING_V2") else {
+            eprintln!("skipping: set SCENEWORKS_DEPTH_ANYTHING_V2 to the Small snapshot dir");
+            return;
+        };
+        let dir = std::path::PathBuf::from(dir);
+        if !dir.join(DEPTH_ANYTHING_V2_FILE).is_file() {
+            eprintln!(
+                "skipping: {DEPTH_ANYTHING_V2_FILE} missing in {}",
+                dir.display()
+            );
+            return;
+        }
+        // A small non-uniform RGB gradient input.
+        let (w, h) = (64u32, 48u32);
+        let img = image::RgbImage::from_fn(w, h, |x, y| {
+            image::Rgb([(x * 4 % 256) as u8, (y * 5 % 256) as u8, 128])
+        });
+        let control = depth_control_image(&img, &dir).expect("candle depth estimate");
+        assert_eq!(
+            control.dimensions(),
+            (w, h),
+            "depth map must match input dims"
+        );
+        // Grayscale broadcast: every pixel's three channels are equal.
+        assert!(
+            control.pixels().all(|p| p[0] == p[1] && p[1] == p[2]),
+            "depth control must be grayscale-broadcast across RGB"
+        );
+    }
 }

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -182,12 +182,14 @@ mod openpose_skeleton;
 // off-Mac candle lane has no registry strict-control path, so it stays unused there.
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 mod canny;
-// Native-MLX depth-map preprocessor for the Fun-Controlnet-Union depth head (epic 8236,
-// sc-8242): arbitrary image → `ControlKind::Depth` control image via the Depth Anything V2
-// port (`mlx-gen-depth`). Sibling of `canny` / `openpose_skeleton`, but — unlike those pure
-// raster preprocessors — depth needs neural inference, so it is macOS-gated (MLX). Consumed
-// by the shared strict-control driver (sc-8243); the off-Mac candle lane has no registry
-// strict-control path, so it stays unused there.
+// Depth-map preprocessor for the Fun-Controlnet-Union depth head (epic 8236): arbitrary image →
+// `ControlKind::Depth` control image via a Depth Anything V2 port. Sibling of `canny` /
+// `openpose_skeleton`, but — unlike those pure raster preprocessors — depth needs neural
+// inference, so it is backend-gated: macOS = `mlx-gen-depth` (sc-8242), off-Mac + `backend-candle`
+// = `candle-gen-depth` (sc-8413, the Windows/CUDA sibling). Consumed by the shared strict-control
+// driver (sc-8243 mac); the off-Mac candle strict-control routing that calls the candle estimator
+// is the separate sc-8304, so `depth_control_image` stays unused on the candle lane until then
+// (hence the `allow(dead_code)` below).
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 mod depth;
 // DWPose pose detection via onnxruntime (epic 3482, sc-3487). On Mac the CoreML EP +


### PR DESCRIPTION
## sc-8413 (worker half) — non-macOS depth auto-estimation via candle-gen-depth

Wires the candle Depth Anything V2 engine (`candle-gen-depth`, merged in candle-gen #191; worker already re-pinned to candle-gen `725190c5` in #1000) into the worker so `ControlKind::Depth` **auto-estimates on the candle backend (Windows/Linux, non-macOS)** instead of erroring `"automatic depth estimation is macOS-only"`. Only user-supplied depth passthrough worked off-Mac before.

### Changes
- **`crates/sceneworks-worker/Cargo.toml`** — add `candle-gen-depth` as an optional dep at the **same git rev (`725190c5`)** as every other candle-gen provider (it re-exports gen_core + candle from `candle-gen`, the same workspace pin → one candle/gen-core build, no skew), and add it to the `backend-candle` feature dep list. A **bespoke utility preprocessor** (NOT inventory-registered), like `candle-gen-face` / `candle-gen-sam3` — called directly from `depth.rs`.
- **`crates/sceneworks-worker/src/depth.rs`** — add a `#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]` `depth_control_image`, the sibling of the macOS MLX path, backed by `candle_gen_depth::DepthAnythingV2::from_dir` / `estimate_control_rgb8`. **Identical signature + `image::RgbImage` control-map contract.** The macOS path is **untouched**. The `DEPTH_ANYTHING_V2_*` constants stay always-available (the strict-control resolver + smokes reference them on every platform).
- **`crates/sceneworks-worker/src/lib.rs`** — refresh the `mod depth` doc comment to describe the dual backend; keep the `allow(dead_code)` (the off-Mac caller arrives with sc-8304).

### Weights
Ungated ~100 MB `depth-anything/Depth-Anything-V2-Small-hf` (`model.safetensors`), resolved/cached via the worker's existing HF-snapshot mechanism — same source the macOS path uses (`ensure_depth_estimator_dir` in `strict_control.rs`, env override `SCENEWORKS_DEPTH_ANYTHING_V2` → HF cache snapshot → lazy single-file fetch).

### cfg gating
`#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]` for the new estimation path. macOS path unchanged. The default off-Mac sidecar (no `backend-candle`) pulls nothing new.

### Tests
- `constants_point_at_ungated_small` — always runs (no weights/GPU), pins the weight source the resolver + estimator agree on.
- `estimates_depth_control_at_input_dims` — real-weight CPU smoke gated on `SCENEWORKS_DEPTH_ANYTHING_V2` (skips when unset/missing, so the `candle-worker` CI lane stays green). `from_dir` falls back to the CPU device when no GPU is present, so it **can** run in CI once the small checkpoint is cached; otherwise the coordinator's local CUDA build runs it.

Both tests are gated `#[cfg(all(test, not(target_os = "macos"), feature = "backend-candle"))]`, so they compile/run only on the `candle-worker` lane (the cuda feature BUILDS against the CUDA toolchain).

### Verification done here
- `cargo check -p sceneworks-worker` (default, non-candle) — clean.
- `cargo check -p sceneworks-worker --locked` — clean, no lock drift (core-llm stays `3870ed1c`; Cargo.lock diff is only the candle-gen-depth addition).
- `cargo fmt -p sceneworks-worker --check` — clean.
- The `backend-candle` cuda build + a real-weight depth render are deferred to the **`candle-worker` CI lane** + the coordinator's local CUDA build (vcvars VS2022 / `CUDA_COMPUTE_CAP=120`).

### Scope
The candle control **lane routing** (the shared strict-control driver that calls this off-Mac) is the **separate sc-8304** — this PR only provides the worker's depth-estimation entry point so that PR can call it. The off-Mac `strict_control.rs` stub is intentionally left for sc-8304.

Story: sc-8413

🤖 Generated with [Claude Code](https://claude.com/claude-code)