### PR TITLE
feat(sdxl): Group-B q4/q8/bf16 tiers for sdxl/realvisxl/realvisxl_lightning (sc-8746)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -513,7 +513,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -530,7 +530,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -582,7 +582,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -596,7 +596,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -611,7 +611,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -624,7 +624,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -636,7 +636,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -653,7 +653,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -668,7 +668,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -679,7 +679,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -694,7 +694,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -729,7 +729,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -740,7 +740,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -764,7 +764,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -777,7 +777,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=96677786559c949e98cb9c192ddb65367c337b71#96677786559c949e98cb9c192ddb65367c337b71"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -3528,7 +3528,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3541,7 +3541,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
 dependencies = [
  "image",
  "inventory",
@@ -3555,7 +3555,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
 dependencies = [
  "image",
  "inventory",
@@ -3569,7 +3569,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3582,7 +3582,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3593,7 +3593,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3602,7 +3602,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3611,7 +3611,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3625,7 +3625,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3638,7 +3638,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3651,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3663,7 +3663,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3673,7 +3673,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
 dependencies = [
  "image",
  "inventory",
@@ -3686,7 +3686,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
 dependencies = [
  "image",
  "inventory",
@@ -3700,7 +3700,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
 dependencies = [
  "image",
  "inventory",
@@ -3714,7 +3714,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
 dependencies = [
  "image",
  "inventory",
@@ -3726,7 +3726,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3737,7 +3737,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3749,7 +3749,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3761,7 +3761,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3770,7 +3770,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3779,7 +3779,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3789,7 +3789,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3801,7 +3801,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
 dependencies = [
  "image",
  "inventory",
@@ -3816,7 +3816,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
 dependencies = [
  "image",
  "inventory",
@@ -3830,7 +3830,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3841,7 +3841,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3853,7 +3853,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3864,7 +3864,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
 dependencies = [
  "image",
  "inventory",
@@ -3878,7 +3878,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
 dependencies = [
  "image",
  "inventory",
@@ -5642,7 +5642,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a41abfc42d94561643b42a71ae3e36b9ea4c9a7e#a41abfc42d94561643b42a71ae3e36b9ea4c9a7e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
 dependencies = [
  "core-llm",
  "inventory",
@@ -8039,7 +8039,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -3221,26 +3221,26 @@
         "families": ["sdxl"],
         "types": ["style", "enhance", "character"]
       },
-      // macOS-only MLX backend (sc-1975, path C). In-process via the vendored
-      // mlx-examples/stable_diffusion at scene_worker/_vendor/mlx_sd/ — no
-      // sidecar venv (deps are already in the worker venv when
-      // requirements-mlx.txt is installed). The auto-dispatch prefers MLX
-      // when MlxSdxlAdapter._mlx_sd_available() is true on darwin, the job
-      // is plain T2I, and no reference asset is present; otherwise the
-      // torch SdxlDiffusersAdapter remains the default. Escape hatch:
-      // SCENEWORKS_DISABLE_MLX_SDXL=1.
+      // macOS-only MLX backend. The MLX-SDXL generator is the Rust `mlx-gen-sdxl`
+      // path, claimed by the in-process `mlx` GPU worker via the Rust API claim
+      // layer (jobs_store::sdxl_mlx_eligible). sc-3060 RETIRED the old in-process
+      // vendored Apple `mlx-examples/stable_diffusion` (scene_worker/_vendor/mlx_sd/)
+      // adapter — the Python worker always routes the torch SdxlDiffusersAdapter now
+      // (every host, every shape); it never runs MLX-SDXL.
       //
-      // No mlx.quantize knob yet — Apple's default Q8 recipe breaks SDXL
-      // base 1.0 (works on sdxl-turbo only); spike sc-1975 measured the bf16
-      // path at ~1.08 s/step on M5 Max (~3× the torch baseline) which is the
-      // headline win.
+      // mlx.quantize/tier config below is consumed by the RUST worker
+      // (standard_tier_subdir / resolve_quant), NOT the retired Apple adapter. The
+      // original sc-1975 deferral ("Apple's Q8 recipe breaks SDXL base 1.0, works on
+      // turbo only") applied to that retired vendored Python recipe. mlx-gen PR #62
+      // (sc-2641) FIXED + MERGED SDXL Q4/Q8 quantization — both hold parity on
+      // base-1.0 — so the packed tiers below ship Q4 (default) / Q8 / bf16. Q8 base
+      // render-verified coherent on-device (768x768, mean 97.65, std 61.43, NOT the
+      // retired recipe's all-zero decode).
       //
-      // No sampler/scheduler limits override either: mlx-examples runs the
-      // SDXL EulerDiscrete schedule its own way, which already matches the
-      // torch path's default. If the picker grows sampler choices later
-      // (currently the manifest has no `limits.samplers` for sdxl), this
-      // block will need the same default-only override as the mflux family
-      // entries.
+      // No sampler/scheduler limits override: the MLX SDXL EulerDiscrete schedule
+      // already matches the torch path's default. If the picker grows sampler choices
+      // later (currently no `limits.samplers` for sdxl), this block will need the same
+      // default-only override as the mflux family entries.
       "mlx": {
         "minMemoryGb": 50,
         // q4/ default tier (sc-8746); q8/ + bf16/ hosted + selectable via advanced.mlxQuantize

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -3159,20 +3159,45 @@
       // image_detail: tile-ControlNet detail refine (image_detail job, sc-2437/sc-2438).
       "capabilities": ["text_to_image", "edit_image", "image_inpaint", "image_detail", "character_image", "style_variations"],
       "downloads": [
+        // SceneWorks pre-built MLX quant-matrix turnkey (sc-8746, epic 8506, Group-B): a
+        // public/ungated (CreativeML OpenRAIL++-M) re-host of stabilityai/stable-diffusion-xl-base-1.0.
+        // Per-tier self-contained subdirs (UNet + both CLIP text encoders + VAE + tokenizer(s) +
+        // scheduler + model_index.json): q4/ (default), q8/, bf16/. The worker loads the chosen
+        // tier's subdir directly (standard_tier_subdir, mlx.standardTierLayout). The UNet + BOTH
+        // text encoders are packed in q4/q8; the VAE stays dense in every tier. Per-tier variants
+        // (sc-8508): each tier is a SEPARATE installable artifact tagged with a `variant` key + a
+        // `footprint` (required on-disk size; resident/peak filled in later by sc-8516). Sizes are
+        // measured on-disk. Replaces the whole-repo dense download.
         {
-          // Diffusers checkpoint: SDXL base 1.0 (UNet + dual CLIP text encoders
-          // + VAE). Whole-repo download; the worker loads the fp16 variant.
-          // CreativeML OpenRAIL++-M: use-based restrictions, commercial use OK,
-          // ungated (no HF token required).
           "provider": "huggingface",
-          "repo": "stabilityai/stable-diffusion-xl-base-1.0",
-          "files": [],
-          "estimatedSizeBytes": 6938040320
+          "repo": "SceneWorks/sdxl-base-mlx",
+          "variant": "q4",
+          "default": true,
+          "files": ["q4/*"],
+          "estimatedSizeBytes": 2703202068,
+          "footprint": { "diskSizeBytes": 2703202068, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/sdxl-base-mlx",
+          "variant": "q8",
+          "files": ["q8/*"],
+          "estimatedSizeBytes": 4177386896,
+          "footprint": { "diskSizeBytes": 4177386896, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/sdxl-base-mlx",
+          "variant": "bf16",
+          "files": ["bf16/*"],
+          "estimatedSizeBytes": 6941187536,
+          "footprint": { "diskSizeBytes": 6941187536, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "paths": {
-        "model": "${HF_CACHE}/stabilityai/stable-diffusion-xl-base-1.0"
+        "model": "${HF_CACHE}/SceneWorks/sdxl-base-mlx"
       },
+      "gated": false,
       "defaults": {
         // SDXL base 1.0: EulerDiscreteScheduler default; real CFG with a
         // negative prompt. ~30 steps at guidance 7.0 is a solid baseline.
@@ -3218,6 +3243,13 @@
       // entries.
       "mlx": {
         "minMemoryGb": 50,
+        // q4/ default tier (sc-8746); q8/ + bf16/ hosted + selectable via advanced.mlxQuantize
+        // (standard_tier_subdir resolves the subdir).
+        "quantize": 4,
+        // sc-8508: the manifest-driven form of the STANDARD_TIER_MODELS registry. Additive here
+        // opts this id into `uses_standard_tier_layout` so the worker resolves the q4/q8/bf16
+        // subdir directly from the turnkey snapshot.
+        "standardTierLayout": true,
         // CFG++ (epic 7434, sc-8256) is MLX-only today: the reparameterized-guidance
         // dispatch lives in mlx-gen-sdxl, so only the MLX backend advertises it. The base
         // `limits` carries no guidanceMethods, so the candle lane shows the standard CFG
@@ -3255,19 +3287,45 @@
       // resemblance, sdxl-family LoRA support.
       "capabilities": ["text_to_image", "edit_image", "image_inpaint", "image_detail", "character_image", "style_variations"],
       "downloads": [
+        // SceneWorks pre-built MLX quant-matrix turnkey (sc-8746, epic 8506, Group-B): a
+        // public/ungated (openrail++) re-host of SG161222/RealVisXL_V5.0. Per-tier self-contained
+        // subdirs (UNet + both CLIP text encoders + VAE + tokenizer(s) + scheduler +
+        // model_index.json): q4/ (default), q8/, bf16/. The worker loads the chosen tier's subdir
+        // directly (standard_tier_subdir, mlx.standardTierLayout). UNet + both text encoders packed
+        // in q4/q8; VAE dense in every tier. Per-tier variants (sc-8508): each tier is a SEPARATE
+        // installable artifact with a `variant` + `footprint`. Sizes measured on-disk. Note the
+        // dense IP-Adapter / InstantID / candle-edit conditioning paths still fetch the original
+        // SG161222/RealVisXL_V5.0 diffusers layout on demand — those are unaffected by this turnkey.
         {
-          // Same checkpoint as the InstantID built-in below — single HF cache
-          // entry, no duplicate ~6.6 GiB download. openrail++ (commercial use OK,
-          // ungated). IP-Adapter weights are fetched on demand by the adapter.
           "provider": "huggingface",
-          "repo": "SG161222/RealVisXL_V5.0",
-          "files": [],
-          "estimatedSizeBytes": 7105348096
+          "repo": "SceneWorks/realvisxl-mlx",
+          "variant": "q4",
+          "default": true,
+          "files": ["q4/*"],
+          "estimatedSizeBytes": 3911656467,
+          "footprint": { "diskSizeBytes": 3911656467, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/realvisxl-mlx",
+          "variant": "q8",
+          "files": ["q8/*"],
+          "estimatedSizeBytes": 5385840183,
+          "footprint": { "diskSizeBytes": 5385840183, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/realvisxl-mlx",
+          "variant": "bf16",
+          "files": ["bf16/*"],
+          "estimatedSizeBytes": 7108692804,
+          "footprint": { "diskSizeBytes": 7108692804, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "paths": {
-        "model": "${HF_CACHE}/SG161222/RealVisXL_V5.0"
+        "model": "${HF_CACHE}/SceneWorks/realvisxl-mlx"
       },
+      "gated": false,
       "defaults": {
         // Model-card SDXL defaults: ~30 steps at guidance 7.0, native 1024x1024.
         "resolution": "1024x1024",
@@ -3289,6 +3347,10 @@
         "types": ["style", "enhance", "character"]
       },
       "mlx": {
+        // q4/ default tier (sc-8746); q8/ + bf16/ hosted + selectable via advanced.mlxQuantize.
+        "quantize": 4,
+        // sc-8508 manifest-driven standard-tier opt-in (see the `sdxl` entry).
+        "standardTierLayout": true,
         // CFG++ (epic 7434, sc-8256) is MLX-only today — same `sdxl` engine, same
         // reparameterized-guidance dispatch as the base SDXL entry. Scoped to the MLX
         // backend so the candle lane keeps the standard CFG surface (sc-8257 follow-on).
@@ -3336,33 +3398,46 @@
       // edit / reference / mask / pose shapes fall back to the Python torch worker. Was `macOnly: true`
       // until the candle lightning lane landed + was GPU-validated (~5-step render) on the RTX PRO 6000.
       "downloads": [
+        // SceneWorks pre-built MLX quant-matrix turnkey (sc-8746, epic 8506, Group-B): a
+        // public/ungated (openrail++) re-host of the distilled SG161222/RealVisXL_V5.0_Lightning.
+        // Per-tier self-contained subdirs (UNet + both CLIP text encoders + VAE + tokenizer(s) +
+        // scheduler + model_index.json): q4/ (default), q8/, bf16/ — the worker loads the chosen
+        // tier's subdir directly (standard_tier_subdir, mlx.standardTierLayout). UNet + both text
+        // encoders packed in q4/q8; VAE dense in every tier. This replaces the old scoped-glob pull
+        // from the ~41 GB upstream repo (which bundled redundant fp16/fp32 component + single-file
+        // variants) — the turnkey ships only the packed fp16 components per tier. Per-tier variants
+        // (sc-8508): each tier is a SEPARATE installable artifact with a `variant` + `footprint`.
+        // Sizes measured on-disk.
         {
-          // Distilled checkpoint, distinct weights from RealVisXL_V5.0. openrail++, ungated,
-          // download-on-demand (not Recommended/auto-download). The repo is ~41 GB — it bundles
-          // fp16 AND fp32 diffusers component variants PLUS two redundant root single-file
-          // checkpoints (`*_fp16.safetensors` ~6.6 GB, `*_fp32.safetensors` ~13 GB). The mlx-gen
-          // `sdxl` loader reads only the **fp16 diffusers components** (it prefers
-          // `<comp>/*.fp16.safetensors`), so scope the pull to those + the tiny configs/tokenizers
-          // = ~6.9 GB. An empty `files` would fetch the whole 41 GB repo (allow_pattern_matches
-          // empty == match-all). Globs use `glob::Pattern` (require_literal_separator=false), so
-          // `*/*.fp16.safetensors` requires a subdir (skips the root single-files) and matches the
-          // fp16 stem (skips the fp32 + sharded variants).
           "provider": "huggingface",
-          "repo": "SG161222/RealVisXL_V5.0_Lightning",
-          "files": [
-            "model_index.json",
-            "scheduler/*",
-            "tokenizer/*",
-            "tokenizer_2/*",
-            "*/config.json",
-            "*/*.fp16.safetensors"
-          ],
-          "estimatedSizeBytes": 6940000000
+          "repo": "SceneWorks/realvisxl-lightning-mlx",
+          "variant": "q4",
+          "default": true,
+          "files": ["q4/*"],
+          "estimatedSizeBytes": 3911657599,
+          "footprint": { "diskSizeBytes": 3911657599, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/realvisxl-lightning-mlx",
+          "variant": "q8",
+          "files": ["q8/*"],
+          "estimatedSizeBytes": 5385843729,
+          "footprint": { "diskSizeBytes": 5385843729, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/realvisxl-lightning-mlx",
+          "variant": "bf16",
+          "files": ["bf16/*"],
+          "estimatedSizeBytes": 7108692804,
+          "footprint": { "diskSizeBytes": 7108692804, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "paths": {
-        "model": "${HF_CACHE}/SG161222/RealVisXL_V5.0_Lightning"
+        "model": "${HF_CACHE}/SceneWorks/realvisxl-lightning-mlx"
       },
+      "gated": false,
       "defaults": {
         // Model-card Lightning defaults: ~5 steps, guidance 1.0 (CFG off — the distilled
         // checkpoint is trained CFG-free, which also halves per-step UNet work; the negative
@@ -3383,6 +3458,13 @@
         // declare the real family rather than an empty list, which would match every LoRA).
         "families": ["sdxl"],
         "types": ["style", "enhance", "character"]
+      },
+      "mlx": {
+        // sc-8746 (epic 8506, Group-B): q4/ default tier; q8/ + bf16/ hosted + selectable via
+        // advanced.mlxQuantize. `standardTierLayout` (sc-8508 manifest-driven form) opts this id
+        // into `uses_standard_tier_layout` so the worker resolves the tier subdir from the turnkey.
+        "quantize": 4,
+        "standardTierLayout": true
       },
       "ui": {
         "label": "RealVisXL Lightning (fast photoreal SDXL)",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -443,7 +443,7 @@ sceneworks-core = { path = "../sceneworks-core" }
 # candle links no z-image crate and compiles UNCHANGED) so `--features backend-candle --target all`
 # resolves the SINGLE gen-core rev 863f98d. (candle-gen #199 is squash-merged on candle-gen main as
 # 22c121a — the canonical SHA all candle-gen-* pins below point at.)
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -795,7 +795,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -811,23 +811,23 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d9
 # exactly this rev, so the worker MUST match (a different rev would compile pmetal-mlx-sys twice). This
 # rebuilds MLX from source. Paired with mlx-llm `6c052ba` below (mlx-llm#45 carries the same fork pin).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
 # Krea 2 Turbo (native MLX, Krea 2 Community License; epic 7565, sc-7572). Same git rev as mlx-gen.
 # Self-registers `krea_2_turbo` (Qwen3-VL-4B TE + 28-block single-stream DiT + Qwen-Image VAE; CFG-free
 # rectified-flow few-step) via inventory only when force-linked (`use mlx_gen_krea as _;` in
 # image_jobs.rs). Loads the packed Q8/Q4 turnkey subdir (krea_model_subdir; the loader auto-detects the
 # packed quant, so the resolved `spec.quantize` is a no-op on it). Depends on mlx-gen-qwen-image for the
 # shared `AutoencoderKLQwenImage` VAE.
-mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
+mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
 # Stable Diffusion 3.5 provider (native MLX, Stability AI Community License; epic 7841, sc-7871). Same
 # git rev as mlx-gen so MLX builds once. Self-registers `sd3_5_large` (true-CFG, 28 steps / guidance 3.5)
 # + `sd3_5_large_turbo` (ADD-distilled few-step, CFG-off) + `sd3_5_medium` (MMDiT-X, true-CFG, 40 steps /
@@ -835,7 +835,7 @@ mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abf
 # (`use mlx_gen_sd3 as _;` in image_jobs.rs). All three carry a `sd3_5_*_quant` converter. Reuses the SDXL
 # CLIP encoder (×2), the FLUX T5-XXL encoder, and the Z-Image 16-ch VAE — its `quantize_sd3_dir` converter
 # is wired in model_jobs.rs for the `sd3_5_{large,large_turbo,medium}_quant` install-time conversions.
-mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
+mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
 # SANA 1600M provider (native MLX, NVIDIA non-commercial license; epic 8485, sc-8489). Same git rev as
 # mlx-gen so MLX builds once. Self-registers `sana_1600m` (Image/t2i, true-CFG, 32× DC-AE divisor,
 # mac_only) via `register_generators!` into the gen-core inventory — surfaces only when force-linked
@@ -843,59 +843,59 @@ mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc
 # conditioning (sc-8488); the `SanaPipeline` composes SanaTextEncoder -> SanaTransformer (Linear DiT) ->
 # DC-AE f32 decoder and exposes the `from_snapshot`/`from_weights` weight-load entrypoints the generic
 # generator-cache load path drives.
-mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
+mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
 # CLIP ViT-L/14 image embedder for the Dataset Doctor analysis job (epic 6529 P2, sc-6535).
 # Self-registers `clip_vit_l14` (gen_core::ImageEmbedder) via inventory only when force-linked
 # (`use mlx_gen_clip as _;` in dataset_analysis_jobs.rs). Reuses mlx-gen-sdxl's CLIP body → same rev.
-mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
+mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -904,19 +904,19 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abf
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
 # Depth Anything V2 (DINOv2 ViT-S/14 + DPT) native-MLX monocular depth estimator (epic 8236,
 # sc-8242). A plain utility crate (NOT a self-registering generation provider): an arbitrary RGB
 # image → a normalized single-channel depth control image, the AUTO depth source for the
 # Fun-Controlnet-Union depth tier (`ControlKind::Depth`) — sibling of the CPU canny/pose
 # preprocessors, but neural so it is macOS-gated (MLX). Consumed by the worker `depth` module /
 # the shared strict-control driver (sc-8243). Same mlx-rs pin as every other mlx-gen crate.
-mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
+mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -925,7 +925,7 @@ mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41ab
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -933,7 +933,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -944,7 +944,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41a
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -955,7 +955,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41ab
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -977,7 +977,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abf
 # a Metal large-tensor limit, not precision). New `VAE_SAFE_DECODE_EDGE_PX=1536` forces decode tiling on
 # a CORRECTNESS cap independent of the memory budget (image + video), so a 2048² upscale that fits memory
 # still tiles. Real-weight 1024→2048 pixel-cosine vs the mflux reference 0.9524 → 0.9974.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -988,7 +988,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
 # The unified LLM engine (epic 7153, sc-7158): the macOS `prompt_refine` job now runs through
 # mlx-llm's generic `mlx-llama` provider (a `core_llm::TextLlm`) resolved model-first via
 # `gen_core::core_llm::load_for_model`, RETIRING the bespoke `mlx-gen-prompt-refine` hand-rolled
@@ -1020,7 +1020,7 @@ mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "7041411f395e43
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41abfc42d94561643b42a71ae3e36b9ea4c9a7e" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -1335,15 +1335,15 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a41a
 # (inference-level memory, like 24 GB cards) and restores the live `Var`s after. SOURCE-ONLY candle-gen
 # fix; both b3aad50 and 5bb83e4 pin gen-core 863f98d, so this stays single-rev (mlx-gen unchanged). ALL
 # candle-gen-* rev lines move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1351,17 +1351,17 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1371,7 +1371,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1379,21 +1379,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1402,17 +1402,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1421,7 +1421,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1454,7 +1454,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1463,12 +1463,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1476,7 +1476,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1485,7 +1485,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1493,7 +1493,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1507,7 +1507,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1534,7 +1534,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1545,7 +1545,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "96677786559c949e98cb9c192ddb65367c337b71", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -245,7 +245,10 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
     ModelRow {
         sceneworks_id: "sdxl",
         engine_id: "sdxl",
-        default_repo: "stabilityai/stable-diffusion-xl-base-1.0",
+        // SceneWorks pre-built quant-matrix turnkey (sc-8746, epic 8506, Group-B): standard
+        // q4/q8/bf16 subdirs (standard_tier_subdir) — UNet + both CLIP text encoders packed,
+        // VAE dense. Public/ungated re-host of stabilityai/stable-diffusion-xl-base-1.0.
+        default_repo: "SceneWorks/sdxl-base-mlx",
         default_steps: 30,
         default_guidance: 7.0,
         adapter_label: "mlx_sdxl",
@@ -253,7 +256,9 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
     ModelRow {
         sceneworks_id: "realvisxl",
         engine_id: "sdxl",
-        default_repo: "SG161222/RealVisXL_V5.0",
+        // SceneWorks pre-built quant-matrix turnkey (sc-8746, epic 8506, Group-B): standard
+        // q4/q8/bf16 subdirs (standard_tier_subdir). Re-host of SG161222/RealVisXL_V5.0.
+        default_repo: "SceneWorks/realvisxl-mlx",
         default_steps: 30,
         default_guidance: 7.0,
         adapter_label: "mlx_sdxl",
@@ -267,7 +272,9 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
     ModelRow {
         sceneworks_id: "realvisxl_lightning",
         engine_id: "sdxl",
-        default_repo: "SG161222/RealVisXL_V5.0_Lightning",
+        // SceneWorks pre-built quant-matrix turnkey (sc-8746, epic 8506, Group-B): standard
+        // q4/q8/bf16 subdirs (standard_tier_subdir). Re-host of SG161222/RealVisXL_V5.0_Lightning.
+        default_repo: "SceneWorks/realvisxl-lightning-mlx",
         default_steps: 5,
         default_guidance: 1.0,
         adapter_label: "mlx_sdxl",
@@ -1269,6 +1276,29 @@ mod tests {
         assert_ne!(base.default_repo, turbo.default_repo);
         assert_ne!(base.default_steps, turbo.default_steps);
         assert_ne!(base.default_guidance, turbo.default_guidance);
+    }
+
+    // sc-8746 (epic 8506, Group-B): the SDXL-family rows point at the SceneWorks pre-built
+    // quant-matrix turnkey repos (standard q4/q8/bf16 subdirs), NOT the original dense sources.
+    // Each engine still shares the `sdxl` engine id; only the default_repo swings to the turnkey.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    #[test]
+    fn sdxl_family_rows_point_at_sceneworks_turnkeys() {
+        for (id, repo) in [
+            ("sdxl", "SceneWorks/sdxl-base-mlx"),
+            ("realvisxl", "SceneWorks/realvisxl-mlx"),
+            ("realvisxl_lightning", "SceneWorks/realvisxl-lightning-mlx"),
+        ] {
+            let row = MODEL_TABLE
+                .iter()
+                .find(|row| row.sceneworks_id == id)
+                .unwrap_or_else(|| panic!("{id} MODEL_TABLE row"));
+            assert_eq!(row.engine_id, "sdxl", "{id} shares the sdxl engine");
+            assert_eq!(row.default_repo, repo, "{id} default_repo → turnkey");
+        }
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -376,28 +376,35 @@ fn is_dense_te_tier(request: &ImageRequest) -> bool {
 /// when it opts into Q8 (`> 4`), else the default `q4/`. Falls back through q4 → q8 → bf16 → `root`
 /// so a partially-downloaded turnkey surfaces as a load error rather than a silent half-load.
 ///
-/// Tier presence is filename-agnostic: a tier is "present" when its `transformer/` holds any
+/// Tier presence is filename-agnostic: a tier is "present" when its backbone component holds any
 /// `*.safetensors` (packed single-file OR a `*-00001-of-*.safetensors` shard) or a `*.index.json`
-/// (dense sharded). This covers every backbone regardless of its packed filename
+/// (dense sharded). The backbone component is `transformer/` for the DiT turnkeys
+/// (flux/qwen/z-image/sd3.5) or `unet/` for the SDXL-family turnkeys (sc-8746) — SDXL packs its UNet
+/// under `unet/`, never `transformer/`. This covers every backbone regardless of its packed filename
 /// (`diffusion_pytorch_model.safetensors`, `model.safetensors`, …), so a new model needs only a
-/// [`STANDARD_TIER_MODELS`] entry, no bespoke resolver.
+/// [`STANDARD_TIER_MODELS`] entry (or `mlx.standardTierLayout`), no bespoke resolver.
 fn standard_tier_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
     let bits = request
         .advanced
         .get("mlxQuantize")
         .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()));
-    let present = |name: &str| -> Option<PathBuf> {
-        let dir = root.join(name);
-        let transformer = dir.join("transformer");
-        let Ok(entries) = std::fs::read_dir(&transformer) else {
-            return None;
+    // A component dir "has weights" when it holds a packed/dense safetensors or a shard index.
+    let component_has_weights = |dir: &Path| -> bool {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return false;
         };
-        let has_weights = entries.flatten().any(|entry| {
+        entries.flatten().any(|entry| {
             let file = entry.file_name();
             let name = file.to_string_lossy();
             name.ends_with(".safetensors") || name.ends_with(".index.json")
-        });
-        has_weights.then_some(dir)
+        })
+    };
+    let present = |name: &str| -> Option<PathBuf> {
+        let dir = root.join(name);
+        // DiT turnkeys pack the backbone under `transformer/`; SDXL-family turnkeys under `unet/`.
+        let has_backbone = component_has_weights(&dir.join("transformer"))
+            || component_has_weights(&dir.join("unet"));
+        has_backbone.then_some(dir)
     };
     // bits<=0 (advanced.mlxQuantize: 0 / "none") → bf16; bits>4 → q8; else the q4 default.
     let preferred = match bits {
@@ -3280,6 +3287,101 @@ mod standard_tier_tests {
             standard_tier_subdir(empty.path(), &request(json!({}))),
             empty.path().to_path_buf()
         );
+    }
+
+    /// sc-8746: the SDXL-family turnkeys pack their backbone under `unet/`, not `transformer/`, so
+    /// [`standard_tier_subdir`]'s probe must recognize a `unet/` component as a present tier.
+    #[test]
+    fn resolves_sdxl_unet_backbone_tiers() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let seed_unet = |tier: &str| {
+            let dir = root.join(tier).join("unet");
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("diffusion_pytorch_model.safetensors"), b"x").unwrap();
+        };
+        seed_unet("q4");
+        seed_unet("q8");
+        seed_unet("bf16");
+        // Default q4, q8 selection, bf16 opt-out all resolve to the unet-backed tier subdir.
+        assert_eq!(
+            standard_tier_subdir(root, &request(json!({}))),
+            root.join("q4")
+        );
+        assert_eq!(
+            standard_tier_subdir(root, &request(json!({ "mlxQuantize": 8 }))),
+            root.join("q8")
+        );
+        assert_eq!(
+            standard_tier_subdir(root, &request(json!({ "mlxQuantize": 0 }))),
+            root.join("bf16")
+        );
+    }
+
+    /// sc-8746 on-device verify (MLX): drive the ACTUAL worker seam against a downloaded SceneWorks
+    /// realvisxl-mlx turnkey — `standard_tier_subdir` resolves the `q4/` subdir from the tier root,
+    /// then `gen_core::load("sdxl", …)` with `Quant::Q4` loads the packed tier and renders. Asserts a
+    /// non-degenerate image (per-pixel std above the all-black/NaN floor). `#[ignore]`d — run by hand
+    /// on a Mac with the tier downloaded:
+    /// ```text
+    /// hf download SceneWorks/realvisxl-mlx --include "q4/*" --local-dir /tmp/realvisxl-q4
+    /// SDXL_TIER_ROOT=/tmp/realvisxl-q4 cargo test -p sceneworks-worker --lib \
+    ///   sdxl_realvisxl_q4_tier_mlx_smoke -- --ignored --nocapture
+    /// ```
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "real-weight MLX smoke; needs a downloaded SceneWorks/realvisxl-mlx q4 tier (SDXL_TIER_ROOT)"]
+    fn sdxl_realvisxl_q4_tier_mlx_smoke() {
+        use gen_core::{GenerationOutput, GenerationRequest, LoadSpec, Quant, WeightsSource};
+
+        let root = PathBuf::from(
+            std::env::var("SDXL_TIER_ROOT")
+                .expect("set SDXL_TIER_ROOT to the downloaded realvisxl-mlx tier root")
+                .trim(),
+        );
+        // The worker resolution: a `realvisxl` request (q4 default, no mlxQuantize) must land on q4/.
+        let req = ImageRequest::from_payload(
+            json!({ "model": "realvisxl", "advanced": {} })
+                .as_object()
+                .unwrap(),
+        );
+        let tier = standard_tier_subdir(&root, &req);
+        assert_eq!(tier, root.join("q4"), "worker must resolve the q4 tier subdir");
+        assert!(
+            tier.join("model_index.json").is_file() && tier.join("unet").is_dir(),
+            "q4 tier subdir missing turnkey layout (model_index.json + unet/): {}",
+            tier.display()
+        );
+
+        // Load the packed q4 tier through the MLX `sdxl` engine (Quant::Q4 = harmless no-op on the
+        // already-packed weights) and render a 768x768 image.
+        let spec = LoadSpec::new(WeightsSource::Dir(tier.clone())).with_quant(Quant::Q4);
+        let generator = gen_core::load("sdxl", &spec).expect("load MLX sdxl provider on q4 tier");
+        let gen_req = GenerationRequest {
+            prompt: "a photorealistic portrait of a red fox in a snowy forest, golden hour"
+                .to_owned(),
+            width: 768,
+            height: 768,
+            count: 1,
+            seed: Some(42),
+            steps: Some(20),
+            guidance: Some(7.0),
+            ..Default::default()
+        };
+        let output = generator
+            .generate(&gen_req, &mut |_p| {})
+            .expect("sdxl q4 tier generate");
+        let image = match output {
+            GenerationOutput::Images(mut images) => images.pop().expect("no image returned"),
+            other => panic!("expected Images output, got {other:?}"),
+        };
+        // Cheap degenerate-floor check: an all-black / NaN-clamped decode collapses toward std 0.
+        let n = image.pixels.len() as f64;
+        assert!(n > 0.0, "empty image buffer");
+        let mean = image.pixels.iter().map(|&p| p as f64).sum::<f64>() / n;
+        let std = (image.pixels.iter().map(|&p| (p as f64 - mean).powi(2)).sum::<f64>() / n).sqrt();
+        println!("[sc-8746 smoke] realvisxl q4 tier render {}x{} std {std:.2}", image.width, image.height);
+        assert!(std > 5.0, "render looks degenerate (std {std:.2}) — possible NaN / all-black decode");
     }
 
     /// A model built with a manifest entry so `uses_standard_tier_layout` / `is_dense_te_tier`

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -165,6 +165,12 @@ mod flux1_control_mlx_smoke;
 // isolation.
 #[cfg(all(test, target_os = "macos"))]
 mod sd3_5_mlx_smoke;
+// Real-weight MLX smoke for the SDXL base 1.0 Q8 worker lane (sc-8746, epic 8506 Group-B). Test-only +
+// macOS-only; drives `gen_core::load("sdxl")` with a Q8 LoadSpec against the packed `q8/` turnkey subdir.
+// Closes the stale sc-1975 Q8-on-SDXL loop on-device: asserts the fixed mlx-gen Q8 path (sc-2641) renders
+// non-degenerate AND specifically NOT all-zero (the retired Apple recipe's exact failure signature).
+#[cfg(all(test, target_os = "macos"))]
+mod sdxl_base_q8_mlx_smoke;
 // The DWPose skeleton rasterizer is consumed only by the macOS Z-Image strict-pose
 // control path; on Mac AND the off-Mac candle DWPose lane (sc-5496) it backs the
 // `pose_jobs` skeleton render; on a candle-disabled box off Mac it still builds +

--- a/crates/sceneworks-worker/src/sdxl_base_q8_mlx_smoke.rs
+++ b/crates/sceneworks-worker/src/sdxl_base_q8_mlx_smoke.rs
@@ -1,0 +1,214 @@
+//! Local real-weight MLX smoke for the SDXL base 1.0 **Q8** worker lane (sc-8746, epic 8506 Group-B).
+//! `#[ignore]`d — run by hand on an Apple-Silicon Mac. It drives the real native-MLX `sdxl` engine via
+//! `gen_core::load("sdxl")` with a **Q8** `LoadSpec` pointed at the packed `q8/` turnkey subdir — the
+//! exact runtime seam `generate_stream` uses (minus the API/job plumbing) when the router routes an
+//! `sdxl` MLX job (`standard_tier_subdir` → the `q8/` subdir; `resolve_quant` → `Quant::Q8`).
+//!
+//! Purpose: this is the on-device evidence that CLOSES the stale sc-1975 Q8-on-SDXL loop. sc-1975
+//! recorded that **Apple's vendored `mlx-examples` Python Q8 recipe** produced an ALL-ZERO (degenerate)
+//! decode on SDXL base 1.0, so the manifest deferred a Q8 default. That vendored in-process MLX-SDXL
+//! adapter was RETIRED by sc-3060 (the Python worker always routes torch for SDXL now); MLX-SDXL is the
+//! Rust `mlx-gen-sdxl` path, whose Q4/Q8 quantization was FIXED + MERGED by mlx-gen PR #62 (sc-2641,
+//! "SDXL Q4/Q8 quantization — both hold parity on base-1.0"). This smoke asserts the Q8 render is (a)
+//! non-degenerate (per-pixel std well above the degenerate floor) and (b) SPECIFICALLY NOT all-zero —
+//! the exact failure mode the original Apple recipe exhibited.
+//!
+//! Setup — point at the published turnkey `SceneWorks/sdxl-base-mlx` (the worker default). With the q8
+//! tier already in the HF cache, no env is needed: the smoke auto-resolves the cached snapshot's `q8/`
+//! subdir (the same selection `image_jobs::base::standard_tier_subdir` makes for `mlxQuantize: 8`).
+//! Override `SDXL_Q8_DIR` to point at a snapshot root or a `q8/`-bearing dir directly.
+//! ```text
+//! # optional: SDXL_Q8_DIR=/path/to/sdxl-base-mlx  (root containing q8/, or the q8/ dir itself)
+//! # optional: SDXL_STEPS=30 SDXL_W=768 SDXL_H=768 SDXL_PROMPT="..." SDXL_OUT_DIR=/tmp/sdxl_q8_smoke
+//! cargo test -p sceneworks-worker --release sdxl_base_q8_mlx_gpu_smoke -- --ignored --nocapture
+//! ```
+
+use std::path::{Path, PathBuf};
+
+use gen_core::{GenerationOutput, GenerationRequest, Image, LoadSpec, Quant, WeightsSource};
+
+fn env_or(key: &str, default: &str) -> String {
+    std::env::var(key)
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| default.to_string())
+}
+
+/// The engine-complete packed subdir to load: mirror `image_jobs::base::standard_tier_subdir`'s q8
+/// selection — prefer `<root>/q8` (SDXL-family turnkeys pack the backbone under `unet/`), else `root`
+/// itself if it already *is* a q8 root. Errors loud if neither resolves so a half-download surfaces as
+/// a clear failure rather than a confusing engine load error.
+fn resolve_q8_dir(root: &Path) -> PathBuf {
+    let is_engine_root = |d: &Path| d.join("unet/diffusion_pytorch_model.safetensors").is_file();
+    let q8 = root.join("q8");
+    if is_engine_root(&q8) {
+        return q8;
+    }
+    assert!(
+        is_engine_root(root),
+        "SDXL_Q8_DIR must point at the turnkey root (containing q8/) or a q8/ dir with a packed \
+         unet/diffusion_pytorch_model.safetensors; neither found under {}",
+        root.display()
+    );
+    root.to_path_buf()
+}
+
+/// Auto-discover the cached `SceneWorks/sdxl-base-mlx` turnkey snapshot in the HF hub cache, returning
+/// the snapshot whose `q8/` subdir carries the packed UNet. `None` if the q8 tier hasn't been pulled
+/// (the smoke then panics with the `SDXL_Q8_DIR` hint).
+fn cached_turnkey_root() -> Option<PathBuf> {
+    let home = std::env::var("HOME").ok()?;
+    let snapshots = PathBuf::from(home)
+        .join(".cache/huggingface/hub/models--SceneWorks--sdxl-base-mlx/snapshots");
+    std::fs::read_dir(&snapshots)
+        .ok()?
+        .filter_map(|e| e.ok())
+        .find_map(|e| {
+            let dir = e.path();
+            dir.join("q8/unet/diffusion_pytorch_model.safetensors")
+                .is_file()
+                .then_some(dir)
+        })
+}
+
+/// Per-pixel mean over the RGB buffer — used both as the "is it black?" floor check and reported for
+/// the record. The original Apple Q8 bug produced an ALL-ZERO decode, so a near-zero mean is the smoking
+/// gun; a coherent render sits well inside the mid-tones.
+fn image_mean(img: &Image) -> f64 {
+    let n = img.pixels.len() as f64;
+    if n == 0.0 {
+        return 0.0;
+    }
+    img.pixels.iter().map(|&p| p as f64).sum::<f64>() / n
+}
+
+/// Mean per-pixel std-dev across the RGB channels — a cheap "is the image non-degenerate" check. A NaN /
+/// all-black / flat decode collapses the std toward 0; this guards that degenerate floor. The real
+/// quality call is the saved-PNG eyeball.
+fn image_std(img: &Image) -> f64 {
+    let n = img.pixels.len() as f64;
+    if n == 0.0 {
+        return 0.0;
+    }
+    let mean = image_mean(img);
+    let var = img
+        .pixels
+        .iter()
+        .map(|&p| (p as f64 - mean).powi(2))
+        .sum::<f64>()
+        / n;
+    var.sqrt()
+}
+
+/// Whether EVERY pixel byte is exactly 0 — the precise degenerate signature of the retired Apple Q8
+/// recipe (sc-1975). A coherent SDXL render can never be all-zero.
+fn is_all_zero(img: &Image) -> bool {
+    !img.pixels.is_empty() && img.pixels.iter().all(|&p| p == 0)
+}
+
+fn save_png(img: &Image, path: &Path) {
+    image::RgbImage::from_raw(img.width, img.height, img.pixels.clone())
+        .expect("rgb buffer")
+        .save(path)
+        .unwrap_or_else(|e| panic!("save {}: {e}", path.display()));
+}
+
+#[test]
+#[ignore = "real-weight MLX smoke; needs the SceneWorks/sdxl-base-mlx q8 turnkey cached + an Apple-Silicon Mac"]
+fn sdxl_base_q8_mlx_gpu_smoke() {
+    let root = match std::env::var("SDXL_Q8_DIR") {
+        Ok(p) if !p.trim().is_empty() => PathBuf::from(p.trim()),
+        _ => cached_turnkey_root().unwrap_or_else(|| {
+            panic!(
+                "no cached SceneWorks/sdxl-base-mlx q8 turnkey found; download it via the manifest \
+                 (`hf download SceneWorks/sdxl-base-mlx --include 'q8/*'`) or set SDXL_Q8_DIR to the \
+                 turnkey root (containing q8/)"
+            )
+        }),
+    };
+    let q8_dir = resolve_q8_dir(&root);
+
+    let out_dir = PathBuf::from(env_or("SDXL_OUT_DIR", "/tmp/sdxl_q8_smoke"));
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+
+    let steps: u32 = env_or("SDXL_STEPS", "30").parse().expect("SDXL_STEPS");
+    let w: u32 = env_or("SDXL_W", "768").parse().expect("SDXL_W");
+    let h: u32 = env_or("SDXL_H", "768").parse().expect("SDXL_H");
+    let prompt = env_or(
+        "SDXL_PROMPT",
+        "a photorealistic portrait of a red fox sitting in a sunlit autumn forest, sharp focus, \
+         shallow depth of field",
+    );
+
+    // Same seam as the worker's MLX image path: a registry load of the `sdxl` generator (the worker-crate
+    // force-link anchor `use mlx_gen_sdxl as _;` keeps it registered) + a Q8 `LoadSpec` pointed at the
+    // packed q8 turnkey subdir. The packed weights auto-detect their quant, so `with_quant(Q8)` matches
+    // the manifest's `mlx.quantize: 8` tier.
+    println!("[smoke] loading sdxl (Q8) from {} ...", q8_dir.display());
+    let spec = LoadSpec::new(WeightsSource::Dir(q8_dir.clone())).with_quant(Quant::Q8);
+    let generator = gen_core::load("sdxl", &spec).expect("load mlx sdxl generator");
+
+    // SDXL base 1.0: real CFG (negative prompt + guidance 7.0), EulerDiscrete default schedule.
+    let req = GenerationRequest {
+        prompt: prompt.clone(),
+        negative_prompt: Some("blurry, low quality, deformed, watermark".to_owned()),
+        width: w,
+        height: h,
+        count: 1,
+        seed: Some(42),
+        steps: Some(steps),
+        guidance: Some(7.0),
+        ..Default::default()
+    };
+    println!("[smoke] rendering {w}x{h} @ {steps} steps (CFG 7.0) ...");
+    let mut last = String::new();
+    let output = generator
+        .generate(&req, &mut |p| {
+            let s = format!("{p:?}");
+            if s != last {
+                println!("[progress] {s}");
+                last = s;
+            }
+        })
+        .expect("sdxl generate");
+    let image = match output {
+        GenerationOutput::Images(mut images) => images.pop().expect("engine returned no image"),
+        other => panic!("expected Images output, got {other:?}"),
+    };
+
+    let mean = image_mean(&image);
+    let std = image_std(&image);
+    let all_zero = is_all_zero(&image);
+    let png = out_dir.join(format!("sdxl_base_q8_{steps}step.png"));
+    save_png(&image, &png);
+    println!(
+        "[smoke] sdxl base Q8 {}x{} mean {:.2} std {:.2} all_zero={} -> {}",
+        image.width,
+        image.height,
+        mean,
+        std,
+        all_zero,
+        png.display()
+    );
+    assert_eq!(
+        (image.width, image.height),
+        (w, h),
+        "engine returned the wrong dimensions"
+    );
+    // The original Apple Q8 recipe (sc-1975) produced an ALL-ZERO decode. Assert the fixed mlx-gen path
+    // (sc-2641) specifically does NOT reproduce that signature.
+    assert!(
+        !all_zero,
+        "sdxl base Q8 decode is ALL-ZERO — the retired Apple recipe's exact failure (sc-1975); the \
+         mlx-gen Q8 path (sc-2641) must not reproduce it"
+    );
+    assert!(
+        std > 20.0,
+        "sdxl base Q8 render looks degenerate (std {std:.2}) — possible NaN / all-black / flat decode"
+    );
+    println!(
+        "[smoke] DONE: sdxl base Q8 render coherent (mean {mean:.2}, std {std:.2}, NOT all-zero) \
+         at {steps} steps through the worker lane"
+    );
+}

--- a/tests/test_worker_image_adapters.py
+++ b/tests/test_worker_image_adapters.py
@@ -1111,9 +1111,9 @@ def test_create_image_adapter_routes_z_image_turbo():
     assert adapter.id == "z_image_diffusers"
 
 def test_sdxl_manifest_has_mlx_block():
-    # sc-1975: sdxl carries an mlx block (no `limits` override here — Apple's
-    # SDXL schedule already matches the torch EulerDiscrete default, and
-    # there's no per-model sampler menu in the sdxl manifest entry to limit).
+    # sdxl carries an mlx block (no `limits` override here — the MLX SDXL schedule
+    # matches the torch EulerDiscrete default, and there's no per-model sampler menu
+    # in the sdxl manifest entry to limit).
     import re
 
     _, find_entry_block, find_mlx_block = _manifest_brace_walker()
@@ -1121,13 +1121,33 @@ def test_sdxl_manifest_has_mlx_block():
     mlx_block = find_mlx_block(block)
     mem_match = re.search(r'"minMemoryGb"\s*:\s*(\d+)', mlx_block)
     assert mem_match and int(mem_match.group(1)) > 0, (
-        "sdxl mlx.minMemoryGb must be a positive int (sc-1975)"
+        "sdxl mlx.minMemoryGb must be a positive int"
     )
-    # No quantize key in v1 — Apple's Q8 recipe breaks SDXL base 1.0 (see
-    # sc-1975 spike finding). bf16 is the only supported precision.
-    assert '"quantize"' not in mlx_block, (
-        "sdxl mlx block must not declare a quantize default in v1 (sc-1975: "
-        "Apple's Q8 recipe breaks on SDXL base 1.0; defer until calibration lands)"
+    # sc-1975 originally deferred a quantize default because APPLE's vendored
+    # `mlx-examples` Python Q8 recipe produced an ALL-ZERO decode on SDXL base 1.0.
+    # That guard is now OBSOLETE (evidence-based flip, not silencing):
+    #   * sc-3060 RETIRED the in-process vendored Python MLX-SDXL adapter — on the
+    #     Python worker, SDXL always routes the torch adapter now. MLX-SDXL is the
+    #     Rust `mlx-gen-sdxl` path.
+    #   * mlx-gen PR #62 (sc-2641) FIXED + MERGED SDXL quantization: "SDXL Q4/Q8
+    #     quantization — both hold parity on base-1.0."
+    #   * sc-8746 (epic 8506, Group-B) ships pre-quantized q4/q8/bf16 tiers via the
+    #     Rust standard_tier_subdir / resolve_quant path — the exact seam that reads
+    #     this `mlx.quantize` value (NOT the retired Apple adapter).
+    # On-device close (this Mac, MLX): SceneWorks/sdxl-base-mlx q8 tier rendered a
+    # coherent 768x768 (mean 97.65, std 61.43, NOT all-zero — the retired Apple bug's
+    # exact signature), verified by crates/sceneworks-worker/src/sdxl_base_q8_mlx_smoke.rs.
+    # So the mlx block SHOULD now carry the tier/quantize config: q4 default (packed),
+    # q8 + bf16 hosted + selectable via advanced.mlxQuantize.
+    quant_match = re.search(r'"quantize"\s*:\s*(\d+)', mlx_block)
+    assert quant_match and int(quant_match.group(1)) in {3, 4, 5, 6, 8}, (
+        "sdxl mlx.quantize must be a supported quant level — sdxl now ships "
+        "pre-quantized Q4/Q8/bf16 tiers via the Rust mlx-gen path (sc-2641 parity + "
+        "sc-8746 tiers; sc-3060 retired the old Apple MLX adapter that sc-1975 gated on)"
+    )
+    # sc-8508: the turnkey opts into the q4/q8/bf16 standard tier layout.
+    assert '"standardTierLayout"' in mlx_block and "true" in mlx_block, (
+        "sdxl mlx block must declare standardTierLayout for the packed-tier turnkey (sc-8746/sc-8508)"
     )
 
 def test_sdxl_auto_dispatch_uses_torch_adapter_on_python_worker(monkeypatch):


### PR DESCRIPTION
## sc-8746 — SDXL-family Group-B tiers (worker-side wiring)

Worker completion for the SceneWorks pre-built MLX quant-matrix turnkeys. The mlx-gen side merged in #621 and the three tier repos are hosted (public, `gated:false`, openrail++):
- `SceneWorks/sdxl-base-mlx` (`sdxl`)
- `SceneWorks/realvisxl-mlx` (`realvisxl`)
- `SceneWorks/realvisxl-lightning-mlx` (`realvisxl_lightning`)

Each has full self-contained q4/q8/bf16 subdirs (UNet + both CLIP text encoders + VAE + tokenizers + scheduler + model_index.json). SDXL packs the UNet + both text encoders; the VAE stays dense. Not dense-TE models.

### Pin bump
- Bumped **every** `mlx-gen-*` crate + the direct `sceneworks-gen-core` pin `a41abfc` → **`ef43eac`** (mlx-gen #621). Worker-direct pins use the full 40-char rev so the source spelling matches candle-gen's transitive gen-core re-pin (short vs full rev are distinct cargo sources and would otherwise trip the skew gate).
- Bumped `candle-gen` pins `9667778` → **`24d975a`** (candle-gen #204, which re-pins gen-core → ef43eac).
- `core-llm` left untouched at `3870ed1` (the candle-gen bump silently pulled it to `54cbac8`; reverted per the known gotcha).

### Skew gate
`scripts/check-gen-core-skew.sh sceneworks-worker --features backend-candle` reports **exactly one** gen-core rev = `ef43eac9f954...` across worker-direct + via-candle-gen.

### Manifest wiring (first-class sc-8508 per-tier schema)
Per-tier `downloads` q4(default)/q8/bf16 with `files` filter, `variant`, and `footprint.diskSizeBytes` (exact bytes measured from the HF repos):

| id | q4 | q8 | bf16 |
|---|---|---|---|
| sdxl | 2703202068 | 4177386896 | 6941187536 |
| realvisxl | 3911656467 | 5385840183 | 7108692804 |
| realvisxl_lightning | 3911657599 | 5385843729 | 7108692804 |

`paths.model` repointed to the SceneWorks turnkeys; `gated:false`; `mlx.quantize: 4` (q4 default) + `mlx.standardTierLayout: true` (manifest-driven `uses_standard_tier_layout` path, preferred over the hardcoded `STANDARD_TIER_MODELS` registry — these ids were not previously in it).

### engines.rs
`default_repo` for the three ids → the SceneWorks turnkey repos, plus a test asserting the SDXL-family rows point at them.

### standard_tier_subdir fix
The tier-presence probe hardcoded `transformer/`; SDXL-family turnkeys pack the backbone under `unet/`, so a tier would fall back to `root` and fail to load. Generalized the probe to accept `transformer/` **or** `unet/`, with a unit test.

### On-device verify (macOS MLX)
Downloaded the `SceneWorks/realvisxl-mlx` q4 tier and drove the real worker seam: `standard_tier_subdir` resolves the `q4/` subdir, then `gen_core::load("sdxl", spec.with_quant(Q4))` loads the packed tier and renders 768×768 — per-pixel std **66.19** (non-degenerate). Added as an `#[ignore]`d `SDXL_TIER_ROOT` smoke.

### Checks
- Skew gate: one rev = ef43eac ✅
- `npm run rust:check` (fmt --check + clippy + build): pass ✅
- `cargo test -p sceneworks-worker --lib`: 479 pass ✅
- candle-parity compile `cargo check -p sceneworks-worker --no-default-features -F backend-candle --all-targets`: pass ✅
- on-device MLX render: ok ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)