### PR TITLE
fix(desktop): disable WebView2 native occlusion so file dialogs stop blanking the app on Windows

### DIFF
--- a/apps/desktop/src/main.rs
+++ b/apps/desktop/src/main.rs
@@ -21,6 +21,21 @@ mod update;
 use tauri::RunEvent;
 
 fn main() {
+    // Windows/WebView2: opening a native file dialog (or any window that takes the
+    // foreground) makes Chromium's native window-occlusion tracker mark the webview
+    // occluded and stop compositing to save power; on the return trip it fails to
+    // re-rasterize the workspace's promoted GPU layer, leaving the app painted blank
+    // until something forces a repaint. Disabling the `CalculateNativeWinOcclusion`
+    // feature keeps the webview compositing while the dialog is open, killing the
+    // blank outright. Set via the WebView2 env var (which appends) rather than
+    // Tauri's `additionalBrowserArgs` (which replaces its defaults, including the
+    // draggable-region flag, and can itself blank the window).
+    #[cfg(windows)]
+    std::env::set_var(
+        "WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS",
+        "--disable-features=CalculateNativeWinOcclusion",
+    );
+
     // Install the tracing backbone for the desktop shell's own logs. The sidecars
     // are separate processes; their stdout is captured into the multi-source ring
     // buffer in `setup.rs` (and re-classified there), independent of this subscriber.

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -982,53 +982,6 @@ export function App() {
       .catch(() => setSetupCompleted(true));
   }, []);
 
-  // Desktop (WebView2) only: opening a native file dialog from an
-  // `<input type="file">` can leave the composited app shell painted blank on
-  // Windows — a WebView2 GPU-compositing bug with the backdrop-filter /
-  // scrollable-overflow layers under `.app`. The DOM stays intact; only the GPU
-  // layer fails to repaint, so it never recovers on its own (picking a file or
-  // cancelling both leave the screen blank). When the window regains focus after
-  // the dialog closes, promote-then-demote the shell layer across two frames to
-  // force WebView2 to rebuild and repaint it. Portaled modals live on
-  // `document.body`, outside `.app`, which is why the image-picker modal's file
-  // input never triggers the blank in the first place.
-  useEffect(() => {
-    if (!isDesktopShell) {
-      return undefined;
-    }
-    let armed = false;
-    const arm = (event) => {
-      const target = event.target;
-      if (target instanceof HTMLInputElement && target.type === "file") {
-        armed = true;
-      }
-    };
-    const repaint = () => {
-      if (!armed) {
-        return;
-      }
-      armed = false;
-      const shell = document.querySelector(".app");
-      if (!(shell instanceof HTMLElement)) {
-        return;
-      }
-      const previous = shell.style.transform;
-      requestAnimationFrame(() => {
-        shell.style.transform = "translateZ(0)";
-        requestAnimationFrame(() => {
-          shell.style.transform = previous;
-        });
-      });
-    };
-    // Capture phase so we arm before the input's own handlers run.
-    document.addEventListener("click", arm, true);
-    window.addEventListener("focus", repaint);
-    return () => {
-      document.removeEventListener("click", arm, true);
-      window.removeEventListener("focus", repaint);
-    };
-  }, []);
-
   useEffect(() => {
     if (!authenticated) {
       return;


### PR DESCRIPTION
## The bug

On Windows desktop, opening a native file dialog (the **Choose** buttons on the Models page LoRA/model upload) blanked the whole app. The earlier repaint nudge (#1028, now in `main`) masked it — the app came back *after* the dialog closed, but still blanked *while* it was open, which is visually jarring and, correctly, felt like a hack.

## Root cause

Chromium's native window-occlusion tracker (`CalculateNativeWinOcclusion`). When the native file dialog takes the foreground, WebView2 marks itself occluded and **stops compositing** to save power; on the way back it fails to re-rasterize the workspace's promoted GPU layer, so the app paints blank until something forces a repaint.

- It's a pure paint failure — the DOM/layout are untouched throughout (the [ErrorBoundary](apps/web/src/components/ErrorBoundary.jsx) never fires), which is why it recovers intact the instant it repaints.
- The image-picker never blanked because it renders in a `Modal` portaled to `document.body` (root layer), not the promoted `.workspace` scroll layer that gets dropped.

This is the same "white screen when another window covers it" bug Electron apps disable this feature to avoid.

## Fix

Disable the occlusion feature so WebView2 keeps compositing while the dialog is open — killing the blank outright, during *and* after. Set via the `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` env var in [main.rs](apps/desktop/src/main.rs), which **appends** to WebView2's args, rather than Tauri's `additionalBrowserArgs` which **replaces** its defaults (including the draggable-region flag) and can itself blank the window ([tauri#13092](https://github.com/tauri-apps/tauri/issues/13092)). Windows-only via `#[cfg(windows)]`.

Because this fixes the cause, the after-the-fact `requestAnimationFrame` repaint workaround in `App.jsx` (from #1028) is **removed** in this PR (net −47 lines there).

## Trade-offs / caveats

- Microsoft [cautions against shipping WebView2 browser flags in production](https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/webview-features-flags); `CalculateNativeWinOcclusion` is a stable, widely-used Chromium flag (Electron ships it), so this is an accepted risk.
- Disabling occlusion means the webview keeps compositing even when fully hidden/minimized — marginally more idle GPU/CPU. A blank window is worse.

## Testing

- App.jsx parses clean (esbuild); `isDesktopShell` still used elsewhere (no dead import).
- **Rust not built here** (cold target needs the full Tauri toolchain); the change is a `#[cfg(windows)] std::env::set_var` with string literals on edition 2021 — trivially compiles. Needs a Windows desktop rebuild to confirm the blank is gone during the dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)