### PR TITLE
fix(routing): un-gate candle Krea LoRA inference off-Mac (sc-8754)

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3885,11 +3885,12 @@ const CANDLE_ROUTED_MODELS: &[&str] = &[
     "boogu_image_edit",
     // Krea 2 Turbo (epic 7565 P4, sc-7581): the candle `candle-gen-krea` provider serves `krea_2_turbo`
     // (12B single-stream rectified-flow DiT + Qwen3-VL-4B TE + Qwen-Image VAE, TDM-distilled CFG-free
-    // few-step). Pure **txt2img** — `image_request_candle_eligible` accepts the plain shape and rejects
-    // edit / reference / mask / quant / LoRA (the provider advertises none). The MODEL_TABLE row + manifest
-    // entry are the MLX twin (sc-7572); sc-7581 adds the candle lane (bf16 off the ungated public
-    // `krea/Krea-2-Turbo`, the boogu pattern). This id is also in `MLX_ROUTED_MODELS`; mirror
-    // `krea_mlx_eligible`.
+    // few-step). txt2img + inference LoRA/LoKr — `image_request_candle_eligible` accepts the plain shape
+    // and a LoRA (Krea is in `CANDLE_LORA_MODELS`; the provider merges a `krea_2_raw`-trained adapter at
+    // Turbo inference, sc-7836), but rejects edit / reference / mask / quant (the provider advertises no
+    // conditioning shapes and `supported_quants: &[]`). The MODEL_TABLE row + manifest entry are the MLX
+    // twin (sc-7572); sc-7581 adds the candle lane (bf16 off the ungated public `krea/Krea-2-Turbo`, the
+    // boogu pattern). This id is also in `MLX_ROUTED_MODELS`; mirror `krea_mlx_eligible`.
     "krea_2_turbo",
     // Stable Diffusion 3.5 (sc-7880, epic 7982): the candle `candle-gen-sd3` provider serves
     // `sd3_5_large` (8B MMDiT, true-CFG), `sd3_5_large_turbo` (ADD-distilled few-step, CFG-free), and
@@ -3918,6 +3919,18 @@ const CANDLE_QUANT_LORA_MODELS: &[&str] = &["lens", "lens_turbo"];
 /// LoRA still defers to the Python torch worker. `CANDLE_QUANT_LORA_MODELS` (Lens) is the superset that
 /// also keeps LoRAs on candle; these two lists are disjoint and the gate consults both.
 const CANDLE_QUANT_MODELS: &[&str] = &["sd3_5_large", "sd3_5_large_turbo", "sd3_5_medium"];
+
+/// The candle image families that advertise inference LoRA/LoKr adapters but NOT on-the-fly quant —
+/// Krea 2 Turbo (sc-7836): `candle-gen-krea` merges a `krea_2_raw`-trained LoRA/LoKr into the dense DiT
+/// (`supports_lora`/`supports_lokr: true`), but ships `supported_quants: &[]` (dense bf16 only). For
+/// these a LoRA stays on the candle lane (the worker's `generate_candle_stream` resolves it via
+/// `model.supports_adapters()`) while an explicit quant request still defers to the Python torch
+/// worker. The mirror of `CANDLE_QUANT_MODELS` (quant-not-LoRA); `CANDLE_QUANT_LORA_MODELS` (Lens) is
+/// the both-set. The three lists are disjoint and the gate consults all three. (sc-7836 landed the
+/// candle-gen engine merge + descriptor un-gate; the SceneWorks-side router un-gate here was missed
+/// because the sc-7837 GPU validation ran through the `candle-gen-krea` test harness, not a real
+/// `image_generate` submission — so a Krea LoRA job hit the no-torch-fallback gap instead of candle.)
+const CANDLE_LORA_MODELS: &[&str] = &["krea_2_turbo"];
 
 /// Whether `worker` is the candle (Windows/CUDA) SDXL worker — identified by the `candle` marker
 /// capability it self-advertises (`gpu::with_candle_capabilities`), mirroring the `nvidia` marker
@@ -4177,11 +4190,15 @@ fn image_request_candle_eligible(model: &str, payload: &Map<String, Value>) -> b
         return false;
     }
     // Lens / Lens-Turbo advertise Q4/Q8 + LoRA/LoKr, so a quant request OR a LoRA stays on the candle
-    // lane for them. SD3.5 (sc-7880) advertises Q4/Q8 but NOT inference LoRA, so a quant request stays
-    // on candle while a LoRA still defers. Every other candle family advertises neither and defers both.
-    let supports_lora = CANDLE_QUANT_LORA_MODELS.contains(&model);
-    let supports_quant = supports_lora || CANDLE_QUANT_MODELS.contains(&model);
-    // LoRAs: not in the candle lane unless the family advertises adapters (Lens).
+    // lane for them. SD3.5 (sc-7880) advertises Q4/Q8 but NOT inference LoRA (quant stays, LoRA defers);
+    // Krea 2 Turbo (sc-7836) is the inverse — inference LoRA/LoKr but NOT quant (LoRA stays, quant
+    // defers). Every other candle family advertises neither and defers both. The two capabilities are
+    // decoupled: `supports_lora` and `supports_quant` each consult the both-set plus their own list.
+    let supports_lora =
+        CANDLE_QUANT_LORA_MODELS.contains(&model) || CANDLE_LORA_MODELS.contains(&model);
+    let supports_quant =
+        CANDLE_QUANT_LORA_MODELS.contains(&model) || CANDLE_QUANT_MODELS.contains(&model);
+    // LoRAs: not in the candle lane unless the family advertises adapters (Lens / Krea).
     if !supports_lora
         && payload
             .get("loras")
@@ -6506,6 +6523,52 @@ mod candle_routing_tests {
                     "{model} conditioning shape must fall back to torch: {case}"
                 );
             }
+        }
+    }
+
+    #[test]
+    fn krea_lora_stays_on_candle_but_quant_and_conditioning_defer() {
+        // sc-7836 (epic 7565 P4): the candle `candle-gen-krea` descriptor advertises
+        // supports_lora/supports_lokr: true (it merges a `krea_2_raw`-trained adapter at Turbo
+        // inference) but `supported_quants: &[]`, so — the inverse of SD3.5 — a LoRA stays on the candle
+        // lane while an explicit quant request (and every conditioning shape) defers to the Python torch
+        // worker. Regression guard for the missed router un-gate: before this, a Krea LoRA hit the
+        // no-torch-fallback candle gap instead of routing to candle.
+        let model = "krea_2_turbo";
+        // Plain txt2img is eligible.
+        assert!(
+            image_request_candle_eligible(model, &object(json!({ "prompt": "an emerald forest" }))),
+            "{model} plain txt2img should be candle-eligible"
+        );
+        // A LoRA stays on candle (descriptor-gated adapter merge, resolved worker-side).
+        assert!(
+            image_request_candle_eligible(
+                model,
+                &object(json!({ "loras": [{ "name": "x", "path": "/x.safetensors" }] }))
+            ),
+            "{model} with a LoRA should stay on candle"
+        );
+        // Q8 / Q4 requests defer (Krea's candle provider is dense bf16 only).
+        for bits in [8, 4] {
+            assert!(
+                !image_request_candle_eligible(
+                    model,
+                    &object(json!({ "advanced": { "mlxQuantize": bits } }))
+                ),
+                "{model} Q{bits} request must fall back to torch (no candle quant lane)"
+            );
+        }
+        // Every conditioning shape defers (txt2img + LoRA only).
+        for case in [
+            json!({ "mode": "edit_image", "sourceAssetId": "a" }),
+            json!({ "referenceAssetId": "a" }),
+            json!({ "maskAssetId": "m" }),
+            json!({ "advanced": { "poses": [{ "id": "pose_1" }] } }),
+        ] {
+            assert!(
+                !image_request_candle_eligible(model, &object(case.clone())),
+                "{model} conditioning shape must fall back to torch: {case}"
+            );
         }
     }
 

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -2328,10 +2328,13 @@ fn is_candle_engine(model: &str) -> bool {
             | "boogu_image"
             | "boogu_image_turbo"
             | "boogu_image_edit"
-            // Krea 2 Turbo (sc-7581, epic 7565 P4): pure txt2img on the generic candle lane (CFG-free
-            // 8-step). Like Boogu, its MLX turnkey (`SceneWorks/krea-2-turbo-mlx`, q8/q4 packed) isn't
-            // candle-readable, so the candle lane loads bf16 from the ungated public `krea/Krea-2-Turbo`
-            // snapshot root (no subdir). No edit/reference/control shapes.
+            // Krea 2 Turbo (sc-7581, epic 7565 P4): txt2img + inference LoRA/LoKr on the generic candle
+            // lane (CFG-free 8-step). Like Boogu, its MLX turnkey (`SceneWorks/krea-2-turbo-mlx`, q8/q4
+            // packed) isn't candle-readable, so the candle lane loads bf16 from the ungated public
+            // `krea/Krea-2-Turbo` snapshot root (no subdir). The `candle-gen-krea` descriptor advertises
+            // supports_lora/supports_lokr (sc-7836), so `generate_candle_stream` resolves a
+            // `krea_2_raw`-trained adapter via `model.supports_adapters()`. No edit/reference/control
+            // shapes and no on-the-fly quant (dense bf16 only).
             | "krea_2_turbo"
             // Stable Diffusion 3.5 (sc-7880, epic 7982): Large / Large Turbo / Medium all ride the generic
             // candle txt2img lane (the `candle-gen-sd3` provider). `generate_candle_stream` resolves Q4/Q8


### PR DESCRIPTION
## Problem
Generating a `krea_2_turbo` image with a LoRA off-Mac (Windows/CUDA candle) failed terminal:

```
candle_unsupported: conditioned shape on a txt2img candle family (krea_2_turbo) is not in the candle/CUDA flow off-Mac … the requested edit / reference / inpaint / LoRA / quant shape has no candle lane for it off-Mac. [epic 5480]
```

## Root cause
The candle **engine** side is complete: `candle-gen-krea/src/adapters.rs` merges a `krea_2_raw`-trained LoRA/LoKr into the dense DiT and the descriptor advertises `supports_lora`/`supports_lokr: true` (**sc-7836**, pinned in Cargo.lock). The worker resolves it via `ResolvedModel::supports_adapters()`.

But the **SceneWorks router** never un-gated it. `image_request_candle_eligible` kept a LoRA on the candle lane only for `CANDLE_QUANT_LORA_MODELS = ["lens","lens_turbo"]`. Krea isn't there → the LoRA job is never claimed by the candle worker → and because Krea is no-torch-fallback, `candle_supported` fails it terminal.

sc-7836 explicitly scoped itself to "the candle engine merge only"; sc-7837's GPU validation ran through the `candle-gen-krea/tests/trainer_e2e.rs` harness, never a real `image_generate` submission — so the missing router un-gate went unnoticed. The MLX twin (sc-7911) *did* un-gate its router (`krea_mlx_eligible` accepts LoRA), which is why this only reproduces off-Mac.

## Fix
`crates/sceneworks-core/src/jobs_store.rs`:
- New `CANDLE_LORA_MODELS = ["krea_2_turbo"]` — inference LoRA but **not** on-the-fly quant (Krea's descriptor ships `supported_quants: &[]`).
- Decouple the gate: `supports_lora = CANDLE_QUANT_LORA_MODELS || CANDLE_LORA_MODELS`; `supports_quant = CANDLE_QUANT_LORA_MODELS || CANDLE_QUANT_MODELS`.
- Regression test `krea_lora_stays_on_candle_but_quant_and_conditioning_defer`.
- Refresh stale comments (`CANDLE_ROUTED_MODELS` + `image_jobs/base.rs`).

## Testing
- `cargo test -p sceneworks-core --lib` candle routing suite: 50 passed (incl. new test).
- `cargo clippy -p sceneworks-core --lib`: clean. `cargo fmt` applied.
- ⏳ **GPU-val pending** on the Windows/Blackwell box: submit a real `krea_2_turbo` `image_generate` with a `krea_2` LoRA and confirm it renders on candle (no `candle_unsupported`).

Fixes sc-8754. Related: sc-7836 (candle engine merge), sc-7911 (MLX router twin), epic 7565.

🤖 Generated with [Claude Code](https://claude.com/claude-code)