### PR TITLE
feat(flux): pre-quantized q4/q8/bf16 tiers — packed-load wiring + pin bumps (sc-8669)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -513,7 +513,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -530,7 +530,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -582,7 +582,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -596,7 +596,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -611,7 +611,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -624,7 +624,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -636,7 +636,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -653,7 +653,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -668,7 +668,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -679,7 +679,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -694,7 +694,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -729,7 +729,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -740,7 +740,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -764,7 +764,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -777,7 +777,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -3528,7 +3528,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3541,7 +3541,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
 dependencies = [
  "image",
  "inventory",
@@ -3555,7 +3555,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
 dependencies = [
  "image",
  "inventory",
@@ -3569,7 +3569,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3582,7 +3582,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3593,7 +3593,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3602,7 +3602,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3611,7 +3611,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3619,12 +3619,13 @@ dependencies = [
  "mlx-gen-sdxl",
  "mlx-gen-z-image",
  "pmetal-mlx-rs",
+ "serde_json",
 ]
 
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3637,7 +3638,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3650,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3662,7 +3663,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3672,7 +3673,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
 dependencies = [
  "image",
  "inventory",
@@ -3685,7 +3686,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
 dependencies = [
  "image",
  "inventory",
@@ -3699,7 +3700,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
 dependencies = [
  "image",
  "inventory",
@@ -3713,7 +3714,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
 dependencies = [
  "image",
  "inventory",
@@ -3725,7 +3726,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3736,7 +3737,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3748,7 +3749,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3760,7 +3761,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3769,7 +3770,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3778,7 +3779,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3788,7 +3789,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3800,7 +3801,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
 dependencies = [
  "image",
  "inventory",
@@ -3815,7 +3816,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
 dependencies = [
  "image",
  "inventory",
@@ -3829,7 +3830,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3840,7 +3841,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3852,7 +3853,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3863,7 +3864,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
 dependencies = [
  "image",
  "inventory",
@@ -3877,7 +3878,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
 dependencies = [
  "image",
  "inventory",
@@ -5641,7 +5642,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
 dependencies = [
  "core-llm",
  "inventory",
@@ -8038,7 +8039,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_distr 0.5.1",
  "safetensors 0.7.0",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70)",
  "serde_json",
  "thiserror 2.0.18",
 ]
@@ -3528,12 +3528,12 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486)",
  "thiserror 2.0.18",
  "tokenizers 0.21.4",
 ]
@@ -3541,7 +3541,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
 dependencies = [
  "image",
  "inventory",
@@ -3555,7 +3555,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
 dependencies = [
  "image",
  "inventory",
@@ -3569,7 +3569,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3582,7 +3582,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3593,7 +3593,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3602,7 +3602,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3611,7 +3611,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3624,7 +3624,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3637,7 +3637,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3650,7 +3650,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3662,7 +3662,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
 dependencies = [
  "image",
  "inventory",
@@ -3685,7 +3685,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
 dependencies = [
  "image",
  "inventory",
@@ -3699,7 +3699,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
 dependencies = [
  "image",
  "inventory",
@@ -3713,7 +3713,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
 dependencies = [
  "image",
  "inventory",
@@ -3725,7 +3725,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3736,7 +3736,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3748,18 +3748,19 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
 dependencies = [
  "inventory",
  "mlx-gen",
  "mlx-gen-pid",
  "pmetal-mlx-rs",
+ "serde_json",
 ]
 
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3768,7 +3769,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3777,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3787,7 +3788,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3799,7 +3800,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
 dependencies = [
  "image",
  "inventory",
@@ -3814,7 +3815,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
 dependencies = [
  "image",
  "inventory",
@@ -3828,7 +3829,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3839,7 +3840,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3851,7 +3852,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3862,7 +3863,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
 dependencies = [
  "image",
  "inventory",
@@ -3876,7 +3877,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
 dependencies = [
  "image",
  "inventory",
@@ -5651,6 +5652,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sceneworks-gen-core"
+version = "0.1.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
+dependencies = [
+ "core-llm",
+ "inventory",
+ "safetensors 0.4.5",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokenizers 0.21.4",
+]
+
+[[package]]
 name = "sceneworks-image-quality"
 version = "0.2.0"
 dependencies = [
@@ -5770,7 +5784,7 @@ dependencies = [
  "pmetal-mlx-rs",
  "reqwest 0.12.28",
  "sceneworks-core",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486)",
  "sceneworks-image-quality",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5bb83e4a85372d694ec5e12b7b03341ac8f849c2#5bb83e4a85372d694ec5e12b7b03341ac8f849c2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -444,7 +444,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_distr 0.5.1",
  "safetensors 0.7.0",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70)",
+ "sceneworks-gen-core",
  "serde_json",
  "thiserror 2.0.18",
 ]
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5bb83e4a85372d694ec5e12b7b03341ac8f849c2#5bb83e4a85372d694ec5e12b7b03341ac8f849c2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5bb83e4a85372d694ec5e12b7b03341ac8f849c2#5bb83e4a85372d694ec5e12b7b03341ac8f849c2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5bb83e4a85372d694ec5e12b7b03341ac8f849c2#5bb83e4a85372d694ec5e12b7b03341ac8f849c2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5bb83e4a85372d694ec5e12b7b03341ac8f849c2#5bb83e4a85372d694ec5e12b7b03341ac8f849c2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5bb83e4a85372d694ec5e12b7b03341ac8f849c2#5bb83e4a85372d694ec5e12b7b03341ac8f849c2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -513,7 +513,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5bb83e4a85372d694ec5e12b7b03341ac8f849c2#5bb83e4a85372d694ec5e12b7b03341ac8f849c2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -530,7 +530,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5bb83e4a85372d694ec5e12b7b03341ac8f849c2#5bb83e4a85372d694ec5e12b7b03341ac8f849c2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5bb83e4a85372d694ec5e12b7b03341ac8f849c2#5bb83e4a85372d694ec5e12b7b03341ac8f849c2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5bb83e4a85372d694ec5e12b7b03341ac8f849c2#5bb83e4a85372d694ec5e12b7b03341ac8f849c2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5bb83e4a85372d694ec5e12b7b03341ac8f849c2#5bb83e4a85372d694ec5e12b7b03341ac8f849c2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -582,7 +582,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5bb83e4a85372d694ec5e12b7b03341ac8f849c2#5bb83e4a85372d694ec5e12b7b03341ac8f849c2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -596,7 +596,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5bb83e4a85372d694ec5e12b7b03341ac8f849c2#5bb83e4a85372d694ec5e12b7b03341ac8f849c2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -611,7 +611,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5bb83e4a85372d694ec5e12b7b03341ac8f849c2#5bb83e4a85372d694ec5e12b7b03341ac8f849c2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -624,7 +624,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5bb83e4a85372d694ec5e12b7b03341ac8f849c2#5bb83e4a85372d694ec5e12b7b03341ac8f849c2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -636,7 +636,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5bb83e4a85372d694ec5e12b7b03341ac8f849c2#5bb83e4a85372d694ec5e12b7b03341ac8f849c2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -653,7 +653,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5bb83e4a85372d694ec5e12b7b03341ac8f849c2#5bb83e4a85372d694ec5e12b7b03341ac8f849c2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -668,7 +668,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5bb83e4a85372d694ec5e12b7b03341ac8f849c2#5bb83e4a85372d694ec5e12b7b03341ac8f849c2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -679,7 +679,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5bb83e4a85372d694ec5e12b7b03341ac8f849c2#5bb83e4a85372d694ec5e12b7b03341ac8f849c2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -694,7 +694,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5bb83e4a85372d694ec5e12b7b03341ac8f849c2#5bb83e4a85372d694ec5e12b7b03341ac8f849c2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5bb83e4a85372d694ec5e12b7b03341ac8f849c2#5bb83e4a85372d694ec5e12b7b03341ac8f849c2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -729,7 +729,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5bb83e4a85372d694ec5e12b7b03341ac8f849c2#5bb83e4a85372d694ec5e12b7b03341ac8f849c2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -740,7 +740,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5bb83e4a85372d694ec5e12b7b03341ac8f849c2#5bb83e4a85372d694ec5e12b7b03341ac8f849c2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5bb83e4a85372d694ec5e12b7b03341ac8f849c2#5bb83e4a85372d694ec5e12b7b03341ac8f849c2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -764,7 +764,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5bb83e4a85372d694ec5e12b7b03341ac8f849c2#5bb83e4a85372d694ec5e12b7b03341ac8f849c2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -777,7 +777,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5bb83e4a85372d694ec5e12b7b03341ac8f849c2#5bb83e4a85372d694ec5e12b7b03341ac8f849c2"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=788f5c22d9b67b6876fdbbee3c7d1510c7f26656#788f5c22d9b67b6876fdbbee3c7d1510c7f26656"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -3533,7 +3533,7 @@ dependencies = [
  "inventory",
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486)",
+ "sceneworks-gen-core",
  "thiserror 2.0.18",
  "tokenizers 0.21.4",
 ]
@@ -4549,7 +4549,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -5641,19 +5641,6 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=863f98d1e01c45e7378562f18f43d7c39c45db70#863f98d1e01c45e7378562f18f43d7c39c45db70"
-dependencies = [
- "core-llm",
- "inventory",
- "safetensors 0.4.5",
- "serde_json",
- "thiserror 2.0.18",
- "tokenizers 0.21.4",
-]
-
-[[package]]
-name = "sceneworks-gen-core"
-version = "0.1.0"
 source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486#cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486"
 dependencies = [
  "core-llm",
@@ -5784,7 +5771,7 @@ dependencies = [
  "pmetal-mlx-rs",
  "reqwest 0.12.28",
  "sceneworks-core",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486)",
+ "sceneworks-gen-core",
  "sceneworks-image-quality",
  "serde",
  "serde_json",
@@ -8051,7 +8038,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -911,18 +911,33 @@
       "adapter": "flux_diffusers",
       "capabilities": ["text_to_image", "style_variations"],
       "downloads": [
+        // SceneWorks pre-built MLX quant-matrix turnkey (sc-8669, epic 8506): a public re-host of
+        // FLUX.1-schnell (Apache-2.0). Per-tier subdirs (q4/ default, q8/, bf16/), each a complete
+        // from_snapshot tree (packed/dense transformer + CLIP + T5 + VAE + both tokenizers +
+        // scheduler). Replaces the whole dense download + install-time quantize.
         {
-          // Whole-repo download (~53.9 GiB: bundles the original single-file
-          // checkpoint AND the diffusers folders FluxPipeline loads).
           "provider": "huggingface",
-          "repo": "black-forest-labs/FLUX.1-schnell",
-          "files": [],
-          "estimatedSizeBytes": 57845743616
+          "repo": "SceneWorks/flux1-schnell-mlx",
+          "files": ["q4/*"],
+          "estimatedSizeBytes": 9611551284
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/flux1-schnell-mlx",
+          "files": ["q8/*"],
+          "estimatedSizeBytes": 17999175703
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/flux1-schnell-mlx",
+          "files": ["bf16/*"],
+          "estimatedSizeBytes": 33725923002
         }
       ],
       "paths": {
-        "model": "${HF_CACHE}/black-forest-labs/FLUX.1-schnell"
+        "model": "${HF_CACHE}/SceneWorks/flux1-schnell-mlx"
       },
+      "gated": false,
       "defaults": {
         // Guidance-distilled: ignores CFG (guidance 0), ~4 steps.
         "resolution": "1024x1024",
@@ -947,10 +962,11 @@
       // Q4/Q8 same speed with lower peak memory. quantize default Q8 (sweet spot —
       // matches bf16 speed on M-series, ~25% mem reduction, no visible quality drift).
       // minMemoryGb mirrors the Q4 peak (sc-1969: ~41.6 GB) so 64 GB Macs see this
-      // tier; advanced.mlxQuantize=4 makes Q4 the runtime pick on smaller Macs.
+      // tier. Default tier is now q4 (sc-8669): the pre-quantized q4/ subdir
+      // auto-downloads + loads packed; q8/ + bf16/ are selectable.
       "mlx": {
         "minMemoryGb": 42,
-        "quantize": 8
+        "quantize": 4
       },
       "ui": {
         "label": "FLUX.1 [schnell]",
@@ -978,16 +994,32 @@
       // no native IP-Adapter trained for it, so this stays flux_dev-only.
       "capabilities": ["text_to_image", "character_image", "style_variations"],
       "downloads": [
+        // SceneWorks pre-built MLX quant-matrix turnkey (sc-8669, epic 8506): a public re-host of
+        // FLUX.1-dev under the FLUX.1 [dev] Non-Commercial License (LICENSE + NOTICE included).
+        // Per-tier subdirs (q4/ default, q8/, bf16/), each a complete from_snapshot tree
+        // (packed/dense transformer + CLIP + T5 + VAE + both tokenizers + scheduler). Replaces the
+        // GATED BFL download + HF-token requirement + install-time quantize.
         {
-          // Gated repo (Non-Commercial License). Whole-repo download (~53.9 GiB).
           "provider": "huggingface",
-          "repo": "black-forest-labs/FLUX.1-dev",
-          "files": [],
-          "estimatedSizeBytes": 57886638080
+          "repo": "SceneWorks/flux1-dev-mlx",
+          "files": ["q4/*"],
+          "estimatedSizeBytes": 9617334683
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/flux1-dev-mlx",
+          "files": ["q8/*"],
+          "estimatedSizeBytes": 18010071290
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/flux1-dev-mlx",
+          "files": ["bf16/*"],
+          "estimatedSizeBytes": 33746402173
         }
       ],
       "paths": {
-        "model": "${HF_CACHE}/black-forest-labs/FLUX.1-dev"
+        "model": "${HF_CACHE}/SceneWorks/flux1-dev-mlx"
       },
       "defaults": {
         // Guided: guidance ~3.5, ~28 steps (higher quality than schnell).
@@ -1011,19 +1043,17 @@
       // generations on flux_dev keep routing to the torch path even on macOS
       // (see _should_route_flux_to_mlx in image_adapters.py). FLUX.1 [dev] uses
       // 28 steps + guidance 3.5 (per the model card), so a single MLX run is
-      // proportionally longer than schnell; Q8 default keeps peak memory tight
-      // on 64 GB Macs.
+      // proportionally longer than schnell. Default tier is now q4 (sc-8669): the
+      // pre-quantized q4/ subdir auto-downloads + loads packed; q8/ + bf16/ selectable.
       "mlx": {
         "minMemoryGb": 42,
-        "quantize": 8
+        "quantize": 4
       },
-      // Gated download: accept the FLUX.1 [dev] Non-Commercial License on the model
-      // card and add a Hugging Face token before downloading. `credentialHost`/
-      // `licenseUrl` drive the Models-screen gated banner + credential-screen link
-      // (sc-1898); `credentialHost` would otherwise derive from the HF provider.
-      "gated": true,
-      "credentialHost": "huggingface.co",
-      "licenseUrl": "https://huggingface.co/black-forest-labs/FLUX.1-dev",
+      // sc-8669: re-hosted ungated on SceneWorks (FLUX.1 [dev] Non-Commercial License redistributed
+      // with LICENSE + NOTICE, the flux2_dev re-host precedent) — no HF token / license-accept gate.
+      // `licenseUrl` still points at the NC license for the Models-screen banner.
+      "gated": false,
+      "licenseUrl": "https://huggingface.co/SceneWorks/flux1-dev-mlx/blob/main/LICENSE.md",
       "ui": {
         "label": "FLUX.1 [dev]",
         "description": "Black Forest Labs FLUX.1 [dev] — higher-quality ~28-step (guidance 3.5) text-to-image. Distributed under the FLUX.1 [dev] Non-Commercial License: generations are for non-commercial use only. Gated Hugging Face download — accept the license at huggingface.co/black-forest-labs/FLUX.1-dev and add a Hugging Face token under Settings → Service credentials (or set HF_TOKEN on a server) before downloading. For commercial use choose FLUX.1 [schnell] (Apache-2.0). 12B transformer + T5-XXL; ~34GB bf16 VRAM, large-VRAM GPU. With a character reference, runs XLabs IP-Adapter for scene-flexible resemblance (faithful identity belongs to PuLID-FLUX).",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -302,16 +302,36 @@
       "adapter": "qwen_image",
       "capabilities": ["text_to_image", "style_variations"],
       "downloads": [
+        // SceneWorks pre-built MLX quant-matrix turnkey (sc-8669, epic 8506): a public/ungated
+        // re-host of Qwen/Qwen-Image-2512 (Apache-2.0). Per-tier subdirs, each a complete
+        // from_snapshot tree (packed/dense transformer/ + dense Qwen2.5-VL text_encoder/ + VAE +
+        // tokenizer + processor + scheduler): q4/ (default), q8/, bf16/. Replaces the dense source
+        // download + install-time quantize — the worker loads the chosen tier's subdir directly
+        // (standard_tier_subdir). Only the transformer is quantized in q4/q8; the TE + VAE stay
+        // dense bf16 in every tier. Sizes are measured on-disk.
         {
           "provider": "huggingface",
-          "repo": "Qwen/Qwen-Image-2512",
-          "files": [],
-          "estimatedSizeBytes": 57704594653
+          "repo": "SceneWorks/qwen-image-mlx",
+          "files": ["q4/*"],
+          "estimatedSizeBytes": 28387655680
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/qwen-image-mlx",
+          "files": ["q8/*"],
+          "estimatedSizeBytes": 38583632655
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/qwen-image-mlx",
+          "files": ["bf16/*"],
+          "estimatedSizeBytes": 57731960832
         }
       ],
       "paths": {
-        "model": "${HF_CACHE}/Qwen/Qwen-Image-2512"
+        "model": "${HF_CACHE}/SceneWorks/qwen-image-mlx"
       },
+      "gated": false,
       "defaults": {
         "resolution": "1024x1024",
         "steps": 20,
@@ -339,10 +359,12 @@
       // active path (epic 1753 §14, mirrors the wan_2_2 precedent).
       // minMemoryGb mirrors the sc-1972 verify measurement (Q8 1024² peak
       // ~66 GB on M5 Max); Q4 brings this within 64 GB-Mac reach via the
-      // advanced.mlxQuantize override.
+      // advanced.mlxQuantize override. Default tier is now q4 (sc-8669): the
+      // pre-quantized q4/ subdir auto-downloads + loads packed (no install-time
+      // quantize); q8/ + bf16/ are selectable.
       "mlx": {
         "minMemoryGb": 50,
-        "quantize": 8,
+        "quantize": 4,
         "limits": {
           "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
           "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
@@ -401,17 +423,34 @@
       // weights on the worker so existing jobs/presets/characters keep resolving.
       "capabilities": ["edit_image", "character_image"],
       "downloads": [
+        // SceneWorks pre-built MLX quant-matrix turnkey (sc-8669, epic 8506): a public/ungated
+        // re-host of Qwen/Qwen-Image-Edit-2511 (Apache-2.0). Per-tier subdirs (q4/ default, q8/,
+        // bf16/), each a complete from_snapshot tree; only the transformer is quantized (the
+        // Qwen2.5-VL TE + VAE stay dense bf16). Shared with qwen_image_edit_2511_lightning (same
+        // checkpoint). Replaces the dense source download + install-time quantize.
         {
-          // Apache-2.0, ungated. Comparable size to the 2509 release.
           "provider": "huggingface",
-          "repo": "Qwen/Qwen-Image-Edit-2511",
-          "files": [],
-          "estimatedSizeBytes": 57720467613
+          "repo": "SceneWorks/qwen-image-edit-2511-mlx",
+          "files": ["q4/*"],
+          "estimatedSizeBytes": 28387655680
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/qwen-image-edit-2511-mlx",
+          "files": ["q8/*"],
+          "estimatedSizeBytes": 38583632655
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/qwen-image-edit-2511-mlx",
+          "files": ["bf16/*"],
+          "estimatedSizeBytes": 57731960832
         }
       ],
       "paths": {
-        "model": "${HF_CACHE}/Qwen/Qwen-Image-Edit-2511"
+        "model": "${HF_CACHE}/SceneWorks/qwen-image-edit-2511-mlx"
       },
+      "gated": false,
       "defaults": {
         // Model-card defaults: 40 steps + true_cfg_scale 4.0 + guidance_scale 1.0.
         "resolution": "1024x1024",
@@ -475,19 +514,34 @@
       // per the distill recipe; user LoRAs still apply on top of the fused base.
       "capabilities": ["edit_image", "character_image"],
       "downloads": [
+        // SceneWorks pre-built MLX quant-matrix turnkey (sc-8669, epic 8506): shares the
+        // Qwen-Image-Edit-2511 base tiers (q4/ default, q8/, bf16/) on SceneWorks/qwen-image-edit-2511-mlx.
+        // Only the transformer is quantized (dense Qwen2.5-VL TE + VAE). The ~1 GB Lightning distill
+        // LoRA is fetched on first use and fused in-process over the chosen tier.
         {
-          // Shares the Qwen-Image-Edit-2511 base; the ~1 GB Lightning LoRA is
-          // fetched on first use and fused in-process.
           "provider": "huggingface",
-          "repo": "Qwen/Qwen-Image-Edit-2511",
-          "files": [],
+          "repo": "SceneWorks/qwen-image-edit-2511-mlx",
+          "files": ["q4/*"],
           "default": true,
-          "estimatedSizeBytes": 57720467613
+          "estimatedSizeBytes": 28387655680
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/qwen-image-edit-2511-mlx",
+          "files": ["q8/*"],
+          "estimatedSizeBytes": 38583632655
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/qwen-image-edit-2511-mlx",
+          "files": ["bf16/*"],
+          "estimatedSizeBytes": 57731960832
         }
       ],
       "paths": {
-        "model": "${HF_CACHE}/Qwen/Qwen-Image-Edit-2511"
+        "model": "${HF_CACHE}/SceneWorks/qwen-image-edit-2511-mlx"
       },
+      "gated": false,
       "defaults": {
         // 4-step distill: cfg 1.0 / true_cfg_scale 1.0 / 4 steps (vs base 40).
         "resolution": "1024x1024",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -443,7 +443,7 @@ sceneworks-core = { path = "../sceneworks-core" }
 # candle links no z-image crate and compiles UNCHANGED) so `--features backend-candle --target all`
 # resolves the SINGLE gen-core rev 863f98d. (candle-gen #199 is squash-merged on candle-gen main as
 # 22c121a — the canonical SHA all candle-gen-* pins below point at.)
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -795,7 +795,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -811,23 +811,23 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01
 # exactly this rev, so the worker MUST match (a different rev would compile pmetal-mlx-sys twice). This
 # rebuilds MLX from source. Paired with mlx-llm `6c052ba` below (mlx-llm#45 carries the same fork pin).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
 # Krea 2 Turbo (native MLX, Krea 2 Community License; epic 7565, sc-7572). Same git rev as mlx-gen.
 # Self-registers `krea_2_turbo` (Qwen3-VL-4B TE + 28-block single-stream DiT + Qwen-Image VAE; CFG-free
 # rectified-flow few-step) via inventory only when force-linked (`use mlx_gen_krea as _;` in
 # image_jobs.rs). Loads the packed Q8/Q4 turnkey subdir (krea_model_subdir; the loader auto-detects the
 # packed quant, so the resolved `spec.quantize` is a no-op on it). Depends on mlx-gen-qwen-image for the
 # shared `AutoencoderKLQwenImage` VAE.
-mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
+mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
 # Stable Diffusion 3.5 provider (native MLX, Stability AI Community License; epic 7841, sc-7871). Same
 # git rev as mlx-gen so MLX builds once. Self-registers `sd3_5_large` (true-CFG, 28 steps / guidance 3.5)
 # + `sd3_5_large_turbo` (ADD-distilled few-step, CFG-off) + `sd3_5_medium` (MMDiT-X, true-CFG, 40 steps /
@@ -835,7 +835,7 @@ mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98
 # (`use mlx_gen_sd3 as _;` in image_jobs.rs). All three carry a `sd3_5_*_quant` converter. Reuses the SDXL
 # CLIP encoder (×2), the FLUX T5-XXL encoder, and the Z-Image 16-ch VAE — its `quantize_sd3_dir` converter
 # is wired in model_jobs.rs for the `sd3_5_{large,large_turbo,medium}_quant` install-time conversions.
-mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
+mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
 # SANA 1600M provider (native MLX, NVIDIA non-commercial license; epic 8485, sc-8489). Same git rev as
 # mlx-gen so MLX builds once. Self-registers `sana_1600m` (Image/t2i, true-CFG, 32× DC-AE divisor,
 # mac_only) via `register_generators!` into the gen-core inventory — surfaces only when force-linked
@@ -843,59 +843,59 @@ mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d
 # conditioning (sc-8488); the `SanaPipeline` composes SanaTextEncoder -> SanaTransformer (Linear DiT) ->
 # DC-AE f32 decoder and exposes the `from_snapshot`/`from_weights` weight-load entrypoints the generic
 # generator-cache load path drives.
-mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
+mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
 # CLIP ViT-L/14 image embedder for the Dataset Doctor analysis job (epic 6529 P2, sc-6535).
 # Self-registers `clip_vit_l14` (gen_core::ImageEmbedder) via inventory only when force-linked
 # (`use mlx_gen_clip as _;` in dataset_analysis_jobs.rs). Reuses mlx-gen-sdxl's CLIP body → same rev.
-mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
+mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -904,19 +904,19 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
 # Depth Anything V2 (DINOv2 ViT-S/14 + DPT) native-MLX monocular depth estimator (epic 8236,
 # sc-8242). A plain utility crate (NOT a self-registering generation provider): an arbitrary RGB
 # image → a normalized single-channel depth control image, the AUTO depth source for the
 # Fun-Controlnet-Union depth tier (`ControlKind::Depth`) — sibling of the CPU canny/pose
 # preprocessors, but neural so it is macOS-gated (MLX). Consumed by the worker `depth` module /
 # the shared strict-control driver (sc-8243). Same mlx-rs pin as every other mlx-gen crate.
-mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
+mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -925,7 +925,7 @@ mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f9
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -933,7 +933,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -944,7 +944,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -955,7 +955,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f9
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -977,7 +977,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98
 # a Metal large-tensor limit, not precision). New `VAE_SAFE_DECODE_EDGE_PX=1536` forces decode tiling on
 # a CORRECTNESS cap independent of the memory budget (image + video), so a 2048² upscale that fits memory
 # still tiles. Real-weight 1024→2048 pixel-cosine vs the mflux reference 0.9524 → 0.9974.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -988,7 +988,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
 # The unified LLM engine (epic 7153, sc-7158): the macOS `prompt_refine` job now runs through
 # mlx-llm's generic `mlx-llama` provider (a `core_llm::TextLlm`) resolved model-first via
 # `gen_core::core_llm::load_for_model`, RETIRING the bespoke `mlx-gen-prompt-refine` hand-rolled
@@ -1020,7 +1020,7 @@ mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "7041411f395e43
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "863f98d1e01c45e7378562f18f43d7c39c45db70" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -443,7 +443,7 @@ sceneworks-core = { path = "../sceneworks-core" }
 # candle links no z-image crate and compiles UNCHANGED) so `--features backend-candle --target all`
 # resolves the SINGLE gen-core rev 863f98d. (candle-gen #199 is squash-merged on candle-gen main as
 # 22c121a — the canonical SHA all candle-gen-* pins below point at.)
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -795,7 +795,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -811,23 +811,23 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e6
 # exactly this rev, so the worker MUST match (a different rev would compile pmetal-mlx-sys twice). This
 # rebuilds MLX from source. Paired with mlx-llm `6c052ba` below (mlx-llm#45 carries the same fork pin).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
 # Krea 2 Turbo (native MLX, Krea 2 Community License; epic 7565, sc-7572). Same git rev as mlx-gen.
 # Self-registers `krea_2_turbo` (Qwen3-VL-4B TE + 28-block single-stream DiT + Qwen-Image VAE; CFG-free
 # rectified-flow few-step) via inventory only when force-linked (`use mlx_gen_krea as _;` in
 # image_jobs.rs). Loads the packed Q8/Q4 turnkey subdir (krea_model_subdir; the loader auto-detects the
 # packed quant, so the resolved `spec.quantize` is a no-op on it). Depends on mlx-gen-qwen-image for the
 # shared `AutoencoderKLQwenImage` VAE.
-mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
+mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
 # Stable Diffusion 3.5 provider (native MLX, Stability AI Community License; epic 7841, sc-7871). Same
 # git rev as mlx-gen so MLX builds once. Self-registers `sd3_5_large` (true-CFG, 28 steps / guidance 3.5)
 # + `sd3_5_large_turbo` (ADD-distilled few-step, CFG-off) + `sd3_5_medium` (MMDiT-X, true-CFG, 40 steps /
@@ -835,7 +835,7 @@ mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3
 # (`use mlx_gen_sd3 as _;` in image_jobs.rs). All three carry a `sd3_5_*_quant` converter. Reuses the SDXL
 # CLIP encoder (×2), the FLUX T5-XXL encoder, and the Z-Image 16-ch VAE — its `quantize_sd3_dir` converter
 # is wired in model_jobs.rs for the `sd3_5_{large,large_turbo,medium}_quant` install-time conversions.
-mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
+mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
 # SANA 1600M provider (native MLX, NVIDIA non-commercial license; epic 8485, sc-8489). Same git rev as
 # mlx-gen so MLX builds once. Self-registers `sana_1600m` (Image/t2i, true-CFG, 32× DC-AE divisor,
 # mac_only) via `register_generators!` into the gen-core inventory — surfaces only when force-linked
@@ -843,59 +843,59 @@ mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3c
 # conditioning (sc-8488); the `SanaPipeline` composes SanaTextEncoder -> SanaTransformer (Linear DiT) ->
 # DC-AE f32 decoder and exposes the `from_snapshot`/`from_weights` weight-load entrypoints the generic
 # generator-cache load path drives.
-mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
+mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
 # CLIP ViT-L/14 image embedder for the Dataset Doctor analysis job (epic 6529 P2, sc-6535).
 # Self-registers `clip_vit_l14` (gen_core::ImageEmbedder) via inventory only when force-linked
 # (`use mlx_gen_clip as _;` in dataset_analysis_jobs.rs). Reuses mlx-gen-sdxl's CLIP body → same rev.
-mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
+mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -904,19 +904,19 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
 # Depth Anything V2 (DINOv2 ViT-S/14 + DPT) native-MLX monocular depth estimator (epic 8236,
 # sc-8242). A plain utility crate (NOT a self-registering generation provider): an arbitrary RGB
 # image → a normalized single-channel depth control image, the AUTO depth source for the
 # Fun-Controlnet-Union depth tier (`ControlKind::Depth`) — sibling of the CPU canny/pose
 # preprocessors, but neural so it is macOS-gated (MLX). Consumed by the worker `depth` module /
 # the shared strict-control driver (sc-8243). Same mlx-rs pin as every other mlx-gen crate.
-mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
+mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -925,7 +925,7 @@ mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -933,7 +933,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -944,7 +944,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -955,7 +955,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -977,7 +977,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3
 # a Metal large-tensor limit, not precision). New `VAE_SAFE_DECODE_EDGE_PX=1536` forces decode tiling on
 # a CORRECTNESS cap independent of the memory budget (image + video), so a 2048² upscale that fits memory
 # still tiles. Real-weight 1024→2048 pixel-cosine vs the mflux reference 0.9524 → 0.9974.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -988,7 +988,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf7
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
 # The unified LLM engine (epic 7153, sc-7158): the macOS `prompt_refine` job now runs through
 # mlx-llm's generic `mlx-llama` provider (a `core_llm::TextLlm`) resolved model-first via
 # `gen_core::core_llm::load_for_model`, RETIRING the bespoke `mlx-gen-prompt-refine` hand-rolled
@@ -1020,7 +1020,7 @@ mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "7041411f395e43
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74d3ce3e63b3b76dbb9e7f3fabb4d9a9247486" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -1335,15 +1335,15 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74
 # (inference-level memory, like 24 GB cards) and restores the live `Var`s after. SOURCE-ONLY candle-gen
 # fix; both b3aad50 and 5bb83e4 pin gen-core 863f98d, so this stays single-rev (mlx-gen unchanged). ALL
 # candle-gen-* rev lines move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1351,17 +1351,17 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1371,7 +1371,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1379,21 +1379,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1402,17 +1402,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1421,7 +1421,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1454,7 +1454,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1463,12 +1463,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1476,7 +1476,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1485,7 +1485,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1493,7 +1493,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1507,7 +1507,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1534,7 +1534,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1545,7 +1545,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1335,15 +1335,15 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cf74
 # (inference-level memory, like 24 GB cards) and restores the live `Var`s after. SOURCE-ONLY candle-gen
 # fix; both b3aad50 and 5bb83e4 pin gen-core 863f98d, so this stays single-rev (mlx-gen unchanged). ALL
 # candle-gen-* rev lines move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5bb83e4a85372d694ec5e12b7b03341ac8f849c2", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5bb83e4a85372d694ec5e12b7b03341ac8f849c2", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5bb83e4a85372d694ec5e12b7b03341ac8f849c2", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5bb83e4a85372d694ec5e12b7b03341ac8f849c2", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5bb83e4a85372d694ec5e12b7b03341ac8f849c2", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1351,17 +1351,17 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5bb83e4a85372d694ec5e12b7b03341ac8f849c2", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5bb83e4a85372d694ec5e12b7b03341ac8f849c2", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5bb83e4a85372d694ec5e12b7b03341ac8f849c2", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1371,7 +1371,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5bb83e4a85372d694ec5e12b7b03341ac8f849c2", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1379,21 +1379,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5bb83e4a85372d694ec5e12b7b03341ac8f849c2", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5bb83e4a85372d694ec5e12b7b03341ac8f849c2", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5bb83e4a85372d694ec5e12b7b03341ac8f849c2", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5bb83e4a85372d694ec5e12b7b03341ac8f849c2", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1402,17 +1402,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5bb83e4a85372d694ec5e12b7b03341ac8f849c2", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5bb83e4a85372d694ec5e12b7b03341ac8f849c2", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5bb83e4a85372d694ec5e12b7b03341ac8f849c2", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1421,7 +1421,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5bb83e4a85372d694ec5e12b7b03341ac8f849c2", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1454,7 +1454,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5bb83e4a85372d694ec5e12b7b03341ac8f849c2", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1463,12 +1463,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5bb83e4a85372d694ec5e12b7b03341ac8f849c2", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5bb83e4a85372d694ec5e12b7b03341ac8f849c2", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1476,7 +1476,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5bb83
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5bb83e4a85372d694ec5e12b7b03341ac8f849c2", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1485,7 +1485,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5bb83e4a85372d694ec5e12b7b03341ac8f849c2", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1493,7 +1493,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5bb83e4a85372d694ec5e12b7b03341ac8f849c2", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1507,7 +1507,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5bb83e4a85372d694ec5e12b7b03341ac8f849c2", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1534,7 +1534,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5bb83e4a85372d694ec5e12b7b03341ac8f849c2", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1545,7 +1545,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5bb83e4a85372d694ec5e12b7b03341ac8f849c2", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "788f5c22d9b67b6876fdbbee3c7d1510c7f26656", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -102,7 +102,8 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
     ModelRow {
         sceneworks_id: "flux_schnell",
         engine_id: "flux1_schnell",
-        default_repo: "black-forest-labs/FLUX.1-schnell",
+        // sc-8669: SceneWorks pre-quantized q4/q8/bf16 turnkey re-host (Apache-2.0).
+        default_repo: "SceneWorks/flux1-schnell-mlx",
         default_steps: 4,
         default_guidance: 0.0,
         adapter_label: "mlx_flux",
@@ -110,7 +111,8 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
     ModelRow {
         sceneworks_id: "flux_dev",
         engine_id: "flux1_dev",
-        default_repo: "black-forest-labs/FLUX.1-dev",
+        // sc-8669: SceneWorks pre-quantized q4/q8/bf16 turnkey re-host (FLUX.1 [dev] Non-Commercial).
+        default_repo: "SceneWorks/flux1-dev-mlx",
         default_steps: 28,
         default_guidance: 3.5,
         adapter_label: "mlx_flux",

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -124,7 +124,9 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
         // (epic 3401 / sc-3575).
         sceneworks_id: "qwen_image",
         engine_id: "qwen_image",
-        default_repo: "Qwen/Qwen-Image-2512",
+        // sc-8669: SceneWorks pre-quantized q4/q8/bf16 turnkey re-host (Apache-2.0); replaces the
+        // gated-free but dense Qwen/Qwen-Image-2512 source + install-time quantize.
+        default_repo: "SceneWorks/qwen-image-mlx",
         default_steps: 20,
         default_guidance: 4.0,
         adapter_label: "mlx_qwen",
@@ -140,7 +142,9 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
     ModelRow {
         sceneworks_id: "qwen_image_edit",
         engine_id: "qwen_image_edit",
-        default_repo: "Qwen/Qwen-Image-Edit-2511",
+        // sc-8669: SceneWorks pre-quantized q4/q8/bf16 Edit-2511 turnkey re-host (shared by all
+        // edit ids + the lightning distill, same checkpoint).
+        default_repo: "SceneWorks/qwen-image-edit-2511-mlx",
         default_steps: 40,
         default_guidance: 4.0,
         adapter_label: "mlx_qwen",
@@ -148,7 +152,7 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
     ModelRow {
         sceneworks_id: "qwen_image_edit_2509",
         engine_id: "qwen_image_edit",
-        default_repo: "Qwen/Qwen-Image-Edit-2511",
+        default_repo: "SceneWorks/qwen-image-edit-2511-mlx",
         default_steps: 40,
         default_guidance: 4.0,
         adapter_label: "mlx_qwen",
@@ -156,7 +160,7 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
     ModelRow {
         sceneworks_id: "qwen_image_edit_2511",
         engine_id: "qwen_image_edit",
-        default_repo: "Qwen/Qwen-Image-Edit-2511",
+        default_repo: "SceneWorks/qwen-image-edit-2511-mlx",
         default_steps: 40,
         default_guidance: 4.0,
         adapter_label: "mlx_qwen",
@@ -171,7 +175,7 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
     ModelRow {
         sceneworks_id: "qwen_image_edit_2511_lightning",
         engine_id: "qwen_image_edit",
-        default_repo: "Qwen/Qwen-Image-Edit-2511",
+        default_repo: "SceneWorks/qwen-image-edit-2511-mlx",
         default_steps: 4,
         default_guidance: 1.0,
         adapter_label: "mlx_qwen",

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -317,6 +317,12 @@ const STANDARD_TIER_MODELS: &[&str] = &[
     "qwen_image",
     "qwen_image_edit_2511",
     "qwen_image_edit_2511_lightning",
+    // FLUX.1 (sc-8669, Group-B): schnell + dev ship the standard q4/q8/bf16 turnkey. FLUX quantizes
+    // all four components (DiT transformer + CLIP + T5 + VAE attention), so the TE is packed too —
+    // hence NOT in DENSE_TE_TIER_MODELS (the q4/q8 load-quant is a harmless no-op on already-packed
+    // weights, bf16 resolves to Quant::None). Replaces the gated BFL download + install-time quantize.
+    "flux_schnell",
+    "flux_dev",
 ];
 
 /// Standard-tier models whose text encoder ships DENSE bf16 in EVERY tier (epic 8506, sc-8711:

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -307,6 +307,16 @@ const STANDARD_TIER_MODELS: &[&str] = &[
     // single-file→diffusers convert (candle-only) and is not a turnkey yet.
     "flux2_klein_9b",
     "flux2_klein_9b_kv",
+    // Qwen-Image (sc-8669, Group-B): base T2I + the two Edit-2511 ids ship the standard
+    // q4/q8/bf16 turnkey. Like FLUX.2-klein only the transformer is packed (the Qwen2.5-VL text
+    // encoder is skip_quantization, the VAE is all-conv), so the TE/VAE stay dense bf16 in every
+    // tier — but, UNLIKE klein, the qwen loader never quantizes the TE regardless of the load
+    // Quant, so these do NOT need a DENSE_TE_TIER_MODELS guard: the q4/q8 load-quant is a harmless
+    // no-op on the already-packed transformer, and the bf16 tier resolves to Quant::None anyway.
+    // `qwen_image_edit_2511` + `_2511_lightning` share one repo (same Edit-2511 checkpoint).
+    "qwen_image",
+    "qwen_image_edit_2511",
+    "qwen_image_edit_2511_lightning",
 ];
 
 /// Standard-tier models whose text encoder ships DENSE bf16 in EVERY tier (epic 8506, sc-8711:

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -4084,7 +4084,8 @@ fn qwen_edit_model_table_rows() {
     ] {
         let m = mlx_model(id).unwrap();
         assert_eq!(m.engine_id(), "qwen_image_edit");
-        assert_eq!(m.default_repo(), "Qwen/Qwen-Image-Edit-2511");
+        // sc-8669: re-hosted pre-quantized q4/q8/bf16 turnkey (shared by all edit ids + lightning).
+        assert_eq!(m.default_repo(), "SceneWorks/qwen-image-edit-2511-mlx");
         assert_eq!(m.default_steps(), 40);
         assert_eq!(m.default_guidance(), 4.0);
         assert_eq!(m.adapter_label(), "mlx_qwen");
@@ -4099,7 +4100,8 @@ fn qwen_edit_lightning_model_row_is_cfg_off_4step_distill() {
     // but runs the 4-step CFG-off recipe + the lightx2v distill.
     let m = mlx_model("qwen_image_edit_2511_lightning").unwrap();
     assert_eq!(m.engine_id(), "qwen_image_edit");
-    assert_eq!(m.default_repo(), "Qwen/Qwen-Image-Edit-2511");
+    // sc-8669: re-hosted pre-quantized turnkey (shared Edit-2511 tiers; distill LoRA fused on top).
+    assert_eq!(m.default_repo(), "SceneWorks/qwen-image-edit-2511-mlx");
     assert_eq!(m.default_steps(), 4);
     assert_eq!(m.default_guidance(), 1.0);
     assert_eq!(m.adapter_label(), "mlx_qwen");


### PR DESCRIPTION
## What
Brings **FLUX.1** (schnell + dev) onto the catalog quant matrix (epic 8506 / sc-8513 Track A, Group-B). Both ids now load pre-quantized **q4/q8/bf16** SceneWorks turnkeys directly — no gated BFL download, no HF token, no install-time quantize. 3rd Group-B crate after z-image (#1010) and qwen-image (#1019).

FLUX quantizes **all four** components (DiT transformer + CLIP + T5 + VAE attention), so it needs only `STANDARD_TIER_MODELS` (the packed TE means q4/q8 load-quant no-ops; bf16 → `Quant::None`). No DENSE_TE guard.

## Hosted (public)
- `SceneWorks/flux1-schnell-mlx` — q4 9.6GB / q8 18.0GB / bf16 33.7GB (Apache-2.0)
- `SceneWorks/flux1-dev-mlx` — q4 9.6GB / q8 18.0GB / bf16 33.7GB (FLUX.1 [dev] Non-Commercial License + NOTICE, re-hosted ungated per the flux2_dev precedent)

Each tier a complete turnkey (packed/dense transformer + CLIP + T5 + VAE + both tokenizers + scheduler).

## Changes (3-repo coordinated set)
- **Cargo.toml / Cargo.lock**: mlx-gen `cf74d3c → a41abfc` (merged [mlx-gen #620](https://github.com/SceneWorks/mlx-gen/pull/620) — FLUX packed-load + 4-component converter) + candle-gen `788f5c2 → 9667778` (merged [candle-gen #203](https://github.com/SceneWorks/candle-gen/pull/203) — gen-core lockstep re-pin). Both move together → the build graph resolves **one** gen-core rev (verified: `scripts/check-gen-core-skew.sh --features backend-candle` = exactly one).
- **`image_jobs/base.rs`**: flux_schnell + flux_dev → `STANDARD_TIER_MODELS`.
- **`engines.rs`**: `default_repo` → the SceneWorks repos.
- **`builtin.models.jsonc`**: per-tier downloads (q4 default + q8 + bf16, measured sizes); **drops the gated BFL download + credentialHost + HF-token requirement** for flux_dev (`gated:false`, licenseUrl → re-host); `mlx.quantize` → 4.

## Verification
- On-device: packed Q4 FLUX.1-dev (all 4 components) loads packed via the real engine path + renders 512² (proven in mlx-gen #620; the hosted tiers are byte-identical to it).
- `cargo test -p sceneworks-worker --lib` — 475 passed. fmt/clippy clean; **gen-core skew = exactly one rev** (macOS + `--features backend-candle`); candle-parity compile clean.
- No test updates needed (flux rows aren't asserted in Rust; the Python `MODEL_TARGETS` tests read the legacy hardcoded dict).

Part of epic 8506 / sc-8513.

🤖 Generated with [Claude Code](https://claude.com/claude-code)