### PR TITLE
fix(api): don't block the image-job POST on Ideogram auto-caption (sc-8818)

### DIFF
--- a/apps/rust-api/src/ideogram.rs
+++ b/apps/rust-api/src/ideogram.rs
@@ -17,20 +17,42 @@
 //! image job is created and dispatched. If the expansion is unavailable (no refiner staged, the job
 //! fails, or it times out), the original prompt is left untouched and the image job still dispatches —
 //! the worker's format-guard + reseed net is the fallback, so a render is always produced.
+//!
+//! LATENCY BOUND (sc-8818): the expansion runs INLINE in the image-job `POST`, so its wait is bounded
+//! to a SINGLE attempt with a ~45s ceiling ([`CAPTION_MAX_WAIT`]/[`MAX_CAPTION_ATTEMPTS`]). It was
+//! previously 3 attempts × 180s, which could hang the `POST` ~9 minutes on a backlogged worker — past
+//! any client/proxy timeout, whereupon impatient retries stacked more refine jobs. A tighter single
+//! bounded attempt returns the `POST` promptly and caps how many refine jobs one request can enqueue.
+//! The fully-async alternative (create the job in a `pending_caption` stage, rewrite the payload from a
+//! background task before dispatch, so the `POST` never waits) is tracked as a follow-up to sc-8818.
 
 use super::*;
 
 /// How often the API polls the in-flight `magic_prompt` job while awaiting its caption. Generation
 /// expansion runs in tens of seconds, so a sub-second poll adds negligible latency.
 const CAPTION_POLL_INTERVAL: Duration = Duration::from_millis(500);
-/// Upper bound on the wait for the caption before falling back to the original prompt — matches the
-/// web's 180s magic-prompt poll tolerance. A genuinely busy worker still has room to deliver the rich
-/// caption; only a stuck/absent worker degrades to the plain prompt.
-const CAPTION_MAX_WAIT: Duration = Duration::from_secs(180);
-/// How many times to re-sample a completed-but-invalid expansion before degrading. The 3B utility
-/// model is stochastic and occasionally emits malformed JSON (real-weight observed, sc-6519), so a
-/// couple of fresh samples materially raise the odds of a usable caption without a human in the loop.
-const MAX_CAPTION_ATTEMPTS: u32 = 3;
+/// Upper bound on the wait for the caption before falling back to the original prompt.
+///
+/// This is a HARD ceiling on how long the image-job `POST` is held while the auto-caption runs. It was
+/// previously 180s *per attempt* × 3 attempts, so a stuck/backlogged worker could hang the HTTP request
+/// for ~9 minutes before the image job was even created — long past any sane client/proxy timeout, at
+/// which point impatient retries stacked more refine jobs (sc-8818). The magic-prompt expansion is a
+/// tens-of-seconds job, so a single bounded attempt with a ~45s ceiling gives a healthy worker ample
+/// room to deliver the rich caption while guaranteeing the `POST` returns promptly; a stuck/absent
+/// worker degrades to the plain prompt (the worker's format-guard + reseed net is the fallback).
+///
+/// The fully-async alternative — create the image job immediately in a `pending_caption` stage and let
+/// a background task rewrite the payload before dispatch, so the `POST` never waits at all — is tracked
+/// separately (relates to sc-8818); it is a cross-cutting store/worker/contract change out of scope for
+/// this bounded-latency fix.
+const CAPTION_MAX_WAIT: Duration = Duration::from_secs(45);
+/// How many magic-prompt jobs a single image `POST` may enqueue while awaiting a caption. Capped at a
+/// SINGLE attempt (sc-8818): re-sampling a completed-but-invalid caption is a quality nicety, but each
+/// extra attempt enqueues a fresh `prompt_refine` job and extends the wall-time the HTTP request is
+/// held — the exact behavior that let a hung `POST` stack refine jobs. One attempt bounds both the
+/// latency and the number of refine jobs a client (or its impatient retries) can pile up; a
+/// completed-but-invalid caption degrades to the plain prompt and the worker's reseed net recovers it.
+const MAX_CAPTION_ATTEMPTS: u32 = 1;
 
 /// Both Ideogram 4 image models are JSON-caption-trained, so both get the auto-caption (mirrors the
 /// worker's `ideogram_caption::is_ideogram_model`).
@@ -162,10 +184,11 @@ enum CaptionOutcome {
 }
 
 /// Run the magic-prompt expansion, re-sampling a completed-but-invalid caption up to
-/// [`MAX_CAPTION_ATTEMPTS`] times. Returns `None` (degrade to the plain prompt) when the job can't be
-/// enqueued, when the model never produces a valid caption, or on an infrastructure failure/timeout.
-/// The web surfaces an expansion failure for the user to retry; the headless path has no human in the
-/// loop, so the re-sample lives here.
+/// [`MAX_CAPTION_ATTEMPTS`] times (currently a SINGLE bounded attempt — see [`CAPTION_MAX_WAIT`] — so
+/// the inline `POST` can't hang on repeated re-samples, sc-8818). Returns `None` (degrade to the plain
+/// prompt) when the job can't be enqueued, when the model produces no valid caption within the attempt
+/// budget, or on an infrastructure failure/timeout. The web surfaces an expansion failure for the user
+/// to retry; the headless path has no human in the loop, so any re-sample budget lives here.
 async fn expand_to_caption(state: &AppState, prompt: &str, aspect_ratio: &str) -> Option<String> {
     for attempt in 1..=MAX_CAPTION_ATTEMPTS {
         let job = match enqueue_magic_prompt_job(state, prompt, aspect_ratio).await {
@@ -258,6 +281,27 @@ async fn await_magic_prompt_outcome(state: &AppState, job_id: &str) -> CaptionOu
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn inline_caption_wait_is_bounded_to_a_single_short_attempt() {
+        // sc-8818: the auto-caption runs INLINE in the image-job POST, so its worst-case wall-time is
+        // MAX_CAPTION_ATTEMPTS × CAPTION_MAX_WAIT. The regression was 3 × 180s = ~9 minutes, which hung
+        // the POST past client/proxy timeouts and let impatient retries stack refine jobs. Guard that
+        // the request can no longer be held for minutes: a single attempt, ceilinged well under a
+        // minute. (A tighter contract than a plain "< 9 min" so the bound can't silently regress.)
+        assert_eq!(
+            MAX_CAPTION_ATTEMPTS, 1,
+            "the inline caption must run at most one attempt so the POST can't stack refine jobs"
+        );
+        let worst_case = CAPTION_MAX_WAIT * MAX_CAPTION_ATTEMPTS;
+        assert!(
+            worst_case <= Duration::from_secs(60),
+            "the inline caption wait must stay under a minute (was {worst_case:?})"
+        );
+        // The poll cadence must be strictly shorter than the ceiling, or the loop could exit on its
+        // first tick without ever giving a healthy worker a chance to deliver the caption.
+        assert!(CAPTION_POLL_INTERVAL < CAPTION_MAX_WAIT);
+    }
 
     #[test]
     fn ideogram_caption_models_match_both_variants() {

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -3932,11 +3932,13 @@ async fn ideogram_plain_text_job_degrades_to_original_prompt_when_expansion_fail
 }
 
 #[tokio::test]
-async fn ideogram_plain_text_job_resamples_on_invalid_caption_then_dispatches() {
-    // sc-6519 real-weight finding: the 3B magic-prompt model is stochastic and occasionally returns
-    // malformed JSON / prose instead of a caption. A completed-but-invalid expansion is re-sampled
-    // with a fresh job (the headless path has no human to retry) before the image job dispatches with
-    // the valid caption.
+async fn ideogram_plain_text_job_degrades_on_invalid_caption_without_resampling() {
+    // sc-8818: the auto-caption runs INLINE in the image-job POST, so it is capped to a SINGLE bounded
+    // attempt (MAX_CAPTION_ATTEMPTS = 1) to keep the request from hanging on repeated re-samples of a
+    // stochastic 3B model. A completed-but-invalid expansion therefore degrades straight to the ORIGINAL
+    // prompt (the worker's format-guard + reseed net recovers it) and does NOT enqueue a second refine
+    // job — so an impatient client's retries can't stack unbounded magic-prompt jobs. (This tightens the
+    // prior sc-6519 behavior, which re-sampled up to 3× and could hold the POST for minutes.)
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let app = create_app(test_settings(&temp_dir)).expect("app creates");
 
@@ -3959,7 +3961,7 @@ async fn ideogram_plain_text_job_resamples_on_invalid_caption_then_dispatches() 
         })
     };
 
-    // The first expansion returns prose, not a caption → the API re-samples a fresh job.
+    // The single expansion attempt returns prose, not a caption.
     let first = wait_for_prompt_refine_job(&app).await;
     complete_prompt_refine_job(
         &app,
@@ -3968,16 +3970,25 @@ async fn ideogram_plain_text_job_resamples_on_invalid_caption_then_dispatches() 
     )
     .await;
 
-    // The re-sampled job produces a valid caption → the image job dispatches with it.
-    let caption =
-        r#"{"compositional_deconstruction": {"background": "a snowy forest", "elements": []}}"#;
-    let second = wait_for_prompt_refine_job_excluding(&app, Some(&first)).await;
-    assert_ne!(second, first, "a fresh expansion job was enqueued");
-    complete_prompt_refine_job(&app, &second, json!({ "refinedPrompt": caption })).await;
-
+    // The image job dispatches PROMPTLY with the original prompt — no second refine job is enqueued.
     let (status, image_job) = submit.await.expect("submit task joins");
     assert_eq!(status, StatusCode::CREATED);
-    assert_eq!(image_job["payload"]["prompt"], caption);
+    assert_eq!(
+        image_job["payload"]["prompt"],
+        "a red fox in a snowy forest"
+    );
+
+    let (_, jobs) = request(app, "GET", "/api/v1/jobs", Value::Null).await;
+    let refine_jobs = jobs
+        .as_array()
+        .expect("jobs is an array")
+        .iter()
+        .filter(|job| job["type"] == "prompt_refine")
+        .count();
+    assert_eq!(
+        refine_jobs, 1,
+        "a completed-but-invalid caption must NOT be re-sampled into a second refine job (sc-8818)"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## [F-016] Ideogram auto-caption blocks the image-job POST for up to ~9 minutes

Fixes the sc-8818 bug: `create_image_job` ran the Ideogram 4 magic-prompt auto-caption **inline**, polling a `prompt_refine` job every 500ms with a 180s cap **per attempt × 3 attempts** (`apps/rust-api/src/ideogram.rs`). On a backlogged/absent worker the HTTP POST could hang **~9 minutes** before the image job was even created — well past client/proxy timeouts — and impatient retries stacked yet more refine jobs.

### Approach chosen: bounded single-attempt cap (the finding's fallback path)

The finding's PREFERRED fix was a fully-async `pending_caption` stage. I assessed that against the current code and it is a genuinely cross-cutting change: a new non-claimable `JobStatus`, `create_job` accepting an initial status, a **new** store method to patch a job's payload (none exists today), the **first** background job-watcher in rust-api (plus a failure/timeout flip so a job never sits un-claimable), and queue-summary/cancel/frontend/TS-contract handling for the new status. That is out of scope for a Medium bug and risks a half-done slice.

So per the story's explicit fallback clause, this PR ships the bounded fix and files the async work as a follow-up:

- Cap the inline expansion to a **single bounded attempt** with a **~45s ceiling** (`MAX_CAPTION_ATTEMPTS = 1`, `CAPTION_MAX_WAIT = 45s`) — the expansion is a tens-of-seconds job, so a healthy worker still delivers the rich caption, but the POST can no longer be held for minutes.
- A completed-but-invalid caption now **degrades straight to the original prompt** (the worker's format-guard + reseed net recovers it) instead of re-sampling, so **one request enqueues at most one refine job** — impatient client retries can't stack unbounded magic-prompt jobs.
- Docs updated on the constants + module to explain the latency bound and the deferred async design.

### Follow-up filed

**sc-9120** (epic 8800, relates to sc-8818): fully-async `pending_caption` stage so the POST never waits at all — with file:line context for the cross-cutting store/worker/contract work.

### Tests

- Updated `ideogram_plain_text_job_degrades_on_invalid_caption_without_resampling` (was the 3× re-sample test) to assert an invalid caption dispatches promptly with the original prompt and enqueues **exactly one** refine job.
- New unit test `inline_caption_wait_is_bounded_to_a_single_short_attempt` locks the bound (1 attempt, worst-case ≤ 60s) so it can't silently regress.
- `cargo test -p sceneworks-rust-api`: 159 pass. `npm run rust:check` (fmt --check + clippy -D warnings + build): clean. No contract/DTO changes → no snapshot regen.

Story: https://app.shortcut.com/trefry/story/8818

🤖 Generated with [Claude Code](https://claude.com/claude-code)