### PR TITLE
feat(models): complete Boogu quant matrix — packed Q4 per variant (sc-8513)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -336,39 +336,58 @@ fn ideogram_model_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
         .unwrap_or_else(|| root.to_path_buf())
 }
 
+/// The Boogu subfolder for a `mlxQuantize` request — `None` keeps the Q8 default. Shared by
+/// [`boogu_model_subdir`] (which subfolder to load) and [`ensure_boogu_tier_present`] (which to
+/// fetch on demand): `<=0` → `<variant>-bf16/` (dense full precision), `1..=4` → `<variant>-q4/`
+/// (packed Q4, sc-8513), anything else → the default `<variant>/` (packed Q8). Returns the subfolder
+/// name relative to the turnkey root.
+fn boogu_tier_subdir(variant: &str, bits: Option<i64>) -> Option<String> {
+    match bits {
+        Some(b) if b <= 0 => Some(format!("{variant}-bf16")),
+        Some(b) if b <= 4 => Some(format!("{variant}-q4")),
+        _ => None,
+    }
+}
+
 /// Pick the engine-complete subfolder of a Boogu turnkey `root` for the requested variant. Each
 /// catalog id maps to a variant folder: `boogu_image`→`base`, `boogu_image_turbo`→`turbo`,
 /// `boogu_image_edit`→`edit`. **Q8 is the shipped default** (the pre-packed `<variant>/` folder); an
-/// explicit advanced `mlxQuantize <= 4` selects the full-precision `<variant>-bf16/` build instead —
-/// the source the engine quantizes at load (no packed Q4 is shipped) or runs dense. Falls back to
-/// whichever subfolder is present, then `root`, so a partially-downloaded bundle surfaces as a load
-/// error rather than a silent half-load. (The `*-bf16/` files are an on-demand download fetched by
-/// [`ensure_boogu_bf16_present`] before this resolves, sc-6568; if that fetch was skipped/failed the
-/// bf16 request falls back to the Q8 folder.)
+/// explicit advanced `mlxQuantize` selects another tier (sc-8513, epic 8506): `<=0` → the dense
+/// `<variant>-bf16/`, `1..=4` → the packed `<variant>-q4/`. Falls back through Q8 → q4 → bf16 → `root`
+/// when the requested tier isn't downloaded, so a partial bundle surfaces as a load error rather than
+/// a silent half-load. (The non-default tiers are on-demand downloads fetched by
+/// [`ensure_boogu_tier_present`] before this resolves, sc-6568/sc-8513.)
 fn boogu_model_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
     let variant = match request.model.as_str() {
         "boogu_image_turbo" => "turbo",
         "boogu_image_edit" => "edit",
         _ => "base",
     };
-    let bf16 = format!("{variant}-bf16");
-    let wants_bf16 = request
+    let bits = request
         .advanced
         .get("mlxQuantize")
-        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()))
-        .is_some_and(|bits| bits <= 4);
+        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()));
+    // q4/q8 ship a single packed transformer file; bf16 is the dense diffusers tree (SHARDED → only
+    // the `.index.json`). Accept either shape.
     let present = |name: &str| -> Option<PathBuf> {
         let dir = root.join(name);
-        dir.join("transformer/diffusion_pytorch_model.safetensors")
-            .is_file()
-            .then_some(dir)
+        let packed = dir
+            .join("transformer/diffusion_pytorch_model.safetensors")
+            .is_file();
+        let sharded = dir
+            .join("transformer/diffusion_pytorch_model.safetensors.index.json")
+            .is_file();
+        (packed || sharded).then_some(dir)
     };
-    if wants_bf16 {
-        if let Some(dir) = present(&bf16) {
+    let q4 = format!("{variant}-q4");
+    let bf16 = format!("{variant}-bf16");
+    if let Some(tier) = boogu_tier_subdir(variant, bits) {
+        if let Some(dir) = present(&tier) {
             return dir;
         }
     }
     present(variant)
+        .or_else(|| present(&q4))
         .or_else(|| present(&bf16))
         .unwrap_or_else(|| root.to_path_buf())
 }
@@ -412,17 +431,17 @@ fn krea_model_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
         .unwrap_or_else(|| root.to_path_buf())
 }
 
-/// On-demand fetch of the full-precision `<variant>-bf16/` Boogu subfolder (sc-6568). The S1 catalog
-/// download pulls only the packed Q8 `<variant>/` subfolder, so when a job opts into the bf16 build
-/// (advanced `mlxQuantize <= 4` — the same gate [`boogu_model_subdir`] uses to select it) and that
-/// subfolder isn't present yet, pull just its files into the HF cache so `boogu_model_subdir` resolves
-/// it. No-op when bf16 isn't requested, the model isn't Boogu, the turnkey snapshot isn't downloaded
-/// yet (`boogu_model_subdir` then falls back to Q8 / surfaces the load error), or the bf16 subfolder
-/// is already complete. Fails loud on a real download error — fast, before any compute; a missing `hf`
-/// CLI leaves the subfolder absent so the request gracefully falls back to Q8. Mirrors
+/// On-demand fetch of a non-default Boogu tier subfolder (sc-6568 / sc-8513). The catalog download
+/// pulls only the packed Q8 `<variant>/` subfolder, so when a job opts into another tier
+/// ([`boogu_tier_subdir`]: `<=0` → `<variant>-bf16/` dense, `1..=4` → `<variant>-q4/` packed) and that
+/// subfolder isn't present yet, pull just its files into the HF cache so [`boogu_model_subdir`]
+/// resolves it. No-op when the Q8 default is requested, the model isn't Boogu, the turnkey snapshot
+/// isn't downloaded yet (`boogu_model_subdir` then falls back to Q8 / surfaces the load error), or the
+/// tier subfolder is already complete. Fails loud on a real download error — fast, before any compute;
+/// a missing `hf` CLI leaves the subfolder absent so the request gracefully falls back to Q8. Mirrors
 /// [`crate::video_jobs::ensure_ltx_q8_present`].
 #[cfg(target_os = "macos")]
-async fn ensure_boogu_bf16_present(
+async fn ensure_boogu_tier_present(
     api: &ApiClient,
     settings: &Settings,
     job: &JobSnapshot,
@@ -434,14 +453,11 @@ async fn ensure_boogu_bf16_present(
         "boogu_image_edit" => "edit",
         _ => return Ok(()),
     };
-    let wants_bf16 = request
-        .advanced
-        .get("mlxQuantize")
-        .and_then(quant_int)
-        .is_some_and(|bits| bits <= 4);
-    if !wants_bf16 {
+    let bits = request.advanced.get("mlxQuantize").and_then(quant_int);
+    let Some(tier) = boogu_tier_subdir(variant, bits) else {
+        // Q8 default ships in the catalog download — nothing to fetch.
         return Ok(());
-    }
+    };
     let Some(model) = mlx_model(&request.model) else {
         return Ok(());
     };
@@ -450,24 +466,27 @@ async fn ensure_boogu_bf16_present(
         // Turnkey not downloaded at all → leave it to the load path's "weights not found" error.
         return Ok(());
     };
-    let bf16 = format!("{variant}-bf16");
-    if root
-        .join(&bf16)
+    let tier_dir = root.join(&tier);
+    // Present already (packed single-file q4 OR sharded-dense bf16 `.index.json`) → no fetch.
+    if tier_dir
         .join("transformer/diffusion_pytorch_model.safetensors")
         .is_file()
+        || tier_dir
+            .join("transformer/diffusion_pytorch_model.safetensors.index.json")
+            .is_file()
     {
         return Ok(());
     }
     let scratch = settings
         .data_dir
         .join("cache")
-        .join(format!(".boogu-bf16-fetch-{}", job.id));
+        .join(format!(".boogu-tier-fetch-{}", job.id));
     tokio::fs::create_dir_all(&scratch).await?;
-    // The bf16 subfolder nests transformer/mllm/vae (leaf-dir globs, like the catalog Q8 entry).
+    // The tier subfolder nests transformer/mllm/vae (leaf-dir globs, like the catalog Q8 entry).
     let files = vec![
-        format!("{bf16}/transformer/*"),
-        format!("{bf16}/mllm/*"),
-        format!("{bf16}/vae/*"),
+        format!("{tier}/transformer/*"),
+        format!("{tier}/mllm/*"),
+        format!("{tier}/vae/*"),
     ];
     let result = crate::model_jobs::download_model_with_hf_cli(
         api,
@@ -1788,7 +1807,7 @@ async fn generate_stream(
     // sc-6568: a bf16 opt-in for Boogu fetches the full-precision `<variant>-bf16/` subfolder on
     // demand (the catalog ships only the Q8 default) before snapshot resolution. No-op for every
     // other model / the default Q8 path.
-    ensure_boogu_bf16_present(api, settings, job, request).await?;
+    ensure_boogu_tier_present(api, settings, job, request).await?;
     let weights_dir = resolve_weights_dir(request, settings)?
         .ok_or_else(|| WorkerError::InvalidPayload("model weights not found".to_owned()))?;
     // sc-3723: surface the descriptor-derived backend ("mlx" for every linked family today; a
@@ -3061,6 +3080,26 @@ mod candle_label_tests {
         ] {
             assert!(!is_candle_engine(model), "{model} must not be a candle engine");
         }
+    }
+}
+
+#[cfg(test)]
+mod boogu_tier_tests {
+    use super::*;
+
+    #[test]
+    fn tier_subdir_selects_by_quant_bits() {
+        // Q8 default (no opt-in / a >4 request) → None (the `<variant>/` folder ships in the catalog
+        // download). 1..=4 → packed q4; <=0 → dense bf16. Consistent with krea/ideogram (sc-8513).
+        assert_eq!(boogu_tier_subdir("base", None), None);
+        assert_eq!(boogu_tier_subdir("base", Some(8)), None);
+        assert_eq!(boogu_tier_subdir("base", Some(4)), Some("base-q4".to_owned()));
+        assert_eq!(boogu_tier_subdir("turbo", Some(2)), Some("turbo-q4".to_owned()));
+        assert_eq!(boogu_tier_subdir("edit", Some(0)), Some("edit-bf16".to_owned()));
+        assert_eq!(
+            boogu_tier_subdir("base", Some(-1)),
+            Some("base-bf16".to_owned())
+        );
     }
 }
 

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -1478,6 +1478,75 @@ fn krea_2_turbo_bf16_real_weights_loads_and_generates() {
     );
 }
 
+/// Q4 tier verify (sc-8513, epic 8506): load the packed Boogu `<variant>-q4/` tier (`Quant::Q4`) — the
+/// new lighter quant that joins the shipped Q8 + dense bf16 — through the real worker `boogu_image`
+/// engine path and render. The `assemble_quantized_snapshot` builder packs transformer + mllm to Q4
+/// (vae dense); this proves the packed turnkey loads + generates. Point `SCENEWORKS_BOOGU_Q4_DIR` at a
+/// built/downloaded `<variant>-q4/` dir; `SCENEWORKS_BOOGU_ENGINE` selects the variant
+/// (`boogu_image` default / `boogu_image_turbo` / `boogu_image_edit`). Run:
+/// `SCENEWORKS_BOOGU_Q4_DIR=… cargo test -p sceneworks-worker --release --lib -- --ignored boogu_q4_real_weights`.
+#[cfg(target_os = "macos")]
+#[test]
+#[ignore = "needs a built/downloaded Boogu q4 tier + a high-memory Metal device"]
+fn boogu_q4_real_weights_loads_and_generates() {
+    let dir = std::path::PathBuf::from(
+        std::env::var("SCENEWORKS_BOOGU_Q4_DIR")
+            .expect("set SCENEWORKS_BOOGU_Q4_DIR to a built/downloaded boogu <variant>-q4 dir"),
+    );
+    let engine =
+        std::env::var("SCENEWORKS_BOOGU_ENGINE").unwrap_or_else(|_| "boogu_image".to_owned());
+    let size: u32 = std::env::var("SCENEWORKS_BOOGU_SIZE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(512);
+    eprintln!(
+        "[boogu-q4] loading {engine} packed Q4 from {}…",
+        dir.display()
+    );
+    let generator = load_engine(&engine, dir, Some(gen_core::Quant::Q4), Vec::new(), None).unwrap();
+    eprintln!("[boogu-q4] LOADED — generating {size}²…");
+    let cancel = gen_core::CancelFlag::new();
+    // The `edit` variant is an instruction-edit engine — it requires a source reference (sc-7645,
+    // passed as a single `multi_references` image). base/turbo are plain t2i (`&[]`).
+    let edit_refs: Vec<Image> = if engine.contains("edit") {
+        vec![synthetic_rgb(size, size, |x, y| {
+            [(x * 255 / size) as u8, (y * 255 / size) as u8, 128]
+        })]
+    } else {
+        Vec::new()
+    };
+    let (w, h, pixels) = generate_one(
+        generator.as_ref(),
+        "a serene mountain lake at dawn",
+        size,
+        size,
+        42,
+        8,
+        None,
+        None,
+        None,
+        &edit_refs,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        false,
+        &PromptEnhance::default(),
+        &cancel,
+        &mut |_| {},
+    )
+    .unwrap();
+    eprintln!("[boogu-q4] GENERATED {w}x{h}");
+    assert_eq!((w, h), (size, size));
+    assert_eq!(pixels.len(), (size * size * 3) as usize);
+    assert!(
+        pixels.windows(2).any(|p| p[0] != p[1]),
+        "render is flat (degenerate)"
+    );
+}
+
 /// Real-weights smoke (sc-5923): FLUX.2-dev EDIT through the worker `flux2_dev_edit` engine path
 /// (the `flux2_edit_engine_id("flux2_dev")` variant, sc-5919/5922). Loads the SAME converted Q4 dev
 /// snapshot, then renders with a single `Conditioning::Reference` AND with a 2-image
@@ -4794,12 +4863,13 @@ fn boogu_engine_defaults_and_quant_resolution() {
 }
 
 /// `boogu_model_subdir` maps each id to its variant folder (`base`/`turbo`/`edit`), picks the
-/// pre-packed Q8 `<variant>/` by default, and the full-precision `<variant>-bf16/` only when
-/// `mlxQuantize <= 4` AND it is present — falling back to the Q8 folder (then root), so a request for
-/// a not-yet-downloaded bf16 build resolves the Q8 default rather than half-loading.
+/// pre-packed Q8 `<variant>/` by default, the packed `<variant>-q4/` for `mlxQuantize 1..=4`, and the
+/// dense `<variant>-bf16/` for `mlxQuantize <= 0` — each only when present, else falling back through
+/// Q8 → q4 → bf16 → root, so a request for a not-yet-downloaded tier resolves the Q8 default rather
+/// than half-loading (sc-8513). Consistent with krea/ideogram (`<=4`→q4, `<=0`→bf16).
 #[cfg(target_os = "macos")]
 #[test]
-fn boogu_subdir_prefers_q8_and_opts_into_bf16() {
+fn boogu_subdir_prefers_q8_and_opts_into_q4_or_bf16() {
     let root = tempfile::tempdir().unwrap();
     let touch = |sub: &str| {
         let dir = root.path().join(sub).join("transformer");
@@ -4825,7 +4895,15 @@ fn boogu_subdir_prefers_q8_and_opts_into_bf16() {
         boogu_model_subdir(root.path(), &req("boogu_image_edit", json!({}))),
         root.path().join("edit")
     );
-    // bf16 opt-in falls back to the Q8 folder when `base-bf16/` is absent (not yet downloaded).
+    // q4/bf16 opt-ins fall back to the Q8 folder when their subfolder is absent (not yet downloaded).
+    assert_eq!(
+        boogu_model_subdir(
+            root.path(),
+            &req("boogu_image", json!({ "mlxQuantize": 4 }))
+        ),
+        root.path().join("base"),
+        "q4 opt-in falls back to Q8 when base-q4 absent",
+    );
     assert_eq!(
         boogu_model_subdir(
             root.path(),
@@ -4834,19 +4912,27 @@ fn boogu_subdir_prefers_q8_and_opts_into_bf16() {
         root.path().join("base"),
         "bf16 opt-in falls back to Q8 when base-bf16 absent",
     );
-    // With the bf16 folder present, `mlxQuantize <= 4` selects it; Q8 stays the default.
+    // With the tier folders present: `1..=4` → q4, `<=0` → bf16; Q8 stays the default.
+    touch("base-q4");
     touch("base-bf16");
     assert_eq!(
         boogu_model_subdir(
             root.path(),
-            &req("boogu_image", json!({ "mlxQuantize": 0 }))
+            &req("boogu_image", json!({ "mlxQuantize": 4 }))
         ),
-        root.path().join("base-bf16")
+        root.path().join("base-q4")
     );
     assert_eq!(
         boogu_model_subdir(
             root.path(),
-            &req("boogu_image", json!({ "mlxQuantize": 4 }))
+            &req("boogu_image", json!({ "mlxQuantize": 2 }))
+        ),
+        root.path().join("base-q4")
+    );
+    assert_eq!(
+        boogu_model_subdir(
+            root.path(),
+            &req("boogu_image", json!({ "mlxQuantize": 0 }))
         ),
         root.path().join("base-bf16")
     );

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -2479,6 +2479,20 @@ mod tier_builder {
             out.display()
         );
 
+        // Boogu (sc-8513, epic 8506): `assemble_quantized_snapshot` builds the whole turnkey in one
+        // call — packs transformer/ + mllm/ and copies the dense mllm/tokenizer.json + vae/ as real
+        // files — so there are no symlinks to dereference. Q4/Q8 only (bf16 ships dense separately).
+        if converter == "boogu_assemble" {
+            assert!(
+                bits > 0,
+                "boogu assemble builds a packed Q tier (set SC8513_BITS=4 or 8)"
+            );
+            mlx_gen_boogu::convert::assemble_quantized_snapshot(&src, &out, bits)
+                .unwrap_or_else(|error| panic!("boogu assemble failed: {error}"));
+            eprintln!("[sc-8513] DONE {tier} at {}", out.display());
+            return;
+        }
+
         if bits <= 0 {
             // bf16: the dense backbone IS the tier — mirror transformer + the dense-reuse subdirs.
             copy_tree_deref(&src.join("transformer"), &out.join("transformer"));


### PR DESCRIPTION
## Summary
Group-A (converter-ready) completion for the catalog quant matrix (epic 8506). Boogu (base/turbo/edit) shipped **Q8** (`<variant>/`, default) + dense **bf16** (`<variant>-bf16/`, on-demand); this adds the packed **Q4** tier so each variant has the full bf16/Q8/Q4 matrix — and makes boogu's tier selection consistent with krea/ideogram.

- **Hosted** `SceneWorks/boogu-image-mlx/<variant>-q4/` for base/turbo/edit (14 GB each: packed transformer + mllm, dense vae), built from the dense `<variant>-bf16/` source via `mlx_gen_boogu::convert::assemble_quantized_snapshot`.
- **Resolver**: `boogu_model_subdir` now selects 3 tiers via a shared `boogu_tier_subdir` helper — `<=0`→bf16, `1..=4`→**q4 (new)**, else Q8 default — with a shard-aware probe (bf16 is sharded). **Behavior change:** the prior quirk mapped `<=4`→bf16 (no Q4 existed); boogu now matches krea/ideogram.
- **On-demand fetch**: `ensure_boogu_bf16_present` → `ensure_boogu_tier_present`, pulling `<variant>-q4/` or `<variant>-bf16/` (whichever is selected) before resolve, so non-default tiers stay opt-in downloads.
- **Builder**: `tier_builder` gains a `boogu_assemble` arm (self-contained — real files, no symlink-deref).
- **On-device verify**: the packed Q4 tier of **all three variants** loads (`Quant::Q4`) and generates a non-degenerate 512² image (`boogu_q4_real_weights...`; the edit variant with a synthetic instruction-edit reference). New `boogu_tier_subdir` unit test + updated `boogu_subdir` selection test.

## Gates (local)
`cargo fmt --all --check`, `cargo clippy -p sceneworks-worker --all-targets -D warnings`, candle parity (`--no-default-features -F backend-candle --all-targets`), full `cargo test -p sceneworks-worker --lib` (475 passed), 3× on-device Q4 gen — all green. Branched off latest origin/main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)