### PR TITLE
fix(api): cap JSON body size, keep large limit only on upload routes (sc-8812)

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -147,6 +147,16 @@ const HEARTBEAT_SSE_WIRE: &str = "event: heartbeat\ndata: {}\n\n";
 // desktop wrapper set the host explicitly (0.0.0.0 / 127.0.0.1 respectively), so this
 // only changes the out-of-the-box default for a direct binary run.
 const DEFAULT_API_HOST: &str = "127.0.0.1";
+// sc-8812 (F-010): router-wide default body limit for JSON/non-upload routes. The
+// 2 GiB `MAX_UPLOAD_BYTES` cap is sized for streaming multipart asset uploads and is
+// far too large to apply globally — every JSON route (`POST /jobs`, `/image/jobs`,
+// progress, presets, keypoint collections, ...) buffers the whole body into memory
+// before parsing, so a router-wide 2 GiB cap lets any authenticated/loopback caller
+// drive multi-GiB memory spikes (a one-request DoS lever). 10 MiB leaves generous
+// headroom for the largest legitimate JSON payloads (batch keypoints, timelines,
+// person-track corrections) while shrinking the per-request ceiling ~200x. The large
+// limit is re-attached per-route ONLY to the multipart/upload endpoints below.
+const MAX_JSON_BODY_BYTES: usize = 10 * 1024 * 1024;
 const MAX_UPLOAD_BYTES: usize = 2 * 1024 * 1024 * 1024;
 const MAX_MODEL_UPLOAD_BYTES: usize = 256 * 1024 * 1024 * 1024;
 const MAX_LORA_MULTIPART_BODY_BYTES: usize = MAX_UPLOAD_BYTES + 16 * 1024 * 1024;
@@ -324,6 +334,15 @@ fn open_bind_override_enabled(value: &str) -> bool {
 }
 
 fn json_rejection_response(rejection: JsonRejection) -> Response {
+    // sc-8812 (F-010): a body over the route's `DefaultBodyLimit` surfaces here as a
+    // `BytesRejection` whose own status is 413. Preserve the rejection's status code
+    // instead of flattening everything to 422, so an oversized body is reported as
+    // PAYLOAD_TOO_LARGE (and the DoS-guard is observable), while genuine decode/parse
+    // failures keep their existing 422 shape.
+    let status = rejection.status();
+    if status == StatusCode::PAYLOAD_TOO_LARGE {
+        return (status, Json(json!({ "detail": rejection.body_text() }))).into_response();
+    }
     let detail = match rejection {
         JsonRejection::JsonDataError(error) => error.body_text(),
         JsonRejection::JsonSyntaxError(error) => error.body_text(),
@@ -741,7 +760,12 @@ pub(crate) fn create_app_with_state(
         )
         .route(
             "/api/v1/projects/:project_id/assets",
-            get(list_assets).post(import_asset),
+            get(list_assets)
+                .post(import_asset)
+                // sc-8812 (F-010): streaming multipart asset upload needs the large
+                // limit; re-attach it per-route since the router default is now the
+                // small JSON cap. GET has no body, so this is harmless for listing.
+                .layer(DefaultBodyLimit::max(MAX_UPLOAD_BYTES)),
         )
         .route(
             "/api/v1/projects/:project_id/assets/:asset_id",
@@ -769,7 +793,9 @@ pub(crate) fn create_app_with_state(
         )
         .route(
             "/api/v1/projects/:project_id/training/uploads",
-            post(upload_training_dataset_item),
+            // sc-8812 (F-010): streaming multipart training-dataset upload; needs the
+            // large per-route limit against the small JSON router default.
+            post(upload_training_dataset_item).layer(DefaultBodyLimit::max(MAX_UPLOAD_BYTES)),
         )
         .route(
             "/api/v1/projects/:project_id/training/datasets/:dataset_id",
@@ -929,13 +955,21 @@ pub(crate) fn create_app_with_state(
             post(create_face_likeness_compare_job),
         )
         .route("/api/v1/poses", post(create_poses))
-        .route("/api/v1/poses/sources", post(create_pose_sources))
+        .route(
+            "/api/v1/poses/sources",
+            // sc-8812 (F-010): multipart pose-source image upload; large per-route limit.
+            post(create_pose_sources).layer(DefaultBodyLimit::max(MAX_UPLOAD_BYTES)),
+        )
         .route(
             "/api/v1/poses/preview/:job_id/:file_name",
             get(get_pose_preview),
         )
         .route("/api/v1/keypoints", post(create_keypoint))
-        .route("/api/v1/keypoints/sources", post(create_keypoint_sources))
+        .route(
+            "/api/v1/keypoints/sources",
+            // sc-8812 (F-010): multipart keypoint-source image upload; large per-route limit.
+            post(create_keypoint_sources).layer(DefaultBodyLimit::max(MAX_UPLOAD_BYTES)),
+        )
         .route("/api/v1/keypoints/presets", get(list_keypoint_presets))
         .route(
             "/api/v1/keypoints/collections",
@@ -1033,7 +1067,11 @@ pub(crate) fn create_app_with_state(
         )
         .fallback(app_fallback)
         .with_state(state.clone())
-        .layer(DefaultBodyLimit::max(MAX_UPLOAD_BYTES))
+        // sc-8812 (F-010): small router-wide default so JSON routes can't buffer
+        // multi-GiB bodies. Multipart/upload routes re-attach the large limit per
+        // route (asset import, training uploads, pose/keypoint sources, and the
+        // model/lora import routes above).
+        .layer(DefaultBodyLimit::max(MAX_JSON_BODY_BYTES))
         .layer(middleware::from_fn_with_state(state, access_control))
         .layer(cors);
     Ok((router, returned_state))

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -10214,3 +10214,94 @@ async fn smart_crop_and_strip_exif_rewrite_and_repoint_items() {
     assert_eq!(stripped["applied"], 1);
     assert_eq!(stripped["dataset"]["version"], 3);
 }
+
+// sc-8812 (F-010): the router-wide default body limit is the small JSON cap
+// (`MAX_JSON_BODY_BYTES`, 10 MiB). A JSON route must reject a body over that cap with
+// 413 *before* buffering/parsing it, so a runaway/malicious caller can't drive a
+// multi-GiB memory spike per request.
+#[tokio::test]
+async fn oversized_json_body_is_rejected_before_parsing() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    // 11 MiB of bytes — over the 10 MiB JSON cap. Content need not be valid JSON:
+    // the `DefaultBodyLimit` layer trips first, so we never reach the parser.
+    let oversized = vec![b'a'; 11 * 1024 * 1024];
+    let (status, _headers, _body) = request_raw(
+        app,
+        "POST",
+        "/api/v1/jobs",
+        oversized,
+        &[("content-type", "application/json")],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::PAYLOAD_TOO_LARGE,
+        "JSON route must 413 a body over the small router-wide cap"
+    );
+}
+
+// sc-8812 (F-010): a JSON body *under* the small cap is still handled normally (proves
+// the tightened cap didn't shrink legitimate JSON traffic below a usable size).
+#[tokio::test]
+async fn under_cap_json_body_is_accepted() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    // Well under 10 MiB, but not empty — routed to the handler (400/validation, not 413).
+    let (status, _) = request(
+        app,
+        "POST",
+        "/api/v1/jobs",
+        json!({ "type": "definitely_not_a_real_job_type" }),
+    )
+    .await;
+
+    assert_ne!(
+        status,
+        StatusCode::PAYLOAD_TOO_LARGE,
+        "a small JSON body must reach the handler, not be size-rejected"
+    );
+}
+
+// sc-8812 (F-010): multipart/upload routes re-attach the large per-route limit, so a
+// body far larger than the small JSON cap is still accepted. This guards against the
+// tightened router-wide default accidentally shrinking an upload route's ceiling.
+#[tokio::test]
+async fn upload_route_accepts_body_larger_than_json_cap() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Large Upload Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id").to_owned();
+
+    // 12 MiB PNG payload — over the 10 MiB JSON cap, under the 2 GiB upload cap.
+    let large_png = vec![0u8; 12 * 1024 * 1024];
+    let (status, upload) = request_multipart_upload(
+        app,
+        &format!("/api/v1/projects/{project_id}/training/uploads"),
+        "large.png",
+        "image/png",
+        &large_png,
+    )
+    .await;
+
+    assert_ne!(
+        status,
+        StatusCode::PAYLOAD_TOO_LARGE,
+        "upload route must accept a body larger than the JSON cap"
+    );
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "large upload should be staged successfully (got {status}: {upload})"
+    );
+}


### PR DESCRIPTION
## Summary

`[F-010]` The 2 GiB `DefaultBodyLimit` — sized for streaming multipart asset upload — was applied **router-wide** (`apps/rust-api/src/lib.rs`). Every JSON route (`POST /jobs`, `/image/jobs`, `/progress`, presets, keypoint collections, etc.) therefore accepted up to 2 GiB, and `Json`/`ApiJson` buffers the whole body into memory before parsing. An authenticated or loopback-trusted caller (or a runaway client) could drive multi-GiB memory spikes per request; a few concurrent requests OOM the API. With LAN access enabled this is a one-request DoS lever for any password holder.

## Changes

- **Small router-wide JSON cap.** New `MAX_JSON_BODY_BYTES = 10 MiB` is now the router-wide default `DefaultBodyLimit`, replacing the 2 GiB `MAX_UPLOAD_BYTES` global. 10 MiB leaves generous headroom for the largest legitimate JSON payloads (batch keypoints, timelines, person-track corrections) while shrinking the per-request memory ceiling ~200x.
- **Large limit re-attached per-route to multipart/upload endpoints only.** Mirroring how `/models/import` and `/loras/import` already do it, the 2 GiB `MAX_UPLOAD_BYTES` limit is now attached per-route to every remaining multipart handler that previously relied on the global default:
  - `POST /projects/:id/assets` (`import_asset`)
  - `POST /projects/:id/training/uploads` (`upload_training_dataset_item`)
  - `POST /poses/sources` (`create_pose_sources`)
  - `POST /keypoints/sources` (`create_keypoint_sources`)

  `/models/import` and `/loras/import` keep their existing (larger) per-route limits, unchanged. No upload route's ceiling was shrunk.
- **413 is now observable.** `json_rejection_response` previously flattened *all* `JsonRejection`s (including the body-limit `BytesRejection`) to 422. It now preserves the rejection's status, so an over-limit body surfaces as `413 PAYLOAD_TOO_LARGE`; genuine JSON decode/parse failures keep their existing 422 shape.
- `retry_job` keeps its existing 1 MiB self-limit (`jobs.rs`), untouched.

## Tests

Three new `#[tokio::test]`s in `apps/rust-api/src/tests.rs`:
- `oversized_json_body_is_rejected_before_parsing` — an 11 MiB body to `POST /jobs` returns 413.
- `under_cap_json_body_is_accepted` — a small JSON body still reaches the handler (not size-rejected).
- `upload_route_accepts_body_larger_than_json_cap` — a 12 MiB multipart upload to `/training/uploads` is accepted (201), proving the per-route large limit still applies.

`cargo test -p sceneworks-rust-api`: 158 passed / 0 failed. `npm run rust:check` (fmt + clippy + test + build): green. No contract/schema files changed, so no snapshot regeneration needed.

Story: https://app.shortcut.com/trefry/story/8812

🤖 Generated with [Claude Code](https://claude.com/claude-code)