### PR TITLE
fix(desktop): grant GPU cap + telemetry commands in remote ACL (sc-8756)

### DIFF
--- a/apps/desktop/build.rs
+++ b/apps/desktop/build.rs
@@ -19,6 +19,9 @@ fn main() {
             "delete_credential",
             "restart_worker",
             "get_gpu_info",
+            // GPU memory cap + live telemetry (epic 7819, sc-7825).
+            "set_gpu_memory_limit",
+            "get_gpu_telemetry",
             // LAN remote access (epic 4484, stories 4/5).
             "get_remote_access",
             "set_remote_access",

--- a/apps/desktop/capabilities/default.json
+++ b/apps/desktop/capabilities/default.json
@@ -25,6 +25,8 @@
     "allow-delete-credential",
     "allow-restart-worker",
     "allow-get-gpu-info",
+    "allow-set-gpu-memory-limit",
+    "allow-get-gpu-telemetry",
     "allow-get-remote-access",
     "allow-set-remote-access",
     "allow-set-remote-access-password",

--- a/apps/desktop/permissions/autogenerated/get_gpu_telemetry.toml
+++ b/apps/desktop/permissions/autogenerated/get_gpu_telemetry.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-get-gpu-telemetry"
+description = "Enables the get_gpu_telemetry command without any pre-configured scope."
+commands.allow = ["get_gpu_telemetry"]
+
+[[permission]]
+identifier = "deny-get-gpu-telemetry"
+description = "Denies the get_gpu_telemetry command without any pre-configured scope."
+commands.deny = ["get_gpu_telemetry"]

--- a/apps/desktop/permissions/autogenerated/set_gpu_memory_limit.toml
+++ b/apps/desktop/permissions/autogenerated/set_gpu_memory_limit.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-set-gpu-memory-limit"
+description = "Enables the set_gpu_memory_limit command without any pre-configured scope."
+commands.allow = ["set_gpu_memory_limit"]
+
+[[permission]]
+identifier = "deny-set-gpu-memory-limit"
+description = "Denies the set_gpu_memory_limit command without any pre-configured scope."
+commands.deny = ["set_gpu_memory_limit"]

--- a/apps/desktop/src/settings.rs
+++ b/apps/desktop/src/settings.rs
@@ -1092,6 +1092,33 @@ mod tests {
         }
     }
 
+    /// sc-8756: the GPU memory cap + telemetry commands (epic 7819) are invoked from the
+    /// same API-served UI at the remote (`http://127.0.0.1:*`) origin as the asset commands
+    /// above, so each likewise needs an `allow-<kebab-command>` grant in
+    /// `capabilities/default.json` or the Tauri ACL silently rejects the invoke in the
+    /// packaged app — the GPU memory slider and live telemetry readout in Settings would
+    /// fail at runtime (the unit tests mock `invoke`, so they can't catch a missing grant).
+    /// Same command↔ACL drift bug family as sc-8753.
+    #[test]
+    fn gpu_settings_commands_are_granted_in_the_remote_capability() {
+        let capability = include_str!("../capabilities/default.json");
+        let manifest: serde_json::Value =
+            serde_json::from_str(capability).expect("capabilities/default.json parses");
+        let permissions = manifest["permissions"]
+            .as_array()
+            .expect("permissions is an array")
+            .iter()
+            .filter_map(|value| value.as_str())
+            .collect::<Vec<_>>();
+        for permission in ["allow-set-gpu-memory-limit", "allow-get-gpu-telemetry"] {
+            assert!(
+                permissions.contains(&permission),
+                "capabilities/default.json is missing `{permission}` — the command would \
+                 be rejected by the ACL at the remote UI origin"
+            );
+        }
+    }
+
     /// sc-8737: the save dialog's initial-directory hint is applied only when it names
     /// an existing directory; empty/whitespace, missing, and non-directory paths are all
     /// skipped (returning `None`) so a stale/bad hint never errors the save — it just


### PR DESCRIPTION
## Summary

`settings::set_gpu_memory_limit` and `settings::get_gpu_telemetry` (epic 7819) were registered in `apps/desktop/src/main.rs`'s `generate_handler!` but were **not** declared in `apps/desktop/build.rs` `AppManifest::new().commands(&[...])` nor granted in `apps/desktop/capabilities/default.json`.

The desktop shell navigates the main window to the API-served UI at `http://127.0.0.1:<port>` (a **remote** origin), so every `window.__TAURI__` invoke there is rejected by the Tauri ACL unless the command's `allow-<kebab-command>` permission is granted (see the `remote` grant + comment in `capabilities/default.json`). As a result, the **Settings GPU memory-cap slider** and the **live GPU telemetry readout** silently failed at runtime in the packaged app. Unit tests mock `invoke`, so they never caught it.

Same command↔ACL drift bug family as sc-8753.

## Changes

- `apps/desktop/build.rs`: add `set_gpu_memory_limit` + `get_gpu_telemetry` to `AppManifest.commands` (regenerates the autogenerated allow/deny permission TOMLs).
- `apps/desktop/capabilities/default.json`: grant `allow-set-gpu-memory-limit` + `allow-get-gpu-telemetry`.
- `apps/desktop/permissions/autogenerated/{set_gpu_memory_limit,get_gpu_telemetry}.toml`: regenerated by build.rs (git-tracked, like the other 23).
- `apps/desktop/src/settings.rs`: companion drift-guard test `gpu_settings_commands_are_granted_in_the_remote_capability`.

## Verification

- Built the `sceneworks-desktop` crate directly (it's excluded from workspace `default-members`, so `npm run rust:check` does not compile it). `cargo test settings::tests` → all 12 pass, including the new drift-guard.
- Confirmed the regenerated permission ids match exactly: `allow-set-gpu-memory-limit`, `allow-get-gpu-telemetry`. The desktop crate compiling with the capability referencing them proves Tauri's ACL codegen validated they resolve (it fails the build on an undefined permission reference).
- Change is Rust/JSON only — no web/TypeScript surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)