### PR TITLE
refactor(image-jobs): route the candle strict-control trio through a shared driver (sc-8304)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -36,9 +36,14 @@ use gen_core::{
 };
 // `AdapterKind` (LoRA/LoKr classification) was MLX-only until sc-5126: the candle Lens lane is the
 // first candle family to take LoRA/LoKr, so it now classifies adapters too and the import moved into
-// the shared block above. `ControlKind` (ControlNet conditioning) stays MLX-only — the candle lane is
-// pure txt2img.
-#[cfg(target_os = "macos")]
+// the shared block above. `ControlKind` (ControlNet conditioning) was MLX-only until sc-8304: the candle
+// strict-control trio (`candle_strict_control.rs`) now shares the cross-platform `strict_control.rs`
+// `(engine_id, supported_kinds)` table + `preprocess_control_entry`, so `ControlKind` is in scope on the
+// candle build too.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 use gen_core::ControlKind;
 #[cfg(target_os = "macos")]
 use mlx_gen_chroma as _;
@@ -1538,10 +1543,16 @@ include!("image_jobs/base.rs");
 #[cfg(target_os = "macos")]
 // Per-generation PiD (pixel-diffusion) super-resolving decoder routing (epic 7840, sc-7849).
 include!("image_jobs/pid.rs");
-#[cfg(target_os = "macos")]
 // Shared strict-control driver (epic 8236, sc-8243): the `(engine_id, control_repo, supported_kinds)`
 // single source of truth + the preprocess (pose/canny/depth/user-passthrough) → `Conditioning::Control`
-// core the three MLX registry strict-control paths (zimage/flux2/qwen below) route through.
+// core the three MLX registry strict-control paths (zimage/flux2/qwen below) route through. Off-Mac the
+// candle strict-control trio (`candle_strict_control.rs`, sc-8304) reuses the SAME table +
+// `preprocess_control_entry` (pose/canny/depth), so this is gated to either platform (the candle build
+// off-Mac, MLX on macOS) rather than macOS-only.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 include!("image_jobs/strict_control.rs");
 #[cfg(target_os = "macos")]
 // Z-Image strict-pose and prompt augmentation helpers.
@@ -1605,6 +1616,12 @@ include!("image_jobs/kolors_ipadapter.rs");
 // bespoke provider, so this is candle-exclusive.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 include!("image_jobs/flux_ipadapter.rs");
+// Shared candle strict-control driver (sc-8304, epic 8236): the `CandleStrictControl` trait + the one
+// `run_candle_strict_control` driver the candle trio (qwen/zimage/flux2 control below) route through —
+// reusing the SAME `STRICT_CONTROL_ENGINES` table + `preprocess_control_entry` (pose/canny/depth) as the
+// MLX `strict_control.rs`. Must precede the three lanes (they reference the trait + driver).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+include!("image_jobs/candle_strict_control.rs");
 // Qwen-Image ControlNet (strict pose) — the Windows/CUDA candle lane ONLY (sc-5489). macOS keeps the
 // MLX `qwen_image_control` registry generator; the candle `QwenControl` is a bespoke provider.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]

--- a/crates/sceneworks-worker/src/image_jobs/candle_strict_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/candle_strict_control.rs
@@ -1,0 +1,222 @@
+// Shared candle (Windows/CUDA) strict-control driver (sc-8304, epic 8236). The candle siblings of the
+// MLX `strict_control.rs` driver: the three bespoke non-registry candle control providers
+// (`ZImageControl` / `Flux2Control` / `QwenControl`) used to each carry a near-identical
+// `start_gen_stream` lane that rendered a DWPose skeleton, fed it as a raw control `Image` to the
+// provider, and scored the result. That scaffold — control-kind resolution + validation against the
+// SAME [`STRICT_CONTROL_ENGINES`] table, pose/canny/depth/user-passthrough preprocessing via the
+// cross-platform [`preprocess_control_entry`], source threading, the per-pose loop, identity-likeness
+// scoring, and the `consume_gen_events` sink — is now ONE driver here. Each provider keeps only its
+// genuinely-divergent bits (base/control weight resolution, its bespoke request struct + `generate`
+// call, raw_settings keys, control-scale defaults, engine label) behind the [`CandleStrictControl`]
+// trait.
+//
+// **Candle-only.** macOS keeps the MLX registry strict-control paths (driven by `strict_control.rs`
+// directly); this driver is the off-Mac candle lane (`#[cfg(all(not(target_os = "macos"), feature =
+// "backend-candle"))]`), `include!`d into the `image_jobs` module so it shares the unqualified imports.
+//
+// **Pose is byte-preserved (REGRESSION-CRITICAL).** A pose job sets no `advanced.controlMode`, so
+// `requested_control_kind` returns [`ControlKind::Pose`] and `preprocess_control_entry` renders the
+// exact same `draw_wholebody` skeleton at the same stickwidth the per-lane code did before — the
+// control `Image` handed to each provider's `generate` is identical. canny / depth are purely additive
+// (reached only when a future request sets `controlMode = canny | depth`), and the candle-gen control
+// engines VAE-encode any RGB control image generically (no pose-only gate), so they flow without an
+// engine change.
+
+/// The genuinely per-provider half of a candle strict-control lane: build the bespoke request struct and
+/// call the provider's `generate(&req, control_image, on_progress)`. Everything else (control-kind
+/// resolution/validation, pose/canny/depth preprocessing, source threading, the per-pose loop, scoring,
+/// streaming) is the shared [`run_candle_strict_control`] driver.
+///
+/// `Model` is the loaded `!Send` provider (`ZImageControl` / `Flux2Control` / `QwenControl`); it is built
+/// and consumed entirely inside the one `spawn_blocking`, so it never needs to be `Send`. The implementor
+/// (the small per-lane config struct) IS moved across the blocking boundary, so it must be `Send +
+/// 'static`.
+trait CandleStrictControl: Send + 'static {
+    /// The loaded candle control provider.
+    type Model;
+
+    /// The [`STRICT_CONTROL_ENGINES`] catalog id whose `supported_kinds` gates this lane's
+    /// `advanced.controlMode` (`z_image_turbo_control` / `flux2_dev_control` / `qwen_image_control`).
+    fn engine_id(&self) -> &'static str;
+
+    /// The engine label recorded on assets / `raw_settings` (`candle_zimage_control` /
+    /// `candle_flux2_control` / `candle_qwen_control`) — byte-preserved per the regression contract.
+    fn engine_label(&self) -> &'static str;
+
+    /// The short `start_gen_stream` tag (`zimage_control` / `flux2_control` / `qwen_control`).
+    fn stream_tag(&self) -> &'static str;
+
+    /// Load the provider on the blocking thread (download already happened in the async preamble).
+    fn load(&self) -> WorkerResult<Self::Model>;
+
+    /// Generate one image conditioned on the already-preprocessed `control` map (pose skeleton, canny
+    /// edges, or depth map — the driver picked which). Builds the bespoke request struct internally; the
+    /// driver supplies the shared seed + cancel + progress callback. Returns the output [`Image`].
+    fn generate_one(
+        &self,
+        model: &Self::Model,
+        control: &Image,
+        seed: u64,
+        cancel: &CancelFlag,
+        on_progress: &mut dyn FnMut(Progress),
+    ) -> WorkerResult<Image>;
+}
+
+/// The shared async preamble + per-pose streaming driver for a candle strict-control lane (sc-8304).
+///
+/// Mirrors the MLX `strict_control.rs` flow, adapted to the candle providers' raw-`Image` control input
+/// (vs the MLX `Conditioning::Control`): resolve + validate the requested [`ControlKind`] against the
+/// engine's `supported_kinds`, resolve the user-supplied control-map passthrough and the canny/depth
+/// source image, provision the depth estimator only for a depth job without a passthrough, then run one
+/// generation per pose — each preprocessing its control map via [`preprocess_control_entry`] (pose =
+/// `draw_wholebody`; canny = `canny`; depth = the backend depth estimator) and scoring the result
+/// against the optional identity reference. `raw_settings` / `pose_count` / the engine label are passed
+/// through to [`consume_gen_events`] unchanged.
+///
+/// `provider` is the per-lane [`CandleStrictControl`] config (it holds the resolved weight paths +
+/// request numerics); it is moved into the blocking thread, loaded once, and drives every pose.
+#[allow(clippy::too_many_arguments)]
+async fn run_candle_strict_control<P: CandleStrictControl>(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    provider: P,
+    raw_settings: JsonObject,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+
+    // Shared strict-control driver: validate the requested ControlKind against the engine's
+    // supported_kinds + resolve an optional user-supplied control-map passthrough. A pose job sets no
+    // `controlMode`, so `kind == Pose` and the skeleton preprocessor runs exactly as the per-lane code
+    // did before (byte-identical pose path).
+    let control_kind = requested_control_kind(request)?;
+    validate_control_kind(provider.engine_id(), &control_kind)?;
+    let user_control = resolve_user_control_map(request, settings, project_path)?;
+    // Source threading: for canny/depth WITHOUT a user-supplied control map, the control map is
+    // auto-derived from the input image (canny edges / Depth-Anything-V2). The pose tier never needs a
+    // source (the skeleton is synthetic).
+    let control_source = resolve_control_source(request, settings, project_path)?;
+    // Auto depth-estimator weights: provisioned only when this is a depth job WITHOUT a user-supplied
+    // depth map (the passthrough short-circuits estimation). Fetched once on the first depth job (the
+    // off-Mac candle estimator, sc-8413).
+    let depth_weights_dir = if control_kind == ControlKind::Depth && user_control.is_none() {
+        Some(ensure_depth_estimator_dir(api, settings, job).await?)
+    } else {
+        None
+    };
+
+    let poses = parse_poses(request);
+    let pose_count = poses.len();
+
+    let (width, height) = (request.width, request.height);
+    let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
+    // One shared seed across the pose set (the MLX `_generate_pose_set` convention) so noise-derived
+    // attributes (hair, wardrobe, lighting) stay constant while only the pose changes. `resolve_seed`
+    // returns `i64` (the asset-write tuple seed); the candle providers' request structs take `u64` (the
+    // per-lane code cast the same at the `generate` call).
+    let seed = resolve_seed(request, 0);
+
+    // Identity-likeness scoring (epic 4406, sc-4410): when this candle strict-pose set carries a
+    // character identity `referenceAssetId`, score every finished pose against that source identity face
+    // through the SHARED generator-agnostic seam. Source decode + face-stack staging are non-fatal; the
+    // `!Send` scorer is built ONCE in the load closure on the blocking thread (source embedded once,
+    // reused across all poses).
+    let likeness_source = resolve_control_identity_source(request, settings, project_path);
+    let face_stack_dir = if likeness_source.is_some() {
+        match ensure_face_stack_dir(api, settings, job).await {
+            Ok(dir) => Some(dir),
+            Err(error) => {
+                tracing::warn!(error = %error, "pose-set face-stack staging failed; likeness scores omitted");
+                None
+            }
+        }
+    } else {
+        None
+    };
+    let likeness_source_ref = likeness_source.as_ref().map(|(_, id)| id.clone());
+
+    let engine_label = provider.engine_label();
+    let stream_tag = provider.stream_tag();
+
+    let (cancel, rx, blocking) = start_gen_stream(
+        job.id.clone(),
+        stream_tag,
+        0,
+        move || {
+            let model = provider.load()?;
+            // Build the scorer once on the blocking thread (the `!Send` face stack lives here).
+            let scorer = match (&face_stack_dir, &likeness_source) {
+                (Some(dir), Some((source, _))) => {
+                    crate::face_likeness::build_face_likeness_scorer(dir, source)
+                }
+                _ => None,
+            };
+            Ok((provider, model, poses, scorer))
+        },
+        move |(provider, model, poses, scorer), tx, cancel| {
+            let user_control = user_control.as_ref();
+            let control_source = control_source.as_ref();
+            let depth_weights_dir = depth_weights_dir.as_deref();
+            drive_gen_items_scored(tx, poses, move |_index, pose, on_progress| {
+                if cancel.is_cancelled() {
+                    return Ok(None);
+                }
+                // Pose = the same `draw_wholebody` skeleton (byte-preserved); canny/depth derive from the
+                // threaded source. A user-supplied control map short-circuits for any kind.
+                let control = preprocess_control_entry(
+                    &control_kind,
+                    user_control,
+                    Some(&pose),
+                    control_source,
+                    width,
+                    height,
+                    stickwidth,
+                    depth_weights_dir,
+                )?;
+                let out =
+                    match provider.generate_one(&model, &control, seed as u64, &cancel, on_progress) {
+                        Ok(out) => out,
+                        Err(_) if cancel.is_cancelled() => return Ok(None),
+                        Err(error) => return Err(error),
+                    };
+                // Score this finished pose against the cached source embedding (sc-4410). The candle
+                // strict-control lane produces the FINAL image directly (no face-restore pass). Clone
+                // paid ONLY when a scorer exists; a full-body / turned pose with no reliable frontal
+                // face → honest detected:false N/A.
+                let face_likeness = scorer.as_ref().and_then(|scorer| {
+                    crate::face_likeness::score_generated_image(
+                        Some(scorer),
+                        &Image {
+                            width: out.width,
+                            height: out.height,
+                            pixels: out.pixels.clone(),
+                        },
+                        likeness_source_ref.as_deref(),
+                    )
+                });
+                Ok(Some((seed, out.width, out.height, out.pixels, face_likeness)))
+            })
+        },
+    );
+
+    consume_gen_events(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        engine_label,
+        &raw_settings,
+        pose_count,
+        rx,
+        cancel,
+        blocking,
+        asset_writes,
+    )
+    .await
+}

--- a/crates/sceneworks-worker/src/image_jobs/flux2_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2_control_candle.rs
@@ -36,6 +36,10 @@ const FLUX2_CONTROL_CANDLE_DEFAULT_GUIDANCE: f32 = 4.0;
 /// The adapter/engine id recorded on candle FLUX.2-dev control assets (distinct from the txt2img
 /// `candle_flux2` + edit `candle_flux2_edit` lanes).
 const FLUX2_CONTROL_CANDLE_ENGINE: &str = "candle_flux2_control";
+/// The [`STRICT_CONTROL_ENGINES`] catalog id this candle lane validates `advanced.controlMode` against
+/// (the dev Fun-Controlnet-Union row — `{Pose, Canny, Depth}`). Mirrors the MLX `flux2_dev_control`
+/// registry engine's `supported_kinds` (sc-8304).
+const FLUX2_CONTROL_CANDLE_ENGINE_ID: &str = "flux2_dev_control";
 
 /// Model ids the candle FLUX.2 strict-pose control route accepts (klein has no control checkpoint).
 fn is_flux2_control_model(model: &str) -> bool {
@@ -211,12 +215,78 @@ fn flux2_control_candle_raw_settings(
     raw
 }
 
+/// The per-lane half of the candle FLUX.2-dev strict-control [`CandleStrictControl`] driver (sc-8304):
+/// the resolved base + control weight paths, the Q4 quant policy, and the request numerics. dev keeps its
+/// embedded guidance (no true-CFG / negative pass). Moved onto the blocking thread, loaded once (Q4
+/// CPU-stage → quantize-onto-GPU), drives every pose.
+struct Flux2StrictControl {
+    base: PathBuf,
+    control: PathBuf,
+    quant: Option<Quant>,
+    prompt: String,
+    width: u32,
+    height: u32,
+    steps: u32,
+    guidance: f32,
+    control_scale: f32,
+}
+
+impl CandleStrictControl for Flux2StrictControl {
+    type Model = Flux2Control;
+
+    fn engine_id(&self) -> &'static str {
+        FLUX2_CONTROL_CANDLE_ENGINE_ID
+    }
+
+    fn engine_label(&self) -> &'static str {
+        FLUX2_CONTROL_CANDLE_ENGINE
+    }
+
+    fn stream_tag(&self) -> &'static str {
+        "flux2_control"
+    }
+
+    fn load(&self) -> WorkerResult<Self::Model> {
+        let paths = Flux2ControlPaths {
+            root: self.base.clone(),
+            control: self.control.clone(),
+        };
+        Flux2Control::load(&paths, self.quant).map_err(|error| {
+            WorkerError::Engine(format!("FLUX.2-dev strict-pose control load failed: {error}"))
+        })
+    }
+
+    fn generate_one(
+        &self,
+        model: &Self::Model,
+        control: &Image,
+        seed: u64,
+        cancel: &CancelFlag,
+        on_progress: &mut dyn FnMut(Progress),
+    ) -> WorkerResult<Image> {
+        let req = Flux2ControlRequest {
+            prompt: self.prompt.clone(),
+            width: self.width,
+            height: self.height,
+            steps: self.steps as usize,
+            guidance: self.guidance,
+            control_scale: self.control_scale,
+            seed,
+            cancel: cancel.clone(),
+        };
+        model.generate(&req, control, on_progress).map_err(|error| {
+            WorkerError::Engine(format!("FLUX.2-dev strict-pose generation failed: {error}"))
+        })
+    }
+}
+
 /// Real candle FLUX.2-dev strict-pose generation: one image per pose, each conditioned on a full DWPose
-/// skeleton via the Fun-Controlnet-Union branch (sc-7736; engine sc-7460). Mirrors
-/// [`generate_candle_zimage_control_stream`] — the control checkpoint is fetched on first use, then the
-/// dev control provider loads once on the blocking thread (Q4 CPU-stage → quantize-onto-GPU) and renders
-/// one image per pose (shared seed so only the pose changes across the set). dev keeps its embedded
-/// guidance (no CFG). `Flux2Control::generate` takes `&self`, so the per-item closure needs no `&mut`.
+/// skeleton (`controlMode` unset) or a canny/depth control map via the Fun-Controlnet-Union branch
+/// (sc-7736; engine sc-7460). Resolves the base + control weights + Q4 quant, then hands a
+/// [`Flux2StrictControl`] to the shared [`run_candle_strict_control`] driver (validation against
+/// `flux2_dev_control`'s `supported_kinds`, per-pose preprocessing, scoring). dev (32B) loads Q4 (manifest
+/// `mlx.quantize: 4` → `resolve_quant`); the control overlay quantizes in place. dev keeps its embedded
+/// guidance (no CFG). The pose path is byte-preserved.
 async fn generate_candle_flux2_control_stream(
     api: &ApiClient,
     settings: &Settings,
@@ -252,8 +322,7 @@ async fn generate_candle_flux2_control_stream(
         .unwrap_or(FLUX2_CONTROL_CANDLE_BASE_REPO)
         .to_owned();
 
-    let poses = parse_poses(request);
-    let pose_count = poses.len();
+    let pose_count = pose_entries(request).len();
     let raw_settings = flux2_control_candle_raw_settings(
         request,
         &repo,
@@ -264,120 +333,27 @@ async fn generate_candle_flux2_control_stream(
         pose_count,
     );
 
-    let (width, height) = (request.width, request.height);
-    let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
-    // One shared seed across the pose set (the MLX `_generate_pose_set` convention) so noise-derived
-    // attributes (hair, wardrobe, lighting) stay constant while only the pose changes.
-    let seed = resolve_seed(request, 0);
-    let prompt = request.prompt.clone();
-
-    // Identity-likeness scoring (epic 4406, sc-4410): when this candle FLUX.2-dev strict-pose set carries
-    // a character identity `referenceAssetId`, score every finished pose against that source identity face
-    // through the SHARED seam. Source decode + face-stack staging are non-fatal; the `!Send` scorer is
-    // built ONCE in the load closure (source embedded once, reused across all poses).
-    let likeness_source = resolve_control_identity_source(request, settings, project_path);
-    let face_stack_dir = if likeness_source.is_some() {
-        match ensure_face_stack_dir(api, settings, job).await {
-            Ok(dir) => Some(dir),
-            Err(error) => {
-                tracing::warn!(error = %error, "pose-set face-stack staging failed; likeness scores omitted");
-                None
-            }
-        }
-    } else {
-        None
+    let provider = Flux2StrictControl {
+        base,
+        control,
+        quant,
+        prompt: request.prompt.clone(),
+        width: request.width,
+        height: request.height,
+        steps,
+        guidance,
+        control_scale,
     };
-    let likeness_source_ref = likeness_source.as_ref().map(|(_, id)| id.clone());
 
-    let (cancel, rx, blocking) = start_gen_stream(
-        job.id.clone(),
-        "flux2_control",
-        0,
-        move || {
-            let paths = Flux2ControlPaths {
-                root: base,
-                control,
-            };
-            let model = Flux2Control::load(&paths, quant).map_err(|error| {
-                WorkerError::Engine(format!("FLUX.2-dev strict-pose control load failed: {error}"))
-            })?;
-            let scorer = match (&face_stack_dir, &likeness_source) {
-                (Some(dir), Some((source, _))) => {
-                    crate::face_likeness::build_face_likeness_scorer(dir, source)
-                }
-                _ => None,
-            };
-            Ok((model, poses, scorer))
-        },
-        move |(model, poses, scorer), tx, cancel| {
-            drive_gen_items_scored(tx, poses, move |_index, pose, on_progress| {
-                if cancel.is_cancelled() {
-                    return Ok(None);
-                }
-                let skeleton = crate::openpose_skeleton::draw_wholebody(
-                    width,
-                    height,
-                    &pose.keypoints,
-                    pose.hands.as_deref(),
-                    pose.face.as_deref(),
-                    stickwidth,
-                );
-                let control = Image {
-                    width,
-                    height,
-                    pixels: skeleton.into_raw(),
-                };
-                let req = Flux2ControlRequest {
-                    prompt: prompt.clone(),
-                    width,
-                    height,
-                    steps: steps as usize,
-                    guidance,
-                    control_scale,
-                    seed: seed as u64,
-                    cancel: cancel.clone(),
-                };
-                let out = match model.generate(&req, &control, &mut *on_progress) {
-                    Ok(out) => out,
-                    Err(_) if cancel.is_cancelled() => return Ok(None),
-                    Err(error) => {
-                        return Err(WorkerError::Engine(format!(
-                            "FLUX.2-dev strict-pose generation failed: {error}"
-                        )));
-                    }
-                };
-                // Score this finished pose against the cached source embedding (sc-4410). FINAL image
-                // (no face-restore pass on this lane). Clone paid ONLY when a scorer exists; a full-body
-                // / turned pose with no reliable frontal face → honest detected:false N/A.
-                let face_likeness = scorer.as_ref().and_then(|scorer| {
-                    crate::face_likeness::score_generated_image(
-                        Some(scorer),
-                        &Image {
-                            width: out.width,
-                            height: out.height,
-                            pixels: out.pixels.clone(),
-                        },
-                        likeness_source_ref.as_deref(),
-                    )
-                });
-                Ok(Some((seed, out.width, out.height, out.pixels, face_likeness)))
-            })
-        },
-    );
-
-    consume_gen_events(
+    run_candle_strict_control(
         api,
         settings,
         job,
         plan,
         project_path,
         backend,
-        FLUX2_CONTROL_CANDLE_ENGINE,
-        &raw_settings,
-        pose_count,
-        rx,
-        cancel,
-        blocking,
+        provider,
+        raw_settings,
         asset_writes,
     )
     .await

--- a/crates/sceneworks-worker/src/image_jobs/qwen_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_control.rs
@@ -25,6 +25,11 @@ const QWEN_CONTROL_DEFAULT_GUIDANCE: f32 = 4.0;
 /// The adapter/engine id recorded on candle Qwen control assets (distinct from the txt2img
 /// `candle_qwen` lane).
 const QWEN_CONTROL_ENGINE: &str = "candle_qwen_control";
+/// The [`STRICT_CONTROL_ENGINES`] catalog id this candle lane validates `advanced.controlMode` against
+/// (the `qwen_image_control` row — `{Pose, Canny, Depth}`). NOTE the candle lane still loads the InstantX
+/// `Qwen-Image-ControlNet-Union` checkpoint (its own default-repo constants above), not the table's
+/// 2512-Fun row — that source swap is the separate sc-8350. Only `supported_kinds` is shared here.
+const QWEN_CONTROL_ENGINE_ID: &str = "qwen_image_control";
 
 /// Model ids the candle Qwen ControlNet route accepts.
 fn is_qwen_control_model(model: &str) -> bool {
@@ -187,10 +192,77 @@ fn qwen_control_raw_settings(
     raw
 }
 
-/// Real candle Qwen strict-pose generation: one image per pose, each conditioned on a full DWPose
-/// skeleton. The provider loads once on the blocking thread; each pose renders its skeleton + generates.
-/// `generate` takes the per-job `CancelFlag` + a `Progress` callback (per-step streaming + mid-denoise
-/// cancel), the same contract as the IP-Adapter lanes.
+/// The per-lane half of the candle Qwen strict-control [`CandleStrictControl`] driver (sc-8304): the
+/// resolved base + InstantX control weight paths + the request numerics. Qwen runs true CFG, so it carries
+/// a negative prompt + guidance. Moved onto the blocking thread, loaded once, drives every pose.
+struct QwenStrictControl {
+    qwen_base: PathBuf,
+    controlnet: PathBuf,
+    prompt: String,
+    negative: String,
+    width: u32,
+    height: u32,
+    steps: u32,
+    guidance: f32,
+    control_scale: f32,
+}
+
+impl CandleStrictControl for QwenStrictControl {
+    type Model = QwenControl;
+
+    fn engine_id(&self) -> &'static str {
+        QWEN_CONTROL_ENGINE_ID
+    }
+
+    fn engine_label(&self) -> &'static str {
+        QWEN_CONTROL_ENGINE
+    }
+
+    fn stream_tag(&self) -> &'static str {
+        "qwen_control"
+    }
+
+    fn load(&self) -> WorkerResult<Self::Model> {
+        let paths = QwenControlPaths {
+            qwen_base: self.qwen_base.clone(),
+            controlnet: self.controlnet.clone(),
+        };
+        QwenControl::load(&paths).map_err(|error| {
+            WorkerError::Engine(format!("Qwen strict-pose control load failed: {error}"))
+        })
+    }
+
+    fn generate_one(
+        &self,
+        model: &Self::Model,
+        control: &Image,
+        seed: u64,
+        cancel: &CancelFlag,
+        on_progress: &mut dyn FnMut(Progress),
+    ) -> WorkerResult<Image> {
+        let req = QwenControlRequest {
+            prompt: self.prompt.clone(),
+            negative: self.negative.clone(),
+            width: self.width,
+            height: self.height,
+            steps: self.steps as usize,
+            guidance: self.guidance,
+            control_scale: self.control_scale,
+            seed,
+            cancel: cancel.clone(),
+        };
+        model.generate(&req, control, on_progress).map_err(|error| {
+            WorkerError::Engine(format!("Qwen strict-pose generation failed: {error}"))
+        })
+    }
+}
+
+/// Real candle Qwen strict-pose generation: one image per pose, each conditioned on a full DWPose skeleton
+/// (`controlMode` unset) or a canny/depth control map. Resolves the base + InstantX control weights, then
+/// hands a [`QwenStrictControl`] to the shared [`run_candle_strict_control`] driver (validation against
+/// `qwen_image_control`'s `supported_kinds`, per-pose preprocessing, scoring). `generate` takes the
+/// per-job `CancelFlag` + a `Progress` callback (per-step streaming + mid-denoise cancel). The pose path
+/// is byte-preserved.
 async fn generate_candle_qwen_control_stream(
     api: &ApiClient,
     settings: &Settings,
@@ -222,126 +294,31 @@ async fn generate_candle_qwen_control_stream(
         .unwrap_or(QWEN_CONTROL_DEFAULT_REPO)
         .to_owned();
 
-    let poses = parse_poses(request);
-    let pose_count = poses.len();
+    let pose_count = pose_entries(request).len();
     let raw_settings =
         qwen_control_raw_settings(request, &repo, steps, guidance, control_scale, pose_count);
 
-    let (width, height) = (request.width, request.height);
-    let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
-    // One shared seed across the pose set (the MLX `_generate_pose_set` convention).
-    let seed = resolve_seed(request, 0);
-    let prompt = request.prompt.clone();
-    let negative = request.negative_prompt.clone();
-
-    // Identity-likeness scoring (epic 4406, sc-4410): when this candle Qwen strict-pose set carries a
-    // character identity `referenceAssetId`, score every finished pose against that source identity face
-    // through the SHARED seam. Source decode + face-stack staging are non-fatal; the `!Send` scorer is
-    // built ONCE in the load closure (source embedded once, reused across all poses).
-    let likeness_source = resolve_control_identity_source(request, settings, project_path);
-    let face_stack_dir = if likeness_source.is_some() {
-        match ensure_face_stack_dir(api, settings, job).await {
-            Ok(dir) => Some(dir),
-            Err(error) => {
-                tracing::warn!(error = %error, "pose-set face-stack staging failed; likeness scores omitted");
-                None
-            }
-        }
-    } else {
-        None
+    let provider = QwenStrictControl {
+        qwen_base,
+        controlnet,
+        prompt: request.prompt.clone(),
+        negative: request.negative_prompt.clone(),
+        width: request.width,
+        height: request.height,
+        steps,
+        guidance,
+        control_scale,
     };
-    let likeness_source_ref = likeness_source.as_ref().map(|(_, id)| id.clone());
 
-    let (cancel, rx, blocking) = start_gen_stream(
-        job.id.clone(),
-        "qwen_control",
-        0,
-        move || {
-            let paths = QwenControlPaths {
-                qwen_base,
-                controlnet,
-            };
-            let model = QwenControl::load(&paths).map_err(|error| {
-                WorkerError::Engine(format!("Qwen strict-pose control load failed: {error}"))
-            })?;
-            let scorer = match (&face_stack_dir, &likeness_source) {
-                (Some(dir), Some((source, _))) => {
-                    crate::face_likeness::build_face_likeness_scorer(dir, source)
-                }
-                _ => None,
-            };
-            Ok((model, poses, scorer))
-        },
-        move |(model, poses, scorer), tx, cancel| {
-            drive_gen_items_scored(tx, poses, move |_index, pose, on_progress| {
-                if cancel.is_cancelled() {
-                    return Ok(None);
-                }
-                let skeleton = crate::openpose_skeleton::draw_wholebody(
-                    width,
-                    height,
-                    &pose.keypoints,
-                    pose.hands.as_deref(),
-                    pose.face.as_deref(),
-                    stickwidth,
-                );
-                let control = Image {
-                    width,
-                    height,
-                    pixels: skeleton.into_raw(),
-                };
-                let req = QwenControlRequest {
-                    prompt: prompt.clone(),
-                    negative: negative.clone(),
-                    width,
-                    height,
-                    steps: steps as usize,
-                    guidance,
-                    control_scale,
-                    seed: seed as u64,
-                    cancel: cancel.clone(),
-                };
-                let out = match model.generate(&req, &control, &mut *on_progress) {
-                    Ok(out) => out,
-                    Err(_) if cancel.is_cancelled() => return Ok(None),
-                    Err(error) => {
-                        return Err(WorkerError::Engine(format!(
-                            "Qwen strict-pose generation failed: {error}"
-                        )));
-                    }
-                };
-                // Score this finished pose against the cached source embedding (sc-4410). FINAL image
-                // (no face-restore pass on this lane). Clone paid ONLY when a scorer exists; a full-body
-                // / turned pose with no reliable frontal face → honest detected:false N/A.
-                let face_likeness = scorer.as_ref().and_then(|scorer| {
-                    crate::face_likeness::score_generated_image(
-                        Some(scorer),
-                        &Image {
-                            width: out.width,
-                            height: out.height,
-                            pixels: out.pixels.clone(),
-                        },
-                        likeness_source_ref.as_deref(),
-                    )
-                });
-                Ok(Some((seed, out.width, out.height, out.pixels, face_likeness)))
-            })
-        },
-    );
-
-    consume_gen_events(
+    run_candle_strict_control(
         api,
         settings,
         job,
         plan,
         project_path,
         backend,
-        QWEN_CONTROL_ENGINE,
-        &raw_settings,
-        pose_count,
-        rx,
-        cancel,
-        blocking,
+        provider,
+        raw_settings,
         asset_writes,
     )
     .await

--- a/crates/sceneworks-worker/src/image_jobs/strict_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/strict_control.rs
@@ -87,7 +87,10 @@ fn strict_control_engine(engine_id: &str) -> Option<&'static StrictControlEngine
 /// The catalog DEFAULT control-weights repo for a Fun-Union strict-control engine — the single source of
 /// truth each engine's `controlWeights.repo`-override resolver falls back to. Panics on a non-Fun-Union
 /// engine id (a programming error: only the three registry strict-control streams call this with their
-/// own engine id).
+/// own engine id). Off-Mac the candle strict-control trio keeps its own per-lane default-repo constants
+/// (the qwen candle lane is still the InstantX checkpoint, not the table's 2512-Fun row — that swap is
+/// the separate sc-8350), so this is unused on the candle lane.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 fn strict_control_default_repo(engine_id: &str) -> &'static str {
     strict_control_engine(engine_id)
         .unwrap_or_else(|| panic!("{engine_id} is not a Fun-Union strict-control engine"))
@@ -216,8 +219,9 @@ fn resolve_control_source(
 /// Estimate a depth control map from an arbitrary input image (sc-8242).
 ///
 /// This is the depth analogue of [`crate::canny::canny_control_image_default`]: given a `source` RGB
-/// image, it runs the native-MLX Depth Anything V2 estimator ([`crate::depth::depth_control_image`])
-/// and returns a normalized single-channel depth-control [`Image`] at the source's dimensions.
+/// image, it runs the backend's Depth Anything V2 estimator ([`crate::depth::depth_control_image`]) and
+/// returns a normalized single-channel depth-control [`Image`] at the source's dimensions. Backend-
+/// neutral: macOS = MLX (sc-8242); off-Mac + `backend-candle` = the candle/CUDA sibling (sc-8413).
 ///
 /// `source` is the raw image to estimate FROM (NOT a pre-made depth map — that flows through the
 /// user-supplied-passthrough branch in [`preprocess_control_entry`] before this is ever reached).
@@ -226,8 +230,8 @@ fn resolve_control_source(
 ///
 /// Errors when no `source` is available (auto depth has nothing to estimate from — the caller must
 /// supply either a source image or a user-supplied depth map) or when the estimator weights are
-/// unavailable. macOS-only (MLX inference); off-Mac there is no registry strict-control path.
-#[cfg(target_os = "macos")]
+/// unavailable. Reached by the MLX registry strict-control paths (macOS) and the candle strict-control
+/// trio (off-Mac, sc-8304) alike.
 fn depth_control_image(
     source: Option<&Image>,
     depth_weights_dir: Option<&Path>,
@@ -257,27 +261,14 @@ fn depth_control_image(
     })
 }
 
-/// Off-Mac stub: there is no registry strict-control path on the candle lane, so depth auto-estimation
-/// is never reached — but the shared driver must still compile. Mirrors the macOS signature.
-#[cfg(not(target_os = "macos"))]
-#[allow(dead_code)]
-fn depth_control_image(
-    _source: Option<&Image>,
-    _depth_weights_dir: Option<&Path>,
-) -> WorkerResult<Image> {
-    Err(WorkerError::InvalidPayload(
-        "automatic depth estimation is macOS-only".to_owned(),
-    ))
-}
-
 /// Provision the Depth Anything V2 (Small) estimator snapshot and return the directory holding
 /// `model.safetensors` (what [`crate::depth::depth_control_image`] loads via `from_dir`).
 ///
 /// Resolution order mirrors [`ensure_flux2_control_weights`]: an explicit `SCENEWORKS_DEPTH_ANYTHING_V2`
 /// dir override → an existing HF cache snapshot → a lazy fetch of the single weight file into the app
 /// cache on first use. The ~100 MB Small checkpoint is fetched only on the first depth job (it never
-/// bloats a base download). Shared by every strict-control engine that admits `ControlKind::Depth`.
-#[cfg(target_os = "macos")]
+/// bloats a base download). Shared by every strict-control engine that admits `ControlKind::Depth` —
+/// the MLX registry paths (macOS) and the candle strict-control trio (off-Mac, sc-8304).
 async fn ensure_depth_estimator_dir(
     api: &ApiClient,
     settings: &Settings,
@@ -331,7 +322,13 @@ async fn ensure_depth_estimator_dir(
 /// - **depth** — [`depth_control_image`] over `source`: the native-MLX Depth Anything V2 estimator
 ///   (sc-8242), using the provisioned `depth_weights_dir`. Like canny, requires a `source` (auto depth
 ///   has nothing to estimate from otherwise); a user-supplied depth map still short-circuits above.
-#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+///
+/// Used by the MLX registry strict-control paths (macOS) and the candle strict-control trio (off-Mac,
+/// sc-8304) alike; dead only on a candle-disabled box off Mac (no strict-control caller there).
+#[cfg_attr(
+    all(not(target_os = "macos"), not(feature = "backend-candle")),
+    allow(dead_code)
+)]
 #[allow(clippy::too_many_arguments)]
 fn preprocess_control_entry(
     kind: &ControlKind,

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -6755,3 +6755,328 @@ fn real_weight_matrix_qwen_depth() {
     );
     assert_matrix_steer("qwen depth", &render, &baseline, 1.0);
 }
+
+// ---------------------------------------------------------------------------
+// Candle (Windows/CUDA) shared strict-control driver (sc-8304): the `CandleStrictControl` trait + the
+// `run_candle_strict_control` driver the candle trio (zimage/flux2/qwen control) route through, reusing
+// the SAME `STRICT_CONTROL_ENGINES` table + `preprocess_control_entry` as the MLX path. Candle-only (the
+// driver + trait are gated `not(macos) + backend-candle`). These compile + run in the candle-worker CI
+// lane; real-weight bits are gated behind env so the lane (no GPU / no weights) stays green.
+// ---------------------------------------------------------------------------
+
+/// A small solid RGB control [`Image`] (passthrough / canny-source fixture) — the candle twin of the
+/// macOS `control_fixture`.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn candle_control_fixture(w: u32, h: u32, rgb: [u8; 3]) -> Image {
+    Image {
+        width: w,
+        height: h,
+        pixels: rgb
+            .iter()
+            .cycle()
+            .take((w * h * 3) as usize)
+            .copied()
+            .collect(),
+    }
+}
+
+/// A single pose entry parsed from a job (reuses `parse_poses` so the test exercises the real path) —
+/// the candle twin of the macOS `one_pose`.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn candle_one_pose() -> PoseInput {
+    let req = request(json!({
+        "projectId": "p", "model": "z_image_turbo", "prompt": "a knight",
+        "advanced": { "poses": [{ "keypoints": [[0.5, 0.5]] }] }
+    }));
+    parse_poses(&req).pop().expect("one pose")
+}
+
+/// A non-flat synthetic source (centered bright square on a dark field) for the candle canny/depth
+/// preprocessor tests — the candle twin of the macOS `matrix_structured_source`.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn candle_structured_source(side: u32) -> Image {
+    let s = side as usize;
+    let mut pixels = vec![20u8; s * s * 3];
+    let (lo, hi) = (s / 4, 3 * s / 4);
+    for y in lo..hi {
+        for x in lo..hi {
+            let i = (y * s + x) * 3;
+            pixels[i] = 230;
+            pixels[i + 1] = 230;
+            pixels[i + 2] = 230;
+        }
+    }
+    Image {
+        width: side,
+        height: side,
+        pixels,
+    }
+}
+
+/// The candle strict-control trio validates against the SAME `STRICT_CONTROL_ENGINES` rows the MLX path
+/// does — each engine id resolves and accepts {Pose, Canny, Depth}; an unknown id is itself an error.
+/// This is the gate that off-Mac canny/depth jobs ride through (a `controlMode` request is validated
+/// against the catalog before any preprocessing).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn candle_strict_control_engine_ids_match_the_catalog() {
+    for id in [
+        ZIMAGE_CTRL_ENGINE_ID,
+        FLUX2_CONTROL_CANDLE_ENGINE_ID,
+        QWEN_CONTROL_ENGINE_ID,
+    ] {
+        let row = strict_control_engine(id).unwrap_or_else(|| panic!("no catalog row for {id}"));
+        for kind in [ControlKind::Pose, ControlKind::Canny, ControlKind::Depth] {
+            assert!(
+                row.supported_kinds.contains(&kind),
+                "{id} should accept {kind:?}"
+            );
+            assert!(validate_control_kind(id, &kind).is_ok(), "{id} {kind:?}");
+        }
+    }
+    // The candle engine ids are the Turbo / dev / qwen rows (NOT base-z-image / flux1 — those are B3).
+    assert_eq!(ZIMAGE_CTRL_ENGINE_ID, "z_image_turbo_control");
+    assert_eq!(FLUX2_CONTROL_CANDLE_ENGINE_ID, "flux2_dev_control");
+    assert_eq!(QWEN_CONTROL_ENGINE_ID, "qwen_image_control");
+}
+
+/// `validate_control_kind` rejects an unsupported kind (an `Other(_)` mode) and an unknown engine id —
+/// the loud-rejection contract the candle lanes inherit from the shared driver.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn candle_strict_control_rejects_unsupported_kind_and_unknown_engine() {
+    let unsupported = ControlKind::Other("scribble".to_owned());
+    for id in [
+        ZIMAGE_CTRL_ENGINE_ID,
+        FLUX2_CONTROL_CANDLE_ENGINE_ID,
+        QWEN_CONTROL_ENGINE_ID,
+    ] {
+        let err = validate_control_kind(id, &unsupported)
+            .expect_err("Other(scribble) is not in any candle engine's supported_kinds");
+        assert!(matches!(err, WorkerError::InvalidPayload(_)), "{id}: {err}");
+    }
+    // An engine id that is not in the Fun-Union catalog is itself rejected.
+    assert!(validate_control_kind("not_a_control_engine", &ControlKind::Pose).is_err());
+}
+
+/// REGRESSION (sc-8304): the candle strict-control trio's engine labels + control-scale defaults are
+/// byte-preserved by the consolidation. The labels are recorded on every asset and the scale rides every
+/// generation, so a drift here changes user-visible output / telemetry.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn candle_strict_control_labels_and_scale_defaults_are_byte_preserved() {
+    assert_eq!(ZIMAGE_CTRL_ENGINE, "candle_zimage_control");
+    assert_eq!(FLUX2_CONTROL_CANDLE_ENGINE, "candle_flux2_control");
+    assert_eq!(QWEN_CONTROL_ENGINE, "candle_qwen_control");
+    // The pose-tier control-scale defaults (the value each lane clamps `advanced.controlScale` toward).
+    assert_eq!(ZIMAGE_CTRL_DEFAULT_SCALE, 1.0);
+    assert_eq!(FLUX2_CONTROL_CANDLE_DEFAULT_SCALE, 0.75);
+    assert_eq!(QWEN_CONTROL_DEFAULT_SCALE, 1.0);
+}
+
+/// The trait routes each provider: each lane's `CandleStrictControl` impl reports the right engine id
+/// (the validation key), engine label (the asset/telemetry tag), and stream tag. Constructed with dummy
+/// paths — only the routing metadata is asserted, no load. This is the seam the shared driver dispatches
+/// through.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn candle_strict_control_trait_routes_each_provider() {
+    let dummy = std::path::PathBuf::from("/nonexistent");
+
+    let zimage = ZImageStrictControl {
+        base: dummy.clone(),
+        controlnet: dummy.clone(),
+        prompt: "p".to_owned(),
+        width: 512,
+        height: 512,
+        steps: 8,
+        control_scale: 1.0,
+    };
+    assert_eq!(zimage.engine_id(), ZIMAGE_CTRL_ENGINE_ID);
+    assert_eq!(zimage.engine_label(), ZIMAGE_CTRL_ENGINE);
+    assert_eq!(zimage.stream_tag(), "zimage_control");
+
+    let flux2 = Flux2StrictControl {
+        base: dummy.clone(),
+        control: dummy.clone(),
+        quant: None,
+        prompt: "p".to_owned(),
+        width: 512,
+        height: 512,
+        steps: 28,
+        guidance: 4.0,
+        control_scale: 0.75,
+    };
+    assert_eq!(flux2.engine_id(), FLUX2_CONTROL_CANDLE_ENGINE_ID);
+    assert_eq!(flux2.engine_label(), FLUX2_CONTROL_CANDLE_ENGINE);
+    assert_eq!(flux2.stream_tag(), "flux2_control");
+
+    let qwen = QwenStrictControl {
+        qwen_base: dummy.clone(),
+        controlnet: dummy.clone(),
+        prompt: "p".to_owned(),
+        negative: "n".to_owned(),
+        width: 512,
+        height: 512,
+        steps: 30,
+        guidance: 4.0,
+        control_scale: 1.0,
+    };
+    assert_eq!(qwen.engine_id(), QWEN_CONTROL_ENGINE_ID);
+    assert_eq!(qwen.engine_label(), QWEN_CONTROL_ENGINE);
+    assert_eq!(qwen.stream_tag(), "qwen_control");
+}
+
+/// `preprocess_control_entry` produces the RIGHT control map per kind off-Mac (the shared driver the
+/// candle trio routes through): pose = a `draw_wholebody` skeleton (byte-identical to the per-lane code —
+/// the regression-critical path), canny = edges off the threaded source, user-passthrough = verbatim for
+/// any kind. Depth (real candle estimator) is a separate env-gated test so this stays GPU/weight-free.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn candle_preprocess_pose_canny_and_passthrough_off_mac() {
+    let (w, h) = (256u32, 256u32);
+    let stick = crate::openpose_skeleton::body_stickwidth(w, h);
+    let pose = candle_one_pose();
+    let source = candle_structured_source(w);
+
+    // Pose: byte-identical to the lane's old inline `draw_wholebody` render.
+    let pose_map = preprocess_control_entry(
+        &ControlKind::Pose,
+        None,
+        Some(&pose),
+        None,
+        w,
+        h,
+        stick,
+        None,
+    )
+    .expect("pose preprocess");
+    let expected = crate::openpose_skeleton::draw_wholebody(
+        w,
+        h,
+        &pose.keypoints,
+        pose.hands.as_deref(),
+        pose.face.as_deref(),
+        stick,
+    );
+    assert_eq!((pose_map.width, pose_map.height), (w, h));
+    assert_eq!(
+        pose_map.pixels,
+        expected.into_raw(),
+        "pose skeleton must be byte-identical to the per-lane render"
+    );
+
+    // Canny: edges derived from the threaded source (non-degenerate — the source has a bright square).
+    let canny_map = preprocess_control_entry(
+        &ControlKind::Canny,
+        None,
+        None,
+        Some(&source),
+        w,
+        h,
+        stick,
+        None,
+    )
+    .expect("canny preprocess");
+    assert_eq!((canny_map.width, canny_map.height), (w, h));
+    assert!(
+        canny_map.pixels.iter().any(|&p| p != canny_map.pixels[0]),
+        "canny edges must be non-degenerate"
+    );
+
+    // Canny without a source is a clear error (canny has no synthetic input).
+    assert!(
+        preprocess_control_entry(&ControlKind::Canny, None, None, None, w, h, stick, None).is_err()
+    );
+
+    // User-supplied passthrough: used verbatim for ANY kind (here depth, with no weights provisioned —
+    // the passthrough short-circuits estimation entirely).
+    let user = candle_control_fixture(w, h, [10, 20, 30]);
+    let through = preprocess_control_entry(
+        &ControlKind::Depth,
+        Some(&user),
+        None,
+        None,
+        w,
+        h,
+        stick,
+        None,
+    )
+    .expect("user passthrough");
+    assert_eq!(through.pixels, user.pixels, "passthrough must be verbatim");
+}
+
+/// Real-weight (CPU-capable) candle depth preprocessing off-Mac: `preprocess_control_entry` with
+/// `ControlKind::Depth` runs the candle Depth-Anything-V2 estimator (sc-8413) over the threaded source.
+/// Gated on `SCENEWORKS_DEPTH_ANYTHING_V2` (the same env the depth smokes use) so the candle-worker CI
+/// lane — which builds the cuda feature but has no GPU and no cached weights — stays green; the estimator
+/// falls back to CPU when no GPU is present, so it CAN run in CI once the ~100 MB Small checkpoint is
+/// cached, else the coordinator's local CUDA build runs it.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn candle_preprocess_depth_estimates_off_mac() {
+    use crate::depth::DEPTH_ANYTHING_V2_FILE;
+    let Ok(dir) = std::env::var("SCENEWORKS_DEPTH_ANYTHING_V2") else {
+        eprintln!("skipping: set SCENEWORKS_DEPTH_ANYTHING_V2 to the Small snapshot dir");
+        return;
+    };
+    let dir = std::path::PathBuf::from(dir);
+    if !dir.join(DEPTH_ANYTHING_V2_FILE).is_file() {
+        eprintln!(
+            "skipping: {DEPTH_ANYTHING_V2_FILE} missing in {}",
+            dir.display()
+        );
+        return;
+    }
+    let (w, h) = (256u32, 256u32);
+    let stick = crate::openpose_skeleton::body_stickwidth(w, h);
+    let source = candle_structured_source(w);
+    let depth = preprocess_control_entry(
+        &ControlKind::Depth,
+        None,
+        None,
+        Some(&source),
+        w,
+        h,
+        stick,
+        Some(dir.as_path()),
+    )
+    .expect("candle depth estimate");
+    assert_eq!((depth.width, depth.height), (w, h), "depth at source dims");
+    // The candle estimator returns a grayscale-broadcast map (every pixel's three channels equal).
+    assert!(
+        depth
+            .pixels
+            .chunks_exact(3)
+            .all(|p| p[0] == p[1] && p[1] == p[2]),
+        "depth control must be grayscale-broadcast"
+    );
+    // A foreground square on a dark field → a non-degenerate depth split.
+    assert!(depth.pixels.iter().any(|&p| p != depth.pixels[0]));
+}
+
+/// Depth without a source OR a provisioned weights dir is a clear error off-Mac (auto depth has nothing
+/// to estimate from / no estimator) — the loud-failure contract, no GPU needed.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn candle_preprocess_depth_requires_source_and_weights() {
+    let (w, h) = (64u32, 64u32);
+    let stick = crate::openpose_skeleton::body_stickwidth(w, h);
+    // No source.
+    assert!(
+        preprocess_control_entry(&ControlKind::Depth, None, None, None, w, h, stick, None).is_err()
+    );
+    // Source present but no weights dir provisioned.
+    let source = candle_structured_source(w);
+    assert!(preprocess_control_entry(
+        &ControlKind::Depth,
+        None,
+        None,
+        Some(&source),
+        w,
+        h,
+        stick,
+        None
+    )
+    .is_err());
+}

--- a/crates/sceneworks-worker/src/image_jobs/zimage_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage_control.rs
@@ -24,6 +24,10 @@ const ZIMAGE_CTRL_DEFAULT_STEPS: u32 = 8;
 /// The adapter/engine id recorded on candle Z-Image control assets (distinct from the txt2img
 /// `candle_z_image`/`candle_zimage` lane).
 const ZIMAGE_CTRL_ENGINE: &str = "candle_zimage_control";
+/// The [`STRICT_CONTROL_ENGINES`] catalog id this candle lane validates `advanced.controlMode` against
+/// (the Turbo Fun-Controlnet-Union row — `{Pose, Canny, Depth}`). Mirrors the MLX
+/// `z_image_turbo_control` registry engine's `supported_kinds` (sc-8304).
+const ZIMAGE_CTRL_ENGINE_ID: &str = "z_image_turbo_control";
 
 /// Model ids the candle Z-Image ControlNet route accepts.
 fn is_zimage_control_model(model: &str) -> bool {
@@ -164,10 +168,73 @@ fn zimage_control_raw_settings(
     raw
 }
 
+/// The per-lane half of the candle Z-Image strict-control [`CandleStrictControl`] driver (sc-8304): the
+/// resolved weight paths + the request numerics. Z-Image-Turbo is distilled (no CFG / negative prompt),
+/// so it carries no guidance. Moved onto the blocking thread, loaded once, drives every pose.
+struct ZImageStrictControl {
+    base: PathBuf,
+    controlnet: PathBuf,
+    prompt: String,
+    width: u32,
+    height: u32,
+    steps: u32,
+    control_scale: f32,
+}
+
+impl CandleStrictControl for ZImageStrictControl {
+    type Model = ZImageControl;
+
+    fn engine_id(&self) -> &'static str {
+        ZIMAGE_CTRL_ENGINE_ID
+    }
+
+    fn engine_label(&self) -> &'static str {
+        ZIMAGE_CTRL_ENGINE
+    }
+
+    fn stream_tag(&self) -> &'static str {
+        "zimage_control"
+    }
+
+    fn load(&self) -> WorkerResult<Self::Model> {
+        let paths = ZImageControlPaths {
+            base: self.base.clone(),
+            control: self.controlnet.clone(),
+        };
+        ZImageControl::load(&paths).map_err(|error| {
+            WorkerError::Engine(format!("Z-Image strict-pose control load failed: {error}"))
+        })
+    }
+
+    fn generate_one(
+        &self,
+        model: &Self::Model,
+        control: &Image,
+        seed: u64,
+        cancel: &CancelFlag,
+        on_progress: &mut dyn FnMut(Progress),
+    ) -> WorkerResult<Image> {
+        let req = ZImageControlRequest {
+            prompt: self.prompt.clone(),
+            width: self.width,
+            height: self.height,
+            steps: self.steps as usize,
+            control_scale: self.control_scale,
+            seed,
+            cancel: cancel.clone(),
+        };
+        model.generate(&req, control, on_progress).map_err(|error| {
+            WorkerError::Engine(format!("Z-Image strict-pose generation failed: {error}"))
+        })
+    }
+}
+
 /// Real candle Z-Image strict-pose generation: one image per pose, each conditioned on a full DWPose
-/// skeleton. The provider loads once on the blocking thread; each pose renders its skeleton + generates.
-/// Z-Image-Turbo is distilled (no CFG / negative prompt), so the request carries no guidance.
-/// `ZImageControl::generate` takes `&self`, so the per-item closure does not need `&mut`.
+/// skeleton (`controlMode` unset) or a canny/depth control map. Resolves the base + control weights, then
+/// hands a [`ZImageStrictControl`] to the shared [`run_candle_strict_control`] driver, which validates the
+/// requested kind against `z_image_turbo_control`'s `supported_kinds`, preprocesses each pose's control
+/// map, runs the per-pose loop, and scores against any identity reference. Z-Image-Turbo is distilled (no
+/// CFG / negative prompt), so the request carries no guidance. The pose path is byte-preserved.
 async fn generate_candle_zimage_control_stream(
     api: &ApiClient,
     settings: &Settings,
@@ -199,123 +266,28 @@ async fn generate_candle_zimage_control_stream(
         .unwrap_or(ZIMAGE_CTRL_DEFAULT_REPO)
         .to_owned();
 
-    let poses = parse_poses(request);
-    let pose_count = poses.len();
+    let pose_count = pose_entries(request).len();
     let raw_settings = zimage_control_raw_settings(request, &repo, steps, control_scale, pose_count);
 
-    let (width, height) = (request.width, request.height);
-    let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
-    // One shared seed across the pose set (the MLX `_generate_pose_set` convention).
-    let seed = resolve_seed(request, 0);
-    let prompt = request.prompt.clone();
-
-    // Identity-likeness scoring (epic 4406, sc-4410): when this candle Z-Image strict-pose set carries a
-    // character identity `referenceAssetId`, score every finished pose against that source identity face
-    // through the SHARED generator-agnostic seam. Resolve the source image + asset id and stage the
-    // antelopev2 face stack (candle leg; no-op if cached). All non-fatal (missing reference / staging
-    // failure → no scorer → scores omitted, set still renders). The `!Send` scorer is built ONCE in the
-    // load closure on the blocking thread (source embedded once, reused across all poses).
-    let likeness_source = resolve_control_identity_source(request, settings, project_path);
-    let face_stack_dir = if likeness_source.is_some() {
-        match ensure_face_stack_dir(api, settings, job).await {
-            Ok(dir) => Some(dir),
-            Err(error) => {
-                tracing::warn!(error = %error, "pose-set face-stack staging failed; likeness scores omitted");
-                None
-            }
-        }
-    } else {
-        None
+    let provider = ZImageStrictControl {
+        base,
+        controlnet,
+        prompt: request.prompt.clone(),
+        width: request.width,
+        height: request.height,
+        steps,
+        control_scale,
     };
-    let likeness_source_ref = likeness_source.as_ref().map(|(_, id)| id.clone());
 
-    let (cancel, rx, blocking) = start_gen_stream(
-        job.id.clone(),
-        "zimage_control",
-        0,
-        move || {
-            let paths = ZImageControlPaths { base, control: controlnet };
-            let model = ZImageControl::load(&paths).map_err(|error| {
-                WorkerError::Engine(format!("Z-Image strict-pose control load failed: {error}"))
-            })?;
-            // Build the scorer once on the blocking thread (the `!Send` face stack lives here).
-            let scorer = match (&face_stack_dir, &likeness_source) {
-                (Some(dir), Some((source, _))) => {
-                    crate::face_likeness::build_face_likeness_scorer(dir, source)
-                }
-                _ => None,
-            };
-            Ok((model, poses, scorer))
-        },
-        move |(model, poses, scorer), tx, cancel| {
-            drive_gen_items_scored(tx, poses, move |_index, pose, on_progress| {
-                if cancel.is_cancelled() {
-                    return Ok(None);
-                }
-                let skeleton = crate::openpose_skeleton::draw_wholebody(
-                    width,
-                    height,
-                    &pose.keypoints,
-                    pose.hands.as_deref(),
-                    pose.face.as_deref(),
-                    stickwidth,
-                );
-                let control = Image {
-                    width,
-                    height,
-                    pixels: skeleton.into_raw(),
-                };
-                let req = ZImageControlRequest {
-                    prompt: prompt.clone(),
-                    width,
-                    height,
-                    steps: steps as usize,
-                    control_scale,
-                    seed: seed as u64,
-                    cancel: cancel.clone(),
-                };
-                let out = match model.generate(&req, &control, &mut *on_progress) {
-                    Ok(out) => out,
-                    Err(_) if cancel.is_cancelled() => return Ok(None),
-                    Err(error) => {
-                        return Err(WorkerError::Engine(format!(
-                            "Z-Image strict-pose generation failed: {error}"
-                        )));
-                    }
-                };
-                // Score this finished pose against the cached source embedding (sc-4410). The candle
-                // strict-control lane produces the FINAL image directly (no face-restore pass). Clone
-                // paid ONLY when a scorer exists; a full-body / turned pose with no reliable frontal
-                // face → honest detected:false N/A.
-                let face_likeness = scorer.as_ref().and_then(|scorer| {
-                    crate::face_likeness::score_generated_image(
-                        Some(scorer),
-                        &Image {
-                            width: out.width,
-                            height: out.height,
-                            pixels: out.pixels.clone(),
-                        },
-                        likeness_source_ref.as_deref(),
-                    )
-                });
-                Ok(Some((seed, out.width, out.height, out.pixels, face_likeness)))
-            })
-        },
-    );
-
-    consume_gen_events(
+    run_candle_strict_control(
         api,
         settings,
         job,
         plan,
         project_path,
         backend,
-        ZIMAGE_CTRL_ENGINE,
-        &raw_settings,
-        pose_count,
-        rx,
-        cancel,
-        blocking,
+        provider,
+        raw_settings,
         asset_writes,
     )
     .await

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -178,19 +178,27 @@ mod openpose_skeleton;
 // Native canny edge-map preprocessor for the Fun-Controlnet-Union canny head
 // (epic 8236, sc-8240). Pure CPU raster (cross-platform + testable everywhere),
 // sibling of `openpose_skeleton`: arbitrary image → `ControlKind::Canny` control
-// image. Consumed by the shared strict-control driver (sc-8243) on macOS; the
-// off-Mac candle lane has no registry strict-control path, so it stays unused there.
-#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+// image. Consumed by the shared strict-control driver (sc-8243) on macOS AND the
+// off-Mac candle strict-control trio (sc-8304); on a candle-disabled box off Mac
+// it still builds + unit-tests but its items are otherwise unused — so allow
+// dead_code only there.
+#[cfg_attr(
+    all(not(target_os = "macos"), not(feature = "backend-candle")),
+    allow(dead_code)
+)]
 mod canny;
 // Depth-map preprocessor for the Fun-Controlnet-Union depth head (epic 8236): arbitrary image →
 // `ControlKind::Depth` control image via a Depth Anything V2 port. Sibling of `canny` /
 // `openpose_skeleton`, but — unlike those pure raster preprocessors — depth needs neural
 // inference, so it is backend-gated: macOS = `mlx-gen-depth` (sc-8242), off-Mac + `backend-candle`
 // = `candle-gen-depth` (sc-8413, the Windows/CUDA sibling). Consumed by the shared strict-control
-// driver (sc-8243 mac); the off-Mac candle strict-control routing that calls the candle estimator
-// is the separate sc-8304, so `depth_control_image` stays unused on the candle lane until then
-// (hence the `allow(dead_code)` below).
-#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+// driver (sc-8243 mac) AND the off-Mac candle strict-control trio (sc-8304, which wires the candle
+// estimator into `preprocess_control_entry`); on a candle-disabled box off Mac the estimator stays
+// unused — so allow dead_code only there.
+#[cfg_attr(
+    all(not(target_os = "macos"), not(feature = "backend-candle")),
+    allow(dead_code)
+)]
 mod depth;
 // DWPose pose detection via onnxruntime (epic 3482, sc-3487). On Mac the CoreML EP +
 // on the off-Mac candle GPU-worker lane the CUDA EP (sc-5496, epic 5482) run the same


### PR DESCRIPTION
## sc-8304 — Route the candle (Windows/CUDA) strict-control trio through a shared driver

REGRESSION-CRITICAL chore (epic 8236, B2). Mirrors the MLX `strict_control.rs` consolidation: collapses the three bespoke candle (Windows/CUDA) strict-control lanes — `z_image_turbo` (`ZImageControl`), `flux2_dev` (`Flux2Control`), `qwen_image`-InstantX (`QwenControl`) — onto ONE shared driver, and adds the canny/depth plumbing so off-Mac control jobs can run those modes.

### Trait + shared driver
New `image_jobs/candle_strict_control.rs`:
- A small **`CandleStrictControl` trait** (`engine_id` / `engine_label` / `stream_tag` / `load` / `generate_one`). Each provider's bespoke request struct + `model.generate(&req, control_image, on_progress)` call stays BEHIND the trait.
- One **`run_candle_strict_control` driver** owning the shared scaffold: control-kind resolution + `validate_control_kind` against the SAME `STRICT_CONTROL_ENGINES` table, user-supplied control-map passthrough, canny/depth **source threading**, depth-weights provisioning, the per-pose loop via the cross-platform `preprocess_control_entry`, identity-likeness scoring, and the `consume_gen_events` sink.

The three lane files (`zimage_control.rs` / `flux2_control_candle.rs` / `qwen_control.rs`) shrink to weight resolution + a per-lane provider struct + the trait impl, then hand off to the driver.

### canny/depth plumbing + source threading + off-Mac depth wiring
- Un-gated the shared `strict_control.rs` (+ `gen_core::ControlKind`) for the candle build (was macOS-only).
- `depth_control_image` / `ensure_depth_estimator_dir` are now **backend-neutral**: macOS = MLX, off-Mac + `backend-candle` = `candle-gen-depth` (sc-8413/#1001). The old off-Mac "automatic depth estimation is macOS-only" stub is gone. User-supplied depth maps still short-circuit estimation before any weights are touched.
- canny/depth estimate off the **live input image** (`resolve_control_source`), not just synthetic pose skeletons.
- Narrowed the `canny` / `depth` module dead-code allows so they apply only on a candle-disabled box off Mac.

### REGRESSION — pose byte-preserved
The pose path renders the identical `draw_wholebody` skeleton at the identical stickwidth, with unchanged engine labels (`candle_zimage_control` / `candle_flux2_control` / `candle_qwen_control`) and control_scale defaults (1.0 / 0.75 / 1.0). A unit test pins the skeleton bytes + labels + scale defaults. canny/depth are purely additive (reached only when a request sets `advanced.controlMode`).

### Scope boundary (B3, NOT in this PR)
- No new candle FLUX.1 control lane (sc-8412).
- No qwen InstantX → 2512-Fun repoint (sc-8350) — the qwen candle lane keeps the InstantX checkpoint; only `supported_kinds` is shared via the catalog row.
- No z-image BASE control (sc-8379).

### Candle-gen pose-gate follow-up: NONE needed
The candle-gen control engines (`ZImageControl` / `Flux2Control` / `QwenControl`) VAE-encode any RGB control map generically — there is no `!= Pose` rejection gate — so canny/depth control maps flow through without a candle-gen engine change.

### Tests (candle-gated, run in the candle-worker CI lane)
- Trait routing per provider (engine id / label / stream tag).
- Engine-id ↔ `STRICT_CONTROL_ENGINES` catalog match (Turbo / dev / qwen rows accept {Pose, Canny, Depth}).
- `validate_control_kind` rejects an unsupported kind + an unknown engine id.
- REGRESSION: pose skeleton byte-identical to the per-lane render; engine labels + control_scale defaults unchanged.
- `preprocess_control_entry` pose / canny / passthrough off-Mac.
- Real-weight candle depth smoke gated on `SCENEWORKS_DEPTH_ANYTHING_V2` (skips when unset → CI stays green; CPU-capable so it can run once weights are cached, else the coordinator's local CUDA build runs it).

Verified locally: `cargo check`/`clippy`/`test --no-run` under `--features backend-candle` (full CUDA build) clean; the 6 CPU-runnable candle tests pass (depth smoke skips without env). The full candle GPU validation is the coordinator's local CUDA build.

Links sc-8304.

🤖 Generated with [Claude Code](https://claude.com/claude-code)