### PR TITLE
chore(web): suppress native context menu on grid thumbnails (sc-8731)

### DIFF
--- a/apps/web/src/components/AssetGrid.test.jsx
+++ b/apps/web/src/components/AssetGrid.test.jsx
@@ -1,7 +1,7 @@
 import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { AssetGrid } from "./assetPanels.jsx";
+import { AssetCard, AssetGrid } from "./assetPanels.jsx";
 
 const assets = [
   { id: "a", type: "image", displayName: "one.png", file: { path: "assets/one.png", mimeType: "image/png" }, projectId: "p1" },
@@ -82,5 +82,47 @@ describe("AssetGrid multi-select (sc-6112)", () => {
     // Suppressing the contextmenu must not disturb the left-click select flow.
     await act(async () => tile.click());
     expect(setSelectedAssetId).toHaveBeenCalledWith("a");
+  });
+});
+
+describe("AssetCard native context-menu suppression (sc-8731)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("suppresses the native menu on the studio AssetCard thumbnail without breaking open-preview", async () => {
+    const onPreview = vi.fn();
+    await act(() => {
+      root.render(
+        <AssetCard
+          asset={assets[0]}
+          deleteAsset={vi.fn()}
+          purgeAsset={vi.fn()}
+          onPreview={onPreview}
+          updateAssetStatus={vi.fn()}
+        />,
+      );
+    });
+    const preview = container.querySelector(".preview-button");
+    expect(preview).not.toBeNull();
+    const event = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+    preview.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+
+    // Left-click still opens the preview.
+    await act(async () => preview.click());
+    expect(onPreview).toHaveBeenCalledWith(assets[0]);
   });
 });

--- a/apps/web/src/components/AssetGrid.test.jsx
+++ b/apps/web/src/components/AssetGrid.test.jsx
@@ -68,4 +68,19 @@ describe("AssetGrid multi-select (sc-6112)", () => {
     await act(async () => tiles()[0].click());
     expect(setSelectedAssetId).toHaveBeenCalledWith("a");
   });
+
+  it("suppresses the native context menu on a Library grid thumbnail cell (sc-8731) without breaking selection", async () => {
+    const setSelectedAssetId = vi.fn();
+    await act(() => {
+      root.render(<AssetGrid assets={assets} onPreview={vi.fn()} selectedAsset={null} setSelectedAssetId={setSelectedAssetId} />);
+    });
+    const tile = tiles()[0];
+    const event = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+    tile.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+
+    // Suppressing the contextmenu must not disturb the left-click select flow.
+    await act(async () => tile.click());
+    expect(setSelectedAssetId).toHaveBeenCalledWith("a");
+  });
 });

--- a/apps/web/src/components/WorkerProgressCard.jsx
+++ b/apps/web/src/components/WorkerProgressCard.jsx
@@ -3,7 +3,7 @@ import { actionStatuses, terminalStatuses } from "../jobTypes.js";
 import { formatSeconds, liveElapsedSeconds, percent } from "../formatting.js";
 import { useAppContext } from "../context/AppContext.js";
 import { deriveWorkerHardware, findWorkerForJob, liveMeters } from "../workers.js";
-import { AssetMedia, AssetThumbnail, assetUrl, posterUrl } from "./assetMedia.jsx";
+import { AssetMedia, AssetThumbnail, assetUrl, posterUrl, suppressThumbnailContextMenu } from "./assetMedia.jsx";
 import { LikenessBadge } from "./LikenessBadge.jsx";
 
 // Live-ticking elapsed seconds for in-flight jobs. Re-exported here after the
@@ -339,6 +339,7 @@ function VideoThumbnail({ assets, onThumbnailClick }) {
       className="worker-progress-card__thumbnails worker-progress-card__thumbnails--video-player"
       role="group"
       aria-label="Job output"
+      onContextMenu={suppressThumbnailContextMenu}
     >
       {src ? (
         <AssetMedia asset={asset} className="worker-progress-card__video" />

--- a/apps/web/src/components/WorkerProgressCard.test.jsx
+++ b/apps/web/src/components/WorkerProgressCard.test.jsx
@@ -497,6 +497,24 @@ describe("WorkerProgressCard thumbnails", () => {
     expect(api.container.querySelector("video")).not.toBeNull();
   });
 
+  it("suppresses the native context menu on the video-player thumbnail (sc-8731)", () => {
+    api = render(
+      <WorkerProgressCard
+        job={videoJob}
+        thumbnailsVariant="video-player"
+        thumbnailAssets={[videoAsset]}
+      />,
+      makeContext([]),
+    );
+    const wrapper = api.container.querySelector(".worker-progress-card__thumbnails--video-player");
+    expect(wrapper).not.toBeNull();
+    const event = new window.MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+    act(() => {
+      wrapper.dispatchEvent(event);
+    });
+    expect(event.defaultPrevented).toBe(true);
+  });
+
   it("renders a video placeholder when no asset is available yet", () => {
     api = render(
       <WorkerProgressCard

--- a/apps/web/src/components/assetMedia.jsx
+++ b/apps/web/src/components/assetMedia.jsx
@@ -25,6 +25,19 @@ export function assetCanRenderAsVideo(asset) {
   return asset?.type === "video" || asset?.file?.mimeType?.startsWith("video/");
 }
 
+// Suppress the native WKWebView context menu on grid thumbnails (sc-8731). Right-
+// clicking a thumbnail image in a Tauri webview otherwise pops the OS "Download
+// Image / Copy Image / Share" menu; thumbnails have no custom menu, so we just
+// swallow the default. Only preventDefault the contextmenu event — never
+// stopPropagation of clicks — so left-click selection / open-preview stay intact.
+// Applied at the shared AssetThumbnail seam so every grid that renders it (Queue's
+// WorkerProgressCard, pickers, studios) inherits the suppression from one place.
+// The full-size AssetMedia renderer is intentionally left alone: it gets its own
+// custom right-click menu in sc-8729.
+function suppressThumbnailContextMenu(event) {
+  event.preventDefault();
+}
+
 // Generated videos get a sibling `<name>.poster.jpg` (the worker extracts frame 0).
 // WKWebView won't paint a <video>'s own first frame as a poster, so the UI shows
 // this real image instead — as the thumbnail and as the player's poster attribute.
@@ -42,7 +55,13 @@ export function posterUrl(asset) {
 // thumbnails for purged outputs read as removed rather than broken.
 export function MissingMedia({ className = "" }) {
   return (
-    <span className={`asset-thumb-missing ${className}`.trim()} role="img" aria-label="Deleted asset" title="Deleted">
+    <span
+      aria-label="Deleted asset"
+      className={`asset-thumb-missing ${className}`.trim()}
+      onContextMenu={suppressThumbnailContextMenu}
+      role="img"
+      title="Deleted"
+    >
       <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
         <path d="M6 6l12 12M18 6L6 18" />
       </svg>
@@ -57,7 +76,7 @@ function ImageThumb({ src, className }) {
   if (failed) {
     return <MissingMedia className={className} />;
   }
-  return <img alt="" className={className} src={src} onError={() => setFailed(true)} />;
+  return <img alt="" className={className} onContextMenu={suppressThumbnailContextMenu} onError={() => setFailed(true)} src={src} />;
 }
 
 export function AssetThumbnail({ asset, className = "" }) {
@@ -66,7 +85,7 @@ export function AssetThumbnail({ asset, className = "" }) {
   }
   const src = assetUrl(asset);
   if (!src) {
-    return <span className={className}>{asset.type ?? "asset"}</span>;
+    return <span className={className} onContextMenu={suppressThumbnailContextMenu}>{asset.type ?? "asset"}</span>;
   }
   if (assetCanRenderAsVideo(asset)) {
     return <VideoPoster asset={asset} className={className} />;
@@ -81,12 +100,12 @@ function VideoPoster({ asset, className }) {
   const [failed, setFailed] = React.useState(false);
   const poster = posterUrl(asset);
   if (!poster) {
-    return <span className={className}>{asset.type ?? "video"}</span>;
+    return <span className={className} onContextMenu={suppressThumbnailContextMenu}>{asset.type ?? "video"}</span>;
   }
   if (failed) {
     return <MissingMedia className={className} />;
   }
-  return <img alt="" className={className} src={poster} onError={() => setFailed(true)} />;
+  return <img alt="" className={className} onContextMenu={suppressThumbnailContextMenu} onError={() => setFailed(true)} src={poster} />;
 }
 
 export const AssetMedia = React.forwardRef(function AssetMedia({ asset, className = "", controls = true, ...mediaProps }, ref) {

--- a/apps/web/src/components/assetMedia.jsx
+++ b/apps/web/src/components/assetMedia.jsx
@@ -32,9 +32,11 @@ export function assetCanRenderAsVideo(asset) {
 // stopPropagation of clicks — so left-click selection / open-preview stay intact.
 // Applied at the shared AssetThumbnail seam so every grid that renders it (Queue's
 // WorkerProgressCard, pickers, studios) inherits the suppression from one place.
-// The full-size AssetMedia renderer is intentionally left alone: it gets its own
-// custom right-click menu in sc-8729.
-function suppressThumbnailContextMenu(event) {
+// The Library grid renders AssetMedia directly (assetPanels.jsx), so AssetGrid
+// imports this and attaches it at the tile-cell level. The full-size
+// FullscreenPreview renderer is intentionally left alone: it gets its own custom
+// right-click menu in sc-8729.
+export function suppressThumbnailContextMenu(event) {
   event.preventDefault();
 }
 

--- a/apps/web/src/components/assetMedia.test.jsx
+++ b/apps/web/src/components/assetMedia.test.jsx
@@ -1,0 +1,75 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AssetMedia, AssetThumbnail, MissingMedia } from "./assetMedia.jsx";
+
+const imageAsset = {
+  id: "img",
+  type: "image",
+  displayName: "one.png",
+  file: { path: "assets/one.png", mimeType: "image/png" },
+  projectId: "p1",
+};
+
+const videoAsset = {
+  id: "vid",
+  type: "video",
+  displayName: "clip.mp4",
+  file: { path: "assets/clip.mp4", mimeType: "video/mp4" },
+  projectId: "p1",
+};
+
+function fireContextMenu(el) {
+  const event = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+  el.dispatchEvent(event);
+  return event;
+}
+
+describe("thumbnail native context-menu suppression (sc-8731)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it("suppresses the native menu on an image thumbnail", async () => {
+    await act(() => root.render(<AssetThumbnail asset={imageAsset} />));
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    const event = fireContextMenu(img);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("suppresses the native menu on a video-poster thumbnail", async () => {
+    await act(() => root.render(<AssetThumbnail asset={videoAsset} />));
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    const event = fireContextMenu(img);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("suppresses the native menu on the deleted-asset placeholder", async () => {
+    await act(() => root.render(<MissingMedia />));
+    const placeholder = container.querySelector(".asset-thumb-missing");
+    expect(placeholder).not.toBeNull();
+    const event = fireContextMenu(placeholder);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("does NOT suppress the native menu on the full-size AssetMedia (owned by sc-8729)", async () => {
+    await act(() => root.render(<AssetMedia asset={imageAsset} />));
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    const event = fireContextMenu(img);
+    expect(event.defaultPrevented).toBe(false);
+  });
+});

--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -505,7 +505,7 @@ export function AssetCard({ asset, deleteAsset, purgeAsset, onPreview, updateAss
     .join(" ");
   return (
     <article className={classes}>
-      <button className="preview-button" onClick={() => onPreview(asset)} type="button">
+      <button className="preview-button" onClick={() => onPreview(asset)} onContextMenu={suppressThumbnailContextMenu} type="button">
         <AssetMedia asset={asset} />
         <LikenessBadge asset={asset} />
       </button>

--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { isAbortError } from "../api.js";
-import { AssetMedia, assetCanRenderAsVideo, assetUrl } from "./assetMedia.jsx";
+import { AssetMedia, assetCanRenderAsVideo, assetUrl, suppressThumbnailContextMenu } from "./assetMedia.jsx";
 import { DocumentView } from "./DocumentView.jsx";
 import { Icon } from "./Icons.jsx";
 import { LikenessBadge } from "./LikenessBadge.jsx";
@@ -306,6 +306,7 @@ export function AssetGrid({ assets, onPreview, selectedAsset, setSelectedAssetId
           <button
             className={selectedAsset?.id === asset.id ? "asset-tile active" : "asset-tile"}
             onClick={() => setSelectedAssetId(asset.id)}
+            onContextMenu={suppressThumbnailContextMenu}
             onDoubleClick={() => onPreview(asset)}
             type="button"
           >


### PR DESCRIPTION
## What & why

In a Tauri WKWebView, right-clicking an asset **grid thumbnail / preview** popped the native OS "Download Image / Copy Image / Share" context menu. Thumbnails have no custom menu — we just want the native one gone. This adds `onContextMenu` → `event.preventDefault()` across every thumbnail surface.

## Where

Verified which component each grid actually renders before implementing, and applied suppression at each seam so all grids are covered:

- **`AssetThumbnail`** seam (`assetMedia.jsx`) — covers its inner `ImageThumb`, `VideoPoster`, `MissingMedia` placeholder, and text fallbacks. Every grid rendering `AssetThumbnail` inherits it: **Queue** image grids (via `WorkerProgressCard`), and the **studios / pickers** (PoseLibrary, DatasetAddDialog, DatasetEditorPanel, AssetPicker, CompactSelector).
- **`AssetGrid`** tile cell (`assetPanels.jsx`) — the **Library** grid renders thumbnails via `AssetMedia`, not `AssetThumbnail`. The shared `suppressThumbnailContextMenu` handler is exported and attached to the `asset-tile` button wrapping each cell (both single- and multi-select layouts).
- **`AssetCard`** preview button (`assetPanels.jsx`) — the studio "Recent Assets" / character-outputs grid (used by `ImageStudio.jsx`, `VideoStudio.jsx`, `characterPanels.jsx`) wraps `AssetMedia` in a `preview-button`. Handler attached to that button.
- **`WorkerProgressCard`** video-player path (`WorkerProgressCard.jsx`) — the Queue video preview renders a bare `AssetMedia` (+ raw `<img>` fallback). Handler attached to the `worker-progress-card__thumbnails--video-player` wrapper.

Only `event.preventDefault()` is called on the `contextmenu` event — clicks are never `stopPropagation`'d — so left-click selection and open-preview are unchanged.

## Scope boundary (sc-8729)

`FullscreenPreview` (the large/preview view in `assetPanels.jsx`) is intentionally **left untouched**: it gets its own custom right-click menu in **sc-8729**. It renders the full-size `AssetMedia` element, which carries no context-menu handler. A guard test asserts `AssetMedia` does NOT suppress the native menu, so sc-8729 is unaffected.

## Tests

- `assetMedia.test.jsx` (new): image / video-poster / deleted-placeholder thumbnails suppress; **guard** that full-size `AssetMedia` does NOT suppress.
- `AssetGrid.test.jsx` (extended): Library grid tile cell suppresses + left-click still single-selects; studio `AssetCard` preview button suppresses + left-click still opens preview.
- `WorkerProgressCard.test.jsx` (extended): Queue video-player wrapper suppresses contextmenu.

## Verification

- Full web vitest suite: **905/905 pass** (54 files)
- `npm run lint`: 0 errors (pre-existing warnings only; none in touched code)
- Note: the suppressed menu is a WKWebView/OS artifact that does not render in a dev-server browser, so the behavior is verified via RTL `event.defaultPrevented` assertions rather than a preview screenshot.

## Acceptance criteria

- ✅ Right-clicking a grid thumbnail/preview shows no native menu
- ✅ Left-click / open-preview / selection still work (no `stopPropagation`)
- ✅ Applies across **Library, Queue (image + video), and studios** (incl. AssetCard studio grids)

🤖 Generated with [Claude Code](https://claude.com/claude-code)