### PR TITLE
feat(z-image): enable base z_image txt2img + faithful base control (sc-8680, sc-8679)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a48aba8c96196c7b89dbaf514c88d0cd05819e02#a48aba8c96196c7b89dbaf514c88d0cd05819e02"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a48aba8c96196c7b89dbaf514c88d0cd05819e02#a48aba8c96196c7b89dbaf514c88d0cd05819e02"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a48aba8c96196c7b89dbaf514c88d0cd05819e02#a48aba8c96196c7b89dbaf514c88d0cd05819e02"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a48aba8c96196c7b89dbaf514c88d0cd05819e02#a48aba8c96196c7b89dbaf514c88d0cd05819e02"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a48aba8c96196c7b89dbaf514c88d0cd05819e02#a48aba8c96196c7b89dbaf514c88d0cd05819e02"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a48aba8c96196c7b89dbaf514c88d0cd05819e02#a48aba8c96196c7b89dbaf514c88d0cd05819e02"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -513,7 +513,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a48aba8c96196c7b89dbaf514c88d0cd05819e02#a48aba8c96196c7b89dbaf514c88d0cd05819e02"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -530,7 +530,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a48aba8c96196c7b89dbaf514c88d0cd05819e02#a48aba8c96196c7b89dbaf514c88d0cd05819e02"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a48aba8c96196c7b89dbaf514c88d0cd05819e02#a48aba8c96196c7b89dbaf514c88d0cd05819e02"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a48aba8c96196c7b89dbaf514c88d0cd05819e02#a48aba8c96196c7b89dbaf514c88d0cd05819e02"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a48aba8c96196c7b89dbaf514c88d0cd05819e02#a48aba8c96196c7b89dbaf514c88d0cd05819e02"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -582,7 +582,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a48aba8c96196c7b89dbaf514c88d0cd05819e02#a48aba8c96196c7b89dbaf514c88d0cd05819e02"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -596,7 +596,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a48aba8c96196c7b89dbaf514c88d0cd05819e02#a48aba8c96196c7b89dbaf514c88d0cd05819e02"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -611,7 +611,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a48aba8c96196c7b89dbaf514c88d0cd05819e02#a48aba8c96196c7b89dbaf514c88d0cd05819e02"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -624,7 +624,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a48aba8c96196c7b89dbaf514c88d0cd05819e02#a48aba8c96196c7b89dbaf514c88d0cd05819e02"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -636,7 +636,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a48aba8c96196c7b89dbaf514c88d0cd05819e02#a48aba8c96196c7b89dbaf514c88d0cd05819e02"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -653,7 +653,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a48aba8c96196c7b89dbaf514c88d0cd05819e02#a48aba8c96196c7b89dbaf514c88d0cd05819e02"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -668,7 +668,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a48aba8c96196c7b89dbaf514c88d0cd05819e02#a48aba8c96196c7b89dbaf514c88d0cd05819e02"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -679,7 +679,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a48aba8c96196c7b89dbaf514c88d0cd05819e02#a48aba8c96196c7b89dbaf514c88d0cd05819e02"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -694,7 +694,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a48aba8c96196c7b89dbaf514c88d0cd05819e02#a48aba8c96196c7b89dbaf514c88d0cd05819e02"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a48aba8c96196c7b89dbaf514c88d0cd05819e02#a48aba8c96196c7b89dbaf514c88d0cd05819e02"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -729,7 +729,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a48aba8c96196c7b89dbaf514c88d0cd05819e02#a48aba8c96196c7b89dbaf514c88d0cd05819e02"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -740,7 +740,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a48aba8c96196c7b89dbaf514c88d0cd05819e02#a48aba8c96196c7b89dbaf514c88d0cd05819e02"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a48aba8c96196c7b89dbaf514c88d0cd05819e02#a48aba8c96196c7b89dbaf514c88d0cd05819e02"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -764,7 +764,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a48aba8c96196c7b89dbaf514c88d0cd05819e02#a48aba8c96196c7b89dbaf514c88d0cd05819e02"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -777,7 +777,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a48aba8c96196c7b89dbaf514c88d0cd05819e02#a48aba8c96196c7b89dbaf514c88d0cd05819e02"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -8039,7 +8039,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3821,13 +3821,12 @@ const CANDLE_ROUTED_MODELS: &[&str] = &[
     // conditioning-incompatible).
     "realvisxl_lightning",
     "z_image_turbo",
-    // Base (non-distilled, full-CFG) Z-Image (epic 8236, sc-8379): same candle `z_image_diffusers` family
-    // as Turbo. On candle it is currently routed ONLY for the strict-control lane (`z_image` +
-    // `advanced.poses` → `generate_candle_zimage_control_stream`, the base Fun-Controlnet-Union branch);
-    // its plain-txt2img candle path is not wired yet, so a non-pose `z_image` job still defers to torch
-    // via `image_request_candle_eligible` (which has no base-z-image txt2img provider). Membership here is
-    // required so the strict-control branch + the pose-reject exclusion in `image_job_is_candle_eligible`
-    // see it as a candle-routed model.
+    // Base (non-distilled, full-CFG) Z-Image (epic 8236, sc-8379 control + sc-8679 txt2img): same candle
+    // `z_image_diffusers` family as Turbo. Now routed for BOTH the strict-control lane (`z_image` +
+    // `advanced.poses` → `generate_candle_zimage_control_stream`, the base Fun-Controlnet-Union branch)
+    // AND plain txt2img (sc-8679): the registered candle `z_image` base generator (shift-6.0 / ~50-step /
+    // real CFG) runs a non-pose `z_image` job through the generic candle txt2img lane, the base sibling of
+    // `z_image_turbo`. Edit/reference/mask shapes still defer to torch (`image_request_candle_eligible`).
     "z_image",
     "flux_schnell",
     "flux_dev",
@@ -4161,15 +4160,13 @@ fn image_request_candle_eligible(model: &str, payload: &Map<String, Value>) -> b
     if !CANDLE_ROUTED_MODELS.contains(&model) {
         return false;
     }
-    // Base (non-distilled) Z-Image is candle-routed ONLY for its strict-control lane (sc-8379); the candle
-    // `is_candle_engine` set has no base-z-image txt2img provider, so a plain (non-pose) `z_image` job must
-    // NOT be claimed for the candle txt2img path here — it falls through to MLX/torch. (The pose job is
-    // branched out by `zimage_control_candle_eligible` in `image_job_is_candle_eligible` before reaching
-    // this gate.) Without this guard a plain `z_image` job would be claimed but the worker's
-    // `is_candle_engine` would not match it, silently dropping it to the unhandled tail.
-    if model == "z_image" {
-        return false;
-    }
+    // Base (non-distilled, full-CFG) Z-Image txt2img (sc-8679, epic 8236): the candle `z_image` base
+    // generator (shift-6.0 / ~50-step / real CFG) is now a candle txt2img provider (`is_candle_engine`),
+    // so a plain (non-pose, non-edit) `z_image` job routes to the generic candle txt2img lane here — the
+    // base sibling of `z_image_turbo`. Its strict-pose control (`advanced.poses`) is still branched out by
+    // `zimage_control_candle_eligible` in `image_job_is_candle_eligible` BEFORE this gate; its edit shapes
+    // are rejected below with every other family. (The prior sc-8379 guard that hard-rejected base z_image
+    // here — because no candle txt2img provider existed — is retired now that one does.)
     // img2img / inpaint / outpaint all arrive as `mode == "edit_image"` (+ a source); reject the
     // whole edit family up front (the worker's `sdxl_sub_mode` keys off the same mode).
     if payload.get("mode").and_then(Value::as_str) == Some("edit_image") {
@@ -6199,23 +6196,36 @@ mod candle_routing_tests {
 
     #[test]
     fn candle_routed_models_plain_txt2img_are_eligible() {
-        // SDXL/RealVisXL (sc-3678) + the four image families wired in sc-5096 — every base txt2img id.
-        // EXCEPT base `z_image` (sc-8379): it is candle-routed ONLY for its strict-control lane (no candle
-        // txt2img provider), so a plain txt2img `z_image` job correctly defers to MLX/torch.
+        // SDXL/RealVisXL (sc-3678) + the image families wired in sc-5096 — every base txt2img id, now
+        // INCLUDING base `z_image` (sc-8679): the registered candle `z_image` base generator makes a plain
+        // txt2img `z_image` job candle-eligible, the base sibling of `z_image_turbo`. (Its strict-pose
+        // control lane is branched out earlier in `image_job_is_candle_eligible`; its edit shapes reject
+        // below — see `new_candle_families_conditioning_shapes_fall_back_to_torch`.)
         for model in CANDLE_ROUTED_MODELS {
-            if *model == "z_image" {
-                assert!(
-                    !image_request_candle_eligible(
-                        model,
-                        &object(json!({ "prompt": "a red fox" }))
-                    ),
-                    "base z_image plain txt2img must NOT be candle-eligible (control-only lane)"
-                );
-                continue;
-            }
             assert!(
                 image_request_candle_eligible(model, &object(json!({ "prompt": "a red fox" }))),
                 "{model} plain txt2img should be candle-eligible"
+            );
+        }
+    }
+
+    #[test]
+    fn base_z_image_txt2img_is_candle_eligible_but_edit_shapes_are_not() {
+        // sc-8679: base `z_image` plain txt2img rides the candle lane (the base sibling of z_image_turbo);
+        // its edit / reference / mask conditioning shapes still defer to the Python torch worker (no candle
+        // base-z-image edit provider — that is a separate story).
+        assert!(
+            image_request_candle_eligible("z_image", &object(json!({ "prompt": "a red fox" }))),
+            "base z_image plain txt2img must be candle-eligible (sc-8679)"
+        );
+        for payload in [
+            json!({ "prompt": "p", "mode": "edit_image", "sourceAssetId": "a" }),
+            json!({ "prompt": "p", "referenceAssetId": "a" }),
+            json!({ "prompt": "p", "maskAssetId": "a" }),
+        ] {
+            assert!(
+                !image_request_candle_eligible("z_image", &object(payload.clone())),
+                "base z_image conditioning shape must fall back to torch: {payload}"
             );
         }
     }
@@ -8140,11 +8150,12 @@ mod candle_routing_tests {
         let payload = json!({ "model": "z_image", "advanced": { "poses": [{ "keypoints": [] }] } });
         assert!(zimage_control_candle_eligible(&object(payload.clone())));
         assert!(image_job_is_candle_eligible(&image_generate_job(payload)));
-        // A base z_image with no poses is plain txt2img — NOT a candle lane (no base-z-image txt2img
-        // provider on candle), so it defers to torch via the txt2img gate.
-        assert!(!image_job_is_candle_eligible(&image_generate_job(
-            json!({ "model": "z_image", "prompt": "a misty fjord" })
-        )));
+        // A base z_image with no poses is plain txt2img — now a candle lane too (sc-8679: the registered
+        // candle `z_image` base generator), so it routes to the generic candle txt2img gate rather than
+        // deferring to torch. It is NOT this strict-control lane, though.
+        let plain = json!({ "model": "z_image", "prompt": "a misty fjord" });
+        assert!(!zimage_control_candle_eligible(&object(plain.clone())));
+        assert!(image_job_is_candle_eligible(&image_generate_job(plain)));
         // Both Turbo and base have a candle pose lane (so neither is pose-rejected).
         assert!(model_has_candle_pose_lane("z_image"));
         assert!(model_has_candle_pose_lane("z_image_turbo"));

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1346,15 +1346,24 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108
 # (inference-level memory, like 24 GB cards) and restores the live `Var`s after. SOURCE-ONLY candle-gen
 # fix; both b3aad50 and 5bb83e4 pin gen-core 863f98d, so this stays single-rev (mlx-gen unchanged). ALL
 # candle-gen-* rev lines move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+# Bumped `90c3215` -> `a48aba8` (candle-gen #208 sc-8680 + #209): faithful base z_image control API — #208
+# renames `ZImageControlPaths.base`→`snapshot`, adds a `base: bool` (the FAITHFUL shift-6.0 / ~50-step /
+# real-CFG base treatment vs the distilled Turbo path), and adds `guidance` + `negative_prompt` to
+# `ZImageControlRequest` (consumed only in base mode); #209 widens the Krea LoKr merge surface (unrelated,
+# ridden in). Both 90c3215 and a48aba8 re-pin candle-gen's OWN gen-core to `0108fe6` (== this worker's
+# mlx-gen pin above), so `--features backend-candle --target all` resolves the SINGLE gen-core rev 0108fe6;
+# candle links no z-image crate into gen-core and the ports are source-only, so it stays single-rev. This
+# BREAKS the sc-8379 base-control provider (`image_jobs/zimage_control.rs`), updated in this same PR
+# (sc-8680 worker half). ALL candle-gen-* rev lines move together. (a48aba8 = candle-gen main HEAD, #208.)
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a48aba8c96196c7b89dbaf514c88d0cd05819e02", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a48aba8c96196c7b89dbaf514c88d0cd05819e02", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a48aba8c96196c7b89dbaf514c88d0cd05819e02", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a48aba8c96196c7b89dbaf514c88d0cd05819e02", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a48aba8c96196c7b89dbaf514c88d0cd05819e02", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1362,17 +1371,17 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a48aba8c96196c7b89dbaf514c88d0cd05819e02", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a48aba8c96196c7b89dbaf514c88d0cd05819e02", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a48aba8c96196c7b89dbaf514c88d0cd05819e02", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1382,7 +1391,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a48aba8c96196c7b89dbaf514c88d0cd05819e02", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1390,21 +1399,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a48aba8c96196c7b89dbaf514c88d0cd05819e02", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a48aba8c96196c7b89dbaf514c88d0cd05819e02", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a48aba8c96196c7b89dbaf514c88d0cd05819e02", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a48aba8c96196c7b89dbaf514c88d0cd05819e02", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1413,17 +1422,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a48aba8c96196c7b89dbaf514c88d0cd05819e02", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a48aba8c96196c7b89dbaf514c88d0cd05819e02", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a48aba8c96196c7b89dbaf514c88d0cd05819e02", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1432,7 +1441,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a48aba8c96196c7b89dbaf514c88d0cd05819e02", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1465,7 +1474,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a48aba8c96196c7b89dbaf514c88d0cd05819e02", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1474,12 +1483,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a48aba8c96196c7b89dbaf514c88d0cd05819e02", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a48aba8c96196c7b89dbaf514c88d0cd05819e02", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1487,7 +1496,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a48aba8c96196c7b89dbaf514c88d0cd05819e02", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1496,7 +1505,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a48aba8c96196c7b89dbaf514c88d0cd05819e02", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1504,7 +1513,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a48aba8c96196c7b89dbaf514c88d0cd05819e02", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1518,7 +1527,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a48aba8c96196c7b89dbaf514c88d0cd05819e02", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1545,7 +1554,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a48aba8c96196c7b89dbaf514c88d0cd05819e02", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1556,7 +1565,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a48aba8c96196c7b89dbaf514c88d0cd05819e02", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -2312,6 +2312,13 @@ fn is_candle_engine(model: &str) -> bool {
             // router defers its conditioning shapes to torch), so it rides the base candle txt2img lane.
             | "realvisxl_lightning"
             | "z_image_turbo"
+            // Base (non-distilled, full-CFG) Z-Image (sc-8679, epic 8236): the registered candle
+            // `z_image` base generator (shift-6.0 / ~50-step / real CFG) rides the generic candle txt2img
+            // lane, the base sibling of `z_image_turbo`. Shares the `standard_tier_subdir` turnkey layout;
+            // `generate_candle_stream` resolves its own repo/steps/guidance/negative from the descriptor.
+            // txt2img only — edit / identity / strict-pose shapes have their own bespoke lanes (the
+            // `z_image` control lane is `advanced.poses`, branched out before this gate).
+            | "z_image"
             | "flux_schnell"
             | "flux_dev"
             | "flux2_klein_9b"
@@ -2369,7 +2376,8 @@ fn is_candle_engine(model: &str) -> bool {
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 fn candle_adapter_label(model: &str) -> &'static str {
     match model {
-        "z_image_turbo" => "candle_z_image",
+        // Base z_image (sc-8679) shares the candle z-image family label with Turbo.
+        "z_image_turbo" | "z_image" => "candle_z_image",
         "flux_schnell" | "flux_dev" => "candle_flux",
         // The base klein + its `_kv` / `_true_v2` weight variants (sc-7459) + dev all run candle FLUX.2.
         "flux2_klein_9b" | "flux2_klein_9b_kv" | "flux2_klein_9b_true_v2" | "flux2_dev" => {
@@ -2653,7 +2661,8 @@ async fn generate_candle_stream(
     match request.model.as_str() {
         // realvisxl_lightning shares the candle `sdxl` engine (sc-7176), so the SDXL flash toggle applies.
         "sdxl" | "realvisxl" | "realvisxl_lightning" => candle_gen_sdxl::set_flash_attn(flash_attn),
-        "z_image_turbo" => candle_gen_z_image::set_accel_attn(flash_attn),
+        // Base z_image (sc-8679) shares the candle z-image accel-attention toggle with Turbo.
+        "z_image_turbo" | "z_image" => candle_gen_z_image::set_accel_attn(flash_attn),
         _ => {}
     }
 
@@ -3163,6 +3172,8 @@ mod candle_label_tests {
             "realvisxl",
             "realvisxl_lightning",
             "z_image_turbo",
+            // Base (non-distilled, full-CFG) Z-Image txt2img (sc-8679): the base sibling of z_image_turbo.
+            "z_image",
             "flux_schnell",
             "flux_dev",
             "flux2_klein_9b",

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -7280,6 +7280,15 @@ fn candle_control_providers_resolve_models_and_repos() {
     );
     assert_eq!(zimage_control_steps(&turbo), ZIMAGE_CTRL_DEFAULT_STEPS);
     assert_eq!(zimage_control_steps(&base), ZIMAGE_CTRL_BASE_DEFAULT_STEPS);
+
+    // sc-8680 — base-mode real-CFG guidance: defaults to 4.0 (the base card / `z_image` manifest), an
+    // `advanced.guidanceScale` override wins and is clamped. Consumed only in base mode (Turbo ignores it).
+    assert_eq!(zimage_control_guidance(&base), ZIMAGE_CTRL_BASE_DEFAULT_GUIDANCE);
+    assert_eq!(ZIMAGE_CTRL_BASE_DEFAULT_GUIDANCE, 4.0);
+    let base_g = request(json!({
+        "projectId": "p", "model": "z_image", "advanced": { "guidanceScale": 6.5 }
+    }));
+    assert_eq!(zimage_control_guidance(&base_g), 6.5);
 }
 
 /// The trait routes each provider: each lane's `CandleStrictControl` impl reports the right engine id
@@ -7292,32 +7301,44 @@ fn candle_strict_control_trait_routes_each_provider() {
     let dummy = std::path::PathBuf::from("/nonexistent");
 
     let zimage = ZImageStrictControl {
-        base: dummy.clone(),
+        snapshot: dummy.clone(),
         controlnet: dummy.clone(),
         prompt: "p".to_owned(),
         width: 512,
         height: 512,
         steps: 8,
         control_scale: 1.0,
+        // Turbo: distilled, no CFG — `is_base` false, guidance/negative inert.
+        is_base: false,
+        guidance: 0.0,
+        negative_prompt: String::new(),
         engine_id: ZIMAGE_CTRL_ENGINE_ID,
     };
     assert_eq!(zimage.engine_id(), ZIMAGE_CTRL_ENGINE_ID);
     assert_eq!(zimage.engine_label(), ZIMAGE_CTRL_ENGINE);
     assert_eq!(zimage.stream_tag(), "zimage_control");
 
-    // Base z_image (sc-8379) routes the SAME provider with the `z_image_control` engine-id row.
+    // Base z_image (sc-8379 control + sc-8680 faithful base): the SAME provider with the `z_image_control`
+    // engine-id row, `is_base = true` (the faithful shift-6.0 / ~50-step / real-CFG path), and threaded
+    // guidance + negative prompt.
     let zimage_base = ZImageStrictControl {
-        base: dummy.clone(),
+        snapshot: dummy.clone(),
         controlnet: dummy.clone(),
         prompt: "p".to_owned(),
         width: 512,
         height: 512,
         steps: 50,
         control_scale: 1.0,
+        is_base: true,
+        guidance: 4.0,
+        negative_prompt: "blurry".to_owned(),
         engine_id: ZIMAGE_CTRL_BASE_ENGINE_ID,
     };
     assert_eq!(zimage_base.engine_id(), ZIMAGE_CTRL_BASE_ENGINE_ID);
     assert_eq!(zimage_base.engine_label(), ZIMAGE_CTRL_ENGINE);
+    assert!(zimage_base.is_base);
+    assert_eq!(zimage_base.guidance, 4.0);
+    assert_eq!(zimage_base.negative_prompt, "blurry");
 
     // FLUX.1-dev control (sc-8412) routes via the `Flux1StrictControl` provider.
     let flux1 = Flux1StrictControl {

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -7283,7 +7283,10 @@ fn candle_control_providers_resolve_models_and_repos() {
 
     // sc-8680 — base-mode real-CFG guidance: defaults to 4.0 (the base card / `z_image` manifest), an
     // `advanced.guidanceScale` override wins and is clamped. Consumed only in base mode (Turbo ignores it).
-    assert_eq!(zimage_control_guidance(&base), ZIMAGE_CTRL_BASE_DEFAULT_GUIDANCE);
+    assert_eq!(
+        zimage_control_guidance(&base),
+        ZIMAGE_CTRL_BASE_DEFAULT_GUIDANCE
+    );
     assert_eq!(ZIMAGE_CTRL_BASE_DEFAULT_GUIDANCE, 4.0);
     let base_g = request(json!({
         "projectId": "p", "model": "z_image", "advanced": { "guidanceScale": 6.5 }

--- a/crates/sceneworks-worker/src/image_jobs/zimage_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage_control.rs
@@ -28,6 +28,10 @@ const ZIMAGE_CTRL_BASE_FILE: &str = "diffusion_pytorch_model.safetensors";
 const ZIMAGE_CTRL_BASE_DEFAULT_REPO: &str = "Tongyi-MAI/Z-Image";
 /// ControlNet conditioning-scale default (the strict-pose tier).
 const ZIMAGE_CTRL_DEFAULT_SCALE: f32 = 1.0;
+/// Base-mode (sc-8680) classifier-free guidance default — the undistilled base `z_image` runs real CFG;
+/// the card recommends 3.0–5.0 (default 4.0), matching the `z_image` manifest `defaults.guidanceScale`
+/// and `candle_gen_z_image`'s `BASE_DEFAULT_GUIDANCE`. Inert on Turbo (guidance-distilled, CFG-free).
+const ZIMAGE_CTRL_BASE_DEFAULT_GUIDANCE: f32 = 4.0;
 /// Denoise-steps default — the 8-step Turbo Fun-ControlNet variant (vs the 4-step distilled txt2img).
 const ZIMAGE_CTRL_DEFAULT_STEPS: u32 = 8;
 /// Denoise-steps default for the base (non-distilled) model — the undistilled foundation runs the full
@@ -131,6 +135,24 @@ fn zimage_control_steps(request: &ImageRequest) -> u32 {
         .unwrap_or(default)
 }
 
+/// Resolve the base-mode (sc-8680) classifier-free guidance scale: `advanced.guidanceScale` → manifest
+/// `guidanceScale` → the base default (4.0), clamped to a sane CFG range. Consumed only by the base
+/// `z_image` control path (real CFG); Turbo ignores it (guidance-distilled). Mirrors
+/// `kolors_control_guidance`.
+fn zimage_control_guidance(request: &ImageRequest) -> f32 {
+    let manifest_default = request
+        .model_manifest_entry
+        .get("guidanceScale")
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .map(|value| value as f32)
+        .unwrap_or(ZIMAGE_CTRL_BASE_DEFAULT_GUIDANCE);
+    advanced::f32_clamped(&request.advanced, "guidanceScale", manifest_default, 0.0..=30.0)
+}
+
 /// The (repo, filename) of the ControlNet weights — `advanced.controlWeights.{repo,filename}` overrides,
 /// else the model's Fun-Controlnet-Union default: the Turbo 8-step variant, or the base
 /// (full-CFG) variant for the base `z_image` model (sc-8379). Parity with the MLX `resolve_control_weights`.
@@ -195,14 +217,16 @@ async fn ensure_zimage_control_weights(
     Ok(dst)
 }
 
-/// Flat telemetry recorded on candle Z-Image control assets. No guidance — Z-Image-Turbo is
-/// guidance-distilled.
+/// Flat telemetry recorded on candle Z-Image control assets. `guidance` is recorded only for the base
+/// `z_image` model (sc-8680, real CFG); Turbo is guidance-distilled (single cond forward), so it omits it.
 fn zimage_control_raw_settings(
     request: &ImageRequest,
     repo: &str,
     steps: u32,
     control_scale: f32,
     pose_count: usize,
+    is_base: bool,
+    guidance: f32,
 ) -> JsonObject {
     let mut raw = request.advanced.clone();
     raw.insert("realModelInference".to_owned(), Value::Bool(true));
@@ -210,6 +234,9 @@ fn zimage_control_raw_settings(
     raw.insert("numInferenceSteps".to_owned(), json!(steps));
     raw.insert("controlScale".to_owned(), json!(control_scale));
     raw.insert("poseCount".to_owned(), json!(pose_count));
+    if is_base {
+        raw.insert("guidanceScale".to_owned(), json!(guidance));
+    }
     raw.insert(
         "controlEngine".to_owned(),
         Value::String(ZIMAGE_CTRL_ENGINE.to_owned()),
@@ -218,16 +245,28 @@ fn zimage_control_raw_settings(
 }
 
 /// The per-lane half of the candle Z-Image strict-control [`CandleStrictControl`] driver (sc-8304): the
-/// resolved weight paths + the request numerics. Z-Image-Turbo is distilled (no CFG / negative prompt),
-/// so it carries no guidance. Moved onto the blocking thread, loaded once, drives every pose.
+/// resolved weight paths + the request numerics. Moved onto the blocking thread, loaded once, drives every
+/// pose. Turbo is distilled (CFG-free, no negative prompt); the base model (sc-8680) runs the FAITHFUL
+/// undistilled treatment — shift-6.0, ~50-step, and real classifier-free guidance — so `is_base` selects
+/// the base control path in `ZImageControl` and threads `guidance` + `negative_prompt` (both inert on Turbo).
 struct ZImageStrictControl {
-    base: PathBuf,
+    snapshot: PathBuf,
     controlnet: PathBuf,
     prompt: String,
     width: u32,
     height: u32,
     steps: u32,
     control_scale: f32,
+    /// `true` for the base `z_image` model (sc-8680) — routes `ZImageControl::generate` to the faithful
+    /// base path (shift-6.0 / ~50-step / real CFG); `false` for `z_image_turbo` (the distilled 8-step
+    /// CFG-free path, byte-unchanged). Sets `ZImageControlPaths.base`.
+    is_base: bool,
+    /// Base-mode classifier-free guidance scale (sc-8680); ignored on Turbo. Threaded to
+    /// `ZImageControlRequest.guidance`.
+    guidance: f32,
+    /// Base-mode negative prompt for the uncond CFG branch (sc-8680); ignored on Turbo. Threaded to
+    /// `ZImageControlRequest.negative_prompt`.
+    negative_prompt: String,
     /// The [`STRICT_CONTROL_ENGINES`] catalog id for this job's model — `z_image_turbo_control` (Turbo) or
     /// `z_image_control` (base, sc-8379) — the `advanced.controlMode` validation key.
     engine_id: &'static str,
@@ -250,8 +289,11 @@ impl CandleStrictControl for ZImageStrictControl {
 
     fn load(&self) -> WorkerResult<Self::Model> {
         let paths = ZImageControlPaths {
-            base: self.base.clone(),
+            snapshot: self.snapshot.clone(),
             control: self.controlnet.clone(),
+            // Base `z_image` (sc-8680) → the faithful undistilled control path (shift-6.0, ~50-step,
+            // real CFG); `z_image_turbo` → the distilled Turbo path (byte-unchanged).
+            base: self.is_base,
         };
         ZImageControl::load(&paths).map_err(|error| {
             WorkerError::Engine(format!("Z-Image strict-pose control load failed: {error}"))
@@ -266,12 +308,20 @@ impl CandleStrictControl for ZImageStrictControl {
         cancel: &CancelFlag,
         on_progress: &mut dyn FnMut(Progress),
     ) -> WorkerResult<Image> {
+        // `guidance` + `negative_prompt` drive the base-mode real-CFG denoise; the distilled Turbo path
+        // ignores both (single cond forward), so a `None`/value is inert there. We always forward the
+        // resolved base values — they only take effect when `base = true` in the loaded `ZImageControl`.
         let req = ZImageControlRequest {
             prompt: self.prompt.clone(),
             width: self.width,
             height: self.height,
             steps: self.steps as usize,
             control_scale: self.control_scale,
+            guidance: self.is_base.then_some(self.guidance),
+            negative_prompt: self
+                .is_base
+                .then(|| self.negative_prompt.clone())
+                .filter(|value| !value.trim().is_empty()),
             seed,
             cancel: cancel.clone(),
         };
@@ -326,18 +376,34 @@ async fn generate_candle_zimage_control_stream(
     } else {
         ZIMAGE_CTRL_ENGINE_ID
     };
+    // Base-mode real-CFG surface (sc-8680): resolve the guidance scale + negative prompt for the
+    // undistilled base `z_image` control path. Inert on Turbo (the distilled path ignores both), so we
+    // resolve them unconditionally and gate on `is_base` at request-build time.
+    let guidance = zimage_control_guidance(request);
+    let negative_prompt = request.negative_prompt.clone();
 
     let pose_count = pose_entries(request).len();
-    let raw_settings = zimage_control_raw_settings(request, &repo, steps, control_scale, pose_count);
+    let raw_settings = zimage_control_raw_settings(
+        request,
+        &repo,
+        steps,
+        control_scale,
+        pose_count,
+        is_base,
+        guidance,
+    );
 
     let provider = ZImageStrictControl {
-        base,
+        snapshot: base,
         controlnet,
         prompt: request.prompt.clone(),
         width: request.width,
         height: request.height,
         steps,
         control_scale,
+        is_base,
+        guidance,
+        negative_prompt,
         engine_id,
     };
 


### PR DESCRIPTION
Three coupled deliverables (candle Windows/Linux), one PR. Refs **sc-8680** + **sc-8679** (epic 8236).

## 1. Lockstep re-pin — all `candle-gen*` deps `90c3215` → `a48aba8`
candle-gen #208 (sc-8680) + #209. Both `90c3215` and `a48aba8` re-pin candle-gen's own gen-core to `0108fe6` (== this worker's mlx-gen pin), so `--features backend-candle` resolves ONE gen-core rev. `Cargo.lock` regenerated for candle-gen crates only (`core-llm` held at `3870ed1c`, mlx-gen untouched). Provenance comment added in the existing style.

**Skew gate — green on both lanes (exactly one `sceneworks-gen-core`):**
- `check-gen-core-skew.sh sceneworks-worker` → `sceneworks-gen-core ... rev=0108fe6b`
- `... --features backend-candle` → `sceneworks-gen-core ... rev=0108fe6b`

## 2. sc-8680 worker half — faithful base control (BREAKING API change)
candle-gen #208 renamed `ZImageControlPaths.base` → `snapshot`, added `base: bool`, and added `guidance` + `negative_prompt` to `ZImageControlRequest`. `image_jobs/zimage_control.rs` (the sc-8379 base-control provider) updated:
- Sets `base = true` for the base `z_image` model, `false` for `z_image_turbo`.
- Threads the job's guidance (`advanced.guidanceScale` → manifest → 4.0) + negative prompt into the request for base mode (inert on Turbo — single cond forward).
- Base `z_image` control now runs the FAITHFUL base path (shift-6.0, ~50-step, real CFG) instead of the Turbo sampler. Turbo path byte-unchanged. Guidance recorded in telemetry for base only.

## 3. sc-8679 — base z_image txt2img candle route
Wire base `z_image` to the generic candle txt2img lane, mirroring `z_image_turbo` (the registered `candle-gen-z-image` `ZImageBaseGenerator`, engine id `z_image`):
- Worker: `is_candle_engine` + `candle_adapter_label` (`candle_z_image`) + the `set_accel_attn` match gain `z_image`.
- Router: `jobs_store::image_request_candle_eligible` drops the sc-8379 hard-reject guard now that a candle base txt2img provider exists; stale `CANDLE_ROUTED_MODELS` / pose-lane comments refreshed.
- base t2i only (real CFG + negative prompt). Edit / img2img / reference / mask still defer to torch (a separate story); the strict-pose control lane (`advanced.poses`) is still branched out first.

## Tests
- `base_z_image_txt2img_is_candle_eligible_but_edit_shapes_are_not` (new) — base z_image txt2img eligible, conditioning shapes reject.
- Flipped `candle_routed_models_plain_txt2img_are_eligible` (z_image carve-out removed) + `zimage_base_control_pose_jobs_route_to_candle` (no-pose base z_image now candle-eligible).
- Worker: `is_candle_engine_covers_only_the_wired_txt2img_families` (+ z_image), `candle_strict_control_trait_routes_each_provider` (new struct fields + base assertions), `candle_control_providers_resolve_models_and_repos` (base guidance default 4.0 + `advanced.guidanceScale` override).

**Verified:** sceneworks-core check + 81 jobs_store tests pass; `backend-candle` **build attempted and green** — full `cargo check -p sceneworks-worker --features backend-candle` + `cargo clippy ... --all-targets -- -D warnings` clean; candle-gated worker tests pass (RTX PRO 6000, `CUDA_COMPUTE_CAP=120`). No gen-core pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)