### PR TITLE
fix(worker): confine LoRA/model import source paths (sc-8803)

### DIFF
--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -1639,30 +1639,36 @@ pub(crate) async fn run_lora_import_job(
         .await?;
     } else if let Some(source_path) = source_path {
         let prefer_move = payload_bool(&job.payload, "uploadedSourcePath");
+        // sc-8803: the source path is client-supplied over the unauthenticated jobs
+        // API; confine it (staged-upload cache for uploads, app-managed roots
+        // otherwise) before the copy/move reaches the filesystem.
+        let source_path = resolve_import_source_path(
+            settings,
+            &job.payload,
+            source_path,
+            "lora-uploads",
+            "LoRA import sourcePath",
+        )?;
         if let Some(secondary_source_path) =
             optional_payload_string(&job.payload, "secondarySourcePath")
         {
+            let secondary_source_path = resolve_import_source_path(
+                settings,
+                &job.payload,
+                secondary_source_path,
+                "lora-uploads",
+                "LoRA import secondarySourcePath",
+            )?;
             // Paired Wan A14B MoE upload (sc-1991): write both halves into one
             // record under the high/low_noise convention so the high half resolves
             // as the primary (transformer) and the low half as the transformer_2
             // sibling, regardless of the user's original upload filenames.
             let (high_name, low_name) = wan_moe_pair_filenames(&target_name);
-            import_lora_source_file_as(
-                Path::new(source_path),
-                &target_dir,
-                &high_name,
-                prefer_move,
-            )
-            .await?;
-            import_lora_source_file_as(
-                Path::new(secondary_source_path),
-                &target_dir,
-                &low_name,
-                prefer_move,
-            )
-            .await?;
+            import_lora_source_file_as(&source_path, &target_dir, &high_name, prefer_move).await?;
+            import_lora_source_file_as(&secondary_source_path, &target_dir, &low_name, prefer_move)
+                .await?;
         } else {
-            import_lora_source_path(Path::new(source_path), &target_dir, prefer_move).await?;
+            import_lora_source_path(&source_path, &target_dir, prefer_move).await?;
         }
     } else if let Some(source_url) = source_url {
         download_lora_source_url(
@@ -1979,8 +1985,18 @@ pub(crate) async fn run_model_import_job(
         )
         .await?;
     } else if let Some(source_path) = source_path {
+        // sc-8803: confine the client-supplied model import source the same way as
+        // LoRA imports (staged model-upload cache for uploads, app-managed roots
+        // otherwise) before the copy/move reaches the filesystem.
+        let source_path = resolve_import_source_path(
+            settings,
+            &job.payload,
+            source_path,
+            "model-uploads",
+            "Model import sourcePath",
+        )?;
         import_lora_source_path(
-            Path::new(source_path),
+            &source_path,
             &target_dir,
             payload_bool(&job.payload, "uploadedSourcePath"),
         )

--- a/crates/sceneworks-worker/src/paths.rs
+++ b/crates/sceneworks-worker/src/paths.rs
@@ -283,6 +283,51 @@ pub(crate) fn project_path_for_payload(
     Ok(Some(PathBuf::from(project.path)))
 }
 
+/// Confine a client-supplied import *source* path (sc-8803 / F-002). LoRA/model
+/// import jobs arrive over the unauthenticated local jobs API (LAN-exposed via
+/// epic 4484), and the worker copies — or with `uploadedSourcePath: true`, moves —
+/// the source into an app-listable target dir, so an unconfined source is an
+/// arbitrary-file-read/exfiltration primitive (and move mode deletes the original).
+/// The rust-api validates `sourcePath` at job creation, but the worker is the
+/// stated trust boundary and must re-confine:
+/// - uploaded sources (move mode) must live in the API's staged-upload cache,
+///   `<data>/cache/<upload_cache>` (`lora-uploads` / `model-uploads`), matching
+///   `cleanup_uploaded_import_source`;
+/// - copy-mode sources must live under the app data dir or, for project-scoped
+///   imports, the owning project's `loras` tree (resolved from the trusted
+///   project store, mirroring `resolve_lora_import_target`).
+///
+/// Symlinks resolve before the root check, like `normalize_app_managed_lora_path`.
+pub(crate) fn resolve_import_source_path(
+    settings: &Settings,
+    payload: &JsonObject,
+    raw_path: &str,
+    upload_cache: &str,
+    label: &str,
+) -> WorkerResult<PathBuf> {
+    let raw_path = raw_path.trim();
+    if raw_path.is_empty() {
+        return Err(WorkerError::InvalidPayload(format!("{label} is required.")));
+    }
+    let mut roots = Vec::new();
+    if payload_bool(payload, "uploadedSourcePath") {
+        let upload_root = settings.data_dir.join("cache").join(upload_cache);
+        roots.push(normalize_absolute_path(&upload_root)?);
+        roots.push(normalize_existing_or_absolute(&upload_root)?);
+    } else {
+        roots.push(normalized_data_dir(settings)?);
+        roots.push(normalize_existing_or_absolute(&settings.data_dir)?);
+        if let Some(project_path) = project_path_for_payload(settings, payload)? {
+            let project_loras = project_path.join("loras");
+            roots.push(normalize_absolute_path(&project_loras)?);
+            roots.push(normalize_existing_or_absolute(&project_loras)?);
+        }
+    }
+    let normalized = normalize_absolute_path(Path::new(raw_path))?;
+    let resolved = normalize_existing_or_absolute(&normalized)?;
+    ensure_path_under(resolved, &roots, label)
+}
+
 pub(crate) fn resolve_lora_import_target(
     settings: &Settings,
     payload: &JsonObject,

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -2768,6 +2768,163 @@ fn lora_paths_resolve_symlinks_before_root_check() {
     assert!(error.to_string().contains("LoRA path must be inside"));
 }
 
+// sc-8803 / F-002: LoRA/model import *source* paths are client-supplied over the
+// unauthenticated jobs API; the worker must confine them before copying (or, for
+// uploads, moving) the file into an app-listable directory.
+#[test]
+fn import_source_paths_are_confined_to_app_managed_roots() {
+    let temp = tempdir().expect("tempdir creates");
+    let data_dir = temp.path().join("data");
+    let staged_dir = data_dir
+        .join("cache")
+        .join("lora-uploads")
+        .join("upload-abc");
+    let loras_dir = data_dir.join("loras").join("existing");
+    let outside_dir = temp.path().join("outside");
+    std::fs::create_dir_all(&staged_dir).expect("staged dir creates");
+    std::fs::create_dir_all(&loras_dir).expect("loras dir creates");
+    std::fs::create_dir_all(&outside_dir).expect("outside dir creates");
+
+    let mut settings = test_settings("http://127.0.0.1".to_owned(), None);
+    settings.data_dir = data_dir.clone();
+
+    // Uploaded (move-mode) sources are accepted only from the staged-upload cache.
+    let staged_file = staged_dir.join("lora.safetensors");
+    std::fs::write(&staged_file, b"staged").expect("staged file writes");
+    let mut uploaded = JsonObject::new();
+    uploaded.insert("uploadedSourcePath".to_owned(), Value::Bool(true));
+    let resolved = super::resolve_import_source_path(
+        &settings,
+        &uploaded,
+        &staged_file.display().to_string(),
+        "lora-uploads",
+        "LoRA import sourcePath",
+    )
+    .expect("staged upload source accepted");
+    assert!(resolved.ends_with("lora.safetensors"));
+
+    // Uploaded flag with a source elsewhere in data_dir is rejected: move mode
+    // would otherwise delete arbitrary app-managed files.
+    let installed_file = loras_dir.join("installed.safetensors");
+    std::fs::write(&installed_file, b"installed").expect("installed file writes");
+    let error = super::resolve_import_source_path(
+        &settings,
+        &uploaded,
+        &installed_file.display().to_string(),
+        "lora-uploads",
+        "LoRA import sourcePath",
+    )
+    .expect_err("uploaded source outside the staged-upload cache rejects");
+    assert!(error
+        .to_string()
+        .contains("LoRA import sourcePath must be inside"));
+
+    // Copy-mode sources under data_dir are accepted (re-import of an installed file).
+    let copy_payload = JsonObject::new();
+    super::resolve_import_source_path(
+        &settings,
+        &copy_payload,
+        &installed_file.display().to_string(),
+        "lora-uploads",
+        "LoRA import sourcePath",
+    )
+    .expect("data_dir source accepted for copy-mode import");
+
+    // The model-import upload cache confines the same way.
+    let model_staged = data_dir
+        .join("cache")
+        .join("model-uploads")
+        .join("upload-def");
+    std::fs::create_dir_all(&model_staged).expect("model staged dir creates");
+    let model_file = model_staged.join("model.safetensors");
+    std::fs::write(&model_file, b"model").expect("model file writes");
+    super::resolve_import_source_path(
+        &settings,
+        &uploaded,
+        &model_file.display().to_string(),
+        "model-uploads",
+        "Model import sourcePath",
+    )
+    .expect("staged model upload accepted");
+
+    // An absolute path outside data_dir (the exfiltration primitive) is rejected
+    // in both modes.
+    let secret = outside_dir.join("id_rsa");
+    std::fs::write(&secret, b"secret").expect("secret writes");
+    for payload in [&uploaded, &copy_payload] {
+        let error = super::resolve_import_source_path(
+            &settings,
+            payload,
+            &secret.display().to_string(),
+            "lora-uploads",
+            "LoRA import sourcePath",
+        )
+        .expect_err("host path outside app-managed roots rejects");
+        assert!(error
+            .to_string()
+            .contains("LoRA import sourcePath must be inside"));
+    }
+
+    // A `..` traversal that starts inside data_dir but escapes is rejected.
+    let traversal = data_dir
+        .join("loras")
+        .join("..")
+        .join("..")
+        .join("outside")
+        .join("id_rsa");
+    super::resolve_import_source_path(
+        &settings,
+        &copy_payload,
+        &traversal.display().to_string(),
+        "lora-uploads",
+        "LoRA import sourcePath",
+    )
+    .expect_err("traversal escape rejects");
+
+    // An empty source path is rejected.
+    super::resolve_import_source_path(
+        &settings,
+        &copy_payload,
+        "  ",
+        "lora-uploads",
+        "LoRA import sourcePath",
+    )
+    .expect_err("empty source path rejects");
+}
+
+// Symlinks resolve before the root check, so a link planted inside data_dir cannot
+// smuggle an outside file through the import copy.
+#[cfg(unix)]
+#[test]
+fn import_source_symlink_escape_is_rejected() {
+    let temp = tempdir().expect("tempdir creates");
+    let data_dir = temp.path().join("data");
+    let loras_dir = data_dir.join("loras");
+    let outside_dir = temp.path().join("outside");
+    std::fs::create_dir_all(&loras_dir).expect("loras dir creates");
+    std::fs::create_dir_all(&outside_dir).expect("outside dir creates");
+
+    let mut settings = test_settings("http://127.0.0.1".to_owned(), None);
+    settings.data_dir = data_dir.clone();
+
+    let outside_file = outside_dir.join("escape.safetensors");
+    std::fs::write(&outside_file, b"outside").expect("outside file writes");
+    let link = loras_dir.join("escape-link.safetensors");
+    std::os::unix::fs::symlink(&outside_file, &link).expect("symlink creates");
+
+    let error = super::resolve_import_source_path(
+        &settings,
+        &JsonObject::new(),
+        &link.display().to_string(),
+        "lora-uploads",
+        "LoRA import sourcePath",
+    )
+    .expect_err("symlink target outside managed roots rejects");
+    assert!(error
+        .to_string()
+        .contains("LoRA import sourcePath must be inside"));
+}
+
 #[tokio::test]
 async fn ffmpeg_runner_surfaces_bounded_stderr_from_failing_process() {
     let args = if cfg!(windows) {


### PR DESCRIPTION
## What

Confines the client-supplied import **source** paths (`sourcePath` / `secondarySourcePath`) in `run_lora_import_job` and `run_model_import_job` before any copy/move reaches the filesystem. Closes finding **F-002 (High, security)** from the 2026-07-01 full code review.

Shortcut: https://app.shortcut.com/trefry/story/8803

## Why

The worker is the stated trust boundary (unauthenticated local jobs API; LAN exposure via epic 4484). Both import jobs passed the payload source path straight to `import_lora_source_path` / `import_lora_source_file_as`, which copy — or with `uploadedSourcePath: true`, **move** — the file with no confinement. A crafted import job could copy any host-readable file (e.g. `~/.ssh/id_rsa`) into `data/loras/<name>/`, where the app makes it listable/fetchable — an arbitrary-file-read/exfiltration primitive; move mode additionally deleted the original. Target dirs and every sibling *read* path were already confined (`normalize_app_managed_lora_path`, sc-5723 / WKA-002); the import *source* was the gap.

## How

New `resolve_import_source_path` helper in `crates/sceneworks-worker/src/paths.rs`, following the existing confinement conventions (normalize + canonicalize-before-root-check, `WorkerError::InvalidPayload` on escape):

- **Uploaded sources** (`uploadedSourcePath: true`, move mode) must live in the API's staged-upload cache — `<data>/cache/lora-uploads` (LoRA) / `<data>/cache/model-uploads` (model) — matching the rust-api's `validate_lora_import_source_path` roots and the worker's `cleanup_uploaded_import_source`. This also blocks move-mode deletion of arbitrary app-managed files.
- **Copy-mode sources** must live under the app data dir, or — for project-scoped imports — the owning project's `loras` tree (resolved from the trusted project store via `project_path_for_payload`, mirroring `resolve_lora_import_target`).
- Symlinks resolve before the root check (same as `normalize_app_managed_lora_path`), so a link planted inside `data/` cannot smuggle an outside file through the copy.

## Surface covered

Every client-supplied import source in `model_jobs.rs`:
- LoRA import `sourcePath` (single-file/dir, copy and move modes)
- LoRA import `secondarySourcePath` (paired Wan A14B MoE upload, sc-1991)
- Model import `sourcePath` (copy and move modes)

Legitimate flows are unaffected: the rust-api only ever emits staged-upload paths (`data/cache/{lora,model}-uploads/upload-<uuid>/…`) for uploads and validates non-upload sources against `data/loras` / `project/loras` / `data/models` at job creation — all inside the roots accepted here.

## Tests

- `tests::import_source_paths_are_confined_to_app_managed_roots` — staged LoRA upload accepted; staged model upload accepted via `model-uploads`; copy-mode `data_dir` source accepted; uploaded flag + source outside the staged cache rejected; absolute outside-`data_dir` path rejected in both modes; `..` traversal escape rejected; empty path rejected.
- `tests::import_source_symlink_escape_is_rejected` (unix) — symlink inside `data/loras` pointing outside is rejected after resolution.

## Verification

- `cargo test -p sceneworks-worker` — 482 passed, 0 failed (135 ignored, pre-existing)
- `npm run rust:check` — green (fmt --check + clippy + build), exit 0
- `cargo check -p sceneworks-worker --no-default-features --features backend-candle --all-targets` — green (candle parity lane)

🤖 Generated with [Claude Code](https://claude.com/claude-code)