### PR TITLE
feat(models): per-tier variants + per-variant install tracking (sc-8508)

### DIFF
--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -780,6 +780,11 @@ pub(crate) struct VideoJobRequest {
 pub(crate) struct ModelDownloadRequest {
     #[serde(default = "default_requested_gpu")]
     pub(crate) requested_gpu: String,
+    /// Quant tier to install for a quant-matrix model (sc-8508): `bf16` / `q8` / `q4`, matching
+    /// `downloads[].variant`. Absent installs the default tier (the entry marked `default: true`,
+    /// else the first supported entry) — the back-compat single-variant behavior.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) variant: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -157,8 +157,24 @@ pub(crate) async fn create_model_download_job(
             status: StatusCode::NOT_FOUND,
             detail: "Model not found".to_owned(),
         })?;
-    let download = model_download(&model)
-        .ok_or_else(|| ApiError::bad_request("Model does not define a Hugging Face download"))?;
+    // Tier selection (sc-8508): an explicit `variant` installs that quant tier's download entry; an
+    // absent variant installs the default tier (back-compat). A variant the model doesn't advertise
+    // is a 400 rather than a silent wrong-tier install.
+    let download = match payload
+        .variant
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+    {
+        Some(variant) => model_download_for_variant(&model, variant).ok_or_else(|| {
+            ApiError::bad_request(format!(
+                "Model does not define a '{variant}' download variant"
+            ))
+        })?,
+        None => model_download(&model).ok_or_else(|| {
+            ApiError::bad_request("Model does not define a Hugging Face download")
+        })?,
+    };
     let repo = required_string_field(&download, "repo")?.to_owned();
     let files = download
         .get("files")
@@ -189,6 +205,24 @@ pub(crate) async fn create_model_download_job(
     );
     job_payload.insert("repo".to_owned(), Value::String(repo.clone()));
     job_payload.insert("files".to_owned(), json!(files));
+    // Record which quant tier this job installs (sc-8508) so the download record + per-variant
+    // install tracking agree on the tier. Falls back to the selected entry's own `variant` when the
+    // request omitted one (the default tier may still be a labeled variant).
+    if let Some(variant) = payload
+        .variant
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .or_else(|| {
+            download
+                .get("variant")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+        })
+    {
+        job_payload.insert("variant".to_owned(), Value::String(variant));
+    }
     // Forward the catalog-declared family so the worker can re-verify the downloaded
     // weights match it (parity with model import). The catalog is project-curated, but
     // a mis-declared family would otherwise silently mismatch downstream adapter
@@ -884,6 +918,112 @@ fn install_state_for(
     }
 }
 
+// Per-variant install state (sc-8508, epic 8506): a single downloadable tier of a quant-matrix
+// model. `install_state_for` reports the DEFAULT variant's install state (back-compat single-variant
+// contract); `model_variants` reports one of these per declared download entry so the catalog knows
+// WHICH tiers are on disk, not just whether *a* variant is.
+struct ModelVariantState {
+    /// The tier key: an explicit `downloads[].variant` (bf16/q8/q4), else "default" for a
+    /// single-variant model (which has exactly one entry).
+    variant: String,
+    /// Whether this specific tier's files are present in the HF cache.
+    installed: bool,
+    /// Resolved install path for this tier (the shared repo cache root; tiers live as `files`-
+    /// filtered subdirs within it). `None` when the repo has never been fetched.
+    installed_path: Option<String>,
+    /// This tier's incomplete-cache signal (some but not all `files` present).
+    cache_incomplete: bool,
+    /// Files this tier is missing from the cache (empty when complete or absent).
+    missing_required_files: Vec<String>,
+    /// This tier's estimated download size (from `downloads[].estimatedSizeBytes` /
+    /// `footprint.diskSizeBytes`).
+    download_size_bytes: Option<u64>,
+    /// The raw `downloads[].footprint` object (disk size + optional measured memory), passed
+    /// through verbatim for the RAM-suggestion surfaces (sc-8509/8516). `Null` when absent.
+    footprint: Value,
+}
+
+// Whether `model`'s `downloads` array declares more than one supported entry OR any entry carries an
+// explicit `variant` — i.e. it is a quant-matrix model whose tiers should be tracked per-variant.
+fn model_has_variant_matrix(model: &Value) -> bool {
+    let Some(downloads) = model.get("downloads").and_then(Value::as_array) else {
+        return false;
+    };
+    let supported: Vec<&Value> = downloads
+        .iter()
+        .filter(|entry| is_supported_model_download(entry))
+        .collect();
+    supported.len() > 1 || supported.iter().any(|entry| entry.get("variant").is_some())
+}
+
+// Build the per-variant install state for every supported download entry. A single-variant model
+// yields one entry keyed "default"; a quant-matrix model yields one per tier. Each entry's install
+// state is probed independently against the HF cache using that tier's own `files` filter, so the
+// catalog can advertise (e.g.) bf16 installed while q4 is missing.
+fn model_variant_states(model: &Value, data_dir: &FsPath) -> Vec<ModelVariantState> {
+    let Some(downloads) = model.get("downloads").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    downloads
+        .iter()
+        .filter(|entry| is_supported_model_download(entry))
+        .map(|entry| {
+            let repo = entry
+                .get("repo")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_owned();
+            let files = string_array_field(entry, "files");
+            let cache_path = huggingface_repo_cache_path(data_dir, &repo);
+            let cache_health = cache_path
+                .as_ref()
+                .map(|path| huggingface_cache_health(path, &files));
+            let installed = cache_health.as_ref().is_some_and(|health| health.installed);
+            let cache_incomplete = cache_health
+                .as_ref()
+                .is_some_and(|health| health.incomplete);
+            let missing_required_files = cache_health
+                .as_ref()
+                .map(|health| health.missing_files.clone())
+                .unwrap_or_default();
+            // The managed dir mirrors the default-download install path; a variant that is present
+            // there (a directly-downloaded turnkey) counts as installed too.
+            let managed_path = data_dir.join("models").join(safe_download_dir(&repo));
+            let managed_installed = model_is_installed(&managed_path);
+            let installed_path = if installed || cache_incomplete {
+                cache_path
+            } else if managed_installed {
+                Some(managed_path)
+            } else {
+                None
+            };
+            ModelVariantState {
+                variant: entry
+                    .get("variant")
+                    .and_then(Value::as_str)
+                    .map(str::to_owned)
+                    .unwrap_or_else(|| "default".to_owned()),
+                installed: installed || managed_installed,
+                installed_path: installed_path.map(|path| path.display().to_string()),
+                cache_incomplete,
+                missing_required_files,
+                download_size_bytes: manifest_download_size_bytes(model, entry)
+                    .or_else(|| variant_footprint_disk_bytes(entry)),
+                footprint: entry.get("footprint").cloned().unwrap_or(Value::Null),
+            }
+        })
+        .collect()
+}
+
+// The on-disk size a `downloads[].footprint.diskSizeBytes` declares, if any — the tier-scoped
+// footprint signal (sc-8508) used as a fallback size when `estimatedSizeBytes` is absent.
+fn variant_footprint_disk_bytes(download: &Value) -> Option<u64> {
+    download
+        .get("footprint")
+        .and_then(|footprint| footprint.get("diskSizeBytes"))
+        .and_then(json_size_to_u64)
+}
+
 // Gated-model signal (sc-1898): a machine-readable `gated` flag plus the credential
 // host the download requires, so the Models screen can route the user to the
 // credential screen before a download will succeed. The host honors an explicit
@@ -914,6 +1054,44 @@ fn apply_gating_fields(object: &mut JsonObject) {
 // conversion status for models that declare an `mlx` variant. Additive fields the
 // web/Docker build ignores; the client only acts on macSupport when the capabilities
 // endpoint reports `macGatingActive`, so non-Mac pickers are untouched.
+// Per-variant catalog fields (sc-8508): emit a `variants` array — one object per declared quant
+// tier — plus a `hasVariantMatrix` boolean the web uses to decide whether to render a tier picker.
+// A single-variant model gets a one-element array keyed "default" that mirrors the top-level
+// install state, so the existing single-variant contract is unchanged.
+fn apply_variant_fields(object: &mut JsonObject, data_dir: &FsPath) {
+    let model = Value::Object(object.clone());
+    let has_matrix = model_has_variant_matrix(&model);
+    let variants = model_variant_states(&model, data_dir)
+        .into_iter()
+        .map(|variant| {
+            json!({
+                "variant": variant.variant,
+                "installed": variant.installed,
+                "installState": if variant.installed { "installed" } else { "missing" },
+                "cacheState": if variant.cache_incomplete {
+                    "incomplete"
+                } else if variant.installed {
+                    "complete"
+                } else {
+                    "missing"
+                },
+                "installedPath": variant
+                    .installed_path
+                    .map(Value::String)
+                    .unwrap_or(Value::Null),
+                "missingRequiredFiles": variant.missing_required_files,
+                "downloadSizeBytes": variant
+                    .download_size_bytes
+                    .map(|value| json!(value))
+                    .unwrap_or(Value::Null),
+                "footprint": variant.footprint,
+            })
+        })
+        .collect::<Vec<_>>();
+    object.insert("hasVariantMatrix".to_owned(), Value::Bool(has_matrix));
+    object.insert("variants".to_owned(), Value::Array(variants));
+}
+
 fn apply_mac_and_mlx_fields(object: &mut JsonObject, data_dir: &FsPath) {
     let mac_support = {
         let id = object.get("id").and_then(Value::as_str).unwrap_or_default();
@@ -1078,6 +1256,11 @@ async fn model_catalog_inner(
                 "removable".to_owned(),
                 Value::Bool(user_managed || state.installed),
             );
+            // Per-variant install tracking (sc-8508, epic 8506): one entry per declared quant tier,
+            // each with its own installed flag + path + size + footprint. A single-variant model
+            // still emits exactly one "default" variant, so the array is a superset of the
+            // (retained) top-level installState/installedPath fields — nothing existing regresses.
+            apply_variant_fields(object, &data_dir);
             apply_gating_fields(object);
             apply_mac_and_mlx_fields(object, &data_dir);
         }
@@ -1242,6 +1425,27 @@ pub(crate) fn model_download(model: &Value) -> Option<Value> {
         }
     }
     fallback.cloned()
+}
+
+/// Select a specific quant tier's download entry for a quant-matrix model (sc-8508). Returns the
+/// supported `downloads` entry whose `variant` matches `variant` (case-insensitive). `None` when the
+/// model declares no such tier — the caller surfaces a 400 rather than silently installing the wrong
+/// tier. A `None` `variant` argument means "the default tier" and is handled by [`model_download`].
+pub(crate) fn model_download_for_variant(model: &Value, variant: &str) -> Option<Value> {
+    let downloads = model.get("downloads")?.as_array()?;
+    let wanted = variant.trim().to_ascii_lowercase();
+    downloads
+        .iter()
+        .find(|download| {
+            is_supported_model_download(download)
+                && download
+                    .get("variant")
+                    .and_then(Value::as_str)
+                    .map(|value| value.trim().to_ascii_lowercase())
+                    .as_deref()
+                    == Some(wanted.as_str())
+        })
+        .cloned()
 }
 
 /// Best-effort credential host for a gated model when the manifest entry doesn't
@@ -1836,6 +2040,148 @@ mod gated_credential_tests {
         assert_eq!(
             model.get("licenseUrl").and_then(Value::as_str),
             Some("https://huggingface.co/stabilityai/stable-diffusion-3.5-large"),
+        );
+    }
+}
+
+#[cfg(test)]
+mod variant_install_tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Seed a HuggingFace repo cache snapshot under `data_dir` containing `files` (repo-relative
+    /// paths). Mirrors the on-disk layout `model_variant_states` probes.
+    fn seed_cache(data_dir: &FsPath, repo: &str, files: &[&str]) {
+        let cache = huggingface_repo_cache_path(data_dir, repo).expect("cache path");
+        let snapshot = cache.join("snapshots").join("abc123");
+        for file in files {
+            let path = snapshot.join(file);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(path, b"x").unwrap();
+        }
+    }
+
+    fn quant_matrix_model(repo: &str) -> Value {
+        json!({
+            "id": "matrix_model",
+            "downloads": [
+                {
+                    "provider": "huggingface",
+                    "repo": repo,
+                    "variant": "q4",
+                    "default": true,
+                    "files": ["q4/*"],
+                    "footprint": { "diskSizeBytes": 5_000_000_000_u64 }
+                },
+                {
+                    "provider": "huggingface",
+                    "repo": repo,
+                    "variant": "q8",
+                    "files": ["q8/*"],
+                    "footprint": { "diskSizeBytes": 10_000_000_000_u64, "peakMemoryBytes": null }
+                },
+                {
+                    "provider": "huggingface",
+                    "repo": repo,
+                    "variant": "bf16",
+                    "files": ["bf16/*"],
+                    "estimatedSizeBytes": 20_000_000_000_u64
+                }
+            ]
+        })
+    }
+
+    #[test]
+    fn detects_matrix_and_single_variant_shapes() {
+        // Multiple supported entries → a matrix.
+        assert!(model_has_variant_matrix(&quant_matrix_model(
+            "SceneWorks/matrix"
+        )));
+        // A single entry with an explicit variant → still a matrix (tier-tracked).
+        assert!(model_has_variant_matrix(&json!({
+            "downloads": [{ "provider": "huggingface", "repo": "o/m", "variant": "q4" }]
+        })));
+        // A single unlabeled entry → NOT a matrix (back-compat single-variant).
+        assert!(!model_has_variant_matrix(&json!({
+            "downloads": [{ "provider": "huggingface", "repo": "o/m" }]
+        })));
+        // No downloads → not a matrix.
+        assert!(!model_has_variant_matrix(&json!({ "id": "x" })));
+    }
+
+    #[test]
+    fn single_variant_model_yields_one_default_variant() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path();
+        let model = json!({
+            "id": "single",
+            "downloads": [{ "provider": "huggingface", "repo": "owner/single" }]
+        });
+        // Not installed yet.
+        let states = model_variant_states(&model, data_dir);
+        assert_eq!(states.len(), 1);
+        assert_eq!(states[0].variant, "default");
+        assert!(!states[0].installed);
+
+        // Seed the cache with a payload file → installed.
+        seed_cache(data_dir, "owner/single", &["model.safetensors"]);
+        let states = model_variant_states(&model, data_dir);
+        assert!(states[0].installed);
+        assert!(states[0].installed_path.is_some());
+    }
+
+    #[test]
+    fn per_variant_tracking_reports_which_tiers_are_on_disk() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path();
+        let repo = "SceneWorks/matrix";
+        let model = quant_matrix_model(repo);
+
+        // Only bf16 is downloaded (its `files` filter matches only the bf16/ tree).
+        seed_cache(data_dir, repo, &["bf16/model.safetensors"]);
+
+        let states = model_variant_states(&model, data_dir);
+        assert_eq!(states.len(), 3);
+        let by_variant = |name: &str| states.iter().find(|s| s.variant == name).unwrap();
+
+        // bf16 present; q4 + q8 absent — the whole point of per-variant tracking.
+        assert!(by_variant("bf16").installed, "bf16 should read installed");
+        assert!(!by_variant("q4").installed, "q4 should read missing");
+        assert!(!by_variant("q8").installed, "q8 should read missing");
+
+        // Footprint + size flow through: q4 uses footprint.diskSizeBytes, bf16 uses estimatedSizeBytes.
+        assert_eq!(by_variant("q4").download_size_bytes, Some(5_000_000_000));
+        assert_eq!(by_variant("bf16").download_size_bytes, Some(20_000_000_000));
+        assert_eq!(
+            by_variant("q8").footprint.get("peakMemoryBytes"),
+            Some(&Value::Null)
+        );
+    }
+
+    #[test]
+    fn variant_footprint_disk_bytes_reads_required_field() {
+        let entry = json!({ "footprint": { "diskSizeBytes": 42 } });
+        assert_eq!(variant_footprint_disk_bytes(&entry), Some(42));
+        assert_eq!(variant_footprint_disk_bytes(&json!({})), None);
+    }
+
+    #[test]
+    fn variant_download_selector_picks_the_right_tier() {
+        let model = quant_matrix_model("SceneWorks/matrix");
+        // Case-insensitive match on the declared variant.
+        assert_eq!(
+            model_download_for_variant(&model, "Q8")
+                .and_then(|d| d.get("files").cloned())
+                .and_then(|f| f.as_array().and_then(|a| a.first().cloned())),
+            Some(Value::String("q8/*".to_owned()))
+        );
+        // Unknown tier → None (the handler turns this into a 400).
+        assert!(model_download_for_variant(&model, "int8").is_none());
+        // The default selector still picks the `default: true` (q4) entry — back-compat.
+        assert_eq!(
+            model_download(&model)
+                .and_then(|d| d.get("variant").and_then(Value::as_str).map(str::to_owned)),
+            Some("q4".to_owned())
         );
     }
 }

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -943,17 +943,24 @@ struct ModelVariantState {
     footprint: Value,
 }
 
-// Whether `model`'s `downloads` array declares more than one supported entry OR any entry carries an
-// explicit `variant` — i.e. it is a quant-matrix model whose tiers should be tracked per-variant.
+// Whether `model`'s `downloads` array is a quant-matrix — i.e. at least one supported entry carries
+// an explicit non-empty `variant` key (q4/q8/bf16). Entry COUNT is deliberately NOT a discriminator:
+// the manifest uses multiple download entries for non-tier reasons too (alternate sources, native
+// fallbacks, co-requisite TE repos — e.g. PiD backbone + gemma-2-2b-it, boogu mlx+native, krea, wan,
+// ltx). Those are not quant matrices, so only variant-presence flags a model as one (sc-8508).
 fn model_has_variant_matrix(model: &Value) -> bool {
     let Some(downloads) = model.get("downloads").and_then(Value::as_array) else {
         return false;
     };
-    let supported: Vec<&Value> = downloads
+    downloads
         .iter()
         .filter(|entry| is_supported_model_download(entry))
-        .collect();
-    supported.len() > 1 || supported.iter().any(|entry| entry.get("variant").is_some())
+        .any(|entry| {
+            entry
+                .get("variant")
+                .and_then(Value::as_str)
+                .is_some_and(|value| !value.trim().is_empty())
+        })
 }
 
 // Build the per-variant install state for every supported download entry. A single-variant model
@@ -964,9 +971,24 @@ fn model_variant_states(model: &Value, data_dir: &FsPath) -> Vec<ModelVariantSta
     let Some(downloads) = model.get("downloads").and_then(Value::as_array) else {
         return Vec::new();
     };
+    // Emitted variant keys must be unique: the single-variant case is exactly one "default", and a
+    // quant matrix has one entry per distinct q4/q8/bf16 tier. Guard against a manifest that maps two
+    // supported entries to the same key (unlabeled alternate sources both collapsing to "default", or
+    // a duplicated `variant`) — keep the first, drop the rest, so downstream per-variant tracking
+    // never emits two same-keyed states (sc-8508).
+    let mut seen_variants = std::collections::HashSet::new();
     downloads
         .iter()
         .filter(|entry| is_supported_model_download(entry))
+        .filter(|entry| {
+            let key = entry
+                .get("variant")
+                .and_then(Value::as_str)
+                .map(|value| value.trim().to_owned())
+                .filter(|value| !value.is_empty())
+                .unwrap_or_else(|| "default".to_owned());
+            seen_variants.insert(key)
+        })
         .map(|entry| {
             let repo = entry
                 .get("repo")
@@ -1001,7 +1023,8 @@ fn model_variant_states(model: &Value, data_dir: &FsPath) -> Vec<ModelVariantSta
                 variant: entry
                     .get("variant")
                     .and_then(Value::as_str)
-                    .map(str::to_owned)
+                    .map(|value| value.trim().to_owned())
+                    .filter(|value| !value.is_empty())
                     .unwrap_or_else(|| "default".to_owned()),
                 installed: installed || managed_installed,
                 installed_path: installed_path.map(|path| path.display().to_string()),
@@ -2093,7 +2116,7 @@ mod variant_install_tests {
 
     #[test]
     fn detects_matrix_and_single_variant_shapes() {
-        // Multiple supported entries → a matrix.
+        // A variant-keyed multi-entry model → a matrix.
         assert!(model_has_variant_matrix(&quant_matrix_model(
             "SceneWorks/matrix"
         )));
@@ -2105,8 +2128,74 @@ mod variant_install_tests {
         assert!(!model_has_variant_matrix(&json!({
             "downloads": [{ "provider": "huggingface", "repo": "o/m" }]
         })));
+        // MULTIPLE unlabeled entries (alternate sources / co-requisite TE repos / native fallback)
+        // → NOT a matrix. Entry count is not the discriminator; only an explicit `variant` is
+        // (sc-8508). Guards against the old `supported.len() > 1` heuristic that falsely flagged
+        // ~30 multi-repo models.
+        assert!(!model_has_variant_matrix(&json!({
+            "downloads": [
+                { "provider": "huggingface", "repo": "org/backbone" },
+                { "provider": "huggingface", "repo": "SceneWorks/gemma-2-2b-it" }
+            ]
+        })));
+        // An empty-string variant is not a real tier label → not a matrix.
+        assert!(!model_has_variant_matrix(&json!({
+            "downloads": [
+                { "provider": "huggingface", "repo": "org/a", "variant": "" },
+                { "provider": "huggingface", "repo": "org/b" }
+            ]
+        })));
         // No downloads → not a matrix.
         assert!(!model_has_variant_matrix(&json!({ "id": "x" })));
+    }
+
+    #[test]
+    fn alternate_source_multi_entry_yields_one_default_variant() {
+        // Two unlabeled download entries (alternate sources / co-requisite TE repo) must NOT be
+        // treated as a quant matrix: both would otherwise collapse to a duplicate "default" key.
+        // The dedup guard emits exactly one "default" variant, matching the single-variant contract.
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path();
+        let model = json!({
+            "id": "alt_source",
+            "downloads": [
+                { "provider": "huggingface", "repo": "org/backbone" },
+                { "provider": "huggingface", "repo": "SceneWorks/gemma-2-2b-it" }
+            ]
+        });
+        assert!(!model_has_variant_matrix(&model));
+        let states = model_variant_states(&model, data_dir);
+        assert_eq!(states.len(), 1, "alternate-source model emits one variant");
+        assert_eq!(states[0].variant, "default");
+    }
+
+    #[test]
+    fn variant_keys_are_unique_across_emitted_states() {
+        // Every emitted variant key must be unique. A manifest that duplicates a variant (or maps
+        // two entries to the same key) keeps only the first; downstream tracking never emits two
+        // same-keyed states (sc-8508).
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path();
+
+        // Genuine matrix → three distinct keys.
+        let matrix = quant_matrix_model("SceneWorks/matrix");
+        let states = model_variant_states(&matrix, data_dir);
+        let mut keys: Vec<_> = states.iter().map(|s| s.variant.clone()).collect();
+        keys.sort();
+        keys.dedup();
+        assert_eq!(keys, vec!["bf16", "q4", "q8"]);
+
+        // Two entries sharing a variant key → collapsed to one (first wins).
+        let dup = json!({
+            "id": "dup",
+            "downloads": [
+                { "provider": "huggingface", "repo": "org/a", "variant": "q4", "files": ["q4/*"] },
+                { "provider": "huggingface", "repo": "org/b", "variant": "q4", "files": ["q4-alt/*"] }
+            ]
+        });
+        let dup_states = model_variant_states(&dup, data_dir);
+        assert_eq!(dup_states.len(), 1);
+        assert_eq!(dup_states[0].variant, "q4");
     }
 
     #[test]

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -210,6 +210,18 @@ fn model_convert_request_parses_optional_mlx_quant_fields() {
 }
 
 #[test]
+fn model_download_request_parses_optional_variant() {
+    // sc-8508: the download endpoint accepts an optional quant `variant` (bf16/q8/q4) to install a
+    // specific tier of a quant-matrix model. Absent = the default tier (back-compat single-variant).
+    let bare: super::ModelDownloadRequest = serde_json::from_value(json!({})).expect("bare body");
+    assert_eq!(bare.variant, None);
+
+    let tiered: super::ModelDownloadRequest =
+        serde_json::from_value(json!({ "variant": "q4" })).expect("variant body");
+    assert_eq!(tiered.variant.as_deref(), Some("q4"));
+}
+
+#[test]
 fn repo_slug_functions_match_cross_language_contract() {
     // story 1667: safe_download_dir is the api-only repo->dir slug op pinned by
     // the shared repo_slugs.json contract. (safe_repo_dir_name moved to

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -161,20 +161,27 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/z-image-mlx",
+          "variant": "q4",
+          "default": true,
           "files": ["q4/*"],
-          "estimatedSizeBytes": 5907321677
+          "estimatedSizeBytes": 5907321677,
+          "footprint": { "diskSizeBytes": 5907321677, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/z-image-mlx",
+          "variant": "q8",
           "files": ["q8/*"],
-          "estimatedSizeBytes": 10996438540
+          "estimatedSizeBytes": 10996438540,
+          "footprint": { "diskSizeBytes": 10996438540, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/z-image-mlx",
+          "variant": "bf16",
           "files": ["bf16/*"],
-          "estimatedSizeBytes": 20538412852
+          "estimatedSizeBytes": 20538412852,
+          "footprint": { "diskSizeBytes": 20538412852, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "paths": {
@@ -338,20 +345,27 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/qwen-image-mlx",
+          "variant": "q4",
+          "default": true,
           "files": ["q4/*"],
-          "estimatedSizeBytes": 28387655680
+          "estimatedSizeBytes": 28387655680,
+          "footprint": { "diskSizeBytes": 28387655680, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/qwen-image-mlx",
+          "variant": "q8",
           "files": ["q8/*"],
-          "estimatedSizeBytes": 38583632655
+          "estimatedSizeBytes": 38583632655,
+          "footprint": { "diskSizeBytes": 38583632655, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/qwen-image-mlx",
+          "variant": "bf16",
           "files": ["bf16/*"],
-          "estimatedSizeBytes": 57731960832
+          "estimatedSizeBytes": 57731960832,
+          "footprint": { "diskSizeBytes": 57731960832, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "paths": {
@@ -457,20 +471,27 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/qwen-image-edit-2511-mlx",
+          "variant": "q4",
+          "default": true,
           "files": ["q4/*"],
-          "estimatedSizeBytes": 28387655680
+          "estimatedSizeBytes": 28387655680,
+          "footprint": { "diskSizeBytes": 28387655680, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/qwen-image-edit-2511-mlx",
+          "variant": "q8",
           "files": ["q8/*"],
-          "estimatedSizeBytes": 38583632655
+          "estimatedSizeBytes": 38583632655,
+          "footprint": { "diskSizeBytes": 38583632655, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/qwen-image-edit-2511-mlx",
+          "variant": "bf16",
           "files": ["bf16/*"],
-          "estimatedSizeBytes": 57731960832
+          "estimatedSizeBytes": 57731960832,
+          "footprint": { "diskSizeBytes": 57731960832, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "paths": {
@@ -547,21 +568,28 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/qwen-image-edit-2511-mlx",
+          "variant": "q4",
+          "default": true,
           "files": ["q4/*"],
           "default": true,
-          "estimatedSizeBytes": 28387655680
+          "estimatedSizeBytes": 28387655680,
+          "footprint": { "diskSizeBytes": 28387655680, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/qwen-image-edit-2511-mlx",
+          "variant": "q8",
           "files": ["q8/*"],
-          "estimatedSizeBytes": 38583632655
+          "estimatedSizeBytes": 38583632655,
+          "footprint": { "diskSizeBytes": 38583632655, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/qwen-image-edit-2511-mlx",
+          "variant": "bf16",
           "files": ["bf16/*"],
-          "estimatedSizeBytes": 57731960832
+          "estimatedSizeBytes": 57731960832,
+          "footprint": { "diskSizeBytes": 57731960832, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "paths": {
@@ -944,20 +972,27 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/flux1-schnell-mlx",
+          "variant": "q4",
+          "default": true,
           "files": ["q4/*"],
-          "estimatedSizeBytes": 9611551284
+          "estimatedSizeBytes": 9611551284,
+          "footprint": { "diskSizeBytes": 9611551284, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/flux1-schnell-mlx",
+          "variant": "q8",
           "files": ["q8/*"],
-          "estimatedSizeBytes": 17999175703
+          "estimatedSizeBytes": 17999175703,
+          "footprint": { "diskSizeBytes": 17999175703, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/flux1-schnell-mlx",
+          "variant": "bf16",
           "files": ["bf16/*"],
-          "estimatedSizeBytes": 33725923002
+          "estimatedSizeBytes": 33725923002,
+          "footprint": { "diskSizeBytes": 33725923002, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "paths": {
@@ -1028,20 +1063,27 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/flux1-dev-mlx",
+          "variant": "q4",
+          "default": true,
           "files": ["q4/*"],
-          "estimatedSizeBytes": 9617334683
+          "estimatedSizeBytes": 9617334683,
+          "footprint": { "diskSizeBytes": 9617334683, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/flux1-dev-mlx",
+          "variant": "q8",
           "files": ["q8/*"],
-          "estimatedSizeBytes": 18010071290
+          "estimatedSizeBytes": 18010071290,
+          "footprint": { "diskSizeBytes": 18010071290, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/flux1-dev-mlx",
+          "variant": "bf16",
           "files": ["bf16/*"],
-          "estimatedSizeBytes": 33746402173
+          "estimatedSizeBytes": 33746402173,
+          "footprint": { "diskSizeBytes": 33746402173, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "paths": {
@@ -1154,9 +1196,12 @@
           // on demand. Gated non-commercial license; macOS-only download.
           "provider": "huggingface",
           "repo": "SceneWorks/ideogram-4-mlx",
+          "variant": "q4",
+          "default": true,
           "files": ["q4/*"],
           "platforms": ["macos"],
-          "estimatedSizeBytes": 15400562623
+          "estimatedSizeBytes": 15400562623,
+          "footprint": { "diskSizeBytes": 15400562623, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           // bf16 snapshot — shared across backends from the separate `SceneWorks/ideogram-4` repo's
@@ -1165,11 +1210,15 @@
           // selectable full-precision MLX tier (sc-8513, epic 8506) — the worker resolves this repo's
           // `bf16/` subdir when advanced mlxQuantize<=0 (rather than a duplicate copy in the MLX repo).
           // A later quant variant can slot in alongside `bf16/` without a rename. Gated non-commercial.
+          // sc-8508: this is a genuine per-tier quant variant (q4 vs bf16 of the same model), so it is
+          // labeled `variant: bf16` — even though the two tiers happen to live in separate HF repos.
           "provider": "huggingface",
           "repo": "SceneWorks/ideogram-4",
+          "variant": "bf16",
           "files": ["bf16/*"],
           "platforms": ["macos", "windows", "linux"],
-          "estimatedSizeBytes": 54760833024
+          "estimatedSizeBytes": 54760833024,
+          "footprint": { "diskSizeBytes": 54760833024, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "paths": {
@@ -1265,9 +1314,12 @@
           // / show the Fix button. The specific path makes the check exact (apps/rust-api models.rs).
           "provider": "huggingface",
           "repo": "SceneWorks/ideogram-4-mlx",
+          "variant": "q4",
+          "default": true,
           "files": ["q4/*", "q4/turbo_lora.safetensors"],
           "platforms": ["macos"],
-          "estimatedSizeBytes": 16247340792
+          "estimatedSizeBytes": 16247340792,
+          "footprint": { "diskSizeBytes": 16247340792, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           // bf16 snapshot — shared from the separate `SceneWorks/ideogram-4` repo's `bf16/` subdir,
@@ -1275,11 +1327,14 @@
           // candle provider loads it (epic 6561 / sc-6859); on macOS it is the selectable full-precision
           // MLX tier (sc-8513) — the worker resolves this repo's `bf16/` when advanced mlxQuantize<=0,
           // rather than duplicating it into the MLX turnkey repo. Same gated non-commercial license.
+          // sc-8508: genuine per-tier quant variant (q4 vs bf16 of the same model) → labeled `bf16`.
           "provider": "huggingface",
           "repo": "SceneWorks/ideogram-4",
+          "variant": "bf16",
           "files": ["bf16/*"],
           "platforms": ["macos", "windows", "linux"],
-          "estimatedSizeBytes": 54760833024
+          "estimatedSizeBytes": 54760833024,
+          "footprint": { "diskSizeBytes": 54760833024, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "paths": {
@@ -1840,22 +1895,29 @@
           // (`DENSE_TE_TIER_MODELS`). Replaces the old gated 49 GiB whole-repo + load-time quantize.
           "provider": "huggingface",
           "repo": "SceneWorks/flux2-klein-9b-mlx",
+          "variant": "q4",
+          "default": true,
           "files": ["q4/*"],
-          "estimatedSizeBytes": 21700000000
+          "estimatedSizeBytes": 21700000000,
+          "footprint": { "diskSizeBytes": 21700000000, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/flux2-klein-9b-mlx",
+          "variant": "q8",
           "files": ["q8/*"],
-          "estimatedSizeBytes": 26100000000
+          "estimatedSizeBytes": 26100000000,
+          "footprint": { "diskSizeBytes": 26100000000, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           // bf16/ — dense transformer + dense Qwen3 TE, the max-fidelity tier. Selectable via
           // per-variant tracking (sc-8508/8509).
           "provider": "huggingface",
           "repo": "SceneWorks/flux2-klein-9b-mlx",
+          "variant": "bf16",
           "files": ["bf16/*"],
-          "estimatedSizeBytes": 34600000000
+          "estimatedSizeBytes": 34600000000,
+          "footprint": { "diskSizeBytes": 34600000000, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "paths": {
@@ -1970,20 +2032,27 @@
           // load via `DENSE_TE_TIER_MODELS`). Replaces the old gated whole-repo + load-time quantize.
           "provider": "huggingface",
           "repo": "SceneWorks/flux2-klein-9b-kv-mlx",
+          "variant": "q4",
+          "default": true,
           "files": ["q4/*"],
-          "estimatedSizeBytes": 21700000000
+          "estimatedSizeBytes": 21700000000,
+          "footprint": { "diskSizeBytes": 21700000000, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/flux2-klein-9b-kv-mlx",
+          "variant": "q8",
           "files": ["q8/*"],
-          "estimatedSizeBytes": 26100000000
+          "estimatedSizeBytes": 26100000000,
+          "footprint": { "diskSizeBytes": 26100000000, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/flux2-klein-9b-kv-mlx",
+          "variant": "bf16",
           "files": ["bf16/*"],
-          "estimatedSizeBytes": 34600000000
+          "estimatedSizeBytes": 34600000000,
+          "footprint": { "diskSizeBytes": 34600000000, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "paths": {
@@ -2189,14 +2258,19 @@
           // bf16 tier added separately. q8/ is a second entry (tier selection: epic 8506 sc-8508/8509).
           "provider": "huggingface",
           "repo": "SceneWorks/flux2-dev-mlx",
+          "variant": "q4",
+          "default": true,
           "files": ["q4/*"],
-          "estimatedSizeBytes": 33600000000
+          "estimatedSizeBytes": 33600000000,
+          "footprint": { "diskSizeBytes": 33600000000, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/flux2-dev-mlx",
+          "variant": "q8",
           "files": ["q8/*"],
-          "estimatedSizeBytes": 55000000000
+          "estimatedSizeBytes": 55000000000,
+          "footprint": { "diskSizeBytes": 55000000000, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           // bf16/ — the dense diffusers tree (sharded), the max-fidelity tier for high-memory Macs
@@ -2205,8 +2279,10 @@
           // generates; 256² fits a 128 GB box, production 1024² wants >128 GB).
           "provider": "huggingface",
           "repo": "SceneWorks/flux2-dev-mlx",
+          "variant": "bf16",
           "files": ["bf16/*"],
-          "estimatedSizeBytes": 113000000000
+          "estimatedSizeBytes": 113000000000,
+          "footprint": { "diskSizeBytes": 113000000000, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "defaults": {
@@ -2587,22 +2663,29 @@
           // separate entries (tier selection: sc-8508/8509). Sizes are the measured on-disk totals.
           "provider": "huggingface",
           "repo": "SceneWorks/sd3.5-large-mlx",
+          "variant": "q4",
+          "default": true,
           "files": ["q4/*"],
-          "estimatedSizeBytes": 27212570624
+          "estimatedSizeBytes": 27212570624,
+          "footprint": { "diskSizeBytes": 27212570624, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sd3.5-large-mlx",
+          "variant": "q8",
           "files": ["q8/*"],
-          "estimatedSizeBytes": 31248461824
+          "estimatedSizeBytes": 31248461824,
+          "footprint": { "diskSizeBytes": 31248461824, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           // bf16/ — the dense diffusers tree (sharded transformer), the max-fidelity tier.
           // Selectable via per-variant tracking (sc-8508/8509).
           "provider": "huggingface",
           "repo": "SceneWorks/sd3.5-large-mlx",
+          "variant": "bf16",
           "files": ["bf16/*"],
-          "estimatedSizeBytes": 38789746688
+          "estimatedSizeBytes": 38789746688,
+          "footprint": { "diskSizeBytes": 38789746688, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "defaults": {
@@ -2692,21 +2775,28 @@
           // quantized). Replaces the gated download + install-time convert. Sizes = measured on-disk.
           "provider": "huggingface",
           "repo": "SceneWorks/sd3.5-large-turbo-mlx",
+          "variant": "q4",
+          "default": true,
           "files": ["q4/*"],
-          "estimatedSizeBytes": 27212570624
+          "estimatedSizeBytes": 27212570624,
+          "footprint": { "diskSizeBytes": 27212570624, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sd3.5-large-turbo-mlx",
+          "variant": "q8",
           "files": ["q8/*"],
-          "estimatedSizeBytes": 31239405568
+          "estimatedSizeBytes": 31239405568,
+          "footprint": { "diskSizeBytes": 31239405568, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           // bf16/ — the dense diffusers tree (sharded transformer), max-fidelity tier (sc-8508/8509).
           "provider": "huggingface",
           "repo": "SceneWorks/sd3.5-large-turbo-mlx",
+          "variant": "bf16",
           "files": ["bf16/*"],
-          "estimatedSizeBytes": 38789746688
+          "estimatedSizeBytes": 38789746688,
+          "footprint": { "diskSizeBytes": 38789746688, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "defaults": {
@@ -2783,21 +2873,28 @@
           // (the dense T5-XXL TE dominates even the small backbone, so the tiers are close in size).
           "provider": "huggingface",
           "repo": "SceneWorks/sd3.5-medium-mlx",
+          "variant": "q4",
+          "default": true,
           "files": ["q4/*"],
-          "estimatedSizeBytes": 24213819392
+          "estimatedSizeBytes": 24213819392,
+          "footprint": { "diskSizeBytes": 24213819392, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sd3.5-medium-mlx",
+          "variant": "q8",
           "files": ["q8/*"],
-          "estimatedSizeBytes": 25334730752
+          "estimatedSizeBytes": 25334730752,
+          "footprint": { "diskSizeBytes": 25334730752, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           // bf16/ — the dense diffusers tree, max-fidelity tier (sc-8508/8509).
           "provider": "huggingface",
           "repo": "SceneWorks/sd3.5-medium-mlx",
+          "variant": "bf16",
           "files": ["bf16/*"],
-          "estimatedSizeBytes": 27436347392
+          "estimatedSizeBytes": 27436347392,
+          "footprint": { "diskSizeBytes": 27436347392, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "defaults": {

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -571,7 +571,6 @@
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
-          "default": true,
           "estimatedSizeBytes": 28387655680,
           "footprint": { "diskSizeBytes": 28387655680, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -27,23 +27,34 @@
         // Q8 convert — the worker loads the chosen tier's subdir directly (standard_tier_subdir).
         // All three components are quantized (DiT + TE + VAE attention) in q4/q8; bf16/ is dense
         // (the f32 transformer downcast to bf16 for catalog consistency). Sizes are measured on-disk.
+        // Per-tier variants (sc-8508): each tier is a SEPARATE installable artifact, tagged with a
+        // `variant` key + a `footprint` (required on-disk size; the measured resident/peak memory is
+        // filled in later by sc-8516). `default: true` marks q4 as the tier that installs when no
+        // explicit variant is requested. The catalog tracks each tier's presence independently.
         {
           "provider": "huggingface",
           "repo": "SceneWorks/z-image-turbo-mlx",
+          "variant": "q4",
+          "default": true,
           "files": ["q4/*"],
-          "estimatedSizeBytes": 5909406487
+          "estimatedSizeBytes": 5909406487,
+          "footprint": { "diskSizeBytes": 5909406487, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/z-image-turbo-mlx",
+          "variant": "q8",
           "files": ["q8/*"],
-          "estimatedSizeBytes": 10998523666
+          "estimatedSizeBytes": 10998523666,
+          "footprint": { "diskSizeBytes": 10998523666, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/z-image-turbo-mlx",
+          "variant": "bf16",
           "files": ["bf16/*"],
-          "estimatedSizeBytes": 20538406851
+          "estimatedSizeBytes": 20538406851,
+          "footprint": { "diskSizeBytes": 20538406851, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "paths": {
@@ -84,6 +95,10 @@
         // q4/ is the shipped default tier (sc-8670); q8/ + bf16/ are hosted and selectable via
         // advanced.mlxQuantize (standard_tier_subdir resolves the subdir).
         "quantize": 4,
+        // sc-8508: the manifest-driven form of the STANDARD_TIER_MODELS registry. Additive here
+        // (z_image_turbo is already registered) — it makes the standard q4/q8/bf16 turnkey routing
+        // catalog-declared, so a future quant-matrix model can opt in from the manifest alone.
+        "standardTierLayout": true,
         "limits": {
           "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
           "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
@@ -237,23 +252,34 @@
       "capabilities": ["edit_image", "image_to_image"],
       "downloads": [
         // Shares the Turbo turnkey (sc-8670) — img2img runs the same Turbo weights/tier subdirs.
+        // Per-tier variants (sc-8508): each tier is a SEPARATE installable artifact, tagged with a
+        // `variant` key + a `footprint` (required on-disk size; the measured resident/peak memory is
+        // filled in later by sc-8516). `default: true` marks q4 as the tier that installs when no
+        // explicit variant is requested. The catalog tracks each tier's presence independently.
         {
           "provider": "huggingface",
           "repo": "SceneWorks/z-image-turbo-mlx",
+          "variant": "q4",
+          "default": true,
           "files": ["q4/*"],
-          "estimatedSizeBytes": 5909406487
+          "estimatedSizeBytes": 5909406487,
+          "footprint": { "diskSizeBytes": 5909406487, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/z-image-turbo-mlx",
+          "variant": "q8",
           "files": ["q8/*"],
-          "estimatedSizeBytes": 10998523666
+          "estimatedSizeBytes": 10998523666,
+          "footprint": { "diskSizeBytes": 10998523666, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/z-image-turbo-mlx",
+          "variant": "bf16",
           "files": ["bf16/*"],
-          "estimatedSizeBytes": 20538406851
+          "estimatedSizeBytes": 20538406851,
+          "footprint": { "diskSizeBytes": 20538406851, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "paths": {

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -276,8 +276,9 @@ pub(crate) fn resolve_weights_dir(
     // Catalog-wide quant-matrix models (sc-8513, epic 8506) ship as SceneWorks pre-quantized
     // turnkeys with self-contained `q4/` (default) + `q8/` + `bf16/` subdirs (replacing any
     // install-time convert); point the engine at the chosen tier's subdir rather than the repo root.
-    // FLUX.2-dev was the pilot; the rollout registers each model in [`STANDARD_TIER_MODELS`].
-    if STANDARD_TIER_MODELS.contains(&request.model.as_str()) {
+    // FLUX.2-dev was the pilot; the rollout registers each model in [`STANDARD_TIER_MODELS`] OR (the
+    // sc-8508 manifest-driven form) flags `mlx.standardTierLayout: true` in its catalog entry.
+    if uses_standard_tier_layout(request) {
         return Ok(snapshot.map(|root| standard_tier_subdir(&root, request)));
     }
     Ok(snapshot)
@@ -290,6 +291,10 @@ pub(crate) fn resolve_weights_dir(
 /// FLUX.2-dev pilot's bespoke resolver. Legacy turnkeys with non-standard defaults/variants
 /// (Ideogram q4-only, Krea q8-default, Boogu per-variant + on-demand bf16) keep their own resolvers
 /// above.
+///
+/// sc-8508 makes this catalog-driven: [`uses_standard_tier_layout`] also honors a manifest
+/// `mlx.standardTierLayout: true` flag, so a NEW quant-matrix model can opt in from the manifest
+/// alone. This registry remains the zero-manifest-change path for every already-wired model.
 const STANDARD_TIER_MODELS: &[&str] = &[
     "flux2_dev",
     "sd3_5_large",
@@ -332,6 +337,39 @@ const STANDARD_TIER_MODELS: &[&str] = &[
 /// z-image, whose text encoders are packed too, so their Q4/Q8 load-quant is a harmless no-op on
 /// already-packed weights.
 const DENSE_TE_TIER_MODELS: &[&str] = &["flux2_klein_9b", "flux2_klein_9b_kv"];
+
+/// Whether a request's model ships the standard SceneWorks quant-matrix turnkey layout (sc-8508):
+/// true when it is registered in [`STANDARD_TIER_MODELS`] OR its manifest entry declares
+/// `mlx.standardTierLayout: true`. The manifest flag is the first-class, catalog-driven form of the
+/// hardcoded registry (epic 8506) — a new quant-matrix model can opt in from the manifest alone,
+/// while the registry keeps every already-wired model working with zero manifest change.
+#[cfg(any(target_os = "macos", feature = "backend-candle"))]
+fn uses_standard_tier_layout(request: &ImageRequest) -> bool {
+    STANDARD_TIER_MODELS.contains(&request.model.as_str())
+        || request
+            .model_manifest_entry
+            .get("mlx")
+            .and_then(|mlx| mlx.get("standardTierLayout"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+}
+
+/// Whether a standard-tier request keeps a DENSE bf16 text encoder in every tier (sc-8508): true
+/// when it is in [`DENSE_TE_TIER_MODELS`] OR its manifest declares `mlx.denseTextEncoderTier: true`.
+/// The manifest flag mirrors the hardcoded set so a new dense-TE turnkey opts in from the catalog.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn is_dense_te_tier(request: &ImageRequest) -> bool {
+    DENSE_TE_TIER_MODELS.contains(&request.model.as_str())
+        || request
+            .model_manifest_entry
+            .get("mlx")
+            .and_then(|mlx| mlx.get("denseTextEncoderTier"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+}
 
 /// Pick the engine-complete tier subdir of a standard SceneWorks quant-matrix turnkey `root`:
 /// `bf16/` when the request opts out of quantization (`advanced.mlxQuantize <= 0` / "none"), `q8/`
@@ -597,7 +635,7 @@ fn resolve_quant(request: &ImageRequest) -> (Option<Quant>, Option<i64>) {
     // + a DENSE bf16 text encoder, so the load Quant must be None — quantizing here would crush the
     // dense bf16 TE we deliberately kept full-precision. The packed transformer self-describes its
     // quant regardless. Tier selection (q4/q8/bf16) is driven by the resolved subdir, not this.
-    if DENSE_TE_TIER_MODELS.contains(&request.model.as_str()) {
+    if is_dense_te_tier(request) {
         return (None, None);
     }
     let raw = request
@@ -3242,5 +3280,52 @@ mod standard_tier_tests {
             standard_tier_subdir(empty.path(), &request(json!({}))),
             empty.path().to_path_buf()
         );
+    }
+
+    /// A model built with a manifest entry so `uses_standard_tier_layout` / `is_dense_te_tier`
+    /// can be exercised without touching the hardcoded registries.
+    #[cfg(any(target_os = "macos", feature = "backend-candle"))]
+    fn manifest_request(model: &str, mlx: serde_json::Value) -> ImageRequest {
+        ImageRequest::from_payload(
+            json!({ "model": model, "modelManifestEntry": { "mlx": mlx } })
+                .as_object()
+                .unwrap(),
+        )
+    }
+
+    /// sc-8508: the standard-tier routing is manifest-driven — a model NOT in
+    /// [`STANDARD_TIER_MODELS`] opts in via `mlx.standardTierLayout: true`, while a registry model
+    /// stays true without the flag and an ordinary model stays false. Back-compat guard.
+    #[cfg(any(target_os = "macos", feature = "backend-candle"))]
+    #[test]
+    fn standard_tier_layout_is_manifest_driven_with_registry_backcompat() {
+        // Registry member, no manifest flag → still true.
+        assert!(uses_standard_tier_layout(&manifest_request(
+            "flux2_dev",
+            json!({})
+        )));
+        // Novel id (not in the registry) opts in from the manifest alone.
+        assert!(uses_standard_tier_layout(&manifest_request(
+            "some_new_matrix_model",
+            json!({ "standardTierLayout": true })
+        )));
+        // Novel id without the flag → not a standard-tier model.
+        assert!(!uses_standard_tier_layout(&manifest_request(
+            "some_dense_model",
+            json!({})
+        )));
+    }
+
+    /// sc-8508: the dense-TE guard is manifest-driven too — registry members
+    /// (`DENSE_TE_TIER_MODELS`) stay true and a novel id opts in via `mlx.denseTextEncoderTier`.
+    #[cfg(any(target_os = "macos", feature = "backend-candle"))]
+    #[test]
+    fn dense_te_tier_is_manifest_driven_with_registry_backcompat() {
+        assert!(is_dense_te_tier(&manifest_request("flux2_klein_9b", json!({}))));
+        assert!(is_dense_te_tier(&manifest_request(
+            "some_dense_te_model",
+            json!({ "denseTextEncoderTier": true })
+        )));
+        assert!(!is_dense_te_tier(&manifest_request("flux2_dev", json!({}))));
     }
 }

--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -44,6 +44,30 @@
       ],
       "description": "Classifier-free-guidance policy from the unified guidance axis (epic 7434). Names match gen-core's GuidanceMethod registry exactly. \"cfg\" is the standard guidance the engine applies by default (the N1 no-op); \"cfg_rescale\" (Lens-style std-rescale), \"apg\" (Bernini adaptive-projected guidance), and \"cfg_pp\" (CFG++, reparameterized low-cfg guidance) are advertised per-model-per-backend only where the linked engine descriptor honors them. The worker N3-falls an unadvertised method back to the engine default."
     },
+    "quantVariantKey": {
+      "type": "string",
+      "enum": ["bf16", "q8", "q4"],
+      "description": "Quantization tier of a downloadable model variant (epic 8506, sc-8508). `bf16` = dense full-precision, `q8` / `q4` = pre-quantized packed tiers. Matches the SceneWorks quant-matrix turnkey subdir names resolved by the worker's standard_tier_subdir. Maps to advanced.mlxQuantize at generation time (bf16 <=> 0/none, q8 <=> 8, q4 <=> 4)."
+    },
+    "variantFootprint": {
+      "type": "object",
+      "description": "Footprint metadata for one downloadable model variant (sc-8508). `diskSizeBytes` is required; the measured-memory fields are OPTIONAL and nullable so a later story (sc-8516) can populate real resident/peak numbers without a schema change. The RAM-suggestion engine (sc-8509/8516) is out of scope here — this only declares the fields it will consume.",
+      "required": ["diskSizeBytes"],
+      "properties": {
+        "diskSizeBytes": {
+          "type": ["integer", "string"],
+          "description": "On-disk size (bytes) of this variant's files after applying the download `files` filter. Required."
+        },
+        "residentMemoryBytes": {
+          "type": ["integer", "string", "null"],
+          "description": "OPTIONAL measured steady-state resident memory (bytes) when this variant is loaded and generating. Null/absent until sc-8516 measures it."
+        },
+        "peakMemoryBytes": {
+          "type": ["integer", "string", "null"],
+          "description": "OPTIONAL measured peak memory (bytes) during load + first generation. Null/absent until sc-8516 measures it."
+        }
+      }
+    },
     "samplerLimits": {
       "type": "object",
       "description": "Per-model sampler / scheduler / guidance capability lists used to gate Image / Video Studio dropdowns. Omit the keys entirely to disable the controls; include single-element [\"default\"] arrays for sealed adapters so the manifest is still self-describing.",
@@ -169,6 +193,14 @@
                 "type": "boolean",
                 "description": "When true, the native checkpoint must be converted to MLX locally via a tracked model_convert job."
               },
+              "standardTierLayout": {
+                "type": "boolean",
+                "description": "When true, this model ships the standard SceneWorks quant-matrix turnkey layout (sc-8508): self-contained q4/ + q8/ + bf16/ subdirs under one repo, each a complete from_snapshot tree. The worker routes weight resolution through standard_tier_subdir on this flag (the manifest-driven generalization of the hardcoded STANDARD_TIER_MODELS registry). Additive — a model already in the registry keeps working without it."
+              },
+              "denseTextEncoderTier": {
+                "type": "boolean",
+                "description": "When true (with standardTierLayout), every tier keeps a DENSE bf16 text encoder — only the transformer is packed (e.g. FLUX.2-klein). The worker forces the load quant to None for these so the dense TE is never re-quantized. Mirrors the DENSE_TE_TIER_MODELS set."
+              },
               "convertSourceRepo": {
                 "type": "string",
                 "description": "Native checkpoint repo used as the conversion source when requiresConversion is true."
@@ -181,7 +213,7 @@
           },
           "downloads": {
             "type": "array",
-            "description": "Download entries list alternate sources for the same model; at most one may be marked default: true. If none is marked, the first supported entry is used.",
+            "description": "Download entries list alternate sources for the same model; at most one may be marked default: true. If none is marked, the first supported entry is used. When a model ships a quant matrix (epic 8506, sc-8508), each tier (bf16 / Q8 / Q4) is a SEPARATE download entry — same repo, distinct `files` filter and `variant` — so each tier is an independently installable artifact whose presence the catalog tracks per-variant.",
             "contains": {
               "type": "object",
               "properties": {
@@ -205,11 +237,19 @@
                 },
                 "default": {
                   "type": "boolean",
-                  "description": "Marks the canonical alternate used for displayed size, install path, and download jobs."
+                  "description": "Marks the canonical alternate used for displayed size, install path, and download jobs. For a quant matrix this marks the DEFAULT tier (the one that installs when no explicit variant is requested)."
+                },
+                "variant": {
+                  "$ref": "#/$defs/quantVariantKey",
+                  "description": "The quantization tier this entry provisions (bf16 / q8 / q4). Present only on quant-matrix entries (sc-8508); a single-variant model omits it. The web/download-job selects a tier by this key, and per-variant install tracking reports which tiers are on disk."
                 },
                 "estimatedSizeBytes": {
                   "type": ["integer", "string"],
                   "description": "Estimated bytes for the actual files downloaded after applying the files filter. Refresh from the provider when upstream files change."
+                },
+                "footprint": {
+                  "$ref": "#/$defs/variantFootprint",
+                  "description": "Per-variant footprint metadata (sc-8508): required on-disk size plus OPTIONAL measured resident/peak memory (populated later by sc-8516). Distinct from estimatedSizeBytes so the RAM-suggestion surfaces (sc-8509/8516) have a stable, tier-scoped signal."
                 },
                 "files": {
                   "type": "array",

--- a/tests/fixtures/rust_api_contract_snapshots/snapshots.json
+++ b/tests/fixtures/rust_api_contract_snapshots/snapshots.json
@@ -2154,6 +2154,7 @@
       ],
       "family": "z-image",
       "gated": false,
+      "hasVariantMatrix": true,
       "id": "base-model",
       "installState": "missing",
       "installedPath": "<runtime-root>/data/models/owner__base-model",
@@ -2186,7 +2187,29 @@
       "type": "image",
       "ui": {
         "label": "User"
-      }
+      },
+      "variants": [
+        {
+          "cacheState": "missing",
+          "downloadSizeBytes": 536870912,
+          "footprint": null,
+          "installState": "missing",
+          "installed": false,
+          "installedPath": null,
+          "missingRequiredFiles": [],
+          "variant": "default"
+        },
+        {
+          "cacheState": "missing",
+          "downloadSizeBytes": 12884901888,
+          "footprint": null,
+          "installState": "missing",
+          "installed": false,
+          "installedPath": null,
+          "missingRequiredFiles": [],
+          "variant": "default"
+        }
+      ]
     },
     {
       "adapter": "z_image_diffusers",
@@ -2208,6 +2231,7 @@
       "downloads": [],
       "family": "z-image",
       "gated": false,
+      "hasVariantMatrix": false,
       "id": "z_image_turbo",
       "installState": "missing",
       "installedPath": null,
@@ -2234,7 +2258,8 @@
       "type": "image",
       "ui": {
         "label": "Z-Image"
-      }
+      },
+      "variants": []
     }
   ],
   "persisted character sidecar": {

--- a/tests/fixtures/rust_api_contract_snapshots/snapshots.json
+++ b/tests/fixtures/rust_api_contract_snapshots/snapshots.json
@@ -2154,7 +2154,7 @@
       ],
       "family": "z-image",
       "gated": false,
-      "hasVariantMatrix": true,
+      "hasVariantMatrix": false,
       "id": "base-model",
       "installState": "missing",
       "installedPath": "<runtime-root>/data/models/owner__base-model",
@@ -2192,16 +2192,6 @@
         {
           "cacheState": "missing",
           "downloadSizeBytes": 536870912,
-          "footprint": null,
-          "installState": "missing",
-          "installed": false,
-          "installedPath": null,
-          "missingRequiredFiles": [],
-          "variant": "default"
-        },
-        {
-          "cacheState": "missing",
-          "downloadSizeBytes": 12884901888,
           "footprint": null,
           "installState": "missing",
           "installed": false,


### PR DESCRIPTION
## What & why
Generalizes the ad-hoc quant-matrix mechanism (the `STANDARD_TIER_MODELS` registry + per-tier `downloads[]` entries with `files` filters) into a **first-class per-variant schema, catalog-driven tier routing, and per-variant install tracking** — so a model can advertise bf16/Q8/Q4 as distinct installable artifacts with sizes, the system knows which tiers are on disk, and `resolve_quant`/weight-resolution honor the chosen installed variant.

Closes sc-8508.

## Scope covered vs acceptance criteria
1. **Schema — tier matrix + footprint** ✅ `packages/schemas/model-manifest.schema.json`: `downloads[].variant` (bf16/q8/q4) + `downloads[].footprint` with required `diskSizeBytes` and **optional nullable** `residentMemoryBytes`/`peakMemoryBytes` (sc-8516 fills the measured numbers later, no future schema change needed). Added `mlx.standardTierLayout` / `mlx.denseTextEncoderTier` flags.
2. **Per-variant install tracking** ✅ `model_variant_states` probes each tier's presence against that entry's own `files` filter and emits a `variants` array (+ `hasVariantMatrix`) on `/models` — each with `installed`, `installState`, `installedPath`, `downloadSizeBytes`, `footprint`. The top-level single-variant `installState`/`installedPath` are retained unchanged.
3. **Plumb tier through resolution + install** ✅ `ModelDownloadRequest.variant` + `model_download_for_variant` install a specific tier (absent = default tier; unknown tier = 400). Worker `uses_standard_tier_layout`/`is_dense_te_tier` make `standard_tier_subdir` + `resolve_quant`'s dense-TE guard manifest-driven while preserving the hardcoded registries, so `resolve_quant` loads the SELECTED installed tier's subdir.
4. **Contracts + web** ✅ rust-api contract snapshots (`tests/fixtures/rust_api_contract_snapshots/snapshots.json`) regenerated via the parity harness (`UPDATE_SNAPSHOTS=1`); web is plain JS/JSX (no generated TS types) and the full vitest suite is green.
5. **Schema-version bump** ✅ **Not needed, stated:** the on-disk install layout is unchanged — tiers already live as `files`-filtered subdirs inside one HF-cached repo snapshot, probed at read time; nothing touches project.db.
6. **Back-compat** ✅ A single-variant model still emits exactly one `"default"` variant; every already-wired tier model (z-image, qwen, flux1, flux2-dev/klein, sd3.5) keeps loading/downloading through the registries with zero manifest change.

## Tests
- Worker `standard_tier_tests`: manifest-driven layout + dense-TE flags with registry back-compat.
- rust-api `variant_install_tests`: matrix detection, per-tier on-disk presence (bf16 installed while q4/q8 missing), footprint size fallback, variant selector, single-variant default.
- rust-api `model_download_request_parses_optional_variant`.
- Full suites green: `cargo test -p sceneworks-worker --lib` (477), `-p sceneworks-rust-api --lib` (150), web vitest (898). `cargo fmt --all --check` clean, `cargo clippy --all-targets -- -D warnings` clean, candle-lane `cargo check -p sceneworks-worker --no-default-features -F backend-candle --all-targets` clean.

## How verified
Ran the parity contract test (12 passed) with the built binary; inspected the snapshot diff to confirm `variants`/`hasVariantMatrix` appear correctly (multi-download fixture → matrix; empty-download fixture → non-matrix).

## Follow-ups
- sc-8516 populates the measured `residentMemoryBytes`/`peakMemoryBytes` footprint fields (fields exist now).
- sc-8509/8516 build the RAM-suggestion engine on top of the footprint signal (out of scope here).
- Web UI could surface a per-tier picker driven by `variants`/`hasVariantMatrix` (not required by this story).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Adversarial-review follow-up (commit `f895f3b3`)

Fixes four review findings on the variant mechanism:

1. **[major] Variant-driven matrix detection.** `model_has_variant_matrix` no longer uses `supported.len() > 1` as the discriminator — that falsely flagged ~30 models whose multiple `downloads[]` entries are non-tier (alternate sources, native fallbacks, co-requisite TE repos: boogu native+mlx, krea, wan, ltx, PiD backbone + `SceneWorks/gemma-2-2b-it`). A model is now a matrix **only** when at least one supported entry carries an explicit non-empty `variant` key.
2. **[major] Full tier labeling.** Every per-tier download entry of every live quant-matrix tier model (`STANDARD_TIER_MODELS` ∪ `DENSE_TE_TIER_MODELS`) is now labeled with `variant` (q4/q8/bf16) + `footprint.diskSizeBytes` (+ `default: true` on q4): `z_image`, `z_image_edit`, `qwen_image`, `qwen_image_edit_2511`, `qwen_image_edit_2511_lightning`, `flux_schnell`, `flux_dev`, `flux2_klein_9b`, `flux2_klein_9b_kv`, `flux2_dev`, `sd3_5_large`, `sd3_5_large_turbo`, `sd3_5_medium` (`z_image_turbo` was already labeled). `ideogram_4` + `ideogram_4_turbo` ship genuine q4/bf16 quant tiers, so they are labeled too. Genuine multi-repo/alternate-source models are left unlabeled and now correctly report `hasVariantMatrix: false`.
3. **[major] Snapshot re-blessed.** Regenerated the rust-api contract snapshots: the 2-alternate-source fixture (`base-model`) flips from `hasVariantMatrix: true` with two `"default"` variants to `hasVariantMatrix: false` with a single `"default"` variant.
4. **[minor] Unique variant keys.** `model_variant_states` dedupes emitted variant keys (first wins), so a single-variant model emits exactly one `"default"` and duplicates never produce two same-keyed states.

Verification: `variant_install_tests` extended (alternate-source multi-entry ⇒ false + one `"default"`; genuine matrix ⇒ unique q4/q8/bf16 keys; duplicate keys collapse). rust-api lib (152) + worker lib (477) green; `npm run rust:check` clean; candle-lane check clean; contract harness 12 passed and the real `builtin.models.jsonc` parses.
