### PR TITLE
feat(lens): wire recovered base Lens packed q4/q8/bf16 tiers → SceneWorks/lens-mlx (sc-8767)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -699,16 +699,47 @@
       "adapter": "lens_turbo",
       "capabilities": ["text_to_image", "style_variations"],
       "downloads": [
+        // SceneWorks pre-built MLX quant-matrix turnkey (sc-8767, epic 8506, Group-B): the recovered +
+        // rebuilt non-distilled base Lens, re-hosted from Comfy-Org/Lens (the original microsoft/Lens
+        // source is dead). Per-tier self-contained subdirs (transformer DiT + gpt-oss-20b MoE text
+        // encoder + FLUX.2 VAE + tokenizer + scheduler + model_index.json): q4/ (default), q8/, bf16/.
+        // The worker loads the chosen tier's subdir directly (standard_tier_subdir,
+        // mlx.standardTierLayout), mirroring lens_turbo. Base Lens is NOT dense-TE: the gpt-oss MoE
+        // encoder ships packed per-tier alongside the transformer (q4/q8 packed), so no
+        // denseTextEncoderTier. Per-tier variants (sc-8508): each tier is a SEPARATE installable
+        // artifact tagged with a `variant` key + a `footprint` (required on-disk diskSizeBytes;
+        // resident/peak backfilled by sc-8770). diskSizeBytes are the EXACT summed on-disk bytes of
+        // each SceneWorks/lens-mlx tier subdir. Replaces the dead whole-repo microsoft/Lens download.
         {
           "provider": "huggingface",
-          "repo": "microsoft/Lens",
-          "files": [],
-          "estimatedSizeBytes": 30800000000
+          "repo": "SceneWorks/lens-mlx",
+          "variant": "q4",
+          "default": true,
+          "files": ["q4/*"],
+          "estimatedSizeBytes": 18998339228,
+          "footprint": { "diskSizeBytes": 18998339228, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/lens-mlx",
+          "variant": "q8",
+          "files": ["q8/*"],
+          "estimatedSizeBytes": 29921486998,
+          "footprint": { "diskSizeBytes": 29921486998, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/lens-mlx",
+          "variant": "bf16",
+          "files": ["bf16/*"],
+          "estimatedSizeBytes": 22347329085,
+          "footprint": { "diskSizeBytes": 22347329085, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "paths": {
-        "model": "${HF_CACHE}/microsoft/Lens"
+        "model": "${HF_CACHE}/SceneWorks/lens-mlx"
       },
+      "gated": false,
       "defaults": {
         // Non-distilled base: 20 steps, CFG 5.0 (vs Turbo's 4 / 1.0).
         "resolution": "1024x1024",
@@ -730,6 +761,19 @@
         // Same `lens` family as Lens-Turbo; a LoRA trained here applies to both.
         "families": ["lens"],
         "types": ["style", "enhance", "character"]
+      },
+      // macOS-only native-MLX backend. mlx.quantize/tier config is consumed by the RUST worker
+      // (standard_tier_subdir / resolve_quant). q4/ default tier (sc-8767); q8/ + bf16/ hosted +
+      // selectable via advanced.mlxQuantize (standard_tier_subdir resolves the subdir). Base Lens is
+      // NOT dense-TE: the gpt-oss-20b MoE text encoder is packed per-tier alongside the transformer,
+      // so there is no denseTextEncoderTier override — every component is packed at the chosen tier.
+      "mlx": {
+        "minMemoryGb": 60,
+        // sc-8508: the manifest-driven form of the STANDARD_TIER_MODELS registry. Additive here opts
+        // this id into `uses_standard_tier_layout` so the worker resolves the q4/q8/bf16 subdir
+        // directly from the turnkey snapshot.
+        "quantize": 4,
+        "standardTierLayout": true
       },
       "ui": {
         "label": "Lens (base)",

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -382,11 +382,13 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
     // The two SceneWorks ids map 1:1 to the engine registry ids of the same name and differ only in
     // their step/guidance defaults: base `lens` is 20-step / CFG 5.0, distilled `lens_turbo` is
     // 4-step / guidance 1.0 (≈ no CFG) — Python `MODEL_TARGETS` parity. Each variant resolves its own
-    // `microsoft/Lens` / `microsoft/Lens-Turbo` HF snapshot dir.
+    // SceneWorks re-host: base `lens` → `SceneWorks/lens-mlx` (recovered/rebuilt from Comfy-Org/Lens,
+    // sc-8767; original microsoft/Lens source is dead), distilled `lens_turbo` → `SceneWorks/lens-turbo-mlx`.
+    // Both are pre-quantized per-tier turnkey snapshots (q4/q8/bf16, standardTierLayout).
     ModelRow {
         sceneworks_id: "lens",
         engine_id: "lens",
-        default_repo: "microsoft/Lens",
+        default_repo: "SceneWorks/lens-mlx",
         default_steps: 20,
         default_guidance: 5.0,
         adapter_label: "mlx_lens",

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -1112,18 +1112,20 @@ fn flux2_klein_9b_kv_real_weights_generates_one_image() {
     );
 }
 
-/// Real-weights smoke: Microsoft Lens base (epic 3164 / sc-5105) — 20-step, standard guidance 5.0 +
-/// a negative prompt (the `mlx-gen-lens` descriptor is `supports_guidance` + `supports_negative_prompt`,
-/// NOT true-CFG). Loads the `microsoft/Lens` snapshot dir (tokenizer/ text_encoder/ transformer/ vae/)
-/// at the Q8 default (encoder MoE + DiT). Needs the HF cache + a Metal device; run on demand:
+/// Real-weights smoke: base Lens (epic 3164 / sc-5105, re-hosted sc-8767) — 20-step, standard
+/// guidance 5.0 + a negative prompt (the `mlx-gen-lens` descriptor is `supports_guidance` +
+/// `supports_negative_prompt`, NOT true-CFG). The upstream `microsoft/Lens` source is dead (Microsoft
+/// pulled it); base `lens` now defaults to the tier-subdir'd `SceneWorks/lens-mlx`, so this loads the
+/// `bf16/` tier subdir (the flat diffusers tree: tokenizer/ text_encoder/ transformer/ vae/) at the Q8
+/// default (encoder MoE + DiT). Needs the HF cache + a Metal device; run on demand:
 /// `cargo test -p sceneworks-worker --lib -- --ignored lens_real_weights`.
 #[cfg(target_os = "macos")]
 #[test]
-#[ignore = "needs real microsoft/Lens weights + Metal device"]
+#[ignore = "needs real SceneWorks/lens-mlx weights + Metal device"]
 fn lens_real_weights_generates_one_image() {
     smoke_generate_one(
         "lens",
-        hf_snapshot("models--microsoft--Lens"),
+        hf_snapshot("models--SceneWorks--lens-mlx").join("bf16"),
         Some(5.0),
         Some("blurry, low quality".to_owned()),
     );

--- a/crates/sceneworks-worker/src/lens_base_q4_mlx_smoke.rs
+++ b/crates/sceneworks-worker/src/lens_base_q4_mlx_smoke.rs
@@ -1,0 +1,211 @@
+//! Local real-weight MLX smoke for the recovered base **Lens** **Q4** worker lane (sc-8767, epic 8506
+//! Group-B). `#[ignore]`d — run by hand on an Apple-Silicon Mac. It drives the real native-MLX `lens`
+//! engine via `gen_core::load("lens")` with a **Q4** `LoadSpec` pointed at the packed `q4/` turnkey
+//! subdir — the exact runtime seam `generate_stream` uses (minus the API/job plumbing) when the router
+//! routes a base `lens` MLX job (`standard_tier_subdir` → the `q4/` subdir; `resolve_quant` →
+//! `Quant::Q4`).
+//!
+//! Purpose: on-device evidence that the recovered SceneWorks/lens-mlx pre-quantized q4 turnkey loads
+//! through the worker packed path (`mlx.standardTierLayout` → `standard_tier_subdir` resolves `q4/`) and
+//! renders a non-degenerate image. Base Lens packs BOTH the transformer DiT and the gpt-oss-20b MoE text
+//! encoder per-tier (it is NOT a dense-TE model), so the q4 load-quant is a harmless no-op on the
+//! already-packed weights. The base differs from lens_turbo only in its 20-step / CFG 5.0 defaults.
+//!
+//! Setup — point at the published turnkey `SceneWorks/lens-mlx` (the worker default). With the q4 tier
+//! already in the HF cache, no env is needed: the smoke auto-resolves the cached snapshot's `q4/` subdir
+//! (the same selection `image_jobs::base::standard_tier_subdir` makes for `mlxQuantize: 4`). Override
+//! `LENS_BASE_Q4_DIR` to point at a snapshot root or a `q4/`-bearing dir directly.
+//! ```text
+//! # optional: LENS_BASE_Q4_DIR=/path/to/lens-mlx  (root containing q4/, or the q4/ dir itself)
+//! # optional: LENS_STEPS=20 LENS_W=1024 LENS_H=1024 LENS_PROMPT="..." LENS_OUT_DIR=/tmp/lens_base_q4_smoke
+//! cargo test -p sceneworks-worker --release lens_base_q4_mlx_gpu_smoke -- --ignored --nocapture
+//! ```
+
+use std::path::{Path, PathBuf};
+
+use gen_core::{GenerationOutput, GenerationRequest, Image, LoadSpec, Quant, WeightsSource};
+
+fn env_or(key: &str, default: &str) -> String {
+    std::env::var(key)
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| default.to_string())
+}
+
+/// The engine-complete packed subdir to load: mirror `image_jobs::base::standard_tier_subdir`'s q4
+/// selection — prefer `<root>/q4` (lens turnkeys pack the backbone under `transformer/`), else `root`
+/// itself if it already *is* a q4 root. Errors loud if neither resolves so a half-download surfaces as
+/// a clear failure rather than a confusing engine load error.
+fn resolve_q4_dir(root: &Path) -> PathBuf {
+    let is_engine_root = |d: &Path| {
+        d.join("transformer/diffusion_pytorch_model.safetensors")
+            .is_file()
+    };
+    let q4 = root.join("q4");
+    if is_engine_root(&q4) {
+        return q4;
+    }
+    assert!(
+        is_engine_root(root),
+        "LENS_BASE_Q4_DIR must point at the turnkey root (containing q4/) or a q4/ dir with a packed \
+         transformer/diffusion_pytorch_model.safetensors; neither found under {}",
+        root.display()
+    );
+    root.to_path_buf()
+}
+
+/// Auto-discover the cached `SceneWorks/lens-mlx` turnkey snapshot in the HF hub cache, returning the
+/// snapshot whose `q4/` subdir carries the packed transformer. `None` if the q4 tier hasn't been pulled
+/// (the smoke then panics with the `LENS_BASE_Q4_DIR` hint).
+fn cached_turnkey_root() -> Option<PathBuf> {
+    let home = std::env::var("HOME").ok()?;
+    let snapshots =
+        PathBuf::from(home).join(".cache/huggingface/hub/models--SceneWorks--lens-mlx/snapshots");
+    std::fs::read_dir(&snapshots)
+        .ok()?
+        .filter_map(|e| e.ok())
+        .find_map(|e| {
+            let dir = e.path();
+            dir.join("q4/transformer/diffusion_pytorch_model.safetensors")
+                .is_file()
+                .then_some(dir)
+        })
+}
+
+/// Per-pixel mean over the RGB buffer — the "is it black?" floor check, reported for the record.
+fn image_mean(img: &Image) -> f64 {
+    let n = img.pixels.len() as f64;
+    if n == 0.0 {
+        return 0.0;
+    }
+    img.pixels.iter().map(|&p| p as f64).sum::<f64>() / n
+}
+
+/// Mean per-pixel std-dev across the RGB channels — a cheap "is the image non-degenerate" check. A
+/// NaN / all-black / flat decode collapses the std toward 0; this guards that degenerate floor. The real
+/// quality call is the saved-PNG eyeball.
+fn image_std(img: &Image) -> f64 {
+    let n = img.pixels.len() as f64;
+    if n == 0.0 {
+        return 0.0;
+    }
+    let mean = image_mean(img);
+    let var = img
+        .pixels
+        .iter()
+        .map(|&p| (p as f64 - mean).powi(2))
+        .sum::<f64>()
+        / n;
+    var.sqrt()
+}
+
+/// Whether EVERY pixel byte is exactly 0 — the precise degenerate signature of a broken decode.
+fn is_all_zero(img: &Image) -> bool {
+    !img.pixels.is_empty() && img.pixels.iter().all(|&p| p == 0)
+}
+
+fn save_png(img: &Image, path: &Path) {
+    image::RgbImage::from_raw(img.width, img.height, img.pixels.clone())
+        .expect("rgb buffer")
+        .save(path)
+        .unwrap_or_else(|e| panic!("save {}: {e}", path.display()));
+}
+
+#[test]
+#[ignore = "real-weight MLX smoke; needs the SceneWorks/lens-mlx q4 turnkey cached + an Apple-Silicon Mac"]
+fn lens_base_q4_mlx_gpu_smoke() {
+    let root = match std::env::var("LENS_BASE_Q4_DIR") {
+        Ok(p) if !p.trim().is_empty() => PathBuf::from(p.trim()),
+        _ => cached_turnkey_root().unwrap_or_else(|| {
+            panic!(
+                "no cached SceneWorks/lens-mlx q4 turnkey found; download it via the manifest \
+                 (`hf download SceneWorks/lens-mlx --include 'q4/*'`) or set LENS_BASE_Q4_DIR to the \
+                 turnkey root (containing q4/)"
+            )
+        }),
+    };
+    let q4_dir = resolve_q4_dir(&root);
+
+    let out_dir = PathBuf::from(env_or("LENS_OUT_DIR", "/tmp/lens_base_q4_smoke"));
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+
+    let steps: u32 = env_or("LENS_STEPS", "20").parse().expect("LENS_STEPS");
+    let w: u32 = env_or("LENS_W", "1024").parse().expect("LENS_W");
+    let h: u32 = env_or("LENS_H", "1024").parse().expect("LENS_H");
+    let prompt = env_or(
+        "LENS_PROMPT",
+        "a photorealistic portrait of a red fox sitting in a sunlit autumn forest, sharp focus, \
+         shallow depth of field",
+    );
+
+    // Same seam as the worker's MLX image path: a registry load of the base `lens` generator (the
+    // worker-crate force-link anchor `use mlx_gen_lens as _;` keeps it registered) + a Q4 `LoadSpec`
+    // pointed at the packed q4 turnkey subdir. The packed weights auto-detect their quant, so
+    // `with_quant(Q4)` matches the manifest's `mlx.quantize: 4` tier.
+    println!(
+        "[smoke] loading lens (base, Q4) from {} ...",
+        q4_dir.display()
+    );
+    let spec = LoadSpec::new(WeightsSource::Dir(q4_dir.clone())).with_quant(Quant::Q4);
+    let generator = gen_core::load("lens", &spec).expect("load mlx lens (base) generator");
+
+    // Base Lens: non-distilled 20-step, CFG 5.0.
+    let req = GenerationRequest {
+        prompt: prompt.clone(),
+        width: w,
+        height: h,
+        count: 1,
+        seed: Some(42),
+        steps: Some(steps),
+        guidance: Some(5.0),
+        ..Default::default()
+    };
+    println!("[smoke] rendering {w}x{h} @ {steps} steps ...");
+    let mut last = String::new();
+    let output = generator
+        .generate(&req, &mut |p| {
+            let s = format!("{p:?}");
+            if s != last {
+                println!("[progress] {s}");
+                last = s;
+            }
+        })
+        .expect("lens (base) generate");
+    let image = match output {
+        GenerationOutput::Images(mut images) => images.pop().expect("engine returned no image"),
+        other => panic!("expected Images output, got {other:?}"),
+    };
+
+    let mean = image_mean(&image);
+    let std = image_std(&image);
+    let all_zero = is_all_zero(&image);
+    let png = out_dir.join(format!("lens_base_q4_{steps}step.png"));
+    save_png(&image, &png);
+    println!(
+        "[smoke] lens (base) Q4 {}x{} mean {:.2} std {:.2} all_zero={} -> {}",
+        image.width,
+        image.height,
+        mean,
+        std,
+        all_zero,
+        png.display()
+    );
+    assert_eq!(
+        (image.width, image.height),
+        (w, h),
+        "engine returned the wrong dimensions"
+    );
+    assert!(
+        !all_zero,
+        "lens (base) Q4 decode is ALL-ZERO — a broken packed load/decode"
+    );
+    assert!(
+        std > 20.0,
+        "lens (base) Q4 render looks degenerate (std {std:.2}) — possible NaN / all-black / flat decode"
+    );
+    println!(
+        "[smoke] DONE: lens (base) Q4 render coherent (mean {mean:.2}, std {std:.2}, NOT all-zero) \
+         at {steps} steps through the worker packed lane"
+    );
+}

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -178,6 +178,13 @@ mod sdxl_base_q8_mlx_smoke;
 // non-degenerate (both transformer + gpt-oss MoE TE are packed per-tier; NOT a dense-TE model).
 #[cfg(all(test, target_os = "macos"))]
 mod lens_turbo_q4_mlx_smoke;
+// Real-weight MLX smoke for the recovered base Lens Q4 worker lane (sc-8767, epic 8506 Group-B).
+// Test-only + macOS-only; drives `gen_core::load("lens")` with a Q4 LoadSpec against the packed `q4/`
+// turnkey subdir. On-device evidence that the SceneWorks/lens-mlx pre-quantized q4 tier loads through the
+// worker packed path (`mlx.standardTierLayout` → `standard_tier_subdir` resolves `q4/`) and renders
+// non-degenerate (both transformer + gpt-oss MoE TE are packed per-tier; NOT a dense-TE model).
+#[cfg(all(test, target_os = "macos"))]
+mod lens_base_q4_mlx_smoke;
 // Real-weight MLX smoke for the Chroma1-Base Q4 worker lane (sc-8777, epic 8506 Group-B). Test-only +
 // macOS-only; drives `gen_core::load("chroma1_base")` with a Q4 LoadSpec against the packed `q4/` turnkey
 // subdir. On-device evidence that the SceneWorks/chroma1-base-mlx pre-quantized q4 tier loads through the


### PR DESCRIPTION
## Summary

Completes **sc-8767**. Converts the base `lens` catalog entry from the **dead** `microsoft/Lens` source into a first-class sc-8508 **tiered** entry, mirroring `lens_turbo`. Base Lens was recovered + rebuilt from **Comfy-Org/Lens** and re-hosted at **SceneWorks/lens-mlx** (q4/q8/bf16), render-verified.

**Worker-only PR** — pure assembly. No `mlx-gen` / `candle-gen` change → **no pin bumps, no candle-gen lockstep, no skew gate**. `lens_turbo` is untouched.

## Changes

- **engines.rs**: base `lens` `default_repo` `microsoft/Lens` → `SceneWorks/lens-mlx` (step/CFG defaults 20 / 5.0 unchanged; `lens_turbo` row untouched). Engine-row comment refreshed for the re-host.
- **config/manifests/builtin.models.jsonc** — base `lens` entry:
  - per-tier `downloads`: **q4 (default)** / q8 / bf16 with `files` filters (`["q4/*"]` …) + `variant` keys
  - `footprint.diskSizeBytes` = **EXACT** summed on-disk bytes per tier subdir (q4 `18998339228`, q8 `29921486998`, bf16 `22347329085`); `residentMemoryBytes`/`peakMemoryBytes` **NULL** (sc-8770 backfills)
  - `paths.model` → `SceneWorks/lens-mlx`, `gated:false`, `mlx.quantize:4`, `mlx.standardTierLayout:true`
  - dead `microsoft/Lens` source + `gated:true` dropped. **NOT dense-TE** (encoder ships packed q4/q8) → no `denseTextEncoderTier` / not added to `DENSE_TE_TIER_MODELS`.
  - **`lens_turbo` entry byte-unchanged** (confirmed).
- Add macOS-only real-weight MLX smoke `lens_base_q4_mlx_smoke` mirroring the `lens_turbo` smoke.

## Verification (on-device, Apple Silicon MLX)

- Base `lens` q4 loads via the worker packed path (`standard_tier_subdir` resolves `q4/`) and renders **coherent** 1024² @ 20 steps (mean 87.74, std 48.54, non-degenerate).
- `lens_turbo` q4 still resolves + renders unchanged (4-step, coherent).

## Checks

- `cargo fmt` clean · `cargo clippy -p sceneworks-worker --lib --all-targets` clean
- `cargo test -p sceneworks-worker --lib`: 480 passed
- candle-parity compile `cargo check -p sceneworks-worker --no-default-features -F backend-candle --all-targets`: clean
- rust-api contracts: not regenerated — the manifest is runtime data; no contract snapshot/binding flows it through. No generated TS types changed → web vitest N/A.

**Notes:** worker-only, no pins; base Lens recovered from Comfy-Org/Lens; `lens_turbo` untouched. Do not merge — coordinator merges after CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)