### PR TITLE
fix(desktop): disable Tauri dragDropEnabled — native file picker blanks WebView2 on Windows (sc-6551)

### DIFF
--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -17,7 +17,8 @@
         "height": 832,
         "minWidth": 960,
         "minHeight": 640,
-        "resizable": true
+        "resizable": true,
+        "dragDropEnabled": false
       }
     ],
     "security": {


### PR DESCRIPTION
## What

Adds `"dragDropEnabled": false` to the main window in [`apps/desktop/tauri.conf.json`](apps/desktop/tauri.conf.json).

## Why

**User-reported symptom (Windows):** On the Models page, clicking **Choose** to upload a LoRA (or a model file) opens the native OS file picker and the entire app screen goes blank and never recovers — regardless of whether the user selects a file or cancels — locking them out of the app.

**Root cause:** Tauri's window `dragDropEnabled` defaults to `true` and was not overridden. With it enabled, Tauri intercepts OS drag/drop at the native layer. On Windows/WebView2 this collides with the native HTML `<input type="file">` dialog used by the upload "Choose" buttons ([`ModelManagerScreen.jsx:1158`](apps/web/src/screens/ModelManagerScreen.jsx#L1158), and the model + Wan low-noise-expert inputs): opening the file dialog blanks the webview and it never repaints.

This is the Windows manifestation of **[sc-6551](https://app.shortcut.com/trefry/story/6551)**, which flagged the same `dragDropEnabled` default breaking HTML5 drops on macOS WKWebView and explicitly predicted it "probably already affects the Windows build." The story's fix option (a) is exactly this change.

## Fix

Setting `dragDropEnabled: false` resolves both platforms:
- **Windows:** the native file dialog no longer blanks WebView2.
- **macOS/Windows:** HTML5 `dataTransfer.files` drop events now reach the webview, restoring drag-to-upload in the dropzones sc-6551 lists (DatasetAddDialog, AssetPicker, ImageEditor).

## Safety / regression

No code anywhere listens for Tauri's native `onDragDropEvent` / `getCurrentWebview().onDragDropEvent()` (grep is empty), so disabling native drag-drop interception regresses nothing — it only stops Tauri from swallowing events the web layer already handles.

## Testing

- `tauri.conf.json` validated as well-formed JSON.
- Config-only change; takes effect in a rebuilt desktop bundle. Not observable in a plain browser session (which was never affected).

Resolves sc-6551.

🤖 Generated with [Claude Code](https://claude.com/claude-code)