### PR TITLE
fix(web): portal ImageEditor "New blank layout" modal to document.body

### DIFF
--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { Stage, Layer, Image as KonvaImage, Line, Rect, Transformer } from "react-konva";
 import { apiFetch } from "../api.js";
 import { terminalStatuses } from "../jobTypes.js";
@@ -3872,7 +3873,12 @@ export function ImageEditor() {
         />
       ) : null}
 
-      {newLayoutOpen ? (
+      {/* Portaled to document.body: the backdrop is `position: fixed`, which only
+          anchors to the viewport when no ancestor establishes a containing block.
+          Rendering it inline under the editor section left it vulnerable to being
+          trapped inside a transformed/filtered ancestor (see Modal.jsx). */}
+      {newLayoutOpen
+        ? createPortal(
         <div
           className="image-editor-modal-backdrop"
           onClick={() => setNewLayoutOpen(false)}
@@ -3922,8 +3928,10 @@ export function ImageEditor() {
               </button>
             </div>
           </div>
-        </div>
-      ) : null}
+        </div>,
+            document.body,
+          )
+        : null}
     </section>
   );
 }


### PR DESCRIPTION
## What

Wrap the image editor's **"New blank layout"** dialog in `createPortal(..., document.body)`, preserving its exact markup, classes, and behavior.

## Why

Follow-up to #1020 (which portaled the shared `Modal` primitive). The editor's New-blank-layout dialog uses its own bespoke `.image-editor-modal-backdrop` — it does **not** go through the shared `Modal` — and was still rendered inline under the editor `<section>`. Its backdrop is `position: fixed; inset: 0`, so it carried the same containing-block vulnerability: any ancestor with `transform` / `filter` / `backdrop-filter` / `contain` / `will-change` / `perspective` (the editor uses react-konva) would confine the overlay to the parent's box instead of the viewport. Portaling to `body` makes it a direct child of `body`, immune to any such ancestor.

## Scope

- **Portaled:** only `.image-editor-modal-backdrop` (the full-screen New-blank-layout modal).
- **Left untouched:** `.image-editor-shortcuts` is `position: absolute` — an intentional corner popover anchored inside the editor canvas, not a full-screen modal. Portaling it would break its placement.

## Verification

- Full web suite green: **876/876** (`vitest run --environment jsdom`); ImageEditor suite 71/71.
- `eslint`: 0 errors. No test changes needed (the blank-canvas tests exercise the pure `blankCanvasDims` helper, not the modal DOM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)