### PR TITLE
chore(desktop): bump product version to 0.5.1

### DIFF
--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sceneworks/desktop",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sceneworks/desktop",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sceneworks/desktop",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "SceneWorks desktop shell (Tauri).",
   "scripts": {
     "dev": "tauri dev",

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SceneWorks",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "identifier": "net.trefry.sceneworks",
   "build": {
     "frontendDist": "ui",


### PR DESCRIPTION
Bumps the desktop product version `0.5.0` → `0.5.1` (`tauri.conf.json`, `package.json`, lockfile).

This is the **update-target release for validating the auto-updater** (sc-1355): once `v0.5.0` is published and installed, tagging `v0.5.1` off this gives an installed `0.5.0` client a newer stable release to detect → prompt → install. Bumping the embedded version (not just the tag) is what stops the post-update app from re-prompting itself.

**Sequencing — don't tag `v0.5.1` until `v0.5.0` is published and installed.** Merging this PR is harmless on its own (no release fires without a tag); it just parks the bump on main so the release is one `git tag v0.5.1` away when you're ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)