### PR TITLE
fix(web): decouple login password draft from live API token (sc-8808)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -469,6 +469,10 @@ export function App() {
   // of "access token required" errors (epic 4484).
   const [accessResolved, setAccessResolved] = useState(false);
   const [token, setToken] = useState(() => window.localStorage.getItem("sceneworks-token") ?? "");
+  // What the user is typing into the login gate (sc-8808). Kept separate from the
+  // live `token` so keystrokes never flip `authenticated` or churn the data/SSE
+  // effects; `token` only changes once /api/v1/auth/verify accepts the draft.
+  const [passwordDraft, setPasswordDraft] = useState("");
   // Wrong-password feedback for the remote-browser login gate (epic 4484 story 7).
   const [authError, setAuthError] = useState("");
   const [projects, setProjects] = useState([]);
@@ -1262,13 +1266,16 @@ export function App() {
 
 
   // Remote-browser login (epic 4484 story 7): the password IS the API access token.
-  // Verify it against the public /api/v1/auth/verify endpoint BEFORE persisting, so a
-  // wrong password keeps the gate up (instead of saving a bad token and silently
-  // failing every subsequent request). A correct password is stored to localStorage
-  // and unlocks the app; it persists across reloads.
+  // Verify the typed draft against the public /api/v1/auth/verify endpoint BEFORE
+  // promoting it to the live `token`, so a wrong password keeps the gate up with an
+  // inline error (instead of saving a bad token and silently failing every subsequent
+  // request). A correct password is stored to localStorage and unlocks the app; it
+  // persists across reloads. Promoting the token here flips `authenticated`, and the
+  // [authenticated, token] effects perform the initial data load and SSE connect
+  // exactly once — no explicit refreshData() call, or it would double-fetch (sc-8808).
   async function saveToken(event) {
     event.preventDefault();
-    const candidate = token.trim();
+    const candidate = passwordDraft.trim();
     if (!candidate) {
       setAuthError("Enter the password.");
       return;
@@ -1285,17 +1292,18 @@ export function App() {
     }
     window.localStorage.setItem("sceneworks-token", candidate);
     setToken(candidate);
+    setPasswordDraft("");
     setAuthError("");
     setError("");
-    refreshData();
   }
 
   // Clear the stored password and re-show the login gate ("lock"/forget affordance,
-  // epic 4484 story 7). Setting the token state to "" forces a re-render so the gate
-  // (which keys off the stored token) reappears.
+  // epic 4484 story 7). Setting the token state to "" re-renders the gate, which
+  // keys off the token state (sc-8808).
   function lockRemote() {
     window.localStorage.removeItem("sceneworks-token");
     setToken("");
+    setPasswordDraft("");
     setAuthError("");
   }
 
@@ -2252,17 +2260,20 @@ export function App() {
           <p className="notice error" key={notice.kind}>{notice.message}</p>
         ))}
 
-        {access.authRequired && !isDesktopShell && !window.localStorage.getItem("sceneworks-token") ? (
+        {/* Gate visibility keys off the token STATE (not a render-time localStorage
+            read), and the input edits a local draft — never the live token — so
+            typing can't flip `authenticated` or fire API/SSE traffic (sc-8808). */}
+        {access.authRequired && !isDesktopShell && !token ? (
           <section className="auth-band">
             <form onSubmit={saveToken}>
               <label htmlFor="token">Password</label>
               <div className="form-row">
                 <input
                   id="token"
-                  onChange={(event) => setToken(event.target.value)}
+                  onChange={(event) => setPasswordDraft(event.target.value)}
                   placeholder="Enter the access password"
                   type="password"
-                  value={token}
+                  value={passwordDraft}
                 />
                 <button type="submit">Unlock</button>
               </div>

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -672,6 +672,126 @@ describe("SceneWorks app shell", () => {
     expect(logsTokens.every((value) => value === "pair-tok-123")).toBe(true);
   });
 
+  // sc-8808 (F-007): the login gate's password box keeps its own draft state.
+  // Before the fix it wrote every keystroke straight into the live `token`, so
+  // the first character flipped `authenticated` and the [authenticated, token]
+  // effects fired refreshData + the SSE ticket POST per keystroke, each 401ing
+  // with a partial password and filling the notices band mid-typing.
+  function mockAuthRequiredFetch({ verifyOk, requests, tokens }) {
+    global.fetch = vi.fn((url, options = {}) => {
+      const path = new URL(url).pathname;
+      requests?.push({ path, method: options.method ?? "GET" });
+      tokens?.push(new Headers(options.headers ?? {}).get("X-SceneWorks-Token"));
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: true }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: true }));
+      }
+      if (path.endsWith("/auth/verify")) {
+        return Promise.resolve(response({ ok: verifyOk }));
+      }
+      if (path.endsWith("/jobs/events/ticket")) {
+        return Promise.resolve(response({ ticket: "stream-ticket" }));
+      }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response([{ id: "project-default", name: "Default Project" }]));
+      }
+      return Promise.resolve(response([]));
+    });
+  }
+
+  it("does not fire API calls or SSE connections while typing the login password", async () => {
+    const requests = [];
+    mockAuthRequiredFetch({ verifyOk: true, requests });
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+
+    const gateInput = document.body.querySelector("#token");
+    expect(gateInput).not.toBeNull();
+    // Auth is required and no token is saved: no protected load, no SSE ticket.
+    expect(requests.every((request) => !request.path.endsWith("/projects"))).toBe(true);
+    expect(requests.every((request) => !request.path.endsWith("/jobs/events/ticket"))).toBe(true);
+    expect(FakeEventSource.instances.length).toBe(0);
+
+    const requestCountBeforeTyping = requests.length;
+    for (const partial of ["s", "se", "sec", "secr", "secre", "secret"]) {
+      await changeField(gateInput, partial);
+      await settle();
+    }
+
+    // Typing is pure local state: zero requests, zero EventSource churn, no notices.
+    expect(requests.length).toBe(requestCountBeforeTyping);
+    expect(FakeEventSource.instances.length).toBe(0);
+    expect(document.body.querySelectorAll(".notice.error").length).toBe(0);
+    expect(gateInput.value).toBe("secret");
+  });
+
+  it("keeps the gate up with an inline error when the password is wrong", async () => {
+    const requests = [];
+    mockAuthRequiredFetch({ verifyOk: false, requests });
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+
+    await changeField(document.body.querySelector("#token"), "wrong-password");
+    await act(async () => {
+      buttonInside(document.body, "Unlock").click();
+    });
+    await settle();
+
+    // Wrong password: inline error inside the gate, token never persisted,
+    // no protected loads and no SSE connection attempted.
+    expect(document.body.querySelector(".auth-band")?.textContent).toContain("Incorrect password. Try again.");
+    expect(window.localStorage.getItem("sceneworks-token")).toBeNull();
+    expect(document.body.querySelector("#token")).not.toBeNull();
+    expect(requests.filter((request) => request.path.endsWith("/auth/verify")).length).toBe(1);
+    expect(requests.every((request) => !request.path.endsWith("/projects"))).toBe(true);
+    expect(FakeEventSource.instances.length).toBe(0);
+  });
+
+  it("unlocks and loads data exactly once after the password verifies", async () => {
+    const requests = [];
+    const tokens = [];
+    mockAuthRequiredFetch({ verifyOk: true, requests, tokens });
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+
+    // Trailing whitespace exercises the trim: the stored token must be exact.
+    await changeField(document.body.querySelector("#token"), "correct-password ");
+    await act(async () => {
+      buttonInside(document.body, "Unlock").click();
+    });
+    await settle();
+
+    expect(window.localStorage.getItem("sceneworks-token")).toBe("correct-password");
+    // The gate keys off the token state, so it drops after verification.
+    expect(document.body.querySelector("#token")).toBeNull();
+    expect(document.body.querySelector(".auth-band")).toBeNull();
+    // The [authenticated, token] effect performs the initial load exactly once
+    // (no duplicate refresh from the submit handler), with the verified token.
+    const projectLoads = requests
+      .map((request, index) => ({ ...request, headerToken: tokens[index] }))
+      .filter((request) => request.path.endsWith("/projects"));
+    expect(projectLoads.length).toBe(1);
+    expect(projectLoads[0].headerToken).toBe("correct-password");
+    // SSE comes up once, via the ticket POST, after authentication.
+    expect(requests.filter((request) => request.path.endsWith("/jobs/events/ticket")).length).toBe(1);
+    expect(FakeEventSource.instances.length).toBe(1);
+    expect(FakeEventSource.instances[0].url).toContain("ticket=stream-ticket");
+  });
+
   it("gates the studios behind workspace creation when no projects exist", async () => {
     const requests = [];
     global.fetch.mockImplementation((url, options = {}) => {


### PR DESCRIPTION
## Summary

Fixes [sc-8808](https://app.shortcut.com/trefry/story/8808) — [F-007] Login password shares state with the live API token, flooding the API per keystroke (High).

On an auth-required remote deployment (epic 4484's flagship scenario), the login gate's password `<input>` wrote every keystroke directly into the live `token` state, and `authenticated` derives from `token.length > 0`. Typing the first character flipped `authenticated` true, so the `[authenticated, token]` effects fired `refreshData()` and tore down/rebuilt the SSE connection (including `POST /jobs/events/ticket`) on **every keystroke** — each with a partial password that 401'd, flooding the API, filling the notices band with errors mid-typing, and churning EventSource connections with backoff timers.

## Changes (`apps/web/src/App.jsx`)

- **Separate `passwordDraft` state** backs the login input. Typing is pure local state — it can no longer flip `authenticated` or touch the data/SSE effects.
- **`setToken` only after successful verification**: `saveToken` verifies the trimmed draft against `POST /api/v1/auth/verify` and only then persists to localStorage and promotes it to the live `token`.
- **Gate visibility keys off the `token` state**, not a render-time `window.localStorage.getItem(...)` read.
- **Removed the explicit `refreshData()` from `saveToken`**: promoting the token flips `authenticated`, and the `[authenticated, token]` effect performs the initial data load exactly once. (Previously unlock double-fetched: once from the effect, once explicitly.)
- **`lockRemote()` also clears the draft** so re-locking presents a clean gate.
- Wrong password keeps showing the existing inline `.auth-band` error (`authError`) instead of polluting the notices band via failing background requests.
- **Desktop/loopback (no-auth) path unchanged**: `authenticated` short-circuits on `isDesktopShell` / `!access.authRequired` exactly as before; the full pre-existing suite passes untouched.

## Tests (`apps/web/src/main.test.jsx`)

Written first; all three **fail against the unfixed `App.jsx`** and pass with the fix:

1. `does not fire API calls or SSE connections while typing the login password` — six keystrokes produce zero fetches, zero `EventSource` instances, and no notices.
2. `keeps the gate up with an inline error when the password is wrong` — verify `{ok:false}` → inline "Incorrect password. Try again.", token not persisted, no protected loads, no SSE.
3. `unlocks and loads data exactly once after the password verifies` — token stored trimmed, gate drops (keyed off token state), exactly one `/projects` load carrying the verified `X-SceneWorks-Token`, one ticket POST + one EventSource with the ticket.

## Validation

- `npm test` (vitest, apps/web): **57 files / 979 tests passed** (0 failures).
- `npm run lint`: 0 errors; warning count identical before/after the change (all pre-existing `react-hooks/exhaustive-deps` warnings).
- Regression check: stashed the `App.jsx` fix and confirmed the 3 new tests fail (3/3) against origin/main's implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)