### PR TITLE
feat(lens-turbo): Group-B pre-quantized packed-load tiers (worker wiring, sc-8763)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6#516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6#516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6#516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6#516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6#516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6#516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -513,7 +513,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6#516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -530,7 +530,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6#516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6#516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6#516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6#516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -582,7 +582,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6#516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -596,7 +596,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6#516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -611,7 +611,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6#516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -624,7 +624,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6#516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -636,7 +636,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6#516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -653,7 +653,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6#516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -668,7 +668,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6#516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -679,7 +679,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6#516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -694,7 +694,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6#516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6#516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -729,7 +729,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6#516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -740,7 +740,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6#516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6#516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -764,7 +764,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6#516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -777,7 +777,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=24d975a#24d975a686c684c7c82af16196f3b49aa2e49b8c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6#516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -3528,7 +3528,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad#186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3541,7 +3541,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad#186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad"
 dependencies = [
  "image",
  "inventory",
@@ -3555,7 +3555,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad#186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad"
 dependencies = [
  "image",
  "inventory",
@@ -3569,7 +3569,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad#186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3582,7 +3582,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad#186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3593,7 +3593,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad#186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3602,7 +3602,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad#186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3611,7 +3611,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad#186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3625,7 +3625,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad#186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3638,7 +3638,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad#186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3651,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad#186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3663,7 +3663,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad#186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3673,7 +3673,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad#186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad"
 dependencies = [
  "image",
  "inventory",
@@ -3686,7 +3686,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad#186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad"
 dependencies = [
  "image",
  "inventory",
@@ -3700,7 +3700,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad#186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad"
 dependencies = [
  "image",
  "inventory",
@@ -3714,7 +3714,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad#186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad"
 dependencies = [
  "image",
  "inventory",
@@ -3726,7 +3726,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad#186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3737,7 +3737,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad#186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3749,7 +3749,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad#186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3761,7 +3761,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad#186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3770,7 +3770,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad#186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3779,7 +3779,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad#186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3789,7 +3789,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad#186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3801,7 +3801,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad#186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad"
 dependencies = [
  "image",
  "inventory",
@@ -3816,7 +3816,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad#186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad"
 dependencies = [
  "image",
  "inventory",
@@ -3830,7 +3830,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad#186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3841,7 +3841,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad#186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3853,7 +3853,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad#186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3864,7 +3864,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad#186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad"
 dependencies = [
  "image",
  "inventory",
@@ -3878,7 +3878,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad#186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad"
 dependencies = [
  "image",
  "inventory",
@@ -4209,7 +4209,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5642,7 +5642,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ef43eac9f954233668a1b7cea3132a01bc950da2#ef43eac9f954233668a1b7cea3132a01bc950da2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad#186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad"
 dependencies = [
  "core-llm",
  "inventory",
@@ -8039,7 +8039,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -739,16 +739,47 @@
       "adapter": "lens_turbo",
       "capabilities": ["text_to_image", "style_variations"],
       "downloads": [
+        // SceneWorks pre-built MLX quant-matrix turnkey (sc-8763, epic 8506, Group-B): a re-host of
+        // microsoft/Lens-Turbo. Per-tier self-contained subdirs (transformer DiT + gpt-oss-20b MXFP4
+        // MoE text encoder + FLUX.2 VAE + tokenizer + scheduler + model_index.json): q4/ (default),
+        // q8/, bf16/. The worker loads the chosen tier's subdir directly (standard_tier_subdir,
+        // mlx.standardTierLayout). lens_turbo is NOT dense-TE: the gpt-oss MoE encoder is packed
+        // per-tier alongside the transformer (so no denseTextEncoderTier). Per-tier variants (sc-8508):
+        // each tier is a SEPARATE installable artifact tagged with a `variant` key + a `footprint`
+        // (required on-disk size; resident/peak filled in later by sc-8516). Sizes are measured
+        // on-disk from the SceneWorks/lens-turbo-mlx repo. Note the q8 text-encoder int8 up-cast of the
+        // MXFP4 MoE is LARGER than bf16, so q8 > bf16 on disk here. Replaces the whole-repo dense
+        // microsoft/Lens-Turbo download.
         {
           "provider": "huggingface",
-          "repo": "microsoft/Lens-Turbo",
-          "files": [],
-          "estimatedSizeBytes": 30800000000
+          "repo": "SceneWorks/lens-turbo-mlx",
+          "variant": "q4",
+          "default": true,
+          "files": ["q4/*"],
+          "estimatedSizeBytes": 21830326407,
+          "footprint": { "diskSizeBytes": 21830326407, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/lens-turbo-mlx",
+          "variant": "q8",
+          "files": ["q8/*"],
+          "estimatedSizeBytes": 32753474289,
+          "footprint": { "diskSizeBytes": 32753474289, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/lens-turbo-mlx",
+          "variant": "bf16",
+          "files": ["bf16/*"],
+          "estimatedSizeBytes": 30651441376,
+          "footprint": { "diskSizeBytes": 30651441376, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "paths": {
-        "model": "${HF_CACHE}/microsoft/Lens-Turbo"
+        "model": "${HF_CACHE}/SceneWorks/lens-turbo-mlx"
       },
+      "gated": false,
       "defaults": {
         "resolution": "1024x1024",
         "steps": 4,
@@ -773,6 +804,19 @@
         // the `lens_turbo` adapter in lora_family.rs.
         "families": ["lens"],
         "types": ["style", "enhance", "character"]
+      },
+      // macOS-only native-MLX backend. mlx.quantize/tier config is consumed by the RUST worker
+      // (standard_tier_subdir / resolve_quant). q4/ default tier (sc-8763); q8/ + bf16/ hosted +
+      // selectable via advanced.mlxQuantize (standard_tier_subdir resolves the subdir). lens_turbo is
+      // NOT dense-TE: the gpt-oss-20b MoE text encoder is packed per-tier alongside the transformer,
+      // so there is no denseTextEncoderTier override — every component is packed at the chosen tier.
+      "mlx": {
+        "minMemoryGb": 60,
+        // sc-8508: the manifest-driven form of the STANDARD_TIER_MODELS registry. Additive here opts
+        // this id into `uses_standard_tier_layout` so the worker resolves the q4/q8/bf16 subdir
+        // directly from the turnkey snapshot.
+        "quantize": 4,
+        "standardTierLayout": true
       },
       "ui": {
         "label": "Lens-Turbo",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -443,7 +443,18 @@ sceneworks-core = { path = "../sceneworks-core" }
 # candle links no z-image crate and compiles UNCHANGED) so `--features backend-candle --target all`
 # resolves the SINGLE gen-core rev 863f98d. (candle-gen #199 is squash-merged on candle-gen main as
 # 22c121a — the canonical SHA all candle-gen-* pins below point at.)
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
+# Bumped `ef43eac` -> `186ac4e` (epic 8506, sc-8763): re-pin every mlx-gen crate + this root
+# sceneworks-gen-core dep to mlx-gen main HEAD = lens pre-quantized packed-load + two-component
+# dir-converter (#622, the next Group-B quant-matrix crate). This is what lets the worker load the
+# SceneWorks pre-built lens-turbo q4/q8/bf16 turnkeys directly (packed-detect) instead of
+# load-then-quantize. `git diff ef43eac..186ac4e -- gen-core/ gen-core-testkit/` is EMPTY — gen-core
+# BYTE-IDENTICAL (the range only ADDS mlx-gen-lens packed-load/convert code), mlx-rs unchanged, so the
+# DEFAULT skew gate stays single-rev/green at 186ac4e. The candle pin below moves `24d975a` ->
+# `516e3d5` IN LOCKSTEP (candle-gen sc-8763 PR #205: re-pins candle-gen's own gen-core ef43eac ->
+# 186ac4e, byte-identical — candle links no lens crate and compiles UNCHANGED) so `--features
+# backend-candle --target all` resolves the SINGLE gen-core rev 186ac4e. (candle-gen #205 is
+# squash-merged on candle-gen main as 516e3d5 — the canonical SHA all candle-gen-* pins below point at.)
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -795,7 +806,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -811,23 +822,23 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f95
 # exactly this rev, so the worker MUST match (a different rev would compile pmetal-mlx-sys twice). This
 # rebuilds MLX from source. Paired with mlx-llm `6c052ba` below (mlx-llm#45 carries the same fork pin).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad" }
 # Krea 2 Turbo (native MLX, Krea 2 Community License; epic 7565, sc-7572). Same git rev as mlx-gen.
 # Self-registers `krea_2_turbo` (Qwen3-VL-4B TE + 28-block single-stream DiT + Qwen-Image VAE; CFG-free
 # rectified-flow few-step) via inventory only when force-linked (`use mlx_gen_krea as _;` in
 # image_jobs.rs). Loads the packed Q8/Q4 turnkey subdir (krea_model_subdir; the loader auto-detects the
 # packed quant, so the resolved `spec.quantize` is a no-op on it). Depends on mlx-gen-qwen-image for the
 # shared `AutoencoderKLQwenImage` VAE.
-mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
+mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad" }
 # Stable Diffusion 3.5 provider (native MLX, Stability AI Community License; epic 7841, sc-7871). Same
 # git rev as mlx-gen so MLX builds once. Self-registers `sd3_5_large` (true-CFG, 28 steps / guidance 3.5)
 # + `sd3_5_large_turbo` (ADD-distilled few-step, CFG-off) + `sd3_5_medium` (MMDiT-X, true-CFG, 40 steps /
@@ -835,7 +846,7 @@ mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43ea
 # (`use mlx_gen_sd3 as _;` in image_jobs.rs). All three carry a `sd3_5_*_quant` converter. Reuses the SDXL
 # CLIP encoder (×2), the FLUX T5-XXL encoder, and the Z-Image 16-ch VAE — its `quantize_sd3_dir` converter
 # is wired in model_jobs.rs for the `sd3_5_{large,large_turbo,medium}_quant` install-time conversions.
-mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
+mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad" }
 # SANA 1600M provider (native MLX, NVIDIA non-commercial license; epic 8485, sc-8489). Same git rev as
 # mlx-gen so MLX builds once. Self-registers `sana_1600m` (Image/t2i, true-CFG, 32× DC-AE divisor,
 # mac_only) via `register_generators!` into the gen-core inventory — surfaces only when force-linked
@@ -843,59 +854,59 @@ mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac
 # conditioning (sc-8488); the `SanaPipeline` composes SanaTextEncoder -> SanaTransformer (Linear DiT) ->
 # DC-AE f32 decoder and exposes the `from_snapshot`/`from_weights` weight-load entrypoints the generic
 # generator-cache load path drives.
-mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
+mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad" }
 # CLIP ViT-L/14 image embedder for the Dataset Doctor analysis job (epic 6529 P2, sc-6535).
 # Self-registers `clip_vit_l14` (gen_core::ImageEmbedder) via inventory only when force-linked
 # (`use mlx_gen_clip as _;` in dataset_analysis_jobs.rs). Reuses mlx-gen-sdxl's CLIP body → same rev.
-mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
+mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -904,19 +915,19 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43ea
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad" }
 # Depth Anything V2 (DINOv2 ViT-S/14 + DPT) native-MLX monocular depth estimator (epic 8236,
 # sc-8242). A plain utility crate (NOT a self-registering generation provider): an arbitrary RGB
 # image → a normalized single-channel depth control image, the AUTO depth source for the
 # Fun-Controlnet-Union depth tier (`ControlKind::Depth`) — sibling of the CPU canny/pose
 # preprocessors, but neural so it is macOS-gated (MLX). Consumed by the worker `depth` module /
 # the shared strict-control driver (sc-8243). Same mlx-rs pin as every other mlx-gen crate.
-mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
+mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -925,7 +936,7 @@ mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43e
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -933,7 +944,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -944,7 +955,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -955,7 +966,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43e
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -977,7 +988,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43ea
 # a Metal large-tensor limit, not precision). New `VAE_SAFE_DECODE_EDGE_PX=1536` forces decode tiling on
 # a CORRECTNESS cap independent of the memory budget (image + video), so a 2048² upscale that fits memory
 # still tiles. Real-weight 1024→2048 pixel-cosine vs the mflux reference 0.9524 → 0.9974.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -988,7 +999,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef4
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad" }
 # The unified LLM engine (epic 7153, sc-7158): the macOS `prompt_refine` job now runs through
 # mlx-llm's generic `mlx-llama` provider (a `core_llm::TextLlm`) resolved model-first via
 # `gen_core::core_llm::load_for_model`, RETIRING the bespoke `mlx-gen-prompt-refine` hand-rolled
@@ -1020,7 +1031,7 @@ mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "7041411f395e43
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43eac9f954233668a1b7cea3132a01bc950da2" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "186ac4eb7b9ecf0ce4fe53ad51af1169e45224ad" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -1335,15 +1346,15 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ef43
 # (inference-level memory, like 24 GB cards) and restores the live `Var`s after. SOURCE-ONLY candle-gen
 # fix; both b3aad50 and 5bb83e4 pin gen-core 863f98d, so this stays single-rev (mlx-gen unchanged). ALL
 # candle-gen-* rev lines move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1351,17 +1362,17 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1371,7 +1382,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1379,21 +1390,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1402,17 +1413,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1421,7 +1432,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1454,7 +1465,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1463,12 +1474,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1476,7 +1487,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d97
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1485,7 +1496,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1493,7 +1504,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1507,7 +1518,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1534,7 +1545,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1545,7 +1556,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "24d975a", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "516e3d5f853c20c3d4fb38dc42fccf5d6d0882e6", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -379,7 +379,7 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
     ModelRow {
         sceneworks_id: "lens_turbo",
         engine_id: "lens_turbo",
-        default_repo: "microsoft/Lens-Turbo",
+        default_repo: "SceneWorks/lens-turbo-mlx",
         default_steps: 4,
         default_guidance: 1.0,
         adapter_label: "mlx_lens",

--- a/crates/sceneworks-worker/src/lens_turbo_q4_mlx_smoke.rs
+++ b/crates/sceneworks-worker/src/lens_turbo_q4_mlx_smoke.rs
@@ -1,0 +1,211 @@
+//! Local real-weight MLX smoke for the Lens-Turbo **Q4** worker lane (sc-8763, epic 8506 Group-B).
+//! `#[ignore]`d — run by hand on an Apple-Silicon Mac. It drives the real native-MLX `lens_turbo`
+//! engine via `gen_core::load("lens_turbo")` with a **Q4** `LoadSpec` pointed at the packed `q4/`
+//! turnkey subdir — the exact runtime seam `generate_stream` uses (minus the API/job plumbing) when
+//! the router routes a `lens_turbo` MLX job (`standard_tier_subdir` → the `q4/` subdir; `resolve_quant`
+//! → `Quant::Q4`).
+//!
+//! Purpose: on-device evidence that the SceneWorks/lens-turbo-mlx pre-quantized q4 turnkey loads through
+//! the worker packed path (`mlx.standardTierLayout` → `standard_tier_subdir` resolves `q4/`) and renders
+//! a non-degenerate image. lens_turbo packs BOTH the transformer DiT and the gpt-oss-20b MXFP4 MoE text
+//! encoder per-tier (it is NOT a dense-TE model), so the q4 load-quant is a harmless no-op on the
+//! already-packed weights.
+//!
+//! Setup — point at the published turnkey `SceneWorks/lens-turbo-mlx` (the worker default). With the q4
+//! tier already in the HF cache, no env is needed: the smoke auto-resolves the cached snapshot's `q4/`
+//! subdir (the same selection `image_jobs::base::standard_tier_subdir` makes for `mlxQuantize: 4`).
+//! Override `LENS_Q4_DIR` to point at a snapshot root or a `q4/`-bearing dir directly.
+//! ```text
+//! # optional: LENS_Q4_DIR=/path/to/lens-turbo-mlx  (root containing q4/, or the q4/ dir itself)
+//! # optional: LENS_STEPS=4 LENS_W=1024 LENS_H=1024 LENS_PROMPT="..." LENS_OUT_DIR=/tmp/lens_turbo_q4_smoke
+//! cargo test -p sceneworks-worker --release lens_turbo_q4_mlx_gpu_smoke -- --ignored --nocapture
+//! ```
+
+use std::path::{Path, PathBuf};
+
+use gen_core::{GenerationOutput, GenerationRequest, Image, LoadSpec, Quant, WeightsSource};
+
+fn env_or(key: &str, default: &str) -> String {
+    std::env::var(key)
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| default.to_string())
+}
+
+/// The engine-complete packed subdir to load: mirror `image_jobs::base::standard_tier_subdir`'s q4
+/// selection — prefer `<root>/q4` (lens turnkeys pack the backbone under `transformer/`), else `root`
+/// itself if it already *is* a q4 root. Errors loud if neither resolves so a half-download surfaces as
+/// a clear failure rather than a confusing engine load error.
+fn resolve_q4_dir(root: &Path) -> PathBuf {
+    let is_engine_root = |d: &Path| {
+        d.join("transformer/diffusion_pytorch_model.safetensors")
+            .is_file()
+    };
+    let q4 = root.join("q4");
+    if is_engine_root(&q4) {
+        return q4;
+    }
+    assert!(
+        is_engine_root(root),
+        "LENS_Q4_DIR must point at the turnkey root (containing q4/) or a q4/ dir with a packed \
+         transformer/diffusion_pytorch_model.safetensors; neither found under {}",
+        root.display()
+    );
+    root.to_path_buf()
+}
+
+/// Auto-discover the cached `SceneWorks/lens-turbo-mlx` turnkey snapshot in the HF hub cache, returning
+/// the snapshot whose `q4/` subdir carries the packed transformer. `None` if the q4 tier hasn't been
+/// pulled (the smoke then panics with the `LENS_Q4_DIR` hint).
+fn cached_turnkey_root() -> Option<PathBuf> {
+    let home = std::env::var("HOME").ok()?;
+    let snapshots = PathBuf::from(home)
+        .join(".cache/huggingface/hub/models--SceneWorks--lens-turbo-mlx/snapshots");
+    std::fs::read_dir(&snapshots)
+        .ok()?
+        .filter_map(|e| e.ok())
+        .find_map(|e| {
+            let dir = e.path();
+            dir.join("q4/transformer/diffusion_pytorch_model.safetensors")
+                .is_file()
+                .then_some(dir)
+        })
+}
+
+/// Per-pixel mean over the RGB buffer — the "is it black?" floor check, reported for the record.
+fn image_mean(img: &Image) -> f64 {
+    let n = img.pixels.len() as f64;
+    if n == 0.0 {
+        return 0.0;
+    }
+    img.pixels.iter().map(|&p| p as f64).sum::<f64>() / n
+}
+
+/// Mean per-pixel std-dev across the RGB channels — a cheap "is the image non-degenerate" check. A
+/// NaN / all-black / flat decode collapses the std toward 0; this guards that degenerate floor. The real
+/// quality call is the saved-PNG eyeball.
+fn image_std(img: &Image) -> f64 {
+    let n = img.pixels.len() as f64;
+    if n == 0.0 {
+        return 0.0;
+    }
+    let mean = image_mean(img);
+    let var = img
+        .pixels
+        .iter()
+        .map(|&p| (p as f64 - mean).powi(2))
+        .sum::<f64>()
+        / n;
+    var.sqrt()
+}
+
+/// Whether EVERY pixel byte is exactly 0 — the precise degenerate signature of a broken decode.
+fn is_all_zero(img: &Image) -> bool {
+    !img.pixels.is_empty() && img.pixels.iter().all(|&p| p == 0)
+}
+
+fn save_png(img: &Image, path: &Path) {
+    image::RgbImage::from_raw(img.width, img.height, img.pixels.clone())
+        .expect("rgb buffer")
+        .save(path)
+        .unwrap_or_else(|e| panic!("save {}: {e}", path.display()));
+}
+
+#[test]
+#[ignore = "real-weight MLX smoke; needs the SceneWorks/lens-turbo-mlx q4 turnkey cached + an Apple-Silicon Mac"]
+fn lens_turbo_q4_mlx_gpu_smoke() {
+    let root = match std::env::var("LENS_Q4_DIR") {
+        Ok(p) if !p.trim().is_empty() => PathBuf::from(p.trim()),
+        _ => cached_turnkey_root().unwrap_or_else(|| {
+            panic!(
+                "no cached SceneWorks/lens-turbo-mlx q4 turnkey found; download it via the manifest \
+                 (`hf download SceneWorks/lens-turbo-mlx --include 'q4/*'`) or set LENS_Q4_DIR to the \
+                 turnkey root (containing q4/)"
+            )
+        }),
+    };
+    let q4_dir = resolve_q4_dir(&root);
+
+    let out_dir = PathBuf::from(env_or("LENS_OUT_DIR", "/tmp/lens_turbo_q4_smoke"));
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+
+    let steps: u32 = env_or("LENS_STEPS", "4").parse().expect("LENS_STEPS");
+    let w: u32 = env_or("LENS_W", "1024").parse().expect("LENS_W");
+    let h: u32 = env_or("LENS_H", "1024").parse().expect("LENS_H");
+    let prompt = env_or(
+        "LENS_PROMPT",
+        "a photorealistic portrait of a red fox sitting in a sunlit autumn forest, sharp focus, \
+         shallow depth of field",
+    );
+
+    // Same seam as the worker's MLX image path: a registry load of the `lens_turbo` generator (the
+    // worker-crate force-link anchor `use mlx_gen_lens as _;` keeps it registered) + a Q4 `LoadSpec`
+    // pointed at the packed q4 turnkey subdir. The packed weights auto-detect their quant, so
+    // `with_quant(Q4)` matches the manifest's `mlx.quantize: 4` tier.
+    println!(
+        "[smoke] loading lens_turbo (Q4) from {} ...",
+        q4_dir.display()
+    );
+    let spec = LoadSpec::new(WeightsSource::Dir(q4_dir.clone())).with_quant(Quant::Q4);
+    let generator = gen_core::load("lens_turbo", &spec).expect("load mlx lens_turbo generator");
+
+    // Lens-Turbo: distilled 4-step, guidance 1.0 (no real CFG).
+    let req = GenerationRequest {
+        prompt: prompt.clone(),
+        width: w,
+        height: h,
+        count: 1,
+        seed: Some(42),
+        steps: Some(steps),
+        guidance: Some(1.0),
+        ..Default::default()
+    };
+    println!("[smoke] rendering {w}x{h} @ {steps} steps ...");
+    let mut last = String::new();
+    let output = generator
+        .generate(&req, &mut |p| {
+            let s = format!("{p:?}");
+            if s != last {
+                println!("[progress] {s}");
+                last = s;
+            }
+        })
+        .expect("lens_turbo generate");
+    let image = match output {
+        GenerationOutput::Images(mut images) => images.pop().expect("engine returned no image"),
+        other => panic!("expected Images output, got {other:?}"),
+    };
+
+    let mean = image_mean(&image);
+    let std = image_std(&image);
+    let all_zero = is_all_zero(&image);
+    let png = out_dir.join(format!("lens_turbo_q4_{steps}step.png"));
+    save_png(&image, &png);
+    println!(
+        "[smoke] lens_turbo Q4 {}x{} mean {:.2} std {:.2} all_zero={} -> {}",
+        image.width,
+        image.height,
+        mean,
+        std,
+        all_zero,
+        png.display()
+    );
+    assert_eq!(
+        (image.width, image.height),
+        (w, h),
+        "engine returned the wrong dimensions"
+    );
+    assert!(
+        !all_zero,
+        "lens_turbo Q4 decode is ALL-ZERO — a broken packed load/decode"
+    );
+    assert!(
+        std > 20.0,
+        "lens_turbo Q4 render looks degenerate (std {std:.2}) — possible NaN / all-black / flat decode"
+    );
+    println!(
+        "[smoke] DONE: lens_turbo Q4 render coherent (mean {mean:.2}, std {std:.2}, NOT all-zero) \
+         at {steps} steps through the worker packed lane"
+    );
+}

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -171,6 +171,13 @@ mod sd3_5_mlx_smoke;
 // non-degenerate AND specifically NOT all-zero (the retired Apple recipe's exact failure signature).
 #[cfg(all(test, target_os = "macos"))]
 mod sdxl_base_q8_mlx_smoke;
+// Real-weight MLX smoke for the Lens-Turbo Q4 worker lane (sc-8763, epic 8506 Group-B). Test-only +
+// macOS-only; drives `gen_core::load("lens_turbo")` with a Q4 LoadSpec against the packed `q4/` turnkey
+// subdir. On-device evidence that the SceneWorks/lens-turbo-mlx pre-quantized q4 tier loads through the
+// worker packed path (`mlx.standardTierLayout` → `standard_tier_subdir` resolves `q4/`) and renders
+// non-degenerate (both transformer + gpt-oss MoE TE are packed per-tier; NOT a dense-TE model).
+#[cfg(all(test, target_os = "macos"))]
+mod lens_turbo_q4_mlx_smoke;
 // The DWPose skeleton rasterizer is consumed only by the macOS Z-Image strict-pose
 // control path; on Mac AND the off-Mac candle DWPose lane (sc-5496) it backs the
 // `pose_jobs` skeleton render; on a candle-disabled box off Mac it still builds +


### PR DESCRIPTION
Worker-side of the Group-B lens-turbo tier crate. mlx-gen #622 (main = `186ac4e`) is merged and SceneWorks/lens-turbo-mlx (q4/q8/bf16) is hosted + on-device render-verified; this wires it into the worker. Base `lens` is out of scope (blocked on a missing source, tracked as sc-8767) — only `lens_turbo` here.

## Pins (`crates/sceneworks-worker/Cargo.toml` + `Cargo.lock`)
- Every `mlx-gen-*` crate + root `sceneworks-gen-core`: `ef43eac` → **`186ac4e`** (mlx-gen #622 = lens pre-quantized packed-load + two-component dir-converter).
- Every `candle-gen-*` crate: `24d975a` → **`516e3d5`** (candle-gen #205 lockstep re-pin; its own gen-core moved `ef43eac` → `186ac4e`, byte-identical, so candle compiles unchanged).
- `core-llm` left untouched (reverted a silent `cargo update` bump).

## Skew gate
`scripts/check-gen-core-skew.sh sceneworks-worker --features backend-candle` reports **exactly one** gen-core rev = `186ac4e`.

## Manifest (`config/manifests/builtin.models.jsonc`) — `lens_turbo`
First-class sc-8508 schema (matching the sdxl/z_image/qwen entries):
- Per-tier `downloads`: `q4` (default) / `q8` / `bf16`, each with `files` filters (`["q4/*"]` …), a `variant` key, and a `footprint.diskSizeBytes` measured **exact-byte** from the SceneWorks/lens-turbo-mlx repo:
  - q4 → 21,830,326,407
  - q8 → 32,753,474,289
  - bf16 → 30,651,441,376  (q8 > bf16: the gpt-oss MoE int8 up-cast exceeds bf16)
- `paths.model` → `SceneWorks/lens-turbo-mlx`, `gated: false`.
- `mlx.quantize: 4` + `mlx.standardTierLayout: true`. lens_turbo is **NOT** dense-TE (its gpt-oss-20b MoE text encoder is packed per-tier alongside the transformer), so **no** `denseTextEncoderTier`.
- JSONC parses.

## engines.rs
`lens_turbo` `default_repo` → `SceneWorks/lens-turbo-mlx`.

## On-device verify
Downloaded the q4 tier and loaded it through the worker packed path (`standard_tier_subdir` resolves `q4/`). Rendered coherent **1024x1024 @ 4 steps** — mean 94.05, std 57.34, **NOT all-zero**. Captured as `lens_turbo_q4_mlx_smoke` (test-only, macOS-only, `#[ignore]`), mirroring the sdxl sc-8746 smoke.

## Checks
- `cargo fmt --all -- --check` ✅
- `cargo clippy -p sceneworks-worker --all-targets -- -D warnings` ✅
- `cargo test -p sceneworks-worker --lib` ✅ (479 passed)
- candle-parity compile `cargo check -p sceneworks-worker --no-default-features -F backend-candle --all-targets` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)