### PR TITLE
S5 (sc-8730): editorLaunch channel + route preview Edit to the Image Editor canvas

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -527,6 +527,11 @@ export function App() {
     setPreviewAsset(null);
   };
   const [studioLaunch, setStudioLaunch] = useState(null);
+  // sc-8730: the launch channel INTO the Image Editor canvas (crop/upscale/refine
+  // screen, activeView === "ImageEditor"). Mirrors studioLaunch but targets the
+  // editor's openAsset(assetId) rather than Image Studio. `id` is a fresh UUID per
+  // launch so relaunching the same asset still fires the editor's id-keyed effect.
+  const [editorLaunch, setEditorLaunch] = useState(null);
   // sc-4198: a small notices store replaces the single `error` string that used to
   // double as a message bus — the fragile "lora import:"/"lora training:" startsWith
   // protocol. Each notice has a stable `kind`; pushing a kind replaces only that kind
@@ -1693,9 +1698,11 @@ export function App() {
     setActiveView("Image");
   }, []);
 
-  // "Edit" from the fullscreen preview: open Image Studio in edit mode with this
-  // image as the source, preselecting the family-matched edit model when possible.
-  function sendAssetToImageEdit(asset) {
+  // Open Image Studio in edit mode with this image as the source, preselecting the
+  // family-matched edit model when possible. sc-8730: this is the model-based path,
+  // no longer wired to the preview Edit button — it stays on the context so S4
+  // (sc-8729) can offer it as an "Edit in > Image Studio" context-menu item.
+  const sendAssetToImageEdit = useCallback((asset) => {
     if (!asset) {
       return;
     }
@@ -1708,7 +1715,24 @@ export function App() {
       model: editModelForAsset(asset, imageModels),
     });
     setActiveView("Image");
-  }
+  }, [imageModels]);
+
+  // sc-8730: "Edit" from the fullscreen preview now opens the Image Editor canvas
+  // (crop/upscale/refine) with this asset loaded via the editor's openAsset. This is
+  // the model-free path; the model-based Image Studio edit_image path lives in
+  // sendAssetToImageEdit above (kept for the S4 "Edit in > Image Studio" menu item).
+  const sendAssetToImageEditor = useCallback((asset) => {
+    if (!asset) {
+      return;
+    }
+    setSelectedAssetId(asset.id);
+    setEditorLaunch({ id: crypto.randomUUID(), assetId: asset.id });
+    setActiveView("ImageEditor");
+  }, []);
+
+  // The editor consumes editorLaunch and calls this to drop it, so navigating away
+  // and back into the Image Editor without a fresh launch doesn't re-open a stale asset.
+  const clearEditorLaunch = useCallback(() => setEditorLaunch(null), []);
 
   function recipeForAsset(asset) {
     return asset?.generationSet?.recipe ?? asset?.recipe ?? null;
@@ -1994,6 +2018,13 @@ export function App() {
     imageLocalJobs,
     documentLocalJobs,
     studioLaunch,
+    // sc-8730: Image Editor launch channel + the two Edit paths. sendAssetToImageEditor
+    // routes to the editor canvas (FullscreenPreview Edit button); sendAssetToImageEdit
+    // routes to Image Studio edit_image (exposed for the S4 sc-8729 context menu).
+    editorLaunch,
+    clearEditorLaunch,
+    sendAssetToImageEditor,
+    sendAssetToImageEdit,
     rememberLocalGenerationJob,
     // Person tracks (Video Studio + Replace Person)
     personTracks,
@@ -2087,6 +2118,7 @@ export function App() {
     jobPrompt, setJobPrompt, projectFilter, setProjectFilter, projects, visibleWorkers, workersById,
     createVideoJob, createVideoUpscaleJob, createImageJob, refinePrompt, magicPrompt, imageCaption, imageDescribe, compareFaceLikeness, latestVideoAssets, recentImageAssets,
     recentVideoAssets, videoLocalJobs, imageLocalJobs, documentLocalJobs, studioLaunch,
+    editorLaunch, clearEditorLaunch, sendAssetToImageEditor, sendAssetToImageEdit,
     rememberLocalGenerationJob, personTracks, personReadiness, createPersonDetectionJob,
     createPersonTrackJob, saveTrackCorrections, imageModels, videoModels, models, macCapabilities,
     loras, deleteLora, deleteModel, createModelDownloadJob, createLoraDownloadJob, createModelConvertJob,
@@ -2337,7 +2369,7 @@ export function App() {
           }}
           nextAsset={previewNavigation.next}
           onClose={closePreview}
-          onEditImage={sendAssetToImageEdit}
+          onEditImage={sendAssetToImageEditor}
           onPreviewAsset={(asset, direction) => {
             if (direction) {
               previewDirectionRef.current = direction;

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -2077,6 +2077,45 @@ describe("SceneWorks app shell", () => {
     expect(onUseRecipe).toHaveBeenCalledWith(asset);
   });
 
+  // sc-8730: the FullscreenPreview "Edit" button invokes onEditImage, which App now
+  // wires to sendAssetToImageEditor (the Image Editor canvas route) instead of the
+  // Image Studio edit_image route. This proves the button → onEditImage contract the
+  // repointed call site depends on.
+  it("routes the FullscreenPreview Edit button through onEditImage", async () => {
+    const noop = () => {};
+    const onEditImage = vi.fn();
+    const asset = {
+      id: "asset-edit",
+      displayName: "Plate",
+      type: "image",
+      status: {},
+      file: { path: "assets/images/plate.png" },
+    };
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <FullscreenPreview
+          asset={asset}
+          deleteAsset={noop}
+          nextAsset={null}
+          onClose={noop}
+          onEditImage={onEditImage}
+          onPreviewAsset={noop}
+          previousAsset={null}
+          purgeAsset={noop}
+          updateAssetStatus={noop}
+        />,
+      );
+    });
+
+    await act(async () => {
+      [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Edit").click();
+    });
+
+    expect(onEditImage).toHaveBeenCalledWith(asset);
+  });
+
   it("reports the scroll direction when navigating the FullscreenPreview", async () => {
     const noop = () => {};
     const onPreviewAsset = vi.fn();

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -761,6 +761,8 @@ export function ImageEditor() {
     purgeAsset,
     registerLeaveGuard,
     imageModels,
+    editorLaunch = null,
+    clearEditorLaunch,
     macCapabilities = DEFAULT_MAC_CAPABILITIES,
   } = useAppContext();
   // Mac UI gating (sc-3486): the upscale tool itself runs in-process on Rust (Real-ESRGAN,
@@ -1355,6 +1357,22 @@ export function ImageEditor() {
     },
     [imageAssets, openFromBlob],
   );
+
+  // sc-8730: consume the App-level Image Editor launch channel. When something outside
+  // the editor (currently the FullscreenPreview "Edit" button via sendAssetToImageEditor)
+  // routes an asset here, App switches activeView to "ImageEditor" and stashes
+  // { id, assetId } in editorLaunch. Keyed on the launch id so it fires once per launch
+  // (relaunching the same asset gets a fresh id) and never on unrelated re-renders.
+  // Entering via the nav with no launch leaves editorLaunch null → no auto-open. We clear
+  // the launch after consuming it so navigating away and back doesn't re-open a stale asset.
+  useEffect(() => {
+    if (!editorLaunch?.assetId) {
+      return;
+    }
+    openAsset(editorLaunch.assetId);
+    clearEditorLaunch?.();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editorLaunch?.id]);
 
   const openFile = useCallback(
     (file) => {

--- a/apps/web/src/screens/ImageEditor.test.jsx
+++ b/apps/web/src/screens/ImageEditor.test.jsx
@@ -195,6 +195,74 @@ describe("ImageEditor scaffold", () => {
     expect(container.querySelector(".image-editor-shortcuts")).toBeNull();
     input.remove();
   });
+
+  // sc-8730: the editorLaunch channel routes an asset into the editor canvas from
+  // outside (the FullscreenPreview "Edit" button). The id-keyed effect calls openAsset
+  // for the launched asset, which fetches its media URL — so a fetch to that URL is the
+  // observable signal that the launch was consumed. Entering with no launch must not
+  // auto-open anything, and consuming the launch calls clearEditorLaunch so navigating
+  // back doesn't re-open a stale asset.
+  describe("editorLaunch channel (sc-8730)", () => {
+    const IMAGE_ASSET = {
+      id: "asset-launch",
+      type: "image",
+      displayName: "Launched plate",
+      projectId: "project_1",
+      file: { path: "assets/images/launched.png" },
+    };
+
+    let fetchSpy;
+
+    beforeEach(() => {
+      fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue({
+        ok: true,
+        status: 200,
+        blob: async () => new Blob(["x"], { type: "image/png" }),
+      });
+    });
+
+    afterEach(() => {
+      fetchSpy.mockRestore();
+    });
+
+    it("does not auto-open anything when entering with no launch", async () => {
+      await render(baseContext({ assets: [IMAGE_ASSET], editorLaunch: null }));
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("opens the launched asset (fetches its media) and clears the launch", async () => {
+      const clearEditorLaunch = vi.fn();
+      await render(
+        baseContext({
+          assets: [IMAGE_ASSET],
+          editorLaunch: { id: "launch-1", assetId: IMAGE_ASSET.id },
+          clearEditorLaunch,
+        }),
+      );
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy.mock.calls[0][0]).toContain(
+        "/api/v1/projects/project_1/files/assets/images/launched.png",
+      );
+      // The launch is consumed exactly once so returning to the editor won't re-open it.
+      expect(clearEditorLaunch).toHaveBeenCalledTimes(1);
+    });
+
+    it("ignores a launch whose asset isn't a renderable image in the project", async () => {
+      const clearEditorLaunch = vi.fn();
+      await render(
+        baseContext({
+          assets: [IMAGE_ASSET],
+          editorLaunch: { id: "launch-2", assetId: "missing-asset" },
+          clearEditorLaunch,
+        }),
+      );
+      // openAsset returns early (asset not found) → no fetch. The launch is still
+      // cleared so it doesn't linger and re-fire on the next id-keyed evaluation.
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(clearEditorLaunch).toHaveBeenCalledTimes(1);
+    });
+  });
 });
 
 describe("crop geometry", () => {


### PR DESCRIPTION
## What & why

Nothing today sends an asset **into the Image Editor canvas** (the crop/upscale/refine screen, `activeView === "ImageEditor"`) from outside — you had to enter via the nav and pick an image with the editor's own picker. Meanwhile the fullscreen preview's **Edit** button routed to Image Studio's `edit_image` mode. This story (S5) creates the missing open-path and repoints the preview Edit button to the editor canvas.

## Changes

- **`App.jsx`**
  - New `editorLaunch` state — `{ id, assetId }` with a fresh `crypto.randomUUID()` per launch so relaunching the same asset still fires the editor's id-keyed effect. Mirrors the existing `studioLaunch` pattern.
  - New `sendAssetToImageEditor(asset)` — selects the asset, sets `editorLaunch`, and `setActiveView("ImageEditor")`.
  - New `clearEditorLaunch()` so the editor can consume the launch and prevent stale re-opens.
  - Exposed `editorLaunch`, `clearEditorLaunch`, `sendAssetToImageEditor`, and `sendAssetToImageEdit` on `AppContext` (added to the memo value + dep array).
  - Converted `sendAssetToImageEdit` to a `useCallback` so it is dep-array-stable; **kept intact** and now on the context so **S4 (sc-8729)** can wire it as an `Edit in > Image Studio` menu item.
  - Repointed `<FullscreenPreview onEditImage=... />` from `sendAssetToImageEdit` → `sendAssetToImageEditor`.
- **`screens/ImageEditor.jsx`**
  - Destructures `editorLaunch` / `clearEditorLaunch` from context.
  - A `useEffect` keyed on `editorLaunch?.id` calls the existing `openAsset(assetId)` then `clearEditorLaunch()`. Entering via the nav with no launch does nothing (no auto-open regression); consuming clears the launch so nav-away/back does not re-open stale.

## Scope vs acceptance criteria

- Clicking **Edit** in the fullscreen preview opens the Image Editor canvas with the asset loaded (via `openAsset`). ✅
- The model-based path (`sendAssetToImageEdit` → Image Studio `edit_image`, family-matched model) still exists and is reachable programmatically via the context for S4. ✅
- Other screens' send buttons (`sendAssetToImage`) unchanged — **preview-only**. ✅
- Entering the Image Editor from the nav with no launch works as before (no auto-open, no stale re-open). ✅

## Tests

- `screens/ImageEditor.test.jsx` — new `editorLaunch channel (sc-8730)` describe:
  - opens the launched asset (fetches its media URL) and calls `clearEditorLaunch` exactly once;
  - **no launch → no auto-open** (no fetch);
  - unknown/non-renderable asset → `openAsset` returns early (no fetch) but launch is still cleared.
- `main.test.jsx` — new case proving the FullscreenPreview **Edit** button invokes `onEditImage(asset)` (the contract the repointed call site depends on).
- Full web suite: **880 passing** (52 files). ESLint: **0 errors** (only pre-existing `exhaustive-deps` warnings; the new effect carries an intentional `eslint-disable-next-line`, matching the codebase convention).

## Verification

Pure-frontend; verified via the vitest suite. No Rust / rust-api contract surface touched. `origin/main` merged in (brings sc-8727's `assetActions.*`); PR diff is limited to the 4 files above.

## Follow-ups

- **S4 (sc-8729)** consumes `sendAssetToImageEdit` from the context as an `Edit in > Image Studio` context-menu item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)