### PR TITLE
fix(core): serialize credential-store read-modify-write (sc-8813)

### DIFF
--- a/crates/sceneworks-core/src/credentials.rs
+++ b/crates/sceneworks-core/src/credentials.rs
@@ -15,7 +15,7 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use crate::store_util::random_hex;
+use crate::store_util::{lock_store_path, random_hex};
 
 /// Filename of the credential store within the config dir. Shared so the rust-api
 /// (writer) and the worker (reader) never drift.
@@ -80,8 +80,16 @@ impl CredentialFileStore {
     }
 
     /// Upsert a host's credential. Returns the normalized host key.
+    ///
+    /// The whole read-modify-write is serialized under a process-wide lock keyed
+    /// on the file path, so concurrent `set`/`delete` calls (rust-api builds a
+    /// fresh store per request) can't clobber each other's entries (sc-8813).
+    /// In-process only — sufficient because the rust-api is the file's sole
+    /// writer; the worker only reads it, which the atomic rename in `save`
+    /// already keeps consistent.
     pub fn set(&self, host: &str, label: &str, scheme: &str, token: &str) -> io::Result<String> {
         let host = normalize_host(host);
+        let _guard = lock_store_path(&self.path);
         let mut map = self.load();
         map.insert(
             host.clone(),
@@ -96,8 +104,10 @@ impl CredentialFileStore {
     }
 
     /// Remove a host's credential. Returns whether anything was removed.
+    /// Serialized against concurrent `set`/`delete` like [`Self::set`] (sc-8813).
     pub fn delete(&self, host: &str) -> io::Result<bool> {
         let host = normalize_host(host);
+        let _guard = lock_store_path(&self.path);
         let mut map = self.load();
         let removed = map.remove(&host).is_some();
         if removed {
@@ -291,6 +301,112 @@ mod tests {
             .permissions()
             .mode();
         assert_eq!(mode & 0o777, 0o600);
+    }
+
+    /// sc-8813 / F-011: `set`/`delete` are read-modify-write over the whole file,
+    /// so unsynchronized concurrent calls silently drop each other's entries.
+    /// Hammer the store from many threads (fresh store instances, like the
+    /// per-request stores in rust-api) and assert no update is lost.
+    #[test]
+    fn concurrent_sets_do_not_lose_updates() {
+        use std::sync::Barrier;
+
+        const THREADS: usize = 8;
+        const HOSTS_PER_THREAD: usize = 8;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_dir = dir.path().to_path_buf();
+        let barrier = std::sync::Arc::new(Barrier::new(THREADS));
+
+        let handles: Vec<_> = (0..THREADS)
+            .map(|thread| {
+                let config_dir = config_dir.clone();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    // Fresh store per thread, mirroring rust-api's per-request stores.
+                    let store = CredentialFileStore::new(&config_dir);
+                    barrier.wait();
+                    for index in 0..HOSTS_PER_THREAD {
+                        store
+                            .set(
+                                &format!("host-{thread}-{index}.example.com"),
+                                "",
+                                "bearer",
+                                &format!("tok-{thread}-{index}"),
+                            )
+                            .expect("set");
+                    }
+                })
+            })
+            .collect();
+        for handle in handles {
+            handle.join().expect("thread");
+        }
+
+        let map = CredentialFileStore::new(&config_dir).load();
+        assert_eq!(
+            map.len(),
+            THREADS * HOSTS_PER_THREAD,
+            "a concurrent set lost another thread's credential"
+        );
+    }
+
+    /// sc-8813 / F-011: interleave `set` (new hosts) with `delete` (seeded hosts)
+    /// and assert the final file is exactly the surviving set — no deleted host
+    /// resurrected, no newly-set host lost.
+    #[test]
+    fn concurrent_set_and_delete_do_not_lose_updates() {
+        use std::sync::Barrier;
+
+        const PAIRS: usize = 8;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_dir = dir.path().to_path_buf();
+        let seed_store = CredentialFileStore::new(&config_dir);
+        for index in 0..PAIRS {
+            seed_store
+                .set(&format!("old-{index}.example.com"), "", "bearer", "tok")
+                .expect("seed");
+        }
+
+        let barrier = std::sync::Arc::new(Barrier::new(PAIRS * 2));
+        let mut handles = Vec::new();
+        for index in 0..PAIRS {
+            let config_dir_set = config_dir.clone();
+            let barrier_set = barrier.clone();
+            handles.push(std::thread::spawn(move || {
+                let store = CredentialFileStore::new(&config_dir_set);
+                barrier_set.wait();
+                store
+                    .set(&format!("new-{index}.example.com"), "", "bearer", "tok")
+                    .expect("set");
+            }));
+            let config_dir_delete = config_dir.clone();
+            let barrier_delete = barrier.clone();
+            handles.push(std::thread::spawn(move || {
+                let store = CredentialFileStore::new(&config_dir_delete);
+                barrier_delete.wait();
+                assert!(
+                    store
+                        .delete(&format!("old-{index}.example.com"))
+                        .expect("delete"),
+                    "seeded host was already gone — a concurrent write clobbered it"
+                );
+            }));
+        }
+        for handle in handles {
+            handle.join().expect("thread");
+        }
+
+        let map = CredentialFileStore::new(&config_dir).load();
+        let expected: Vec<String> = (0..PAIRS)
+            .map(|index| format!("new-{index}.example.com"))
+            .collect();
+        let actual: Vec<String> = map.keys().cloned().collect();
+        assert_eq!(
+            actual, expected,
+            "set/delete interleaving lost or resurrected an entry"
+        );
     }
 
     #[test]

--- a/crates/sceneworks-core/src/store_util.rs
+++ b/crates/sceneworks-core/src/store_util.rs
@@ -74,8 +74,17 @@ fn project_locks() -> &'static [ReentrantMutex<()>] {
 }
 
 pub(crate) fn lock_project_files(project_path: &Path) -> ReentrantMutexGuard<'static, ()> {
+    lock_store_path(project_path)
+}
+
+/// Same striped process-wide lock, keyed on an arbitrary store file/dir path
+/// rather than a project dir — for stores that live outside a project (e.g. the
+/// config-dir credential file, sc-8813). Hold the guard across the whole
+/// read -> mutate -> write. Same scope caveat as [`lock_project_files`]: it
+/// serializes threads within one process, not separate OS processes.
+pub(crate) fn lock_store_path(path: &Path) -> ReentrantMutexGuard<'static, ()> {
     let mut hasher = DefaultHasher::new();
-    project_path.hash(&mut hasher);
+    path.hash(&mut hasher);
     let index = (hasher.finish() as usize) % PROJECT_LOCK_STRIPES;
     project_locks()[index].lock()
 }


### PR DESCRIPTION
Shortcut: https://app.shortcut.com/trefry/story/8813 — [F-011] Serialize credential-store read-modify-write to prevent lost updates (Bug, security/Medium)

## Problem

`CredentialFileStore::set`/`delete` (`crates/sceneworks-core/src/credentials.rs`) each did an **unlocked** load → mutate → save of `credentials.json`. Two concurrent calls interleave and one write silently overwrites the other — a saved credential can vanish after a concurrent set/delete, and the user sees a token that "didn't stick" plus worker download auth failures. This was the one store in the crate that didn't serialize its RMW (every other goes through `lock_project_files` / `JobsStore.lock`).

## Fix

- Generalized the existing striped process-wide lock: extracted `lock_store_path(path)` in `store_util.rs` (same 256-stripe reentrant-mutex table, keyed on any file path); `lock_project_files` now delegates to it.
- `set` and `delete` hold the guard across the full load → mutate → save. These are the store's only mutators (`save` is private and only called from them); `load`/`list` are pure reads.
- A per-store `Mutex` field would NOT have worked: rust-api constructs a **fresh `CredentialFileStore` per request** (`apps/rust-api/src/credentials.rs::credential_store`), so the lock must be process-wide.

## What the lock does and doesn't cover (cross-process analysis)

- **Writers:** rust-api is the file's sole writer (Settings → Service credentials routes). Verified by sweeping all `CREDENTIALS_FILENAME` / `CredentialFileStore` usages.
- **Readers:** the worker process reads `credentials.json` once at startup (`sceneworks-worker/src/credentials.rs::load_worker_credentials`) — it never writes. Reads racing a write are already safe because `save()` stages into a temp file and atomically renames into place (a reader sees the old or the new file, never a torn one).
- Therefore an in-process lock fully covers the actual race. This matches the documented posture of `lock_project_files` ("does not coordinate separate OS processes… out of scope for the single-API desktop model"). Residual (documented, not a real deployment today): multiple **API** processes sharing one config dir would still race; no repo-wide cross-process file-locking convention exists to reuse.

## Tests (written first, verified failing pre-fix)

- `concurrent_sets_do_not_lose_updates` — 8 threads × 8 distinct hosts behind a `Barrier`, fresh store per thread (mirrors per-request stores). Pre-fix: only 8/64 entries survived. 
- `concurrent_set_and_delete_do_not_lose_updates` — 8 seeded hosts deleted concurrently with 8 new hosts set; asserts the final map is exactly the survivors (nothing lost, nothing resurrected). Pre-fix: deletes/sets clobbered each other.
- Both pass 15/15 repeated runs post-fix.

## Validation

- `cargo test -p sceneworks-core` — 348 passed, 0 failed
- `npm run rust:check` — exit 0 (fmt + clippy + full workspace tests + build)
- `cargo check -p sceneworks-worker --no-default-features -F backend-candle --all-targets` — green (parity lane)

Out of scope (per story): sibling finding F-147 / sc-8949 (fsync-before-rename in this file + `store_util.rs`) is intentionally NOT included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)