### PR TITLE
feat(web): shared Save As / Reveal asset action layer (sc-8727)

### DIFF
--- a/apps/web/src/assetActions.js
+++ b/apps/web/src/assetActions.js
@@ -1,0 +1,141 @@
+// Shared "Save As" / "Reveal in Finder/Explorer" action layer for assets (sc-8727).
+//
+// Both the Save As button (sc-8728) and the asset context menu (sc-8729) call these
+// functions, so the desktop-vs-browser branching lives in exactly one place:
+//
+//   - Desktop shell (Tauri): resolve the asset's absolute on-disk path via the
+//     `resolve_asset_path` command, then hand it to `save_asset_as` (native save
+//     dialog + copy) or `reveal_in_os` (Finder/Explorer select).
+//   - Remote browser / LAN mode (no `window.__TAURI__`): fall back to a normal
+//     browser download of the asset's served URL. Reveal has no browser analogue,
+//     so callers hide it and `revealAsset` throws if invoked anyway.
+//
+// Content-agnostic: works identically for image and video assets.
+import { isDesktop, tauriInvoke } from "./runtime.js";
+import { assetUrl } from "./components/assetMedia.jsx";
+
+// Map the common asset MIME types to a file extension, for when the source path
+// carries no extension we can reuse. Kept small and explicit rather than pulling a
+// mime-db dependency — these are the formats the worker actually emits.
+const MIME_EXTENSIONS = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/jpg": "jpg",
+  "image/webp": "webp",
+  "image/gif": "gif",
+  "image/avif": "avif",
+  "image/bmp": "bmp",
+  "image/tiff": "tiff",
+  "video/mp4": "mp4",
+  "video/webm": "webm",
+  "video/quicktime": "mov",
+  "video/x-matroska": "mkv",
+};
+
+// Pull the lowercase extension (no dot) off a path/filename, or "" if it has none.
+// Guards against a trailing dot and a leading-dot "dotfile" with no real extension.
+function extensionFromPath(pathOrName) {
+  const name = String(pathOrName ?? "")
+    .replaceAll("\\", "/")
+    .split("/")
+    .pop();
+  const dot = name.lastIndexOf(".");
+  if (dot <= 0 || dot === name.length - 1) {
+    return "";
+  }
+  return name.slice(dot + 1).toLowerCase();
+}
+
+// The extension we believe the asset's bytes actually are: prefer the source file
+// path's extension (that's the real on-disk format), then fall back to the MIME type.
+function assetExtension(asset) {
+  const fromPath = extensionFromPath(asset?.file?.path);
+  if (fromPath) {
+    return fromPath;
+  }
+  const mime = String(asset?.file?.mimeType ?? "").toLowerCase().split(";")[0].trim();
+  return MIME_EXTENSIONS[mime] ?? "";
+}
+
+// The filename we suggest in the save dialog / download: the asset's display name,
+// with a correct extension appended when it's missing (or mismatched from the real
+// format). Falls back to the asset id, then a generic "asset", so we never suggest an
+// empty name.
+export function suggestedFilename(asset) {
+  const base = String(asset?.displayName ?? asset?.id ?? "asset").trim() || "asset";
+  const ext = assetExtension(asset);
+  if (!ext) {
+    return base;
+  }
+  // Already ends with the right extension — leave it as-is.
+  if (extensionFromPath(base) === ext) {
+    return base;
+  }
+  return `${base}.${ext}`;
+}
+
+// Resolve an asset to its absolute on-disk path via the desktop command. Only valid
+// when `isDesktop`; the two desktop-only actions below call this.
+function resolveAbsolutePath(asset) {
+  return tauriInvoke("resolve_asset_path", {
+    projectId: asset?.projectId,
+    relativePath: asset?.file?.path,
+  });
+}
+
+// Trigger a normal browser download of the asset's served URL. Uses a transient
+// `<a download>` click, which is the portable way to name a cross-origin-safe,
+// same-origin download without a fetch/blob round-trip. Content-agnostic.
+function browserDownload(asset) {
+  const href = assetUrl(asset);
+  if (!href) {
+    throw new Error("This asset has no downloadable URL.");
+  }
+  const anchor = document.createElement("a");
+  anchor.href = href;
+  anchor.download = suggestedFilename(asset);
+  anchor.rel = "noopener";
+  // Some browsers require the anchor to be in the document for the click to count.
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+}
+
+// Save an asset to a user-chosen location.
+//   - Desktop: resolve the absolute path, then open the native save dialog pre-filled
+//     with the suggested filename and copy the bytes there. A user-cancel (the command
+//     returns null) is handled quietly — no error. Returns the destination path on
+//     success, or null on cancel.
+//   - Browser/LAN: trigger a normal download of the asset URL. Returns null (there's no
+//     destination path to report).
+// Works for both image and video assets.
+export async function saveAssetAs(asset) {
+  if (!asset) {
+    throw new Error("An asset is required.");
+  }
+  if (!isDesktop) {
+    browserDownload(asset);
+    return null;
+  }
+  const absolutePath = await resolveAbsolutePath(asset);
+  // `save_asset_as` returns the destination path, or null when the user cancels.
+  const destination = await tauriInvoke("save_asset_as", {
+    sourcePath: absolutePath,
+    suggestedFilename: suggestedFilename(asset),
+  });
+  return destination ?? null;
+}
+
+// Reveal an asset in Finder/Explorer with the file selected. Desktop-only — there is
+// no browser equivalent, so callers hide/disable this in browser mode. Guarded here
+// too: throws a clear error rather than dereferencing the absent Tauri bridge.
+export async function revealAsset(asset) {
+  if (!isDesktop) {
+    throw new Error("Reveal in Finder/Explorer is only available in the desktop app.");
+  }
+  if (!asset) {
+    throw new Error("An asset is required.");
+  }
+  const absolutePath = await resolveAbsolutePath(asset);
+  await tauriInvoke("reveal_in_os", { path: absolutePath });
+}

--- a/apps/web/src/assetActions.test.js
+++ b/apps/web/src/assetActions.test.js
@@ -1,0 +1,176 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// assetActions derives `isDesktop` from window.__TAURI__ at module load (via
+// runtime.js), so — like SettingsScreen.test.jsx — we set/delete the Tauri bridge
+// and re-import the module fresh in each test to exercise both branches.
+const IMAGE_ASSET = {
+  id: "asset_img",
+  type: "image",
+  displayName: "Mira",
+  projectId: "project_1",
+  file: { path: "assets/images/Mira.png", mimeType: "image/png" },
+};
+const VIDEO_ASSET = {
+  id: "asset_vid",
+  type: "video",
+  displayName: "Clip",
+  projectId: "project_1",
+  file: { path: "assets/videos/Clip.mp4", mimeType: "video/mp4" },
+};
+
+async function importDesktop(invoke) {
+  window.__TAURI__ = { core: { invoke } };
+  vi.resetModules();
+  return import("./assetActions.js");
+}
+
+async function importBrowser() {
+  delete window.__TAURI__;
+  vi.resetModules();
+  return import("./assetActions.js");
+}
+
+afterEach(() => {
+  delete window.__TAURI__;
+  vi.restoreAllMocks();
+});
+
+describe("suggestedFilename (sc-8727)", () => {
+  it("keeps the display name when it already has the right extension", async () => {
+    const { suggestedFilename } = await importBrowser();
+    expect(suggestedFilename({ displayName: "Mira.png", file: { path: "a/Mira.png", mimeType: "image/png" } })).toBe("Mira.png");
+  });
+
+  it("appends the source-path extension when the display name has none (image)", async () => {
+    const { suggestedFilename } = await importBrowser();
+    expect(suggestedFilename(IMAGE_ASSET)).toBe("Mira.png");
+  });
+
+  it("appends the source-path extension for a video asset", async () => {
+    const { suggestedFilename } = await importBrowser();
+    expect(suggestedFilename(VIDEO_ASSET)).toBe("Clip.mp4");
+  });
+
+  it("derives the extension from the mime type when the path has none", async () => {
+    const { suggestedFilename } = await importBrowser();
+    const asset = { displayName: "shot", file: { path: "assets/images/shot", mimeType: "image/jpeg" } };
+    expect(suggestedFilename(asset)).toBe("shot.jpg");
+  });
+
+  it("falls back to the id, then a generic name, and leaves off an unknown extension", async () => {
+    const { suggestedFilename } = await importBrowser();
+    expect(suggestedFilename({ id: "asset_9", file: {} })).toBe("asset_9");
+    expect(suggestedFilename({})).toBe("asset");
+  });
+});
+
+describe("saveAssetAs — desktop (sc-8727)", () => {
+  it("resolves the path then saves with the suggested filename (image)", async () => {
+    const invoke = vi.fn(async (command) => {
+      if (command === "resolve_asset_path") return "/data/project_1/assets/images/Mira.png";
+      if (command === "save_asset_as") return "/Users/me/Desktop/Mira.png";
+      return null;
+    });
+    const { saveAssetAs } = await importDesktop(invoke);
+
+    const dest = await saveAssetAs(IMAGE_ASSET);
+
+    expect(invoke).toHaveBeenNthCalledWith(1, "resolve_asset_path", {
+      projectId: "project_1",
+      relativePath: "assets/images/Mira.png",
+    });
+    expect(invoke).toHaveBeenNthCalledWith(2, "save_asset_as", {
+      sourcePath: "/data/project_1/assets/images/Mira.png",
+      suggestedFilename: "Mira.png",
+    });
+    expect(dest).toBe("/Users/me/Desktop/Mira.png");
+  });
+
+  it("works for a video asset too", async () => {
+    const invoke = vi.fn(async (command) => {
+      if (command === "resolve_asset_path") return "/data/project_1/assets/videos/Clip.mp4";
+      if (command === "save_asset_as") return "/Users/me/Desktop/Clip.mp4";
+      return null;
+    });
+    const { saveAssetAs } = await importDesktop(invoke);
+
+    await saveAssetAs(VIDEO_ASSET);
+
+    expect(invoke).toHaveBeenNthCalledWith(2, "save_asset_as", {
+      sourcePath: "/data/project_1/assets/videos/Clip.mp4",
+      suggestedFilename: "Clip.mp4",
+    });
+  });
+
+  it("returns null quietly when the user cancels the save dialog", async () => {
+    const invoke = vi.fn(async (command) => {
+      if (command === "resolve_asset_path") return "/data/project_1/assets/images/Mira.png";
+      return null; // save_asset_as returns null on cancel
+    });
+    const { saveAssetAs } = await importDesktop(invoke);
+
+    await expect(saveAssetAs(IMAGE_ASSET)).resolves.toBeNull();
+  });
+});
+
+describe("saveAssetAs — browser (sc-8727)", () => {
+  it("triggers an <a download> and never calls invoke", async () => {
+    const { saveAssetAs } = await importBrowser();
+
+    const clicked = [];
+    const clickSpy = vi
+      .spyOn(window.HTMLAnchorElement.prototype, "click")
+      .mockImplementation(function mockClick() {
+        clicked.push({ href: this.href, download: this.download });
+      });
+
+    const dest = await saveAssetAs(IMAGE_ASSET);
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(clicked[0].download).toBe("Mira.png");
+    expect(clicked[0].href).toContain(
+      "/api/v1/projects/project_1/files/assets/images/Mira.png",
+    );
+    expect(dest).toBeNull();
+    // No anchor left dangling in the DOM.
+    expect(document.querySelector("a[download]")).toBeNull();
+  });
+
+  it("works for a video asset in the browser", async () => {
+    const { saveAssetAs } = await importBrowser();
+    const clicked = [];
+    vi.spyOn(window.HTMLAnchorElement.prototype, "click").mockImplementation(function mockClick() {
+      clicked.push({ href: this.href, download: this.download });
+    });
+
+    await saveAssetAs(VIDEO_ASSET);
+
+    expect(clicked[0].download).toBe("Clip.mp4");
+    expect(clicked[0].href).toContain("/api/v1/projects/project_1/files/assets/videos/Clip.mp4");
+  });
+});
+
+describe("revealAsset (sc-8727)", () => {
+  it("resolves the path then reveals it in the OS (desktop)", async () => {
+    const invoke = vi.fn(async (command) => {
+      if (command === "resolve_asset_path") return "/data/project_1/assets/images/Mira.png";
+      return null;
+    });
+    const { revealAsset } = await importDesktop(invoke);
+
+    await revealAsset(IMAGE_ASSET);
+
+    expect(invoke).toHaveBeenNthCalledWith(1, "resolve_asset_path", {
+      projectId: "project_1",
+      relativePath: "assets/images/Mira.png",
+    });
+    expect(invoke).toHaveBeenNthCalledWith(2, "reveal_in_os", {
+      path: "/data/project_1/assets/images/Mira.png",
+    });
+  });
+
+  it("throws in browser mode (desktop-only)", async () => {
+    const { revealAsset } = await importBrowser();
+    await expect(revealAsset(IMAGE_ASSET)).rejects.toThrow(/desktop app/i);
+  });
+});


### PR DESCRIPTION
## What & why

S2 of the Save As / Reveal feature. Adds the shared **frontend action layer** that both the Save As button (sc-8728) and the asset context menu (sc-8729) will call, so the desktop-vs-browser branching lives in exactly one place. Builds on the desktop commands landed in #1021 (sc-8726): `resolve_asset_path`, `save_asset_as`, `reveal_in_os`.

New module: `apps/web/src/assetActions.js`.

### `saveAssetAs(asset)`
- **Desktop** (`isDesktop` from `runtime.js`): resolve the asset's absolute path via `resolve_asset_path({ projectId, relativePath })`, then `save_asset_as({ sourcePath, suggestedFilename })` (native dialog + copy). Returns the destination path, or `null` on user-cancel (handled quietly — no error).
- **Browser/LAN**: triggers a normal download via a transient `<a download>` whose `href = assetUrl(asset)` and `download = suggestedFilename(asset)`. Never calls `invoke`.
- Content-agnostic — works for image and video assets.

### `revealAsset(asset)`
- Desktop-only: resolve the absolute path, then `reveal_in_os({ path })`. Throws a clear error in browser mode; callers also hide it.

### Suggested filename
Display name with a correct extension, derived from the source path extension first, then the MIME type (`asset.file.mimeType`). Falls back to the asset id, then a generic `asset`.

Verified the Tauri command signatures in `apps/desktop/src/settings.rs` and matched the camelCase-key convention Tauri maps to snake_case Rust args (as `SettingsScreen.jsx` does with `invoke("reveal_in_os", { path })`).

## Scope vs acceptance criteria
- ✅ Desktop Save As opens the native dialog with a display-name filename; file lands at the chosen path.
- ✅ Browser/LAN Save As triggers a normal download; Reveal is desktop-only (throws + callers gate).
- ✅ Works for both image and video assets.
- ✅ Reveal resolves + calls `reveal_in_os` to select the file.
- Wiring the UI buttons/menu items is sc-8728 / sc-8729 (out of scope here).

## Tests
`apps/web/src/assetActions.test.js` — 12 tests, following the `SettingsScreen.test.jsx` pattern of set/delete `window.__TAURI__` + fresh module import per branch:
- filename/extension derivation (image path, video path, mime fallback, id/generic fallback, keep-existing-extension)
- desktop path calls `resolve_asset_path` then `save_asset_as` with correct camelCase args (image + video); cancel returns `null` quietly
- browser path builds `<a download>` with right href/filename, never calls `invoke`, leaves no dangling anchor
- reveal is desktop-only (throws in browser)

Full web suite green: **888 tests / 53 files passed**. ESLint clean on the new files.

## Follow-ups
- **"Remember last-used save directory" needs a Rust arg.** `save_asset_as(source_path, suggested_filename)` in `apps/desktop/src/settings.rs` owns the native dialog and does not accept a starting directory, so the frontend cannot influence the dialog's default folder. This story implements everything possible at the frontend layer (correct default filename). Persisting/steering the last-used directory requires adding a `start_dir` argument to `save_asset_as` (Rust) — filing as a tracked follow-up rather than expanding this pure-frontend story's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)