### PR TITLE
feat(desktop): remember last Save As directory (sc-8737)

### DIFF
--- a/apps/desktop/build.rs
+++ b/apps/desktop/build.rs
@@ -12,6 +12,8 @@ fn main() {
             "set_data_dir",
             "choose_data_dir",
             "reveal_in_os",
+            "resolve_asset_path",
+            "save_asset_as",
             "list_credentials",
             "set_credential",
             "delete_credential",

--- a/apps/desktop/capabilities/default.json
+++ b/apps/desktop/capabilities/default.json
@@ -18,6 +18,8 @@
     "allow-set-data-dir",
     "allow-choose-data-dir",
     "allow-reveal-in-os",
+    "allow-resolve-asset-path",
+    "allow-save-asset-as",
     "allow-list-credentials",
     "allow-set-credential",
     "allow-delete-credential",

--- a/apps/desktop/permissions/autogenerated/resolve_asset_path.toml
+++ b/apps/desktop/permissions/autogenerated/resolve_asset_path.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-resolve-asset-path"
+description = "Enables the resolve_asset_path command without any pre-configured scope."
+commands.allow = ["resolve_asset_path"]
+
+[[permission]]
+identifier = "deny-resolve-asset-path"
+description = "Denies the resolve_asset_path command without any pre-configured scope."
+commands.deny = ["resolve_asset_path"]

--- a/apps/desktop/permissions/autogenerated/save_asset_as.toml
+++ b/apps/desktop/permissions/autogenerated/save_asset_as.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-save-asset-as"
+description = "Enables the save_asset_as command without any pre-configured scope."
+commands.allow = ["save_asset_as"]
+
+[[permission]]
+identifier = "deny-save-asset-as"
+description = "Denies the save_asset_as command without any pre-configured scope."
+commands.deny = ["save_asset_as"]

--- a/apps/desktop/src/settings.rs
+++ b/apps/desktop/src/settings.rs
@@ -1065,6 +1065,33 @@ mod tests {
         std::fs::remove_dir_all(&root).ok();
     }
 
+    /// sc-8753: the asset Save As / Reveal commands are invoked from the API-served UI
+    /// at the remote (`http://127.0.0.1:*`) origin, so each must be granted an
+    /// `allow-<kebab-command>` permission in `capabilities/default.json` or the Tauri
+    /// ACL silently rejects the invoke in the real app (the unit tests mock `invoke`, so
+    /// they can't catch a missing grant). Guards against future command↔ACL drift for
+    /// the asset commands specifically: `resolve_asset_path` (Reveal + Save As both call
+    /// it first) and `save_asset_as`.
+    #[test]
+    fn asset_commands_are_granted_in_the_remote_capability() {
+        let capability = include_str!("../capabilities/default.json");
+        let manifest: serde_json::Value =
+            serde_json::from_str(capability).expect("capabilities/default.json parses");
+        let permissions = manifest["permissions"]
+            .as_array()
+            .expect("permissions is an array")
+            .iter()
+            .filter_map(|value| value.as_str())
+            .collect::<Vec<_>>();
+        for permission in ["allow-resolve-asset-path", "allow-save-asset-as"] {
+            assert!(
+                permissions.contains(&permission),
+                "capabilities/default.json is missing `{permission}` — the command would \
+                 be rejected by the ACL at the remote UI origin"
+            );
+        }
+    }
+
     /// sc-8737: the save dialog's initial-directory hint is applied only when it names
     /// an existing directory; empty/whitespace, missing, and non-directory paths are all
     /// skipped (returning `None`) so a stale/bad hint never errors the save — it just

--- a/apps/desktop/src/settings.rs
+++ b/apps/desktop/src/settings.rs
@@ -757,18 +757,40 @@ pub fn resolve_asset_path(project_id: String, relative_path: String) -> Result<S
     Ok(project_file.path.to_string_lossy().into_owned())
 }
 
+/// Decide whether a caller-supplied `start_dir` should seed the native save dialog's
+/// initial directory (sc-8737). Returns `Some(path)` only when the value is non-empty
+/// (after trimming) AND names an existing directory on disk; otherwise `None`, so an
+/// empty/missing/non-directory hint is skipped gracefully rather than erroring the save.
+/// Extracted as a pure helper so the accept/reject decision is unit-testable without the
+/// GUI dialog.
+fn sanitized_start_dir(start_dir: Option<&str>) -> Option<PathBuf> {
+    let trimmed = start_dir?.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let path = PathBuf::from(trimmed);
+    if path.is_dir() {
+        Some(path)
+    } else {
+        None
+    }
+}
+
 /// Save an asset file to a user-chosen destination (sc-8726). Opens the native "save as"
 /// dialog pre-filled with `suggested_filename`, then copies the bytes from `source_path`
 /// to the chosen destination. `source_path` must be an already-resolved absolute path
 /// (see [`resolve_asset_path`]); it is validated to live inside an app-managed root by the
 /// same guard as [`reveal_in_os`] so the frontend can't ask us to copy an arbitrary file
-/// off disk. Returns `Ok(None)` when the user cancels the dialog and `Ok(Some(dest))` with
-/// the absolute destination path on success.
+/// off disk. When `start_dir` names an existing directory the dialog opens there so the
+/// user returns to their last-used save location (sc-8737); an empty/missing/non-existent
+/// hint is ignored. Returns `Ok(None)` when the user cancels the dialog and `Ok(Some(dest))`
+/// with the absolute destination path on success.
 #[tauri::command]
 pub async fn save_asset_as(
     app: AppHandle,
     source_path: String,
     suggested_filename: String,
+    start_dir: Option<String>,
 ) -> Result<Option<String>, String> {
     // Guard the SOURCE before opening any dialog: only files inside the SceneWorks data
     // dir / HF cache may be copied out.
@@ -778,6 +800,9 @@ pub async fn save_asset_as(
     let mut dialog = app.dialog().file();
     if !suggested.is_empty() {
         dialog = dialog.set_file_name(suggested);
+    }
+    if let Some(dir) = sanitized_start_dir(start_dir.as_deref()) {
+        dialog = dialog.set_directory(dir);
     }
     let Some(destination) = dialog
         .blocking_save_file()
@@ -1036,6 +1061,36 @@ mod tests {
             .expect("resolve asset");
         let expected = std::fs::canonicalize(&asset_path).expect("canonical asset");
         assert_eq!(resolved.path, expected);
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// sc-8737: the save dialog's initial-directory hint is applied only when it names
+    /// an existing directory; empty/whitespace, missing, and non-directory paths are all
+    /// skipped (returning `None`) so a stale/bad hint never errors the save — it just
+    /// falls back to the OS default location.
+    #[test]
+    fn start_dir_applied_only_for_existing_directory() {
+        // None / empty / whitespace → skipped.
+        assert_eq!(sanitized_start_dir(None), None);
+        assert_eq!(sanitized_start_dir(Some("")), None);
+        assert_eq!(sanitized_start_dir(Some("   ")), None);
+
+        let root = scratch_dir("startdir");
+        // A path that doesn't exist → skipped.
+        let missing = root.join("does-not-exist");
+        assert_eq!(sanitized_start_dir(Some(&missing.to_string_lossy())), None);
+
+        // A file (not a directory) → skipped.
+        let file = root.join("a-file.png");
+        std::fs::write(&file, b"x").expect("write file");
+        assert_eq!(sanitized_start_dir(Some(&file.to_string_lossy())), None);
+
+        // An existing directory → applied (trimmed).
+        let dir = root.join("saved-here");
+        std::fs::create_dir_all(&dir).expect("create dir");
+        let padded = format!("  {}  ", dir.to_string_lossy());
+        assert_eq!(sanitized_start_dir(Some(&padded)), Some(dir.clone()));
 
         std::fs::remove_dir_all(&root).ok();
     }

--- a/apps/web/src/assetActions.js
+++ b/apps/web/src/assetActions.js
@@ -74,6 +74,50 @@ export function suggestedFilename(asset) {
   return `${base}.${ext}`;
 }
 
+// localStorage key + in-memory fallback for the last directory a Save As succeeded in
+// (sc-8737). Persisted across reloads so the next Save As dialog re-opens where the user
+// last saved. localStorage access is guarded (private-mode / non-browser env can throw or
+// be absent); the module-level variable is the fallback so the feature still works within
+// a session even when storage is unavailable.
+const LAST_SAVE_DIR_KEY = "sceneworks:lastSaveDir";
+let lastSaveDirFallback = "";
+
+// The directory portion of an absolute file path, handling both POSIX (`/`) and Windows
+// (`\`) separators. Returns "" when no separator is present (nothing to remember).
+function parentDirectory(destinationPath) {
+  const path = String(destinationPath ?? "");
+  const cut = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+  return cut > 0 ? path.slice(0, cut) : "";
+}
+
+// The last successful Save As directory, from localStorage (falling back to the
+// in-memory value if storage is unavailable). "" when nothing has been saved yet.
+function readLastSaveDir() {
+  try {
+    const stored = globalThis.localStorage?.getItem(LAST_SAVE_DIR_KEY);
+    if (stored) {
+      return stored;
+    }
+  } catch {
+    // localStorage blocked/unavailable — fall through to the in-memory value.
+  }
+  return lastSaveDirFallback;
+}
+
+// Remember the directory of the most recent successful save. Always updates the in-memory
+// fallback; best-effort persists to localStorage so it survives a reload.
+function rememberLastSaveDir(directory) {
+  if (!directory) {
+    return;
+  }
+  lastSaveDirFallback = directory;
+  try {
+    globalThis.localStorage?.setItem(LAST_SAVE_DIR_KEY, directory);
+  } catch {
+    // localStorage blocked/unavailable — the in-memory fallback still carries it.
+  }
+}
+
 // Resolve an asset to its absolute on-disk path via the desktop command. Only valid
 // when `isDesktop`; the two desktop-only actions below call this.
 function resolveAbsolutePath(asset) {
@@ -118,11 +162,22 @@ export async function saveAssetAs(asset) {
     return null;
   }
   const absolutePath = await resolveAbsolutePath(asset);
-  // `save_asset_as` returns the destination path, or null when the user cancels.
-  const destination = await tauriInvoke("save_asset_as", {
+  // Seed the dialog with the last directory we saved into so the user returns there
+  // (sc-8737). Only pass a non-empty hint; the Rust side ignores a stale/missing dir.
+  const startDir = readLastSaveDir();
+  const args = {
     sourcePath: absolutePath,
     suggestedFilename: suggestedFilename(asset),
-  });
+  };
+  if (startDir) {
+    args.startDir = startDir;
+  }
+  // `save_asset_as` returns the destination path, or null when the user cancels.
+  const destination = await tauriInvoke("save_asset_as", args);
+  if (destination) {
+    // Remember where this save landed so the next Save As opens in the same place.
+    rememberLastSaveDir(parentDirectory(destination));
+  }
   return destination ?? null;
 }
 

--- a/apps/web/src/assetActions.test.js
+++ b/apps/web/src/assetActions.test.js
@@ -33,6 +33,13 @@ async function importBrowser() {
 afterEach(() => {
   delete window.__TAURI__;
   vi.restoreAllMocks();
+  // The last-save-dir feature (sc-8737) persists to localStorage; clear it so tests
+  // that assert "no startDir before any save" aren't contaminated by an earlier save.
+  try {
+    globalThis.localStorage?.clear();
+  } catch {
+    // no-op
+  }
 });
 
 describe("suggestedFilename (sc-8727)", () => {
@@ -110,6 +117,107 @@ describe("saveAssetAs — desktop (sc-8727)", () => {
     const { saveAssetAs } = await importDesktop(invoke);
 
     await expect(saveAssetAs(IMAGE_ASSET)).resolves.toBeNull();
+  });
+});
+
+describe("saveAssetAs — last-used save directory (sc-8737)", () => {
+  // A save_asset_as mock that records the args each invocation received, so we can
+  // assert whether/what startDir was passed across successive saves.
+  function invokeRecording(destination) {
+    const saveCalls = [];
+    const invoke = vi.fn(async (command, args) => {
+      if (command === "resolve_asset_path") return "/data/project_1/assets/images/Mira.png";
+      if (command === "save_asset_as") {
+        saveCalls.push(args);
+        return destination;
+      }
+      return null;
+    });
+    return { invoke, saveCalls };
+  }
+
+  it("passes no startDir before any save has succeeded", async () => {
+    const { invoke, saveCalls } = invokeRecording("/Users/me/Pictures/Mira.png");
+    const { saveAssetAs } = await importDesktop(invoke);
+
+    await saveAssetAs(IMAGE_ASSET);
+
+    expect(saveCalls).toHaveLength(1);
+    expect(saveCalls[0]).not.toHaveProperty("startDir");
+  });
+
+  it("opens the next Save As in the previously-saved POSIX directory", async () => {
+    const { invoke, saveCalls } = invokeRecording("/Users/me/Pictures/Mira.png");
+    const { saveAssetAs } = await importDesktop(invoke);
+
+    await saveAssetAs(IMAGE_ASSET); // first save records /Users/me/Pictures
+    await saveAssetAs(VIDEO_ASSET); // second save should be seeded with it
+
+    expect(saveCalls).toHaveLength(2);
+    expect(saveCalls[0]).not.toHaveProperty("startDir");
+    expect(saveCalls[1].startDir).toBe("/Users/me/Pictures");
+  });
+
+  it("handles a Windows destination path (backslash separators)", async () => {
+    const { invoke, saveCalls } = invokeRecording("C:\\Users\\me\\Pictures\\Mira.png");
+    const { saveAssetAs } = await importDesktop(invoke);
+
+    await saveAssetAs(IMAGE_ASSET);
+    await saveAssetAs(VIDEO_ASSET);
+
+    expect(saveCalls[1].startDir).toBe("C:\\Users\\me\\Pictures");
+  });
+
+  it("persists the last directory across a module reload via localStorage", async () => {
+    const first = invokeRecording("/Users/me/Exports/Mira.png");
+    const firstMod = await importDesktop(first.invoke);
+    await firstMod.saveAssetAs(IMAGE_ASSET);
+
+    // Re-import fresh (as a page reload would) — the module-level fallback is gone,
+    // but localStorage should still carry the directory.
+    const second = invokeRecording("/Users/me/Exports/Clip.mp4");
+    const secondMod = await importDesktop(second.invoke);
+    await secondMod.saveAssetAs(VIDEO_ASSET);
+
+    expect(second.saveCalls[0].startDir).toBe("/Users/me/Exports");
+  });
+
+  it("does not persist a startDir when the save is cancelled", async () => {
+    const invoke = vi.fn(async (command) => {
+      if (command === "resolve_asset_path") return "/data/project_1/assets/images/Mira.png";
+      return null; // cancelled
+    });
+    const { saveAssetAs } = await importDesktop(invoke);
+
+    await saveAssetAs(IMAGE_ASSET); // cancelled → nothing remembered
+
+    // A subsequent save still has no startDir.
+    const { invoke: invoke2, saveCalls } = invokeRecording("/Users/me/Desktop/Clip.mp4");
+    const { saveAssetAs: saveAssetAs2 } = await importDesktop(invoke2);
+    await saveAssetAs2(VIDEO_ASSET);
+    expect(saveCalls[0]).not.toHaveProperty("startDir");
+  });
+
+  it("falls back to an in-memory value when localStorage is unavailable", async () => {
+    const original = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      get() {
+        throw new Error("localStorage disabled");
+      },
+    });
+    try {
+      const { invoke, saveCalls } = invokeRecording("/Users/me/Pictures/Mira.png");
+      const { saveAssetAs } = await importDesktop(invoke);
+      await saveAssetAs(IMAGE_ASSET);
+      await saveAssetAs(VIDEO_ASSET);
+      // Storage threw on both read and write; the module-level fallback still carries it.
+      expect(saveCalls[1].startDir).toBe("/Users/me/Pictures");
+    } finally {
+      if (original) {
+        Object.defineProperty(globalThis, "localStorage", original);
+      }
+    }
   });
 });
 


### PR DESCRIPTION
## What & why

Two related changes to the desktop asset Save As / Reveal path:

1. **sc-8737** — remember the last Save As directory so the native dialog re-opens where the user last saved.
2. **sc-8753 (bug)** — fix an ACL exposure that made the Save As / Reveal commands fail in the packaged app in the first place. This is a prerequisite for #1 to work at all in the real app.

## Changes

### sc-8753 — grant ACL permissions for `save_asset_as` + `resolve_asset_path`

The desktop shell navigates the main window to the API-served React UI at `http://127.0.0.1:<port>`, so every `window.__TAURI__` invoke is rejected by the Tauri ACL at that remote origin unless the command has an `allow-<command>` permission granted in `capabilities/default.json` (see the `remote` grant + comment there). `save_asset_as` and `resolve_asset_path` (added in the sc-8726 work) were registered in `main.rs` `generate_handler!` but **never declared in `build.rs` nor granted in the capability** — so in the packaged app, Save As and Reveal (which calls `resolve_asset_path` first) both failed silently. Unit tests mock `invoke`, so they didn't catch it.

- `apps/desktop/build.rs`: register `resolve_asset_path` + `save_asset_as` in the `AppManifest` command list (next to `reveal_in_os`).
- `apps/desktop/capabilities/default.json`: grant `allow-resolve-asset-path` + `allow-save-asset-as`.
- `apps/desktop/permissions/autogenerated/{resolve_asset_path,save_asset_as}.toml`: the build-generated permission definitions (tracked in-repo like every peer command).
- **Verified** the generated permission identifiers are exactly `allow-resolve-asset-path` and `allow-save-asset-as` (Tauri derives `allow-<kebab-command>`; confirmed against both the regenerated `target/.../out/app-manifest` files and the committed autogenerated TOMLs).
- Added a drift-guard unit test (`asset_commands_are_granted_in_the_remote_capability`) that parses `capabilities/default.json` and asserts both grants are present, so a future asset-command addition without an ACL grant fails CI.

### sc-8737 — remember last Save As directory

**Rust — `apps/desktop/src/settings.rs`**
- `save_asset_as` gains an optional `start_dir: Option<String>` (backward-compatible; `None` = current behavior).
- New pure helper `sanitized_start_dir` returns the dir only when it's non-empty (trimmed) **and** names an existing directory; applied via the tauri-plugin-dialog builder's `.set_directory(...)` (verified against `tauri-plugin-dialog 2.7.1`). Empty/missing/non-dir hints are skipped gracefully — never erroring the save.
- Source-containment guard + copy behavior unchanged.

**Frontend — `apps/web/src/assetActions.js`**
- Remember each successful save's parent directory (both `/` and `\` separators) in `localStorage` (stable key, in-memory fallback when storage is unavailable), and pass it as `startDir` on the next desktop `saveAssetAs`, only when non-empty. Default-filename behavior untouched.

## Scope vs. acceptance criteria

- ✅ sc-8737 Rust optional `start_dir`, applied only for an existing dir, skipped gracefully; guard/copy unchanged; correct dialog API verified.
- ✅ sc-8737 Frontend persists last-save dir (parent, both separators), passes `startDir`, `localStorage` + in-memory fallback, only non-empty.
- ✅ Default filename behavior unchanged.
- ✅ sc-8753 ACL grants added + verified; Save As / Reveal now invokable from the remote UI origin.

## Tests

**Rust** (`cargo test -p sceneworks-desktop` — 22 passed): `start_dir_applied_only_for_existing_directory` (None/empty/whitespace/missing/non-dir skipped, existing dir applied+trimmed) and `asset_commands_are_granted_in_the_remote_capability` (ACL drift guard).

**Web** (`npm run test` in `apps/web` — 920 passed): `saveAssetAs — last-used save directory (sc-8737)` block — no `startDir` before any save; seeded from prior save's parent (POSIX + Windows separators); localStorage-reload persistence; not remembered on cancel; in-memory fallback when `localStorage` throws.

## Verification

- `cargo fmt -p sceneworks-desktop -- --check` — clean
- `cargo clippy -p sceneworks-desktop --all-targets -- -D warnings` — clean
- `cargo test -p sceneworks-desktop` — 22/22 pass
- `cargo build -p sceneworks-desktop` — builds (regenerates + validates the ACL; a bad/unknown permission id would fail the build)
- Confirmed generated permission ids: `allow-resolve-asset-path`, `allow-save-asset-as`
- `apps/web`: `npm run test` — 920/920 pass; `npm run lint` — 0 errors

## Follow-up (out of scope, filed separately)

Discovered the same ACL gap for `set_gpu_memory_limit` and `get_gpu_telemetry` (epic 7819) — registered in `generate_handler!` but absent from `build.rs` + `capabilities/default.json`. Not fixed here to keep the diff scoped; tracked as a separate story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)