### PR TITLE
feat(sensenova): wire the _fast id to its pre-merged packed q4/q8/bf16 tiers (sc-8775)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=376b1ef657045afe5e37926591f05afd72a8650c#376b1ef657045afe5e37926591f05afd72a8650c"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=376b1ef657045afe5e37926591f05afd72a8650c#376b1ef657045afe5e37926591f05afd72a8650c"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=376b1ef657045afe5e37926591f05afd72a8650c#376b1ef657045afe5e37926591f05afd72a8650c"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=376b1ef657045afe5e37926591f05afd72a8650c#376b1ef657045afe5e37926591f05afd72a8650c"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=376b1ef657045afe5e37926591f05afd72a8650c#376b1ef657045afe5e37926591f05afd72a8650c"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=376b1ef657045afe5e37926591f05afd72a8650c#376b1ef657045afe5e37926591f05afd72a8650c"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -513,7 +513,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=376b1ef657045afe5e37926591f05afd72a8650c#376b1ef657045afe5e37926591f05afd72a8650c"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -530,7 +530,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=376b1ef657045afe5e37926591f05afd72a8650c#376b1ef657045afe5e37926591f05afd72a8650c"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=376b1ef657045afe5e37926591f05afd72a8650c#376b1ef657045afe5e37926591f05afd72a8650c"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=376b1ef657045afe5e37926591f05afd72a8650c#376b1ef657045afe5e37926591f05afd72a8650c"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=376b1ef657045afe5e37926591f05afd72a8650c#376b1ef657045afe5e37926591f05afd72a8650c"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -582,7 +582,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=376b1ef657045afe5e37926591f05afd72a8650c#376b1ef657045afe5e37926591f05afd72a8650c"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -596,7 +596,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=376b1ef657045afe5e37926591f05afd72a8650c#376b1ef657045afe5e37926591f05afd72a8650c"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -611,7 +611,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=376b1ef657045afe5e37926591f05afd72a8650c#376b1ef657045afe5e37926591f05afd72a8650c"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -624,7 +624,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=376b1ef657045afe5e37926591f05afd72a8650c#376b1ef657045afe5e37926591f05afd72a8650c"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -636,7 +636,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=376b1ef657045afe5e37926591f05afd72a8650c#376b1ef657045afe5e37926591f05afd72a8650c"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -653,7 +653,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=376b1ef657045afe5e37926591f05afd72a8650c#376b1ef657045afe5e37926591f05afd72a8650c"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -668,7 +668,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=376b1ef657045afe5e37926591f05afd72a8650c#376b1ef657045afe5e37926591f05afd72a8650c"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -679,7 +679,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=376b1ef657045afe5e37926591f05afd72a8650c#376b1ef657045afe5e37926591f05afd72a8650c"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -694,7 +694,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=376b1ef657045afe5e37926591f05afd72a8650c#376b1ef657045afe5e37926591f05afd72a8650c"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=376b1ef657045afe5e37926591f05afd72a8650c#376b1ef657045afe5e37926591f05afd72a8650c"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -729,7 +729,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=376b1ef657045afe5e37926591f05afd72a8650c#376b1ef657045afe5e37926591f05afd72a8650c"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -740,7 +740,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=376b1ef657045afe5e37926591f05afd72a8650c#376b1ef657045afe5e37926591f05afd72a8650c"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=376b1ef657045afe5e37926591f05afd72a8650c#376b1ef657045afe5e37926591f05afd72a8650c"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -764,7 +764,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=376b1ef657045afe5e37926591f05afd72a8650c#376b1ef657045afe5e37926591f05afd72a8650c"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -777,7 +777,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=376b1ef657045afe5e37926591f05afd72a8650c#376b1ef657045afe5e37926591f05afd72a8650c"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -8040,7 +8040,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -513,7 +513,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -530,7 +530,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -582,7 +582,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -596,7 +596,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -611,7 +611,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -624,7 +624,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -636,7 +636,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -653,7 +653,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -668,7 +668,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -679,7 +679,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -694,7 +694,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -729,7 +729,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -740,7 +740,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -764,7 +764,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -777,7 +777,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=90c32152226daccd38ea65f4f321e0259136075a#90c32152226daccd38ea65f4f321e0259136075a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d6ae1369734e2e316485fdbcc2b6ac053511c76#5d6ae1369734e2e316485fdbcc2b6ac053511c76"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1086,7 +1086,7 @@ dependencies = [
 [[package]]
 name = "core-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/core-llm?branch=main#3870ed1c7495caa6bcb8cc0836b9dd4356969737"
+source = "git+https://github.com/SceneWorks/core-llm?branch=main#54cbac806304e823470ce3ded08f78589acdbb62"
 dependencies = [
  "inventory",
  "minijinja",
@@ -3528,7 +3528,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0108fe6b91d169368de923be1ae2e2faf4a31d5d#0108fe6b91d169368de923be1ae2e2faf4a31d5d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d#cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3541,7 +3541,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0108fe6b91d169368de923be1ae2e2faf4a31d5d#0108fe6b91d169368de923be1ae2e2faf4a31d5d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d#cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d"
 dependencies = [
  "image",
  "inventory",
@@ -3555,7 +3555,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0108fe6b91d169368de923be1ae2e2faf4a31d5d#0108fe6b91d169368de923be1ae2e2faf4a31d5d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d#cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d"
 dependencies = [
  "image",
  "inventory",
@@ -3569,7 +3569,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0108fe6b91d169368de923be1ae2e2faf4a31d5d#0108fe6b91d169368de923be1ae2e2faf4a31d5d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d#cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3577,12 +3577,13 @@ dependencies = [
  "mlx-gen-pid",
  "mlx-gen-z-image",
  "pmetal-mlx-rs",
+ "serde_json",
 ]
 
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0108fe6b91d169368de923be1ae2e2faf4a31d5d#0108fe6b91d169368de923be1ae2e2faf4a31d5d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d#cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3593,7 +3594,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0108fe6b91d169368de923be1ae2e2faf4a31d5d#0108fe6b91d169368de923be1ae2e2faf4a31d5d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d#cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3602,7 +3603,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0108fe6b91d169368de923be1ae2e2faf4a31d5d#0108fe6b91d169368de923be1ae2e2faf4a31d5d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d#cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3611,7 +3612,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0108fe6b91d169368de923be1ae2e2faf4a31d5d#0108fe6b91d169368de923be1ae2e2faf4a31d5d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d#cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3625,7 +3626,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0108fe6b91d169368de923be1ae2e2faf4a31d5d#0108fe6b91d169368de923be1ae2e2faf4a31d5d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d#cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3638,7 +3639,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0108fe6b91d169368de923be1ae2e2faf4a31d5d#0108fe6b91d169368de923be1ae2e2faf4a31d5d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d#cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3651,7 +3652,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0108fe6b91d169368de923be1ae2e2faf4a31d5d#0108fe6b91d169368de923be1ae2e2faf4a31d5d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d#cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3663,7 +3664,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0108fe6b91d169368de923be1ae2e2faf4a31d5d#0108fe6b91d169368de923be1ae2e2faf4a31d5d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d#cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3673,7 +3674,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0108fe6b91d169368de923be1ae2e2faf4a31d5d#0108fe6b91d169368de923be1ae2e2faf4a31d5d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d#cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d"
 dependencies = [
  "image",
  "inventory",
@@ -3686,7 +3687,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0108fe6b91d169368de923be1ae2e2faf4a31d5d#0108fe6b91d169368de923be1ae2e2faf4a31d5d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d#cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d"
 dependencies = [
  "image",
  "inventory",
@@ -3700,7 +3701,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0108fe6b91d169368de923be1ae2e2faf4a31d5d#0108fe6b91d169368de923be1ae2e2faf4a31d5d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d#cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d"
 dependencies = [
  "image",
  "inventory",
@@ -3714,7 +3715,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0108fe6b91d169368de923be1ae2e2faf4a31d5d#0108fe6b91d169368de923be1ae2e2faf4a31d5d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d#cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d"
 dependencies = [
  "image",
  "inventory",
@@ -3726,7 +3727,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0108fe6b91d169368de923be1ae2e2faf4a31d5d#0108fe6b91d169368de923be1ae2e2faf4a31d5d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d#cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3737,7 +3738,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0108fe6b91d169368de923be1ae2e2faf4a31d5d#0108fe6b91d169368de923be1ae2e2faf4a31d5d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d#cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3749,7 +3750,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0108fe6b91d169368de923be1ae2e2faf4a31d5d#0108fe6b91d169368de923be1ae2e2faf4a31d5d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d#cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3761,7 +3762,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0108fe6b91d169368de923be1ae2e2faf4a31d5d#0108fe6b91d169368de923be1ae2e2faf4a31d5d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d#cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3770,7 +3771,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0108fe6b91d169368de923be1ae2e2faf4a31d5d#0108fe6b91d169368de923be1ae2e2faf4a31d5d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d#cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3779,7 +3780,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0108fe6b91d169368de923be1ae2e2faf4a31d5d#0108fe6b91d169368de923be1ae2e2faf4a31d5d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d#cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3789,7 +3790,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0108fe6b91d169368de923be1ae2e2faf4a31d5d#0108fe6b91d169368de923be1ae2e2faf4a31d5d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d#cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3801,7 +3802,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0108fe6b91d169368de923be1ae2e2faf4a31d5d#0108fe6b91d169368de923be1ae2e2faf4a31d5d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d#cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d"
 dependencies = [
  "image",
  "inventory",
@@ -3816,7 +3817,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0108fe6b91d169368de923be1ae2e2faf4a31d5d#0108fe6b91d169368de923be1ae2e2faf4a31d5d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d#cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d"
 dependencies = [
  "image",
  "inventory",
@@ -3830,7 +3831,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0108fe6b91d169368de923be1ae2e2faf4a31d5d#0108fe6b91d169368de923be1ae2e2faf4a31d5d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d#cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3841,7 +3842,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0108fe6b91d169368de923be1ae2e2faf4a31d5d#0108fe6b91d169368de923be1ae2e2faf4a31d5d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d#cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3853,7 +3854,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0108fe6b91d169368de923be1ae2e2faf4a31d5d#0108fe6b91d169368de923be1ae2e2faf4a31d5d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d#cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3864,7 +3865,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0108fe6b91d169368de923be1ae2e2faf4a31d5d#0108fe6b91d169368de923be1ae2e2faf4a31d5d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d#cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d"
 dependencies = [
  "image",
  "inventory",
@@ -3878,7 +3879,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0108fe6b91d169368de923be1ae2e2faf4a31d5d#0108fe6b91d169368de923be1ae2e2faf4a31d5d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d#cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d"
 dependencies = [
  "image",
  "inventory",
@@ -4209,7 +4210,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5642,7 +5643,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0108fe6b91d169368de923be1ae2e2faf4a31d5d#0108fe6b91d169368de923be1ae2e2faf4a31d5d"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d#cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d"
 dependencies = [
  "core-llm",
  "inventory",
@@ -8039,7 +8040,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -988,19 +988,45 @@
       // base model is recommended for max-quality reference work.
       "capabilities": ["text_to_image", "edit_image", "character_image"],
       "downloads": [
+        // SceneWorks pre-built MLX quant-matrix turnkey (sc-8775, epic 8506): the DISTILLED variant's
+        // own re-host, distinct from the base sensenova-u1-8b-mlx. The 8-step distill LoRA is
+        // PRE-MERGED into the generation path at convert time, then the backbone is packed — so each
+        // per-tier subdir (q4/ default, q8/, bf16/) is a self-contained tree (packed/merged backbone +
+        // tokenizer + config + a `distill_merged.json` marker). The engine's `load_fast` loads the
+        // chosen tier directly and skips the load-time merge (the marker signals it is already baked
+        // in; a packed base cannot re-merge). Per-tier variants (sc-8508): each tier is a SEPARATE
+        // installable artifact with a required `footprint.diskSizeBytes` (EXACT on-disk bytes measured
+        // from the hosted repo per subdir). `default: true` marks q4 as the default tier.
         {
-          // Shares the SenseNova-U1 8B base weights; the ~0.4GB 8-step distill
-          // LoRA is fetched on demand at load time and merged in-process.
           "provider": "huggingface",
-          "repo": "sensenova/SenseNova-U1-8B-MoT",
-          "files": [],
+          "repo": "SceneWorks/sensenova-u1-8b-fast-mlx",
+          "variant": "q4",
           "default": true,
-          "estimatedSizeBytes": 35200000000
+          "files": ["q4/*"],
+          "estimatedSizeBytes": 11824473055,
+          "footprint": { "diskSizeBytes": 11824473055, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/sensenova-u1-8b-fast-mlx",
+          "variant": "q8",
+          "files": ["q8/*"],
+          "estimatedSizeBytes": 19927870497,
+          "footprint": { "diskSizeBytes": 19927870497, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/sensenova-u1-8b-fast-mlx",
+          "variant": "bf16",
+          "files": ["bf16/*"],
+          "estimatedSizeBytes": 35121579949,
+          "footprint": { "diskSizeBytes": 35121579949, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "paths": {
-        "model": "${HF_CACHE}/sensenova/SenseNova-U1-8B-MoT"
+        "model": "${HF_CACHE}/SceneWorks/sensenova-u1-8b-fast-mlx"
       },
+      "gated": false,
       "defaults": {
         "resolution": "2048x2048",
         // 8-step distill LoRA: cfg 1.0 / 8 steps (vs base 4.0 / 50).
@@ -1027,9 +1053,18 @@
         "families": ["sensenova-u1"],
         "types": []
       },
+      "mlx": {
+        // q4/ is the shipped default tier (sc-8775); q8/ + bf16/ are hosted and selectable via
+        // advanced.mlxQuantize (standard_tier_subdir resolves the flat unified tier subdir). Same
+        // unified-MoT packed layout as the base — the WHOLE (pre-merged) backbone packs, no separate
+        // TE, so NO denseTextEncoderTier. The distill LoRA is baked in at convert time (sc-8775), so
+        // load is via the engine's `load_fast` marker-skip path, not a load-time merge.
+        "quantize": 4,
+        "standardTierLayout": true
+      },
       "ui": {
         "label": "SenseNova-U1 8B Fast",
-        "description": "8-step distilled SenseNova-U1 — ~5–6× faster text-to-image, editing, and Character Studio reference (~50s/image on MPS vs ~4.6 min) at a small quality trade-off. Same wardrobe-preserving reference tradeoff as the base SenseNova-U1 8B (carries outfit + accessories + tattoos across new scenes, face may drift — pick InstantID or PuLID-FLUX for face-locked identity). Shares the SenseNova-U1 8B base weights (~35GB); a ~0.4GB distill LoRA downloads automatically on first use. Distilled editing is experimental — use the base SenseNova-U1 8B for max-quality reference work.",
+        "description": "8-step distilled SenseNova-U1 — ~5–6× faster text-to-image, editing, and Character Studio reference (~50s/image on MPS vs ~4.6 min) at a small quality trade-off. Same wardrobe-preserving reference tradeoff as the base SenseNova-U1 8B (carries outfit + accessories + tattoos across new scenes, face may drift — pick InstantID or PuLID-FLUX for face-locked identity). Ships as its own pre-built quant-matrix (q4 default / q8 / bf16), each a self-contained tier with the 8-step distill LoRA already merged in — no separate LoRA download. Distilled editing is experimental — use the base SenseNova-U1 8B for max-quality reference work.",
         "recommendedFor": ["text_to_image", "edit_image", "character_image"],
         // Edit-style variation knob (imageGuidanceScale); see SenseNova-U1 8B
         // for context. The fast variant defaults match the base variant.

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -454,7 +454,17 @@ sceneworks-core = { path = "../sceneworks-core" }
 # 186ac4e, byte-identical — candle links no lens crate and compiles UNCHANGED) so `--features
 # backend-candle --target all` resolves the SINGLE gen-core rev 186ac4e. (candle-gen #205 is
 # squash-merged on candle-gen main as 516e3d5 — the canonical SHA all candle-gen-* pins below point at.)
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe6b91d169368de923be1ae2e2faf4a31d5d" }
+# Rev 0108fe6 -> cc9a8c1 (sc-8775 #625): bumps EVERY mlx-gen crate + gen-core 0108fe6 -> cc9a8c1 to pick
+# up the marker-gated `load_fast` that loads the DISTILLED SenseNova fast id's PRE-MERGED packed
+# q4/q8/bf16 tiers (distill LoRA baked in at convert time; the old pin errors on the quantized base).
+# PURE mlx-gen-sensenova Rust — `git diff 0108fe6..cc9a8c1 -- gen-core/` is EMPTY (gen-core
+# BYTE-IDENTICAL), mlx-rs unchanged (38e1cc1). Cargo unifies the git dep by REV (not content), so the
+# candle-gen pin below moves 90c3215 -> 5d6ae13 IN LOCKSTEP (candle-gen #211 re-pins candle-gen's own
+# gen-core 627828b -> cc9a8c1, byte-identical — candle links no sensenova packed-convert crate and
+# compiles UNCHANGED) so `--features backend-candle` resolves the SINGLE gen-core rev cc9a8c1. NB:
+# 5d6ae13 is candle-gen #211's BRANCH commit (pre-merge); flip all candle-gen-* pins to the merged
+# candle-gen `main` rev once #211 lands.
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -806,7 +816,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe6b91d169368de923be1ae2e2faf4a31d5d" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -822,23 +832,23 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe6b91d
 # exactly this rev, so the worker MUST match (a different rev would compile pmetal-mlx-sys twice). This
 # rebuilds MLX from source. Paired with mlx-llm `6c052ba` below (mlx-llm#45 carries the same fork pin).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe6b91d169368de923be1ae2e2faf4a31d5d" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe6b91d169368de923be1ae2e2faf4a31d5d" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe6b91d169368de923be1ae2e2faf4a31d5d" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d" }
 # Krea 2 Turbo (native MLX, Krea 2 Community License; epic 7565, sc-7572). Same git rev as mlx-gen.
 # Self-registers `krea_2_turbo` (Qwen3-VL-4B TE + 28-block single-stream DiT + Qwen-Image VAE; CFG-free
 # rectified-flow few-step) via inventory only when force-linked (`use mlx_gen_krea as _;` in
 # image_jobs.rs). Loads the packed Q8/Q4 turnkey subdir (krea_model_subdir; the loader auto-detects the
 # packed quant, so the resolved `spec.quantize` is a no-op on it). Depends on mlx-gen-qwen-image for the
 # shared `AutoencoderKLQwenImage` VAE.
-mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe6b91d169368de923be1ae2e2faf4a31d5d" }
+mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d" }
 # Stable Diffusion 3.5 provider (native MLX, Stability AI Community License; epic 7841, sc-7871). Same
 # git rev as mlx-gen so MLX builds once. Self-registers `sd3_5_large` (true-CFG, 28 steps / guidance 3.5)
 # + `sd3_5_large_turbo` (ADD-distilled few-step, CFG-off) + `sd3_5_medium` (MMDiT-X, true-CFG, 40 steps /
@@ -846,7 +856,7 @@ mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe
 # (`use mlx_gen_sd3 as _;` in image_jobs.rs). All three carry a `sd3_5_*_quant` converter. Reuses the SDXL
 # CLIP encoder (×2), the FLUX T5-XXL encoder, and the Z-Image 16-ch VAE — its `quantize_sd3_dir` converter
 # is wired in model_jobs.rs for the `sd3_5_{large,large_turbo,medium}_quant` install-time conversions.
-mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe6b91d169368de923be1ae2e2faf4a31d5d" }
+mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d" }
 # SANA 1600M provider (native MLX, NVIDIA non-commercial license; epic 8485, sc-8489). Same git rev as
 # mlx-gen so MLX builds once. Self-registers `sana_1600m` (Image/t2i, true-CFG, 32× DC-AE divisor,
 # mac_only) via `register_generators!` into the gen-core inventory — surfaces only when force-linked
@@ -854,59 +864,59 @@ mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe6
 # conditioning (sc-8488); the `SanaPipeline` composes SanaTextEncoder -> SanaTransformer (Linear DiT) ->
 # DC-AE f32 decoder and exposes the `from_snapshot`/`from_weights` weight-load entrypoints the generic
 # generator-cache load path drives.
-mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe6b91d169368de923be1ae2e2faf4a31d5d" }
+mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe6b91d169368de923be1ae2e2faf4a31d5d" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe6b91d169368de923be1ae2e2faf4a31d5d" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe6b91d169368de923be1ae2e2faf4a31d5d" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe6b91d169368de923be1ae2e2faf4a31d5d" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d" }
 # CLIP ViT-L/14 image embedder for the Dataset Doctor analysis job (epic 6529 P2, sc-6535).
 # Self-registers `clip_vit_l14` (gen_core::ImageEmbedder) via inventory only when force-linked
 # (`use mlx_gen_clip as _;` in dataset_analysis_jobs.rs). Reuses mlx-gen-sdxl's CLIP body → same rev.
-mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe6b91d169368de923be1ae2e2faf4a31d5d" }
+mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe6b91d169368de923be1ae2e2faf4a31d5d" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe6b91d169368de923be1ae2e2faf4a31d5d" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe6b91d169368de923be1ae2e2faf4a31d5d" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe6b91d169368de923be1ae2e2faf4a31d5d" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe6b91d169368de923be1ae2e2faf4a31d5d" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe6b91d169368de923be1ae2e2faf4a31d5d" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe6b91d169368de923be1ae2e2faf4a31d5d" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -915,19 +925,19 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe6b91d169368de923be1ae2e2faf4a31d5d" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe6b91d169368de923be1ae2e2faf4a31d5d" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d" }
 # Depth Anything V2 (DINOv2 ViT-S/14 + DPT) native-MLX monocular depth estimator (epic 8236,
 # sc-8242). A plain utility crate (NOT a self-registering generation provider): an arbitrary RGB
 # image → a normalized single-channel depth control image, the AUTO depth source for the
 # Fun-Controlnet-Union depth tier (`ControlKind::Depth`) — sibling of the CPU canny/pose
 # preprocessors, but neural so it is macOS-gated (MLX). Consumed by the worker `depth` module /
 # the shared strict-control driver (sc-8243). Same mlx-rs pin as every other mlx-gen crate.
-mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe6b91d169368de923be1ae2e2faf4a31d5d" }
+mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -936,7 +946,7 @@ mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108f
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe6b91d169368de923be1ae2e2faf4a31d5d" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -944,7 +954,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe6b91d169368de923be1ae2e2faf4a31d5d" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -955,7 +965,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe6b91d169368de923be1ae2e2faf4a31d5d" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -966,7 +976,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108f
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe6b91d169368de923be1ae2e2faf4a31d5d" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -988,7 +998,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe
 # a Metal large-tensor limit, not precision). New `VAE_SAFE_DECODE_EDGE_PX=1536` forces decode tiling on
 # a CORRECTNESS cap independent of the memory budget (image + video), so a 2048² upscale that fits memory
 # still tiles. Real-weight 1024→2048 pixel-cosine vs the mflux reference 0.9524 → 0.9974.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe6b91d169368de923be1ae2e2faf4a31d5d" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -999,7 +1009,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "010
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe6b91d169368de923be1ae2e2faf4a31d5d" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d" }
 # The unified LLM engine (epic 7153, sc-7158): the macOS `prompt_refine` job now runs through
 # mlx-llm's generic `mlx-llama` provider (a `core_llm::TextLlm`) resolved model-first via
 # `gen_core::core_llm::load_for_model`, RETIRING the bespoke `mlx-gen-prompt-refine` hand-rolled
@@ -1031,7 +1041,7 @@ mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "7041411f395e43
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108fe6b91d169368de923be1ae2e2faf4a31d5d" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -1346,15 +1356,15 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0108
 # (inference-level memory, like 24 GB cards) and restores the live `Var`s after. SOURCE-ONLY candle-gen
 # fix; both b3aad50 and 5bb83e4 pin gen-core 863f98d, so this stays single-rev (mlx-gen unchanged). ALL
 # candle-gen-* rev lines move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1362,17 +1372,17 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1382,7 +1392,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1390,21 +1400,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1413,17 +1423,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1432,7 +1442,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1465,7 +1475,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1474,12 +1484,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1487,7 +1497,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1496,7 +1506,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1504,7 +1514,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1518,7 +1528,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1545,7 +1555,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1556,7 +1566,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "90c32152226daccd38ea65f4f321e0259136075a", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -459,11 +459,9 @@ sceneworks-core = { path = "../sceneworks-core" }
 # q4/q8/bf16 tiers (distill LoRA baked in at convert time; the old pin errors on the quantized base).
 # PURE mlx-gen-sensenova Rust — `git diff 0108fe6..cc9a8c1 -- gen-core/` is EMPTY (gen-core
 # BYTE-IDENTICAL), mlx-rs unchanged (38e1cc1). Cargo unifies the git dep by REV (not content), so the
-# candle-gen pin below moves 90c3215 -> 5d6ae13 IN LOCKSTEP (candle-gen #211 re-pins candle-gen's own
-# gen-core 627828b -> cc9a8c1, byte-identical — candle links no sensenova packed-convert crate and
-# compiles UNCHANGED) so `--features backend-candle` resolves the SINGLE gen-core rev cc9a8c1. NB:
-# 5d6ae13 is candle-gen #211's BRANCH commit (pre-merge); flip all candle-gen-* pins to the merged
-# candle-gen `main` rev once #211 lands.
+# candle-gen pin below moves to 376b1ef IN LOCKSTEP (candle-gen #211 merge, which re-pins candle-gen's
+# own gen-core 627828b -> cc9a8c1, byte-identical — candle links no sensenova packed-convert crate and
+# compiles UNCHANGED) so `--features backend-candle` resolves the SINGLE gen-core rev cc9a8c1.
 sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cc9a8c12ac32e966dfb92fe1f678dd9a16766e4d" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -1356,24 +1354,23 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "cc9a
 # (inference-level memory, like 24 GB cards) and restores the live `Var`s after. SOURCE-ONLY candle-gen
 # fix; both b3aad50 and 5bb83e4 pin gen-core 863f98d, so this stays single-rev (mlx-gen unchanged). ALL
 # candle-gen-* rev lines move together.
-# Bumped `90c3215` -> `a48aba8` (candle-gen #208, sc-8680) -> `5d6ae13` (candle-gen #211, sc-8775): #208
-# adds faithful base z_image control (renames `ZImageControlPaths.base`→`snapshot`, adds `base: bool` +
-# `guidance`/`negative_prompt` to `ZImageControlRequest`) — the Windows/CUDA half of the sc-8680 worker
+# Bumped `90c3215` -> `a48aba8` (candle-gen #208, sc-8680) -> `376b1ef` (candle-gen #211 merge, sc-8775):
+# #208 adds faithful base z_image control (renames `ZImageControlPaths.base`→`snapshot`, adds `base: bool`
+# + `guidance`/`negative_prompt` to `ZImageControlRequest`) — the Windows/CUDA half of the sc-8680 worker
 # base-control provider (`image_jobs/zimage_control.rs`, updated in #1044); #211 then re-pins candle-gen's
 # OWN gen-core 627828b -> cc9a8c1 IN LOCKSTEP with this worker's mlx-gen bump to cc9a8c1 (mlx-gen #625,
 # sc-8775 sensenova fast packed-load), so `--features backend-candle` resolves the SINGLE gen-core rev
-# cc9a8c1. 5d6ae13 = candle-gen main (incl. the #208 z-image control) + the #211 gen-core repin; NB it is
-# #211's BRANCH commit (pre-merge) — flip all candle-gen-* to the merged candle-gen `main` rev once #211
-# lands. ALL candle-gen-* rev lines move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
+# cc9a8c1. 376b1ef = candle-gen main (incl. the #208 z-image control) + the #211 gen-core repin. ALL
+# candle-gen-* rev lines move together.
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "376b1ef657045afe5e37926591f05afd72a8650c", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "376b1ef657045afe5e37926591f05afd72a8650c", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "376b1ef657045afe5e37926591f05afd72a8650c", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "376b1ef657045afe5e37926591f05afd72a8650c", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "376b1ef657045afe5e37926591f05afd72a8650c", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1381,17 +1378,17 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "376b1ef657045afe5e37926591f05afd72a8650c", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "376b1ef657045afe5e37926591f05afd72a8650c", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "376b1ef657045afe5e37926591f05afd72a8650c", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1401,7 +1398,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "376b1ef657045afe5e37926591f05afd72a8650c", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1409,21 +1406,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "376b1ef657045afe5e37926591f05afd72a8650c", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "376b1ef657045afe5e37926591f05afd72a8650c", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "376b1ef657045afe5e37926591f05afd72a8650c", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "376b1ef657045afe5e37926591f05afd72a8650c", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1432,17 +1429,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "376b1ef657045afe5e37926591f05afd72a8650c", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "376b1ef657045afe5e37926591f05afd72a8650c", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "376b1ef657045afe5e37926591f05afd72a8650c", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1451,7 +1448,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "376b1ef657045afe5e37926591f05afd72a8650c", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1484,7 +1481,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "376b1ef657045afe5e37926591f05afd72a8650c", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1493,12 +1490,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "376b1ef657045afe5e37926591f05afd72a8650c", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "376b1ef657045afe5e37926591f05afd72a8650c", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1506,7 +1503,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "376b1ef657045afe5e37926591f05afd72a8650c", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1515,7 +1512,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "376b1ef657045afe5e37926591f05afd72a8650c", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1523,7 +1520,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "376b1ef657045afe5e37926591f05afd72a8650c", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1537,7 +1534,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "376b1ef657045afe5e37926591f05afd72a8650c", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1564,7 +1561,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "376b1ef657045afe5e37926591f05afd72a8650c", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1575,7 +1572,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d6ae1369734e2e316485fdbcc2b6ac053511c76", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "376b1ef657045afe5e37926591f05afd72a8650c", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -353,7 +353,12 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
     ModelRow {
         sceneworks_id: "sensenova_u1_8b_fast",
         engine_id: "sensenova_u1_8b_fast",
-        default_repo: "sensenova/SenseNova-U1-8B-MoT",
+        // sc-8775: SceneWorks MLX quant-matrix re-host of the *distilled* variant — q4/q8/bf16 packed
+        // tiers with the 8-step distill LoRA PRE-MERGED into the generation path at convert time (a
+        // distinct checkpoint from the base re-host). Each tier carries a `distill_merged.json` marker
+        // so the engine's `load_fast` loads it directly without re-merging (a packed base can't
+        // re-merge). Replaces the old dense-base + distill-LoRA-at-load path.
+        default_repo: "SceneWorks/sensenova-u1-8b-fast-mlx",
         default_steps: 8,
         default_guidance: 1.0,
         adapter_label: "mlx_sensenova",

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -245,9 +245,9 @@ fn mlx_model_table_maps_known_families() {
     );
     let fast = mlx_model("sensenova_u1_8b_fast").unwrap();
     assert_eq!(fast.engine_id(), "sensenova_u1_8b_fast");
-    // sc-8771: _fast is UNCHANGED — stays on the dense bf16 repo + distill-LoRA-at-load path
-    // (packed fast tiers are tracked separately as sc-8775), NOT the new packed re-host.
-    assert_eq!(fast.default_repo(), "sensenova/SenseNova-U1-8B-MoT");
+    // sc-8775: _fast now points at its OWN SceneWorks MLX quant-matrix re-host (q4/q8/bf16 packed
+    // tiers with the 8-step distill LoRA pre-merged at convert time), distinct from the base re-host.
+    assert_eq!(fast.default_repo(), "SceneWorks/sensenova-u1-8b-fast-mlx");
     assert_eq!(fast.default_steps(), 8);
     assert_eq!(fast.default_guidance(), 1.0);
     assert_eq!(fast.adapter_label(), "mlx_sensenova");

--- a/crates/sceneworks-worker/src/sensenova_jobs.rs
+++ b/crates/sceneworks-worker/src/sensenova_jobs.rs
@@ -1558,6 +1558,79 @@ mod tests {
         );
     }
 
+    /// sc-8775 on-device verify (MLX, epic 8506 Group-B): the DISTILLED `_fast` variant's own packed
+    /// re-host. `SceneWorks/sensenova-u1-8b-fast-mlx` ships the 8-step distill LoRA PRE-MERGED into the
+    /// generation path and then packed, so its `q4/model.safetensors` is a distinct checkpoint from the
+    /// base re-host. The worker's `standard_tier_subdir` resolves the flat `q4/` subdir identically to
+    /// the base (covered by `resolves_flat_unified_backbone_tiers`); `load_sensenova_model`'s shared
+    /// `load_raw` + `T2iModel::from_weights` auto-detect the packed `.scales` sidecars and build the
+    /// quantized decoder stack with the merged gen-path weights (NO dense transient, NO load-time
+    /// merge). A short 8-NFE / CFG-1.0 T2I rollout — the distilled defaults — then renders a real image,
+    /// proving the pre-merged packed tier both loads AND generates non-degenerately (a bad merge would
+    /// corrupt the gen path and flatten the decode). The marker-gated `load_fast` skip that the engine
+    /// registry uses for this tier is separately proven in mlx-gen's `prequantize_real_weights`
+    /// (`SC8771_MODEL=sensenova_u1_8b_fast`). Run on demand:
+    /// `cargo test -p sceneworks-worker --lib -- --ignored sensenova_fast_q4_tier_real_weights`.
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "real-weight MLX smoke; needs the SceneWorks/sensenova-u1-8b-fast-mlx q4 tier cached + a Metal device"]
+    fn sensenova_fast_q4_tier_real_weights_produces_image() {
+        let root = hf_snapshot("models--SceneWorks--sensenova-u1-8b-fast-mlx");
+        let q4_dir = root.join("q4");
+        assert!(
+            q4_dir.join("model.safetensors").is_file(),
+            "packed fast q4 tier not found at {} — download it: \
+             hf download SceneWorks/sensenova-u1-8b-fast-mlx --include 'q4/*'",
+            q4_dir.display()
+        );
+        // The distill LoRA is baked in; the marker rides the tier for provenance/loader gating.
+        assert!(
+            q4_dir.join("distill_merged.json").is_file(),
+            "pre-merged fast tier missing its distill_merged.json marker at {}",
+            q4_dir.display()
+        );
+        let (model, tokenizer) = load_sensenova_model(&q4_dir).expect("load packed fast q4 model");
+        // Distilled defaults: 8 NFE at CFG 1.0 (the `_fast` variant's manifest defaults).
+        let opts = T2iOptions {
+            cfg_scale: 1.0,
+            img_cfg_scale: 1.0,
+            num_steps: 8,
+            timestep_shift: 3.0,
+            seed: 42,
+            ..Default::default()
+        };
+        let out = model
+            .generate(
+                &tokenizer,
+                "a single red circle on a white background, flat vector illustration",
+                512,
+                512,
+                &opts,
+                None,
+                None,
+            )
+            .expect("fast t2i generate");
+        let decoded = decoded_to_image(&out.image).expect("decode");
+        assert_eq!(
+            decoded.pixels.len(),
+            (decoded.width * decoded.height * 3) as usize
+        );
+        // Non-degenerate check: a NaN/all-black/flat decode (e.g. a corrupt merge) collapses std → 0.
+        let n = decoded.pixels.len() as f64;
+        let mean = decoded.pixels.iter().map(|&p| p as f64).sum::<f64>() / n;
+        let std = (decoded
+            .pixels
+            .iter()
+            .map(|&p| (p as f64 - mean).powi(2))
+            .sum::<f64>()
+            / n)
+            .sqrt();
+        assert!(
+            std > 10.0,
+            "packed fast q4 render looks degenerate (std {std:.2}, mean {mean:.2}) — possible NaN / all-black / flat decode or a bad distill merge"
+        );
+    }
+
     #[cfg(target_os = "macos")]
     #[test]
     fn build_segments_trailing_image_without_marker_is_appended() {


### PR DESCRIPTION
Worker half of **sc-8775** — points `sensenova_u1_8b_fast` at its own SceneWorks MLX quant-matrix re-host (the 8-step distill LoRA **pre-merged then packed**; engine PR SceneWorks/mlx-gen#625), distinct from the base re-host wired in sc-8771 (#1043).

## Changes
- **engines.rs**: `_fast` `default_repo` → `SceneWorks/sensenova-u1-8b-fast-mlx`.
- **builtin.models.jsonc**: the `_fast` entry gets the sc-8508 per-tier schema — q4(default)/q8/bf16 downloads with `files` filters, `variant`, and required `footprint.diskSizeBytes` (EXACT bytes measured from the built tiers); `paths` → the fast re-host; `gated:false`; `mlx.quantize:4` + `mlx.standardTierLayout:true`. Same flat unified layout as the base — resolved by sc-8771's `standard_tier_subdir` flat-tier support, **no new resolver**. Description updated (self-contained pre-merged tiers, no separate LoRA download).
- **image_jobs/tests.rs**: `_fast` `default_repo` assertion → the fast re-host.
- **sensenova_jobs.rs**: `sensenova_fast_q4_tier_real_weights_produces_image` (`#[ignore]` real-weight MLX smoke) loads the packed fast q4 tier and renders a distilled 8-NFE / CFG-1.0 T2I, asserting a non-degenerate decode + the `distill_merged.json` marker rides the tier.

## Measured tier footprints (built on-device; same source as mlx-gen#625)
| tier | bytes | render px std |
|------|-------|--------------|
| q4 | 11,824,473,055 | 84.0 |
| q8 | 19,927,870,497 | 89.7 |
| bf16 (merged) | 35,121,579,949 | 91.6 |

## ⚠️ Blocked until (do NOT merge before)
1. **mlx-gen#625 merged + the `mlx-gen-*` pins bumped to that rev.** The pre-merged packed fast tiers require the marker-gated `load_fast`; on the current pin, loading a packed fast q4/q8 tier errors on the quantized base (`merge_dense_delta`). I'll do the pin bump + re-run the gen-core skew gate once #625 lands.
2. **The three tiers uploaded to `SceneWorks/sensenova-u1-8b-fast-mlx`** (q4/q8/bf16). This is the maintainer's HF-publish step; upload commands are in the sc-8775 handoff.

The code changes here compile + pass CI on the current pin (they are pin-independent for compilation); the blockers are runtime/hosting only.

Relates to sc-8771, epic 3180 / epic 8506.

🤖 Generated with [Claude Code](https://claude.com/claude-code)