### PR TITLE
fix(release): don't upload the NSIS updater payload twice (sc-1355)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,10 +224,16 @@ jobs:
           payload="${sig%.sig}"          # the artifact the .sig signs (the update payload)
           payload_name="$(basename "$payload")"
 
-          # Upload installers + the updater payload (the payload is normally the
-          # NSIS .exe already in `installers`; upload it explicitly so a .nsis.zip
-          # payload is also covered).
-          gh release upload "$TAG" --clobber "${installers[@]}" "$payload"
+          # Upload the installers, then the updater payload — but only if it isn't
+          # already one of the installers. The NSIS payload IS the `-setup.exe`
+          # that `nsis/*.exe` already globbed, so listing it twice in one
+          # `gh release upload` makes the second create the same asset name and 404s.
+          # The guard still covers a hypothetical `.nsis.zip` payload (not in the glob).
+          gh release upload "$TAG" --clobber "${installers[@]}"
+          case " ${installers[*]} " in
+            *" $payload "*) : ;;  # already uploaded above
+            *) gh release upload "$TAG" --clobber "$payload" ;;
+          esac
 
           # Merge the windows-x86_64 entry into the macos-seeded manifest.
           gh release download "$TAG" -p latest.json --clobber


### PR DESCRIPTION
Second follow-up to the `v0.5.0` release. With the `--config` quoting fixed (#1006), the Windows job **built** both installers fine but then failed at the manifest step:

```
HTTP 404 ... releases/.../assets?name=SceneWorks_0.5.0_x64-setup.exe
```

**Cause:** the upload listed the NSIS `-setup.exe` **twice** in one `gh release upload` — once via the `nsis/*.exe` installers glob and again as the explicit `$payload` (the file the `.sig` signs is that same exe). `gh` 404s creating a duplicate asset name in a single call, so the job died *after* uploading the installers but *before* merging the `windows-x86_64` entry into `latest.json`.

**Fix:** upload the installers, then upload `$payload` only if it isn't already one of them (a `case` guard) — still covering a hypothetical `.nsis.zip` payload that the glob wouldn't catch.

**Note on the existing `v0.5.0` draft:** I already repaired it out-of-band — signed the already-uploaded `setup.exe` with the same key locally and patched `latest.json`, so the current draft has both platform entries and is publishable as-is. This PR just makes the *next* release (e.g. `v0.5.1`) work without manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)