### PR TITLE
feat(desktop): wire cross-platform auto-updater via GitHub releases (sc-1355)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,12 @@ jobs:
       APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
       APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
       APPLE_API_KEY_PATH: ${{ secrets.APPLE_API_KEY_PATH }}
+      # Minisign keypair for the in-app auto-updater (sc-1355): signs the
+      # `.app.tar.gz` updater payload so the shipped app can verify it against
+      # plugins.updater.pubkey. Only needed when createUpdaterArtifacts is on (set
+      # via --config below), so other CI lanes / local builds don't require it.
+      TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+      TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
@@ -67,9 +73,12 @@ jobs:
       # `tauri build` runs the beforeBuildCommand (sidecar + web/api + the nested
       # binary pre-signing from #715) and, because the APPLE_* env is set, signs +
       # notarizes + staples the .app. This is the heavy MLX-from-source build; the
-      # nax runner keeps it warm.
+      # nax runner keeps it warm. `--config createUpdaterArtifacts:true` additionally
+      # emits the `.app.tar.gz` updater payload + `.sig` for the in-app updater
+      # (sc-1355). It's enabled HERE only — kept out of the committed tauri.conf.json
+      # so non-release builds don't require the signing key.
       - name: Build, sign & notarize the desktop bundle
-        run: npm run build --prefix apps/desktop
+        run: npm --prefix apps/desktop run build -- --config '{"bundle":{"createUpdaterArtifacts":true}}'
 
       # Tauri staples the .app but not the wrapping .dmg — staple the DMG so the
       # downloaded artifact verifies offline (shared script; same as `release:mac`).
@@ -82,7 +91,7 @@ jobs:
       # release). Tags with a pre-release suffix (e.g. v1.2.3-rc.1) are marked
       # prerelease. The tag name goes through an env var, not inline `${{ }}`, to
       # avoid script-injection from the ref.
-      - name: Draft GitHub Release with the stapled DMG
+      - name: Draft GitHub Release with the stapled DMG + updater payload
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -94,6 +103,14 @@ jobs:
             echo "No DMG produced under target/release/bundle/dmg/" >&2
             exit 1
           fi
+          # The auto-updater payload (createUpdaterArtifacts): the .app.tar.gz the
+          # app downloads + the .sig whose contents go into latest.json (sc-1355).
+          tarballs=(target/release/bundle/macos/*.app.tar.gz)
+          sigs=(target/release/bundle/macos/*.app.tar.gz.sig)
+          if [ ${#tarballs[@]} -eq 0 ] || [ ${#sigs[@]} -eq 0 ]; then
+            echo "No macOS updater artifacts under target/release/bundle/macos/ (*.app.tar.gz[.sig])" >&2
+            exit 1
+          fi
           notes=$(printf '%s\n' \
             '## macOS (Apple Silicon, macOS 26.2+)' \
             'Signed & notarized build. Open the DMG and drag SceneWorks to Applications.' \
@@ -102,7 +119,21 @@ jobs:
             'Run the .msi installer. Requires an NVIDIA GPU; the CUDA/cuDNN runtime is downloaded on first launch.')
           args=(--draft --generate-notes --title "SceneWorks $TAG" --notes "$notes")
           case "$TAG" in *-*) args+=(--prerelease) ;; esac
-          gh release create "$TAG" "${args[@]}" "${dmgs[0]}"
+          # Attach the DMG (fresh install) + the updater tarball (in-app update payload).
+          gh release create "$TAG" "${args[@]}" "${dmgs[0]}" "${tarballs[0]}"
+
+          # Seed latest.json with the darwin-aarch64 entry. The URL is the canonical
+          # tag asset URL (valid once the draft is published); the signature is the
+          # .sig contents. The Windows job merges its entry in afterward.
+          tarball_name="$(basename "${tarballs[0]}")"
+          node apps/desktop/scripts/build-update-manifest.mjs \
+            --target darwin-aarch64 \
+            --version "${TAG#v}" \
+            --url "https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${tarball_name}" \
+            --sig "${sigs[0]}" \
+            --notes "SceneWorks $TAG" \
+            --out latest.json
+          gh release upload "$TAG" --clobber latest.json
 
   windows:
     # Attach the Windows installers to the draft release the macos job created.
@@ -117,6 +148,10 @@ jobs:
       # compute_80 PTX the driver JITs forward to sm_120 — one binary covers
       # Ampere->Blackwell (sc-3676); build-sidecar.mjs defaults this too.
       CUDA_COMPUTE_CAP: "80"
+      # Same minisign keypair as the macos job — signs the NSIS updater payload so
+      # the shipped app verifies it against plugins.updater.pubkey (sc-1355).
+      TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+      TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -154,13 +189,18 @@ jobs:
       # sidecar by default (nvcc compiles every provider's CUDA kernels) and stages
       # the ffmpeg resource, then packages both installers. The ~2.7 GB CUDA/cuDNN/
       # onnxruntime runtime is downloaded on first run (cuda_provision.rs), so the
-      # installers stay small.
+      # installers stay small. `--config createUpdaterArtifacts:true` also signs the
+      # NSIS `-setup.exe` updater payload (+ `.sig`) for the in-app updater (sc-1355).
       - name: Build Windows candle installers (NSIS + MSI)
-        run: npm --prefix apps/desktop run build -- --bundles nsis,msi
+        run: npm --prefix apps/desktop run build -- --bundles nsis,msi --config '{"bundle":{"createUpdaterArtifacts":true}}'
       # Upload to the draft release the macos job created. The user ships the MSI
       # (per desktop-windows.yml); the NSIS .exe is attached too as an alternative.
-      # --clobber so re-running the job replaces rather than 409s.
-      - name: Attach Windows installers to the release
+      # --clobber so re-running the job replaces rather than 409s. Then merge the
+      # windows-x86_64 entry into the latest.json the macos job seeded (sc-1355): the
+      # NSIS `-setup.exe` is the updater payload; its `.sig` contents go in the
+      # manifest. The artifact the `.sig` signs is derived from the .sig path, so this
+      # stays correct whether Tauri emits a `-setup.exe` or a `.nsis.zip`.
+      - name: Attach Windows installers + merge updater manifest
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -172,4 +212,27 @@ jobs:
             echo "No installers produced under target/release/bundle/{msi,nsis}/" >&2
             exit 1
           fi
-          gh release upload "$TAG" --clobber "${installers[@]}"
+          sigs=(target/release/bundle/nsis/*.sig)
+          if [ ${#sigs[@]} -eq 0 ]; then
+            echo "No NSIS updater signature under target/release/bundle/nsis/*.sig" >&2
+            exit 1
+          fi
+          sig="${sigs[0]}"
+          payload="${sig%.sig}"          # the artifact the .sig signs (the update payload)
+          payload_name="$(basename "$payload")"
+
+          # Upload installers + the updater payload (the payload is normally the
+          # NSIS .exe already in `installers`; upload it explicitly so a .nsis.zip
+          # payload is also covered).
+          gh release upload "$TAG" --clobber "${installers[@]}" "$payload"
+
+          # Merge the windows-x86_64 entry into the macos-seeded manifest.
+          gh release download "$TAG" -p latest.json --clobber
+          node apps/desktop/scripts/build-update-manifest.mjs \
+            --target windows-x86_64 \
+            --version "${TAG#v}" \
+            --url "https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${payload_name}" \
+            --sig "$sig" \
+            --in latest.json \
+            --out latest.json
+          gh release upload "$TAG" --clobber latest.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1771,6 +1771,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3079,6 +3089,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3447,6 +3487,12 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -4150,7 +4196,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4299,6 +4345,18 @@ dependencies = [
  "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -4479,7 +4537,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5226,15 +5298,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -5399,6 +5476,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.7.0",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5407,6 +5496,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -5505,6 +5621,8 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-shell",
+ "tauri-plugin-updater",
+ "tracing",
  "zip 2.4.2",
 ]
 
@@ -6069,6 +6187,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6345,7 +6479,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -6379,6 +6513,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6401,7 +6546,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -6577,6 +6722,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest 0.13.3",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip 4.6.1",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6586,7 +6764,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -6609,7 +6787,7 @@ checksum = "b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -8480,7 +8658,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",
@@ -8525,6 +8703,16 @@ dependencies = [
  "libc",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]
@@ -8683,6 +8871,18 @@ dependencies = [
  "memchr",
  "thiserror 2.0.18",
  "zopfli",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -23,9 +23,19 @@ keyring = { version = "3", features = ["apple-native", "windows-native", "sync-s
 sceneworks-core = { path = "../../crates/sceneworks-core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# Structured logging for the shell's own lifecycle events (e.g. auto-update,
+# sc-1355). The subscriber is installed in main() via init_logging(); the sidecars
+# log separately through the session-log ring buffer.
+tracing = { workspace = true }
 tauri = { version = "2", features = [] }
 tauri-plugin-dialog = "2"
 tauri-plugin-shell = "2"
+# Cross-platform in-app auto-updater (sc-1355). Checks the GitHub "latest release"
+# pointer (plugins.updater.endpoints in tauri.conf.json), verifies the minisign
+# signature against plugins.updater.pubkey, and installs/restarts on user accept.
+# Driven from the Rust shell (update.rs) — no JS/ACL surface since the UI is the
+# loopback-served React app at a remote origin.
+tauri-plugin-updater = "2"
 
 [target.'cfg(unix)'.dependencies]
 # SIGTERM the Python worker / API sidecar for graceful shutdown before force-kill.

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sceneworks/desktop",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sceneworks/desktop",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sceneworks/desktop",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "SceneWorks desktop shell (Tauri).",
   "scripts": {
     "dev": "tauri dev",

--- a/apps/desktop/scripts/build-update-manifest.mjs
+++ b/apps/desktop/scripts/build-update-manifest.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// Builds (or merges into) the Tauri updater manifest `latest.json` (sc-1355).
+//
+// The macOS and Windows release jobs build on separate runners, so neither can
+// produce a complete manifest alone. The macOS job runs this in "init" mode to
+// create latest.json with its `darwin-aarch64` entry; the Windows job (which
+// `needs: macos`) downloads that file and runs this again with `--in` to merge in
+// its `windows-x86_64` entry. The result is uploaded to the GitHub Release and
+// served at plugins.updater.endpoints (…/releases/latest/download/latest.json).
+//
+// The per-platform `signature` is the CONTENTS of the `.sig` file emitted next to
+// the updater bundle (createUpdaterArtifacts) — the app verifies it against
+// plugins.updater.pubkey. The `url` is the release asset's canonical download URL
+// (…/releases/download/<tag>/<asset>); we construct it deterministically rather
+// than reading it back, because a draft release reports an `untagged-*` URL that
+// only becomes the tag URL once published.
+//
+// Usage:
+//   node build-update-manifest.mjs \
+//     --target darwin-aarch64 --version 0.4.1 \
+//     --url https://github.com/OWNER/REPO/releases/download/v0.4.1/SceneWorks.app.tar.gz \
+//     --sig path/to/SceneWorks.app.tar.gz.sig \
+//     [--notes "..."] [--in latest.json] --out latest.json
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 2) {
+    const key = argv[i];
+    if (!key.startsWith("--")) {
+      throw new Error(`expected a --flag, got "${key}"`);
+    }
+    out[key.slice(2)] = argv[i + 1];
+  }
+  return out;
+}
+
+const args = parseArgs(process.argv.slice(2));
+
+for (const required of ["target", "version", "url", "sig", "out"]) {
+  if (!args[required]) {
+    console.error(`build-update-manifest: missing --${required}`);
+    process.exit(1);
+  }
+}
+
+const signature = readFileSync(args.sig, "utf8").trim();
+if (!signature) {
+  console.error(`build-update-manifest: signature file ${args.sig} is empty`);
+  process.exit(1);
+}
+
+let manifest;
+if (args.in && existsSync(args.in)) {
+  manifest = JSON.parse(readFileSync(args.in, "utf8"));
+  manifest.platforms ??= {};
+} else {
+  manifest = {
+    version: args.version,
+    notes: args.notes ?? "See the release notes for what changed.",
+    pub_date: new Date().toISOString(),
+    platforms: {},
+  };
+}
+
+manifest.platforms[args.target] = { signature, url: args.url };
+
+writeFileSync(args.out, `${JSON.stringify(manifest, null, 2)}\n`);
+console.log(
+  `build-update-manifest: wrote ${args.out} with platform "${args.target}" ` +
+    `(version ${manifest.version}, ${Object.keys(manifest.platforms).length} platform(s))`,
+);

--- a/apps/desktop/src/main.rs
+++ b/apps/desktop/src/main.rs
@@ -14,6 +14,9 @@ mod cuda_provision;
 mod net;
 mod settings;
 mod setup;
+// In-app cross-platform auto-updater (sc-1355): startup check against the GitHub
+// "latest release" pointer, user-prompted download + install + restart.
+mod update;
 
 use tauri::RunEvent;
 
@@ -30,6 +33,13 @@ fn main() {
     let app = tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
+        .setup(|app| {
+            // Kick off the auto-update check once the app is initialized (no-op in
+            // debug builds). Fail-soft: never blocks launch (sc-1355).
+            update::spawn_startup_check(app.handle());
+            Ok(())
+        })
         .manage(setup::Managed::default())
         .invoke_handler(tauri::generate_handler![
             setup::start_setup,

--- a/apps/desktop/src/update.rs
+++ b/apps/desktop/src/update.rs
@@ -1,0 +1,99 @@
+//! In-app cross-platform auto-updater (sc-1355).
+//!
+//! On launch the release build asks the GitHub "latest release" pointer
+//! (`plugins.updater.endpoints` in `tauri.conf.json`) whether a newer build
+//! exists for this platform. The endpoint serves a `latest.json` manifest with a
+//! per-target `platforms` map; `tauri-plugin-updater` picks `darwin-aarch64` /
+//! `windows-x86_64` for the running build, verifies the minisign signature against
+//! `plugins.updater.pubkey`, and — on user accept — downloads, installs, and
+//! restarts into the new version.
+//!
+//! Driven entirely from the Rust shell: the UI is the API-served React app at a
+//! loopback `http://127.0.0.1:<port>` origin, so a JS-side updater would need ACL
+//! grants at a remote origin. Here we reuse `tauri-plugin-dialog` for the prompt
+//! and keep the whole flow out of the webview. The check is fail-soft — offline,
+//! no published release, or a parse error just logs and lets the app start.
+
+use tauri::AppHandle;
+use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
+use tauri_plugin_updater::{Update, UpdaterExt};
+
+/// Spawn a non-blocking startup update check. No-op in debug builds (`tauri dev`),
+/// where the running version is the dev build and no signed bundle exists to swap.
+pub fn spawn_startup_check(app: &AppHandle) {
+    if cfg!(debug_assertions) {
+        return;
+    }
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        if let Err(err) = check_and_prompt(&app).await {
+            // Never surface a check failure to the user — a missing network, an
+            // unpublished release, or a transient GitHub hiccup must not block use.
+            tracing::warn!(error = %err, "auto-update: check failed, continuing without update");
+        }
+    });
+}
+
+/// Query the endpoint and, if a newer release exists, prompt the user. Accepting
+/// hands off to [`install_update`]; declining just returns.
+async fn check_and_prompt(app: &AppHandle) -> tauri_plugin_updater::Result<()> {
+    let Some(update) = app.updater()?.check().await? else {
+        tracing::info!("auto-update: already on the latest release");
+        return Ok(());
+    };
+
+    let current = update.current_version.clone();
+    let latest = update.version.clone();
+    tracing::info!(%current, %latest, "auto-update: newer release available");
+
+    let app_for_install = app.clone();
+    app.dialog()
+        .message(format!(
+            "SceneWorks {latest} is available (you have {current}).\n\n\
+             Download and install it now? SceneWorks will restart to finish."
+        ))
+        .title("Update available")
+        .kind(MessageDialogKind::Info)
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            "Update now".to_string(),
+            "Later".to_string(),
+        ))
+        .show(move |accepted| {
+            if !accepted {
+                tracing::info!("auto-update: user deferred the update");
+                return;
+            }
+            // The dialog callback is sync; run the async download/install on the
+            // runtime. `update` is moved in (it carries the verified manifest).
+            tauri::async_runtime::spawn(async move {
+                if let Err(err) = install_update(&app_for_install, update).await {
+                    tracing::error!(error = %err, "auto-update: install failed");
+                    app_for_install
+                        .dialog()
+                        .message(
+                            "The update could not be installed. You can download the \
+                             latest release manually from the SceneWorks releases page.",
+                        )
+                        .title("Update failed")
+                        .kind(MessageDialogKind::Error)
+                        .blocking_show();
+                }
+            });
+        });
+
+    Ok(())
+}
+
+/// Download + install the verified update, then restart into it. `restart()`
+/// diverges (`-> !`), so it is the function's tail and nothing runs after it.
+async fn install_update(app: &AppHandle, update: Update) -> tauri_plugin_updater::Result<()> {
+    tracing::info!(version = %update.version, "auto-update: downloading");
+    update
+        .download_and_install(
+            |_chunk_len: usize, _content_len: Option<u64>| {},
+            || tracing::info!("auto-update: download complete, installing"),
+        )
+        .await?;
+    tracing::info!("auto-update: installed, restarting");
+    app.restart()
+}

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -55,5 +55,13 @@
         "languages": ["English"]
       }
     }
+  },
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://github.com/SceneWorks/SceneWorks/releases/latest/download/latest.json"
+      ],
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEUwNkVBODNCNjY5NUZCMDgKUldRSSs1Vm1PNmh1NEVjNHc2U0RCZWdZMHg5aHBvbkt3Ylh4dVgyRFJOYytlUEJJbVhER3BYU2kK"
+    }
   }
 }

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SceneWorks",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "identifier": "net.trefry.sceneworks",
   "build": {
     "frontendDist": "ui",


### PR DESCRIPTION
Wires Tauri's built-in updater so the desktop app updates from GitHub Releases — [sc-1355](https://app.shortcut.com/trefry/story/1355).

## What

On launch a **release** build asks the GitHub *latest-release* pointer whether there's a newer build **for its own platform**, prompts the user, and installs + restarts on accept.

- **Source:** `plugins.updater.endpoints` → `https://github.com/SceneWorks/SceneWorks/releases/latest/download/latest.json`. `/releases/latest/` resolves to the newest **published, non-prerelease** release, so updates go live only when a stable release is published (drafts + `-rc` excluded).
- **Rust-driven** (`apps/desktop/src/update.rs`), not the webview — the UI is the API-served React app at a loopback remote origin, so a JS updater would need ACL grants there. Reuses `tauri-plugin-dialog` for the prompt. **Fail-soft** (offline/no-release just logs and starts); **no-op in `tauri dev`**.
- **Cross-runner manifest:** `apps/desktop/scripts/build-update-manifest.mjs` — macOS seeds `darwin-aarch64`, Windows (`needs: macos`) merges `windows-x86_64`, then publishes the combined `latest.json`.

## CI / signing

- `createUpdaterArtifacts` is **build-time only and requires the signing key**, so it's kept OUT of committed config and enabled only in `release.yml` via `tauri build --config` — other CI lanes and local builds need no key.
- Requires repo secrets `TAURI_SIGNING_PRIVATE_KEY` + `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` (added). Public key committed in `tauri.conf.json`.

## Verification

- `cargo check`, `clippy -p sceneworks-desktop --all-targets -- -D warnings`, `cargo fmt --check` — clean (incl. post-merge with main).
- `latest.json` init+merge dry-run → correct Tauri schema.
- `release.yml` parses.

## Not in this PR (owner)

End-to-end AC validation (detect→prompt→install→restart on **both** Windows and Mac) needs a throwaway tagged + published release — pending. Version coupling: the release checklist must bump `tauri.conf.json` + `package.json` to match each tag or no update is offered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)