### PR TITLE
feat(z-image): load SceneWorks pre-built q4/q8/bf16 turnkeys + mlx-gen pin bump (sc-8670)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d#22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d#22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d#22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d#22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d#22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d#22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -513,7 +513,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d#22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -530,7 +530,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d#22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d#22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d#22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d#22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -582,7 +582,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d#22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -596,7 +596,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d#22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -611,7 +611,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d#22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -624,7 +624,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d#22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -636,7 +636,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d#22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -653,7 +653,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d#22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -668,7 +668,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d#22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -679,7 +679,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d#22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -694,7 +694,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d#22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d#22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -729,7 +729,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d#22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -740,7 +740,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d#22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d#22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -764,7 +764,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d#22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -777,7 +777,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d#22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d"
 dependencies = [
  "candle-core",
  "candle-gen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=725190c5a0dcf55f6657ca4becbb242b3f606fe0#725190c5a0dcf55f6657ca4becbb242b3f606fe0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=725190c5a0dcf55f6657ca4becbb242b3f606fe0#725190c5a0dcf55f6657ca4becbb242b3f606fe0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=725190c5a0dcf55f6657ca4becbb242b3f606fe0#725190c5a0dcf55f6657ca4becbb242b3f606fe0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=725190c5a0dcf55f6657ca4becbb242b3f606fe0#725190c5a0dcf55f6657ca4becbb242b3f606fe0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=725190c5a0dcf55f6657ca4becbb242b3f606fe0#725190c5a0dcf55f6657ca4becbb242b3f606fe0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=725190c5a0dcf55f6657ca4becbb242b3f606fe0#725190c5a0dcf55f6657ca4becbb242b3f606fe0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -513,7 +513,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=725190c5a0dcf55f6657ca4becbb242b3f606fe0#725190c5a0dcf55f6657ca4becbb242b3f606fe0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -530,7 +530,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=725190c5a0dcf55f6657ca4becbb242b3f606fe0#725190c5a0dcf55f6657ca4becbb242b3f606fe0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=725190c5a0dcf55f6657ca4becbb242b3f606fe0#725190c5a0dcf55f6657ca4becbb242b3f606fe0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=725190c5a0dcf55f6657ca4becbb242b3f606fe0#725190c5a0dcf55f6657ca4becbb242b3f606fe0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=725190c5a0dcf55f6657ca4becbb242b3f606fe0#725190c5a0dcf55f6657ca4becbb242b3f606fe0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -582,7 +582,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=725190c5a0dcf55f6657ca4becbb242b3f606fe0#725190c5a0dcf55f6657ca4becbb242b3f606fe0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -596,7 +596,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=725190c5a0dcf55f6657ca4becbb242b3f606fe0#725190c5a0dcf55f6657ca4becbb242b3f606fe0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -611,7 +611,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=725190c5a0dcf55f6657ca4becbb242b3f606fe0#725190c5a0dcf55f6657ca4becbb242b3f606fe0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -624,7 +624,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=725190c5a0dcf55f6657ca4becbb242b3f606fe0#725190c5a0dcf55f6657ca4becbb242b3f606fe0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -636,7 +636,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=725190c5a0dcf55f6657ca4becbb242b3f606fe0#725190c5a0dcf55f6657ca4becbb242b3f606fe0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -653,7 +653,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=725190c5a0dcf55f6657ca4becbb242b3f606fe0#725190c5a0dcf55f6657ca4becbb242b3f606fe0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -668,7 +668,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=725190c5a0dcf55f6657ca4becbb242b3f606fe0#725190c5a0dcf55f6657ca4becbb242b3f606fe0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -679,7 +679,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=725190c5a0dcf55f6657ca4becbb242b3f606fe0#725190c5a0dcf55f6657ca4becbb242b3f606fe0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -694,7 +694,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=725190c5a0dcf55f6657ca4becbb242b3f606fe0#725190c5a0dcf55f6657ca4becbb242b3f606fe0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=725190c5a0dcf55f6657ca4becbb242b3f606fe0#725190c5a0dcf55f6657ca4becbb242b3f606fe0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -729,7 +729,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=725190c5a0dcf55f6657ca4becbb242b3f606fe0#725190c5a0dcf55f6657ca4becbb242b3f606fe0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -740,7 +740,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=725190c5a0dcf55f6657ca4becbb242b3f606fe0#725190c5a0dcf55f6657ca4becbb242b3f606fe0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=725190c5a0dcf55f6657ca4becbb242b3f606fe0#725190c5a0dcf55f6657ca4becbb242b3f606fe0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -764,7 +764,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=725190c5a0dcf55f6657ca4becbb242b3f606fe0#725190c5a0dcf55f6657ca4becbb242b3f606fe0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -777,7 +777,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=725190c5a0dcf55f6657ca4becbb242b3f606fe0#725190c5a0dcf55f6657ca4becbb242b3f606fe0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a1a56576793ca9d1b084ac76a5833ce1c873e24#8a1a56576793ca9d1b084ac76a5833ce1c873e24"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -3482,7 +3482,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3495,7 +3495,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
 dependencies = [
  "image",
  "inventory",
@@ -3509,7 +3509,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
 dependencies = [
  "image",
  "inventory",
@@ -3523,7 +3523,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3536,7 +3536,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3547,7 +3547,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3556,7 +3556,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3565,7 +3565,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3578,7 +3578,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3591,7 +3591,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3604,7 +3604,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3616,7 +3616,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3626,7 +3626,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
 dependencies = [
  "image",
  "inventory",
@@ -3639,7 +3639,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
 dependencies = [
  "image",
  "inventory",
@@ -3653,7 +3653,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
 dependencies = [
  "image",
  "inventory",
@@ -3667,7 +3667,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
 dependencies = [
  "image",
  "inventory",
@@ -3679,7 +3679,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3690,7 +3690,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3702,7 +3702,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3713,7 +3713,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3722,7 +3722,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3731,7 +3731,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3741,7 +3741,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3753,7 +3753,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
 dependencies = [
  "image",
  "inventory",
@@ -3768,7 +3768,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
 dependencies = [
  "image",
  "inventory",
@@ -3782,7 +3782,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3793,7 +3793,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3805,7 +3805,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3816,7 +3816,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
 dependencies = [
  "image",
  "inventory",
@@ -3830,13 +3830,14 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
 dependencies = [
  "image",
  "inventory",
  "mlx-gen",
  "mlx-gen-pid",
  "pmetal-mlx-rs",
+ "serde_json",
 ]
 
 [[package]]
@@ -5521,7 +5522,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=bdf3233c92a7198086def67d271d45d7f5c1bccf#bdf3233c92a7198086def67d271d45d7f5c1bccf"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
 dependencies = [
  "core-llm",
  "inventory",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -20,19 +20,36 @@
       // work pick sdxl / realvisxl; for identity pick instantid_realvisxl.
       "capabilities": ["text_to_image", "style_variations"],
       "downloads": [
-        // Refresh estimatedSizeBytes from the Hugging Face recursive tree API:
-        // https://huggingface.co/api/models/<repo>/tree/main?recursive=true
-        // The value should match the bytes downloaded after any files filter, not necessarily the full repo.
+        // SceneWorks pre-built MLX quant-matrix turnkey (sc-8670, epic 8506): a public/ungated
+        // re-host of Tongyi-MAI/Z-Image-Turbo (Apache-2.0). Per-tier subdirs, each a complete
+        // from_snapshot tree (packed/dense transformer/ + Qwen3 text_encoder/ + VAE + tokenizer +
+        // scheduler): q4/ (default), q8/, bf16/. Replaces the old diffusers download + install-time
+        // Q8 convert — the worker loads the chosen tier's subdir directly (standard_tier_subdir).
+        // All three components are quantized (DiT + TE + VAE attention) in q4/q8; bf16/ is dense
+        // (the f32 transformer downcast to bf16 for catalog consistency). Sizes are measured on-disk.
         {
           "provider": "huggingface",
-          "repo": "Tongyi-MAI/Z-Image-Turbo",
-          "files": [],
-          "estimatedSizeBytes": 32899667397
+          "repo": "SceneWorks/z-image-turbo-mlx",
+          "files": ["q4/*"],
+          "estimatedSizeBytes": 5909406487
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/z-image-turbo-mlx",
+          "files": ["q8/*"],
+          "estimatedSizeBytes": 10998523666
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/z-image-turbo-mlx",
+          "files": ["bf16/*"],
+          "estimatedSizeBytes": 20538406851
         }
       ],
       "paths": {
-        "model": "${HF_CACHE}/Tongyi-MAI/Z-Image-Turbo"
+        "model": "${HF_CACHE}/SceneWorks/z-image-turbo-mlx"
       },
+      "gated": false,
       "defaults": {
         "resolution": "1024x1024",
         "steps": 8,
@@ -64,7 +81,9 @@
       // Q4 brings this within tighter Mac budgets via advanced.mlxQuantize.
       "mlx": {
         "minMemoryGb": 40,
-        "quantize": 8,
+        // q4/ is the shipped default tier (sc-8670); q8/ + bf16/ are hosted and selectable via
+        // advanced.mlxQuantize (standard_tier_subdir resolves the subdir).
+        "quantize": 4,
         "limits": {
           "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
           "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
@@ -120,18 +139,33 @@
       "adapter": "z_image_diffusers",
       "capabilities": ["text_to_image", "style_variations"],
       "downloads": [
-        // Refresh estimatedSizeBytes from the Hugging Face recursive tree API:
-        // https://huggingface.co/api/models/<repo>/tree/main?recursive=true
+        // SceneWorks pre-built MLX quant-matrix turnkey (sc-8670, epic 8506): public/ungated re-host
+        // of the undistilled Tongyi-MAI/Z-Image base (Apache-2.0, bf16-native source). Per-tier
+        // self-contained subdirs q4/ (default), q8/, bf16/ — the worker loads the chosen tier's
+        // subdir directly (standard_tier_subdir). Sizes are measured on-disk.
         {
           "provider": "huggingface",
-          "repo": "Tongyi-MAI/Z-Image",
-          "files": [],
-          "estimatedSizeBytes": 20547479575
+          "repo": "SceneWorks/z-image-mlx",
+          "files": ["q4/*"],
+          "estimatedSizeBytes": 5907321677
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/z-image-mlx",
+          "files": ["q8/*"],
+          "estimatedSizeBytes": 10996438540
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/z-image-mlx",
+          "files": ["bf16/*"],
+          "estimatedSizeBytes": 20538412852
         }
       ],
       "paths": {
-        "model": "${HF_CACHE}/Tongyi-MAI/Z-Image"
+        "model": "${HF_CACHE}/SceneWorks/z-image-mlx"
       },
+      "gated": false,
       "defaults": {
         "resolution": "1024x1024",
         // Undistilled base — the card recommends 28–50 steps; 50 matches the reference
@@ -159,7 +193,8 @@
       // budgets via advanced.mlxQuantize.
       "mlx": {
         "minMemoryGb": 48,
-        "quantize": 8,
+        // q4/ default tier (sc-8670); q8/ + bf16/ hosted + selectable via advanced.mlxQuantize.
+        "quantize": 4,
         "limits": {
           "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
           "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
@@ -201,16 +236,30 @@
       "adapter": "z_image_diffusers",
       "capabilities": ["edit_image", "image_to_image"],
       "downloads": [
+        // Shares the Turbo turnkey (sc-8670) — img2img runs the same Turbo weights/tier subdirs.
         {
           "provider": "huggingface",
-          "repo": "Tongyi-MAI/Z-Image-Turbo",
-          "files": [],
-          "estimatedSizeBytes": 32899667397
+          "repo": "SceneWorks/z-image-turbo-mlx",
+          "files": ["q4/*"],
+          "estimatedSizeBytes": 5909406487
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/z-image-turbo-mlx",
+          "files": ["q8/*"],
+          "estimatedSizeBytes": 10998523666
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/z-image-turbo-mlx",
+          "files": ["bf16/*"],
+          "estimatedSizeBytes": 20538406851
         }
       ],
       "paths": {
-        "model": "${HF_CACHE}/Tongyi-MAI/Z-Image-Turbo"
+        "model": "${HF_CACHE}/SceneWorks/z-image-turbo-mlx"
       },
+      "gated": false,
       "defaults": {
         "resolution": "1024x1024",
         "steps": 8,

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -438,11 +438,11 @@ sceneworks-core = { path = "../sceneworks-core" }
 # z-image q4/q8/bf16 turnkeys directly (packed-detect) instead of load-then-quantize. `git diff
 # bdf3233..863f98d -- gen-core/ gen-core-testkit/` is EMPTY — gen-core BYTE-IDENTICAL (the range only
 # ADDS mlx-gen-z-image packed-load/convert code), mlx-rs unchanged (38e1cc1), so the DEFAULT skew gate
-# stays single-rev/green at 863f98d. The candle pin below moves `725190c` -> `8a1a565` IN LOCKSTEP
+# stays single-rev/green at 863f98d. The candle pin below moves `725190c` -> `22c121a` IN LOCKSTEP
 # (candle-gen sc-8670 PR #199: re-pins candle-gen's own gen-core bdf3233 -> 863f98d, byte-identical —
 # candle links no z-image crate and compiles UNCHANGED) so `--features backend-candle --target all`
-# resolves the SINGLE gen-core rev 863f98d. (Pre-merge of candle-gen #199 this points at the branch
-# commit 8a1a565; flip to the squash-merged candle-gen main SHA once #199 lands.)
+# resolves the SINGLE gen-core rev 863f98d. (candle-gen #199 is squash-merged on candle-gen main as
+# 22c121a — the canonical SHA all candle-gen-* pins below point at.)
 sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -1315,22 +1315,22 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f
 # cadence block emit `TrainingProgress::Sample` from the in-progress adapter (krea/z-image/lens/sdxl/wan).
 # PURELY ADDITIVE; the worker already consumes `TrainingProgress::Sample` (sc-5637 #676), so the import
 # surface is unchanged.
-# Bumped `8db8e64` -> `8a1a565` (candle-gen #199, sc-8670): re-pins candle-gen's OWN gen-core
+# Bumped `8db8e64` -> `22c121a` (candle-gen #199, sc-8670): re-pins candle-gen's OWN gen-core
 # bdf3233 -> 863f98d IN LOCKSTEP with this worker's mlx-gen bump to 863f98d (z-image packed-load,
-# mlx-gen #618). 8a1a565 = candle-gen main (incl. the #198 preview-samples change above) + that
+# mlx-gen #618). 22c121a = candle-gen main (incl. the #198 preview-samples change above) + that
 # gen-core re-pin, so `--features backend-candle --target all` resolves the SINGLE gen-core rev
 # 863f98d (== this worker's mlx pin). gen-core is BYTE-IDENTICAL bdf3233..863f98d; candle links no
-# z-image crate and compiles UNCHANGED. ALL candle-gen-* rev lines move together. (Pre-merge of
-# candle-gen #199 this is the branch commit; flip to the squash-merged main SHA once #199 lands.)
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
+# z-image crate and compiles UNCHANGED. ALL candle-gen-* rev lines move together. (22c121a is the
+# squash-merged candle-gen main SHA from #199.)
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1338,17 +1338,17 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1358,7 +1358,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1366,21 +1366,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1389,17 +1389,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1408,7 +1408,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1441,7 +1441,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1450,12 +1450,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1463,7 +1463,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a5
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1472,7 +1472,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1480,7 +1480,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1494,7 +1494,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1521,7 +1521,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1530,9 +1530,9 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # is the ungated ~100 MB `depth-anything/Depth-Anything-V2-Small-hf` checkpoint, resolved/cached via the
 # worker's existing HF-snapshot mechanism. Same git rev as every candle-gen provider above — candle-gen-depth
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
-# still resolves ONE candle-gen / gen-core build (8a1a565 pins gen-core 863f98d, matching the worker's mlx
+# still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "22c121a30ee9a6b6741c6fafcf0e3dd4fb34ad5d", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -432,7 +432,18 @@ sceneworks-core = { path = "../sceneworks-core" }
 # 875cf7f -> bdf3233, byte-identical — candle links no sana crate and compiles UNCHANGED) so
 # `--features backend-candle --target all` resolves the SINGLE gen-core rev bdf3233. (Candle-gen is
 # pinned to the squash-merged candle-gen main SHA 0da70db from PR #187.)
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
+# Bumped `bdf3233` -> `863f98d` (epic 8506, sc-8670): re-pin every mlx-gen crate + this root
+# sceneworks-gen-core dep to mlx-gen main HEAD = z-image pre-quantized packed-load + dir-converter
+# (#618, the Group-B quant-matrix pilot). This is what lets the worker load the SceneWorks pre-built
+# z-image q4/q8/bf16 turnkeys directly (packed-detect) instead of load-then-quantize. `git diff
+# bdf3233..863f98d -- gen-core/ gen-core-testkit/` is EMPTY — gen-core BYTE-IDENTICAL (the range only
+# ADDS mlx-gen-z-image packed-load/convert code), mlx-rs unchanged (38e1cc1), so the DEFAULT skew gate
+# stays single-rev/green at 863f98d. The candle pin below moves `725190c` -> `8a1a565` IN LOCKSTEP
+# (candle-gen sc-8670 PR #199: re-pins candle-gen's own gen-core bdf3233 -> 863f98d, byte-identical —
+# candle links no z-image crate and compiles UNCHANGED) so `--features backend-candle --target all`
+# resolves the SINGLE gen-core rev 863f98d. (Pre-merge of candle-gen #199 this points at the branch
+# commit 8a1a565; flip to the squash-merged candle-gen main SHA once #199 lands.)
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -784,7 +795,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -800,23 +811,23 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a
 # exactly this rev, so the worker MUST match (a different rev would compile pmetal-mlx-sys twice). This
 # rebuilds MLX from source. Paired with mlx-llm `6c052ba` below (mlx-llm#45 carries the same fork pin).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
 # Krea 2 Turbo (native MLX, Krea 2 Community License; epic 7565, sc-7572). Same git rev as mlx-gen.
 # Self-registers `krea_2_turbo` (Qwen3-VL-4B TE + 28-block single-stream DiT + Qwen-Image VAE; CFG-free
 # rectified-flow few-step) via inventory only when force-linked (`use mlx_gen_krea as _;` in
 # image_jobs.rs). Loads the packed Q8/Q4 turnkey subdir (krea_model_subdir; the loader auto-detects the
 # packed quant, so the resolved `spec.quantize` is a no-op on it). Depends on mlx-gen-qwen-image for the
 # shared `AutoencoderKLQwenImage` VAE.
-mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
+mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
 # Stable Diffusion 3.5 provider (native MLX, Stability AI Community License; epic 7841, sc-7871). Same
 # git rev as mlx-gen so MLX builds once. Self-registers `sd3_5_large` (true-CFG, 28 steps / guidance 3.5)
 # + `sd3_5_large_turbo` (ADD-distilled few-step, CFG-off) + `sd3_5_medium` (MMDiT-X, true-CFG, 40 steps /
@@ -824,7 +835,7 @@ mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf323
 # (`use mlx_gen_sd3 as _;` in image_jobs.rs). All three carry a `sd3_5_*_quant` converter. Reuses the SDXL
 # CLIP encoder (×2), the FLUX T5-XXL encoder, and the Z-Image 16-ch VAE — its `quantize_sd3_dir` converter
 # is wired in model_jobs.rs for the `sd3_5_{large,large_turbo,medium}_quant` install-time conversions.
-mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
+mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
 # SANA 1600M provider (native MLX, NVIDIA non-commercial license; epic 8485, sc-8489). Same git rev as
 # mlx-gen so MLX builds once. Self-registers `sana_1600m` (Image/t2i, true-CFG, 32× DC-AE divisor,
 # mac_only) via `register_generators!` into the gen-core inventory — surfaces only when force-linked
@@ -832,59 +843,59 @@ mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233
 # conditioning (sc-8488); the `SanaPipeline` composes SanaTextEncoder -> SanaTransformer (Linear DiT) ->
 # DC-AE f32 decoder and exposes the `from_snapshot`/`from_weights` weight-load entrypoints the generic
 # generator-cache load path drives.
-mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
+mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
 # CLIP ViT-L/14 image embedder for the Dataset Doctor analysis job (epic 6529 P2, sc-6535).
 # Self-registers `clip_vit_l14` (gen_core::ImageEmbedder) via inventory only when force-linked
 # (`use mlx_gen_clip as _;` in dataset_analysis_jobs.rs). Reuses mlx-gen-sdxl's CLIP body → same rev.
-mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
+mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -893,19 +904,19 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf323
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
 # Depth Anything V2 (DINOv2 ViT-S/14 + DPT) native-MLX monocular depth estimator (epic 8236,
 # sc-8242). A plain utility crate (NOT a self-registering generation provider): an arbitrary RGB
 # image → a normalized single-channel depth control image, the AUTO depth source for the
 # Fun-Controlnet-Union depth tier (`ControlKind::Depth`) — sibling of the CPU canny/pose
 # preprocessors, but neural so it is macOS-gated (MLX). Consumed by the worker `depth` module /
 # the shared strict-control driver (sc-8243). Same mlx-rs pin as every other mlx-gen crate.
-mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
+mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -914,7 +925,7 @@ mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf32
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -922,7 +933,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -933,7 +944,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -944,7 +955,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf32
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -966,7 +977,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf323
 # a Metal large-tensor limit, not precision). New `VAE_SAFE_DECODE_EDGE_PX=1536` forces decode tiling on
 # a CORRECTNESS cap independent of the memory budget (image + video), so a 2048² upscale that fits memory
 # still tiles. Real-weight 1024→2048 pixel-cosine vs the mflux reference 0.9524 → 0.9974.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -977,7 +988,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
 # The unified LLM engine (epic 7153, sc-7158): the macOS `prompt_refine` job now runs through
 # mlx-llm's generic `mlx-llama` provider (a `core_llm::TextLlm`) resolved model-first via
 # `gen_core::core_llm::load_for_model`, RETIRING the bespoke `mlx-gen-prompt-refine` hand-rolled
@@ -1009,7 +1020,7 @@ mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "7041411f395e43
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3233c92a7198086def67d271d45d7f5c1bccf" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -1299,15 +1310,15 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "bdf3
 # Depth-Anything-V2 (candle-gen-depth), base z_image t2i, Qwen-Image-2512 base drop-in + 2512-Fun VACE
 # control, FLUX.1-dev control branch. gen-core UNCHANGED at bdf3233 (additive ports), single-rev skew gate
 # stays green. ALL candle-gen-* rev lines move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "725190c5a0dcf55f6657ca4becbb242b3f606fe0", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "725190c5a0dcf55f6657ca4becbb242b3f606fe0", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "725190c5a0dcf55f6657ca4becbb242b3f606fe0", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "725190c5a0dcf55f6657ca4becbb242b3f606fe0", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "725190c5a0dcf55f6657ca4becbb242b3f606fe0", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1315,17 +1326,17 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "725190c5a0dcf55f6657ca4becbb242b3f606fe0", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "725190c5a0dcf55f6657ca4becbb242b3f606fe0", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "725190c5a0dcf55f6657ca4becbb242b3f606fe0", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1335,7 +1346,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "725190c5a0dcf55f6657ca4becbb242b3f606fe0", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1343,21 +1354,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "725190c5a0dcf55f6657ca4becbb242b3f606fe0", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "725190c5a0dcf55f6657ca4becbb242b3f606fe0", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "725190c5a0dcf55f6657ca4becbb242b3f606fe0", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "725190c5a0dcf55f6657ca4becbb242b3f606fe0", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1366,17 +1377,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "725190c5a0dcf55f6657ca4becbb242b3f606fe0", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "725190c5a0dcf55f6657ca4becbb242b3f606fe0", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "725190c5a0dcf55f6657ca4becbb242b3f606fe0", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1385,7 +1396,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "725190c5a0dcf55f6657ca4becbb242b3f606fe0", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1418,7 +1429,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "725190c5a0dcf55f6657ca4becbb242b3f606fe0", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1427,12 +1438,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "725190c5a0dcf55f6657ca4becbb242b3f606fe0", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "725190c5a0dcf55f6657ca4becbb242b3f606fe0", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1440,7 +1451,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "72519
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "725190c5a0dcf55f6657ca4becbb242b3f606fe0", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1449,7 +1460,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "725190c5a0dcf55f6657ca4becbb242b3f606fe0", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1457,7 +1468,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "725190c5a0dcf55f6657ca4becbb242b3f606fe0", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1471,7 +1482,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "725190c5a0dcf55f6657ca4becbb242b3f606fe0", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1498,7 +1509,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "725190c5a0dcf55f6657ca4becbb242b3f606fe0", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1509,7 +1520,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (725190c5 pins the gen-core rev matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "725190c5a0dcf55f6657ca4becbb242b3f606fe0", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a1a56576793ca9d1b084ac76a5833ce1c873e24", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -38,7 +38,9 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
     ModelRow {
         sceneworks_id: "z_image_turbo",
         engine_id: "z_image_turbo",
-        default_repo: "Tongyi-MAI/Z-Image-Turbo",
+        // SceneWorks pre-built quant-matrix turnkey (sc-8670, epic 8506): q4/ (default) + q8/ + bf16/
+        // packed subdirs, resolved by `standard_tier_subdir`. Re-host of Tongyi-MAI/Z-Image-Turbo.
+        default_repo: "SceneWorks/z-image-turbo-mlx",
         default_steps: 8,
         default_guidance: 0.0,
         adapter_label: "mlx_z_image",
@@ -53,7 +55,9 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
     ModelRow {
         sceneworks_id: "z_image",
         engine_id: "z_image",
-        default_repo: "Tongyi-MAI/Z-Image",
+        // SceneWorks pre-built quant-matrix turnkey (sc-8670): q4/ (default) + q8/ + bf16/ subdirs.
+        // Re-host of the undistilled Tongyi-MAI/Z-Image base (bf16-native source).
+        default_repo: "SceneWorks/z-image-mlx",
         default_steps: 50,
         default_guidance: 4.0,
         adapter_label: "mlx_z_image",
@@ -89,7 +93,8 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
     ModelRow {
         sceneworks_id: "z_image_edit",
         engine_id: "z_image_turbo",
-        default_repo: "Tongyi-MAI/Z-Image-Turbo",
+        // Shares the Turbo turnkey (sc-8670) — img2img runs the same Turbo weights/tier subdirs.
+        default_repo: "SceneWorks/z-image-turbo-mlx",
         default_steps: 8,
         default_guidance: 0.0,
         adapter_label: "mlx_z_image",
@@ -1229,9 +1234,10 @@ mod tests {
     }
 
     // sc-8320: the base (non-distilled) `z_image` t2i row resolves to its OWN engine id (not Turbo's),
-    // points at the `Tongyi-MAI/Z-Image` base snapshot, and carries the undistilled defaults (real CFG
-    // guidance 4.0, ~50 steps) — proving it is selectable and routes to the base path distinct from
-    // `z_image_turbo` (which stays 8-step, CFG-free at `Tongyi-MAI/Z-Image-Turbo`).
+    // points at its own snapshot repo, and carries the undistilled defaults (real CFG guidance 4.0,
+    // ~50 steps) — proving it is selectable and routes to the base path distinct from `z_image_turbo`
+    // (which stays 8-step, CFG-free). Repos are the SceneWorks pre-built quant-matrix turnkeys
+    // (sc-8670): base = `SceneWorks/z-image-mlx`, turbo = `SceneWorks/z-image-turbo-mlx`.
     #[cfg(any(
         target_os = "macos",
         all(not(target_os = "macos"), feature = "backend-candle")
@@ -1243,7 +1249,7 @@ mod tests {
             .find(|row| row.sceneworks_id == "z_image")
             .expect("z_image base MODEL_TABLE row");
         assert_eq!(base.engine_id, "z_image");
-        assert_eq!(base.default_repo, "Tongyi-MAI/Z-Image");
+        assert_eq!(base.default_repo, "SceneWorks/z-image-mlx");
         assert_eq!(base.default_steps, 50);
         assert!((base.default_guidance - 4.0).abs() < f32::EPSILON);
         assert_eq!(base.adapter_label, "mlx_z_image");

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -266,6 +266,11 @@ const STANDARD_TIER_MODELS: &[&str] = &[
     "sd3_5_large",
     "sd3_5_large_turbo",
     "sd3_5_medium",
+    // Z-Image (sc-8670, Group-B pilot): turbo + base ship the standard q4/q8/bf16 turnkey; the
+    // edit id reuses the turbo turnkey (engine_id z_image_turbo, same repo).
+    "z_image_turbo",
+    "z_image",
+    "z_image_edit",
 ];
 
 /// Pick the engine-complete tier subdir of a standard SceneWorks quant-matrix turnkey `root`:


### PR DESCRIPTION
Wires the worker to the SceneWorks pre-built **Z-Image quant-matrix turnkeys** (epic 8506, the Group-B packed-load pilot sc-8670 / sc-8669) so it loads packed q4/q8/bf16 tiers **directly** instead of downloading the diffusers source and quantizing at load.

## Hosted artifacts (public, ungated, Apache-2.0)
- https://huggingface.co/SceneWorks/z-image-turbo-mlx — `q4/` (default) + `q8/` + `bf16/`, each a complete from_snapshot turnkey.
- https://huggingface.co/SceneWorks/z-image-mlx — same layout (undistilled base).

Each tier was built by `mlx_gen_z_image::convert` and **render-verified** loading packed/dense and producing a coherent 1024² image before upload.

## Changes
- **Manifest** (`builtin.models.jsonc`): `z_image_turbo` / `z_image` / `z_image_edit` → per-tier downloads (q4 default / q8 / bf16), `paths`→SceneWorks, `gated:false`, `mlx.quantize` 8→4.
- **engines.rs**: `default_repo`→the SceneWorks turnkeys (all three rows); updated `z_image_base_row_is_distinct_from_turbo`.
- **image_jobs/base.rs**: register the three ids in `STANDARD_TIER_MODELS` (the generalized `standard_tier_subdir` resolver, same as SD3.5).
- **Pin bump**: every mlx-gen crate + root `sceneworks-gen-core` `bdf3233 → 863f98d` (mlx-gen #618 = z-image packed-load + dir-converter), and **all candle-gen pins `725190c → 8a1a565` IN LOCKSTEP** (candle-gen #199 re-pins its gen-core to 863f98d, on top of the #198 preview-samples change main just merged) so both skew lanes resolve a single gen-core rev.

## Verification
- `cargo fmt` + `clippy -D warnings` clean.
- `scripts/check-gen-core-skew.sh` green on **both** the default and `--features backend-candle` lanes (single rev 863f98d).
- 474 worker lib tests pass.

## Depends on / follow-ups
- **candle-gen #199** must merge; then flip the worker's candle-gen pin from the branch commit `8a1a565` → the #199 squash-merge SHA (CI is already green on `8a1a565`).
- mlx-gen #618 is already merged.

Relates: epic 8506, sc-8669.

🤖 Generated with [Claude Code](https://claude.com/claude-code)