### PR TITLE
feat(lens): add off-Mac candle diffusers download entries for lens/lens_turbo (sc-8799)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -716,6 +716,7 @@
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
+          "platforms": ["macos"],
           "estimatedSizeBytes": 18998339228,
           "footprint": { "diskSizeBytes": 18998339228, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
@@ -724,6 +725,7 @@
           "repo": "SceneWorks/lens-mlx",
           "variant": "q8",
           "files": ["q8/*"],
+          "platforms": ["macos"],
           "estimatedSizeBytes": 29921486998,
           "footprint": { "diskSizeBytes": 29921486998, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
@@ -732,8 +734,27 @@
           "repo": "SceneWorks/lens-mlx",
           "variant": "bf16",
           "files": ["bf16/*"],
+          "platforms": ["macos"],
           "estimatedSizeBytes": 22347329085,
           "footprint": { "diskSizeBytes": 22347329085, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          // Off-Mac candle (Windows/Linux) diffusers rehost (sc-8799): the MLX turnkeys above are packed
+          // q4/q8/bf16 tiers the candle diffusers loader can't read, so the candle lane loads THIS
+          // self-contained diffusers snapshot (tokenizer/ text_encoder/ transformer/ vae/ at the repo
+          // root — what candle_gen_lens::Pipeline::load_components reads), rebuilt from Comfy-Org/Lens +
+          // openai/gpt-oss-20b (MXFP4) + FLUX.2-dev after the original microsoft/Lens went dead. Whole
+          // repo (files: []); the candle provider quantizes on-the-fly (Q4/Q8, descriptor-gated) at
+          // load, so the single bf16 source serves every candle quant tier. Mirrors ideogram_4's
+          // off-Mac bf16 entry + the Wan2.2 macOS-MLX/off-Mac-diffusers split. Resolved by
+          // `candle_lens_repo` (image_jobs/base.rs). Candle sibling of the MLX host sc-8767.
+          "provider": "huggingface",
+          "repo": "SceneWorks/Lens",
+          "variant": "bf16",
+          "files": [],
+          "platforms": ["windows", "linux"],
+          "estimatedSizeBytes": 22334041829,
+          "footprint": { "diskSizeBytes": 22334041829, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "paths": {
@@ -815,6 +836,7 @@
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
+          "platforms": ["macos"],
           "estimatedSizeBytes": 21830326407,
           // Measured on-device (sc-8516, harness crates/sceneworks-worker/src/footprint_measure.rs):
           // Apple Silicon, 1024², fresh process, via mlx_rs::memory::{get_active_memory,get_peak_memory}.
@@ -830,6 +852,7 @@
           "repo": "SceneWorks/lens-turbo-mlx",
           "variant": "q8",
           "files": ["q8/*"],
+          "platforms": ["macos"],
           "estimatedSizeBytes": 32753474289,
           "footprint": { "diskSizeBytes": 32753474289, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
@@ -838,8 +861,25 @@
           "repo": "SceneWorks/lens-turbo-mlx",
           "variant": "bf16",
           "files": ["bf16/*"],
+          "platforms": ["macos"],
           "estimatedSizeBytes": 30651441376,
           "footprint": { "diskSizeBytes": 30651441376, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          // Off-Mac candle (Windows/Linux) diffusers rehost (sc-8799): the distilled sibling of the
+          // base-Lens off-Mac entry above. The MLX turnkeys are packed q4/q8/bf16 tiers the candle
+          // diffusers loader can't read, so the candle lane loads THIS self-contained diffusers snapshot
+          // (tokenizer/ text_encoder/ transformer/ vae/ at the repo root), rebuilt from Comfy-Org/Lens'
+          // lens_turbo_bf16 DiT + openai/gpt-oss-20b (MXFP4) + FLUX.2-dev after microsoft/Lens-Turbo went
+          // dead. Whole repo (files: []); candle quantizes on-the-fly at load. Resolved by
+          // `candle_lens_repo`. Candle sibling of the MLX host sc-8763.
+          "provider": "huggingface",
+          "repo": "SceneWorks/Lens-Turbo",
+          "variant": "bf16",
+          "files": [],
+          "platforms": ["windows", "linux"],
+          "estimatedSizeBytes": 22334041788,
+          "footprint": { "diskSizeBytes": 22334041788, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "paths": {


### PR DESCRIPTION
## Summary

Follow-up to #1048 (which wired `generate_candle_stream` to resolve `SceneWorks/Lens` for the candle Windows/CUDA lane). The **model catalog** (`config/manifests/builtin.models.jsonc`) still listed only the MLX-packed `SceneWorks/lens-mlx` / `lens-turbo-mlx` downloads with **no `platforms` tag** — so `retain_downloads_for_os` kept them on all platforms, and a Windows/Linux box would fetch the MLX tiers (unreadable by the candle diffusers loader) and never fetch `SceneWorks/Lens`. The resolver knew the right repo; the downloader didn't. This closes that half.

## Change

Split the Lens / Lens-Turbo `downloads` per platform, mirroring the existing `ideogram_4` and Wan2.2 macOS-MLX-vs-off-Mac-diffusers pattern:

- Tag the three MLX `q4`/`q8`/`bf16` tiers `platforms: ["macos"]`.
- Add a `platforms: ["windows", "linux"]` entry per model fetching the **whole** [`SceneWorks/Lens`](https://huggingface.co/SceneWorks/Lens) / [`SceneWorks/Lens-Turbo`](https://huggingface.co/SceneWorks/Lens-Turbo) diffusers rehost (`files: []`). The candle provider quantizes on-the-fly (Q4/Q8, descriptor-gated) at load, so one bf16 source serves every candle quant tier — matching how `generate_candle_stream` loads the snapshot root.

macOS is unchanged (only the MLX tiers survive the filter there).

## Verification

- `sceneworks-core` `builtin_manifests` — JSONC parses/seeds (3/3).
- `sceneworks-rust-api` `downloadable_model_catalog` — parse + per-OS platform filtering + install-state (7/7).
- `sceneworks-rust-api` `model_and_lora_routes_match_manifest_behavior` (1/1).

Completes sc-8799 (candle sibling of the MLX hosts sc-8767 / sc-8763).

🤖 Generated with [Claude Code](https://claude.com/claude-code)