### PR TITLE
chore(web): preview menu polish — Save As displayed variant + submenu flip-left (sc-8749)

### DIFF
--- a/apps/web/src/components/assetPanels.contextMenu.test.jsx
+++ b/apps/web/src/components/assetPanels.contextMenu.test.jsx
@@ -49,6 +49,35 @@ const videoAsset = {
   file: { path: "assets/videos/clip.mp4", mimeType: "video/mp4" },
 };
 
+// An asset with upscale variants — displayedAsset defaults to the upscaled variant,
+// which differs from the base asset. Used to prove Save As / Reveal target the
+// displayed variant, not the base asset (sc-8749).
+const originalVariant = {
+  id: "asset-variant-original",
+  projectId: "project-1",
+  displayName: "Plate (original)",
+  type: "image",
+  status: {},
+  file: { path: "assets/images/plate.png", mimeType: "image/png" },
+};
+const upscaledVariant = {
+  id: "asset-variant-upscaled",
+  projectId: "project-1",
+  displayName: "Plate (upscaled)",
+  type: "image",
+  status: {},
+  file: { path: "assets/images/plate-upscaled.png", mimeType: "image/png" },
+};
+const variantAsset = {
+  id: "asset-with-variants",
+  projectId: "project-1",
+  displayName: "Plate",
+  type: "image",
+  status: {},
+  file: { path: "assets/images/plate.png", mimeType: "image/png" },
+  variants: { original: originalVariant, upscaled: upscaledVariant },
+};
+
 let container;
 let root;
 let FullscreenPreview;
@@ -258,6 +287,87 @@ describe("FullscreenPreview context menu (desktop)", () => {
       saveButton.click();
     });
     expect(actionMocks.saveAssetAs).toHaveBeenCalledWith(imageAsset);
+  });
+
+  // sc-8749 item 1: Save As / Reveal target the DISPLAYED variant (upscaled by
+  // default when an asset has upscale variants), not the base asset.
+  it("Save As (menu) saves the displayed upscaled variant for a variant-bearing asset", async () => {
+    await renderPreview(baseProps({ asset: variantAsset }));
+    await rightClickStage();
+
+    await act(async () => {
+      [...document.body.querySelectorAll(".preview-context-menu-item")]
+        .find((b) => b.textContent.trim() === "Save As…")
+        .click();
+    });
+    expect(actionMocks.saveAssetAs).toHaveBeenCalledWith(upscaledVariant);
+    expect(actionMocks.saveAssetAs).not.toHaveBeenCalledWith(variantAsset);
+  });
+
+  it("Reveal (menu) reveals the displayed upscaled variant for a variant-bearing asset", async () => {
+    await renderPreview(baseProps({ asset: variantAsset }));
+    await rightClickStage();
+
+    await act(async () => {
+      [...document.body.querySelectorAll(".preview-context-menu-item")]
+        .find((b) => b.textContent.trim() === "Reveal in Finder/Explorer")
+        .click();
+    });
+    expect(actionMocks.revealAsset).toHaveBeenCalledWith(upscaledVariant);
+  });
+
+  it("footer Save As saves the displayed upscaled variant for a variant-bearing asset", async () => {
+    await renderPreview(baseProps({ asset: variantAsset }));
+    const saveButton = [...document.body.querySelectorAll(".preview-actions button")].find(
+      (b) => b.textContent.trim() === "Save As…",
+    );
+    await act(async () => {
+      saveButton.click();
+    });
+    expect(actionMocks.saveAssetAs).toHaveBeenCalledWith(upscaledVariant);
+    expect(actionMocks.saveAssetAs).not.toHaveBeenCalledWith(variantAsset);
+  });
+
+  // sc-8749 item 2: the "Edit in" submenu flips to the left of the main menu when
+  // there isn't room on the right of the viewport.
+  it("Edit in submenu flips left when the menu opens near the right edge", async () => {
+    const onEditImage = vi.fn();
+    const onEditInStudio = vi.fn();
+    await renderPreview(baseProps({ asset: imageAsset, onEditImage, onEditInStudio }));
+    await rightClickStage();
+
+    const submenu = document.body.querySelector(".preview-context-menu-submenu");
+    // Simulate the trigger sitting hard against the right edge of a narrow viewport:
+    // no room on the right, plenty on the left.
+    const originalInnerWidth = window.innerWidth;
+    Object.defineProperty(window, "innerWidth", { value: 300, configurable: true });
+    submenu.getBoundingClientRect = () => ({ left: 100, right: 300, top: 0, bottom: 24, width: 200, height: 24 });
+
+    await act(async () => {
+      document.body.querySelector(".preview-context-menu-submenu-trigger").click();
+    });
+
+    expect(submenu.classList.contains("flip-left")).toBe(true);
+    Object.defineProperty(window, "innerWidth", { value: originalInnerWidth, configurable: true });
+  });
+
+  it("Edit in submenu stays on the right when there is room", async () => {
+    const onEditImage = vi.fn();
+    const onEditInStudio = vi.fn();
+    await renderPreview(baseProps({ asset: imageAsset, onEditImage, onEditInStudio }));
+    await rightClickStage();
+
+    const submenu = document.body.querySelector(".preview-context-menu-submenu");
+    const originalInnerWidth = window.innerWidth;
+    Object.defineProperty(window, "innerWidth", { value: 1600, configurable: true });
+    submenu.getBoundingClientRect = () => ({ left: 100, right: 300, top: 0, bottom: 24, width: 200, height: 24 });
+
+    await act(async () => {
+      document.body.querySelector(".preview-context-menu-submenu-trigger").click();
+    });
+
+    expect(submenu.classList.contains("flip-left")).toBe(false);
+    Object.defineProperty(window, "innerWidth", { value: originalInnerWidth, configurable: true });
   });
 });
 

--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -543,6 +543,9 @@ export function AssetCard({ asset, deleteAsset, purgeAsset, onPreview, updateAss
 // asserted against these in tests.
 const PREVIEW_MENU_WIDTH = 220;
 const PREVIEW_MENU_HEIGHT = 260;
+// Estimated "Edit in" submenu panel width used for the right-edge flip decision when
+// jsdom has no layout to measure (sc-8749). Matches the CSS min-width.
+const SUBMENU_PANEL_WIDTH = 160;
 
 // Clamp a desired {x, y} open-position so the menu box stays within the viewport,
 // nudging it left/up when it would overflow the right/bottom edges and never letting
@@ -573,6 +576,11 @@ function PreviewContextMenu({ x, y, items, submenu, onClose }) {
     ),
   );
   const [submenuOpen, setSubmenuOpen] = React.useState(false);
+  // Which side the "Edit in" submenu panel opens on. Default right (CSS left:100%);
+  // flip to the left when there isn't room on the right of the viewport (sc-8749).
+  const submenuRef = React.useRef(null);
+  const submenuPanelRef = React.useRef(null);
+  const [submenuFlipLeft, setSubmenuFlipLeft] = React.useState(false);
 
   // Refine the clamp once we can measure the real rendered box, then focus the menu
   // so keyboard (Escape / arrow traversal) works without a click.
@@ -608,6 +616,32 @@ function PreviewContextMenu({ x, y, items, submenu, onClose }) {
     };
   }, [onClose]);
 
+  // Choose which side the submenu opens on when it becomes visible. Measure the
+  // trigger's right edge against the viewport; if the panel (rendered right by
+  // default via CSS left:100%) would overflow, flip it to the left. Re-measured on
+  // every open so viewport/menu changes are respected (sc-8749).
+  React.useEffect(() => {
+    if (!submenuOpen) {
+      setSubmenuFlipLeft(false);
+      return;
+    }
+    const trigger = submenuRef.current;
+    if (!trigger) {
+      return;
+    }
+    const rect = trigger.getBoundingClientRect?.();
+    if (!rect) {
+      return;
+    }
+    const viewportWidth = typeof window !== "undefined" ? window.innerWidth : 0;
+    const panelWidth = submenuPanelRef.current?.getBoundingClientRect?.().width || SUBMENU_PANEL_WIDTH;
+    const roomRight = viewportWidth - rect.right;
+    const roomLeft = rect.left;
+    // Flip left only when the right side can't fit the panel AND the left side has
+    // more room — otherwise keep the default right placement.
+    setSubmenuFlipLeft(roomRight < panelWidth && roomLeft > roomRight);
+  }, [submenuOpen]);
+
   const runAction = (onSelect) => {
     onClose();
     onSelect?.();
@@ -636,9 +670,10 @@ function PreviewContextMenu({ x, y, items, submenu, onClose }) {
       ))}
       {submenu ? (
         <div
-          className={`preview-context-menu-submenu${submenuOpen ? " open" : ""}`}
+          className={`preview-context-menu-submenu${submenuOpen ? " open" : ""}${submenuFlipLeft ? " flip-left" : ""}`}
           onMouseEnter={() => setSubmenuOpen(true)}
           onMouseLeave={() => setSubmenuOpen(false)}
+          ref={submenuRef}
         >
           <button
             aria-expanded={submenuOpen}
@@ -651,7 +686,12 @@ function PreviewContextMenu({ x, y, items, submenu, onClose }) {
             {submenu.label}
             <span aria-hidden="true" className="preview-context-menu-caret">▸</span>
           </button>
-          <div className="preview-context-menu-submenu-panel" role="menu" aria-label={submenu.label}>
+          <div
+            className="preview-context-menu-submenu-panel"
+            ref={submenuPanelRef}
+            role="menu"
+            aria-label={submenu.label}
+          >
             {submenu.items.map((item) => (
               <button
                 className="preview-context-menu-item"
@@ -778,11 +818,14 @@ export function FullscreenPreview({
   const openContextMenu = React.useCallback(
     (event) => {
       event.preventDefault();
+      // Save As / Reveal target the DISPLAYED variant — what the user is actually
+      // looking at, including the upscaled variant (sc-8749). The remaining footer
+      // actions stay on the base `asset`.
       const items = [
-        { key: "save-as", label: "Save As…", onSelect: () => saveAssetAs(asset) },
+        { key: "save-as", label: "Save As…", onSelect: () => saveAssetAs(displayedAsset) },
       ];
       if (isDesktop) {
-        items.push({ key: "reveal", label: "Reveal in Finder/Explorer", onSelect: () => revealAsset(asset) });
+        items.push({ key: "reveal", label: "Reveal in Finder/Explorer", onSelect: () => revealAsset(displayedAsset) });
       }
       if (!isVideo) {
         items.push({ key: "zoom-in", label: "Zoom In", onSelect: zoomIn });
@@ -799,7 +842,7 @@ export function FullscreenPreview({
       const submenu = submenuItems.length ? { label: "Edit in", items: submenuItems } : null;
       setContextMenu({ x: event.clientX, y: event.clientY, items, submenu });
     },
-    [asset, isVideo, zoomIn, zoomOut, fitToView, onEditImage, onEditInStudio],
+    [asset, displayedAsset, isVideo, zoomIn, zoomOut, fitToView, onEditImage, onEditInStudio],
   );
 
   return (
@@ -905,8 +948,9 @@ export function FullscreenPreview({
             </div>
           ) : null}
           <div className="preview-actions">
-            {/* Simple, discoverable Save As path — present in desktop AND browser (sc-8729). */}
-            <button onClick={() => saveAssetAs(asset)} type="button">
+            {/* Simple, discoverable Save As path — present in desktop AND browser (sc-8729).
+                Saves the DISPLAYED variant (upscaled when shown), not the base asset (sc-8749). */}
+            <button onClick={() => saveAssetAs(displayedAsset)} type="button">
               Save As…
             </button>
             {onUseRecipe && asset.type === "image" && (asset.generationSet?.recipe || asset.recipe) ? (

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1280,6 +1280,13 @@ label {
   gap: 2px;
 }
 
+/* When there isn't room on the right of the viewport, open the submenu to the LEFT
+   of the main menu instead of off-screen (sc-8749). JS sets .flip-left on open. */
+.preview-context-menu-submenu.flip-left .preview-context-menu-submenu-panel {
+  left: auto;
+  right: 100%;
+}
+
 /* Toolbars */
 .toolbar,
 .review-actions,


### PR DESCRIPTION
## sc-8749 — Preview menu polish (two items)

Both changes live in `FullscreenPreview` (`apps/web/src/components/assetPanels.jsx`) — the custom right-click menu + footer shipped in sc-8729.

### Item 1 — Save As targets the displayed variant
**Product decision:** Save As must save `displayedAsset` (what the user is looking at, including the upscaled variant), not the base `asset`.

- Context-menu **Save As** → `saveAssetAs(displayedAsset)`
- Footer **Save As** button → `saveAssetAs(displayedAsset)`
- Context-menu **Reveal** → `revealAsset(displayedAsset)` (kept consistent with Save As, per story)
- The other footer actions (Favorite / Reject / Discard / Edit) are unchanged and still operate on the base `asset`.

For assets without upscale variants, `displayedAsset === asset`, so behavior is unchanged there.

### Item 2 — `Edit in >` submenu right-edge viewport clamping
The nested submenu panel opens with CSS `left:100%`, so near the right edge of the viewport it rendered off-screen. Added a JS side-decision on submenu open: measure the trigger's right edge against `window.innerWidth`; when there isn't room on the right (and there's more room on the left), apply a `.flip-left` class that switches the panel to `right:100%` (opens to the LEFT of the main menu). Default right placement is preserved when there's room. Closing/keyboard behavior is untouched.

### Scope
Pure frontend. Touches `assetPanels.jsx`, `styles.css`, and the existing menu test file only.

### Tests
Extended `apps/web/src/components/assetPanels.contextMenu.test.jsx`:
- Variant-bearing asset (displayedAsset ≠ asset): menu Save As, footer Save As, and Reveal all fire with the **displayed upscaled variant** (and explicitly not the base asset).
- Submenu **flips left** when the trigger sits at the right edge of a narrow viewport (mocked `getBoundingClientRect` + `window.innerWidth`), and **stays right** when there's room.

Full `apps/web` vitest suite green (948 passing, 14 in this file), eslint clean (0 new warnings/errors). Existing sc-8729 menu tests unchanged and passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)