### PR TITLE
feat(image-jobs): three candle strict-control providers — FLUX.1-dev, Qwen 2512-Fun, Z-Image base (sc-8412, sc-8350, sc-8379)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -942,7 +942,8 @@
         // Shakker `FLUX.1-dev-ControlNet-Union-Pro-2.0` branch on it (true structural lock, one image per
         // pose) via the `flux1_dev_control` registry generator. The control checkpoint (~3.5 GB) is
         // fetched on the first control job. Surfaces flux_dev in the Character Studio pose picker
-        // (character_image not required — poseLibrary gates it). MLX-only (no candle control lane yet).
+        // (character_image not required — poseLibrary gates it). Served on both macOS (MLX
+        // `flux1_dev_control`) and off-Mac (the candle `Flux1DevControl` strict-control lane, sc-8412).
         "poseLibrary": true,
         // Strict ControlNet → expose the control-lock-strength slider (advanced.controlScale; the Shakker
         // Union-Pro-2.0 README recommends ~0.7, worker default 0.7).

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3821,6 +3821,14 @@ const CANDLE_ROUTED_MODELS: &[&str] = &[
     // conditioning-incompatible).
     "realvisxl_lightning",
     "z_image_turbo",
+    // Base (non-distilled, full-CFG) Z-Image (epic 8236, sc-8379): same candle `z_image_diffusers` family
+    // as Turbo. On candle it is currently routed ONLY for the strict-control lane (`z_image` +
+    // `advanced.poses` → `generate_candle_zimage_control_stream`, the base Fun-Controlnet-Union branch);
+    // its plain-txt2img candle path is not wired yet, so a non-pose `z_image` job still defers to torch
+    // via `image_request_candle_eligible` (which has no base-z-image txt2img provider). Membership here is
+    // required so the strict-control branch + the pose-reject exclusion in `image_job_is_candle_eligible`
+    // see it as a candle-routed model.
+    "z_image",
     "flux_schnell",
     "flux_dev",
     "flux2_klein_9b",
@@ -4093,6 +4101,25 @@ fn image_job_is_candle_eligible(job: &JobSnapshot) -> bool {
     if model == "z_image_turbo" && zimage_control_candle_eligible(&job.payload) {
         return true;
     }
+    // Base (non-distilled, full-CFG) Z-Image strict-control (sc-8379, epic 8236): `z_image` +
+    // `advanced.poses` is the SAME bespoke candle `ZImageControl` lane as Turbo
+    // (`generate_candle_zimage_control_stream`, base Fun-Controlnet-Union branch), NOT txt2img — branch it
+    // out before the txt2img gate (which would defer the pose job to torch and has no base-z-image txt2img
+    // provider anyway). Same payload shape as the Turbo gate. Mirrors the worker's `zimage_control_\
+    // available` (which accepts both `z_image_turbo` and `z_image`).
+    if model == "z_image" && zimage_control_candle_eligible(&job.payload) {
+        return true;
+    }
+    // FLUX.1-dev strict-control Shakker Union-Pro-2.0 (sc-8412, epic 8236): `flux_dev` + `advanced.poses` is
+    // the bespoke candle `Flux1DevControl` lane (`generate_candle_flux1_control_stream`), NOT txt2img — the
+    // `image_request_candle_eligible` gate below DEFERS any `advanced.poses` job to torch, and the
+    // pose-reject would otherwise claim-to-reject it (it now HAS a candle pose lane). Branch it out first (the
+    // qwen/kolors/z_image/flux2-control reasoning, for the FLUX.1-dev family). A `flux_dev` reference job (a
+    // `referenceAssetId`) is the FLUX XLabs IP-Adapter branch above; a pure-pose job reaches here. Mirrors
+    // the worker's `flux1_control_candle_available`.
+    if model == "flux_dev" && flux1_control_candle_eligible(&job.payload) {
+        return true;
+    }
     // FLUX.2-dev strict-pose Fun-Controlnet-Union (sc-7736, epic 6564): `flux2_dev` + `advanced.poses` is
     // the bespoke candle `Flux2Control` lane (`generate_candle_flux2_control_stream`), NOT txt2img — the
     // `image_request_candle_eligible` gate below DEFERS any `advanced.poses` job to torch, and the pose-
@@ -4119,6 +4146,15 @@ fn image_job_is_candle_eligible(job: &JobSnapshot) -> bool {
 /// routing tests can probe it with synthetic payloads (parity with `image_request_mlx_eligible`).
 fn image_request_candle_eligible(model: &str, payload: &Map<String, Value>) -> bool {
     if !CANDLE_ROUTED_MODELS.contains(&model) {
+        return false;
+    }
+    // Base (non-distilled) Z-Image is candle-routed ONLY for its strict-control lane (sc-8379); the candle
+    // `is_candle_engine` set has no base-z-image txt2img provider, so a plain (non-pose) `z_image` job must
+    // NOT be claimed for the candle txt2img path here — it falls through to MLX/torch. (The pose job is
+    // branched out by `zimage_control_candle_eligible` in `image_job_is_candle_eligible` before reaching
+    // this gate.) Without this guard a plain `z_image` job would be claimed but the worker's
+    // `is_candle_engine` would not match it, silently dropping it to the unhandled tail.
+    if model == "z_image" {
         return false;
     }
     // img2img / inpaint / outpaint all arrive as `mode == "edit_image"` (+ a source); reject the
@@ -4686,12 +4722,13 @@ fn kolors_control_candle_eligible(payload: &Map<String, Value>) -> bool {
         .is_some_and(|poses| !poses.is_empty())
 }
 
-/// Z-Image strict-pose Fun-ControlNet candle-routing conditions (sc-5489, epic 5480). The candle
-/// `ZImageControl` provider serves `z_image_turbo` + a non-empty `advanced.poses` (one image per pose,
-/// each conditioned on a DWPose skeleton via the VACE-style `Z-Image-Turbo-Fun-Controlnet-Union-2.1`
-/// branch), NOT an `edit_image`. Same shape as the qwen/kolors gates — the model gate (`z_image_turbo`)
-/// is applied at the call site. Mirrors the worker's `zimage_control_available`. Candle-only — the macOS
-/// path is the MLX `z_image_turbo_control` registry generator.
+/// Z-Image strict-control Fun-ControlNet candle-routing conditions (sc-5489 origin / sc-8379 base, epic
+/// 8236). The candle `ZImageControl` provider serves `z_image_turbo` OR the base `z_image` + a non-empty
+/// `advanced.poses` (one image per pose, each conditioned on a DWPose skeleton via the VACE-style
+/// Fun-Controlnet-Union branch — the Turbo or base checkpoint), NOT an `edit_image`. Same shape as the
+/// qwen/kolors gates — the model gate (`z_image_turbo` / `z_image`) is applied at the call site (both call
+/// this). Mirrors the worker's `zimage_control_available`. Candle-only — the macOS path is the MLX
+/// `z_image_turbo_control` / `z_image_control` registry generators.
 fn zimage_control_candle_eligible(payload: &Map<String, Value>) -> bool {
     if payload.get("mode").and_then(Value::as_str) == Some("edit_image") {
         return false;
@@ -4768,6 +4805,25 @@ fn zimage_identity_candle_eligible(payload: &Map<String, Value>) -> bool {
     !has_poses
 }
 
+/// FLUX.1-dev strict-control Shakker Union-Pro-2.0 candle-routing conditions (sc-8412, epic 8236). The
+/// candle `Flux1DevControl` provider serves `flux_dev` + a non-empty `advanced.poses` (one image per pose,
+/// each conditioned on a DWPose skeleton via the Shakker `FLUX.1-dev-ControlNet-Union-Pro-2.0` residual
+/// branch on the dense bf16 dev base), NOT an `edit_image`. Same shape as the qwen/kolors/zimage/flux2
+/// control gates — the model gate (`flux_dev`) is applied at the call site. Mirrors the worker's
+/// `flux1_control_candle_available`. Candle-only — the macOS path is the MLX `flux1_dev_control` registry
+/// generator (sc-8244).
+fn flux1_control_candle_eligible(payload: &Map<String, Value>) -> bool {
+    if payload.get("mode").and_then(Value::as_str) == Some("edit_image") {
+        return false;
+    }
+    payload
+        .get("advanced")
+        .and_then(Value::as_object)
+        .and_then(|advanced| advanced.get("poses"))
+        .and_then(Value::as_array)
+        .is_some_and(|poses| !poses.is_empty())
+}
+
 /// FLUX.2-dev strict-pose Fun-Controlnet-Union candle-routing conditions (sc-7736, epic 6564). The candle
 /// `Flux2Control` provider serves `flux2_dev` + a non-empty `advanced.poses` (one image per pose, each
 /// conditioned on a DWPose skeleton via the VACE-style `FLUX.2-dev-Fun-Controlnet-Union` branch overlaid
@@ -4786,13 +4842,13 @@ fn flux2_dev_control_candle_eligible(payload: &Map<String, Value>) -> bool {
         .is_some_and(|poses| !poses.is_empty())
 }
 
-/// Candle-routed image models that HAVE a candle strict-pose lane (sc-5489; flux2_dev sc-7736). A
-/// `advanced.poses` job on any OTHER candle-routed model has no pose path on candle (plain-SDXL pose ships
-/// via InstantID, `instantid_realvisxl`, not `sdxl`).
+/// Candle-routed image models that HAVE a candle strict-control lane (sc-5489; flux2_dev sc-7736; base
+/// z_image + flux_dev sc-8379 / sc-8412). A `advanced.poses` job on any OTHER candle-routed model has no
+/// pose path on candle (plain-SDXL pose ships via InstantID, `instantid_realvisxl`, not `sdxl`).
 fn model_has_candle_pose_lane(model: &str) -> bool {
     matches!(
         model,
-        "qwen_image" | "kolors" | "z_image_turbo" | "flux2_dev"
+        "qwen_image" | "kolors" | "z_image_turbo" | "z_image" | "flux2_dev" | "flux_dev"
     )
 }
 
@@ -6127,7 +6183,19 @@ mod candle_routing_tests {
     #[test]
     fn candle_routed_models_plain_txt2img_are_eligible() {
         // SDXL/RealVisXL (sc-3678) + the four image families wired in sc-5096 — every base txt2img id.
+        // EXCEPT base `z_image` (sc-8379): it is candle-routed ONLY for its strict-control lane (no candle
+        // txt2img provider), so a plain txt2img `z_image` job correctly defers to MLX/torch.
         for model in CANDLE_ROUTED_MODELS {
+            if *model == "z_image" {
+                assert!(
+                    !image_request_candle_eligible(
+                        model,
+                        &object(json!({ "prompt": "a red fox" }))
+                    ),
+                    "base z_image plain txt2img must NOT be candle-eligible (control-only lane)"
+                );
+                continue;
+            }
             assert!(
                 image_request_candle_eligible(model, &object(json!({ "prompt": "a red fox" }))),
                 "{model} plain txt2img should be candle-eligible"
@@ -8000,6 +8068,51 @@ mod candle_routing_tests {
         assert!(!zimage_control_candle_eligible(&object(json!({
             "model": "z_image_turbo", "mode": "edit_image", "advanced": { "poses": [{}] }
         }))));
+    }
+
+    #[test]
+    fn zimage_base_control_pose_jobs_route_to_candle() {
+        // sc-8379: the BASE z_image model + advanced.poses routes to the same candle strict-control lane
+        // as Turbo (the base Fun-Controlnet-Union branch) via the bespoke branch, NOT the txt2img gate.
+        let payload = json!({ "model": "z_image", "advanced": { "poses": [{ "keypoints": [] }] } });
+        assert!(zimage_control_candle_eligible(&object(payload.clone())));
+        assert!(image_job_is_candle_eligible(&image_generate_job(payload)));
+        // A base z_image with no poses is plain txt2img — NOT a candle lane (no base-z-image txt2img
+        // provider on candle), so it defers to torch via the txt2img gate.
+        assert!(!image_job_is_candle_eligible(&image_generate_job(
+            json!({ "model": "z_image", "prompt": "a misty fjord" })
+        )));
+        // Both Turbo and base have a candle pose lane (so neither is pose-rejected).
+        assert!(model_has_candle_pose_lane("z_image"));
+        assert!(model_has_candle_pose_lane("z_image_turbo"));
+    }
+
+    #[test]
+    fn flux1_dev_control_pose_jobs_route_to_candle() {
+        // sc-8412: flux_dev + advanced.poses routes to the candle Shakker Union-Pro-2.0 strict-control
+        // lane via the bespoke branch, NOT the txt2img gate (which DEFERS any advanced.poses to torch).
+        let payload =
+            json!({ "model": "flux_dev", "advanced": { "poses": [{ "keypoints": [] }] } });
+        assert!(flux1_control_candle_eligible(&object(payload.clone())));
+        assert!(image_job_is_candle_eligible(&image_generate_job(payload)));
+        // No poses → plain txt2img routes via the txt2img gate instead.
+        assert!(!flux1_control_candle_eligible(&object(
+            json!({ "model": "flux_dev" })
+        )));
+        assert!(!flux1_control_candle_eligible(&object(json!({
+            "model": "flux_dev", "advanced": { "poses": [] }
+        }))));
+        // edit_image with poses is NOT this lane.
+        assert!(!flux1_control_candle_eligible(&object(json!({
+            "model": "flux_dev", "mode": "edit_image", "advanced": { "poses": [{}] }
+        }))));
+        // A flux_dev reference job (no poses) routes via the FLUX XLabs IP-Adapter branch, not this one.
+        assert!(!flux1_control_candle_eligible(&object(json!({
+            "model": "flux_dev", "referenceAssetId": "asset_1"
+        }))));
+        // flux_dev now HAS a candle pose lane (so it is not pose-rejected); schnell does not.
+        assert!(model_has_candle_pose_lane("flux_dev"));
+        assert!(!model_has_candle_pose_lane("flux_schnell"));
     }
 }
 

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -245,13 +245,24 @@ use candle_gen_kolors::{IpAdapterKolors, IpAdapterKolorsPaths, IpAdapterKolorsRe
 // (`image_jobs/flux_ipadapter.rs`) drives.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_flux::{IpAdapterFlux, IpAdapterFluxPaths, IpAdapterFluxRequest};
-// Qwen-Image ControlNet (strict pose) provider (sc-5489, epic 5480) — the candle (Windows/CUDA)
-// strict-pose lane (the first candle ControlNet family beyond the InstantID SDXL path). Candle-only:
-// macOS keeps the MLX `qwen_image_control` registry generator. `candle_gen_qwen_image` is already a
-// force-link anchor (`use candle_gen_qwen_image as _;`) from the Qwen txt2img wiring; this is the
-// named-type import the bespoke pose route (`image_jobs/qwen_control.rs`) drives.
+// FLUX.1-dev strict-control Fun-Controlnet-Union provider (sc-8412, epic 8236) — the candle (Windows/CUDA)
+// FLUX.1-dev sibling of the FLUX.2 / Z-Image / Qwen strict-control lanes, living in `candle-gen-flux` (the
+// Shakker Union-Pro-2.0 residual-emitter control branch overlaid on the FLUX.1-dev base via the
+// compose-ready DiT seam). Candle-only: macOS keeps the MLX `flux1_dev_control` registry generator
+// (flux1_control.rs). `candle_gen_flux` is already force-link anchored above (the registered txt2img
+// `flux1_*`); this is the named-type import the bespoke control route
+// (`image_jobs/flux1_control_candle.rs`) drives.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-use candle_gen_qwen_image::{QwenControl, QwenControlPaths, QwenControlRequest};
+use candle_gen_flux::{Flux1ControlPaths, Flux1ControlRequest, Flux1DevControl};
+// Qwen-Image 2512-Fun-Controlnet-Union (strict control) provider (sc-5489 origin / sc-8350 repoint, epic
+// 8236) — the candle (Windows/CUDA) strict-control lane. As of sc-8350 this rides the input-agnostic
+// `QwenFunControl` VACE engine on the Qwen-Image-2512 base (the InstantX `QwenControl` is retired on the
+// candle lane; the engine stays in the crate, unused by the worker). Candle-only: macOS keeps the MLX
+// `qwen_image_control` registry generator. `candle_gen_qwen_image` is already a force-link anchor (`use
+// candle_gen_qwen_image as _;`) from the Qwen txt2img wiring; this is the named-type import the bespoke
+// control route (`image_jobs/qwen_control.rs`) drives.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+use candle_gen_qwen_image::{QwenFunControl, QwenFunControlPaths, QwenFunControlRequest};
 // Qwen-Image-Edit provider (sc-5487, epic 5480) — the candle (Windows/CUDA) reference-edit lane (the
 // last family of sc-5487; SDXL + FLUX.2-klein edit already shipped). Candle-only: macOS keeps the MLX
 // `qwen_image_edit` registry path. The named-type import the bespoke edit route
@@ -855,11 +866,32 @@ pub(crate) async fn run_image_generate_job(
         )
         .await?;
         true
+    } else if settings.backend_candle_enabled && flux1_control_candle_available(&request, settings)
+    {
+        // FLUX.1-dev strict-control Shakker Union-Pro-2.0 (sc-8412, epic 8236) — `flux_dev` +
+        // `advanced.poses` is the bespoke candle `Flux1DevControl` lane
+        // (`generate_candle_flux1_control_stream`), NOT txt2img — the `is_candle_engine` txt2img branch
+        // below would silently drop the poses, and the no-pose-lane reject branch would reject them.
+        // Branch it out first (the qwen/kolors/z_image/flux2-control reasoning, for the FLUX.1-dev family —
+        // the 5th wired strict-control family). Disjoint from the FLUX XLabs IP-Adapter lane above (that
+        // one keys on a `referenceAssetId`; this is `advanced.poses`). Mirrors the router's
+        // `flux1_control_candle_eligible`.
+        generate_candle_flux1_control_stream(
+            api,
+            settings,
+            job,
+            &plan,
+            &project_path,
+            backend,
+            &mut asset_writes,
+        )
+        .await?;
+        true
     } else if settings.backend_candle_enabled
         && is_candle_engine(&request.model)
         && !matches!(
             request.model.as_str(),
-            "qwen_image" | "kolors" | "z_image_turbo" | "flux2_dev"
+            "qwen_image" | "kolors" | "z_image_turbo" | "z_image" | "flux2_dev" | "flux_dev"
         )
         && request.mode != "edit_image"
         && !pose_entries(&request).is_empty()
@@ -869,12 +901,12 @@ pub(crate) async fn run_image_generate_job(
         // and not bounced to torch. The candle worker CLAIMS these (jobs_store
         // `image_job_candle_pose_reject`) precisely to fail them loudly here, checked BEFORE the
         // `is_candle_engine` txt2img branch below. SDXL identity-pose ships via InstantID; the wired
-        // candle pose families are qwen_image / kolors / z_image_turbo / flux2_dev.
+        // candle pose families are qwen_image / kolors / z_image_turbo / z_image / flux2_dev / flux_dev.
         return Err(WorkerError::InvalidPayload(format!(
             "strict pose (advanced.poses) is not supported for model '{}' on the candle backend — \
              refusing rather than silently generating an unconditioned image (wired candle pose \
-             families: qwen_image, kolors, z_image_turbo, flux2_dev; SDXL identity-pose runs via \
-             InstantID)",
+             families: qwen_image, kolors, z_image_turbo, z_image, flux2_dev, flux_dev; SDXL \
+             identity-pose runs via InstantID)",
             request.model
         )));
     } else if settings.backend_candle_enabled && is_candle_engine(&request.model) {
@@ -1622,8 +1654,9 @@ include!("image_jobs/flux_ipadapter.rs");
 // MLX `strict_control.rs`. Must precede the three lanes (they reference the trait + driver).
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 include!("image_jobs/candle_strict_control.rs");
-// Qwen-Image ControlNet (strict pose) — the Windows/CUDA candle lane ONLY (sc-5489). macOS keeps the
-// MLX `qwen_image_control` registry generator; the candle `QwenControl` is a bespoke provider.
+// Qwen-Image 2512-Fun-Controlnet-Union (strict control) — the Windows/CUDA candle lane ONLY (sc-5489
+// origin / sc-8350 repoint). macOS keeps the MLX `qwen_image_control` registry generator; the candle
+// `QwenFunControl` is a bespoke provider (the InstantX `QwenControl` is retired on the candle lane).
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 include!("image_jobs/qwen_control.rs");
 // Kolors ControlNet (strict pose) — the Windows/CUDA candle lane ONLY (sc-5489). macOS keeps the MLX
@@ -1639,6 +1672,12 @@ include!("image_jobs/zimage_control.rs");
 // bespoke provider (the dev VACE control branch over the Q4 dev DiT).
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 include!("image_jobs/flux2_control_candle.rs");
+// FLUX.1-dev Shakker Union-Pro-2.0 (strict control) — the Windows/CUDA candle lane ONLY (sc-8412, epic
+// 8236). macOS keeps the MLX `flux1_dev_control` registry generator (flux1_control.rs); the candle
+// `Flux1DevControl` is a bespoke provider (the Shakker residual-emitter control branch over the dense
+// bf16 dev DiT).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+include!("image_jobs/flux1_control_candle.rs");
 // Z-Image img2img / edit — the Windows/CUDA candle lane ONLY (sc-6595). macOS keeps the MLX
 // `z_image_turbo` registry generator's `Conditioning::Reference` img2img path; the candle `ZImageEdit`
 // is a bespoke provider.

--- a/crates/sceneworks-worker/src/image_jobs/candle_strict_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/candle_strict_control.rs
@@ -36,11 +36,13 @@ trait CandleStrictControl: Send + 'static {
     type Model;
 
     /// The [`STRICT_CONTROL_ENGINES`] catalog id whose `supported_kinds` gates this lane's
-    /// `advanced.controlMode` (`z_image_turbo_control` / `flux2_dev_control` / `qwen_image_control`).
+    /// `advanced.controlMode` (`z_image_turbo_control` / `z_image_control` / `flux1_dev_control` /
+    /// `flux2_dev_control` / `qwen_image_control`).
     fn engine_id(&self) -> &'static str;
 
     /// The engine label recorded on assets / `raw_settings` (`candle_zimage_control` /
-    /// `candle_flux2_control` / `candle_qwen_control`) — byte-preserved per the regression contract.
+    /// `candle_flux1_control` / `candle_flux2_control` / `candle_qwen_control`) — byte-preserved per the
+    /// regression contract.
     fn engine_label(&self) -> &'static str;
 
     /// The short `start_gen_stream` tag (`zimage_control` / `flux2_control` / `qwen_control`).

--- a/crates/sceneworks-worker/src/image_jobs/flux1_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux1_control_candle.rs
@@ -1,0 +1,354 @@
+// Candle (Windows/CUDA) FLUX.1-dev strict-control Fun-Controlnet-Union route (sc-8412, epic 8236) —
+// `flux_dev` + `advanced.poses` off-Mac via `candle_gen_flux::Flux1DevControl`. The candle sibling of the
+// MLX FLUX.1-dev strict-control path (flux1_control.rs `generate_flux1_dev_control_stream`, sc-8244 /
+// engine sc-8239): one image per library pose (or, with `advanced.controlMode = canny|depth` + a source,
+// an auto-derived canny / Depth-Anything-V2 map), each fed to the Shakker
+// `FLUX.1-dev-ControlNet-Union-Pro-2.0` residual-emitter branch overlaid on the FLUX.1-dev base. True
+// structural lock, not the best-effort reference tier.
+//
+// **Candle-only.** macOS keeps the MLX `flux1_dev_control` registry generator (flux1_control.rs); the
+// candle `Flux1DevControl` is a bespoke provider, so this whole file is gated to the Windows/CUDA candle
+// build (the `include!` in image_jobs.rs carries the cfg). It is `include!`d into the `image_jobs`
+// module, so it shares that module's imports (`parse_poses`/`pose_entries`/`Settings`/`WorkerResult`/
+// `huggingface_snapshot_dir`/`ensure_hf_cached_file`/`start_gen_stream`/… all in scope unqualified).
+//
+// The FLUX.1-dev base is HF-gated; the Shakker Union-Pro-2.0 control overlay is ungated. The candle
+// `Flux1DevControl` provider loads BOTH dense bf16 (no on-the-fly quant seam — the 12B dev fits dense at
+// bf16), so the worker passes no `Quant`. dev is guidance-distilled — a single embedded-guidance forward,
+// no true-CFG / negative pass. Union-Pro-2.0 dropped the discrete mode index, so the control kind is
+// input-agnostic: it only gates the accepted set (pose/canny/depth); it does not branch the forward.
+
+/// Default Shakker Union-Pro-2.0 control-weights repo + filename — the single diffusers `.safetensors`
+/// shipped in the repo. Parity with the MLX `flux1_control.rs` defaults (which reads the repo from the
+/// shared `STRICT_CONTROL_ENGINES` table); the candle lane keeps its own constant (its own default-repo,
+/// like the other candle control lanes).
+const FLUX1_CONTROL_CANDLE_REPO: &str = "Shakker-Labs/FLUX.1-dev-ControlNet-Union-Pro-2.0";
+const FLUX1_CONTROL_CANDLE_FILE: &str = "diffusion_pytorch_model.safetensors";
+/// The FLUX.1-dev base diffusers repo when the manifest omits `repo` (HF-gated). The candle lane loads
+/// the dense bf16 snapshot.
+const FLUX1_CONTROL_CANDLE_BASE_REPO: &str = "black-forest-labs/FLUX.1-dev";
+/// Control-conditioning-scale default — the Shakker Union-Pro-2.0 README sweet spot ≈ 0.7 (the engine
+/// `DEFAULT_CONTROL_SCALE` too, and the MLX lane's default). Clamp [0, 2].
+const FLUX1_CONTROL_CANDLE_DEFAULT_SCALE: f32 = 0.7;
+/// Denoise-steps default — the guidance-distilled dev (~25 steps; the engine request default).
+const FLUX1_CONTROL_CANDLE_DEFAULT_STEPS: u32 = 25;
+/// Embedded-guidance default — distilled dev scalar (NOT true-CFG, no negative pass).
+const FLUX1_CONTROL_CANDLE_DEFAULT_GUIDANCE: f32 = 3.5;
+/// The adapter/engine id recorded on candle FLUX.1-dev control assets (distinct from the txt2img
+/// `candle_flux` + FLUX.2 `candle_flux2_control` lanes).
+const FLUX1_CONTROL_CANDLE_ENGINE: &str = "candle_flux1_control";
+/// The [`STRICT_CONTROL_ENGINES`] catalog id this candle lane validates `advanced.controlMode` against
+/// (the FLUX.1-dev Union-Pro-2.0 row — `{Pose, Canny, Depth}`). Mirrors the MLX `flux1_dev_control`
+/// registry engine's `supported_kinds` (sc-8304).
+const FLUX1_CONTROL_CANDLE_ENGINE_ID: &str = "flux1_dev_control";
+
+/// Model ids the candle FLUX.1 strict-control route accepts (schnell has no control checkpoint).
+fn is_flux1_control_model(model: &str) -> bool {
+    model == "flux_dev"
+}
+
+/// Resolve the FLUX.1-dev base (diffusers) snapshot: an explicit `modelPath` (advanced or manifest) → the
+/// HF cache snapshot for the manifest `repo` (default `black-forest-labs/FLUX.1-dev`). `None` ⇒ not
+/// present locally (the job is not candle-runnable). Mirrors `resolve_flux2_control_base`.
+fn resolve_flux1_control_base(
+    request: &ImageRequest,
+    settings: &Settings,
+) -> WorkerResult<Option<PathBuf>> {
+    if let Some(path) = request
+        .advanced
+        .get("modelPath")
+        .or_else(|| request.model_manifest_entry.get("modelPath"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+    {
+        return resolve_app_managed_model_dir(settings, &path, "FLUX.1 control modelPath").map(Some);
+    }
+    let repo = request
+        .model_manifest_entry
+        .get("repo")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(FLUX1_CONTROL_CANDLE_BASE_REPO);
+    Ok(huggingface_snapshot_dir(&settings.data_dir, repo))
+}
+
+/// True when this is a candle-eligible FLUX.1-dev strict-control job: `flux_dev` with a non-empty
+/// `advanced.poses`, not edit mode, whose base resolves locally. Mirrors
+/// `jobs_store::flux1_control_candle_eligible` so the worker and router agree. Control-weights presence is
+/// NOT part of the gate: they are fetched on first use in the stream.
+fn flux1_control_candle_available(request: &ImageRequest, settings: &Settings) -> bool {
+    is_flux1_control_model(&request.model)
+        && request.mode != "edit_image"
+        && !pose_entries(request).is_empty()
+        && matches!(resolve_flux1_control_base(request, settings), Ok(Some(_)))
+}
+
+/// Resolve denoise steps: `advanced.steps` (clamped 1..=50) → manifest `steps` → default (25).
+fn flux1_control_candle_steps(request: &ImageRequest) -> u32 {
+    let parse = |value: &Value| {
+        value
+            .as_u64()
+            .or_else(|| value.as_str()?.trim().parse().ok())
+    };
+    request
+        .advanced
+        .get("steps")
+        .and_then(parse)
+        .or_else(|| request.model_manifest_entry.get("steps").and_then(parse))
+        .map(|steps| steps.clamp(1, 50) as u32)
+        .unwrap_or(FLUX1_CONTROL_CANDLE_DEFAULT_STEPS)
+}
+
+/// Resolve embedded guidance: `advanced.guidanceScale` → manifest `guidanceScale` → default (3.5),
+/// clamped. dev rides this scalar on the transformer's guidance embedder (no true-CFG).
+fn flux1_control_candle_guidance(request: &ImageRequest) -> f32 {
+    let manifest_default = request
+        .model_manifest_entry
+        .get("guidanceScale")
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .map(|value| value as f32)
+        .unwrap_or(FLUX1_CONTROL_CANDLE_DEFAULT_GUIDANCE);
+    advanced::f32_clamped(
+        &request.advanced,
+        "guidanceScale",
+        manifest_default,
+        0.0..=30.0,
+    )
+}
+
+/// The (repo, filename) of the control weights — `advanced.controlWeights.{repo,filename}` overrides,
+/// else the Shakker Union-Pro-2.0 default (parity with the MLX `flux1_control_repo_file`).
+fn flux1_control_candle_repo_file(request: &ImageRequest) -> (String, String) {
+    let cw = request
+        .advanced
+        .get("controlWeights")
+        .and_then(Value::as_object);
+    let pick = |key: &str, default: &str| {
+        cw.and_then(|m| m.get(key))
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+            .unwrap_or(default)
+            .to_owned()
+    };
+    (
+        pick("repo", FLUX1_CONTROL_CANDLE_REPO),
+        pick("filename", FLUX1_CONTROL_CANDLE_FILE),
+    )
+}
+
+/// Resolve the Shakker Union-Pro-2.0 weight **file** the `Flux1DevControl` provider loads, downloading on
+/// first use. Order: an env-pinned file (`SCENEWORKS_CONTROLNET_FLUX1`) → a whole-repo HF cache snapshot →
+/// download into the app cache. Mirrors the MLX `ensure_flux1_control_weights` / candle
+/// `ensure_flux2_control_candle_weights`. The control checkpoint is lazy-fetched only on the first pose
+/// job (vs bloating the base download).
+async fn ensure_flux1_control_candle_weights(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &ImageRequest,
+) -> WorkerResult<PathBuf> {
+    let (repo, file) = flux1_control_candle_repo_file(request);
+    if let Ok(p) = std::env::var("SCENEWORKS_CONTROLNET_FLUX1") {
+        let p = PathBuf::from(p);
+        if p.is_file() {
+            return Ok(p);
+        }
+    }
+    if let Some(snapshot) = huggingface_snapshot_dir(&settings.data_dir, &repo) {
+        let f = snapshot.join(&file);
+        if f.is_file() {
+            return Ok(f);
+        }
+    }
+    let client = reqwest::Client::new();
+    let context = DownloadContext {
+        api,
+        client: &client,
+        settings,
+        job_id: &job.id,
+        cancel_message: "FLUX.1-dev strict-control generation canceled while fetching control weights.",
+        fresh_download: false,
+    };
+    let dst = settings
+        .data_dir
+        .join("cache")
+        .join("controlnet-flux1-candle")
+        .join(&file);
+    ensure_hf_cached_file(&context, &repo, "main", &file, &dst).await?;
+    Ok(dst)
+}
+
+/// Flat telemetry recorded on candle FLUX.1-dev control assets (parity with the MLX
+/// `flux1_control_raw_settings`). dev is dense bf16 (no quant) — no `mlxQuantize` key.
+fn flux1_control_candle_raw_settings(
+    request: &ImageRequest,
+    repo: &str,
+    steps: u32,
+    guidance: f32,
+    control_scale: f32,
+    pose_count: usize,
+) -> JsonObject {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("repo".to_owned(), Value::String(repo.to_owned()));
+    raw.insert("numInferenceSteps".to_owned(), json!(steps));
+    raw.insert("guidanceScale".to_owned(), json!(guidance));
+    raw.insert("controlScale".to_owned(), json!(control_scale));
+    raw.insert("poseCount".to_owned(), json!(pose_count));
+    raw.insert(
+        "controlEngine".to_owned(),
+        Value::String(FLUX1_CONTROL_CANDLE_ENGINE.to_owned()),
+    );
+    raw
+}
+
+/// The per-lane half of the candle FLUX.1-dev strict-control [`CandleStrictControl`] driver (sc-8412):
+/// the resolved base + Shakker control weight paths, the request numerics, and the resolved control-kind
+/// label (input-agnostic — used only to satisfy the engine's accepted-set check, shared across the pose
+/// set). dev keeps its embedded guidance (no true-CFG / negative pass). Moved onto the blocking thread,
+/// loaded once (dense bf16), drives every pose.
+struct Flux1StrictControl {
+    base: PathBuf,
+    control: PathBuf,
+    prompt: String,
+    width: u32,
+    height: u32,
+    steps: u32,
+    guidance: f32,
+    control_scale: f32,
+    /// The resolved control kind for this set (`pose` | `canny` | `depth`) — input-agnostic; the engine
+    /// validates it against its accepted set but does NOT branch the forward (Union-Pro-2.0 dropped the
+    /// discrete mode index). The whole pose set shares one `controlMode`, so a single label is correct.
+    control_kind: String,
+}
+
+impl CandleStrictControl for Flux1StrictControl {
+    type Model = Flux1DevControl;
+
+    fn engine_id(&self) -> &'static str {
+        FLUX1_CONTROL_CANDLE_ENGINE_ID
+    }
+
+    fn engine_label(&self) -> &'static str {
+        FLUX1_CONTROL_CANDLE_ENGINE
+    }
+
+    fn stream_tag(&self) -> &'static str {
+        "flux1_control"
+    }
+
+    fn load(&self) -> WorkerResult<Self::Model> {
+        let paths = Flux1ControlPaths {
+            flux_base: self.base.clone(),
+            control: self.control.clone(),
+        };
+        Flux1DevControl::load(&paths).map_err(|error| {
+            WorkerError::Engine(format!("FLUX.1-dev strict-control load failed: {error}"))
+        })
+    }
+
+    fn generate_one(
+        &self,
+        model: &Self::Model,
+        control: &Image,
+        seed: u64,
+        cancel: &CancelFlag,
+        on_progress: &mut dyn FnMut(Progress),
+    ) -> WorkerResult<Image> {
+        let req = Flux1ControlRequest {
+            prompt: self.prompt.clone(),
+            width: self.width,
+            height: self.height,
+            steps: self.steps as usize,
+            guidance: self.guidance,
+            control_scale: self.control_scale,
+            control_kind: self.control_kind.clone(),
+            seed,
+            cancel: cancel.clone(),
+        };
+        model.generate(&req, control, on_progress).map_err(|error| {
+            WorkerError::Engine(format!("FLUX.1-dev strict-control generation failed: {error}"))
+        })
+    }
+}
+
+/// Real candle FLUX.1-dev strict-control generation: one image per pose, each conditioned on a full DWPose
+/// skeleton (`controlMode` unset) or a canny/depth control map via the Shakker Union-Pro-2.0 branch
+/// (sc-8412; engine sc-8239). Resolves the base + control weights, then hands a [`Flux1StrictControl`] to
+/// the shared [`run_candle_strict_control`] driver (validation against `flux1_dev_control`'s
+/// `supported_kinds`, per-pose preprocessing, scoring). dev loads dense bf16 (no quant) and keeps its
+/// embedded guidance (no CFG). The pose path is byte-preserved.
+async fn generate_candle_flux1_control_stream(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+    let base = resolve_flux1_control_base(request, settings)?.ok_or_else(|| {
+        WorkerError::InvalidPayload("FLUX.1-dev base (FLUX.1-dev) weights not found".to_owned())
+    })?;
+    let control = ensure_flux1_control_candle_weights(api, settings, job, request).await?;
+
+    let steps = flux1_control_candle_steps(request);
+    let guidance = flux1_control_candle_guidance(request);
+    let control_scale = advanced::f32_clamped(
+        &request.advanced,
+        "controlScale",
+        FLUX1_CONTROL_CANDLE_DEFAULT_SCALE,
+        0.0..=2.0,
+    );
+    // Resolve the requested control kind up front (the whole pose set shares one `controlMode`). The
+    // shared driver re-validates it against `flux1_dev_control`'s `supported_kinds`; here we just carry the
+    // label into the request struct (input-agnostic — the engine validates the accepted set but does not
+    // branch the forward). Defaults to `pose` when `controlMode` is unset (byte-preserved skeleton path).
+    let control_kind = control_kind_label(&requested_control_kind(request)?);
+    let repo = request
+        .model_manifest_entry
+        .get("repo")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(FLUX1_CONTROL_CANDLE_BASE_REPO)
+        .to_owned();
+
+    let pose_count = pose_entries(request).len();
+    let raw_settings =
+        flux1_control_candle_raw_settings(request, &repo, steps, guidance, control_scale, pose_count);
+
+    let provider = Flux1StrictControl {
+        base,
+        control,
+        prompt: request.prompt.clone(),
+        width: request.width,
+        height: request.height,
+        steps,
+        guidance,
+        control_scale,
+        control_kind,
+    };
+
+    run_candle_strict_control(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        provider,
+        raw_settings,
+        asset_writes,
+    )
+    .await
+}

--- a/crates/sceneworks-worker/src/image_jobs/qwen_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_control.rs
@@ -1,21 +1,29 @@
-// Candle (Windows/CUDA) Qwen-Image ControlNet (strict pose) route (sc-5489, epic 5480) — `qwen_image`
-// + `advanced.poses` off-Mac via `candle_gen_qwen_image::QwenControl`. The candle sibling of the MLX
-// Qwen strict-pose path (qwen.rs `generate_qwen_control_stream`): one image per pose, each conditioned
-// on a full DWPose skeleton (rendered cross-platform by `openpose_skeleton::draw_wholebody`) fed to the
-// InstantX Qwen-Image-ControlNet-Union branch.
+// Candle (Windows/CUDA) Qwen-Image 2512-Fun-Controlnet-Union (strict control) route (sc-5489 origin /
+// sc-8350 repoint, epic 8236) — `qwen_image` + `advanced.poses` off-Mac via
+// `candle_gen_qwen_image::QwenFunControl`. The candle sibling of the MLX Qwen 2512-Fun strict-control path
+// (qwen.rs `generate_qwen_control_stream`): one image per pose (or, with `advanced.controlMode =
+// canny|depth` + a source, an auto-derived canny / Depth-Anything-V2 map), each fed to the VACE-style
+// `alibaba-pai/Qwen-Image-2512-Fun-Controlnet-Union` branch overlaid on the Qwen-Image-2512 base.
 //
-// **Candle-only.** macOS keeps the MLX `qwen_image_control` registry generator; the candle `QwenControl`
+// **sc-8350 source swap.** This lane previously loaded the InstantX `Qwen-Image-ControlNet-Union`
+// checkpoint (`QwenControl`, a residual-ControlNet on the `Qwen/Qwen-Image` base). It now rides the
+// 2512-Fun-Union VACE engine (`QwenFunControl`) on the `Qwen/Qwen-Image-2512` base — input-agnostic
+// (pose/canny/depth, no mode index), matching the `STRICT_CONTROL_ENGINES` `qwen_image_control` row. The
+// candle-gen InstantX `control.rs` engine (`QwenControl`) stays in the crate but is no longer used by the
+// worker.
+//
+// **Candle-only.** macOS keeps the MLX `qwen_image_control` registry generator; the candle `QwenFunControl`
 // is a bespoke provider, so this whole file is gated to the Windows/CUDA candle build (the `include!` in
 // image_jobs.rs carries the cfg). It is `include!`d into the `image_jobs` module, so it shares that
 // module's imports (`parse_poses`/`Settings`/`WorkerResult`/`huggingface_snapshot_dir`/
 // `ensure_hf_cached_file`/`start_gen_stream`/… all in scope unqualified).
 
-/// Default InstantX Qwen-Image-ControlNet-Union weights (Apache-2.0, DWPose-trained) — same repo/file
-/// the MLX path uses (`qwen.rs` `QWEN_CONTROL_REPO`/`QWEN_CONTROL_FILE`).
-const QWEN_CONTROL_REPO: &str = "InstantX/Qwen-Image-ControlNet-Union";
+/// Default 2512-Fun-Controlnet-Union weights (Apache-2.0, input-agnostic VACE control) — same repo/file
+/// the MLX path uses (`qwen.rs` 2512-Fun constants); the candle lane keeps its own constant (sc-8350).
+const QWEN_CONTROL_REPO: &str = "alibaba-pai/Qwen-Image-2512-Fun-Controlnet-Union";
 const QWEN_CONTROL_FILE: &str = "diffusion_pytorch_model.safetensors";
-/// The Qwen-Image base diffusers repo when the manifest omits `repo`.
-const QWEN_CONTROL_DEFAULT_REPO: &str = "Qwen/Qwen-Image";
+/// The Qwen-Image-2512 base diffusers repo when the manifest omits `repo` (the 2512-Fun base, sc-8350).
+const QWEN_CONTROL_DEFAULT_REPO: &str = "Qwen/Qwen-Image-2512";
 /// ControlNet conditioning-scale default (the strict-pose tier).
 const QWEN_CONTROL_DEFAULT_SCALE: f32 = 1.0;
 /// Denoise-steps default (Qwen-Image production).
@@ -26,9 +34,9 @@ const QWEN_CONTROL_DEFAULT_GUIDANCE: f32 = 4.0;
 /// `candle_qwen` lane).
 const QWEN_CONTROL_ENGINE: &str = "candle_qwen_control";
 /// The [`STRICT_CONTROL_ENGINES`] catalog id this candle lane validates `advanced.controlMode` against
-/// (the `qwen_image_control` row — `{Pose, Canny, Depth}`). NOTE the candle lane still loads the InstantX
-/// `Qwen-Image-ControlNet-Union` checkpoint (its own default-repo constants above), not the table's
-/// 2512-Fun row — that source swap is the separate sc-8350. Only `supported_kinds` is shared here.
+/// (the `qwen_image_control` row — `{Pose, Canny, Depth}`). As of sc-8350 the candle lane loads the
+/// 2512-Fun-Controlnet-Union checkpoint on the Qwen-Image-2512 base (`QwenFunControl`), matching the
+/// table's `qwen_image_control` repo (`alibaba-pai/Qwen-Image-2512-Fun-Controlnet-Union`) exactly.
 const QWEN_CONTROL_ENGINE_ID: &str = "qwen_image_control";
 
 /// Model ids the candle Qwen ControlNet route accepts.
@@ -36,9 +44,9 @@ fn is_qwen_control_model(model: &str) -> bool {
     model == "qwen_image"
 }
 
-/// Resolve the Qwen-Image base (diffusers) snapshot: an explicit `modelPath` (advanced or manifest) →
-/// the HF cache snapshot for the manifest `repo` (default `Qwen/Qwen-Image`). `None` ⇒ not present
-/// locally (the job is not candle-runnable, falls through to torch). Mirrors
+/// Resolve the Qwen-Image-2512 base (diffusers) snapshot: an explicit `modelPath` (advanced or manifest) →
+/// the HF cache snapshot for the manifest `repo` (default `Qwen/Qwen-Image-2512`, sc-8350). `None` ⇒ not
+/// present locally (the job is not candle-runnable, falls through to torch). Mirrors
 /// `resolve_kolors_ipadapter_base`.
 fn resolve_qwen_control_base(
     request: &ImageRequest,
@@ -129,9 +137,9 @@ fn qwen_control_repo_file(request: &ImageRequest) -> (String, String) {
     )
 }
 
-/// Resolve the InstantX ControlNet weight **file** the `QwenControl` provider loads, downloading on
-/// first use. Order: an env-pinned file (`SCENEWORKS_CONTROLNET_QWEN`) → a whole-repo HF cache snapshot
-/// → download into the app cache.
+/// Resolve the 2512-Fun-Controlnet-Union weight **file** the `QwenFunControl` provider loads (sc-8350),
+/// downloading on first use. Order: an env-pinned file (`SCENEWORKS_CONTROLNET_QWEN`) → a whole-repo HF
+/// cache snapshot → download into the app cache.
 async fn ensure_qwen_control_weights(
     api: &ApiClient,
     settings: &Settings,
@@ -192,9 +200,10 @@ fn qwen_control_raw_settings(
     raw
 }
 
-/// The per-lane half of the candle Qwen strict-control [`CandleStrictControl`] driver (sc-8304): the
-/// resolved base + InstantX control weight paths + the request numerics. Qwen runs true CFG, so it carries
-/// a negative prompt + guidance. Moved onto the blocking thread, loaded once, drives every pose.
+/// The per-lane half of the candle Qwen 2512-Fun strict-control [`CandleStrictControl`] driver (sc-8304 /
+/// sc-8350): the resolved base + 2512-Fun-Union control weight paths + the request numerics. Qwen runs
+/// true CFG, so it carries a negative prompt + guidance. Moved onto the blocking thread, loaded once,
+/// drives every pose.
 struct QwenStrictControl {
     qwen_base: PathBuf,
     controlnet: PathBuf,
@@ -208,7 +217,7 @@ struct QwenStrictControl {
 }
 
 impl CandleStrictControl for QwenStrictControl {
-    type Model = QwenControl;
+    type Model = QwenFunControl;
 
     fn engine_id(&self) -> &'static str {
         QWEN_CONTROL_ENGINE_ID
@@ -223,12 +232,12 @@ impl CandleStrictControl for QwenStrictControl {
     }
 
     fn load(&self) -> WorkerResult<Self::Model> {
-        let paths = QwenControlPaths {
+        let paths = QwenFunControlPaths {
             qwen_base: self.qwen_base.clone(),
             controlnet: self.controlnet.clone(),
         };
-        QwenControl::load(&paths).map_err(|error| {
-            WorkerError::Engine(format!("Qwen strict-pose control load failed: {error}"))
+        QwenFunControl::load(&paths).map_err(|error| {
+            WorkerError::Engine(format!("Qwen 2512-Fun strict-control load failed: {error}"))
         })
     }
 
@@ -240,7 +249,7 @@ impl CandleStrictControl for QwenStrictControl {
         cancel: &CancelFlag,
         on_progress: &mut dyn FnMut(Progress),
     ) -> WorkerResult<Image> {
-        let req = QwenControlRequest {
+        let req = QwenFunControlRequest {
             prompt: self.prompt.clone(),
             negative: self.negative.clone(),
             width: self.width,
@@ -252,7 +261,7 @@ impl CandleStrictControl for QwenStrictControl {
             cancel: cancel.clone(),
         };
         model.generate(&req, control, on_progress).map_err(|error| {
-            WorkerError::Engine(format!("Qwen strict-pose generation failed: {error}"))
+            WorkerError::Engine(format!("Qwen 2512-Fun strict-control generation failed: {error}"))
         })
     }
 }

--- a/crates/sceneworks-worker/src/image_jobs/qwen_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_control.rs
@@ -120,7 +120,7 @@ fn qwen_control_guidance(request: &ImageRequest) -> f32 {
 }
 
 /// The (repo, filename) of the ControlNet weights — `advanced.controlWeights.{repo,filename}` overrides,
-/// else the InstantX Union default (parity with the MLX `resolve_control_weights_for`).
+/// else the 2512-Fun-Controlnet-Union default (parity with the MLX `resolve_control_weights_for`).
 fn qwen_control_repo_file(request: &ImageRequest) -> (String, String) {
     let cw = request.advanced.get("controlWeights").and_then(Value::as_object);
     let pick = |key: &str, default: &str| {
@@ -267,7 +267,7 @@ impl CandleStrictControl for QwenStrictControl {
 }
 
 /// Real candle Qwen strict-pose generation: one image per pose, each conditioned on a full DWPose skeleton
-/// (`controlMode` unset) or a canny/depth control map. Resolves the base + InstantX control weights, then
+/// (`controlMode` unset) or a canny/depth control map. Resolves the Qwen-Image-2512 base + 2512-Fun control weights, then
 /// hands a [`QwenStrictControl`] to the shared [`run_candle_strict_control`] driver (validation against
 /// `qwen_image_control`'s `supported_kinds`, per-pose preprocessing, scoring). `generate` takes the
 /// per-job `CancelFlag` + a `Progress` callback (per-step streaming + mid-denoise cancel). The pose path

--- a/crates/sceneworks-worker/src/image_jobs/strict_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/strict_control.rs
@@ -87,9 +87,9 @@ fn strict_control_engine(engine_id: &str) -> Option<&'static StrictControlEngine
 /// The catalog DEFAULT control-weights repo for a Fun-Union strict-control engine — the single source of
 /// truth each engine's `controlWeights.repo`-override resolver falls back to. Panics on a non-Fun-Union
 /// engine id (a programming error: only the three registry strict-control streams call this with their
-/// own engine id). Off-Mac the candle strict-control trio keeps its own per-lane default-repo constants
-/// (the qwen candle lane is still the InstantX checkpoint, not the table's 2512-Fun row — that swap is
-/// the separate sc-8350), so this is unused on the candle lane.
+/// own engine id). Off-Mac the candle strict-control lanes keep their own per-lane default-repo constants
+/// (the qwen candle lane now resolves the table's 2512-Fun row, sc-8350), so this is unused on the candle
+/// lane.
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 fn strict_control_default_repo(engine_id: &str) -> &'static str {
     strict_control_engine(engine_id)

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -6891,7 +6891,9 @@ fn candle_structured_source(side: u32) -> Image {
 fn candle_strict_control_engine_ids_match_the_catalog() {
     for id in [
         ZIMAGE_CTRL_ENGINE_ID,
+        ZIMAGE_CTRL_BASE_ENGINE_ID,
         FLUX2_CONTROL_CANDLE_ENGINE_ID,
+        FLUX1_CONTROL_CANDLE_ENGINE_ID,
         QWEN_CONTROL_ENGINE_ID,
     ] {
         let row = strict_control_engine(id).unwrap_or_else(|| panic!("no catalog row for {id}"));
@@ -6903,9 +6905,12 @@ fn candle_strict_control_engine_ids_match_the_catalog() {
             assert!(validate_control_kind(id, &kind).is_ok(), "{id} {kind:?}");
         }
     }
-    // The candle engine ids are the Turbo / dev / qwen rows (NOT base-z-image / flux1 — those are B3).
+    // The candle engine ids now cover the Turbo + base z-image / dev / flux1 / qwen rows (epic 8236 B3:
+    // sc-8412 flux1, sc-8350 qwen 2512-Fun, sc-8379 base z-image).
     assert_eq!(ZIMAGE_CTRL_ENGINE_ID, "z_image_turbo_control");
+    assert_eq!(ZIMAGE_CTRL_BASE_ENGINE_ID, "z_image_control");
     assert_eq!(FLUX2_CONTROL_CANDLE_ENGINE_ID, "flux2_dev_control");
+    assert_eq!(FLUX1_CONTROL_CANDLE_ENGINE_ID, "flux1_dev_control");
     assert_eq!(QWEN_CONTROL_ENGINE_ID, "qwen_image_control");
 }
 
@@ -6917,7 +6922,9 @@ fn candle_strict_control_rejects_unsupported_kind_and_unknown_engine() {
     let unsupported = ControlKind::Other("scribble".to_owned());
     for id in [
         ZIMAGE_CTRL_ENGINE_ID,
+        ZIMAGE_CTRL_BASE_ENGINE_ID,
         FLUX2_CONTROL_CANDLE_ENGINE_ID,
+        FLUX1_CONTROL_CANDLE_ENGINE_ID,
         QWEN_CONTROL_ENGINE_ID,
     ] {
         let err = validate_control_kind(id, &unsupported)
@@ -6936,11 +6943,71 @@ fn candle_strict_control_rejects_unsupported_kind_and_unknown_engine() {
 fn candle_strict_control_labels_and_scale_defaults_are_byte_preserved() {
     assert_eq!(ZIMAGE_CTRL_ENGINE, "candle_zimage_control");
     assert_eq!(FLUX2_CONTROL_CANDLE_ENGINE, "candle_flux2_control");
+    assert_eq!(FLUX1_CONTROL_CANDLE_ENGINE, "candle_flux1_control");
     assert_eq!(QWEN_CONTROL_ENGINE, "candle_qwen_control");
     // The pose-tier control-scale defaults (the value each lane clamps `advanced.controlScale` toward).
     assert_eq!(ZIMAGE_CTRL_DEFAULT_SCALE, 1.0);
     assert_eq!(FLUX2_CONTROL_CANDLE_DEFAULT_SCALE, 0.75);
+    assert_eq!(FLUX1_CONTROL_CANDLE_DEFAULT_SCALE, 0.7);
     assert_eq!(QWEN_CONTROL_DEFAULT_SCALE, 1.0);
+}
+
+/// sc-8412 / sc-8350 / sc-8379 (epic 8236): the three new/changed candle control providers resolve the
+/// RIGHT model ids + default repos. FLUX.1-dev rides the Shakker Union-Pro-2.0 row; the qwen lane now
+/// defaults to the 2512-Fun-Union checkpoint on the Qwen-Image-2512 base (NOT the retired InstantX repo);
+/// the z-image lane recognizes both Turbo and the base model with their respective repos + step defaults.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn candle_control_providers_resolve_models_and_repos() {
+    // sc-8412 — FLUX.1-dev control: `flux_dev` only (schnell rejected), Shakker Union-Pro-2.0 default repo.
+    assert!(is_flux1_control_model("flux_dev"));
+    assert!(!is_flux1_control_model("flux_schnell"));
+    assert!(!is_flux1_control_model("flux2_dev"));
+    let flux1 = request(json!({ "projectId": "p", "model": "flux_dev" }));
+    let (f1_repo, f1_file) = flux1_control_candle_repo_file(&flux1);
+    assert_eq!(f1_repo, "Shakker-Labs/FLUX.1-dev-ControlNet-Union-Pro-2.0");
+    assert_eq!(f1_file, "diffusion_pytorch_model.safetensors");
+    assert_eq!(
+        FLUX1_CONTROL_CANDLE_BASE_REPO,
+        "black-forest-labs/FLUX.1-dev"
+    );
+
+    // sc-8350 — qwen InstantX → 2512-Fun: the default control repo + base repo are the 2512-Fun row, NOT
+    // the retired InstantX `Qwen-Image-ControlNet-Union`.
+    let qwen = request(json!({ "projectId": "p", "model": "qwen_image" }));
+    let (q_repo, _q_file) = qwen_control_repo_file(&qwen);
+    assert_eq!(q_repo, "alibaba-pai/Qwen-Image-2512-Fun-Controlnet-Union");
+    assert_eq!(QWEN_CONTROL_DEFAULT_REPO, "Qwen/Qwen-Image-2512");
+    assert_ne!(q_repo, "InstantX/Qwen-Image-ControlNet-Union");
+
+    // sc-8379 — z-image base: both Turbo and base are recognized; the base selects the base repos + the
+    // ~50-step default + the `z_image_control` engine-id row.
+    assert!(is_zimage_control_model("z_image_turbo"));
+    assert!(is_zimage_control_model("z_image"));
+    assert!(!is_zimage_base_model("z_image_turbo"));
+    assert!(is_zimage_base_model("z_image"));
+    let turbo = request(json!({ "projectId": "p", "model": "z_image_turbo" }));
+    let base = request(json!({ "projectId": "p", "model": "z_image" }));
+    assert_eq!(
+        zimage_control_base_default_repo(&turbo.model),
+        "Tongyi-MAI/Z-Image-Turbo"
+    );
+    assert_eq!(
+        zimage_control_base_default_repo(&base.model),
+        "Tongyi-MAI/Z-Image"
+    );
+    let (turbo_ctrl_repo, _) = zimage_control_repo_file(&turbo);
+    let (base_ctrl_repo, _) = zimage_control_repo_file(&base);
+    assert_eq!(
+        turbo_ctrl_repo,
+        "alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1"
+    );
+    assert_eq!(
+        base_ctrl_repo,
+        "alibaba-pai/Z-Image-Fun-Controlnet-Union-2.1"
+    );
+    assert_eq!(zimage_control_steps(&turbo), ZIMAGE_CTRL_DEFAULT_STEPS);
+    assert_eq!(zimage_control_steps(&base), ZIMAGE_CTRL_BASE_DEFAULT_STEPS);
 }
 
 /// The trait routes each provider: each lane's `CandleStrictControl` impl reports the right engine id
@@ -6960,10 +7027,41 @@ fn candle_strict_control_trait_routes_each_provider() {
         height: 512,
         steps: 8,
         control_scale: 1.0,
+        engine_id: ZIMAGE_CTRL_ENGINE_ID,
     };
     assert_eq!(zimage.engine_id(), ZIMAGE_CTRL_ENGINE_ID);
     assert_eq!(zimage.engine_label(), ZIMAGE_CTRL_ENGINE);
     assert_eq!(zimage.stream_tag(), "zimage_control");
+
+    // Base z_image (sc-8379) routes the SAME provider with the `z_image_control` engine-id row.
+    let zimage_base = ZImageStrictControl {
+        base: dummy.clone(),
+        controlnet: dummy.clone(),
+        prompt: "p".to_owned(),
+        width: 512,
+        height: 512,
+        steps: 50,
+        control_scale: 1.0,
+        engine_id: ZIMAGE_CTRL_BASE_ENGINE_ID,
+    };
+    assert_eq!(zimage_base.engine_id(), ZIMAGE_CTRL_BASE_ENGINE_ID);
+    assert_eq!(zimage_base.engine_label(), ZIMAGE_CTRL_ENGINE);
+
+    // FLUX.1-dev control (sc-8412) routes via the `Flux1StrictControl` provider.
+    let flux1 = Flux1StrictControl {
+        base: dummy.clone(),
+        control: dummy.clone(),
+        prompt: "p".to_owned(),
+        width: 512,
+        height: 512,
+        steps: 25,
+        guidance: 3.5,
+        control_scale: 0.7,
+        control_kind: "pose".to_owned(),
+    };
+    assert_eq!(flux1.engine_id(), FLUX1_CONTROL_CANDLE_ENGINE_ID);
+    assert_eq!(flux1.engine_label(), FLUX1_CONTROL_CANDLE_ENGINE);
+    assert_eq!(flux1.stream_tag(), "flux1_control");
 
     let flux2 = Flux2StrictControl {
         base: dummy.clone(),

--- a/crates/sceneworks-worker/src/image_jobs/zimage_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage_control.rs
@@ -11,32 +11,69 @@
 // module, so it shares that module's imports (`parse_poses`/`pose_entries`/`Settings`/`WorkerResult`/
 // `huggingface_snapshot_dir`/`ensure_hf_cached_file`/`start_gen_stream`/… all in scope unqualified).
 
-/// Default Fun-Controlnet-Union weights — the **8-step** variant the MLX path uses (zimage.rs
+/// Default Turbo Fun-Controlnet-Union weights — the **8-step** variant the MLX path uses (zimage.rs
 /// `ZIMAGE_CONTROL_FILE`); the candle `ZImageControl::generate` runs the matching 8-step schedule.
 const ZIMAGE_CTRL_REPO: &str = "alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1";
 const ZIMAGE_CTRL_FILE: &str = "Z-Image-Turbo-Fun-Controlnet-Union-2.1-8steps.safetensors";
-/// The Z-Image base diffusers repo when the manifest omits `repo`.
+/// The Z-Image-Turbo base diffusers repo when the manifest omits `repo`.
 const ZIMAGE_CTRL_DEFAULT_REPO: &str = "Tongyi-MAI/Z-Image-Turbo";
+/// Base (non-distilled, real-CFG) Z-Image Fun-Controlnet-Union weights (sc-8379) — the same VACE
+/// Fun-Union control branch as the Turbo variant, assembled from a base `Tongyi-MAI/Z-Image` snapshot +
+/// the base control checkpoint. The base + Turbo Fun-Union safetensors are byte-structurally identical
+/// (same key layout), so the candle `ZImageControl` loader handles both; the diffusers checkpoint ships a
+/// single `.safetensors`. Mirrors the MLX `z_image_control` engine repo (`STRICT_CONTROL_ENGINES`).
+const ZIMAGE_CTRL_BASE_REPO: &str = "alibaba-pai/Z-Image-Fun-Controlnet-Union-2.1";
+const ZIMAGE_CTRL_BASE_FILE: &str = "diffusion_pytorch_model.safetensors";
+/// The base Z-Image diffusers repo when the manifest omits `repo` (sc-8379).
+const ZIMAGE_CTRL_BASE_DEFAULT_REPO: &str = "Tongyi-MAI/Z-Image";
 /// ControlNet conditioning-scale default (the strict-pose tier).
 const ZIMAGE_CTRL_DEFAULT_SCALE: f32 = 1.0;
-/// Denoise-steps default — the 8-step Fun-ControlNet variant (vs the 4-step distilled txt2img).
+/// Denoise-steps default — the 8-step Turbo Fun-ControlNet variant (vs the 4-step distilled txt2img).
 const ZIMAGE_CTRL_DEFAULT_STEPS: u32 = 8;
+/// Denoise-steps default for the base (non-distilled) model — the undistilled foundation runs the full
+/// ~50-step schedule (the base manifest `defaults.steps`). The candle `ZImageControl` engine takes a
+/// `steps` count directly (it is guidance-distilled in shape but the schedule length is request-driven),
+/// so the worker just feeds the higher default; an `advanced.steps` override still wins.
+const ZIMAGE_CTRL_BASE_DEFAULT_STEPS: u32 = 50;
 /// The adapter/engine id recorded on candle Z-Image control assets (distinct from the txt2img
 /// `candle_z_image`/`candle_zimage` lane).
 const ZIMAGE_CTRL_ENGINE: &str = "candle_zimage_control";
-/// The [`STRICT_CONTROL_ENGINES`] catalog id this candle lane validates `advanced.controlMode` against
-/// (the Turbo Fun-Controlnet-Union row — `{Pose, Canny, Depth}`). Mirrors the MLX
+/// The [`STRICT_CONTROL_ENGINES`] catalog id the Turbo candle lane validates `advanced.controlMode`
+/// against (the Turbo Fun-Controlnet-Union row — `{Pose, Canny, Depth}`). Mirrors the MLX
 /// `z_image_turbo_control` registry engine's `supported_kinds` (sc-8304).
 const ZIMAGE_CTRL_ENGINE_ID: &str = "z_image_turbo_control";
+/// The [`STRICT_CONTROL_ENGINES`] catalog id the BASE candle lane validates against (the base Z-Image
+/// Fun-Controlnet-Union row — `{Pose, Canny, Depth}`, sc-8379). Mirrors the MLX `z_image_control` engine.
+const ZIMAGE_CTRL_BASE_ENGINE_ID: &str = "z_image_control";
 
-/// Model ids the candle Z-Image ControlNet route accepts.
+/// Model ids the candle Z-Image ControlNet route accepts: the distilled `z_image_turbo` (8-step) and the
+/// base `z_image` (full-CFG, ~50-step; sc-8379). Both ride the same candle `ZImageControl` engine — the
+/// base + Turbo Fun-Union safetensors are byte-structurally identical — differing only in the
+/// base/control repos + step count.
 fn is_zimage_control_model(model: &str) -> bool {
-    model == "z_image_turbo"
+    matches!(model, "z_image_turbo" | "z_image")
+}
+
+/// True when this is the base (non-distilled) Z-Image control model (sc-8379) — selects the base repos,
+/// the base step default, and the `z_image_control` engine-id validation row.
+fn is_zimage_base_model(model: &str) -> bool {
+    model == "z_image"
+}
+
+/// The default base diffusers repo for this control job's model — Turbo (`Tongyi-MAI/Z-Image-Turbo`) or
+/// the base undistilled `Tongyi-MAI/Z-Image` (sc-8379), selected by the request model id.
+fn zimage_control_base_default_repo(model: &str) -> &'static str {
+    if is_zimage_base_model(model) {
+        ZIMAGE_CTRL_BASE_DEFAULT_REPO
+    } else {
+        ZIMAGE_CTRL_DEFAULT_REPO
+    }
 }
 
 /// Resolve the Z-Image base (diffusers) snapshot: an explicit `modelPath` (advanced or manifest) → the
-/// HF cache snapshot for the manifest `repo` (default `Tongyi-MAI/Z-Image-Turbo`). `None` ⇒ not present
-/// locally (the job is not candle-runnable, falls through to torch). Mirrors `resolve_kolors_control_base`.
+/// HF cache snapshot for the manifest `repo` (default `Tongyi-MAI/Z-Image-Turbo`, or `Tongyi-MAI/Z-Image`
+/// for the base model, sc-8379). `None` ⇒ not present locally (the job is not candle-runnable, falls
+/// through to torch). Mirrors `resolve_kolors_control_base`.
 fn resolve_zimage_control_base(
     request: &ImageRequest,
     settings: &Settings,
@@ -58,12 +95,12 @@ fn resolve_zimage_control_base(
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .unwrap_or(ZIMAGE_CTRL_DEFAULT_REPO);
+        .unwrap_or_else(|| zimage_control_base_default_repo(&request.model));
     Ok(huggingface_snapshot_dir(&settings.data_dir, repo))
 }
 
-/// True when this is a candle-eligible Z-Image strict-pose job: `z_image_turbo` with a non-empty
-/// `advanced.poses`, not edit mode, whose base resolves locally. Mirrors
+/// True when this is a candle-eligible Z-Image strict-control job: `z_image_turbo` or the base `z_image`
+/// (sc-8379) with a non-empty `advanced.poses`, not edit mode, whose base resolves locally. Mirrors
 /// `jobs_store::zimage_control_candle_eligible` so the worker and router agree.
 fn zimage_control_available(request: &ImageRequest, settings: &Settings) -> bool {
     is_zimage_control_model(&request.model)
@@ -72,12 +109,18 @@ fn zimage_control_available(request: &ImageRequest, settings: &Settings) -> bool
         && matches!(resolve_zimage_control_base(request, settings), Ok(Some(_)))
 }
 
-/// Resolve denoise steps: `advanced.steps` (clamped 1..=50) → manifest `steps` → default (8).
+/// Resolve denoise steps: `advanced.steps` (clamped 1..=50) → manifest `steps` → model default (Turbo 8,
+/// base 50; sc-8379). The base undistilled model runs the longer schedule for its real-CFG quality.
 fn zimage_control_steps(request: &ImageRequest) -> u32 {
     let parse = |value: &Value| {
         value
             .as_u64()
             .or_else(|| value.as_str()?.trim().parse().ok())
+    };
+    let default = if is_zimage_base_model(&request.model) {
+        ZIMAGE_CTRL_BASE_DEFAULT_STEPS
+    } else {
+        ZIMAGE_CTRL_DEFAULT_STEPS
     };
     request
         .advanced
@@ -85,12 +128,18 @@ fn zimage_control_steps(request: &ImageRequest) -> u32 {
         .and_then(parse)
         .or_else(|| request.model_manifest_entry.get("steps").and_then(parse))
         .map(|steps| steps.clamp(1, 50) as u32)
-        .unwrap_or(ZIMAGE_CTRL_DEFAULT_STEPS)
+        .unwrap_or(default)
 }
 
 /// The (repo, filename) of the ControlNet weights — `advanced.controlWeights.{repo,filename}` overrides,
-/// else the Fun-Controlnet-Union 8-step default (parity with the MLX `resolve_control_weights`).
+/// else the model's Fun-Controlnet-Union default: the Turbo 8-step variant, or the base
+/// (full-CFG) variant for the base `z_image` model (sc-8379). Parity with the MLX `resolve_control_weights`.
 fn zimage_control_repo_file(request: &ImageRequest) -> (String, String) {
+    let (default_repo, default_file) = if is_zimage_base_model(&request.model) {
+        (ZIMAGE_CTRL_BASE_REPO, ZIMAGE_CTRL_BASE_FILE)
+    } else {
+        (ZIMAGE_CTRL_REPO, ZIMAGE_CTRL_FILE)
+    };
     let cw = request.advanced.get("controlWeights").and_then(Value::as_object);
     let pick = |key: &str, default: &str| {
         cw.and_then(|m| m.get(key))
@@ -101,8 +150,8 @@ fn zimage_control_repo_file(request: &ImageRequest) -> (String, String) {
             .to_owned()
     };
     (
-        pick("repo", ZIMAGE_CTRL_REPO),
-        pick("filename", ZIMAGE_CTRL_FILE),
+        pick("repo", default_repo),
+        pick("filename", default_file),
     )
 }
 
@@ -179,13 +228,16 @@ struct ZImageStrictControl {
     height: u32,
     steps: u32,
     control_scale: f32,
+    /// The [`STRICT_CONTROL_ENGINES`] catalog id for this job's model — `z_image_turbo_control` (Turbo) or
+    /// `z_image_control` (base, sc-8379) — the `advanced.controlMode` validation key.
+    engine_id: &'static str,
 }
 
 impl CandleStrictControl for ZImageStrictControl {
     type Model = ZImageControl;
 
     fn engine_id(&self) -> &'static str {
-        ZIMAGE_CTRL_ENGINE_ID
+        self.engine_id
     }
 
     fn engine_label(&self) -> &'static str {
@@ -229,12 +281,14 @@ impl CandleStrictControl for ZImageStrictControl {
     }
 }
 
-/// Real candle Z-Image strict-pose generation: one image per pose, each conditioned on a full DWPose
-/// skeleton (`controlMode` unset) or a canny/depth control map. Resolves the base + control weights, then
-/// hands a [`ZImageStrictControl`] to the shared [`run_candle_strict_control`] driver, which validates the
-/// requested kind against `z_image_turbo_control`'s `supported_kinds`, preprocesses each pose's control
-/// map, runs the per-pose loop, and scores against any identity reference. Z-Image-Turbo is distilled (no
-/// CFG / negative prompt), so the request carries no guidance. The pose path is byte-preserved.
+/// Real candle Z-Image strict-control generation: one image per pose, each conditioned on a full DWPose
+/// skeleton (`controlMode` unset) or a canny/depth control map. Serves both `z_image_turbo` (8-step
+/// distilled) and the base `z_image` (full-CFG, ~50-step; sc-8379) — same candle `ZImageControl` engine,
+/// model-selected base/control repos + step default + engine-id validation row. Resolves the base +
+/// control weights, then hands a [`ZImageStrictControl`] to the shared [`run_candle_strict_control`]
+/// driver, which validates the requested kind against the model's `supported_kinds`, preprocesses each
+/// pose's control map, runs the per-pose loop, and scores against any identity reference. The pose path is
+/// byte-preserved.
 async fn generate_candle_zimage_control_stream(
     api: &ApiClient,
     settings: &Settings,
@@ -245,8 +299,10 @@ async fn generate_candle_zimage_control_stream(
     asset_writes: &mut Vec<Value>,
 ) -> WorkerResult<()> {
     let request = &plan.request;
+    let is_base = is_zimage_base_model(&request.model);
     let base = resolve_zimage_control_base(request, settings)?.ok_or_else(|| {
-        WorkerError::InvalidPayload("Z-Image base (Z-Image-Turbo) weights not found".to_owned())
+        let label = if is_base { "Z-Image" } else { "Z-Image-Turbo" };
+        WorkerError::InvalidPayload(format!("Z-Image base ({label}) weights not found"))
     })?;
     let controlnet = ensure_zimage_control_weights(api, settings, job, request).await?;
 
@@ -263,8 +319,13 @@ async fn generate_candle_zimage_control_stream(
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .unwrap_or(ZIMAGE_CTRL_DEFAULT_REPO)
+        .unwrap_or_else(|| zimage_control_base_default_repo(&request.model))
         .to_owned();
+    let engine_id = if is_base {
+        ZIMAGE_CTRL_BASE_ENGINE_ID
+    } else {
+        ZIMAGE_CTRL_ENGINE_ID
+    };
 
     let pose_count = pose_entries(request).len();
     let raw_settings = zimage_control_raw_settings(request, &repo, steps, control_scale, pose_count);
@@ -277,6 +338,7 @@ async fn generate_candle_zimage_control_stream(
         height: request.height,
         steps,
         control_scale,
+        engine_id,
     };
 
     run_candle_strict_control(


### PR DESCRIPTION
Worker halves of three epic-8236 stories, wiring candle (Windows/CUDA) control providers onto the shared `CandleStrictControl` trait + `run_candle_strict_control` driver (sc-8304, #1002). The candle-gen engine code is already merged at rev `725190c`; this PR is the worker providers + dispatch + eligibility mirrors + catalog. **Real-weight renders are deferred to the e2e phase (sc-8246)** — these changes are CI-safe (the `candle-worker` lane stays green; all new tests are pure-CPU metadata/routing checks).

## sc-8412 — NEW FLUX.1-dev candle control lane
- New `image_jobs/flux1_control_candle.rs`: a `CandleStrictControl` provider backed by `candle_gen_flux::Flux1DevControl` — the Shakker `FLUX.1-dev-ControlNet-Union-Pro-2.0` overlay on the dense **bf16** FLUX.1-dev base (HF-gated). Input-agnostic (pose/canny/depth, no mode index, no quant seam). Engine label `candle_flux1_control`; validates `advanced.controlMode` against the `flux1_dev_control` catalog row.
- Force-link named-type import + `include!` + dispatch branch in `image_jobs.rs`.
- `jobs_store::flux1_control_candle_eligible` mirror + call site; `model_has_candle_pose_lane` += `flux_dev`; reject-list exclusion += `flux_dev`.
- Manifest: `flux_dev` already advertises `controlModes: [pose,canny,depth]`; the "MLX-only" comment is updated (now served off-Mac via the candle lane).

## sc-8350 — Qwen InstantX → 2512-Fun repoint
- `qwen_control.rs` now rides `candle_gen_qwen_image::QwenFunControl` on the **Qwen-Image-2512** base via `alibaba-pai/Qwen-Image-2512-Fun-Controlnet-Union` (the `qwen_image_control` table repo) — retiring the InstantX `QwenControl` path on the candle lane (the candle-gen InstantX engine stays in the crate, unused by the worker).
- Same request shape (true CFG + negative prompt) flows through the driver; canny/depth are input-agnostic on the 2512-Fun engine.

## sc-8379 — Z-Image BASE control
- `zimage_control.rs` `is_zimage_control_model` now accepts the base `z_image` in addition to `z_image_turbo`. Base defaults resolve alongside Turbo: base model repo `Tongyi-MAI/Z-Image`, base control repo `alibaba-pai/Z-Image-Fun-Controlnet-Union-2.1`, ~50-step default, and the `z_image_control` engine-id validation row. Both ride the **same** candle `ZImageControl` engine — the base + Turbo Fun-Union safetensors are byte-structurally identical.
- `jobs_store`: `z_image` added to `CANDLE_ROUTED_MODELS` (**control-only** — explicitly excluded from the candle txt2img gate since there is no base-z-image txt2img provider; a plain `z_image` job correctly defers to MLX/torch), a `zimage_control_candle_eligible` call site for `z_image`, and `model_has_candle_pose_lane` += `z_image`. Reject-list exclusion += `z_image`.
- Manifest: base `z_image` already advertises `controlModes: [pose,canny,depth]` (sc-8251).

## Scope boundaries
- The cross-platform `STRICT_CONTROL_ENGINES` table + `preprocess_control_entry` are unchanged (they already carried the three engine rows — sc-8304). This PR only adds the candle providers + their routing.
- The base z_image engine API does not distinguish CFG vs distilled (no `guidance` field on `ZImageControlRequest` at `725190c`), so the base lane loads the base checkpoint through the same provider with the longer step default; a CFG seam can be threaded later if the engine exposes one.

## Tests (added, CI-safe — no weights)
- **worker (candle-gated):** engine-id/label/scale-default tables extended for flux1 + base z-image; trait-routing assertions for `Flux1StrictControl` + base `ZImageStrictControl`; new `candle_control_providers_resolve_models_and_repos` (model gates, default repos, qwen 2512-Fun swap proven `!= InstantX`, z-image base step default).
- **core (router):** `flux1_dev_control_pose_jobs_route_to_candle`, `zimage_base_control_pose_jobs_route_to_candle` (incl. base z_image plain-txt2img defers), plus updated `candle_routed_models_plain_txt2img_are_eligible` (z_image is the control-only exception).
- Verified locally: `cargo check` + `cargo test --no-run` for `sceneworks-worker --features backend-candle` (CUDA sm_120, MSVC 14.44); core + worker candle-gated tests pass; `cargo fmt --check` clean.

Stories: sc-8412, sc-8350, sc-8379 (epic 8236).

🤖 Generated with [Claude Code](https://claude.com/claude-code)