### PR TITLE
feat(models): complete Krea 2 Turbo quant matrix — bf16 tier (sc-8513)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1487,6 +1487,39 @@
           "estimatedSizeBytes": 20600000000
         },
         {
+          // Q4 `q4/` subdir of the same MLX turnkey (sc-8513, epic 8506) — the lighter quant tier,
+          // selectable via advanced mlxQuantize<=4 (sc-8508/8509). Same complete-root shape as q8.
+          "provider": "huggingface",
+          "repo": "SceneWorks/krea-2-turbo-mlx",
+          "files": [
+            "q4/transformer/*",
+            "q4/text_encoder/*",
+            "q4/vae/*",
+            "q4/tokenizer/*",
+            "q4/scheduler/*",
+            "q4/model_index.json"
+          ],
+          "platforms": ["macos"],
+          "estimatedSizeBytes": 12488709648
+        },
+        {
+          // bf16 `bf16/` subdir of the MLX turnkey (sc-8513) — the dense max-fidelity tier (SHARDED
+          // transformer). krea's loader takes the dense base with no quantize (Quant::None). Selectable
+          // via advanced mlxQuantize<=0 (sc-8508/8509). Mirror of the dense `krea/Krea-2-Turbo` tree.
+          "provider": "huggingface",
+          "repo": "SceneWorks/krea-2-turbo-mlx",
+          "files": [
+            "bf16/transformer/*",
+            "bf16/text_encoder/*",
+            "bf16/vae/*",
+            "bf16/tokenizer/*",
+            "bf16/scheduler/*",
+            "bf16/model_index.json"
+          ],
+          "platforms": ["macos"],
+          "estimatedSizeBytes": 35678119918
+        },
+        {
           // Candle (Windows/Linux CUDA) dense bf16 — the ungated public `krea/Krea-2-Turbo` diffusers tree
           // (Krea 2 Community License). The native candle loader (`Weights::from_dir`) reads the diffusers
           // subdirs from the snapshot ROOT (no quant subdir — the boogu pattern), so it does NOT use the

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -382,24 +382,33 @@ fn boogu_model_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
 /// packed quant, so the resolved `spec.quantize` is a no-op on it. Mirrors [`ideogram_model_subdir`]
 /// (q4/q8 subdirs) with Boogu's packed-transformer filename and a Q8-default selection.
 fn krea_model_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
-    let wants_q4 = request
+    let bits = request
         .advanced
         .get("mlxQuantize")
-        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()))
-        .is_some_and(|bits| bits <= 4);
+        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()));
+    // q4/q8 ship a single packed transformer file; the bf16 tier (sc-8513) is the dense diffusers
+    // tree (SHARDED → only the `.index.json`). Accept either shape.
     let present = |name: &str| -> Option<PathBuf> {
         let dir = root.join(name);
-        dir.join("transformer/diffusion_pytorch_model.safetensors")
-            .is_file()
-            .then_some(dir)
+        let packed = dir
+            .join("transformer/diffusion_pytorch_model.safetensors")
+            .is_file();
+        let sharded = dir
+            .join("transformer/diffusion_pytorch_model.safetensors.index.json")
+            .is_file();
+        (packed || sharded).then_some(dir)
     };
-    if wants_q4 {
-        if let Some(dir) = present("q4") {
-            return dir;
-        }
-    }
-    present("q8")
+    // bits<=0 → bf16 (the dense base; krea's loader takes it with no quantize); bits<=4 → q4; else the
+    // default q8 (the P1-validated near-lossless quant).
+    let preferred = match bits {
+        Some(b) if b <= 0 => "bf16",
+        Some(b) if b <= 4 => "q4",
+        _ => "q8",
+    };
+    present(preferred)
+        .or_else(|| present("q8"))
         .or_else(|| present("q4"))
+        .or_else(|| present("bf16"))
         .unwrap_or_else(|| root.to_path_buf())
 }
 

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -1420,6 +1420,64 @@ fn sd3_5_hosted_tier_real_weights_generates_one_image() {
     );
 }
 
+/// bf16 tier verify (sc-8513, epic 8506): load the DENSE SHARDED Krea 2 Turbo `bf16/` tier
+/// (`Quant::None` — krea's loader takes the dense base with no quantize) through the real worker
+/// `krea_2_turbo` engine path and render. Proves the hosted `SceneWorks/krea-2-turbo-mlx/bf16`
+/// turnkey (the sharded dense transformer + dense TE/VAE) loads + generates — the tier that
+/// completes the krea matrix alongside the already-hosted q4/q8. Point `SCENEWORKS_KREA_BF16_DIR`
+/// at the downloaded (or staged) `bf16/` subdir. CFG-free, so no guidance is forwarded. Run:
+/// `SCENEWORKS_KREA_BF16_DIR=… cargo test -p sceneworks-worker --release --lib -- --ignored krea_2_turbo_bf16_real_weights`.
+#[cfg(target_os = "macos")]
+#[test]
+#[ignore = "needs the downloaded/staged Krea 2 Turbo bf16 tier + a high-memory Metal device"]
+fn krea_2_turbo_bf16_real_weights_loads_and_generates() {
+    let dir = std::path::PathBuf::from(
+        std::env::var("SCENEWORKS_KREA_BF16_DIR")
+            .expect("set SCENEWORKS_KREA_BF16_DIR to the downloaded krea bf16/ tier dir"),
+    );
+    let size: u32 = std::env::var("SCENEWORKS_KREA_SIZE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(512);
+    eprintln!(
+        "[krea-bf16] loading krea_2_turbo dense bf16 (Quant::None) from {}…",
+        dir.display()
+    );
+    let generator = load_engine("krea_2_turbo", dir, None, Vec::new(), None).unwrap();
+    eprintln!("[krea-bf16] LOADED — generating {size}²…");
+    let cancel = gen_core::CancelFlag::new();
+    let (w, h, pixels) = generate_one(
+        generator.as_ref(),
+        "a serene mountain lake at dawn",
+        size,
+        size,
+        42,
+        8,
+        None,
+        None,
+        None,
+        &[],
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        false,
+        &PromptEnhance::default(),
+        &cancel,
+        &mut |_| {},
+    )
+    .unwrap();
+    eprintln!("[krea-bf16] GENERATED {w}x{h}");
+    assert_eq!((w, h), (size, size));
+    assert_eq!(pixels.len(), (size * size * 3) as usize);
+    assert!(
+        pixels.windows(2).any(|p| p[0] != p[1]),
+        "render is flat (degenerate)"
+    );
+}
+
 /// Real-weights smoke (sc-5923): FLUX.2-dev EDIT through the worker `flux2_dev_edit` engine path
 /// (the `flux2_edit_engine_id("flux2_dev")` variant, sc-5919/5922). Loads the SAME converted Q4 dev
 /// snapshot, then renders with a single `Conditioning::Reference` AND with a 2-image


### PR DESCRIPTION
## Summary
Group-A (converter-ready) completion for the catalog quant matrix (epic 8506): Krea 2 Turbo already shipped q4/q8 packed turnkeys on `SceneWorks/krea-2-turbo-mlx`; this adds the missing **bf16** tier so it has the full bf16/Q8/Q4 matrix.

- **Hosted** `SceneWorks/krea-2-turbo-mlx/bf16/` — the dense diffusers tree (sharded transformer + dense TE/VAE/tokenizer), a mirror of the ungated `krea/Krea-2-Turbo` source. krea's loader takes the dense base directly (`Quant::None`, no quantize).
- **Manifest**: declare the `q4/*` and `bf16/*` MLX (macOS) tier downloads alongside the existing q8 default (q4 was hosted but undeclared). The candle Windows/Linux dense-bf16 entry is untouched.
- **Resolver** `krea_model_subdir`: add bf16 selection (advanced `mlxQuantize<=0`) with a **shard-aware** presence probe (single packed file OR `.index.json`).
- **On-device verify**: the dense sharded bf16 tier loads (`Quant::None`) through the real worker `krea_2_turbo` engine and generates a non-degenerate 512² image (`krea_2_turbo_bf16_real_weights_loads_and_generates`).

## Gates (local)
`cargo fmt --all --check`, `cargo clippy -p sceneworks-worker --all-targets -D warnings`, candle parity (`--no-default-features -F backend-candle --all-targets`), full `cargo test -p sceneworks-worker --lib` (473 passed), engines manifest-parse tests, on-device bf16 gen — all green. Branched off latest origin/main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)