### PR TITLE
fix(worker): wire cancel/progress + heartbeat into SAM2/SAM3 propagate (sc-8807)

### DIFF
--- a/crates/sceneworks-worker/src/media_jobs.rs
+++ b/crates/sceneworks-worker/src/media_jobs.rs
@@ -925,7 +925,16 @@ async fn segment_assembly_frames(
     // fallback during the cutover). Both return one binary mask per clip frame; either path's
     // failure degrades to box masks (handled by the replacement loader) — a track that already
     // located the person is never failed by the mask pass.
-    let masks = match person_segmenter_kind() {
+    //
+    // The blocking segment step runs under `run_blocking_with_heartbeat` (sc-8390 / sc-8807): a
+    // cold-start propagate (multi-GB checkpoint parse + quantize + per-frame 1008² propagation)
+    // can exceed the API's 90s stale-sweep, so the keepalive pings `Busy` every interval AND
+    // polls for a user cancel, tripping `cancel` — which the engine's per-frame propagate
+    // contract (gen-core d8038beb) observes between frames. A user cancel is terminal for the
+    // whole person-track job (never a degrade); any other failure keeps the degrade contract.
+    let cancel = gen_core::CancelFlag::new();
+    let cancel_message = "Person tracking canceled during segmentation.";
+    let outcome = match person_segmenter_kind() {
         PersonSegmenter::Sam3 => {
             let (model, tokenizer) = match crate::person_segment_sam3::ensure_segmenter_weights(
                 settings,
@@ -937,16 +946,28 @@ async fn segment_assembly_frames(
                 Err(WorkerError::Canceled(message)) => return Err(WorkerError::Canceled(message)),
                 Err(_) => return Ok("degraded"),
             };
-            match tokio::task::spawn_blocking(move || {
-                crate::person_segment_sam3::segment_track_blocking(
-                    model, tokenizer, clip_paths, anchors,
-                )
-            })
+            let flag = cancel.clone();
+            run_blocking_with_heartbeat(
+                api,
+                settings,
+                &job.id,
+                Some(cancel),
+                cancel_message,
+                "person segment task",
+                tokio::task::spawn_blocking(move || {
+                    crate::person_segment_sam3::segment_track_blocking(
+                        model,
+                        tokenizer,
+                        clip_paths,
+                        anchors,
+                        Some(flag),
+                        Some(Box::new(|frame, total| {
+                            tracing::debug!(event = "sam3_propagate_progress", frame, total);
+                        })),
+                    )
+                }),
+            )
             .await
-            {
-                Ok(Ok(masks)) => masks,
-                _ => return Ok("degraded"),
-            }
         }
         PersonSegmenter::Sam2 => {
             let weights =
@@ -959,15 +980,35 @@ async fn segment_assembly_frames(
                     }
                     Err(_) => return Ok("degraded"),
                 };
-            match tokio::task::spawn_blocking(move || {
-                crate::person_segment::propagate_track_blocking(weights, clip_paths, anchors)
-            })
+            let flag = cancel.clone();
+            run_blocking_with_heartbeat(
+                api,
+                settings,
+                &job.id,
+                Some(cancel),
+                cancel_message,
+                "person segment task",
+                tokio::task::spawn_blocking(move || {
+                    crate::person_segment::propagate_track_blocking(
+                        weights,
+                        clip_paths,
+                        anchors,
+                        Some(flag),
+                        Some(Box::new(|frame, total| {
+                            tracing::debug!(event = "sam2_propagate_progress", frame, total);
+                        })),
+                    )
+                }),
+            )
             .await
-            {
-                Ok(Ok(masks)) => masks,
-                _ => return Ok("degraded"),
-            }
         }
+    };
+    let masks = match outcome {
+        Ok(masks) => masks,
+        // The keepalive posted the terminal `Canceled` already; propagate it (job canceled).
+        Err(WorkerError::Canceled(message)) => return Err(WorkerError::Canceled(message)),
+        // Any other failure (engine error, task join) degrades to box masks, as before.
+        Err(_) => return Ok("degraded"),
     };
 
     // Write every clip frame's non-empty mask (detected + gap) and set its sidecar `mask`. All the
@@ -1117,15 +1158,35 @@ async fn segment_assembly_frames(
         Err(WorkerError::Canceled(message)) => return Err(WorkerError::Canceled(message)),
         Err(_) => return Ok("degraded"),
     };
-    let masks = match tokio::task::spawn_blocking(move || {
-        crate::person_segment_sam3_candle::segment_track_blocking(
-            model, tokenizer, clip_paths, anchors,
-        )
-    })
-    .await
-    {
-        Ok(Ok(masks)) => masks,
-        _ => return Ok("degraded"),
+    // Keepalive + user cancel across the blocking segment step (sc-8390 / sc-8807), mirroring the
+    // macOS twin. The pinned candle-gen-sam3 propagate takes no cancel/progress params yet
+    // (sc-8972), so the tripped flag stops at the coarse seams (cold parse / model build) only.
+    let cancel = gen_core::CancelFlag::new();
+    let flag = cancel.clone();
+    let outcome = run_blocking_with_heartbeat(
+        api,
+        settings,
+        &job.id,
+        Some(cancel),
+        "Person tracking canceled during segmentation.",
+        "person segment task",
+        tokio::task::spawn_blocking(move || {
+            crate::person_segment_sam3_candle::segment_track_blocking(
+                model,
+                tokenizer,
+                clip_paths,
+                anchors,
+                Some(flag),
+            )
+        }),
+    )
+    .await;
+    let masks = match outcome {
+        Ok(masks) => masks,
+        // The keepalive posted the terminal `Canceled` already; propagate it (job canceled).
+        Err(WorkerError::Canceled(message)) => return Err(WorkerError::Canceled(message)),
+        // Any other failure (engine error, task join) degrades to box masks, as before.
+        Err(_) => return Ok("degraded"),
     };
 
     // Write every clip frame's non-empty mask (detected + gap) and set its sidecar `mask`.
@@ -2842,7 +2903,13 @@ mod person_track_e2e_tests {
             let gap_frames = anchors.iter().filter(|a| a.is_none()).count();
 
             let masks = tokio::task::spawn_blocking(move || {
-                crate::person_segment::propagate_track_blocking(seg_weights, clip_paths, anchors)
+                crate::person_segment::propagate_track_blocking(
+                    seg_weights,
+                    clip_paths,
+                    anchors,
+                    None,
+                    None,
+                )
             })
             .await
             .expect("propagate task joins")
@@ -3038,7 +3105,9 @@ mod person_track_e2e_tests {
                     .expect("sam3 weights provisioned");
             let (cp3, an3) = (clip_paths.clone(), anchors.clone());
             let sam3 = tokio::task::spawn_blocking(move || {
-                crate::person_segment_sam3::segment_track_blocking(sam3_model, sam3_tok, cp3, an3)
+                crate::person_segment_sam3::segment_track_blocking(
+                    sam3_model, sam3_tok, cp3, an3, None, None,
+                )
             })
             .await
             .expect("sam3 task joins")
@@ -3082,7 +3151,7 @@ mod person_track_e2e_tests {
                 };
             let (cp2, an2) = (clip_paths.clone(), anchors.clone());
             let sam2 = tokio::task::spawn_blocking(move || {
-                crate::person_segment::propagate_track_blocking(sam2_weights, cp2, an2)
+                crate::person_segment::propagate_track_blocking(sam2_weights, cp2, an2, None, None)
             })
             .await
             .expect("sam2 task joins")

--- a/crates/sceneworks-worker/src/person_segment.rs
+++ b/crates/sceneworks-worker/src/person_segment.rs
@@ -22,11 +22,32 @@ use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 
 use crate::downloads::{ensure_hf_cached_file, DownloadContext};
+use gen_core::CancelFlag;
 // CARVE-OUT(epic 3720): backend-specific; absorbed by Segmenter in Phase 6.
 use mlx_gen::weights::Weights;
 use mlx_gen_sam2::{Sam2ModelSize, Sam2VideoPredictor};
 
 use crate::{Settings, WorkerError, WorkerResult};
+
+/// Cancel copy surfaced when a segmentation is interrupted by a user cancel — either by the
+/// engine's per-frame propagate cancel contract (gen-core d8038beb) or by the coarse checks
+/// around the cold weight load (sc-8807). Shared by the SAM2/SAM3 segmenter modules.
+pub(crate) const CANCEL_MESSAGE: &str = "Person segmentation canceled by user.";
+
+/// Per-frame propagate progress callback `(frame_index, total_frames)`, invoked from the blocking
+/// thread after each propagated frame (the gen-core d8038beb video per-step progress contract).
+/// Boxed + `Send` so call sites can move it into `spawn_blocking`.
+pub(crate) type SegmentProgress = Box<dyn FnMut(usize, usize) + Send>;
+
+/// Bail out with [`WorkerError::Canceled`] when the threaded flag has been tripped — the coarse
+/// cancel seam guarding the phases the engine cannot observe (frame decode, the cold multi-GB
+/// weight load/parse, quantize). The engine itself checks the same flag between frames (sc-8807).
+pub(crate) fn check_segment_canceled(cancel: Option<&CancelFlag>) -> WorkerResult<()> {
+    if cancel.is_some_and(CancelFlag::is_cancelled) {
+        return Err(WorkerError::Canceled(CANCEL_MESSAGE.to_owned()));
+    }
+    Ok(())
+}
 
 /// The production SAM2 size (matches the spike + the `SceneWorks/sam2-mlx` upload).
 const SEG_FILE: &str = "sam2.1_hiera_large.safetensors";
@@ -157,16 +178,25 @@ pub(crate) fn mask_box_coverage(pixels: &[u8], box_norm: BoxNorm, width: u32, he
 /// Returns one binary mask (row-major `width*height`, `0`/`255`) per clip frame, in clip order.
 /// The model loads once and is cached process-wide; run under `spawn_blocking` (image decode + GPU
 /// propagation are blocking).
+///
+/// `cancel` is the user-cancel flag (sc-8807): checked at the coarse phase boundaries here (frame
+/// decode, cold weight load) and threaded into the engine's per-frame propagate cancel contract
+/// (gen-core d8038beb), so a tripped flag stops the clip between frames with
+/// [`WorkerError::Canceled`]. `progress` is invoked `(frame_index, total_frames)` after each
+/// propagated frame (per pass — the drift-correcting pass 2 restarts the count).
 pub(crate) fn propagate_track_blocking(
     weights_path: PathBuf,
     clip_frame_paths: Vec<PathBuf>,
     anchors: Vec<Option<BoxNorm>>,
+    cancel: Option<CancelFlag>,
+    mut progress: Option<SegmentProgress>,
 ) -> WorkerResult<Vec<Vec<u8>>> {
     assert_eq!(
         clip_frame_paths.len(),
         anchors.len(),
         "frames/anchors mismatch"
     );
+    check_segment_canceled(cancel.as_ref())?;
     let prompt =
         anchors.first().copied().flatten().ok_or_else(|| {
             WorkerError::InvalidPayload("propagate clip needs a prompt frame".into())
@@ -190,6 +220,10 @@ pub(crate) fn propagate_track_blocking(
     }
     let frame_refs: Vec<&[u8]> = rgb.iter().map(|f| f.as_slice()).collect();
 
+    // Guard the (possibly cold) weight load — the engine only observes the flag once
+    // propagation starts.
+    check_segment_canceled(cancel.as_ref())?;
+
     let cell = PREDICTOR.get_or_init(|| Mutex::new(None));
     // Recover from a poisoned lock rather than panicking every subsequent job: a
     // prior propagation that panicked mid-run leaves the lock poisoned, so take the
@@ -209,7 +243,7 @@ pub(crate) fn propagate_track_blocking(
     }
     let predictor = guard.as_ref().expect("predictor loaded");
 
-    let run = |seeds: &[(usize, BoxNorm)]| -> WorkerResult<Vec<Vec<u8>>> {
+    let mut run = |seeds: &[(usize, BoxNorm)]| -> WorkerResult<Vec<Vec<u8>>> {
         let mut state = predictor
             .init_state_from_frames(&frame_refs, height, width)
             .map_err(|e| WorkerError::Engine(format!("sam2 init_state: {e}")))?;
@@ -222,12 +256,21 @@ pub(crate) fn propagate_track_blocking(
                 )
                 .map_err(|e| WorkerError::Engine(format!("sam2 add_box: {e}")))?;
         }
-        // gen-core d8038beb (sc-7176 pin sync): `propagate` gained `cancel` + per-frame `progress`
-        // params (the video per-step cancel contract). Pass `None, None` to preserve the prior
-        // uncancellable, progress-silent behavior on this MLX path.
+        // gen-core d8038beb (sc-7176 pin sync): `propagate` takes `cancel` + per-frame `progress`
+        // (the video per-step cancel contract). Thread the caller's flag/callback so a user cancel
+        // stops between frames and each frame reports progress (sc-8807).
         let masks = predictor
-            .propagate(&mut state, None, None)
-            .map_err(|e| WorkerError::Engine(format!("sam2 propagate: {e}")))?;
+            .propagate(
+                &mut state,
+                cancel.as_ref(),
+                progress
+                    .as_deref_mut()
+                    .map(|cb| cb as &mut dyn FnMut(usize, usize)),
+            )
+            .map_err(|e| match e {
+                mlx_gen::Error::Canceled => WorkerError::Canceled(CANCEL_MESSAGE.to_owned()),
+                e => WorkerError::Engine(format!("sam2 propagate: {e}")),
+            })?;
         // `propagate` yields the prompt frame onward in order; build a dense per-clip-frame vec.
         let mut out = vec![Vec::new(); clip_frame_paths.len()];
         for (frame_idx, low) in &masks {
@@ -297,6 +340,39 @@ mod tests {
         assert_eq!(*guard, None, "cached model is dropped on poison recovery");
         *guard = Some(42); // reload
         assert_eq!(*guard, Some(42));
+    }
+
+    /// sc-8807: a pre-tripped cancel flag short-circuits the propagate BEFORE any frame decode or
+    /// (cold, multi-GB) weight load — the paths point at nothing, so reaching either would error
+    /// with `InvalidPayload`/`Engine` instead of `Canceled`. Pins the coarse cancel seam ordering.
+    #[test]
+    fn pre_tripped_cancel_short_circuits_before_decode_and_weights() {
+        let cancel = CancelFlag::new();
+        cancel.cancel();
+        let result = propagate_track_blocking(
+            PathBuf::from("/nonexistent/sam2.safetensors"),
+            vec![PathBuf::from("/nonexistent/frame.png")],
+            vec![Some((0.1, 0.1, 0.5, 0.5))],
+            Some(cancel),
+            None,
+        );
+        assert!(
+            matches!(result, Err(WorkerError::Canceled(ref m)) if m == CANCEL_MESSAGE),
+            "expected Canceled, got {result:?}"
+        );
+    }
+
+    /// An un-tripped (or absent) flag never trips the coarse cancel seam.
+    #[test]
+    fn check_segment_canceled_passes_when_flag_is_live_or_absent() {
+        assert!(check_segment_canceled(None).is_ok());
+        let cancel = CancelFlag::new();
+        assert!(check_segment_canceled(Some(&cancel)).is_ok());
+        cancel.cancel();
+        assert!(matches!(
+            check_segment_canceled(Some(&cancel)),
+            Err(WorkerError::Canceled(_))
+        ));
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/person_segment_sam3.rs
+++ b/crates/sceneworks-worker/src/person_segment_sam3.rs
@@ -27,6 +27,8 @@ use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
 use crate::downloads::{ensure_hf_cached_file, DownloadContext};
+use crate::person_segment::{check_segment_canceled, SegmentProgress, CANCEL_MESSAGE};
+use gen_core::CancelFlag;
 use mlx_gen::weights::Weights;
 use mlx_gen_sam3::{
     Sam3ImageSegmenter, Sam3TextConfig, Sam3Tokenizer, Sam3Tracker, Sam3VideoModel,
@@ -259,17 +261,26 @@ fn mask_to_frame(mask_logits: &[f32], grid: usize, width: u32, height: u32) -> V
 /// empty vec for a frame where the selected object was absent (orchestrator skips empties → box
 /// fallback). The checkpoint parses once and is cached process-wide; run under `spawn_blocking`
 /// (image decode + GPU inference are blocking).
+///
+/// `cancel` is the user-cancel flag (sc-8807): checked at the coarse phase boundaries here (frame
+/// decode, the cold 3.2 GB checkpoint parse, model build + quantize) and threaded into the
+/// engine's per-frame propagate cancel contract (gen-core d8038beb), so a tripped flag stops the
+/// clip between frames with [`WorkerError::Canceled`]. `progress` is invoked
+/// `(frame_index, total_frames)` after each propagated frame.
 pub(crate) fn segment_track_blocking(
     model_path: PathBuf,
     tokenizer_path: PathBuf,
     clip_frame_paths: Vec<PathBuf>,
     anchors: Vec<Option<BoxNorm>>,
+    cancel: Option<CancelFlag>,
+    mut progress: Option<SegmentProgress>,
 ) -> WorkerResult<Vec<Vec<u8>>> {
     assert_eq!(
         clip_frame_paths.len(),
         anchors.len(),
         "frames/anchors mismatch"
     );
+    check_segment_canceled(cancel.as_ref())?;
     if !anchors.iter().any(Option::is_some) {
         return Err(WorkerError::InvalidPayload(
             "person segmentation clip needs at least one detected frame to associate".into(),
@@ -292,6 +303,10 @@ pub(crate) fn segment_track_blocking(
         }
         frames.push(input_tensor(&img));
     }
+
+    // Guard the cold 3.2 GB checkpoint parse + model build + quantize — the engine only observes
+    // the flag once propagation starts.
+    check_segment_canceled(cancel.as_ref())?;
 
     // Cached checkpoint; recover from a poisoned lock by dropping the cached weights and reloading
     // (mirrors person_segment / sc-4277 F-MLXW-13).
@@ -323,13 +338,27 @@ pub(crate) fn segment_track_blocking(
     let (input_ids, text_mask) = tokenizer
         .encode(CONCEPT_PROMPT)
         .map_err(|e| WorkerError::Engine(format!("sam3 tokenize: {e}")))?;
+    // The quantize pass above is seconds-long on a cold start; re-check before committing to the
+    // propagate loop.
+    check_segment_canceled(cancel.as_ref())?;
 
-    // gen-core d8038beb (sc-7176 pin sync): `propagate` gained `cancel` + per-frame `progress` params
-    // (the video per-step cancel contract). `None, None` preserves the prior uncancellable,
-    // progress-silent behavior on this MLX path.
+    // gen-core d8038beb (sc-7176 pin sync): `propagate` takes `cancel` + per-frame `progress`
+    // (the video per-step cancel contract). Thread the caller's flag/callback so a user cancel
+    // stops between frames and each frame reports progress (sc-8807).
     let outputs = model
-        .propagate(&frames, &input_ids, &text_mask, None, None)
-        .map_err(|e| WorkerError::Engine(format!("sam3 propagate: {e}")))?;
+        .propagate(
+            &frames,
+            &input_ids,
+            &text_mask,
+            cancel.as_ref(),
+            progress
+                .as_deref_mut()
+                .map(|cb| cb as &mut dyn FnMut(usize, usize)),
+        )
+        .map_err(|e| match e {
+            mlx_gen::Error::Canceled => WorkerError::Canceled(CANCEL_MESSAGE.to_owned()),
+            e => WorkerError::Engine(format!("sam3 propagate: {e}")),
+        })?;
 
     // Associate SAM3's identities to the selected track, then emit that object's per-frame mask.
     let Some(selected) = select_object(&outputs, &anchors) else {
@@ -595,11 +624,18 @@ fn mask_centroid_x(mask_logits: &[f32], grid: usize) -> Option<f64> {
 /// driving frames are already decoded `Image`s, so the temp-PNG round-trip is skipped. `frames` must
 /// be non-empty and uniform-sized. The checkpoint parses once and is cached process-wide; run under
 /// `spawn_blocking` (GPU inference is blocking).
+///
+/// `cancel`/`progress` follow [`segment_track_blocking`] (sc-8807): coarse checks around the cold
+/// checkpoint parse + model build, the engine's per-frame cancel between frames, and a
+/// `(frame_index, total_frames)` callback after each propagated frame.
 pub(crate) fn segment_all_persons_in_memory(
     model_path: &Path,
     tokenizer_path: &Path,
     frames: &[image::RgbImage],
+    cancel: Option<CancelFlag>,
+    mut progress: Option<SegmentProgress>,
 ) -> WorkerResult<AllPersonMasks> {
+    check_segment_canceled(cancel.as_ref())?;
     let first = frames.first().ok_or_else(|| {
         WorkerError::InvalidPayload("scail2 segmentation: no frames to segment".into())
     })?;
@@ -613,6 +649,10 @@ pub(crate) fn segment_all_persons_in_memory(
         ));
     }
     let tensors: Vec<Array> = frames.iter().map(input_tensor).collect();
+
+    // Guard the cold 3.2 GB checkpoint parse + model build + quantize — the engine only observes
+    // the flag once propagation starts.
+    check_segment_canceled(cancel.as_ref())?;
 
     // Cached checkpoint; recover from a poisoned lock by dropping + reloading (mirrors
     // `segment_track_blocking` / sc-4277 F-MLXW-13).
@@ -641,12 +681,24 @@ pub(crate) fn segment_all_persons_in_memory(
     let (input_ids, text_mask) = tokenizer
         .encode(CONCEPT_PROMPT)
         .map_err(|e| WorkerError::Engine(format!("sam3 tokenize: {e}")))?;
+    check_segment_canceled(cancel.as_ref())?;
 
-    // gen-core d8038beb (sc-7176 pin sync): `propagate` gained `cancel` + per-frame `progress` params;
-    // `None, None` preserves the prior uncancellable, progress-silent behavior on this MLX path.
+    // gen-core d8038beb (sc-7176 pin sync): `propagate` takes `cancel` + per-frame `progress`
+    // (the video per-step cancel contract). Thread the caller's flag/callback (sc-8807).
     let outputs = model
-        .propagate(&tensors, &input_ids, &text_mask, None, None)
-        .map_err(|e| WorkerError::Engine(format!("sam3 propagate: {e}")))?;
+        .propagate(
+            &tensors,
+            &input_ids,
+            &text_mask,
+            cancel.as_ref(),
+            progress
+                .as_deref_mut()
+                .map(|cb| cb as &mut dyn FnMut(usize, usize)),
+        )
+        .map_err(|e| match e {
+            mlx_gen::Error::Canceled => WorkerError::Canceled(CANCEL_MESSAGE.to_owned()),
+            e => WorkerError::Engine(format!("sam3 propagate: {e}")),
+        })?;
 
     // Paint order: each object's centroid-x in the FIRST frame it appears, ascending (tie-break on
     // first-seen frame, then object id, so repeated runs agree).
@@ -696,6 +748,40 @@ pub(crate) fn segment_all_persons_in_memory(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// sc-8807: a pre-tripped cancel flag short-circuits BEFORE frame decode / the cold 3.2 GB
+    /// checkpoint parse — the paths point at nothing, so reaching either would error with
+    /// `InvalidPayload`/`Engine` instead of `Canceled`. Pins the coarse cancel seam ordering on
+    /// both video entry points.
+    #[test]
+    fn pre_tripped_cancel_short_circuits_both_video_paths() {
+        let cancel = CancelFlag::new();
+        cancel.cancel();
+        let track = segment_track_blocking(
+            PathBuf::from("/nonexistent/model.safetensors"),
+            PathBuf::from("/nonexistent/tokenizer.json"),
+            vec![PathBuf::from("/nonexistent/frame.png")],
+            vec![Some((0.1, 0.1, 0.5, 0.5))],
+            Some(cancel.clone()),
+            None,
+        );
+        assert!(
+            matches!(track, Err(WorkerError::Canceled(_))),
+            "segment_track_blocking: expected Canceled, got {track:?}"
+        );
+        let frames = vec![image::RgbImage::new(4, 4)];
+        let all = segment_all_persons_in_memory(
+            Path::new("/nonexistent/model.safetensors"),
+            Path::new("/nonexistent/tokenizer.json"),
+            &frames,
+            Some(cancel),
+            None,
+        );
+        assert!(
+            matches!(all, Err(WorkerError::Canceled(_))),
+            "segment_all_persons_in_memory: expected Canceled"
+        );
+    }
 
     #[test]
     fn normalize_box_maps_xyxy_pixels_to_unit_cxcywh() {
@@ -869,6 +955,8 @@ mod tests {
             tokenizer,
             vec![image.clone(), image],
             vec![Some(anchor), Some(anchor)],
+            None,
+            None,
         )
         .expect("segment_track_blocking");
 

--- a/crates/sceneworks-worker/src/person_segment_sam3_candle.rs
+++ b/crates/sceneworks-worker/src/person_segment_sam3_candle.rs
@@ -24,9 +24,27 @@ use candle_gen::candle_core::{Device, Tensor};
 use candle_gen::default_device;
 use candle_gen::gen_core::Quant;
 use candle_gen_sam3::{Sam3TextConfig, Sam3Tokenizer, Sam3VideoModel, VideoFrameOutput, Weights};
+use gen_core::CancelFlag;
 
 use crate::downloads::{ensure_hf_cached_file, DownloadContext};
 use crate::{Settings, WorkerError, WorkerResult};
+
+/// Cancel copy surfaced when a segmentation is interrupted by a user cancel — the candle sibling
+/// of `person_segment::CANCEL_MESSAGE` (Mac-only, so duplicated like the other shared helpers).
+pub(crate) const CANCEL_MESSAGE: &str = "Person segmentation canceled by user.";
+
+/// Bail out with [`WorkerError::Canceled`] when the threaded flag has been tripped — the coarse
+/// cancel seam guarding frame decode, the cold multi-GB checkpoint parse, and model build/quantize
+/// (sc-8807). Unlike the MLX twin, this is the ONLY cancel granularity on the candle lane: the
+/// pinned `candle-gen-sam3` `Sam3VideoModel::propagate` does not yet take the gen-core d8038beb
+/// `cancel`/`progress` params, so a tripped flag cannot stop mid-propagate (per-frame cancel +
+/// progress need the upstream candle-gen API bump — tracked in sc-8972).
+fn check_segment_canceled(cancel: Option<&CancelFlag>) -> WorkerResult<()> {
+    if cancel.is_some_and(CancelFlag::is_cancelled) {
+        return Err(WorkerError::Canceled(CANCEL_MESSAGE.to_owned()));
+    }
+    Ok(())
+}
 
 /// SAM3 checkpoint files (loaded stock from `facebook/sam3`, no conversion).
 const MODEL_FILE: &str = "model.safetensors";
@@ -257,17 +275,23 @@ fn mask_to_frame(mask_logits: &[f32], grid: usize, width: u32, height: u32) -> V
 /// empty vec for a frame where the selected object was absent (orchestrator skips empties → box
 /// fallback). The checkpoint parses once and is cached process-wide; run under `spawn_blocking` (image
 /// decode + GPU inference are blocking).
+///
+/// `cancel` is the user-cancel flag (sc-8807), checked at the coarse phase boundaries (frame decode,
+/// cold checkpoint parse, model build/quantize). Per-frame cancel + progress inside the propagate
+/// loop need the candle-gen-sam3 API bump (sc-8972) — see [`check_segment_canceled`].
 pub(crate) fn segment_track_blocking(
     model_path: PathBuf,
     tokenizer_path: PathBuf,
     clip_frame_paths: Vec<PathBuf>,
     anchors: Vec<Option<BoxNorm>>,
+    cancel: Option<CancelFlag>,
 ) -> WorkerResult<Vec<Vec<u8>>> {
     assert_eq!(
         clip_frame_paths.len(),
         anchors.len(),
         "frames/anchors mismatch"
     );
+    check_segment_canceled(cancel.as_ref())?;
     if !anchors.iter().any(Option::is_some) {
         return Err(WorkerError::InvalidPayload(
             "person segmentation clip needs at least one detected frame to associate".into(),
@@ -292,6 +316,10 @@ pub(crate) fn segment_track_blocking(
         }
         frames.push(input_tensor(&img, &device)?);
     }
+
+    // Guard the cold multi-GB checkpoint parse + model build — the last cancel seam before the
+    // (currently uncancellable, sc-8972) propagate loop.
+    check_segment_canceled(cancel.as_ref())?;
 
     // Cached checkpoint; recover from a poisoned lock by dropping the cached weights and reloading.
     let cell = WEIGHTS.get_or_init(|| Mutex::new(None));
@@ -322,7 +350,10 @@ pub(crate) fn segment_track_blocking(
     let (input_ids, text_mask) = tokenizer
         .encode(CONCEPT_PROMPT, &device)
         .map_err(|e| WorkerError::Engine(format!("sam3 tokenize: {e}")))?;
+    check_segment_canceled(cancel.as_ref())?;
 
+    // The pinned candle-gen-sam3 `propagate` takes no `cancel`/`progress` yet (unlike the MLX twin,
+    // gen-core d8038beb); per-frame cancel + progress land with the upstream API bump (sc-8972).
     let outputs = model
         .propagate(&frames, &input_ids, &text_mask)
         .map_err(|e| WorkerError::Engine(format!("sam3 propagate: {e}")))?;
@@ -386,11 +417,16 @@ fn mask_centroid_x(mask_logits: &[f32], grid: usize) -> Option<f64> {
 /// `Image`s. `frames` must be non-empty and uniform-sized. The checkpoint parses once and is cached
 /// process-wide; a fresh `Sam3VideoModel` is built per call (clean tracking state). Run under
 /// `spawn_blocking` (GPU inference is blocking).
+///
+/// `cancel` follows [`segment_track_blocking`] (sc-8807): coarse checks only until the
+/// candle-gen-sam3 propagate API bump (sc-8972).
 pub(crate) fn segment_all_persons_in_memory(
     model_path: &Path,
     tokenizer_path: &Path,
     frames: &[image::RgbImage],
+    cancel: Option<CancelFlag>,
 ) -> WorkerResult<AllPersonMasks> {
+    check_segment_canceled(cancel.as_ref())?;
     let first = frames.first().ok_or_else(|| {
         WorkerError::InvalidPayload("scail2 segmentation: no frames to segment".into())
     })?;
@@ -409,6 +445,10 @@ pub(crate) fn segment_all_persons_in_memory(
         .iter()
         .map(|f| input_tensor(f, &device))
         .collect::<WorkerResult<Vec<_>>>()?;
+
+    // Guard the cold multi-GB checkpoint parse + model build — the last cancel seam before the
+    // (currently uncancellable, sc-8972) propagate loop.
+    check_segment_canceled(cancel.as_ref())?;
 
     // Cached checkpoint; recover from a poisoned lock by dropping + reloading (mirrors
     // `segment_track_blocking`).
@@ -439,7 +479,9 @@ pub(crate) fn segment_all_persons_in_memory(
     let (input_ids, text_mask) = tokenizer
         .encode(CONCEPT_PROMPT, &device)
         .map_err(|e| WorkerError::Engine(format!("sam3 tokenize: {e}")))?;
+    check_segment_canceled(cancel.as_ref())?;
 
+    // No `cancel`/`progress` on the pinned candle-gen-sam3 propagate yet (sc-8972).
     let outputs = model
         .propagate(&tensors, &input_ids, &text_mask)
         .map_err(|e| WorkerError::Engine(format!("sam3 propagate: {e}")))?;
@@ -512,6 +554,37 @@ mod tests {
         assert_eq!(parse_quant("F32"), None);
         assert_eq!(parse_quant("none"), None);
         assert_eq!(parse_quant("garbage"), None, "unrecognized → dense");
+    }
+
+    /// sc-8807: a pre-tripped cancel flag short-circuits BEFORE frame decode / the cold multi-GB
+    /// checkpoint parse — the paths point at nothing, so reaching either would error with
+    /// `InvalidPayload`/`Engine` instead of `Canceled`. Pins the coarse cancel seam ordering.
+    #[test]
+    fn pre_tripped_cancel_short_circuits_both_video_paths() {
+        let cancel = CancelFlag::new();
+        cancel.cancel();
+        let track = segment_track_blocking(
+            PathBuf::from("/nonexistent/model.safetensors"),
+            PathBuf::from("/nonexistent/tokenizer.json"),
+            vec![PathBuf::from("/nonexistent/frame.png")],
+            vec![Some((0.1, 0.1, 0.5, 0.5))],
+            Some(cancel.clone()),
+        );
+        assert!(
+            matches!(track, Err(WorkerError::Canceled(_))),
+            "segment_track_blocking: expected Canceled, got {track:?}"
+        );
+        let frames = vec![image::RgbImage::new(4, 4)];
+        let all = segment_all_persons_in_memory(
+            Path::new("/nonexistent/model.safetensors"),
+            Path::new("/nonexistent/tokenizer.json"),
+            &frames,
+            Some(cancel),
+        );
+        assert!(
+            matches!(all, Err(WorkerError::Canceled(_))),
+            "segment_all_persons_in_memory: expected Canceled"
+        );
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/progress.rs
+++ b/crates/sceneworks-worker/src/progress.rs
@@ -100,7 +100,17 @@ where
     loop {
         tokio::select! {
             result = &mut task => {
-                let value = result.map_err(|error| task_join_error(task_label, error))??;
+                let value = result.map_err(|error| task_join_error(task_label, error))?;
+                // An engine that honors the tripped `cancel` flag itself (the per-frame video
+                // cancel contract, gen-core d8038beb) surfaces `WorkerError::Canceled` from
+                // inside the task; post the terminal `Canceled` here exactly like the
+                // poll-detected path below so the job never dangles non-terminal (sc-8807).
+                if let Err(WorkerError::Canceled(message)) = &value {
+                    let message = message.clone();
+                    mark_job_canceled(api, job_id, &message).await?;
+                    return Err(WorkerError::Canceled(message));
+                }
+                let value = value?;
                 if canceled {
                     mark_job_canceled(api, job_id, cancel_message).await?;
                     return Err(WorkerError::Canceled(cancel_message.to_owned()));

--- a/crates/sceneworks-worker/src/scail2_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/scail2_gpu_smoke.rs
@@ -115,6 +115,7 @@ fn scail2_candle_gpu_smoke() {
         &sam3_model,
         &sam3_tok,
         std::slice::from_ref(&ref_rgb),
+        None,
     )
     .expect("sam3 reference segmentation");
     let ref_bg = if replacement {
@@ -143,6 +144,7 @@ fn scail2_candle_gpu_smoke() {
         &sam3_model,
         &sam3_tok,
         &driving_rgb,
+        None,
     )
     .expect("sam3 driving segmentation");
     let drive_bg = if replacement {

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -3433,3 +3433,164 @@ mod stub_fallback_gate {
         ensure_video_engine_weights(&request, &settings).expect("non-engine model passes");
     }
 }
+
+// ---------------------------------------------------------------------------
+// sc-8807: the shared blocking keepalive (`run_blocking_with_heartbeat`) is the seam the
+// SAM2/SAM3 propagate steps now run through. These tests pin the three behaviors the segment
+// wiring relies on, with a stand-in blocking task in place of the real (weights-requiring)
+// propagate: (a) the worker heartbeat is pinged while the task runs, (b) the API cancel poll
+// trips the threaded `CancelFlag`, and (c) the terminal `Canceled` is posted whether the task
+// honors the flag itself (the MLX per-frame cancel contract) or runs to completion first (the
+// candle coarse-seam lane, sc-8972).
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+struct KeepaliveStubState {
+    heartbeats: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    progress: std::sync::Arc<std::sync::Mutex<Vec<Value>>>,
+}
+
+impl KeepaliveStubState {
+    fn new() -> Self {
+        Self {
+            heartbeats: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            progress: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+        }
+    }
+}
+
+/// A stub API that always reports `cancel_requested: true`, counts worker heartbeats, and records
+/// every job-progress post (so the terminal `Canceled` write is observable).
+async fn spawn_keepalive_stub(state: KeepaliveStubState) -> String {
+    async fn heartbeat_route(State(state): State<KeepaliveStubState>) -> Response {
+        state
+            .heartbeats
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        // The body does not parse as a WorkerSnapshot; `heartbeat()` tolerates the decode
+        // failure as a transport error, so the ping still counts without modeling the snapshot.
+        Json(json!({})).into_response()
+    }
+    async fn job_route(axum::extract::Path(job_id): axum::extract::Path<String>) -> Response {
+        Json(job_snapshot_json(&job_id, true)).into_response()
+    }
+    async fn progress_route(
+        State(state): State<KeepaliveStubState>,
+        axum::extract::Path(job_id): axum::extract::Path<String>,
+        Json(payload): Json<Value>,
+    ) -> Response {
+        state.progress.lock().unwrap().push(payload);
+        Json(job_snapshot_json(&job_id, true)).into_response()
+    }
+    let app = Router::new()
+        .route(
+            "/api/v1/workers/:worker_id/heartbeat",
+            post(heartbeat_route),
+        )
+        .route("/api/v1/jobs/:job_id", get(job_route))
+        .route("/api/v1/jobs/:job_id/progress", post(progress_route))
+        .with_state(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("listener binds");
+    let address = listener.local_addr().expect("listener has address");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("stub serves");
+    });
+    format!("http://{address}")
+}
+
+/// The MLX lane: the keepalive trips the flag, the engine honors it between propagated frames and
+/// surfaces `WorkerError::Canceled` from inside the task — the terminal `Canceled` must be posted
+/// and the error propagated (never a dangling non-terminal job).
+#[tokio::test]
+async fn keepalive_posts_terminal_canceled_when_the_task_honors_the_flag() {
+    let state = KeepaliveStubState::new();
+    let base = spawn_keepalive_stub(state.clone()).await;
+    let mut settings = test_settings("http://127.0.0.1".to_owned(), None);
+    settings.api_url = base;
+    let api = ApiClient::new(&settings);
+
+    let flag = gen_core::CancelFlag::new();
+    let task_flag = flag.clone();
+    let task = tokio::task::spawn_blocking(move || -> super::WorkerResult<u32> {
+        let start = std::time::Instant::now();
+        while !task_flag.is_cancelled() {
+            if start.elapsed() > Duration::from_secs(30) {
+                return Err(WorkerError::Engine("cancel flag never tripped".to_owned()));
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        // The engine's per-frame cancel contract (gen-core d8038beb) surfaces Canceled itself.
+        Err(WorkerError::Canceled(
+            "Person segmentation canceled by user.".to_owned(),
+        ))
+    });
+    let result = super::run_blocking_with_heartbeat(
+        &api,
+        &settings,
+        "job-8807-mlx",
+        Some(flag),
+        "Person tracking canceled during segmentation.",
+        "sam propagate stand-in",
+        task,
+    )
+    .await;
+
+    assert!(
+        matches!(result, Err(WorkerError::Canceled(ref m)) if m == "Person segmentation canceled by user."),
+        "expected the task's Canceled to propagate, got {result:?}"
+    );
+    assert!(
+        state.heartbeats.load(std::sync::atomic::Ordering::SeqCst) >= 1,
+        "Busy heartbeat pinged during the blocking task"
+    );
+    let posts = state.progress.lock().unwrap();
+    assert!(
+        posts.iter().any(|p| p["status"] == "canceled"),
+        "terminal Canceled posted to the job, got {posts:?}"
+    );
+}
+
+/// The candle lane (coarse seams only until sc-8972): the compute cannot observe the flag
+/// mid-propagate and runs to completion — the keepalive still posts the terminal `Canceled` with
+/// its own cancel copy and returns `WorkerError::Canceled`.
+#[tokio::test]
+async fn keepalive_cancels_the_job_even_when_the_task_cannot_observe_the_flag() {
+    let state = KeepaliveStubState::new();
+    let base = spawn_keepalive_stub(state.clone()).await;
+    let mut settings = test_settings("http://127.0.0.1".to_owned(), None);
+    settings.api_url = base;
+    let api = ApiClient::new(&settings);
+
+    let flag = gen_core::CancelFlag::new();
+    let wait_flag = flag.clone();
+    let task = tokio::task::spawn_blocking(move || -> super::WorkerResult<u32> {
+        // Wait until the keepalive has tripped the flag (so `canceled` is set before we return),
+        // then finish successfully — the uncancellable-compute shape.
+        let start = std::time::Instant::now();
+        while !wait_flag.is_cancelled() && start.elapsed() < Duration::from_secs(30) {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        Ok(7)
+    });
+    let result = super::run_blocking_with_heartbeat(
+        &api,
+        &settings,
+        "job-8807-candle",
+        Some(flag),
+        "Person tracking canceled during segmentation.",
+        "candle propagate stand-in",
+        task,
+    )
+    .await;
+
+    assert!(
+        matches!(result, Err(WorkerError::Canceled(ref m)) if m == "Person tracking canceled during segmentation."),
+        "expected the keepalive's Canceled, got {result:?}"
+    );
+    let posts = state.progress.lock().unwrap();
+    assert!(
+        posts.iter().any(|p| p["status"] == "canceled"),
+        "terminal Canceled posted to the job, got {posts:?}"
+    );
+}

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -3514,32 +3514,57 @@ async fn resolve_candle_scail2_conditioning(
         .ok_or_else(|| WorkerError::InvalidPayload("scail2 driving frame is malformed".into()))?;
 
     // Segment + paint the reference mask (animation keeps the reference's world → white background).
+    // Both SAM3 passes run under `run_blocking_with_heartbeat` (sc-8390 / sc-8807) so the cold
+    // multi-GB checkpoint parse + per-frame propagation never trip the API's 90s stale-sweep. The
+    // pinned candle-gen-sam3 propagate takes no cancel/progress params yet (sc-8972), so the
+    // tripped flag stops at the coarse seams (cold parse / model build) only.
+    let scail2_cancel_message = "SCAIL-2 canceled during person segmentation.";
+    let cancel = gen_core::CancelFlag::new();
+    let flag = cancel.clone();
     let (rm, rt) = (sam_model.clone(), sam_tokenizer.clone());
-    let ref_mask = tokio::task::spawn_blocking(move || -> WorkerResult<Image> {
-        let masks = crate::person_segment_sam3_candle::segment_all_persons_in_memory(
-            &rm,
-            &rt,
-            std::slice::from_ref(&ref_rgb),
-        )?;
-        crate::scail2_masks::paint_reference_mask(&masks, crate::scail2_masks::BG_WHITE)
-    })
-    .await
-    .map_err(|error| WorkerError::Io(std::io::Error::other(error)))??;
+    let ref_mask = run_blocking_with_heartbeat(
+        api,
+        settings,
+        &job.id,
+        Some(cancel),
+        scail2_cancel_message,
+        "scail2 reference segment task",
+        tokio::task::spawn_blocking(move || -> WorkerResult<Image> {
+            let masks = crate::person_segment_sam3_candle::segment_all_persons_in_memory(
+                &rm,
+                &rt,
+                std::slice::from_ref(&ref_rgb),
+                Some(flag),
+            )?;
+            crate::scail2_masks::paint_reference_mask(&masks, crate::scail2_masks::BG_WHITE)
+        }),
+    )
+    .await?;
 
     // Segment + paint the per-frame driving masks (animation → black background).
-    let driving_mask = tokio::task::spawn_blocking(move || -> WorkerResult<Vec<Image>> {
-        let masks = crate::person_segment_sam3_candle::segment_all_persons_in_memory(
-            &sam_model,
-            &sam_tokenizer,
-            &driving_rgb,
-        )?;
-        Ok(crate::scail2_masks::paint_driving_masks(
-            &masks,
-            crate::scail2_masks::BG_BLACK,
-        ))
-    })
-    .await
-    .map_err(|error| WorkerError::Io(std::io::Error::other(error)))??;
+    let cancel = gen_core::CancelFlag::new();
+    let flag = cancel.clone();
+    let driving_mask = run_blocking_with_heartbeat(
+        api,
+        settings,
+        &job.id,
+        Some(cancel),
+        scail2_cancel_message,
+        "scail2 driving segment task",
+        tokio::task::spawn_blocking(move || -> WorkerResult<Vec<Image>> {
+            let masks = crate::person_segment_sam3_candle::segment_all_persons_in_memory(
+                &sam_model,
+                &sam_tokenizer,
+                &driving_rgb,
+                Some(flag),
+            )?;
+            Ok(crate::scail2_masks::paint_driving_masks(
+                &masks,
+                crate::scail2_masks::BG_BLACK,
+            ))
+        }),
+    )
+    .await?;
 
     Ok(vec![
         Conditioning::Reference {
@@ -3686,16 +3711,28 @@ async fn resolve_candle_scail2_replace_conditioning(
             .ok_or_else(|| {
                 WorkerError::InvalidPayload("scail2 reference image is malformed".into())
             })?;
-    let ref_mask = tokio::task::spawn_blocking(move || -> WorkerResult<Image> {
-        let masks = crate::person_segment_sam3_candle::segment_all_persons_in_memory(
-            &sam_model,
-            &sam_tokenizer,
-            std::slice::from_ref(&ref_rgb),
-        )?;
-        crate::scail2_masks::paint_reference_mask(&masks, crate::scail2_masks::BG_BLACK)
-    })
-    .await
-    .map_err(|error| WorkerError::Io(std::io::Error::other(error)))??;
+    // Heartbeat keepalive + user cancel across the cold SAM3 parse + single-frame propagate
+    // (sc-8390 / sc-8807); coarse cancel seams only until the candle-gen-sam3 API bump (sc-8972).
+    let cancel = gen_core::CancelFlag::new();
+    let flag = cancel.clone();
+    let ref_mask = run_blocking_with_heartbeat(
+        api,
+        settings,
+        &job.id,
+        Some(cancel),
+        "SCAIL-2 canceled during person segmentation.",
+        "scail2 reference segment task",
+        tokio::task::spawn_blocking(move || -> WorkerResult<Image> {
+            let masks = crate::person_segment_sam3_candle::segment_all_persons_in_memory(
+                &sam_model,
+                &sam_tokenizer,
+                std::slice::from_ref(&ref_rgb),
+                Some(flag),
+            )?;
+            crate::scail2_masks::paint_reference_mask(&masks, crate::scail2_masks::BG_BLACK)
+        }),
+    )
+    .await?;
 
     let conditioning = vec![
         Conditioning::Reference {
@@ -4443,32 +4480,61 @@ async fn resolve_scail2_conditioning(
         .ok_or_else(|| WorkerError::InvalidPayload("scail2 driving frame is malformed".into()))?;
 
     // Segment + paint the reference mask (animation keeps the reference's world → white background).
+    // Both SAM3 passes run under `run_blocking_with_heartbeat` (sc-8390 / sc-8807): the cold
+    // multi-GB checkpoint parse + per-frame 1008² propagation over a driving clip can exceed the
+    // API's 90s stale-sweep, and the keepalive's cancel poll trips `cancel`, which the engine's
+    // per-frame propagate contract (gen-core d8038beb) observes between frames.
+    let scail2_cancel_message = "SCAIL-2 canceled during person segmentation.";
+    let cancel = gen_core::CancelFlag::new();
+    let flag = cancel.clone();
     let (rm, rt) = (sam_model.clone(), sam_tokenizer.clone());
-    let ref_mask = tokio::task::spawn_blocking(move || -> WorkerResult<Image> {
-        let masks = crate::person_segment_sam3::segment_all_persons_in_memory(
-            &rm,
-            &rt,
-            std::slice::from_ref(&ref_rgb),
-        )?;
-        crate::scail2_masks::paint_reference_mask(&masks, crate::scail2_masks::BG_WHITE)
-    })
-    .await
-    .map_err(|error| WorkerError::Io(std::io::Error::other(error)))??;
+    let ref_mask = run_blocking_with_heartbeat(
+        api,
+        settings,
+        &job.id,
+        Some(cancel),
+        scail2_cancel_message,
+        "scail2 reference segment task",
+        tokio::task::spawn_blocking(move || -> WorkerResult<Image> {
+            let masks = crate::person_segment_sam3::segment_all_persons_in_memory(
+                &rm,
+                &rt,
+                std::slice::from_ref(&ref_rgb),
+                Some(flag),
+                None,
+            )?;
+            crate::scail2_masks::paint_reference_mask(&masks, crate::scail2_masks::BG_WHITE)
+        }),
+    )
+    .await?;
 
     // Segment + paint the per-frame driving masks (animation → black background).
-    let driving_mask = tokio::task::spawn_blocking(move || -> WorkerResult<Vec<Image>> {
-        let masks = crate::person_segment_sam3::segment_all_persons_in_memory(
-            &sam_model,
-            &sam_tokenizer,
-            &driving_rgb,
-        )?;
-        Ok(crate::scail2_masks::paint_driving_masks(
-            &masks,
-            crate::scail2_masks::BG_BLACK,
-        ))
-    })
-    .await
-    .map_err(|error| WorkerError::Io(std::io::Error::other(error)))??;
+    let cancel = gen_core::CancelFlag::new();
+    let flag = cancel.clone();
+    let driving_mask = run_blocking_with_heartbeat(
+        api,
+        settings,
+        &job.id,
+        Some(cancel),
+        scail2_cancel_message,
+        "scail2 driving segment task",
+        tokio::task::spawn_blocking(move || -> WorkerResult<Vec<Image>> {
+            let masks = crate::person_segment_sam3::segment_all_persons_in_memory(
+                &sam_model,
+                &sam_tokenizer,
+                &driving_rgb,
+                Some(flag),
+                Some(Box::new(|frame, total| {
+                    tracing::debug!(event = "scail2_sam3_propagate_progress", frame, total);
+                })),
+            )?;
+            Ok(crate::scail2_masks::paint_driving_masks(
+                &masks,
+                crate::scail2_masks::BG_BLACK,
+            ))
+        }),
+    )
+    .await?;
 
     Ok(vec![
         Conditioning::Reference {
@@ -4618,16 +4684,29 @@ async fn resolve_scail2_replace_conditioning(
             .ok_or_else(|| {
                 WorkerError::InvalidPayload("scail2 reference image is malformed".into())
             })?;
-    let ref_mask = tokio::task::spawn_blocking(move || -> WorkerResult<Image> {
-        let masks = crate::person_segment_sam3::segment_all_persons_in_memory(
-            &sam_model,
-            &sam_tokenizer,
-            std::slice::from_ref(&ref_rgb),
-        )?;
-        crate::scail2_masks::paint_reference_mask(&masks, crate::scail2_masks::BG_BLACK)
-    })
-    .await
-    .map_err(|error| WorkerError::Io(std::io::Error::other(error)))??;
+    // Heartbeat keepalive + user cancel across the cold SAM3 parse + single-frame propagate
+    // (sc-8390 / sc-8807).
+    let cancel = gen_core::CancelFlag::new();
+    let flag = cancel.clone();
+    let ref_mask = run_blocking_with_heartbeat(
+        api,
+        settings,
+        &job.id,
+        Some(cancel),
+        "SCAIL-2 canceled during person segmentation.",
+        "scail2 reference segment task",
+        tokio::task::spawn_blocking(move || -> WorkerResult<Image> {
+            let masks = crate::person_segment_sam3::segment_all_persons_in_memory(
+                &sam_model,
+                &sam_tokenizer,
+                std::slice::from_ref(&ref_rgb),
+                Some(flag),
+                None,
+            )?;
+            crate::scail2_masks::paint_reference_mask(&masks, crate::scail2_masks::BG_BLACK)
+        }),
+    )
+    .await?;
 
     let conditioning = vec![
         Conditioning::Reference {


### PR DESCRIPTION
Shortcut: https://app.shortcut.com/trefry/story/8807 (F-006, code review 2026-07-01, High)
Follow-up filed: https://app.shortcut.com/trefry/story/8972 (candle-gen-sam3 propagate API bump)

## Problem

`Sam2VideoPredictor::propagate` / `Sam3VideoModel::propagate` gained `cancel` + per-frame `progress` params (gen-core d8038beb) for exactly the video per-step cancel contract, but every MLX call site passed `None, None`, and the segment step ran under plain `spawn_blocking` with no `run_blocking_with_heartbeat` wrapper — unlike the YOLO detect step (media_jobs.rs:600, sc-8390). A cold-start SAM3 segmentation (multi-GB parse + quantize + ~24-frame 1008² propagate) can exceed 90s of heartbeat silence and be swept `interrupted` mid-work, and a user cancel could not stop a propagate in flight.

## What changed

**Engine seams (MLX):**
- `person_segment.rs` (SAM2) and `person_segment_sam3.rs` (SAM3 `segment_track_blocking` + `segment_all_persons_in_memory`) now take `cancel: Option<CancelFlag>` + `progress: Option<SegmentProgress>` and thread both into the engine's `propagate`. The engine's `Error::Canceled` maps to `WorkerError::Canceled`; coarse `check_segment_canceled` seams guard the phases the engine cannot observe (frame decode, the cold 3.2 GB checkpoint parse, model build + quantize).

**Call sites — every propagate site now runs under `run_blocking_with_heartbeat` (sc-8390 pattern):**
- `media_jobs.rs` macOS `segment_assembly_frames` (SAM3 + legacy SAM2 A/B path): keepalive pings `Busy` every interval and polls/trips the user cancel; a cancel is terminal for the person-track job, any other segment failure keeps the degrade-to-box-masks contract.
- `media_jobs.rs` candle `segment_assembly_frames` (off-Mac SAM3): same keepalive + threaded flag.
- `video_jobs.rs` SCAIL-2 `animate_character` + `replace_person` conditioning resolvers, both MLX and candle lanes (reference-mask and driving-clip SAM3 passes).
- Ignored real-weights E2E/smoke tests updated for the new signatures (`None, None`).

**Shared keepalive (`progress.rs`):** when the blocking task itself surfaces `WorkerError::Canceled` (the engine-honored per-frame cancel), `run_blocking_with_heartbeat` now posts the terminal `Canceled` before propagating — matching its poll-detected path — so an engine-acknowledged cancel never leaves the job dangling non-terminal.

**Candle twin status:** the pinned `candle-gen-sam3` `Sam3VideoModel::propagate(frames, input_ids, text_mask)` (rev 376b1ef) exposes **no** cancel/progress params, so the candle lane gets the heartbeat keepalive + coarse cancel seams (cold parse / model build) only. The upstream API bump + lockstep pin dance is deliberately out of scope here and tracked as **sc-8972**, referenced at every candle seam in code.

## Tests

- `tests.rs`: two stub-server (axum) keepalive tests — engine honors the tripped flag mid-task (terminal `Canceled` posted, error propagated) and compute that cannot observe the flag (keepalive still cancels the job on return). Both assert the `Busy` heartbeat fired during the blocking task.
- `person_segment.rs` / `person_segment_sam3.rs` / `person_segment_sam3_candle.rs`: pre-tripped-flag short-circuit tests pinning the coarse-seam ordering (Canceled surfaces before any frame decode or weight load) for all four blocking entry points.
- Real propagate cancel/progress behavior needs weights + GPU; the existing `#[ignore]` smokes cover those paths manually.

## Verification

- `cargo test -p sceneworks-worker` — 485 passed, 0 failed (5 new tests included)
- `npm run rust:check` (fmt + clippy + test + build) — green
- `cargo check -p sceneworks-worker --no-default-features --features backend-candle --all-targets` — green (note: the off-Mac-only candle modules are cfg-excluded on macOS; the Linux parity lane in CI compiles them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)