### PR TITLE
refactor(core): share image/video payload-parsing helpers, preserving per-lane semantics (sc-8817)

### DIFF
--- a/crates/sceneworks-core/src/image_request.rs
+++ b/crates/sceneworks-core/src/image_request.rs
@@ -10,6 +10,10 @@
 use serde_json::Value;
 
 use crate::contracts::{ImageUpscaleRequest, JsonObject};
+use crate::payload_util::{
+    array_or_empty, clamped_u32, int_array, nonempty_string_or, object_or_empty, optional_i64,
+    optional_id, string_list, string_or,
+};
 
 /// Default model when the payload omits one (matches the Python worker).
 const DEFAULT_MODEL: &str = "z_image_turbo";
@@ -72,11 +76,11 @@ impl ImageRequest {
             prompt: string_or(payload, "prompt", ""),
             negative_prompt: string_or(payload, "negativePrompt", ""),
             model: nonempty_string_or(payload, "model", DEFAULT_MODEL),
-            count: clamped_u32(payload, "count", 4, 1, 8),
+            count: clamped_u32(payload.get("count"), 4, 1, 8),
             seed: optional_i64(payload, "seed"),
             seeds: int_array(payload, "seeds"),
-            width: clamped_u32(payload, "width", 1024, 256, 4096),
-            height: clamped_u32(payload, "height", 1024, 256, 4096),
+            width: clamped_u32(payload.get("width"), 1024, 256, 4096),
+            height: clamped_u32(payload.get("height"), 1024, 256, 4096),
             style_preset: nonempty_string_or(payload, "stylePreset", DEFAULT_STYLE_PRESET),
             loras: array_or_empty(payload, "loras"),
             character_id: optional_id(payload, "characterId"),
@@ -111,109 +115,6 @@ fn parse_upscale(payload: &JsonObject) -> ImageUpscaleRequest {
         .get("upscale")
         .cloned()
         .and_then(|value| serde_json::from_value(value).ok())
-        .unwrap_or_default()
-}
-
-fn string_or(payload: &JsonObject, key: &str, default: &str) -> String {
-    payload
-        .get(key)
-        .and_then(Value::as_str)
-        .unwrap_or(default)
-        .to_owned()
-}
-
-/// Like `string_or` but a present-but-empty value also falls back to the default
-/// (matches the Python `.get(key, default)` where the UI never sends an empty model).
-fn nonempty_string_or(payload: &JsonObject, key: &str, default: &str) -> String {
-    payload
-        .get(key)
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .unwrap_or(default)
-        .to_owned()
-}
-
-fn optional_id(payload: &JsonObject, key: &str) -> Option<String> {
-    payload
-        .get(key)
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(str::to_owned)
-}
-
-/// Read an int that may arrive as a JSON number or a numeric string, clamp to
-/// `[min, max]`, default when absent/unparseable.
-fn clamped_u32(payload: &JsonObject, key: &str, default: u32, min: u32, max: u32) -> u32 {
-    payload
-        .get(key)
-        .and_then(|value| {
-            value
-                .as_i64()
-                .or_else(|| value.as_str()?.trim().parse().ok())
-        })
-        .and_then(|value| u32::try_from(value).ok())
-        .unwrap_or(default)
-        .clamp(min, max)
-}
-
-fn optional_i64(payload: &JsonObject, key: &str) -> Option<i64> {
-    payload.get(key).and_then(|value| {
-        value
-            .as_i64()
-            .or_else(|| value.as_str()?.trim().parse().ok())
-    })
-}
-
-fn int_array(payload: &JsonObject, key: &str) -> Vec<i64> {
-    payload
-        .get(key)
-        .and_then(Value::as_array)
-        .map(|values| {
-            values
-                .iter()
-                .filter_map(|value| {
-                    value
-                        .as_i64()
-                        .or_else(|| value.as_str()?.trim().parse().ok())
-                })
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
-/// Collect a JSON string array into trimmed, non-empty owned strings (sc-6211, mirrors the video
-/// request's `referenceAssetIds` parsing). Absent / non-array / all-blank → empty.
-fn string_list(payload: &JsonObject, key: &str) -> Vec<String> {
-    payload
-        .get(key)
-        .and_then(Value::as_array)
-        .map(|values| {
-            values
-                .iter()
-                .filter_map(Value::as_str)
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .map(str::to_owned)
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
-fn array_or_empty(payload: &JsonObject, key: &str) -> Vec<Value> {
-    payload
-        .get(key)
-        .and_then(Value::as_array)
-        .cloned()
-        .unwrap_or_default()
-}
-
-fn object_or_empty(payload: &JsonObject, key: &str) -> JsonObject {
-    payload
-        .get(key)
-        .and_then(Value::as_object)
-        .cloned()
         .unwrap_or_default()
 }
 

--- a/crates/sceneworks-core/src/lib.rs
+++ b/crates/sceneworks-core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod lora_family;
 pub mod lora_url;
 pub mod media_convert;
 pub mod observability;
+pub mod payload_util;
 pub mod project_store;
 pub mod session_log;
 pub mod slug;

--- a/crates/sceneworks-core/src/payload_util.rs
+++ b/crates/sceneworks-core/src/payload_util.rs
@@ -1,0 +1,238 @@
+//! Shared payload-parsing helpers for the image- and video-generation job requests
+//! (sc-8817). Both [`crate::image_request`] and [`crate::video_request`] parse a job
+//! `payload` (a [`JsonObject`]) into a typed request, and both need the same small set
+//! of "read this key, coerce it, fall back to a default" primitives.
+//!
+//! Historically these helpers were copy-pasted into each module and had already drifted:
+//! `image_request::string_or` returned the raw string value, while
+//! `video_request::string_or` trimmed and empty-filtered it (the semantics
+//! `image_request` spelled `nonempty_string_or`). Collapsing them into one function would
+//! silently change one lane's behavior, so this module deliberately exposes **two**
+//! clearly-named string variants:
+//!
+//! * [`string_or`] — the RAW value (no trimming, a present-but-empty string stays empty).
+//! * [`nonempty_string_or`] — trimmed, with a present-but-empty/whitespace value falling
+//!   back to the default.
+//!
+//! Each existing call site is wired to the variant that preserves its prior behavior.
+
+use serde_json::Value;
+
+use crate::contracts::JsonObject;
+
+/// Read a string key, returning the RAW value (no trimming); a present-but-empty string
+/// is preserved. Falls back to `default` only when the key is absent or non-string.
+pub(crate) fn string_or(payload: &JsonObject, key: &str, default: &str) -> String {
+    payload
+        .get(key)
+        .and_then(Value::as_str)
+        .unwrap_or(default)
+        .to_owned()
+}
+
+/// Read a string key, trimmed, where a present-but-empty (or whitespace-only) value also
+/// falls back to `default` (matches the Python `.get(key, default)` where the UI never
+/// sends an empty model/mode/etc.).
+pub(crate) fn nonempty_string_or(payload: &JsonObject, key: &str, default: &str) -> String {
+    payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(default)
+        .to_owned()
+}
+
+/// Read an optional string id: trimmed, `None` when absent, non-string, or blank.
+pub(crate) fn optional_id(payload: &JsonObject, key: &str) -> Option<String> {
+    payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+/// Read an optional int that may arrive as a JSON number or a numeric string. `None`
+/// when absent or unparseable.
+pub(crate) fn optional_i64(payload: &JsonObject, key: &str) -> Option<i64> {
+    payload.get(key).and_then(|value| {
+        value
+            .as_i64()
+            .or_else(|| value.as_str()?.trim().parse().ok())
+    })
+}
+
+/// Parse an int (JSON number or numeric string), clamp to `[min, max]`, default when
+/// absent/unparseable — the `safe_int` contract. Takes the raw `Option<&Value>` so both
+/// the `payload.get(key)` (image) and pre-fetched `payload.get("width")` (video) call
+/// sites share one primitive.
+pub(crate) fn clamped_u32(value: Option<&Value>, default: u32, min: u32, max: u32) -> u32 {
+    value
+        .and_then(|value| {
+            value
+                .as_i64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .and_then(|value| u32::try_from(value).ok())
+        .unwrap_or(default)
+        .clamp(min, max)
+}
+
+/// Collect a JSON int array (numbers or numeric strings), dropping non-numeric entries.
+/// Absent / non-array → empty.
+pub(crate) fn int_array(payload: &JsonObject, key: &str) -> Vec<i64> {
+    payload
+        .get(key)
+        .and_then(Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(|value| {
+                    value
+                        .as_i64()
+                        .or_else(|| value.as_str()?.trim().parse().ok())
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Collect a JSON string array into trimmed, non-empty owned strings (blanks and
+/// non-strings are dropped). Absent / non-array / all-blank → empty.
+pub(crate) fn string_list(payload: &JsonObject, key: &str) -> Vec<String> {
+    payload
+        .get(key)
+        .and_then(Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_owned)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Clone a JSON array key verbatim; absent / non-array → empty.
+pub(crate) fn array_or_empty(payload: &JsonObject, key: &str) -> Vec<Value> {
+    payload
+        .get(key)
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+}
+
+/// Clone a JSON object key verbatim; absent / non-object → empty.
+pub(crate) fn object_or_empty(payload: &JsonObject, key: &str) -> JsonObject {
+    payload
+        .get(key)
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn payload(value: Value) -> JsonObject {
+        value.as_object().cloned().unwrap()
+    }
+
+    // --- Characterization tests capturing the CURRENT per-lane behavior (sc-8817). ---
+    // The image lane historically used `string_or` = RAW and `nonempty_string_or` =
+    // trim+empty-filter; the video lane's `string_or` was actually the trim+filter variant.
+    // These lock the raw-vs-trim distinction so the dedup is provably behavior-preserving.
+
+    #[test]
+    fn string_or_returns_raw_value_including_present_but_empty() {
+        // Present-but-empty stays empty (does NOT fall back to the default).
+        let p = payload(json!({ "k": "" }));
+        assert_eq!(string_or(&p, "k", "def"), "");
+        // Leading/trailing whitespace is preserved verbatim.
+        let p = payload(json!({ "k": "  spaced  " }));
+        assert_eq!(string_or(&p, "k", "def"), "  spaced  ");
+        // Absent / non-string → default.
+        let p = payload(json!({ "n": 5 }));
+        assert_eq!(string_or(&p, "k", "def"), "def");
+        assert_eq!(string_or(&p, "n", "def"), "def");
+    }
+
+    #[test]
+    fn nonempty_string_or_trims_and_empty_filters() {
+        // Present-but-empty / whitespace-only → default.
+        let p = payload(json!({ "k": "" }));
+        assert_eq!(nonempty_string_or(&p, "k", "def"), "def");
+        let p = payload(json!({ "k": "   " }));
+        assert_eq!(nonempty_string_or(&p, "k", "def"), "def");
+        // Non-blank values are trimmed.
+        let p = payload(json!({ "k": "  spaced  " }));
+        assert_eq!(nonempty_string_or(&p, "k", "def"), "spaced");
+        // Absent → default.
+        let p = payload(json!({}));
+        assert_eq!(nonempty_string_or(&p, "k", "def"), "def");
+    }
+
+    #[test]
+    fn optional_id_trims_and_drops_blanks() {
+        let p = payload(json!({ "id": "  x  ", "blank": "  ", "n": 3 }));
+        assert_eq!(optional_id(&p, "id").as_deref(), Some("x"));
+        assert!(optional_id(&p, "blank").is_none());
+        assert!(optional_id(&p, "n").is_none());
+        assert!(optional_id(&p, "missing").is_none());
+    }
+
+    #[test]
+    fn optional_i64_reads_numbers_and_numeric_strings() {
+        let p = payload(json!({ "a": 5, "b": "42", "c": "nope", "d": null }));
+        assert_eq!(optional_i64(&p, "a"), Some(5));
+        assert_eq!(optional_i64(&p, "b"), Some(42));
+        assert_eq!(optional_i64(&p, "c"), None);
+        assert_eq!(optional_i64(&p, "d"), None);
+        assert_eq!(optional_i64(&p, "missing"), None);
+    }
+
+    #[test]
+    fn clamped_u32_parses_and_clamps() {
+        let p = payload(json!({ "a": 99, "b": "3", "c": "bad", "d": -1 }));
+        assert_eq!(clamped_u32(p.get("a"), 4, 1, 8), 8);
+        assert_eq!(clamped_u32(p.get("b"), 4, 1, 8), 3);
+        // Unparseable / absent → default (then clamped).
+        assert_eq!(clamped_u32(p.get("c"), 4, 1, 8), 4);
+        assert_eq!(clamped_u32(None, 4, 1, 8), 4);
+        // Negative can't become u32 → default.
+        assert_eq!(clamped_u32(p.get("d"), 4, 1, 8), 4);
+    }
+
+    #[test]
+    fn int_array_reads_numbers_and_numeric_strings_dropping_others() {
+        let p = payload(json!({ "seeds": [1, "2", null, "bad", 3] }));
+        assert_eq!(int_array(&p, "seeds"), vec![1, 2, 3]);
+        let p = payload(json!({ "seeds": "notarray" }));
+        assert!(int_array(&p, "seeds").is_empty());
+        assert!(int_array(&payload(json!({})), "seeds").is_empty());
+    }
+
+    #[test]
+    fn string_list_trims_and_drops_blanks_and_nonstrings() {
+        let p = payload(json!({ "ids": ["a", "  ", "  b  ", 42, null] }));
+        assert_eq!(string_list(&p, "ids"), vec!["a", "b"]);
+        assert!(string_list(&payload(json!({ "ids": "x" })), "ids").is_empty());
+        assert!(string_list(&payload(json!({})), "ids").is_empty());
+    }
+
+    #[test]
+    fn array_and_object_or_empty_clone_or_default() {
+        let p = payload(json!({ "arr": [1, 2], "obj": { "k": 1 }, "wrong": 5 }));
+        assert_eq!(array_or_empty(&p, "arr"), vec![json!(1), json!(2)]);
+        assert!(array_or_empty(&p, "wrong").is_empty());
+        assert!(array_or_empty(&p, "missing").is_empty());
+        assert_eq!(object_or_empty(&p, "obj").get("k"), Some(&json!(1)));
+        assert!(object_or_empty(&p, "wrong").is_empty());
+        assert!(object_or_empty(&p, "missing").is_empty());
+    }
+}

--- a/crates/sceneworks-core/src/video_request.rs
+++ b/crates/sceneworks-core/src/video_request.rs
@@ -18,6 +18,10 @@
 use serde_json::Value;
 
 use crate::contracts::JsonObject;
+use crate::payload_util::{
+    array_or_empty, clamped_u32, nonempty_string_or, object_or_empty, optional_i64, optional_id,
+    string_list,
+};
 
 /// Defaults matching the Python `video_request_from_job` (`.get(key, default)`).
 const DEFAULT_MODE: &str = "image_to_video";
@@ -91,16 +95,16 @@ impl VideoRequest {
     pub fn from_payload(payload: &JsonObject) -> Self {
         let (width, height) = normalized_dimensions(payload.get("width"), payload.get("height"));
         Self {
-            project_id: string_or(payload, "projectId", ""),
-            mode: string_or(payload, "mode", DEFAULT_MODE),
-            prompt: string_or(payload, "prompt", ""),
-            negative_prompt: string_or(payload, "negativePrompt", ""),
-            model: string_or(payload, "model", DEFAULT_MODEL),
+            project_id: nonempty_string_or(payload, "projectId", ""),
+            mode: nonempty_string_or(payload, "mode", DEFAULT_MODE),
+            prompt: nonempty_string_or(payload, "prompt", ""),
+            negative_prompt: nonempty_string_or(payload, "negativePrompt", ""),
+            model: nonempty_string_or(payload, "model", DEFAULT_MODEL),
             duration: safe_float(payload.get("duration"), 6.0, 1.0, 30.0),
-            fps: safe_int(payload.get("fps"), 25, 1, 60),
+            fps: clamped_u32(payload.get("fps"), 25, 1, 60),
             width,
             height,
-            quality: string_or(payload, "quality", DEFAULT_QUALITY),
+            quality: nonempty_string_or(payload, "quality", DEFAULT_QUALITY),
             seed: optional_i64(payload, "seed"),
             loras: array_or_empty(payload, "loras"),
             character_id: optional_id(payload, "characterId"),
@@ -110,7 +114,11 @@ impl VideoRequest {
                 payload.get("fitMode").and_then(Value::as_str),
             ),
             person_track_id: optional_id(payload, "personTrackId"),
-            replacement_mode: string_or(payload, "replacementMode", DEFAULT_REPLACEMENT_MODE),
+            replacement_mode: nonempty_string_or(
+                payload,
+                "replacementMode",
+                DEFAULT_REPLACEMENT_MODE,
+            ),
             last_frame_asset_id: optional_id(payload, "lastFrameAssetId"),
             source_clip_asset_id: optional_id(payload, "sourceClipAssetId"),
             source_clip_asset_ids: string_list(payload, "sourceClipAssetIds"),
@@ -186,8 +194,8 @@ pub fn is_wan_model(model: &str) -> bool {
 /// Clamp + floor dimensions exactly like the Python `normalized_dimensions`: parse
 /// (default 768x512), clamp to 256..=1920, floor to a multiple of 32, floor of 256.
 fn normalized_dimensions(width: Option<&Value>, height: Option<&Value>) -> (u32, u32) {
-    let w = floor_to_32(safe_int(width, 768, 256, 1920));
-    let h = floor_to_32(safe_int(height, 512, 256, 1920));
+    let w = floor_to_32(clamped_u32(width, 768, 256, 1920));
+    let h = floor_to_32(clamped_u32(height, 512, 256, 1920));
     (w, h)
 }
 
@@ -195,49 +203,9 @@ fn floor_to_32(value: u32) -> u32 {
     (value - (value % 32)).max(256)
 }
 
-fn string_or(payload: &JsonObject, key: &str, default: &str) -> String {
-    payload
-        .get(key)
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .unwrap_or(default)
-        .to_owned()
-}
-
-fn optional_id(payload: &JsonObject, key: &str) -> Option<String> {
-    payload
-        .get(key)
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(str::to_owned)
-}
-
-fn optional_i64(payload: &JsonObject, key: &str) -> Option<i64> {
-    payload.get(key).and_then(|value| {
-        value
-            .as_i64()
-            .or_else(|| value.as_str()?.trim().parse().ok())
-    })
-}
-
-/// Parse an int (JSON number or numeric string), clamp to `[min, max]`, default
-/// when absent/unparseable — the `safe_int` contract.
-fn safe_int(value: Option<&Value>, default: u32, min: u32, max: u32) -> u32 {
-    value
-        .and_then(|value| {
-            value
-                .as_i64()
-                .or_else(|| value.as_str()?.trim().parse().ok())
-        })
-        .and_then(|value| u32::try_from(value).ok())
-        .unwrap_or(default)
-        .clamp(min, max)
-}
-
 /// Parse a float (JSON number or numeric string), clamp to `[min, max]`, default
-/// when absent/unparseable — the `safe_float` contract.
+/// when absent/unparseable — the `safe_float` contract. Video-specific (image has no
+/// float payload field), so it stays local rather than moving into `payload_util`.
 fn safe_float(value: Option<&Value>, default: f32, min: f32, max: f32) -> f32 {
     value
         .and_then(|value| {
@@ -249,40 +217,6 @@ fn safe_float(value: Option<&Value>, default: f32, min: f32, max: f32) -> f32 {
         .filter(|value| value.is_finite())
         .unwrap_or(default)
         .clamp(min, max)
-}
-
-/// Parse a list of non-empty trimmed string ids (e.g. `referenceAssetIds`); blanks
-/// and non-strings are dropped, so the worker only ever sees real asset ids.
-fn string_list(payload: &JsonObject, key: &str) -> Vec<String> {
-    payload
-        .get(key)
-        .and_then(Value::as_array)
-        .map(|values| {
-            values
-                .iter()
-                .filter_map(Value::as_str)
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .map(str::to_owned)
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
-fn array_or_empty(payload: &JsonObject, key: &str) -> Vec<Value> {
-    payload
-        .get(key)
-        .and_then(Value::as_array)
-        .cloned()
-        .unwrap_or_default()
-}
-
-fn object_or_empty(payload: &JsonObject, key: &str) -> JsonObject {
-    payload
-        .get(key)
-        .and_then(Value::as_object)
-        .cloned()
-        .unwrap_or_default()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Deduplicates the copy-pasted payload-parsing helpers between `image_request.rs` and `video_request.rs` (sc-8817, F-015) by hoisting them into a shared `sceneworks-core::payload_util` module.

## The known semantic drift — preserved, not collapsed

The two lanes had **same-named helpers with different semantics**:

- `image_request::string_or` returned the **RAW** value (a present-but-empty string stayed empty; no trimming).
- `video_request::string_or` **TRIMMED + empty-filtered** — i.e. it was actually image's `nonempty_string_or`.

Collapsing them into one function would have silently changed one lane's payload parsing. Instead, `payload_util` exposes **two clearly-named string variants** and each existing call site is wired to the one that preserves *its* prior behavior:

- `string_or` = raw. Image keeps using it for `projectId` / `prompt` / `negativePrompt`.
- `nonempty_string_or` = trim + empty-filter. Image keeps using it for `mode` / `model` / `stylePreset`. **Every** `string_or` call in `video_request` was remapped to `nonempty_string_or`, since video's `string_or` had that behavior.

## Other hoisted helpers

`optional_id`, `optional_i64`, `string_list`, `int_array`, `array_or_empty`, `object_or_empty` were byte-identical across the two files and moved verbatim.

The int-clamp helper is unified on the more general `Option<&Value>` signature (video's `safe_int`): image's `clamped_u32(payload, key, ..)` becomes `clamped_u32(payload.get(key), ..)` with identical results. `safe_float` stays local to `video_request` (image has no float payload field).

## Tests

- Added characterization tests in `payload_util` that lock the raw-vs-trim distinction (`string_or_returns_raw_value_including_present_but_empty` vs `nonempty_string_or_trims_and_empty_filters`) and every hoisted helper's behavior — so the refactor is provably behavior-preserving.
- Both lanes' existing parser tests are unchanged and pass.
- `cargo test -p sceneworks-core` green; `cargo fmt --all --check`, `cargo clippy` clean; `cargo build -p sceneworks-core` green. No contract snapshots reference these modules (none regenerated).

Story: https://app.shortcut.com/trefry/story/8817

🤖 Generated with [Claude Code](https://claude.com/claude-code)