### PR TITLE
fix(core): route training_store project.db opens through connect_project_db (sc-8815)

### DIFF
--- a/crates/sceneworks-core/src/training_store.rs
+++ b/crates/sceneworks-core/src/training_store.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use rusqlite::{params, Connection};
 use serde::{Deserialize, Serialize};
@@ -1266,6 +1267,22 @@ fn resolve_item_source(
     })
 }
 
+/// Open `project.db` for a training-store read/write with the same 5s
+/// `busy_timeout` every other project.db opener uses, so cross-connection
+/// overlap (worker embedding writes racing an API dataset read) queues instead
+/// of failing immediately with `database is locked` (sc-8815). Runs the
+/// version-gated comprehensive migration too — matching `character_store`'s
+/// migrating variant — so the `assets`/`training_datasets` tables are
+/// guaranteed present before we query them (the migration is a no-op read once
+/// the schema is current).
+fn connect_project_db(project_path: &Path) -> ProjectStoreResult<Connection> {
+    fs::create_dir_all(project_path)?;
+    let connection = Connection::open(project_path.join("project.db"))?;
+    connection.busy_timeout(Duration::from_millis(5000))?;
+    apply_project_migrations(&connection)?;
+    Ok(connection)
+}
+
 fn resolve_asset_source(
     project_path: &Path,
     project_id: &str,
@@ -1275,7 +1292,7 @@ fn resolve_asset_source(
     if !is_safe_id(asset_id) {
         return Err(ProjectStoreError::BadRequest("Invalid asset ID".to_owned()));
     }
-    let connection = Connection::open(project_path.join("project.db"))?;
+    let connection = connect_project_db(project_path)?;
     let (file_path, sidecar_path): (String, Option<String>) = connection
         .query_row(
             "select file_path, sidecar_path from assets where id = ?1",
@@ -1380,10 +1397,11 @@ fn ensure_dataset_project(project_id: &str, dataset: &TrainingDataset) -> Projec
 }
 
 pub fn ensure_training_dataset_table(project_path: &Path) -> ProjectStoreResult<()> {
-    let connection = Connection::open(project_path.join("project.db"))?;
-    // Route through the version-gated comprehensive migration so the training
-    // path stops replaying DDL on every call (the table is created either way).
-    apply_project_migrations(&connection)
+    // `connect_project_db` runs the version-gated comprehensive migration so the
+    // training path stops replaying DDL on every call (the table is created
+    // either way) and picks up the shared 5s busy_timeout (sc-8815).
+    connect_project_db(project_path)?;
+    Ok(())
 }
 
 pub fn apply_training_dataset_migrations(connection: &Connection) -> ProjectStoreResult<()> {
@@ -1415,7 +1433,7 @@ fn list_dataset_summaries_from_index(
     project_path: &Path,
     project_id: &str,
 ) -> ProjectStoreResult<Vec<TrainingDatasetSummary>> {
-    let connection = Connection::open(project_path.join("project.db"))?;
+    let connection = connect_project_db(project_path)?;
     let mut statement = connection.prepare(
         "
         select id, project_id, name, modality, status, version, item_count, created_at, updated_at, file_path, character_id
@@ -1489,7 +1507,7 @@ fn index_dataset(
 ) -> ProjectStoreResult<()> {
     ensure_training_dataset_table(project_path)?;
     let rel_path = relative_string(project_path, manifest_path)?;
-    let connection = Connection::open(project_path.join("project.db"))?;
+    let connection = connect_project_db(project_path)?;
     connection.execute(
         "
         insert or replace into training_datasets (
@@ -1515,7 +1533,7 @@ fn index_dataset(
 
 fn remove_dataset_index(project_path: &Path, dataset_id: &str) -> ProjectStoreResult<()> {
     ensure_training_dataset_table(project_path)?;
-    let connection = Connection::open(project_path.join("project.db"))?;
+    let connection = connect_project_db(project_path)?;
     connection.execute(
         "delete from training_datasets where id = ?1",
         params![dataset_id],
@@ -2268,5 +2286,69 @@ mod tests {
 
         // Metadata write: the dataset version is untouched (the pixels didn't change).
         assert_eq!(store.get_dataset("proj", "ds_test").unwrap().version, 1);
+    }
+
+    /// sc-8815: every training-store project.db opener now routes through
+    /// `connect_project_db`, so it (a) runs migrations — the `assets` and
+    /// `training_datasets` tables exist even on a fresh db — and (b) inherits the
+    /// shared 5s `busy_timeout`, so a second writer queues behind an in-flight
+    /// write transaction instead of failing instantly with `database is locked`.
+    #[test]
+    fn connect_project_db_migrates_and_queues_on_contention() {
+        use std::sync::mpsc;
+        use std::thread;
+        use std::time::Instant;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let project_path = dir.path().to_path_buf();
+
+        // (a) Fresh db: the helper runs the comprehensive migration, so core
+        // tables queried by the training surface are present.
+        let connection = connect_project_db(&project_path).expect("connect");
+        for table in ["assets", "training_datasets"] {
+            let count: i64 = connection
+                .query_row(
+                    "select count(*) from sqlite_master where type = 'table' and name = ?1",
+                    params![table],
+                    |row| row.get(0),
+                )
+                .expect("table lookup");
+            assert_eq!(count, 1, "migration should create `{table}`");
+        }
+
+        // (b) Hold an exclusive write transaction on one connection, then have a
+        // second connection attempt a write. With the 5s busy_timeout the second
+        // write blocks until the first commits rather than returning SQLITE_BUSY
+        // immediately. A 0ms default timeout (raw Connection::open) would error
+        // in well under our hold window.
+        let hold = Duration::from_millis(300);
+        connection
+            .execute_batch("begin immediate; insert into training_datasets (id, project_id, name, modality, status, version, item_count, file_path, created_at, updated_at) values ('lock', 'p', 'n', 'image', 'draft', 1, 0, 'f', 't', 't');")
+            .expect("begin write");
+
+        let (tx, rx) = mpsc::channel();
+        let writer_path = project_path.clone();
+        let writer = thread::spawn(move || {
+            let started = Instant::now();
+            let conn = connect_project_db(&writer_path).expect("second connect");
+            let result = conn.execute(
+                "insert into training_datasets (id, project_id, name, modality, status, version, item_count, file_path, created_at, updated_at) values ('other', 'p', 'n', 'image', 'draft', 1, 0, 'f', 't', 't')",
+                [],
+            );
+            tx.send(started.elapsed()).ok();
+            result
+        });
+
+        // Keep the write lock held past what a 0ms timeout would tolerate.
+        thread::sleep(hold);
+        connection.execute_batch("commit").expect("commit");
+
+        let elapsed = rx.recv().expect("writer reported");
+        let write_result = writer.join().expect("writer thread");
+        write_result.expect("second writer should queue, not fail with SQLITE_BUSY");
+        assert!(
+            elapsed >= hold,
+            "second writer ({elapsed:?}) should have blocked for the lock hold ({hold:?}) rather than erroring instantly"
+        );
     }
 }


### PR DESCRIPTION
## What

Five sites in `crates/sceneworks-core/src/training_store.rs` opened `project.db` via raw `Connection::open(...)`, inheriting rusqlite's default **0 ms** `busy_timeout`. Under any cross-connection overlap (a worker embedding write racing an API dataset read on the same `project.db`) these paths failed immediately with `database is locked` instead of queueing — intermittent 500s on the training-dataset surface. `resolve_asset_source` additionally skipped migrations and queried `assets` directly.

Fixes [sc-8815](https://app.shortcut.com/trefry/story/8815) ([F-013], Bug).

## Change

- Add a module-private `connect_project_db` helper in `training_store.rs`, matching `character_store`'s **migrating** variant: opens with the shared 5 s `busy_timeout` **and** runs the version-gated comprehensive `apply_project_migrations` (a no-op read once the schema is current).
- Route **all five** sites through it:
  - `resolve_asset_source` (queries `assets` directly → now migrations-first, table guaranteed present)
  - `ensure_training_dataset_table` (drops its now-redundant explicit `apply_project_migrations` call)
  - `list_dataset_summaries_from_index`
  - `index_dataset`
  - `remove_dataset_index`

### Why the migrating variant everywhere

Two `connect_project_db` helpers exist in the crate: `project_store`'s (busy_timeout only) and `character_store`'s (busy_timeout + migrations). `resolve_asset_source` and `list_dataset_summaries_from_index` query tables (`assets`, `training_datasets`) without a preceding `ensure_*` migration call, so they need the migrating variant to guarantee the tables exist. The migration is version-gated, so for sites that already migrated (`ensure_training_dataset_table`, `index_dataset`, `remove_dataset_index`) the second call is a cheap no-op read. One consistent helper avoids a footgun.

## Tests

- New regression test `connect_project_db_migrates_and_queues_on_contention`: asserts the helper migrates a fresh db (`assets` / `training_datasets` tables present) and that a second writer **queues** behind an in-flight write transaction rather than erroring instantly with `SQLITE_BUSY`. (rusqlite exposes no `busy_timeout` getter, so the observable queueing contract is asserted instead.)
- `cargo test -p sceneworks-core` — green (347 lib + integration tests pass).
- `npm run rust:check` — green (fmt, clippy, build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)