### PR TITLE
feat(models): FLUX.2-klein quant matrix — transformer-only packed tiers, bf16 TE (sc-8711)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1721,16 +1721,35 @@
       "macOnly": true,
       "downloads": [
         {
-          // Gated repo (FLUX Non-Commercial License). Whole-repo download (~49 GiB
-          // — Qwen3 text embedder + Flux2 transformer + VAE).
+          // SceneWorks pre-quantized MLX turnkey (sc-8711, epic 8506): a public/ungated re-host of
+          // black-forest-labs/FLUX.2-klein-9B under the FLUX Non-Commercial License (LICENSE.md
+          // travels with the weights — no BFL token or license click). Per-tier subdirs: q4/ (the
+          // default), q8/, bf16/. UNLIKE flux2-dev, only the transformer is packed in q4/q8 — the
+          // 8B Qwen3 text encoder stays DENSE bf16 in every tier (epic 8506: quantize the
+          // transformer, keep the TE bf16), so the worker loads each tier with Quant::None
+          // (`DENSE_TE_TIER_MODELS`). Replaces the old gated 49 GiB whole-repo + load-time quantize.
           "provider": "huggingface",
-          "repo": "black-forest-labs/FLUX.2-klein-9B",
-          "files": [],
-          "estimatedSizeBytes": 52613349376
+          "repo": "SceneWorks/flux2-klein-9b-mlx",
+          "files": ["q4/*"],
+          "estimatedSizeBytes": 21700000000
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/flux2-klein-9b-mlx",
+          "files": ["q8/*"],
+          "estimatedSizeBytes": 26100000000
+        },
+        {
+          // bf16/ — dense transformer + dense Qwen3 TE, the max-fidelity tier. Selectable via
+          // per-variant tracking (sc-8508/8509).
+          "provider": "huggingface",
+          "repo": "SceneWorks/flux2-klein-9b-mlx",
+          "files": ["bf16/*"],
+          "estimatedSizeBytes": 34600000000
         }
       ],
       "paths": {
-        "model": "${HF_CACHE}/black-forest-labs/FLUX.2-klein-9B"
+        "model": "${HF_CACHE}/SceneWorks/flux2-klein-9b-mlx"
       },
       "defaults": {
         // Step-distilled to 4 steps; guidance MUST be 1.0 on distilled klein
@@ -1750,23 +1769,24 @@
         "families": ["flux2"],
         "types": ["style", "enhance", "character"]
       },
-      // Q8 sweet spot on M-series: same per-step speed as bf16, ~25% peak
-      // memory reduction. minMemoryGb tracks bf16 peak ~36 GB measured at
-      // 1024² 4-step on M5 Max; 64 GB Macs are well in range.
+      // Default tier is q4 (packed transformer + dense bf16 Qwen3 TE). minMemoryGb tracks the
+      // default q4 footprint with headroom; the dense TE (~16 GB) dominates the floor, and
+      // generate is activation-bound at 1024²/4-step. The bf16 tier needs more — per-tier memory
+      // tracking is sc-8508/8509. `quantize: 4` records the DEFAULT tier; the actual load Quant is
+      // forced to None (`DENSE_TE_TIER_MODELS`) so the dense bf16 TE is preserved.
       "mlx": {
         "minMemoryGb": 42,
-        "quantize": 8
+        "quantize": 4
       },
-      // Gated FLUX Non-Commercial License (same posture as flux_dev: accept
-      // license + add HF token before downloading). Generations are
-      // non-commercial use only — matches SceneWorks's overall non-commercial
-      // posture, so no new app-level guardrail beyond the existing one.
-      "gated": true,
-      "credentialHost": "huggingface.co",
-      "licenseUrl": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9B",
+      // SceneWorks public/ungated re-host (LICENSE.md travels with the weights). FLUX
+      // Non-Commercial License — generations are non-commercial use only, matching SceneWorks's
+      // overall non-commercial posture, so no new app-level guardrail beyond the existing one. No
+      // HF token or license click needed before downloading.
+      "gated": false,
+      "licenseUrl": "https://huggingface.co/SceneWorks/flux2-klein-9b-mlx/blob/main/LICENSE.md",
       "ui": {
         "label": "FLUX.2 [klein] 9B",
-        "description": "Black Forest Labs FLUX.2 [klein] 9B — 4-step distilled text-to-image + reference editing, MLX-only (Apple Silicon). 9B flow transformer + 8B Qwen3 text embedder; ~36 GB bf16 peak at 1024². Distributed under the FLUX Non-Commercial License (gated): accept the license at huggingface.co/black-forest-labs/FLUX.2-klein-9B and add a Hugging Face token under Settings → Service credentials before downloading. For faster reference editing on the same architecture, see FLUX.2 [klein] 9B-KV.",
+        "description": "Black Forest Labs FLUX.2 [klein] 9B — 4-step distilled text-to-image + reference editing, MLX-only (Apple Silicon). 9B flow transformer + 8B Qwen3 text embedder; ~36 GB bf16 peak at 1024². Pre-quantized and hosted by SceneWorks (Q4 default ~22 GB; Q8 and bf16 selectable) — downloads ready-to-run with no install-time conversion. Only the transformer is quantized; the Qwen3 text encoder stays full-precision bf16 in every tier for fidelity. Distributed under the FLUX Non-Commercial License (non-commercial use only); SceneWorks hosts a public, ungated re-host, so no Hugging Face token or license acceptance is needed before downloading. For faster reference editing on the same architecture, see FLUX.2 [klein] 9B-KV.",
         "recommendedFor": ["text_to_image", "character_image", "style_variations"],
         "pid": { "checkpointId": "pid_flux2" },
         // Edit-style backbone (Flux2KleinEdit handles reference natively; no
@@ -1834,14 +1854,30 @@
       "macOnly": true,
       "downloads": [
         {
+          // SceneWorks pre-quantized MLX turnkey (sc-8711, epic 8506): public/ungated re-host of
+          // black-forest-labs/FLUX.2-klein-9b-kv. Per-tier subdirs q4/ (default), q8/, bf16/ — only
+          // the transformer is packed; the Qwen3 TE stays DENSE bf16 in every tier (Quant::None at
+          // load via `DENSE_TE_TIER_MODELS`). Replaces the old gated whole-repo + load-time quantize.
           "provider": "huggingface",
-          "repo": "black-forest-labs/FLUX.2-klein-9b-kv",
-          "files": [],
-          "estimatedSizeBytes": 52613349376
+          "repo": "SceneWorks/flux2-klein-9b-kv-mlx",
+          "files": ["q4/*"],
+          "estimatedSizeBytes": 21700000000
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/flux2-klein-9b-kv-mlx",
+          "files": ["q8/*"],
+          "estimatedSizeBytes": 26100000000
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/flux2-klein-9b-kv-mlx",
+          "files": ["bf16/*"],
+          "estimatedSizeBytes": 34600000000
         }
       ],
       "paths": {
-        "model": "${HF_CACHE}/black-forest-labs/FLUX.2-klein-9b-kv"
+        "model": "${HF_CACHE}/SceneWorks/flux2-klein-9b-kv-mlx"
       },
       "defaults": {
         "resolution": "1024x1024",
@@ -1859,16 +1895,17 @@
         "families": ["flux2"],
         "types": ["style", "enhance", "character"]
       },
+      // Default tier q4 (packed transformer + dense bf16 Qwen3 TE); the actual load Quant is forced
+      // to None (`DENSE_TE_TIER_MODELS`) so the dense TE is preserved. Per-tier memory: sc-8508/8509.
       "mlx": {
         "minMemoryGb": 42,
-        "quantize": 8
+        "quantize": 4
       },
-      "gated": true,
-      "credentialHost": "huggingface.co",
-      "licenseUrl": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9b-kv",
+      "gated": false,
+      "licenseUrl": "https://huggingface.co/SceneWorks/flux2-klein-9b-kv-mlx/blob/main/LICENSE.md",
       "ui": {
         "label": "FLUX.2 [klein] 9B-KV",
-        "description": "A KV-optimized distill of FLUX.2 [klein] 9B: text-to-image, reference editing, and style variations, plus KV-cache acceleration that makes reference editing ~2.4× faster than the base 9B edit path on Apple Silicon (validated M5 Max 128 GB, sc-2163). The cache engages automatically when you attach a reference; without one it runs plain text-to-image on par with the base 9B (sc-2173). Distributed under the FLUX Non-Commercial License (gated). Same ~36 GB bf16 peak at 1024² as the base 9B.",
+        "description": "A KV-optimized distill of FLUX.2 [klein] 9B: text-to-image, reference editing, and style variations, plus KV-cache acceleration that makes reference editing ~2.4× faster than the base 9B edit path on Apple Silicon (validated M5 Max 128 GB, sc-2163). The cache engages automatically when you attach a reference; without one it runs plain text-to-image on par with the base 9B (sc-2173). Pre-quantized and hosted by SceneWorks (Q4 default ~22 GB; Q8 and bf16 selectable) — only the transformer is quantized, the Qwen3 text encoder stays full-precision bf16 in every tier. Distributed under the FLUX Non-Commercial License (non-commercial use only); SceneWorks hosts a public, ungated re-host, so no Hugging Face token or license acceptance is needed before downloading. Same ~36 GB bf16 peak at 1024² as the base 9B.",
         "recommendedFor": ["character_image"],
         "pid": { "checkpointId": "pid_flux2" },
         // Same edit-style knob as the base 9B (Flux2KleinEdit). The cache

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -300,7 +300,22 @@ const STANDARD_TIER_MODELS: &[&str] = &[
     "z_image_turbo",
     "z_image",
     "z_image_edit",
+    // FLUX.2-klein (sc-8711): the two distilled weight variants ship the standard q4/q8/bf16
+    // turnkey, but with a DENSE bf16 Qwen3 text encoder in every tier (only the transformer is
+    // packed) — so they additionally appear in [`DENSE_TE_TIER_MODELS`], which forces the load
+    // Quant to None so the dense TE is never re-quantized. `_true_v2` stays on its install-time
+    // single-file→diffusers convert (candle-only) and is not a turnkey yet.
+    "flux2_klein_9b",
+    "flux2_klein_9b_kv",
 ];
+
+/// Standard-tier models whose text encoder ships DENSE bf16 in EVERY tier (epic 8506, sc-8711:
+/// quantize the transformer, keep the TE bf16). Their pre-packed transformer self-describes its
+/// quant on load, so [`resolve_quant`] must return `None` for them — otherwise the load-time
+/// `.quantize()` would re-quantize the dense bf16 TE down to Q4/Q8. Contrast flux2_dev / sd3.5 /
+/// z-image, whose text encoders are packed too, so their Q4/Q8 load-quant is a harmless no-op on
+/// already-packed weights.
+const DENSE_TE_TIER_MODELS: &[&str] = &["flux2_klein_9b", "flux2_klein_9b_kv"];
 
 /// Pick the engine-complete tier subdir of a standard SceneWorks quant-matrix turnkey `root`:
 /// `bf16/` when the request opts out of quantization (`advanced.mlxQuantize <= 0` / "none"), `q8/`
@@ -562,6 +577,13 @@ fn quant_int(value: &Value) -> Option<i64> {
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn resolve_quant(request: &ImageRequest) -> (Option<Quant>, Option<i64>) {
+    // Dense-TE turnkeys (FLUX.2-klein, sc-8711): the tier subdir already holds a packed transformer
+    // + a DENSE bf16 text encoder, so the load Quant must be None — quantizing here would crush the
+    // dense bf16 TE we deliberately kept full-precision. The packed transformer self-describes its
+    // quant regardless. Tier selection (q4/q8/bf16) is driven by the resolved subdir, not this.
+    if DENSE_TE_TIER_MODELS.contains(&request.model.as_str()) {
+        return (None, None);
+    }
     let raw = request
         .advanced
         .get("mlxQuantize")

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -1547,6 +1547,71 @@ fn boogu_q4_real_weights_loads_and_generates() {
     );
 }
 
+/// Mixed-precision tier verify (sc-8513): load a tier with a PACKED Q4/Q8 transformer + a DENSE bf16
+/// text encoder and render. `SCENEWORKS_KLEIN_QUANT` sets the load hint — `none` (default) keeps the
+/// dense TE bf16 (the flux2 loader still detects + loads the packed transformer as-is, sc-5917), while
+/// `q4`/`q8` would also quantize the dense TE at load. Confirms the "quantize the transformer only,
+/// keep the TE bf16" tier works end to end. `SCENEWORKS_KLEIN_DIR` = the built tier;
+/// `SCENEWORKS_KLEIN_ENGINE` = the variant (`flux2_klein_9b` default). Run:
+/// `SCENEWORKS_KLEIN_DIR=… SCENEWORKS_KLEIN_QUANT=none cargo test -p sceneworks-worker --release --lib -- --ignored klein_tier_real_weights`.
+#[cfg(target_os = "macos")]
+#[test]
+#[ignore = "needs a built FLUX.2-klein tier dir + a high-memory Metal device"]
+fn klein_tier_real_weights_loads_and_generates() {
+    let dir = std::path::PathBuf::from(
+        std::env::var("SCENEWORKS_KLEIN_DIR")
+            .expect("set SCENEWORKS_KLEIN_DIR to a built klein tier"),
+    );
+    let engine =
+        std::env::var("SCENEWORKS_KLEIN_ENGINE").unwrap_or_else(|_| "flux2_klein_9b".to_owned());
+    let quant = match std::env::var("SCENEWORKS_KLEIN_QUANT").as_deref() {
+        Ok("q4") => Some(gen_core::Quant::Q4),
+        Ok("q8") => Some(gen_core::Quant::Q8),
+        _ => None,
+    };
+    let size: u32 = std::env::var("SCENEWORKS_KLEIN_SIZE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(512);
+    eprintln!(
+        "[klein] loading {engine} from {} ({quant:?})…",
+        dir.display()
+    );
+    let generator = load_engine(&engine, dir, quant, Vec::new(), None).unwrap();
+    eprintln!("[klein] LOADED — generating {size}²…");
+    let cancel = gen_core::CancelFlag::new();
+    let (w, h, pixels) = generate_one(
+        generator.as_ref(),
+        "a serene mountain lake at dawn",
+        size,
+        size,
+        42,
+        8,
+        Some(4.0),
+        None,
+        None,
+        &[],
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        false,
+        &PromptEnhance::default(),
+        &cancel,
+        &mut |_| {},
+    )
+    .unwrap();
+    eprintln!("[klein] GENERATED {w}x{h}");
+    assert_eq!((w, h), (size, size));
+    assert_eq!(pixels.len(), (size * size * 3) as usize);
+    assert!(
+        pixels.windows(2).any(|p| p[0] != p[1]),
+        "render is flat (degenerate)"
+    );
+}
+
 /// bf16 tier verify (sc-8513, epic 8506): load the DENSE Ideogram 4 `bf16/` tier (`Quant::None`) from
 /// the shared `SceneWorks/ideogram-4` repo through the real worker `ideogram_4` engine path and render.
 /// Proves the macOS MLX lane loads the cross-repo bf16 (resolved by `resolve_weights_dir` when

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -2446,7 +2446,9 @@ mod tier_builder {
                 "scheduler",
                 "model_index.json",
             ],
-            "flux2_dev_quant" => &["text_encoder", "vae", "tokenizer", "model_index.json"],
+            "flux2_dev_quant" | "flux2_klein_quant" => {
+                &["text_encoder", "vae", "tokenizer", "model_index.json"]
+            }
             other => panic!("unknown SC8513_CONVERTER {other}"),
         }
     }
@@ -2518,7 +2520,15 @@ mod tier_builder {
                 "sd3_5_medium_quant" => {
                     convert_sd3_prequant(&src, &out, Sd3Variant::Medium, bits, group_size)
                 }
-                "flux2_dev_quant" => convert_flux2_dev_prequant(&src, &out, bits, group_size),
+                // FLUX.2-dev (Mistral TE) and FLUX.2-klein (Qwen3 TE) share the family
+                // converter. `quantize_flux2_text_encoder_dir`'s `is_target` matches only Mistral
+                // layer names, so on klein the Qwen3 TE stays DENSE bf16 — exactly epic 8506's
+                // "quantize the transformer, keep the TE bf16" for a non-standard TE (sc-8711).
+                // The same call yields a packed transformer + dense bf16 Qwen3 TE; the worker loads
+                // it with Quant::None (`DENSE_TE_TIER_MODELS`) so the dense TE is never re-quantized.
+                "flux2_dev_quant" | "flux2_klein_quant" => {
+                    convert_flux2_dev_prequant(&src, &out, bits, group_size)
+                }
                 other => panic!("unknown SC8513_CONVERTER {other}"),
             };
             result.unwrap_or_else(|error| panic!("production convert failed: {error}"));

--- a/tests/test_worker_image_adapters.py
+++ b/tests/test_worker_image_adapters.py
@@ -1063,11 +1063,16 @@ def test_flux2_klein_manifest_entries_present():
         assert '"adapter": "mlx_flux2"' in block, model_id
         assert '"family": "flux2-klein"' in block, model_id
         assert '"macOnly": true' in block, model_id
-        assert '"gated": true' in block, model_id
+        # sc-8711 (epic 8506): re-hosted as a public, ungated SceneWorks MLX quant-matrix
+        # turnkey (q4/q8/bf16), so the entry is `gated: false` with no credentialHost — the
+        # FLUX Non-Commercial LICENSE.md travels with the weights.
+        assert '"gated": false' in block, model_id
         mlx_block = find_mlx_block(block)
         quant_match = re.search(r'"quantize"\s*:\s*(\d+)', mlx_block)
         assert quant_match is not None, f"{model_id}: mlx.quantize missing"
-        assert int(quant_match.group(1)) == 8, f"{model_id}: quantize should be 8 (sweet spot)"
+        # quantize records the DEFAULT tier (q4); the load Quant is forced to None so the
+        # dense bf16 Qwen3 TE is preserved (DENSE_TE_TIER_MODELS).
+        assert int(quant_match.group(1)) == 4, f"{model_id}: default tier should be q4 (sc-8711)"
         assert '"text_to_image"' in block, model_id
         assert '"character_image"' in block, model_id
 


### PR DESCRIPTION
## What

Ships the **bf16 / q8 / q4 quant matrix** for `flux2_klein_9b` and `flux2_klein_9b_kv` as SceneWorks pre-built MLX turnkeys (epic 8506, sc-8711), replacing the gated BFL whole-repo download + load-time quantize.

- [SceneWorks/flux2-klein-9b-mlx](https://huggingface.co/SceneWorks/flux2-klein-9b-mlx) — `q4/` (default), `q8/`, `bf16/`
- [SceneWorks/flux2-klein-9b-kv-mlx](https://huggingface.co/SceneWorks/flux2-klein-9b-kv-mlx) — `q4/` (default), `q8/`, `bf16/`

Both public + ungated (`gated=false`), LICENSE.md travels with the weights (FLUX Non-Commercial — non-commercial use only).

## The klein twist: transformer-only quant, dense bf16 TE

Unlike flux2_dev (Mistral TE, packed in every tier), klein's **8B Qwen3 text encoder stays full-precision bf16 in every tier** — per Michael's "we're not quantizing text encoders right now" + epic 8506's "quantize the transformer, keep the TE bf16". So only the transformer is packed in q4/q8.

The worker therefore loads each tier with **`Quant::None`** (new `DENSE_TE_TIER_MODELS`), so the dense bf16 TE is never re-quantized at load; the packed transformer self-describes its quant via the flux2 loader (sc-5917). Contrast flux2_dev, where the resolved Q4 was a harmless no-op because its TE was packed too.

## Changes

- **`base.rs`**: register `flux2_klein_9b`/`_kv` in `STANDARD_TIER_MODELS` (tier-subdir selection q4/q8/bf16) + new `DENSE_TE_TIER_MODELS` that forces `resolve_quant → None`.
- **`model_jobs.rs`**: `tier_builder` `flux2_klein_quant` arm — shares the FLUX.2-family converter; the Qwen3 TE passes through dense because `is_target` matches only Mistral layer names.
- **`builtin.models.jsonc`**: per-tier `q4`(default)/`q8`/`bf16` downloads from the SceneWorks repos; `gated:false`, drop `credentialHost`, SceneWorks `licenseUrl`; `mlx.quantize:4` records the default tier (load Quant forced to None).
- **`tests.rs`**: configurable on-device klein tier verify (`SCENEWORKS_KLEIN_QUANT`).

## Verification

- `cargo fmt --all --check`, `cargo clippy -p sceneworks-worker --all-targets -D warnings`, candle parity `cargo check --no-default-features -F backend-candle --all-targets`, full `cargo test -p sceneworks-worker --lib` (475 passed) — all green, post-merge.
- **On-device**: q4 + q8 tiers for **both** `flux2_klein_9b` and `flux2_klein_9b_kv` load with `Quant::None` and generate 512² (the packed transformer loads packed, the dense bf16 Qwen3 TE is left untouched).

## Out of scope

`flux2_klein_9b_true_v2` stays on its single-file→diffusers convert (candle-only) and is not a turnkey yet — tracked in sc-8711.

Relates: sc-8513, epic 8506.

🤖 Generated with [Claude Code](https://claude.com/claude-code)