### PR TITLE
fix(worker): heartbeat/cancel interval arm in image-detail event loop (sc-8805)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/detail.rs
+++ b/crates/sceneworks-worker/src/image_jobs/detail.rs
@@ -321,6 +321,33 @@ fn detail_result(
     .expect("json! object literal")
 }
 
+/// Acknowledge a user cancel mid-refine: trip the engine flag and show a NON-terminal
+/// "Cancelling…" (indeterminate bar). The terminal Canceled is deferred to after the
+/// blocking refinement actually stops so the worker row isn't freed while it's still
+/// grinding the current tile (sc-5516; mirrors the image path's `begin_image_cancel`,
+/// sc-5515). Best-effort update.
+pub(crate) async fn begin_detail_cancel(
+    api: &ApiClient,
+    job_id: &str,
+    cancel: &CancelFlag,
+    backend: &str,
+) {
+    cancel.cancel();
+    let _ = update_job(
+        api,
+        job_id,
+        image_progress(
+            JobStatus::Running,
+            ProgressStage::Generating,
+            0.0,
+            "Cancelling — stopping the current tile…",
+            None,
+            backend,
+        ),
+    )
+    .await;
+}
+
 /// Native MLX tile-ControlNet detail refine (`JobType::ImageDetail`) on the macOS engine.
 pub(crate) async fn run_image_detail_job(
     api: &ApiClient,
@@ -436,49 +463,59 @@ pub(crate) async fn run_image_detail_job(
 
     let mut last_cancel_check = Instant::now();
     let mut canceled = false;
-    while let Some((done, total)) = rx.recv().await {
-        if canceled {
-            continue; // drain so the blocking sender never blocks; terminal posts after stop.
-        }
-        if last_cancel_check.elapsed() >= Duration::from_secs(2) {
-            last_cancel_check = Instant::now();
-            if cancel_requested_peek(api, &job.id).await {
-                // Trip the engine flag and show a NON-terminal "Cancelling…" (indeterminate bar);
-                // the terminal Canceled is deferred to after the blocking refinement actually
-                // stops so the worker row isn't freed while it's still grinding the current tile
-                // (sc-5516; mirrors the image path sc-5515). Best-effort update.
-                cancel.cancel();
-                let _ = update_job(
+    // Heartbeat + cancel-poll on a fixed interval, not only when the blocking thread
+    // finishes a tile. The cold SDXL+tile-ControlNet load and each full multi-step tile
+    // refine emit nothing, so without an interval arm the worker posts no Busy heartbeat
+    // (the API's staleness sweep would falsely mark the job `interrupted` — sc-4276 /
+    // sc-8390) and a user cancel would only be seen at a tile boundary. Mirrors
+    // `consume_gen_events` (base.rs); the shared `CancelFlag` is also inside the engine's
+    // `GenerationRequest`, so tripping it here interrupts the in-flight tile promptly
+    // rather than waiting for the tile-loop boundary check.
+    let mut interval = tokio::time::interval(progress_report_interval(settings));
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        tokio::select! {
+            maybe_tile = rx.recv() => {
+                let Some((done, total)) = maybe_tile else {
+                    break;
+                };
+                if canceled {
+                    continue; // drain so the blocking sender never blocks; terminal posts after stop.
+                }
+                if last_cancel_check.elapsed() >= Duration::from_secs(2) {
+                    last_cancel_check = Instant::now();
+                    if cancel_requested_peek(api, &job.id).await {
+                        begin_detail_cancel(api, &job.id, &cancel, backend).await;
+                        canceled = true;
+                        continue;
+                    }
+                }
+                update_job(
                     api,
                     &job.id,
                     image_progress(
                         JobStatus::Running,
                         ProgressStage::Generating,
-                        0.0,
-                        "Cancelling — finishing the current tile…",
+                        0.45 + 0.5 * (done as f64 / total.max(1) as f64),
+                        &format!("Refining detail tile {done}/{total}."),
                         None,
                         backend,
                     ),
                 )
-                .await;
-                canceled = true;
-                continue;
+                .await?;
+                heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+            }
+            _ = interval.tick() => {
+                heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+                if !canceled && last_cancel_check.elapsed() >= Duration::from_secs(2) {
+                    last_cancel_check = Instant::now();
+                    if cancel_requested_peek(api, &job.id).await {
+                        begin_detail_cancel(api, &job.id, &cancel, backend).await;
+                        canceled = true;
+                    }
+                }
             }
         }
-        update_job(
-            api,
-            &job.id,
-            image_progress(
-                JobStatus::Running,
-                ProgressStage::Generating,
-                0.45 + 0.5 * (done as f64 / total.max(1) as f64),
-                &format!("Refining detail tile {done}/{total}."),
-                None,
-                backend,
-            ),
-        )
-        .await?;
-        heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
     }
 
     let join = blocking

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -3343,6 +3343,44 @@ async fn begin_training_cancel_trips_flag_and_stays_non_terminal() {
     );
 }
 
+/// sc-5516 / sc-8805 — the detail sibling: `begin_detail_cancel` trips the engine flag
+/// (which the interval-armed detail event loop now reaches within one ~2s poll even while
+/// the model is cold-loading or a tile is mid-refine) and acknowledges with a NON-terminal
+/// `running` update; the terminal `Canceled` is posted by `run_image_detail_job` only after
+/// the blocking refinement actually stops. macOS-only because `image_jobs/detail.rs` is the
+/// macOS MLX route (off-Mac `run_image_detail_job` is a hard error stub).
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn begin_detail_cancel_trips_flag_and_stays_non_terminal() {
+    let (base_url, posts) = spawn_progress_capture_stub().await;
+    let mut settings = test_settings(base_url.clone(), None);
+    settings.api_url = base_url;
+    let api = ApiClient::new(&settings);
+    let cancel = gen_core::CancelFlag::new();
+    crate::image_jobs::begin_detail_cancel(&api, "job-1", &cancel, "mlx").await;
+    assert!(
+        cancel.is_cancelled(),
+        "begin_detail_cancel must trip the engine cancel flag"
+    );
+    let posts = posts.lock().expect("posts lock");
+    assert_eq!(
+        posts.len(),
+        1,
+        "exactly one acknowledgement update is posted"
+    );
+    assert_eq!(
+        posts[0]["status"], "running",
+        "the cancel acknowledgement must stay NON-terminal (sc-5516)"
+    );
+    assert!(
+        posts[0]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("Cancelling"),
+        "the acknowledgement message should read as Cancelling…"
+    );
+}
+
 /// sc-4176 — on macOS an MLX-routed model whose weights don't resolve must
 /// fail loudly with a precise re-download error instead of silently completing
 /// with procedural stub output; non-engine model ids keep the stub path.


### PR DESCRIPTION
## Summary

Fixes [sc-8805](https://app.shortcut.com/trefry/story/8805) — F-004 from the 2026-07-01 full code review (High, bad-pattern).

`run_image_detail_job` (`crates/sceneworks-worker/src/image_jobs/detail.rs`) drove a bespoke `while let Some(..) = rx.recv().await` event loop with **no `tokio::select!` interval arm**. The loop only woke when the blocking thread emitted a tile-boundary event, so:

- **Cold model load**: the multi-GB SDXL + tile-ControlNet load emits nothing → no `Busy` heartbeat → the API staleness sweep (silent >90s ⇒ `interrupted`, sc-8390) could falsely sweep a cold-cache detail job. This is the same sc-4276 staleness bug that `consume_gen_events` (base.rs) was already fixed for — the fix never propagated to this sibling.
- **Cancel latency**: `cancel_requested_peek` only ran when a tile event arrived, so a user cancel could take a full 24-step tile refine (tens of seconds to minutes) to even trip the flag.

## Fix

Mirror the `consume_gen_events` pattern (the repo convention for streaming consumers per the `run_blocking_with_heartbeat` docs in `progress.rs`): the recv is now wrapped in `tokio::select!` with an `interval.tick()` arm (`progress_report_interval`, `MissedTickBehavior::Delay`) that

- posts a `WorkerStatus::Busy` heartbeat every interval, covering the **whole loop lifetime** — cold model load and per-tile refinement alike, and
- runs the ~2s `cancel_requested_peek`, tripping the shared `CancelFlag` promptly. That flag is also embedded in the engine's `GenerationRequest` (per-step engine poll) and checked at the tile-loop boundary, so cancel now interrupts the in-flight tile rather than waiting for the next tile event.

The cancel acknowledgement (trip flag + NON-terminal `running` "Cancelling…" update; terminal `Canceled` still deferred to actual-stop so the worker row isn't freed early, sc-5516) is needed from both select! arms, so it's extracted into `begin_detail_cancel` — the detail sibling of `begin_image_cancel` / `begin_video_cancel` / `begin_training_cancel`.

## Tests

- Added `tests::begin_detail_cancel_trips_flag_and_stays_non_terminal` (macOS-gated, matching the existing sc-5516 `begin_video_cancel` / `begin_training_cancel` stub-server tests): asserts the flag trips, exactly one acknowledgement POST, `status == "running"` (non-terminal), message reads "Cancelling…".
- The select!-with-interval arm itself follows the same untested-by-unit-test convention as `consume_gen_events` and the caption/upscale/media/training loops (exercising it end-to-end needs real weights); verified by compile + full suite.
- `cargo test -p sceneworks-worker` — 615+ tests green.
- `npm run rust:check` (fmt + clippy + test + build) — exit 0.
- `cargo check -p sceneworks-worker --no-default-features --features backend-candle --all-targets` (candle parity lane) — green (detail.rs is macOS-gated; the off-Mac stub is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)