### PR TITLE
fix(api,web): ticket-authenticated media URLs for remote-auth mode (sc-8810)

### DIFF
--- a/apps/rust-api/src/auth.rs
+++ b/apps/rust-api/src/auth.rs
@@ -16,6 +16,7 @@ pub(crate) async fn access_control(
         || !requires_token(request.uri().path())
         || loopback_trusted(state.settings.trust_loopback, peer)
         || is_authorized(request.headers(), &state.settings)
+        || media_ticket_authorized(&state, &request)
     {
         return next.run(request).await;
     }
@@ -86,6 +87,56 @@ pub(crate) fn requires_token(path: &str) -> bool {
 /// a live listener; mirrors `should_warn_open_bind`.
 pub(crate) fn loopback_trusted(trust_loopback: bool, peer: Option<SocketAddr>) -> bool {
     trust_loopback && peer.is_some_and(|addr| addr.ip().is_loopback())
+}
+
+/// Whether a request may bypass the header-token check because it carries a valid
+/// media ticket (sc-8810). Browsers cannot attach headers to element-driven requests
+/// (`<img src>`, `<video src>`, `<a download>`), so — mirroring the SSE ticket — an
+/// authenticated client mints a short-lived ticket (POST /api/v1/files/ticket) and
+/// appends it as a `?ticket=` query param. The bypass is scoped hard: GET only, and
+/// only the read-only media routes (project files + pose previews); every other
+/// route still requires the real token, and an SSE event ticket is never accepted
+/// here (separate store).
+fn media_ticket_authorized(state: &AppState, request: &Request<axum::body::Body>) -> bool {
+    if request.method() != Method::GET {
+        return false;
+    }
+    if !is_ticketed_media_path(request.uri().path()) {
+        return false;
+    }
+    match ticket_from_query(request.uri().query().unwrap_or_default()) {
+        Some(ticket) => state.media_tickets.validate(ticket),
+        None => false,
+    }
+}
+
+/// The exact route families a media ticket unlocks:
+///   GET /api/v1/projects/:project_id/files/*relative_path
+///   GET /api/v1/poses/preview/:job_id/:file_name
+/// Matched on the raw request path (same shape the router matches); the handlers
+/// keep their own traversal/validity checks, the ticket only answers "is this
+/// caller allowed", identically to a header-token caller on these routes.
+pub(crate) fn is_ticketed_media_path(path: &str) -> bool {
+    if let Some(rest) = path.strip_prefix("/api/v1/projects/") {
+        let mut segments = rest.split('/');
+        let has_project = segments.next().is_some_and(|s| !s.is_empty());
+        let files_literal = segments.next() == Some("files");
+        let has_file = segments.next().is_some_and(|s| !s.is_empty());
+        return has_project && files_literal && has_file;
+    }
+    if let Some(rest) = path.strip_prefix("/api/v1/poses/preview/") {
+        return !rest.is_empty();
+    }
+    false
+}
+
+/// Extract the raw `ticket` query-param value. Tickets are hex UUIDs, so no
+/// percent-decoding is needed; a decoded-away match simply fails validation.
+fn ticket_from_query(query: &str) -> Option<&str> {
+    query
+        .split('&')
+        .find_map(|pair| pair.strip_prefix("ticket="))
+        .filter(|value| !value.is_empty())
 }
 
 pub(crate) fn is_authorized(headers: &HeaderMap, settings: &Settings) -> bool {

--- a/apps/rust-api/src/events.rs
+++ b/apps/rust-api/src/events.rs
@@ -38,66 +38,22 @@ impl EventHub {
     }
 }
 
-#[derive(Debug)]
-pub(crate) struct EventTicketStore {
-    ttl: Duration,
-    tickets: Mutex<HashMap<String, Instant>>,
-}
-
-impl EventTicketStore {
-    pub(crate) fn new(ttl_seconds: u64) -> Self {
-        Self {
-            ttl: Duration::from_secs(ttl_seconds),
-            tickets: Mutex::new(HashMap::new()),
-        }
-    }
-
-    fn issue(&self) -> Result<EventTicket, ApiError> {
-        let now = Instant::now();
-        let mut tickets = self.tickets.lock();
-        prune_tickets(&mut tickets, now);
-        let ticket = Uuid::new_v4().simple().to_string();
-        tickets.insert(ticket.clone(), now + self.ttl);
-        Ok(EventTicket {
-            ticket,
-            expires_in_seconds: self.ttl.as_secs(),
-        })
-    }
-
-    fn consume(&self, ticket: &str) -> Result<(), ApiError> {
-        let now = Instant::now();
-        let mut tickets = self.tickets.lock();
-        prune_tickets(&mut tickets, now);
-        match tickets.remove(ticket) {
-            Some(expires_at) if expires_at >= now => Ok(()),
-            _ => Err(ApiError::unauthorized(
-                "Invalid or expired event stream ticket",
-            )),
-        }
-    }
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct EventTicket {
-    ticket: String,
-    expires_in_seconds: u64,
-}
-
-pub(crate) async fn create_event_ticket(
-    State(state): State<AppState>,
-) -> Result<Json<EventTicket>, ApiError> {
-    Ok(Json(state.event_tickets.issue()?))
+pub(crate) async fn create_event_ticket(State(state): State<AppState>) -> Json<TicketResponse> {
+    Json(state.event_tickets.issue())
 }
 
 pub(crate) async fn job_events(
     State(state): State<AppState>,
     Query(query): Query<EventsQuery>,
 ) -> Result<Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>>, ApiError> {
-    if !state.settings.access_token.is_empty() {
-        state
+    if !state.settings.access_token.is_empty()
+        && !state
             .event_tickets
-            .consume(query.ticket.as_deref().unwrap_or_default())?;
+            .consume(query.ticket.as_deref().unwrap_or_default())
+    {
+        return Err(ApiError::unauthorized(
+            "Invalid or expired event stream ticket",
+        ));
     }
     Ok(Sse::new(sse_event_stream(state.events.subscribe())))
 }
@@ -140,8 +96,4 @@ fn sse_message_event(message: EventMessage) -> Event {
 
 fn heartbeat_event() -> Event {
     Event::default().event("heartbeat").data(HEARTBEAT_SSE_DATA)
-}
-
-fn prune_tickets(tickets: &mut HashMap<String, Instant>, now: Instant) {
-    tickets.retain(|_, expires_at| *expires_at >= now);
 }

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -89,6 +89,8 @@ mod workers;
 use workers::*;
 mod events;
 use events::*;
+mod tickets;
+use tickets::*;
 mod dto;
 use dto::*;
 mod manifest;
@@ -131,6 +133,12 @@ const DEFAULT_CORS_ORIGINS: &str = concat!(
     "http://localhost:5176,http://127.0.0.1:5176"
 );
 const EVENT_BUFFER_SIZE: usize = 100;
+// SSE tickets are single-use and consumed on connect, so a tight window suffices.
+const EVENT_TICKET_TTL_SECONDS: u64 = 30;
+// Media tickets ride in <img>/<video>/<a download> URLs (headers impossible), so
+// they are multi-use; the web client re-arms the sliding ticket every TTL/3, and a
+// leaked URL dies at most one TTL after the last authenticated refresh (sc-8810).
+const MEDIA_TICKET_TTL_SECONDS: u64 = 300;
 const HEARTBEAT_SSE_DATA: &str = "{}";
 #[cfg(test)]
 const HEARTBEAT_SSE_WIRE: &str = "event: heartbeat\ndata: {}\n\n";
@@ -274,7 +282,8 @@ pub struct AppState {
     jobs_store: Arc<JobsStore>,
     project_store: Arc<ProjectStore>,
     events: Arc<EventHub>,
-    event_tickets: Arc<EventTicketStore>,
+    event_tickets: Arc<TicketStore>,
+    media_tickets: Arc<TicketStore>,
     manifest_cache: Arc<Mutex<ManifestCache>>,
     manifest_write_locks: Arc<Mutex<HashMap<PathBuf, Arc<AsyncMutex<()>>>>>,
     model_size_cache: Arc<Mutex<ModelSizeCache>>,
@@ -707,7 +716,8 @@ pub(crate) fn create_app_with_state(
         jobs_store,
         project_store,
         events: Arc::new(EventHub::default()),
-        event_tickets: Arc::new(EventTicketStore::new(30)),
+        event_tickets: Arc::new(TicketStore::new(EVENT_TICKET_TTL_SECONDS)),
+        media_tickets: Arc::new(TicketStore::new(MEDIA_TICKET_TTL_SECONDS)),
         manifest_cache: Arc::new(Mutex::new(ManifestCache::default())),
         manifest_write_locks: Arc::new(Mutex::new(HashMap::new())),
         model_size_cache: Arc::new(Mutex::new(ModelSizeCache::default())),
@@ -992,6 +1002,9 @@ pub(crate) fn create_app_with_state(
         .route("/api/v1/jobs/claim", post(claim_job))
         .route("/api/v1/jobs/events", get(job_events))
         .route("/api/v1/jobs/events/ticket", post(create_event_ticket))
+        // Media ticket (sc-8810): auth-protected mint endpoint; the ticket is honored
+        // as a query param by the project-files and pose-preview GETs (see auth.rs).
+        .route("/api/v1/files/ticket", post(create_media_ticket))
         .route("/api/v1/jobs/:job_id", get(get_job))
         .route("/api/v1/jobs/:job_id/cancel", post(cancel_job))
         .route("/api/v1/jobs/:job_id/retry", post(retry_job))

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -9052,6 +9052,213 @@ async fn event_tickets_are_protected_and_match_contract_shape() {
 }
 
 #[tokio::test]
+async fn media_tickets_authenticate_project_file_urls() {
+    // sc-8810: element-driven media requests (<img>/<video>/<a download>) cannot
+    // attach the token header, so the files route honors a short-lived query-param
+    // ticket minted by an authenticated client — mirroring the SSE ticket.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let mut settings = test_settings(&temp_dir);
+    settings.access_token = "secret-token".to_owned();
+    let app = create_app(settings).expect("app creates");
+    let auth = [("x-sceneworks-token", "secret-token")];
+
+    let (_, created) = request_with_headers(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Ticketed media" }),
+        &auth,
+    )
+    .await;
+    let project_id = created["id"].as_str().expect("project id").to_owned();
+    let project_path = std::path::PathBuf::from(created["path"].as_str().unwrap());
+    std::fs::write(project_path.join("assets/images/image.png"), b"image-bytes")
+        .expect("media writes");
+    let file_uri = format!("/api/v1/projects/{project_id}/files/assets/images/image.png");
+
+    // Minting a media ticket itself requires authentication.
+    let (status, _) = request(app.clone(), "POST", "/api/v1/files/ticket", Value::Null).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    let (status, ticket) = request_with_headers(
+        app.clone(),
+        "POST",
+        "/api/v1/files/ticket",
+        Value::Null,
+        &auth,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let ticket_value = ticket["ticket"].as_str().expect("ticket string").to_owned();
+    assert!(ticket_value.len() == 32 && ticket_value.chars().all(|c| c.is_ascii_hexdigit()));
+    assert_eq!(ticket["expiresInSeconds"], 300);
+
+    // Re-minting while the ticket is alive returns the SAME sliding ticket, so
+    // already-rendered media URLs stay stable across client refreshes.
+    let (_, reissued) = request_with_headers(
+        app.clone(),
+        "POST",
+        "/api/v1/files/ticket",
+        Value::Null,
+        &auth,
+    )
+    .await;
+    assert_eq!(reissued["ticket"], ticket_value.as_str());
+
+    // Bare media URL (what an <img src> sends): still 401 without a ticket.
+    let (status, _) = request(app.clone(), "GET", &file_uri, Value::Null).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+
+    // With the ticket: authorized, and multi-use (a page renders many thumbnails
+    // and <video> issues multiple Range requests against one URL).
+    for _ in 0..2 {
+        let (status, _, bytes) = request_raw(
+            app.clone(),
+            "GET",
+            &format!("{file_uri}?ticket={ticket_value}"),
+            Body::empty(),
+            &[],
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(bytes, b"image-bytes");
+    }
+
+    // A garbage ticket stays locked out.
+    let (status, _) = request(
+        app.clone(),
+        "GET",
+        &format!("{file_uri}?ticket=not-a-ticket"),
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+
+    // Scope isolation: an SSE event ticket is NOT valid on the files route…
+    let (_, event_ticket) = request_with_headers(
+        app.clone(),
+        "POST",
+        "/api/v1/jobs/events/ticket",
+        Value::Null,
+        &auth,
+    )
+    .await;
+    let event_ticket_value = event_ticket["ticket"].as_str().expect("event ticket");
+    let (status, _) = request(
+        app.clone(),
+        "GET",
+        &format!("{file_uri}?ticket={event_ticket_value}"),
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+
+    // …and a media ticket is NOT valid on the SSE stream…
+    let (status, _) = request(
+        app.clone(),
+        "GET",
+        &format!("/api/v1/jobs/events?ticket={ticket_value}"),
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+
+    // …and a media ticket never unlocks any non-media route.
+    let (status, _) = request(
+        app.clone(),
+        "GET",
+        &format!("/api/v1/jobs?ticket={ticket_value}"),
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    let (status, _) = request(
+        app.clone(),
+        "GET",
+        &format!("/api/v1/projects?ticket={ticket_value}"),
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    // A files-shaped path with a non-GET method stays locked too.
+    let (status, _) = request(
+        app.clone(),
+        "POST",
+        &format!("{file_uri}?ticket={ticket_value}"),
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+
+    // Pose previews are the other element-driven media family: the ticket clears
+    // auth (the 404 is the handler's own missing-file answer, not a 401).
+    let (status, _) = request(
+        app.clone(),
+        "GET",
+        "/api/v1/poses/preview/job_missing/preview.png",
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    let (status, _) = request(
+        app,
+        "GET",
+        &format!("/api/v1/poses/preview/job_missing/preview.png?ticket={ticket_value}"),
+        Value::Null,
+    )
+    .await;
+    assert_ne!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[test]
+fn media_ticket_paths_cover_exactly_the_media_routes() {
+    use super::auth::is_ticketed_media_path;
+    // Project files + pose previews are ticketed…
+    assert!(is_ticketed_media_path(
+        "/api/v1/projects/p1/files/assets/images/one.png"
+    ));
+    assert!(is_ticketed_media_path("/api/v1/projects/p1/files/a"));
+    assert!(is_ticketed_media_path("/api/v1/poses/preview/job_1/p.png"));
+    // …nothing else is.
+    assert!(!is_ticketed_media_path("/api/v1/projects"));
+    assert!(!is_ticketed_media_path("/api/v1/projects/p1"));
+    assert!(!is_ticketed_media_path("/api/v1/projects/p1/files"));
+    assert!(!is_ticketed_media_path("/api/v1/projects/p1/files/"));
+    assert!(!is_ticketed_media_path("/api/v1/projects/p1/assets"));
+    assert!(!is_ticketed_media_path("/api/v1/projects//files/a"));
+    assert!(!is_ticketed_media_path("/api/v1/poses/preview/"));
+    assert!(!is_ticketed_media_path("/api/v1/jobs"));
+    assert!(!is_ticketed_media_path("/api/v1/credentials"));
+}
+
+#[test]
+fn ticket_store_sliding_reuse_and_expiry() {
+    use super::tickets::TicketStore;
+    // Sliding (media) tickets: reusable, stable across re-issue, non-consuming.
+    let store = TicketStore::new(300);
+    let first = store.issue_sliding();
+    let second = store.issue_sliding();
+    assert_eq!(first.ticket, second.ticket, "live sliding ticket is reused");
+    assert!(store.validate(&first.ticket));
+    assert!(store.validate(&first.ticket), "validate must not consume");
+    assert!(!store.validate("bogus"));
+    assert!(!store.validate(""));
+
+    // Single-use (SSE) tickets: consume removes them.
+    let sse = store.issue();
+    assert!(store.consume(&sse.ticket));
+    assert!(!store.consume(&sse.ticket), "consume is single-use");
+
+    // TTL 0: expired as soon as any time passes (the sleep guards against two
+    // Instant::now() calls landing on the same tick).
+    let expired = TicketStore::new(0);
+    let sliding = expired.issue_sliding();
+    let single = expired.issue();
+    std::thread::sleep(Duration::from_millis(5));
+    assert!(!expired.validate(&sliding.ticket));
+    assert!(!expired.consume(&single.ticket));
+}
+
+#[tokio::test]
 async fn lagged_event_subscribers_are_disconnected() {
     let hub = EventHub::default();
     let mut stream = hub.subscribe();

--- a/apps/rust-api/src/tickets.rs
+++ b/apps/rust-api/src/tickets.rs
@@ -1,0 +1,111 @@
+use super::*;
+
+// Short-lived query-param tickets for endpoints the browser cannot reach with an
+// auth header (epic 4484). Two flavors share this store:
+//  - SSE (`/api/v1/jobs/events`): `EventSource` can't set headers → single-use
+//    `issue()` + `consume()` tickets (sc-4484 story: events ticket).
+//  - Media (`GET /api/v1/projects/:id/files/*`, `GET /api/v1/poses/preview/*`):
+//    `<img src>`/`<video src>`/`<a download>` requests can't set headers either →
+//    reusable `issue_sliding()` + `validate()` tickets (sc-8810). A page renders
+//    dozens of media URLs (and <video> issues multiple Range requests), so these
+//    tickets are multi-use within their TTL; the web client refreshes well before
+//    expiry and `issue_sliding` keeps returning (and re-arming) the same ticket so
+//    already-rendered <img>/<video> URLs stay valid without a re-render.
+//
+// Separate `TicketStore` instances give scope isolation for free: an event ticket
+// is never accepted on the files route and vice versa.
+#[derive(Debug)]
+pub(crate) struct TicketStore {
+    ttl: Duration,
+    state: Mutex<TicketStoreState>,
+}
+
+#[derive(Debug, Default)]
+struct TicketStoreState {
+    tickets: HashMap<String, Instant>,
+    // Most recently issued ticket, so `issue_sliding` can hand the same value to
+    // every caller while it stays alive (URL stability across React re-renders).
+    latest: Option<String>,
+}
+
+impl TicketStore {
+    pub(crate) fn new(ttl_seconds: u64) -> Self {
+        Self {
+            ttl: Duration::from_secs(ttl_seconds),
+            state: Mutex::new(TicketStoreState::default()),
+        }
+    }
+
+    /// Issue a fresh single-use ticket (SSE flavor; pair with `consume`).
+    pub(crate) fn issue(&self) -> TicketResponse {
+        let now = Instant::now();
+        let mut state = self.state.lock();
+        prune_tickets(&mut state.tickets, now);
+        let ticket = Uuid::new_v4().simple().to_string();
+        state.tickets.insert(ticket.clone(), now + self.ttl);
+        state.latest = Some(ticket.clone());
+        TicketResponse {
+            ticket,
+            expires_in_seconds: self.ttl.as_secs(),
+        }
+    }
+
+    /// Issue a reusable ticket (media flavor; pair with `validate`). While the most
+    /// recent ticket is still valid this returns it again and re-arms its expiry to
+    /// a full TTL, so a client refreshing on an interval keeps one stable ticket
+    /// alive for its whole session. A leaked URL therefore dies at most one TTL
+    /// after the last authenticated refresh.
+    pub(crate) fn issue_sliding(&self) -> TicketResponse {
+        let now = Instant::now();
+        let mut state = self.state.lock();
+        prune_tickets(&mut state.tickets, now);
+        if let Some(ticket) = state.latest.clone() {
+            if state.tickets.contains_key(&ticket) {
+                state.tickets.insert(ticket.clone(), now + self.ttl);
+                return TicketResponse {
+                    ticket,
+                    expires_in_seconds: self.ttl.as_secs(),
+                };
+            }
+        }
+        drop(state);
+        self.issue()
+    }
+
+    /// Single-use check: the ticket is removed whether or not it is still valid.
+    pub(crate) fn consume(&self, ticket: &str) -> bool {
+        let now = Instant::now();
+        let mut state = self.state.lock();
+        prune_tickets(&mut state.tickets, now);
+        matches!(state.tickets.remove(ticket), Some(expires_at) if expires_at >= now)
+    }
+
+    /// Non-consuming check for multi-use (media) tickets.
+    pub(crate) fn validate(&self, ticket: &str) -> bool {
+        if ticket.is_empty() {
+            return false;
+        }
+        let now = Instant::now();
+        let mut state = self.state.lock();
+        prune_tickets(&mut state.tickets, now);
+        matches!(state.tickets.get(ticket), Some(expires_at) if *expires_at >= now)
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TicketResponse {
+    pub(crate) ticket: String,
+    pub(crate) expires_in_seconds: u64,
+}
+
+/// POST /api/v1/files/ticket — auth-protected (header token or loopback trust via
+/// the access-control middleware), so only an already-authenticated client can
+/// mint a media ticket.
+pub(crate) async fn create_media_ticket(State(state): State<AppState>) -> Json<TicketResponse> {
+    Json(state.media_tickets.issue_sliding())
+}
+
+fn prune_tickets(tickets: &mut HashMap<String, Instant>, now: Instant) {
+    tickets.retain(|_, expires_at| *expires_at >= now);
+}

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { apiFetch, eventUrl, isAbortError } from "./api.js";
+import { apiFetch, eventUrl, isAbortError, setMediaTicket } from "./api.js";
 import { Icon } from "./components/Icons.jsx";
 import { Logo } from "./components/Logo.jsx";
 import { StatusDot } from "./components/StatusDot.jsx";
@@ -762,6 +762,57 @@ export function App() {
       (accessResolved && (!access.authRequired || token.length > 0)),
     [accessResolved, access, token],
   );
+  // sc-8810: whether media URLs are renderable yet. When auth is on, element-driven
+  // requests (<img>/<video>) can't send the token header, so every media URL needs
+  // the query-param ticket minted below. Data loads hold until the first ticket is
+  // stored (mediaReady), otherwise thumbnails rendered in the gap would 401 and
+  // stick as "deleted" placeholders. When auth is off this resolves immediately.
+  const [mediaReady, setMediaReady] = useState(false);
+  const ready = authenticated && mediaReady;
+
+  useEffect(() => {
+    if (!authenticated || !accessResolved) {
+      return undefined;
+    }
+    if (!access.authRequired) {
+      setMediaTicket("");
+      setMediaReady(true);
+      return undefined;
+    }
+    let closed = false;
+    let timer = null;
+    let attempt = 0;
+    async function acquire() {
+      try {
+        // Header-authenticated mint (loopback-trusted desktop sends no token and
+        // still passes). The server keeps re-arming the same sliding ticket, so
+        // already-rendered media URLs stay valid across refreshes.
+        const response = await apiFetch("/api/v1/files/ticket", token, { method: "POST" });
+        if (closed) {
+          return;
+        }
+        setMediaTicket(response.ticket);
+        setMediaReady(true);
+        attempt = 0;
+        const ttlMs = Math.max(15, Number(response.expiresInSeconds) || 0) * 1000;
+        timer = window.setTimeout(acquire, Math.max(5000, Math.floor(ttlMs / 3)));
+      } catch {
+        if (closed) {
+          return;
+        }
+        const delay = Math.min(30000, 1000 * 2 ** attempt);
+        attempt += 1;
+        timer = window.setTimeout(acquire, delay);
+      }
+    }
+    acquire();
+    return () => {
+      closed = true;
+      if (timer) {
+        window.clearTimeout(timer);
+      }
+    };
+  }, [access.authRequired, accessResolved, authenticated, token]);
   const imageModels = useMemo(() => {
     const items = models.filter((model) => model.type === "image" && model.installState !== "missing");
     return items.length || models.length ? items : fallbackModels.filter((model) => model.type === "image");
@@ -983,14 +1034,14 @@ export function App() {
   }, []);
 
   useEffect(() => {
-    if (!authenticated) {
+    if (!ready) {
       return;
     }
     refreshDataRef.current?.();
-  }, [authenticated, token]);
+  }, [ready, token]);
 
   useEffect(() => {
-    if (!activeProject || !authenticated) {
+    if (!activeProject || !ready) {
       setAssets([]);
       setCharacters([]);
       setPersonTracks([]);
@@ -1017,10 +1068,12 @@ export function App() {
     refreshPersonTracksRef.current?.(activeProject.id, { signal });
     refreshTimelinesRef.current?.(activeProject.id, { signal });
     return () => controller.abort();
-  }, [activeProject?.id, authenticated, token]);
+  }, [activeProject?.id, ready, token]);
 
   useEffect(() => {
-    if (!authenticated) {
+    // Gated on `ready` (not just `authenticated`): SSE job updates carry assets whose
+    // thumbnails render immediately, so the media ticket must exist first (sc-8810).
+    if (!ready) {
       return undefined;
     }
 
@@ -1159,7 +1212,7 @@ export function App() {
       }
       events?.close();
     };
-  }, [access.authRequired, authenticated, token]);
+  }, [access.authRequired, ready, token]);
 
   async function refreshData() {
     const fetchInitial = async (label, path, fallback, optional = false) => {

--- a/apps/web/src/api.js
+++ b/apps/web/src/api.js
@@ -44,3 +44,31 @@ export function eventUrl(path, ticket) {
   }
   return url.toString();
 }
+
+// ---- Media tickets (sc-8810) ---------------------------------------------------
+// Element-driven requests (<img src>, <video src>, <a download>) cannot attach the
+// X-SceneWorks-Token header, so in remote-auth mode every bare media URL would 401.
+// Mirroring the SSE ticket, App.jsx mints a short-lived reusable ticket from
+// POST /api/v1/files/ticket (header-authenticated) and stores it here; every media
+// URL producer routes through `withMediaTicket` so the ticket rides along as a
+// query param that the API honors on the project-files and pose-preview routes.
+// Module-level (not React state) because URL producers like assetUrl() are plain
+// functions called from render paths and non-component code (browserDownload).
+let mediaTicket = "";
+
+export function setMediaTicket(ticket) {
+  mediaTicket = typeof ticket === "string" ? ticket : "";
+}
+
+export function getMediaTicket() {
+  return mediaTicket;
+}
+
+// Append the current media ticket to a media URL. No-op while no ticket is set
+// (desktop/loopback or auth-off deployments), so local mode is untouched.
+export function withMediaTicket(url) {
+  if (!url || !mediaTicket) {
+    return url;
+  }
+  return `${url}${url.includes("?") ? "&" : "?"}ticket=${encodeURIComponent(mediaTicket)}`;
+}

--- a/apps/web/src/components/assetMedia.jsx
+++ b/apps/web/src/components/assetMedia.jsx
@@ -1,7 +1,10 @@
 import React from "react";
-import { API_BASE_URL } from "../api.js";
+import { API_BASE_URL, withMediaTicket } from "../api.js";
 
-export function assetUrl(asset) {
+// Ticket-free URL builder; internal so every exported producer appends the media
+// ticket (sc-8810) exactly once, and posterUrl can swap the file extension before
+// the query string exists.
+function bareAssetUrl(asset) {
   if (asset?.url) {
     return API_BASE_URL + asset.url;
   }
@@ -15,6 +18,13 @@ export function assetUrl(asset) {
     return `${API_BASE_URL}/api/v1/projects/${asset.projectId}/files/${normalizedPath}`;
   }
   return "";
+}
+
+// Displayable/fetchable URL for an asset. In remote-auth mode this carries the
+// media ticket so element-driven requests (<img>/<video>/<a download>) — which
+// cannot send the token header — still authenticate (sc-8810).
+export function assetUrl(asset) {
+  return withMediaTicket(bareAssetUrl(asset));
 }
 
 export function assetCanRenderAsImage(asset) {
@@ -44,11 +54,11 @@ export function suppressThumbnailContextMenu(event) {
 // WKWebView won't paint a <video>'s own first frame as a poster, so the UI shows
 // this real image instead — as the thumbnail and as the player's poster attribute.
 export function posterUrl(asset) {
-  const src = assetUrl(asset);
+  const src = bareAssetUrl(asset);
   if (!src || !assetCanRenderAsVideo(asset)) {
     return "";
   }
-  return src.replace(/\.\w+$/, ".poster.jpg");
+  return withMediaTicket(src.replace(/\.\w+$/, ".poster.jpg"));
 }
 
 // Placeholder shown when an asset's underlying file can't be loaded — e.g. it

--- a/apps/web/src/keypointLibrary.js
+++ b/apps/web/src/keypointLibrary.js
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { API_BASE_URL, apiFetch } from "./api.js";
+import { API_BASE_URL, apiFetch, withMediaTicket } from "./api.js";
 import { useAppContext } from "./context/AppContext.js";
 
 // The reserved global project that holds user-created keypoint (face-angle) preset assets
@@ -30,7 +30,9 @@ export function keypointSourceImageUrl(sourceImageRef) {
     return "";
   }
   const normalized = String(sourceImageRef).replaceAll("\\", "/");
-  return `${API_BASE_URL}/api/v1/projects/${GLOBAL_KEYPOINTS_PROJECT_ID}/files/${normalized}`;
+  return withMediaTicket(
+    `${API_BASE_URL}/api/v1/projects/${GLOBAL_KEYPOINTS_PROJECT_ID}/files/${normalized}`,
+  );
 }
 
 export async function loadKeypointPresets(token, options = {}) {

--- a/apps/web/src/mediaTicket.test.jsx
+++ b/apps/web/src/mediaTicket.test.jsx
@@ -1,0 +1,144 @@
+// sc-8810: media URLs must authenticate in remote-auth mode. Element-driven
+// requests (<img src>, <video src>, <a download>) cannot send the token header,
+// so every media-URL producer appends the short-lived media ticket minted from
+// POST /api/v1/files/ticket. These tests pin the central helper and the
+// producers that ride on it (assetUrl/posterUrl, DocumentReader's fetch).
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { API_BASE_URL, getMediaTicket, setMediaTicket, withMediaTicket } from "./api.js";
+import { assetUrl, posterUrl } from "./components/assetMedia.jsx";
+import { AssetDetail } from "./components/assetPanels.jsx";
+import { keypointSourceImageUrl } from "./keypointLibrary.js";
+
+const imageAsset = {
+  id: "img",
+  type: "image",
+  displayName: "one.png",
+  file: { path: "assets/one.png", mimeType: "image/png" },
+  projectId: "p1",
+};
+
+const videoAsset = {
+  id: "vid",
+  type: "video",
+  displayName: "clip.mp4",
+  file: { path: "assets/clip.mp4", mimeType: "video/mp4" },
+  projectId: "p1",
+};
+
+afterEach(() => {
+  setMediaTicket("");
+});
+
+describe("withMediaTicket", () => {
+  it("is a no-op while no ticket is set (desktop/loopback and auth-off modes)", () => {
+    setMediaTicket("");
+    expect(withMediaTicket("http://x/api/v1/projects/p1/files/a.png")).toBe(
+      "http://x/api/v1/projects/p1/files/a.png",
+    );
+    expect(withMediaTicket("")).toBe("");
+  });
+
+  it("appends the ticket as a query param, joining on existing query strings", () => {
+    setMediaTicket("abc123");
+    expect(getMediaTicket()).toBe("abc123");
+    expect(withMediaTicket("http://x/files/a.png")).toBe("http://x/files/a.png?ticket=abc123");
+    expect(withMediaTicket("http://x/files/a.png?v=2")).toBe("http://x/files/a.png?v=2&ticket=abc123");
+  });
+
+  it("leaves empty URLs alone even with a ticket set", () => {
+    setMediaTicket("abc123");
+    expect(withMediaTicket("")).toBe("");
+    expect(withMediaTicket(null)).toBe(null);
+  });
+});
+
+describe("asset URL producers carry the media ticket", () => {
+  it("assetUrl appends the ticket to file-path URLs", () => {
+    setMediaTicket("t0ken");
+    expect(assetUrl(imageAsset)).toBe(
+      `${API_BASE_URL}/api/v1/projects/p1/files/assets/one.png?ticket=t0ken`,
+    );
+  });
+
+  it("assetUrl appends the ticket to normalized `url` assets", () => {
+    setMediaTicket("t0ken");
+    expect(assetUrl({ ...imageAsset, url: "/api/v1/projects/p1/files/assets/one.png" })).toBe(
+      `${API_BASE_URL}/api/v1/projects/p1/files/assets/one.png?ticket=t0ken`,
+    );
+  });
+
+  it("assetUrl stays bare without a ticket", () => {
+    expect(assetUrl(imageAsset)).toBe(`${API_BASE_URL}/api/v1/projects/p1/files/assets/one.png`);
+  });
+
+  it("posterUrl swaps the extension BEFORE the ticket query string", () => {
+    setMediaTicket("t0ken");
+    expect(posterUrl(videoAsset)).toBe(
+      `${API_BASE_URL}/api/v1/projects/p1/files/assets/clip.poster.jpg?ticket=t0ken`,
+    );
+  });
+
+  it("keypointSourceImageUrl appends the ticket", () => {
+    setMediaTicket("t0ken");
+    const url = keypointSourceImageUrl("assets/keypoints/asset_x.png");
+    expect(url).toContain("/files/assets/keypoints/asset_x.png?ticket=t0ken");
+  });
+});
+
+describe("DocumentReader authenticates its document fetch (sc-8810)", () => {
+  let container;
+  let root;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    global.fetch = originalFetch;
+  });
+
+  it("fetches the document through a ticketed URL", async () => {
+    setMediaTicket("d0cticket");
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ segments: [{ type: "text", text: "hello" }] }),
+    }));
+    const documentAsset = {
+      id: "doc",
+      type: "document",
+      displayName: "story.json",
+      file: { path: "assets/documents/story.json", mimeType: "application/json" },
+      projectId: "p1",
+    };
+    await act(async () =>
+      root.render(
+        <AssetDetail
+          asset={documentAsset}
+          deleteAsset={() => {}}
+          purgeAsset={() => {}}
+          onPreview={() => {}}
+          onSendImage={() => {}}
+          onSendVideo={() => {}}
+          onSendEditor={() => {}}
+          updateAssetStatus={() => {}}
+          updateAssetTags={() => {}}
+          availableTags={[]}
+        />,
+      ),
+    );
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const [url] = global.fetch.mock.calls[0];
+    expect(url).toBe(
+      `${API_BASE_URL}/api/v1/projects/p1/files/assets/documents/story.json?ticket=d0cticket`,
+    );
+    expect(container.textContent).toContain("hello");
+  });
+});

--- a/apps/web/src/screens/PoseLibraryScreen.jsx
+++ b/apps/web/src/screens/PoseLibraryScreen.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { API_BASE_URL, apiFetch, isAbortError } from "../api.js";
+import { API_BASE_URL, apiFetch, isAbortError, withMediaTicket } from "../api.js";
 import { AssetDetail, AssetGrid, FullscreenPreview, emptyTrash } from "../components/assetPanels.jsx";
 import { AssetThumbnail } from "../components/assetMedia.jsx";
 import { DatasetAddDialog } from "../components/DatasetAddDialog.jsx";
@@ -361,9 +361,11 @@ function PoseCreatePanel({ hidden, categories, onSaved, existingPoses }) {
                   >
                     <img
                       alt={`Pose skeleton from ${candidate.sourceDisplayName}`}
-                      src={`${API_BASE_URL}/api/v1/poses/preview/${encodeURIComponent(
-                        candidate.jobId,
-                      )}/${encodeURIComponent(candidate.skeletonFile)}`}
+                      src={withMediaTicket(
+                        `${API_BASE_URL}/api/v1/poses/preview/${encodeURIComponent(
+                          candidate.jobId,
+                        )}/${encodeURIComponent(candidate.skeletonFile)}`,
+                      )}
                     />
                     <span>
                       {candidate.sourceDisplayName} · {candidate.facing}

--- a/apps/web/src/screens/ReplacePersonPanel.jsx
+++ b/apps/web/src/screens/ReplacePersonPanel.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { API_BASE_URL } from "../api.js";
+import { API_BASE_URL, withMediaTicket } from "../api.js";
 import { AssetPickerField } from "../components/AssetPicker.jsx";
 import { AssetMedia } from "../components/assetMedia.jsx";
 
@@ -59,7 +59,7 @@ function maskUrl(projectId, relPath) {
     return "";
   }
   const normalized = String(relPath).replaceAll("\\", "/");
-  return `${API_BASE_URL}/api/v1/projects/${projectId}/files/${normalized}`;
+  return withMediaTicket(`${API_BASE_URL}/api/v1/projects/${projectId}/files/${normalized}`);
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes [sc-8810](https://app.shortcut.com/trefry/story/8810) — **[F-008] Asset media URLs cannot authenticate — every image/video/document 401s in remote-auth mode** (High).

In the LAN remote-browser deployment (epic 4484: non-loopback peer + access token set), every thumbnail, preview, video, pose preview, document read, and browser download 401'd. `GET /api/v1/projects/:id/files/*` accepted the token only via `X-SceneWorks-Token`/`Authorization` headers, but element-driven requests (`<img src>`, `<video src>`, `<a download>`) cannot send headers, and `DocumentReader` fetched bare URLs. The SSE stream got a ticket mechanism for exactly this constraint; media never did. This PR mirrors that pattern for media.

## Rust (`apps/rust-api`)

- **`tickets.rs` (new):** the SSE `EventTicketStore` is generalized into `TicketStore` with two flavors:
  - single-use `issue()`/`consume()` — SSE, unchanged semantics, TTL still 30s, same wire shape (`{ticket, expiresInSeconds}`) and error message;
  - reusable `issue_sliding()`/`validate()` — media. Re-minting while the ticket is alive re-arms it and returns the **same** ticket, so already-rendered `<img>/<video>` URLs stay valid without a client re-render. A leaked URL dies at most one TTL (300s) after the last authenticated refresh.
  - Separate store instances per flavor give scope isolation for free: an event ticket is never accepted on the files route and vice versa.
- **`POST /api/v1/files/ticket` (new):** header-authenticated mint endpoint (loopback-trusted desktop passes tokenless, remote browsers pass their token).
- **`auth.rs`:** `access_control` honors `?ticket=` **only** for `GET` on the two element-driven media families — `/api/v1/projects/:id/files/*` and `/api/v1/poses/preview/*`. Every other route still requires the real token; `PUBLIC_PATHS`, loopback trust, and the handlers' own traversal guards are untouched. Auth-off and desktop/loopback modes behave exactly as before.

## Web (`apps/web`)

- **`api.js`:** `setMediaTicket`/`getMediaTicket`/`withMediaTicket` central helper — a no-op while no ticket is set, so local/desktop deployments are byte-identical.
- **Every bare-media-URL producer routes through it:** `assetUrl()` and `posterUrl()` (extension swap happens *before* the query string) — covering `AssetThumbnail`/`AssetMedia`, `WorkerProgressCard`, asset panels + fullscreen preview, `DocumentReader`'s raw `fetch`, `DocumentView` segments, `browserDownload()`/`saveAssetAs`, `assetBatch` preloads, `ReferenceCaptionPicker`, `ImageEditor` (element srcs + blob fetches), `KeyPointLibraryScreen` — plus the three direct builders: `keypointSourceImageUrl`, `ReplacePersonPanel` mask URLs, and the Pose Library `/api/v1/poses/preview/*` thumbnails.
- **`App.jsx`:** when auth is required, mints the media ticket and re-arms it every TTL/3 (exponential backoff on failure). Initial data loads and the SSE stream now gate on the first ticket (`ready`), so thumbnails can't render 401 in the gap and stick as "deleted" placeholders.

## Tests

- **Rust (155 pass):** route-level — bare media GET 401s; mint requires auth; ticketed GET 200 and multi-use; garbage ticket, cross-scope tickets (event↔media), non-GET, and non-media routes all stay 401; pose preview clears auth (404 not 401); sliding re-mint returns the same ticket; unit — `TicketStore` sliding reuse/validate-not-consume/consume-single-use/TTL-expiry; `is_ticketed_media_path` exact route coverage. Existing SSE-ticket and auth tests unchanged and green.
- **Web (985 pass, 58 files):** `withMediaTicket` behavior, `assetUrl`/`posterUrl` producers (incl. no-ticket no-op), `keypointSourceImageUrl`, and `DocumentReader` fetching through the ticketed URL.
- **E2E over real HTTP** against the built binary with `SCENEWORKS_ACCESS_TOKEN` set: bare 401 → mint 401/200 → ticketed 200 (twice) → Range 206 → non-media 401 → bogus 401 → pose preview 404 → re-mint SAME ticket.
- `npm run rust:check` (fmt, clippy `-D warnings`, workspace tests, build) green; web lint introduces no new warnings; contract snapshot shapes untouched (event ticket wire format preserved).

## Notes / limitations

- If the API restarts, in-memory tickets vanish; already-rendered media URLs 401 until the next render picks up the freshly minted ticket (the client re-mints within TTL/3). Same class of behavior as the SSE ticket store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)