### PR TITLE
fix(ci): pin all GitHub Actions to commit SHAs + Dependabot updates (sc-8801)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Keeps the SHA-pinned GitHub Actions in .github/workflows/ fresh (sc-8801).
+# Dependabot rewrites the pinned commit SHA and its trailing `# vX.Y.Z` comment
+# when upstream publishes a new release.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,8 +11,8 @@ jobs:
   web:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
           cache: "npm"
@@ -29,19 +29,20 @@ jobs:
   parity:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
           cache: "pip"
           cache-dependency-path: ".github/workflows/check.yml"
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
         with:
+          toolchain: stable
           components: clippy,rustfmt
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 (v2.9.1+1)
       - name: Install contract test dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -54,18 +54,19 @@ jobs:
       # Ampere->Blackwell (sc-3676); build-sidecar.mjs defaults this too.
       CUDA_COMPUTE_CAP: "80"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
         with:
+          toolchain: stable
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 (v2.9.1+1)
       # Put the VS2022 MSVC toolchain (cl.exe) on PATH so nvcc finds the host
       # compiler when candle-kernels' build script compiles the CUDA kernels.
       - name: Set up MSVC developer environment
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       # Install the CUDA 12.9 Toolkit (nvcc + cudart/cublas/curand/nvrtc dev libs)
       # the candle `cuda` feature links against. Sets CUDA_PATH for the build +
       # the redist staging in build-sidecar.mjs.
@@ -74,7 +75,7 @@ jobs:
         # pin tops out at 12.8.0 (network method still validates against the map), so
         # `cuda: "12.9.1"` failed with "Version not available". (Kept in lockstep with
         # server-candle-linux.yml's pin.)
-        uses: Jimver/cuda-toolkit@v0.2.35
+        uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76 # v0.2.35
         with:
           cuda: "12.9.1"
           method: "network"
@@ -115,7 +116,7 @@ jobs:
       - name: Build Windows candle installers (NSIS + MSI)
         run: npm --prefix apps/desktop run build -- --bundles nsis,msi
       - name: Upload installer artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: sceneworks-windows-installers
           path: |

--- a/.github/workflows/macos-mlx.yml
+++ b/.github/workflows/macos-mlx.yml
@@ -57,9 +57,10 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: [self-hosted, macOS, ARM64, nax]
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
         with:
+          toolchain: stable
           components: clippy
       # No MACOSX_DEPLOYMENT_TARGET override: the workspace /.cargo/config.toml pins
       # 26.2, so the NAX kernels compile in and the fast path is actually built.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,9 +55,11 @@ jobs:
       TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
       TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
+        with:
+          toolchain: stable
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "20"
 
@@ -155,21 +157,23 @@ jobs:
       TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
       TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
+        with:
+          toolchain: stable
       # Put the VS2022 MSVC toolchain (cl.exe) on PATH so nvcc finds the host
       # compiler when candle-kernels' build script compiles the CUDA kernels.
       - name: Set up MSVC developer environment
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       # Install the CUDA 12.9 Toolkit (nvcc + cudart/cublas/curand/nvrtc dev libs)
       # the candle `cuda` feature links against. Sets CUDA_PATH for the build +
       # the redist staging in build-sidecar.mjs. (Pin kept in lockstep with
       # desktop-windows.yml / server-candle-linux.yml.)
       - name: Install CUDA Toolkit 12.9
-        uses: Jimver/cuda-toolkit@v0.2.35
+        uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76 # v0.2.35
         with:
           cuda: "12.9.1"
           method: "network"

--- a/.github/workflows/server-candle-linux.yml
+++ b/.github/workflows/server-candle-linux.yml
@@ -34,14 +34,15 @@ jobs:
       # Ampere->Blackwell (mirrors the Windows lane / build-sidecar.mjs default).
       CUDA_COMPUTE_CAP: "80"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
         with:
+          toolchain: stable
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 (v2.9.1+1)
       # Install the CUDA 12.9 Toolkit (nvcc + cudart/cublas/curand/nvrtc dev libs)
       # the candle `cuda` feature links against. Sets CUDA_PATH for the build.
       # `--toolkit` skips the (GPU-less runner) driver install — we only compile.
@@ -50,7 +51,7 @@ jobs:
         # pin tops out at 12.8.0 (network method still validates against the map), so
         # `cuda: "12.9.1"` failed with "Version not available". (Kept in lockstep with
         # desktop-windows.yml's pin.)
-        uses: Jimver/cuda-toolkit@v0.2.35
+        uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76 # v0.2.35
         with:
           cuda: "12.9.1"
           method: "network"
@@ -83,7 +84,7 @@ jobs:
       - name: Build candle server (rust-api, embed-web + backend-candle)
         run: cargo build -p sceneworks-rust-api --release --features embed-web,backend-candle
       - name: Upload candle server artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: sceneworks-api-candle-linux
           path: target/release/sceneworks-rust-api

--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -63,7 +63,7 @@ jobs:
       # SASS directly (no load-time JIT). compute_80 PTX would also forward-JIT.
       CUDA_COMPUTE_CAP: "120"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       # No rust-toolchain action: the self-hosted box has rustup + the repo's
       # `rust-toolchain.toml`-pinned toolchain (incl. clippy) pre-installed, and the
       # action's bash step breaks here — `bash` resolves to the box's WSL stub, not


### PR DESCRIPTION
## What & why

Fixes finding F-001 (High, security) from the 2026-07-01 full code review: third-party GitHub Actions were referenced by mutable tags/branches (`dtolnay/rust-toolchain@stable` — a moving branch — `Swatinem/rust-cache@v2`, `ilammy/msvc-dev-cmd@v1`, `Jimver/cuda-toolkit@v0.2.35`). In `release.yml` these run in jobs whose env holds `TAURI_SIGNING_PRIVATE_KEY(_PASSWORD)` and the Apple notary credentials, and the macOS job runs on the self-hosted signing Mac. A compromised upstream tag could exfiltrate the minisign updater key that signs the `latest.json` payloads the shipped app auto-installs (full user-base compromise) and get code execution on the box holding the Developer ID cert.

Story: https://app.shortcut.com/trefry/story/8801

## Changes

- **Every** `uses:` reference in all six workflow files is now pinned to a full commit SHA with a `# <version>` comment.
- **`actions/*` pinned too (deliberate choice):** the finding only mandated non-`actions/*`, but this repo's release/signing path is security-sensitive (self-hosted signing runner + updater key), GitHub's own actions have had tag-moving incidents in the ecosystem's threat model, and the cost is zero once Dependabot maintains the pins — so first-party actions are pinned as well.
- **`dtolnay/rust-toolchain` semantics preserved:** that action infers the toolchain from the ref name (`@stable`), which a SHA pin loses, so every pinned usage now passes `with: toolchain: stable` explicitly (the pinned commit's `action.yml` also defaults to `stable`, so this is belt-and-braces).
- **`.github/dependabot.yml` added** with a weekly, grouped `github-actions` update ecosystem so the pinned SHAs stay fresh (Dependabot rewrites both the SHA and the trailing version comment). Note: Dependabot tracks tag/release pins; the `dtolnay/rust-toolchain` pin follows a branch, so it may need occasional manual refresh.

## Tag → SHA mapping (verified via `git ls-remote` against each upstream, 2026-07-01)

| Action | Ref used before | Pinned SHA | Resolves to |
|---|---|---|---|
| dtolnay/rust-toolchain | `stable` (branch) | `4be7066ada62dd38de10e7b70166bc74ed198c30` | `refs/heads/stable` head |
| Swatinem/rust-cache | `v2` (annotated tag) | `e18b497796c12c097a38f9edb9d0641fb99eee32` | peeled `v2^{}` (= v2.9.1 + 1 changelog commit, verified via compare API: ahead 1 / behind 0) |
| ilammy/msvc-dev-cmd | `v1` | `0b201ec74fa43914dc39ae48a89fd1d8cb592756` | `v1` = `v1.13.0` |
| Jimver/cuda-toolkit | `v0.2.35` | `3d45d157f327c09c04b50ee6ccdea2d9d017ec76` | `v0.2.35` |
| actions/checkout | `v4` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | `v4` = `v4.3.1` |
| actions/checkout | `v5` | `93cb6efe18208431cddfb8368fd83d5badbf9bfd` | `v5` = `v5.0.1` |
| actions/setup-node | `v4` | `49933ea5288caeca8642d1e84afbd3f7d6820020` | `v4` = `v4.4.0` |
| actions/setup-node | `v5` | `a0853c24544627f65ddf259abe73b1d18a591444` | `v5` = `v5.0.0` |
| actions/setup-python | `v5` | `a26af69be951a213d495a4c3e4e4022e16d87065` | `v5` = `v5.6.0` |
| actions/upload-artifact | `v4` | `ea165f8d65b6e75b540449e92b4886f43607fa02` | `v4` = `v4.6.2` |

Annotated tags were peeled to the commit SHA (`ref^{}`); `uses:` requires a commit SHA, not a tag object. The exact-version annotations come from reverse-matching each SHA against the upstream tag list.

## Scope vs the finding

The finding cited `release.yml`, `desktop-windows.yml`, and `check.yml`. A full sweep of `.github/workflows/` also found the same mutable refs in `macos-mlx.yml` (runs on the self-hosted signing Mac!), `server-candle-linux.yml`, and `windows-candle.yml` — all pinned. No composite actions exist under `.github/actions/`. No `uses:` reference remains unpinned.

## Verification

- `actionlint` run before and after the change; the outputs diff **identical** (the only findings are pre-existing custom self-hosted runner labels `nax`/`cuda`, unrelated to this change). yamllint is not installed locally and was not installed (per policy); YAML validity additionally confirmed by parsing every `.github/**/*.yml` with a YAML loader.
- Every pinned SHA cross-checked with `git ls-remote` (branch head / peeled tag) and, for the annotated-tag and rust-toolchain cases, with the GitHub commits/compare API.
- The `dtolnay/rust-toolchain` pinned commit's `action.yml` was fetched and inspected to confirm the `toolchain` input exists and defaults to `stable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)