### PR TITLE
perf(web): stabilize refreshData identity so appContextValue memo holds (sc-8811)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -698,6 +698,21 @@ export function App() {
     createTrainingJob,
   } = useTraining({ token, activeProject, setError, setJobs });
 
+  // sc-8811: useModelsAndLoras lists these two cross-cutting refresh orchestrators as
+  // useCallback deps of deleteModel/deleteLora, which sit in appContextValue's
+  // dependency array. The orchestrator bodies (refreshData / refreshDataWithLoraOverlay,
+  // defined below) are plain per-render function declarations published into the
+  // refs above, so passing them in directly would give deleteModel/deleteLora — and
+  // therefore the whole ~130-key context value — a fresh identity on every App render,
+  // silently defeating the sc-4194 memoization. These identity-stable wrappers delegate
+  // through the refs instead: callers always invoke the latest body (fresh token /
+  // activeProject), while the hook's actions stay referentially stable.
+  const stableRefreshData = useCallback((...args) => refreshDataRef.current?.(...args), []);
+  const stableRefreshDataWithLoraOverlay = useCallback(
+    (...args) => refreshDataWithLoraOverlayRef.current?.(...args),
+    [],
+  );
+
   const {
     models,
     setModels,
@@ -717,8 +732,8 @@ export function App() {
     setError,
     setJobs,
     setActiveView,
-    refreshData,
-    refreshDataWithLoraOverlay,
+    refreshData: stableRefreshData,
+    refreshDataWithLoraOverlay: stableRefreshDataWithLoraOverlay,
   });
 
   const {

--- a/apps/web/src/hooks/hookStability.test.jsx
+++ b/apps/web/src/hooks/hookStability.test.jsx
@@ -13,6 +13,9 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { usePresets } from "./usePresets.js";
 import { usePersonTracks } from "./usePersonTracks.js";
 import { useCharacters } from "./useCharacters.js";
+import { useModelsAndLoras } from "./useModelsAndLoras.js";
+import { useTraining } from "./useTraining.js";
+import { useTimelines } from "./useTimelines.js";
 
 const ACTION_KEYS = {
   usePresets: ["refreshPresets", "createPreset", "updatePreset", "duplicatePreset", "deletePreset"],
@@ -21,6 +24,26 @@ const ACTION_KEYS = {
     "refreshCharacters", "createCharacter", "updateCharacter", "archiveCharacter",
     "unarchiveCharacter", "listArchivedCharacters",
     "addCharacterReference", "createCharacterLook", "attachCharacterLora", "createCharacterTestJob",
+  ],
+  // sc-8811: deleteModel/deleteLora depend on the App-provided refreshData /
+  // refreshDataWithLoraOverlay props, which App must pass identity-stable
+  // (ref-delegating useCallbacks). With the stable stand-ins below, every action
+  // must hold its identity across an unrelated re-render.
+  useModelsAndLoras: [
+    "refreshLoras", "deleteModel", "deleteLora", "createModelImportJob", "createLoraImportJob",
+    "createModelDownloadJob", "createLoraDownloadJob", "createModelConvertJob",
+  ],
+  useTraining: [
+    "refreshTrainingDatasets", "loadTrainingDataset", "loadTrainingDatasetReadiness",
+    "setTrainingDatasetItemQualityAck", "createTrainingDataset", "uploadTrainingDatasetItem",
+    "updateTrainingDataset", "batchRenameTrainingDataset", "writeTrainingDatasetCaptionSidecars",
+    "createTrainingDatasetCaptionJob", "createTrainingDatasetUpscaleJob",
+    "createTrainingDatasetAnalysisJob", "createTrainingDatasetFaceAnalysisJob",
+    "smartCropTrainingDataset", "stripExifTrainingDataset", "createTrainingJob",
+  ],
+  useTimelines: [
+    "refreshTimelines", "createTimeline", "saveTimeline", "exportTimeline",
+    "extractTimelineFrame", "queueTimelineVideoJob",
   ],
 };
 
@@ -56,12 +79,19 @@ describe("data hook action identity stability (sc-4194)", () => {
     // Stable across renders so the only thing changing on the forced re-render is the
     // counter — mirrors how App feeds these hooks identity-stable token/project/setters
     // while jobs churn. If the actions still change identity, it's the hook's fault.
+    // A superset of every hook's props: each hook destructures only what it takes.
+    const activeProject = { id: "p1", name: "P1" };
     const stableProps = {
       token: "tok",
-      activeProject: { id: "p1", name: "P1" },
+      activeProject,
+      activeProjectRef: { current: activeProject },
       setError: () => {},
+      setJobs: () => {},
       requestedGpu: "auto",
       setActiveView: () => {},
+      createVideoJob: async () => null,
+      refreshData: async () => {},
+      refreshDataWithLoraOverlay: async () => {},
     };
 
     function Harness() {
@@ -87,7 +117,7 @@ describe("data hook action identity stability (sc-4194)", () => {
   it.each(Object.entries(ACTION_KEYS).map(([name]) => name))(
     "%s returns stable action identities across an unrelated re-render",
     async (hookName) => {
-      const hooks = { usePresets, usePersonTracks, useCharacters };
+      const hooks = { usePresets, usePersonTracks, useCharacters, useModelsAndLoras, useTraining, useTimelines };
       const { Harness, captures, bumpRef } = probe(hooks[hookName], ACTION_KEYS[hookName]);
 
       root = createRoot(container);

--- a/apps/web/src/hooks/useModelsAndLoras.js
+++ b/apps/web/src/hooks/useModelsAndLoras.js
@@ -15,7 +15,11 @@ function uploadLimitLabel(bytes) {
 // import re-pulls both via the lora overlay), so they share one hook. App keeps the
 // cross-cutting orchestrators — refreshData (bulk loader; seeds models+loras through
 // the returned setters) and refreshDataWithLoraOverlay (refreshData + refreshLoras,
-// also called by the SSE handler) — and passes them in.
+// also called by the SSE handler) — and passes them in. Both props MUST be
+// identity-stable (sc-8811): they are useCallback deps of deleteModel/deleteLora,
+// which sit in appContextValue's dependency array, so an unstable prop rebuilds the
+// context value every App render and defeats the sc-4194 memoization. App passes
+// ref-delegating useCallbacks for both.
 export function useModelsAndLoras({
   token,
   activeProject,

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -640,6 +640,51 @@ describe("SceneWorks app shell", () => {
     expect(queueChip()?.textContent).toContain("Queue 2");
   });
 
+  // sc-8811 regression (F-009): appContextValue must keep its identity across an App
+  // re-render that touches none of its entries. Before the fix, refreshData /
+  // refreshDataWithLoraOverlay were plain per-render declarations passed into
+  // useModelsAndLoras, so deleteModel/deleteLora — and therefore the whole memoized
+  // context value — got a fresh identity on EVERY App render (each SSE tick, each
+  // keystroke), silently defeating the sc-4194 memoization and re-rendering every
+  // useAppContext consumer. A queue.updated event only changes queueSummary, which is
+  // not part of the context value, so the provider value identity must survive it.
+  it("keeps appContextValue identity stable across an unrelated re-render (sc-8811)", async () => {
+    const providedValues = [];
+    const OriginalProvider = AppContext.Provider;
+    // Swap in a recording pass-through provider so the test can observe the exact
+    // value identities App feeds the context on each committed render.
+    AppContext.Provider = function RecordingProvider({ value, children }) {
+      providedValues.push(value);
+      return <OriginalProvider value={value}>{children}</OriginalProvider>;
+    };
+    try {
+      root = createRoot(container);
+      await act(async () => {
+        root.render(<App />);
+      });
+      await settle();
+
+      const before = providedValues[providedValues.length - 1];
+      const countBefore = providedValues.length;
+      expect(before).toBeTruthy();
+
+      // Pure queue.updated (no workers array, no job.updated): re-renders App via
+      // setQueueSummary without changing anything appContextValue depends on.
+      await act(async () => {
+        FakeEventSource.instances[0].listeners["queue.updated"]({
+          data: JSON.stringify({ counts: { active: 2, queued: 2 }, activeJobs: [{ id: "job-a" }] }),
+        });
+      });
+      await settle();
+
+      const after = providedValues[providedValues.length - 1];
+      expect(providedValues.length).toBeGreaterThan(countBefore); // the event really re-rendered App
+      expect(after).toBe(before); // identity preserved → consumer tree memoization holds
+    } finally {
+      AppContext.Provider = OriginalProvider;
+    }
+  });
+
   // sc-4168 regression: App must provide `token` through AppContext. Screens that
   // call apiFetch directly (Logs, Image Editor, Pose Library, useUserPoseLoader)
   // read it from context; before the fix they got `undefined` and never sent the


### PR DESCRIPTION
## Summary

Fixes [sc-8811](https://app.shortcut.com/trefry/story/8811) — F-009 (High, efficiency): the sc-4194 `appContextValue` memoization was silently defeated on every App render.

`refreshData` / `refreshDataWithLoraOverlay` are plain function declarations recreated on every App render. They were passed directly into `useModelsAndLoras`, where they are `useCallback` deps of `deleteModel` / `deleteLora` — both of which sit in `appContextValue`'s dependency array. So the ~130-key context value got a fresh identity on **every** App render (each SSE job/worker/queue tick, each password keystroke, theme toggles…), and every `useAppContext` consumer re-rendered every time — the whole-tree memoization sc-4194 engineered was dead weight.

## Fix

- **`apps/web/src/App.jsx`** — pass identity-stable `useCallback` wrappers (`stableRefreshData`, `stableRefreshDataWithLoraOverlay`) that delegate through the existing `refreshDataRef` / `refreshDataWithLoraOverlayRef` (already published every render for the SSE handlers). Callers always invoke the latest body — fresh `token`/`activeProject`, no stale closures — while the hook's actions keep a stable identity. This matches the codebase's established refs-for-mutable-reads pattern rather than reordering the orchestrators above the data hooks (which would hit a TDZ cycle: `refreshData` seeds `setModels`/`setLoras` returned by the very hook that takes it as a prop).
- **`apps/web/src/hooks/useModelsAndLoras.js`** — document the identity-stability contract on the two props.

## Audit

Per the story, audited the **entire** `appContextValue` dependency chain (130 entries), classifying every dep (state / useMemo / useCallback / hook-returned action) and scanning all 56 `useCallback`/`useMemo` dep arrays in App.jsx for second-order instability (plain per-render functions like `sendAssetRecipeToImage`, `closePreview`, `hasVisibleLocalFailure` leaking into dep arrays). `refreshData` / `refreshDataWithLoraOverlay` were the **only** identity-unstable members; useTraining/useTimelines/useCharacters/usePresets/usePersonTracks actions are all useCallback-stable with stable inputs.

## Tests

- `hookStability.test.jsx` (sc-4194) now also covers **useModelsAndLoras, useTraining, useTimelines** — the coverage gap that let this regress unnoticed.
- New App-level regression in `main.test.jsx`: renders the real `<App />` against the mocked API/SSE harness, records the exact value identities fed to `AppContext.Provider`, fires a pure `queue.updated` event (re-renders App via `setQueueSummary`, which is not part of the context value), and asserts the provider value identity is unchanged. **Verified red before the fix, green after.**

## Validation

- `npm test` (apps/web): 57 files, 983/983 passing.
- `npm run lint` (apps/web): 0 errors, 49 warnings — byte-identical to the origin/main baseline (all pre-existing).
- sc-8808 (#1055) not regressed: unlock still performs exactly one data load + one SSE connect via the `[authenticated, token]` effects (covered by the existing sc-8808 suite tests, all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)