### PR TITLE
feat(models): Ideogram 4 bf16 as a selectable macOS MLX tier — cross-repo, no duplicate (sc-8513)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -999,14 +999,16 @@
           "estimatedSizeBytes": 15400562623
         },
         {
-          // Candle (Windows/Linux CUDA) bf16 snapshot (epic 6561 / sc-6859): the candle provider can't
-          // read the MLX-quantized turnkey above, so off-Mac loads bf16 from a separate repo. Weights
-          // live under the `bf16/` subdir (the worker's `candle_ideogram_subdir`) so quant variants can
-          // slot in later without a rename. Same gated non-commercial license; Windows/Linux download.
+          // bf16 snapshot — shared across backends from the separate `SceneWorks/ideogram-4` repo's
+          // `bf16/` subdir (the MLX-quantized `ideogram-4-mlx` turnkey above is not bf16). Off-Mac the
+          // candle provider loads it (epic 6561 / sc-6859, `candle_ideogram_subdir`); on macOS it is the
+          // selectable full-precision MLX tier (sc-8513, epic 8506) — the worker resolves this repo's
+          // `bf16/` subdir when advanced mlxQuantize<=0 (rather than a duplicate copy in the MLX repo).
+          // A later quant variant can slot in alongside `bf16/` without a rename. Gated non-commercial.
           "provider": "huggingface",
           "repo": "SceneWorks/ideogram-4",
           "files": ["bf16/*"],
-          "platforms": ["windows", "linux"],
+          "platforms": ["macos", "windows", "linux"],
           "estimatedSizeBytes": 54760833024
         }
       ],
@@ -1108,13 +1110,15 @@
           "estimatedSizeBytes": 16247340792
         },
         {
-          // Candle (Windows/Linux CUDA) bf16 snapshot (epic 6561 / sc-6859): off-Mac loads bf16 from
-          // `SceneWorks/ideogram-4`'s `bf16/` subdir, which carries `turbo_lora.safetensors` alongside
-          // the base weights (the turbo loader merges it at load). Same gated license; Win/Linux only.
+          // bf16 snapshot — shared from the separate `SceneWorks/ideogram-4` repo's `bf16/` subdir,
+          // which carries `turbo_lora.safetensors` (the turbo loader merges it at load). Off-Mac the
+          // candle provider loads it (epic 6561 / sc-6859); on macOS it is the selectable full-precision
+          // MLX tier (sc-8513) — the worker resolves this repo's `bf16/` when advanced mlxQuantize<=0,
+          // rather than duplicating it into the MLX turnkey repo. Same gated non-commercial license.
           "provider": "huggingface",
           "repo": "SceneWorks/ideogram-4",
           "files": ["bf16/*"],
-          "platforms": ["windows", "linux"],
+          "platforms": ["macos", "windows", "linux"],
           "estimatedSizeBytes": 54760833024
         }
       ],

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -197,6 +197,13 @@ fn model_repo(request: &ImageRequest, model: &ResolvedModel) -> String {
         .to_owned()
 }
 
+/// The separate `SceneWorks/ideogram-4` repo that hosts Ideogram 4's bf16 tree under `bf16/` — shared
+/// by the candle off-Mac lane (sc-6859) and, on macOS, the selectable full-precision MLX tier
+/// (sc-8513). The MLX `q4/`/`q8/` turnkey lives in `SceneWorks/ideogram-4-mlx`; bf16 is resolved from
+/// THIS repo rather than duplicated. (The candle lane has its own cfg-gated [`CANDLE_IDEOGRAM_REPO`].)
+#[cfg(target_os = "macos")]
+const IDEOGRAM_BF16_REPO: &str = "SceneWorks/ideogram-4";
+
 /// Resolve the weights snapshot directory: an explicit `modelPath` dir wins, else the
 /// HuggingFace cache snapshot for the model repo. `None` when the model is not a known
 /// engine family or its snapshot is absent. Available on the candle lane too (sc-5501): the
@@ -227,6 +234,28 @@ pub(crate) fn resolve_weights_dir(
     // turbo variant (mlx-gen #488) shares the same turnkey — each subdir also carries the bundled
     // `turbo_lora.safetensors` the `ideogram_4_turbo` engine installs at load.
     if request.model == "ideogram_4" || request.model == "ideogram_4_turbo" {
+        // bf16 (sc-8513, epic 8506) is the SHARED `SceneWorks/ideogram-4` repo's `bf16/` subdir — the
+        // same full-precision tree the candle off-Mac lane loads (sc-6859) — NOT duplicated into the
+        // MLX turnkey. When the macOS request opts into bf16 (advanced mlxQuantize<=0) AND it is
+        // downloaded, resolve there (the dense weights load with no quantize); else the q4 (default)/q8
+        // turnkey subdir. A partial bf16 download falls back rather than half-loading. (macOS/MLX only —
+        // the candle lane resolves bf16 through its own `candle_ideogram_subdir` path, unchanged.)
+        #[cfg(target_os = "macos")]
+        {
+            let wants_bf16 = request
+                .advanced
+                .get("mlxQuantize")
+                .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()))
+                .is_some_and(|bits| bits <= 0);
+            if wants_bf16 {
+                if let Some(bf16) = huggingface_snapshot_dir(&settings.data_dir, IDEOGRAM_BF16_REPO)
+                    .map(|root| root.join("bf16"))
+                    .filter(|dir| dir.join("transformer/model.safetensors").is_file())
+                {
+                    return Ok(Some(bf16));
+                }
+            }
+        }
         return Ok(snapshot.map(|root| ideogram_model_subdir(&root, request)));
     }
     // Boogu (epic 6387) ships a turnkey with pre-packed Q8 `base/ turbo/ edit/` subfolders (default) +

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -1478,6 +1478,63 @@ fn krea_2_turbo_bf16_real_weights_loads_and_generates() {
     );
 }
 
+/// bf16 tier verify (sc-8513, epic 8506): load the DENSE Ideogram 4 `bf16/` tier (`Quant::None`) from
+/// the shared `SceneWorks/ideogram-4` repo through the real worker `ideogram_4` engine path and render.
+/// Proves the macOS MLX lane loads the cross-repo bf16 (resolved by `resolve_weights_dir` when
+/// `mlxQuantize<=0`) and generates — the full-precision tier that joins the existing q4/q8. Point
+/// `SCENEWORKS_IDEOGRAM_BF16_DIR` at the downloaded `bf16/` subdir. Asymmetric CFG (guidance 7.0). Run:
+/// `SCENEWORKS_IDEOGRAM_BF16_DIR=… cargo test -p sceneworks-worker --release --lib -- --ignored ideogram_4_bf16_real_weights`.
+#[cfg(target_os = "macos")]
+#[test]
+#[ignore = "needs the downloaded Ideogram 4 bf16 tier + a high-memory Metal device"]
+fn ideogram_4_bf16_real_weights_loads_and_generates() {
+    let dir = std::path::PathBuf::from(
+        std::env::var("SCENEWORKS_IDEOGRAM_BF16_DIR")
+            .expect("set SCENEWORKS_IDEOGRAM_BF16_DIR to the downloaded ideogram bf16/ tier dir"),
+    );
+    let size: u32 = std::env::var("SCENEWORKS_IDEOGRAM_SIZE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(512);
+    eprintln!(
+        "[ideogram-bf16] loading ideogram_4 dense bf16 (Quant::None) from {}…",
+        dir.display()
+    );
+    let generator = load_engine("ideogram_4", dir, None, Vec::new(), None).unwrap();
+    eprintln!("[ideogram-bf16] LOADED — generating {size}²…");
+    let cancel = gen_core::CancelFlag::new();
+    let (w, h, pixels) = generate_one(
+        generator.as_ref(),
+        "a serene mountain lake at dawn",
+        size,
+        size,
+        42,
+        20,
+        Some(7.0),
+        None,
+        None,
+        &[],
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        false,
+        &PromptEnhance::default(),
+        &cancel,
+        &mut |_| {},
+    )
+    .unwrap();
+    eprintln!("[ideogram-bf16] GENERATED {w}x{h}");
+    assert_eq!((w, h), (size, size));
+    assert_eq!(pixels.len(), (size * size * 3) as usize);
+    assert!(
+        pixels.windows(2).any(|p| p[0] != p[1]),
+        "render is flat (degenerate)"
+    );
+}
+
 /// Real-weights smoke (sc-5923): FLUX.2-dev EDIT through the worker `flux2_dev_edit` engine path
 /// (the `flux2_edit_engine_id("flux2_dev")` variant, sc-5919/5922). Loads the SAME converted Q4 dev
 /// snapshot, then renders with a single `Conditioning::Reference` AND with a 2-image


### PR DESCRIPTION
## Summary
Group-A (converter-ready) completion for the catalog quant matrix (epic 8506). Ideogram 4 (+ turbo) ship q4 (default) + q8 (on-demand) MLX turnkeys; **bf16 was only wired for the candle off-Mac lane**. Its bf16 weights already live in the shared `SceneWorks/ideogram-4` repo's `bf16/` subdir (54 GB), so rather than duplicate 54 GB into the MLX repo, the macOS lane now resolves them **in place**.

- **Manifest**: the existing `ideogram-4` bf16 download (both `ideogram_4` and `ideogram_4_turbo`) now lists `macos` in `platforms` alongside windows/linux — one shared bf16 artifact across backends.
- **Resolver (macOS)**: `resolve_weights_dir` resolves `SceneWorks/ideogram-4`'s `bf16/` subdir when the request opts into bf16 (advanced `mlxQuantize<=0`) and it's downloaded, else falls back to the q4/q8 turnkey subdir (no half-load). New `IDEOGRAM_BF16_REPO` const; the cross-repo block is **macOS-gated** so the candle lane (its own `candle_ideogram_subdir` path) is byte-identical.
- **On-device verify**: the dense bf16 tier loads (`Quant::None`) through the real worker `ideogram_4` engine and generates a non-degenerate 512² image (`ideogram_4_bf16_real_weights_loads_and_generates`, 41s on a 128 GB Mac). **No upload** — bf16 already hosted; pure wiring.

## Why cross-repo (not a copy)
A copy would duplicate 54 GB and was disk-blocked. The bf16 tree is identical regardless of repo; pointing the MLX lane at the existing `ideogram-4` bf16 (the same source the candle lane uses) avoids the duplicate entirely.

## Gates (local)
`cargo fmt --all --check`, `cargo clippy -p sceneworks-worker --all-targets -D warnings`, candle parity (`--no-default-features -F backend-candle --all-targets`), full `cargo test -p sceneworks-worker --lib` (473 passed), engines manifest-parse tests, on-device bf16 gen — all green. Branched off latest origin/main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)