### PR TITLE
feat(training): cancel button + full-size sample preview on LoRA training card

### DIFF
--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -247,7 +247,7 @@ export function trainingSampleGroups(job, projectId) {
     .filter((group) => group.assets.length);
 }
 
-function TrainingLiveProgress({ jobs, projectId }) {
+function TrainingLiveProgress({ jobs, projectId, onCancel, onPreview }) {
   if (!jobs.length) {
     return null;
   }
@@ -261,15 +261,23 @@ function TrainingLiveProgress({ jobs, projectId }) {
         <span>{jobs.length} active</span>
       </div>
       <div className="training-live-list worker-progress-card-stack">
-        {jobs.map((job) => (
-          <WorkerProgressCard
-            key={job.id}
-            job={job}
-            thumbnailsVariant="image-grid"
-            thumbnailGroups={trainingSampleGroups(job, projectId)}
-            expectedThumbnailCount={4}
-          />
-        ))}
+        {jobs.map((job) => {
+          const sampleGroups = trainingSampleGroups(job, projectId);
+          // Flatten every sample across cycles so the fullscreen preview can page
+          // through the whole run rather than just the clicked group.
+          const sampleScope = sampleGroups.flatMap((group) => group.assets);
+          return (
+            <WorkerProgressCard
+              key={job.id}
+              job={job}
+              thumbnailsVariant="image-grid"
+              thumbnailGroups={sampleGroups}
+              expectedThumbnailCount={4}
+              onCancel={onCancel}
+              onThumbnailClick={onPreview ? (asset) => onPreview(asset, sampleScope) : undefined}
+            />
+          );
+        })}
       </div>
     </section>
   );
@@ -288,6 +296,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
     characters = [],
     gpuOptions = defaultGpuOptions,
     jobs = [],
+    jobAction,
     setPreviewAsset,
     importAsset: importAssetRaw,
     trainingDatasets = [],
@@ -1433,7 +1442,14 @@ export function TrainingStudio({ mode = "training" } = {}) {
             </div>
           </div>
         </div>
-        {datasetLibraryMode ? null : <TrainingLiveProgress jobs={activeTrainingJobs} projectId={activeProject?.id} />}
+        {datasetLibraryMode ? null : (
+          <TrainingLiveProgress
+            jobs={activeTrainingJobs}
+            projectId={activeProject?.id}
+            onCancel={jobAction ? (job) => jobAction(job, "cancel") : undefined}
+            onPreview={setPreviewAsset}
+          />
+        )}
 
         {!authenticated ? (
           <div className="training-empty-state" role="status">


### PR DESCRIPTION
## What

The LoRA Training Studio's live-progress card was the only worker progress surface missing a **Cancel** button, and its training **samples weren't clickable**. This adds both:

- **Cancel button** on in-flight training runs.
- **Click a sample → fullscreen preview** at full size, with left/right navigation across the whole run.

## Why

`WorkerProgressCard` (the shared progress component used by Image Studio, Video Studio, Queue, etc.) already supports both `onCancel` and `onThumbnailClick`. The training surface's `TrainingLiveProgress` simply wasn't passing those props — so this is a pure wiring change, no new component behavior.

## How

In `apps/web/src/screens/TrainingStudio.jsx`:

1. Pulled `jobAction` from context and passed `onCancel={(job) => jobAction(job, "cancel")}` to the card. Cancel is a generic per-job endpoint (`POST /api/v1/jobs/:job_id/cancel`), so `lora_train` jobs cancel correctly server-side; the button renders the existing "Canceling…" disabled state on `cancelRequested`.
2. Passed `onThumbnailClick` wired to `setPreviewAsset` (the same fullscreen preview used elsewhere). Each sample opens scoped to the **flattened list of all samples across every sampling cycle**, so the preview's prev/next pages through the entire run rather than just the clicked group.

## Reviewer notes

- The cancel and thumbnail-click behaviors themselves are already covered by `WorkerProgressCard.test.jsx` (`invokes onCancel when the Cancel button is clicked`, `invokes onThumbnailClick when a cell is activated`). This change is a prop pass-through to that tested component.
- `TrainingStudio.test.jsx` — 7/7 pass. ESLint — 0 errors on the changed file (pre-existing exhaustive-deps warnings unchanged).
- Worker-side latency caveat (not a UI bug): a single-threaded training step won't observe the cancel until its step boundary; the UI correctly shows "Canceling…" in the interim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)