### PR TITLE
feat(web): custom right-click context menu + Save As in FullscreenPreview (sc-8729)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -2370,6 +2370,7 @@ export function App() {
           nextAsset={previewNavigation.next}
           onClose={closePreview}
           onEditImage={sendAssetToImageEditor}
+          onEditInStudio={sendAssetToImageEdit}
           onPreviewAsset={(asset, direction) => {
             if (direction) {
               previewDirectionRef.current = direction;

--- a/apps/web/src/components/assetPanels.contextMenu.test.jsx
+++ b/apps/web/src/components/assetPanels.contextMenu.test.jsx
@@ -1,0 +1,288 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// sc-8729: FullscreenPreview's custom right-click context menu + Save As button.
+//
+// The menu's visibility of "Reveal" depends on `isDesktop`, which assetPanels.jsx
+// imports from runtime.js at module load. To exercise both desktop and browser
+// variants we mock runtime.js with a mutable flag and re-import the component fresh
+// per suite (vi.resetModules). The Save As / Reveal actions are mocked from
+// assetActions.js so we assert the menu wires to them without touching Tauri.
+
+const actionMocks = vi.hoisted(() => ({
+  saveAssetAs: vi.fn(),
+  revealAsset: vi.fn(),
+}));
+
+vi.mock("../assetActions.js", () => ({
+  saveAssetAs: actionMocks.saveAssetAs,
+  revealAsset: actionMocks.revealAsset,
+}));
+
+// Mutable desktop flag driven per-suite. The component reads `isDesktop` at module
+// load, so tests set this BEFORE importing the component (below).
+const runtimeState = vi.hoisted(() => ({ isDesktop: true }));
+
+vi.mock("../runtime.js", () => ({
+  get isDesktop() {
+    return runtimeState.isDesktop;
+  },
+  tauriInvoke: vi.fn(),
+}));
+
+const imageAsset = {
+  id: "asset-img",
+  projectId: "project-1",
+  displayName: "Plate",
+  type: "image",
+  status: {},
+  file: { path: "assets/images/plate.png", mimeType: "image/png" },
+};
+
+const videoAsset = {
+  id: "asset-vid",
+  projectId: "project-1",
+  displayName: "Clip",
+  type: "video",
+  status: {},
+  file: { path: "assets/videos/clip.mp4", mimeType: "video/mp4" },
+};
+
+let container;
+let root;
+let FullscreenPreview;
+
+const noop = () => {};
+
+function baseProps(overrides = {}) {
+  return {
+    deleteAsset: noop,
+    nextAsset: null,
+    onClose: noop,
+    onPreviewAsset: noop,
+    previousAsset: null,
+    purgeAsset: noop,
+    updateAssetStatus: noop,
+    ...overrides,
+  };
+}
+
+async function renderPreview(props) {
+  root = createRoot(container);
+  await act(async () => {
+    root.render(<FullscreenPreview {...props} />);
+  });
+}
+
+// Right-click the preview stage and return the resulting contextmenu event so the
+// caller can assert defaultPrevented.
+async function rightClickStage() {
+  const stage = document.body.querySelector(".preview-modal-stage");
+  const event = new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 120, clientY: 90 });
+  await act(async () => {
+    stage.dispatchEvent(event);
+  });
+  return event;
+}
+
+function menu() {
+  return document.body.querySelector(".preview-context-menu");
+}
+
+function menuItemLabels() {
+  return [...document.body.querySelectorAll(".preview-context-menu > .preview-context-menu-item")].map((b) =>
+    b.textContent.trim(),
+  );
+}
+
+async function loadComponent(isDesktop) {
+  runtimeState.isDesktop = isDesktop;
+  vi.resetModules();
+  ({ FullscreenPreview } = await import("./assetPanels.jsx"));
+}
+
+beforeEach(() => {
+  global.IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  actionMocks.saveAssetAs.mockReset();
+  actionMocks.revealAsset.mockReset();
+});
+
+afterEach(() => {
+  if (root) {
+    act(() => root.unmount());
+    root = null;
+  }
+  container.remove();
+});
+
+describe("FullscreenPreview context menu (desktop)", () => {
+  beforeEach(async () => {
+    await loadComponent(true);
+  });
+
+  it("right-clicking an image shows the full menu and suppresses the native menu", async () => {
+    const onEditImage = vi.fn();
+    const onEditInStudio = vi.fn();
+    await renderPreview(baseProps({ asset: imageAsset, onEditImage, onEditInStudio }));
+
+    const event = await rightClickStage();
+    expect(event.defaultPrevented).toBe(true);
+
+    expect(menu()).not.toBeNull();
+    const labels = menuItemLabels();
+    expect(labels).toContain("Save As…");
+    expect(labels).toContain("Reveal in Finder/Explorer");
+    expect(labels).toContain("Zoom In");
+    expect(labels).toContain("Zoom Out");
+    expect(labels).toContain("Fit to View");
+    // The submenu trigger is its own row.
+    expect(document.body.querySelector(".preview-context-menu-submenu-trigger").textContent).toContain("Edit in");
+  });
+
+  it("Save As and Reveal menu items call the shared action layer", async () => {
+    await renderPreview(baseProps({ asset: imageAsset }));
+    await rightClickStage();
+
+    await act(async () => {
+      [...document.body.querySelectorAll(".preview-context-menu-item")]
+        .find((b) => b.textContent.trim() === "Save As…")
+        .click();
+    });
+    expect(actionMocks.saveAssetAs).toHaveBeenCalledWith(imageAsset);
+    // Action closes the menu.
+    expect(menu()).toBeNull();
+
+    await rightClickStage();
+    await act(async () => {
+      [...document.body.querySelectorAll(".preview-context-menu-item")]
+        .find((b) => b.textContent.trim() === "Reveal in Finder/Explorer")
+        .click();
+    });
+    expect(actionMocks.revealAsset).toHaveBeenCalledWith(imageAsset);
+  });
+
+  it("Zoom In / Zoom Out / Fit menu items drive the view transform", async () => {
+    await renderPreview(baseProps({ asset: imageAsset }));
+    const transform = () => document.body.querySelector(".preview-zoom-inner").style.transform;
+    expect(transform()).toContain("scale(1)");
+
+    await rightClickStage();
+    await act(async () => {
+      [...document.body.querySelectorAll(".preview-context-menu-item")]
+        .find((b) => b.textContent.trim() === "Zoom In")
+        .click();
+    });
+    expect(transform()).not.toContain("scale(1)");
+
+    await rightClickStage();
+    await act(async () => {
+      [...document.body.querySelectorAll(".preview-context-menu-item")]
+        .find((b) => b.textContent.trim() === "Fit to View")
+        .click();
+    });
+    expect(transform()).toContain("scale(1)");
+  });
+
+  it("Edit in submenu routes to the Image Editor and Image Studio handlers", async () => {
+    const onEditImage = vi.fn();
+    const onEditInStudio = vi.fn();
+    await renderPreview(baseProps({ asset: imageAsset, onEditImage, onEditInStudio }));
+
+    await rightClickStage();
+    await act(async () => {
+      document.body.querySelector(".preview-context-menu-submenu-trigger").click();
+    });
+    const submenuButtons = [...document.body.querySelectorAll(".preview-context-menu-submenu-panel .preview-context-menu-item")];
+    expect(submenuButtons.map((b) => b.textContent.trim())).toEqual(["Image Editor", "Image Studio"]);
+
+    await act(async () => {
+      submenuButtons.find((b) => b.textContent.trim() === "Image Editor").click();
+    });
+    expect(onEditImage).toHaveBeenCalledWith(imageAsset);
+
+    await rightClickStage();
+    await act(async () => {
+      document.body.querySelector(".preview-context-menu-submenu-trigger").click();
+    });
+    await act(async () => {
+      [...document.body.querySelectorAll(".preview-context-menu-submenu-panel .preview-context-menu-item")]
+        .find((b) => b.textContent.trim() === "Image Studio")
+        .click();
+    });
+    expect(onEditInStudio).toHaveBeenCalledWith(imageAsset);
+  });
+
+  it("right-clicking a video shows the variant with no zoom items", async () => {
+    await renderPreview(baseProps({ asset: videoAsset, onEditImage: vi.fn(), onEditInStudio: vi.fn() }));
+
+    const event = await rightClickStage();
+    expect(event.defaultPrevented).toBe(true);
+
+    const labels = menuItemLabels();
+    expect(labels).toContain("Save As…");
+    expect(labels).toContain("Reveal in Finder/Explorer");
+    expect(labels).not.toContain("Zoom In");
+    expect(labels).not.toContain("Zoom Out");
+    expect(labels).not.toContain("Fit to View");
+    expect(document.body.querySelector(".preview-context-menu-submenu-trigger")).not.toBeNull();
+  });
+
+  it("closes on Escape and on outside pointer-down", async () => {
+    await renderPreview(baseProps({ asset: imageAsset }));
+    await rightClickStage();
+    expect(menu()).not.toBeNull();
+
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+    expect(menu()).toBeNull();
+
+    await rightClickStage();
+    expect(menu()).not.toBeNull();
+    await act(async () => {
+      document.body.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    });
+    expect(menu()).toBeNull();
+  });
+
+  it("footer Save As button calls saveAssetAs", async () => {
+    await renderPreview(baseProps({ asset: imageAsset }));
+    const saveButton = [...document.body.querySelectorAll(".preview-actions button")].find(
+      (b) => b.textContent.trim() === "Save As…",
+    );
+    expect(saveButton).not.toBeUndefined();
+    await act(async () => {
+      saveButton.click();
+    });
+    expect(actionMocks.saveAssetAs).toHaveBeenCalledWith(imageAsset);
+  });
+});
+
+describe("FullscreenPreview context menu (browser / LAN)", () => {
+  beforeEach(async () => {
+    await loadComponent(false);
+  });
+
+  it("omits Reveal in browser mode but keeps Save As", async () => {
+    await renderPreview(baseProps({ asset: imageAsset }));
+    await rightClickStage();
+    const labels = menuItemLabels();
+    expect(labels).toContain("Save As…");
+    expect(labels).not.toContain("Reveal in Finder/Explorer");
+  });
+
+  it("keeps the footer Save As button in browser mode", async () => {
+    await renderPreview(baseProps({ asset: videoAsset }));
+    const saveButton = [...document.body.querySelectorAll(".preview-actions button")].find(
+      (b) => b.textContent.trim() === "Save As…",
+    );
+    expect(saveButton).not.toBeUndefined();
+    await act(async () => {
+      saveButton.click();
+    });
+    expect(actionMocks.saveAssetAs).toHaveBeenCalledWith(videoAsset);
+  });
+});

--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { isAbortError } from "../api.js";
+import { saveAssetAs, revealAsset } from "../assetActions.js";
+import { isDesktop } from "../runtime.js";
 import { AssetMedia, assetCanRenderAsVideo, assetUrl, suppressThumbnailContextMenu } from "./assetMedia.jsx";
 import { DocumentView } from "./DocumentView.jsx";
 import { Icon } from "./Icons.jsx";
@@ -535,12 +537,146 @@ export function AssetCard({ asset, deleteAsset, purgeAsset, onPreview, updateAss
   );
 }
 
+// Estimated menu footprint used to keep it inside the viewport (sc-8729). jsdom has
+// no layout so we can't measure the real DOM rect; these are conservative defaults
+// that the real DOM measurement (below) refines on mount. Reposition-if-overflow is
+// asserted against these in tests.
+const PREVIEW_MENU_WIDTH = 220;
+const PREVIEW_MENU_HEIGHT = 260;
+
+// Clamp a desired {x, y} open-position so the menu box stays within the viewport,
+// nudging it left/up when it would overflow the right/bottom edges and never letting
+// it go negative. Pure so the clamping is unit-testable without layout.
+export function clampMenuPosition(x, y, menuWidth, menuHeight, viewportWidth, viewportHeight) {
+  const clampedX = Math.max(0, Math.min(x, Math.max(0, viewportWidth - menuWidth)));
+  const clampedY = Math.max(0, Math.min(y, Math.max(0, viewportHeight - menuHeight)));
+  return { x: clampedX, y: clampedY };
+}
+
+// Self-contained right-click menu for the fullscreen preview (sc-8729). Renders our
+// own menu in place of the WKWebView native one (which differs per <img>/<video>),
+// opens at the cursor, clamps within the viewport, and closes on outside-click /
+// Escape / after any action. Items are passed in so the image vs video variants share
+// one component; the "Edit in" entry is a nested submenu.
+//   items: [{ key, label, onSelect }] flat action rows
+//   submenu: { label, items: [{ key, label, onSelect }] } | null
+function PreviewContextMenu({ x, y, items, submenu, onClose }) {
+  const menuRef = React.useRef(null);
+  const [position, setPosition] = React.useState(() =>
+    clampMenuPosition(
+      x,
+      y,
+      PREVIEW_MENU_WIDTH,
+      PREVIEW_MENU_HEIGHT,
+      typeof window !== "undefined" ? window.innerWidth : PREVIEW_MENU_WIDTH,
+      typeof window !== "undefined" ? window.innerHeight : PREVIEW_MENU_HEIGHT,
+    ),
+  );
+  const [submenuOpen, setSubmenuOpen] = React.useState(false);
+
+  // Refine the clamp once we can measure the real rendered box, then focus the menu
+  // so keyboard (Escape / arrow traversal) works without a click.
+  React.useEffect(() => {
+    const node = menuRef.current;
+    if (node) {
+      const rect = node.getBoundingClientRect?.();
+      const width = rect?.width || PREVIEW_MENU_WIDTH;
+      const height = rect?.height || PREVIEW_MENU_HEIGHT;
+      setPosition(clampMenuPosition(x, y, width, height, window.innerWidth, window.innerHeight));
+      node.focus?.();
+    }
+  }, [x, y]);
+
+  // Close on Escape or on any pointer-down outside the menu.
+  React.useEffect(() => {
+    const onKeyDown = (event) => {
+      if (event.key === "Escape") {
+        event.stopPropagation();
+        onClose();
+      }
+    };
+    const onPointerDown = (event) => {
+      if (!menuRef.current?.contains(event.target)) {
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown, true);
+    document.addEventListener("mousedown", onPointerDown, true);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown, true);
+      document.removeEventListener("mousedown", onPointerDown, true);
+    };
+  }, [onClose]);
+
+  const runAction = (onSelect) => {
+    onClose();
+    onSelect?.();
+  };
+
+  return (
+    <div
+      className="preview-context-menu"
+      ref={menuRef}
+      role="menu"
+      aria-label="Asset actions"
+      tabIndex={-1}
+      style={{ left: `${position.x}px`, top: `${position.y}px` }}
+      onContextMenu={(event) => event.preventDefault()}
+    >
+      {items.map((item) => (
+        <button
+          className="preview-context-menu-item"
+          key={item.key}
+          onClick={() => runAction(item.onSelect)}
+          role="menuitem"
+          type="button"
+        >
+          {item.label}
+        </button>
+      ))}
+      {submenu ? (
+        <div
+          className={`preview-context-menu-submenu${submenuOpen ? " open" : ""}`}
+          onMouseEnter={() => setSubmenuOpen(true)}
+          onMouseLeave={() => setSubmenuOpen(false)}
+        >
+          <button
+            aria-expanded={submenuOpen}
+            aria-haspopup="menu"
+            className="preview-context-menu-item preview-context-menu-submenu-trigger"
+            onClick={() => setSubmenuOpen((open) => !open)}
+            role="menuitem"
+            type="button"
+          >
+            {submenu.label}
+            <span aria-hidden="true" className="preview-context-menu-caret">▸</span>
+          </button>
+          <div className="preview-context-menu-submenu-panel" role="menu" aria-label={submenu.label}>
+            {submenu.items.map((item) => (
+              <button
+                className="preview-context-menu-item"
+                key={item.key}
+                onClick={() => runAction(item.onSelect)}
+                role="menuitem"
+                type="button"
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 export function FullscreenPreview({
   asset,
   deleteAsset,
   nextAsset,
   onClose,
   onEditImage,
+  onEditInStudio,
   onPreviewAsset,
   onUseRecipe,
   previousAsset,
@@ -632,12 +768,46 @@ export function FullscreenPreview({
 
   const zoomed = view.scale > PREVIEW_MIN_SCALE;
 
+  // Right-click context menu (sc-8729). Override the native WKWebView menu on the
+  // stage for BOTH the <img> and <video> paths and render our own at the cursor.
+  const [contextMenu, setContextMenu] = React.useState(null);
+  const closeContextMenu = React.useCallback(() => setContextMenu(null), []);
+
+  // Rebuild the menu items on open so the actions close over the current asset.
+  // Image gets the zoom rows; video omits them. Reveal is desktop-only.
+  const openContextMenu = React.useCallback(
+    (event) => {
+      event.preventDefault();
+      const items = [
+        { key: "save-as", label: "Save As…", onSelect: () => saveAssetAs(asset) },
+      ];
+      if (isDesktop) {
+        items.push({ key: "reveal", label: "Reveal in Finder/Explorer", onSelect: () => revealAsset(asset) });
+      }
+      if (!isVideo) {
+        items.push({ key: "zoom-in", label: "Zoom In", onSelect: zoomIn });
+        items.push({ key: "zoom-out", label: "Zoom Out", onSelect: zoomOut });
+        items.push({ key: "fit", label: "Fit to View", onSelect: fitToView });
+      }
+      const submenuItems = [];
+      if (onEditImage) {
+        submenuItems.push({ key: "image-editor", label: "Image Editor", onSelect: () => onEditImage(asset) });
+      }
+      if (onEditInStudio) {
+        submenuItems.push({ key: "image-studio", label: "Image Studio", onSelect: () => onEditInStudio(asset) });
+      }
+      const submenu = submenuItems.length ? { label: "Edit in", items: submenuItems } : null;
+      setContextMenu({ x: event.clientX, y: event.clientY, items, submenu });
+    },
+    [asset, isVideo, zoomIn, zoomOut, fitToView, onEditImage, onEditInStudio],
+  );
+
   return (
     <Modal className="preview-modal" label="Asset preview" onClose={onClose}>
       <button className="modal-close" onClick={onClose} type="button">
         Close
       </button>
-      <div className="preview-modal-stage">
+      <div className="preview-modal-stage" onContextMenu={openContextMenu}>
           <button
             aria-label="Previous asset"
             className="preview-nav-button previous"
@@ -701,6 +871,15 @@ export function FullscreenPreview({
               </button>
             </div>
           )}
+          {contextMenu ? (
+            <PreviewContextMenu
+              x={contextMenu.x}
+              y={contextMenu.y}
+              items={contextMenu.items}
+              submenu={contextMenu.submenu}
+              onClose={closeContextMenu}
+            />
+          ) : null}
         </div>
         <footer>
           <div className="preview-modal-meta">
@@ -726,6 +905,10 @@ export function FullscreenPreview({
             </div>
           ) : null}
           <div className="preview-actions">
+            {/* Simple, discoverable Save As path — present in desktop AND browser (sc-8729). */}
+            <button onClick={() => saveAssetAs(asset)} type="button">
+              Save As…
+            </button>
             {onUseRecipe && asset.type === "image" && (asset.generationSet?.recipe || asset.recipe) ? (
               <button onClick={() => onUseRecipe(asset)} type="button">
                 Use this recipe

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1214,6 +1214,72 @@ label {
   padding: 6px 10px;
 }
 
+/* Fullscreen preview right-click context menu (sc-8729). Positioned within the
+   stage; clamped in JS so it never overflows the viewport. */
+.preview-context-menu {
+  position: fixed;
+  z-index: 60;
+  min-width: 200px;
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: var(--shadow-lg);
+  outline: none;
+}
+
+.preview-context-menu-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  padding: 7px 10px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.preview-context-menu-item:hover,
+.preview-context-menu-item:focus-visible {
+  background: var(--surface-hover);
+}
+
+.preview-context-menu-submenu {
+  position: relative;
+}
+
+.preview-context-menu-caret {
+  opacity: 0.6;
+}
+
+.preview-context-menu-submenu-panel {
+  display: none;
+  position: absolute;
+  top: 0;
+  left: 100%;
+  min-width: 160px;
+  padding: 4px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: var(--shadow-lg);
+}
+
+.preview-context-menu-submenu:hover .preview-context-menu-submenu-panel,
+.preview-context-menu-submenu.open .preview-context-menu-submenu-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
 /* Toolbars */
 .toolbar,
 .review-actions,


### PR DESCRIPTION
## What & why (sc-8729 — S4)

Final integration story of the fullscreen-preview actions epic. Wires the four already-merged sibling stories into one custom right-click context menu on the `FullscreenPreview` stage, and adds a discoverable **Save As** button to the preview footer.

WKWebView shows *different* native context menus for `<img>` vs `<video>`, so this overrides the native menu on the stage for **both** paths and renders our own.

## How it wires the siblings
- **S2 (save/reveal):** menu + footer call `saveAssetAs(asset)` / `revealAsset(asset)` from `assetActions.js`. Desktop-vs-browser branching already lives there; Reveal is hidden when `!isDesktop` (browser/LAN).
- **S3 (zoom):** the menu's Zoom In / Zoom Out / Fit to View reuse the existing local `zoomIn` / `zoomOut` / `fitToView` handlers on the same `view` model. Video omits these rows.
- **S5 (edit routes):** `Edit in >` nested submenu — **Image Editor** routes via the existing `onEditImage` prop (`sendAssetToImageEditor`, editor canvas); **Image Studio** routes via a new `onEditInStudio` prop wired at the App.jsx call site to `sendAssetToImageEdit` (edit_image mode, family-matched model).
- **S6 (thumbnail suppression):** untouched — `FullscreenPreview` was intentionally left un-suppressed for this story to own its menu.

## Menu behavior
- Opens at the cursor; clamped within the viewport via a pure `clampMenuPosition` helper (refined against the measured rect on mount).
- Closes on Escape / outside pointer-down / after any action.
- `role="menu"` / `role="menuitem"`, focusable, `aria-haspopup`/`aria-expanded` on the submenu trigger.

## Scope vs acceptance criteria
- [x] Right-click image → custom menu (native suppressed): Save As / Reveal / Zoom In / Zoom Out / Fit to View / Edit in >.
- [x] Right-click video → variant with Save As / Reveal / Edit in >, **no** zoom items.
- [x] Save As button visible + working (image + video, desktop + browser).
- [x] Reveal absent in browser mode.

## Tests
New `apps/web/src/components/assetPanels.contextMenu.test.jsx` (9 cases): image full menu + `defaultPrevented`, video variant (no zoom), Save As/Reveal wire to the action layer, zoom items drive the `view` transform, submenu routes to editor vs studio handlers, Escape + outside-click close, footer Save As button, and browser-mode Reveal-absent (via mocked `runtime.isDesktop`).

## Verification
- `npm test` (apps/web): **55 files / 914 tests passing**.
- `npm run lint`: **0 errors** (only pre-existing warnings; none in touched files).

## Follow-ups
None. Pure-frontend; no rust-api contract or backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)