### PR TITLE
fix(lens): repoint LoRA training base → SceneWorks/Lens rehost (sc-8797)

### DIFF
--- a/apps/web/src/quantTier.js
+++ b/apps/web/src/quantTier.js
@@ -21,10 +21,14 @@ const TIER_QUANTIZE = {
 };
 
 // Human labels for the picker, keyed by tier. Unknown/"default" tiers fall back to the raw key.
+// "training" is NOT a quant tier: it's the flat-diffusers LoRA-training base some tiered models
+// (lens, sc-8797) additionally host on macOS. It's absent from TIER_QUANTIZE, so the generation
+// picker and RAM suggestion ignore it; only the Models download panel lists it (with this label).
 const TIER_LABELS = {
   bf16: "Full precision (bf16)",
   q8: "Q8 (balanced)",
   q4: "Q4 (smallest)",
+  training: "LoRA training base (bf16 diffusers)",
 };
 
 // Display order (smallest → largest); tiers not in this list sort after, alphabetically.

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -308,7 +308,10 @@ function deleteResultText(result, name) {
 // The declared quant tiers of a matrix model, in suggestion-fidelity order (bf16 → q8 → q4, i.e.
 // highest first) so the panel lists the biggest/best at the top. `suggestTier` already orders on
 // this basis; we surface the same order to the user. Each entry is the raw `variants[]` object.
-const TIER_DISPLAY_ORDER = ["bf16", "q8", "q4"];
+// "training" (sc-8797) is the extra flat-diffusers LoRA-training-base artifact a tiered model can
+// host (lens on macOS); it renders last so the quant tiers stay the visual focus. It is not in
+// tierSuggestion's fidelity list, so it is never the suggested/preselected download.
+const TIER_DISPLAY_ORDER = ["bf16", "q8", "q4", "training"];
 
 function orderedMatrixVariants(model) {
   if (!model?.hasVariantMatrix || !Array.isArray(model.variants)) {

--- a/apps/worker/scene_worker/lens_train_runner.py
+++ b/apps/worker/scene_worker/lens_train_runner.py
@@ -481,7 +481,8 @@ def train(spec: dict[str, Any], progress: _Progress) -> dict[str, Any]:
         f"steps={steps} rank={rank} alpha={alpha} lr={learning_rate} targets={target_modules}"
     )
 
-    # ---- Load the base model (microsoft/Lens by default) -------------------
+    # ---- Load the base model (the SceneWorks/Lens rehost by default; the ----
+    # ---- original microsoft/Lens repo is dead, sc-8797) ---------------------
     progress.emit(event="stage", stage="loading_model", message=f"Loading Lens base model ({source}).")
     text_encoder_kwargs: dict[str, Any] = {"subfolder": "text_encoder", "dtype": dtype}
     mxfp4_config = getattr(transformers, "Mxfp4Config", None)

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -755,6 +755,24 @@
           "platforms": ["windows", "linux"],
           "estimatedSizeBytes": 22334041829,
           "footprint": { "diskSizeBytes": 22334041829, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          // macOS LoRA-training base (sc-8797): the same SceneWorks/Lens diffusers rehost the off-Mac
+          // entry above fetches, exposed as an installable variant on macOS. The MLX q4/q8/bf16 tiers
+          // above are packed turnkey SUBDIRS the trainer's flat-diffusers loader doesn't read and the
+          // training installed-gate (`training_base_model_installed`, keyed on the target's
+          // `baseModelRepo` HF-cache presence) doesn't see — before the tier split (sc-8767) the lens
+          // install WAS the flat microsoft/Lens repo, so one download served inference + training.
+          // Installing this variant restores that for macOS training; off-Mac needs nothing extra (the
+          // bf16 candle entry already fetches the whole repo). Per-variant install state probes this
+          // entry's own repo, so it tracks independently of the MLX tiers (sc-8508).
+          "provider": "huggingface",
+          "repo": "SceneWorks/Lens",
+          "variant": "training",
+          "files": [],
+          "platforms": ["macos"],
+          "estimatedSizeBytes": 22334041829,
+          "footprint": { "diskSizeBytes": 22334041829, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "paths": {
@@ -905,7 +923,8 @@
         "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
       },
       "loraCompatibility": {
-        // Lens LoRA training (sc-1583) trains on the non-distilled microsoft/Lens
+        // Lens LoRA training (sc-1583) trains on the non-distilled base Lens (the
+        // SceneWorks/Lens diffusers rehost since sc-8797; microsoft/Lens is dead)
         // and applies the adapter here on Lens-Turbo. The `lens` family maps to
         // the `lens_turbo` adapter in lora_family.rs.
         "families": ["lens"],

--- a/crates/sceneworks-core/src/training.rs
+++ b/crates/sceneworks-core/src/training.rs
@@ -1120,9 +1120,13 @@ fn z_image_turbo_lora_target() -> TrainingTarget {
 /// of Turbo, so the adapter transfers cleanly — and the output registers as a
 /// `lens` family LoRA the Lens adapter loads onto Lens-Turbo at generation time.
 /// `base_model_repo` points the plan's `baseModelPath` at the Lens HF cache,
-/// independent of the served `lens_turbo` model. `microsoft/Lens-Base` (50-step
-/// supervised) is the fallback base if RL-tuning hurts LoRA stability; override
-/// via `advanced.baseModelRepo` (sc-1584).
+/// independent of the served `lens_turbo` model. Microsoft pulled the original
+/// `microsoft/Lens*` repos from HF, so the base is the `SceneWorks/Lens` re-host
+/// (sc-8797) — a self-contained diffusers snapshot rebuilt from Comfy-Org/Lens +
+/// openai/gpt-oss-20b (MXFP4) + FLUX.2-dev, layout-identical to the original, the
+/// same repo the off-Mac candle inference lane loads (sc-8799). The old
+/// `microsoft/Lens-Base` (50-step supervised) fallback (sc-1584) died with the
+/// pull; `advanced.baseModelRepo` still overrides the source if another appears.
 ///
 /// Unlike Z-Image's separate `to_q/to_k/to_v`, Lens uses *fused* QKV attention
 /// (`img_qkv`/`txt_qkv`) plus joint-attention output projections. The image output
@@ -1137,7 +1141,7 @@ fn lens_turbo_lora_target() -> TrainingTarget {
         output_kind: TrainingOutputKind::Lora,
         family: "lens".to_owned(),
         base_model: "lens".to_owned(),
-        base_model_repo: Some("microsoft/Lens".to_owned()),
+        base_model_repo: Some("SceneWorks/Lens".to_owned()),
         kernel: "lens_lora".to_owned(),
         defaults: TrainingConfig {
             rank: 16,
@@ -1170,9 +1174,10 @@ fn lens_turbo_lora_target() -> TrainingTarget {
                 // errors on the ModuleList itself (sc-2218). Suffixes must match the
                 // LensTransformer2DModel module names or PEFT injects nothing.
                 "loraTargetModules": ["img_qkv", "txt_qkv", "to_out.0", "to_add_out"],
-                // Non-distilled training base; override with "microsoft/Lens-Base"
-                // to train on the 50-step supervised checkpoint instead (sc-1584).
-                "baseModelRepo": "microsoft/Lens",
+                // Non-distilled training base: the SceneWorks/Lens diffusers re-host
+                // (the original microsoft/Lens is dead, sc-8797). Override via this
+                // key to train on an alternative checkpoint (sc-1584).
+                "baseModelRepo": "SceneWorks/Lens",
                 // In-training previews render on the loaded base model (not the
                 // distilled Turbo), so they use the base's 20-step / CFG 5.0
                 // settings — 4-step / CFG 1.0 on the non-distilled base is garbage.

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -316,7 +316,8 @@ fn engine_trainer_id(plan: &TrainingPlan) -> Option<&'static str> {
         // Kolors is an SDXL U-Net under a ChatGLM3-6B encoder; the engine registers its
         // LoRA/LoKr trainer under the same id as its generator (`"kolors"`), sc-4568.
         "kolors_lora" => Some("kolors"),
-        // Lens trains the base `microsoft/Lens` DiT; the engine registers its LoRA/LoKr trainer
+        // Lens trains the base (non-distilled) Lens DiT — the `SceneWorks/Lens` diffusers rehost
+        // since sc-8797 (microsoft/Lens is dead); the engine registers its LoRA/LoKr trainer
         // under the base generator id `"lens"` (arch-identical to lens_turbo), sc-5148.
         "lens_lora" => Some("lens"),
         // Krea trains the undistilled `krea/Krea-2-Raw` DiT; the engine registers its LoRA/LoKr
@@ -2109,7 +2110,8 @@ mod tests {
     }
 
     /// sc-5180 — the Lens training cutover's worker smoke: load the Lens trainer from the installed
-    /// `microsoft/Lens` snapshot and run two LoRA micro-steps on a one-image dataset. Proves the
+    /// `SceneWorks/Lens` snapshot (the training-base diffusers rehost; the original `microsoft/Lens`
+    /// is dead, sc-8797) and run two LoRA micro-steps on a one-image dataset. Proves the
     /// worker LINKS `mlx-gen-lens` (the `load_trainer("lens", …)` trainer registration survives
     /// linker GC — the dead-strip gotcha that bit Kolors) and a real step runs (finite loss) + writes
     /// an adapter through the full worker path. The trainer loads the gpt-oss encoder Q8 (~12 GB) +
@@ -2118,17 +2120,17 @@ mod tests {
     /// `cargo test -p sceneworks-worker --lib -- --ignored lens_real_weights_trains --nocapture`.
     #[cfg(target_os = "macos")]
     #[test]
-    #[ignore = "needs real microsoft/Lens weights + Metal device; loads the 20B gpt-oss encoder (Q8)"]
+    #[ignore = "needs real SceneWorks/Lens weights + Metal device; loads the 20B gpt-oss encoder (Q8)"]
     fn lens_real_weights_trains_a_lora_step() {
         let home = std::path::PathBuf::from(std::env::var_os("HOME").expect("HOME set"));
         let snapshot = std::fs::read_dir(
-            home.join(".cache/huggingface/hub/models--microsoft--Lens/snapshots"),
+            home.join(".cache/huggingface/hub/models--SceneWorks--Lens/snapshots"),
         )
         .expect("lens snapshots dir")
         .flatten()
         .map(|entry| entry.path())
         .find(|path| path.is_dir() && path.join("transformer").is_dir())
-        .expect("a microsoft/Lens snapshot dir");
+        .expect("a SceneWorks/Lens snapshot dir");
 
         let tmp = tempfile::tempdir().expect("tempdir");
         let image_path = tmp.path().join("swatch.png");
@@ -2683,15 +2685,16 @@ mod tests {
     }
 
     /// sc-7817 — the candle Lens training smoke. Loads `load_trainer("lens", …)` from the installed
-    /// `microsoft/Lens` snapshot (`tokenizer/ text_encoder/ transformer/ vae/`) and trains two LoRA
+    /// `SceneWorks/Lens` snapshot (`tokenizer/ text_encoder/ transformer/ vae/` — the training-base
+    /// diffusers rehost; the original `microsoft/Lens` is dead, sc-8797) and trains two LoRA
     /// micro-steps at resolution 64 (the gpt-oss-20b encoder load dominates; the per-step DiT graph
     /// stays tiny). Checkpointing on for the large 48-layer MMDiT. Run on demand (one smoke per GPU):
     /// `cargo test -p sceneworks-worker --lib --features backend-candle -- --ignored candle_lens_real_weights --nocapture`.
     #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
     #[test]
-    #[ignore = "needs real microsoft/Lens weights + a CUDA device; loads the gpt-oss-20b encoder"]
+    #[ignore = "needs real SceneWorks/Lens weights + a CUDA device; loads the gpt-oss-20b encoder"]
     fn candle_lens_real_weights_trains_a_lora_step() {
-        let snapshot = candle_hf_snapshot("models--microsoft--Lens", "transformer");
+        let snapshot = candle_hf_snapshot("models--SceneWorks--Lens", "transformer");
         candle_real_weights_smoke("lens", &snapshot, 64, true, "candle_lens_smoke.safetensors");
     }
 

--- a/documents/TRAINING_QUICKSTART.md
+++ b/documents/TRAINING_QUICKSTART.md
@@ -212,16 +212,18 @@ under-fit; use earlier checkpoints if a 3000-step balanced run starts overfittin
 > stack (peak rises to ~46 GB; a 64 GB+ Mac is recommended with them on), and the
 > distilled sampler ignores `sampleSteps`/`sampleGuidanceScale`.
 
-> **Lens LoRA (`microsoft/Lens` → Lens-Turbo):** the `lens_lora` kernel
+> **Lens LoRA (base Lens → Lens-Turbo):** the `lens_lora` kernel
 > (`target.kernel`) trains an image LoRA for Microsoft Lens. Lens-Turbo is a
-> 4-step *distillation* of `microsoft/Lens`; training a LoRA directly on the
+> 4-step *distillation* of base Lens; training a LoRA directly on the
 > distilled velocity field drifts (the same failure mode the Z-Image de-distill
 > adapter exists to avoid). So — unlike Z-Image — Lens needs **no de-distill
-> adapter**: it trains on the non-distilled **`microsoft/Lens`** (20-step, CFG 5.0,
+> adapter**: it trains on the non-distilled base (20-step, CFG 5.0,
 > the direct weight-parent of Turbo) and the resulting `lens`-family LoRA applies
-> cleanly to **Lens-Turbo** at inference. Install the **Lens (base)** model
-> (`microsoft/Lens`) from the Model Manager before a real run; `microsoft/Lens-Base`
-> (50-step supervised) is the fallback base, selectable via
+> cleanly to **Lens-Turbo** at inference. The training base is the
+> **`SceneWorks/Lens`** diffusers rehost (sc-8797; Microsoft pulled the original
+> `microsoft/Lens*` repos). On Windows/Linux the **Lens (base)** install already
+> fetches it; on macOS install the Lens **training** variant from the Model
+> Manager before a real run. Another source is selectable via
 > `advanced.baseModelRepo`.
 >
 > Like the Lens inference path, training runs in the isolated **Lens sidecar venv**
@@ -373,7 +375,7 @@ messages:
 | Symptom | Cause | Fix |
 | --- | --- | --- |
 | *"Base model 'z_image_turbo' is not installed."* (submit) | Z-Image-Turbo not downloaded | Install it from the Model Manager, then retry the real run. Dry runs work without it. |
-| *"Base model 'lens' is not installed."* (submit) | `microsoft/Lens` (the Lens training base) not downloaded | Install **Lens (base)** from the Model Manager. Lens trains on the non-distilled base and applies the LoRA to Lens-Turbo. |
+| *"Base model 'lens' is not installed."* (submit) | `SceneWorks/Lens` (the Lens training base) not downloaded | Install **Lens (base)** from the Model Manager (on macOS, its **training** variant — the MLX inference tiers alone don't include the flat training base). Lens trains on the non-distilled base and applies the LoRA to Lens-Turbo. |
 | *"LoRA adapter attached no trainable parameters…"* (runtime) | `loraTargetModules` matched nothing | For Lens use the fused-QKV names (`img_qkv`, `txt_qkv`, `to_out`, `to_add_out`), not Z-Image's `to_q`/`to_k`/`to_v`. |
 | *"Lens LoRA training requires the isolated Lens sidecar venv…"* (submit) | Worker built without the Lens sidecar | Rebuild with `INCLUDE_LENS=1`, or set `SCENEWORKS_LENS_PYTHON`. |
 | *"… cannot target CPU workers."* (submit) | `requestedGpu` was `cpu` | Training is GPU-only. Use `auto` or a GPU id. |

--- a/tests/fixtures/rust_migration_contracts/training/target-registry.json
+++ b/tests/fixtures/rust_migration_contracts/training/target-registry.json
@@ -302,7 +302,7 @@
       "outputKind": "lora",
       "family": "lens",
       "baseModel": "lens",
-      "baseModelRepo": "microsoft/Lens",
+      "baseModelRepo": "SceneWorks/Lens",
       "kernel": "lens_lora",
       "defaults": {
         "rank": 16,
@@ -316,7 +316,7 @@
         "seed": 42,
         "optimizer": "adamw8bit",
         "advanced": {
-          "baseModelRepo": "microsoft/Lens",
+          "baseModelRepo": "SceneWorks/Lens",
           "cacheLatents": true,
           "cacheTextEmbeddings": true,
           "gradientCheckpointing": true,

--- a/tests/test_worker_training.py
+++ b/tests/test_worker_training.py
@@ -1087,7 +1087,7 @@ def test_lens_trainer_drives_sidecar_and_shapes_result(tmp_path, monkeypatch):
     assert result["kernel"] == "lens_lora"
     assert result["stepsCompleted"] == 4
     assert result["outputPath"] == os.path.join(plan["output"]["outputDir"], "aurora.safetensors")
-    assert result["baseModelSource"] == "microsoft/Lens"
+    assert result["baseModelSource"] == "SceneWorks/Lens"
     assert result["triggerWords"] == ["auroraStyle"]
     assert os.path.exists(result["outputPath"])
 

--- a/tests/worker_runtime_shared.py
+++ b/tests/worker_runtime_shared.py
@@ -385,7 +385,7 @@ def _lens_train_plan(tmp_path, *, steps=4):
             "targetId": "lens_turbo_lora",
             "kernel": "lens_lora",
             "baseModel": "lens",
-            "baseModelRepo": "microsoft/Lens",
+            "baseModelRepo": "SceneWorks/Lens",
             "baseModelPath": str(tmp_path / "absent"),
         },
         "config": {


### PR DESCRIPTION
## Why
Microsoft pulled `microsoft/Lens*` from HF. Inference was recovered (tiered `SceneWorks/lens-mlx` turnkeys sc-8767; `SceneWorks/Lens` candle diffusers rehost sc-8799), but the **LoRA-training** path still hardcoded the dead `microsoft/Lens` base: `training_base_model_installed` and `resolve_base_model_path` key on the target's `baseModelRepo`, so a real `lens_lora` run could never provision its base (dead-404 source, no longer catalogued anywhere).

## What
**Core repoint (all trainer lanes)** — `lens_turbo_lora` in `crates/sceneworks-core/src/training.rs`: `base_model_repo` + `advanced.baseModelRepo` → **`SceneWorks/Lens`**, the flat self-contained diffusers rehost (`tokenizer/ text_encoder/ transformer/ vae/`, layout-identical to the original — story option (c), already live + GPU-validated for candle inference by sc-8799). The mlx, candle, and torch-sidecar lanes all read the plan's repo/path, so this one entry fixes all three. The dead `microsoft/Lens-Base` fallback note (sc-1584) is retired; the `advanced.baseModelRepo` override mechanism stays.

**Platform provisioning**
- **Windows/Linux**: nothing extra — the `lens` catalog install already fetches the whole `SceneWorks/Lens` repo (sc-8799), so the installed-gate and `baseModelPath` line up.
- **macOS**: new `variant: "training"` download entry on the `lens` model fetching `SceneWorks/Lens` (the MLX q4/q8/bf16 tiers are packed turnkey subdirs the flat-diffusers trainer loader doesn't read). Per-variant install state probes the entry's own repo (sc-8508). The Model Manager tier panel lists it (`TIER_DISPLAY_ORDER` + label); it's deliberately absent from `tierQuantize`, so the generation tier picker and RAM suggestion ignore it.

**Tests/fixtures/docs**: regenerated `target-registry.json` contract fixture; Python contract tests; the ignored real-weight smokes (mlx + candle) now resolve the `SceneWorks/Lens` snapshot; TRAINING_QUICKSTART.

## Validation
- **GPU (RTX, Windows/CUDA)**: `candle_lens_real_weights_trains_a_lora_step` against the freshly-downloaded `SceneWorks/Lens` snapshot — trainer loads all components, 2 LoRA micro-steps, finite loss (0.627), adapter written. First real-weight proof of the repointed base end-to-end.
- `cargo test -p sceneworks-core` (lib + training_contracts), `-p sceneworks-worker --lib`, `-p sceneworks-rust-api` (2 pre-existing Windows path-separator failures on main, unrelated), `pytest tests/test_worker_training.py -k lens`, web vitest (quantTier/tierSuggestion/ModelManager), `cargo fmt --check`.

## Related
- mlx-gen twin (repro-test snapshot lookup): SceneWorks/mlx-gen#627
- Follow-ups: sc-8965 (torch inference lane + macOS lens_turbo smokes still on dead repos), sc-8966 (Training Studio ready-gate variant-awareness on macOS)
- Relates: sc-8767, sc-8799, sc-8763

🤖 Generated with [Claude Code](https://claude.com/claude-code)