### PR TITLE
fix(worker): cross-process lock for manifest upserts (sc-8843)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5733,6 +5733,7 @@ dependencies = [
  "candle-gen-wan",
  "candle-gen-z-image",
  "candle-llm",
+ "fs2",
  "futures-util",
  "glob",
  "image",

--- a/apps/rust-api/src/manifest.rs
+++ b/apps/rust-api/src/manifest.rs
@@ -51,10 +51,17 @@ async fn acquire_manifest_file_lock(path: &FsPath) -> Result<ManifestFileLock, A
                 ))
             })?;
         let deadline = std::time::Instant::now() + MANIFEST_LOCK_TIMEOUT;
+        // fs2 signals lock contention with a platform-specific error: `EWOULDBLOCK`
+        // (`ErrorKind::WouldBlock`) on Unix, but `ERROR_LOCK_VIOLATION` (raw OS 33,
+        // `ErrorKind::Uncategorized`) on Windows. Matching on `ErrorKind` misses the
+        // Windows case and would mis-propagate a real, retryable contention as a hard
+        // error (sc-8843). Compare by RAW OS CODE against fs2's own contention error,
+        // which is correct on every platform.
+        let contended = fs2::lock_contended_error().raw_os_error();
         loop {
             match file.try_lock_exclusive() {
                 Ok(()) => return Ok(ManifestFileLock { _file: file }),
-                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                Err(error) if error.raw_os_error() == contended => {
                     if std::time::Instant::now() >= deadline {
                         return Err(ApiError::internal(format!(
                             "Timed out after {MANIFEST_LOCK_TIMEOUT:?} waiting for manifest lock {}",

--- a/apps/rust-api/src/manifest.rs
+++ b/apps/rust-api/src/manifest.rs
@@ -1,6 +1,80 @@
 use super::*;
 
+use fs2::FileExt as _;
+
 const MANIFEST_CACHE_LIMIT: usize = 16;
+/// Max time to block on the cross-process manifest lock before erroring. Mirrors the
+/// worker's `MANIFEST_LOCK_TIMEOUT` (sc-8843): the API and the utility-worker pool
+/// (separate processes) write the SAME `user.*.jsonc` files, so both take the same
+/// `<manifest>.lock` sibling to serialize cross-writer read→merge→rename.
+const MANIFEST_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+const MANIFEST_LOCK_POLL: std::time::Duration = std::time::Duration::from_millis(25);
+
+/// RAII holder for the cross-process advisory exclusive lock on a `<manifest>.lock`
+/// sibling. Released when the file handle drops. Acquired on a blocking thread since
+/// flock is synchronous (see [`acquire_manifest_file_lock`]).
+struct ManifestFileLock {
+    _file: std::fs::File,
+}
+
+fn manifest_lock_path(manifest_path: &FsPath) -> PathBuf {
+    let mut name = manifest_path
+        .file_name()
+        .map(std::ffi::OsString::from)
+        .unwrap_or_default();
+    name.push(".lock");
+    manifest_path.with_file_name(name)
+}
+
+/// Acquire the cross-process manifest lock, off the async runtime (flock blocks).
+async fn acquire_manifest_file_lock(path: &FsPath) -> Result<ManifestFileLock, ApiError> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await.map_err(|error| {
+            ApiError::internal(format!(
+                "Failed to create manifest directory {}: {error}",
+                parent.display()
+            ))
+        })?;
+    }
+    let lock_path = manifest_lock_path(path);
+    tokio::task::spawn_blocking(move || {
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&lock_path)
+            .map_err(|error| {
+                ApiError::internal(format!(
+                    "Failed to open manifest lock {}: {error}",
+                    lock_path.display()
+                ))
+            })?;
+        let deadline = std::time::Instant::now() + MANIFEST_LOCK_TIMEOUT;
+        loop {
+            match file.try_lock_exclusive() {
+                Ok(()) => return Ok(ManifestFileLock { _file: file }),
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    if std::time::Instant::now() >= deadline {
+                        return Err(ApiError::internal(format!(
+                            "Timed out after {MANIFEST_LOCK_TIMEOUT:?} waiting for manifest lock {}",
+                            lock_path.display()
+                        )));
+                    }
+                    std::thread::sleep(MANIFEST_LOCK_POLL);
+                }
+                Err(error) => {
+                    return Err(ApiError::internal(format!(
+                        "Failed to acquire manifest lock {}: {error}",
+                        lock_path.display()
+                    )))
+                }
+            }
+        }
+    })
+    .await
+    .map_err(|error| ApiError::internal(format!("Manifest lock task failed: {error}")))?
+}
 pub(crate) const API_MANAGED_MANIFEST_HEADER: &str = "// This file is rewritten by the SceneWorks API. Inline JSONC comments are not preserved across writes.";
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
@@ -53,6 +127,10 @@ where
 {
     let lock = manifest_write_lock(state, path);
     let _guard = lock.lock().await;
+    // Cross-process lock (sc-8843): the utility-worker pool writes the same
+    // `user.*.jsonc` files from separate processes, so the in-process mutex above is
+    // not enough — hold the shared `<manifest>.lock` across the whole read→merge→save.
+    let _file_lock = acquire_manifest_file_lock(path).await?;
     let entries = load_manifest_entries(state, path, field).await?;
     let (entries, result) = operation(entries)?;
     save_manifest_entries(path, field, entries).await?;

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -6,6 +6,11 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
+# Cross-process advisory file lock (flock) serializing the manifest read→merge→write
+# in manifest.rs. The default utility pool is 4 SEPARATE PROCESSES, so an in-process
+# mutex can't stop two parallel installs from clobbering each other's manifest entry
+# (F-041 / sc-8843). Already the workspace's file-lock choice (apps/rust-api).
+fs2 = "0.4"
 futures-util = "0.3"
 glob = "0.3"
 # PNG encoding for generated image assets (epic 3018, sc-3020). png-only keeps the

--- a/crates/sceneworks-worker/src/manifest.rs
+++ b/crates/sceneworks-worker/src/manifest.rs
@@ -130,12 +130,17 @@ impl ManifestLock {
             .truncate(false)
             .open(&lock_path)?;
         let deadline = std::time::Instant::now() + MANIFEST_LOCK_TIMEOUT;
+        // fs2 signals lock contention with a platform-specific error: `EWOULDBLOCK`
+        // (`ErrorKind::WouldBlock`) on Unix, but `ERROR_LOCK_VIOLATION` (raw OS 33,
+        // `ErrorKind::Uncategorized`) on Windows. Matching on `ErrorKind` misses the
+        // Windows case and would mis-propagate a real, retryable contention as a hard
+        // error (sc-8843). Compare by RAW OS CODE against fs2's own contention error,
+        // which is correct on every platform.
+        let contended = fs2::lock_contended_error().raw_os_error();
         loop {
             match file.try_lock_exclusive() {
                 Ok(()) => return Ok(Self { _file: file }),
-                // fs2 surfaces contention as `EWOULDBLOCK`, which maps to
-                // `ErrorKind::WouldBlock`; retry until the deadline.
-                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                Err(error) if error.raw_os_error() == contended => {
                     if std::time::Instant::now() >= deadline {
                         return Err(WorkerError::Io(std::io::Error::new(
                             std::io::ErrorKind::TimedOut,

--- a/crates/sceneworks-worker/src/manifest.rs
+++ b/crates/sceneworks-worker/src/manifest.rs
@@ -1,6 +1,19 @@
 //! JSONC manifest read/upsert/write helpers shared by the LoRA and model manifests.
 use super::*;
 
+use std::io::Write as _;
+
+use fs2::FileExt as _;
+
+/// Max time to block waiting for the cross-process manifest lock before giving up
+/// with a clear error. Manifest RMW is a few KB of JSON, so a real hold is sub-ms;
+/// a stall this long means a stuck/crashed peer, and failing loudly beats silently
+/// skipping the write and losing the freshly-installed entry (sc-8843).
+const MANIFEST_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+/// Poll cadence while spin-waiting on `try_lock_exclusive` (fs2 has no timed
+/// blocking-lock API, so we retry rather than block indefinitely).
+const MANIFEST_LOCK_POLL: std::time::Duration = std::time::Duration::from_millis(25);
+
 pub(crate) async fn read_json_value(path: &Path) -> WorkerResult<Value> {
     Ok(serde_json::from_slice(&tokio::fs::read(path).await?)?)
 }
@@ -10,12 +23,48 @@ pub(crate) async fn read_json_value(path: &Path) -> WorkerResult<Value> {
 /// the same id is merged (incoming fields win) but keeps its original `createdAt`.
 /// Shared by the LoRA (`"loras"`) and model (`"models"`) manifests, which differed
 /// only by this array key (sc-4279 / F-MLXW-15).
+///
+/// The default utility pool is 4 SEPARATE PROCESSES, so an in-process mutex cannot
+/// serialize concurrent installs — two parallel upserts would each read the old
+/// file, merge their own entry, and the second rename would clobber the first,
+/// losing an entry (F-041 / sc-8843). The entire read→merge→write(rename) therefore
+/// runs under a cross-process advisory *exclusive* file lock on a `<manifest>.lock`
+/// sibling. The API writer (`apps/rust-api/src/manifest.rs`) takes the SAME sibling
+/// lock so worker↔API writes to these shared files serialize too.
 pub(crate) async fn upsert_manifest_entry(
     path: &Path,
     collection_key: &str,
     entry: serde_json::Map<String, Value>,
 ) -> WorkerResult<()> {
-    let mut manifest = match tokio::fs::read_to_string(path).await {
+    // `id` is validated up front (cheap, no I/O) so a malformed payload fails before
+    // we take the lock.
+    if entry.get("id").and_then(Value::as_str).is_none() {
+        return Err(WorkerError::InvalidPayload(format!(
+            "{collection_key} manifest entry requires id"
+        )));
+    }
+    let path = path.to_path_buf();
+    let collection_key = collection_key.to_owned();
+    // The critical section is blocking (fs2 advisory lock + sync read/write) so it
+    // runs on a blocking thread rather than stalling the async runtime.
+    tokio::task::spawn_blocking(move || upsert_manifest_entry_locked(&path, &collection_key, entry))
+        .await
+        .map_err(|error| task_join_error("manifest upsert", error))?
+}
+
+/// Blocking read→merge→write of `path`, run under a cross-process exclusive lock on
+/// the `<manifest>.lock` sibling. Callers must invoke this off the async runtime.
+fn upsert_manifest_entry_locked(
+    path: &Path,
+    collection_key: &str,
+    entry: serde_json::Map<String, Value>,
+) -> WorkerResult<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let _guard = ManifestLock::acquire(path)?;
+
+    let mut manifest = match std::fs::read_to_string(path) {
         Ok(payload) => serde_json::from_str(&strip_jsonc_comments(&payload))?,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             let mut object = serde_json::Map::new();
@@ -25,6 +74,7 @@ pub(crate) async fn upsert_manifest_entry(
         }
         Err(error) => return Err(error.into()),
     };
+    // Re-fetch under the lock; validated above, so this is infallible in practice.
     let entry_id = entry.get("id").and_then(Value::as_str).ok_or_else(|| {
         WorkerError::InvalidPayload(format!("{collection_key} manifest entry requires id"))
     })?;
@@ -60,7 +110,80 @@ pub(crate) async fn upsert_manifest_entry(
     if !found {
         collection.push(Value::Object(entry));
     }
-    write_json_value(path, &manifest).await
+    write_json_value_blocking(path, &manifest)
+    // `_guard` (and the advisory lock) drops here, after the atomic rename lands.
+}
+
+/// RAII holder for a cross-process advisory exclusive lock on a `<manifest>.lock`
+/// sibling file. The lock is released when the underlying file handle drops.
+struct ManifestLock {
+    _file: std::fs::File,
+}
+
+impl ManifestLock {
+    fn acquire(manifest_path: &Path) -> WorkerResult<Self> {
+        let lock_path = manifest_lock_path(manifest_path);
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&lock_path)?;
+        let deadline = std::time::Instant::now() + MANIFEST_LOCK_TIMEOUT;
+        loop {
+            match file.try_lock_exclusive() {
+                Ok(()) => return Ok(Self { _file: file }),
+                // fs2 surfaces contention as `EWOULDBLOCK`, which maps to
+                // `ErrorKind::WouldBlock`; retry until the deadline.
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    if std::time::Instant::now() >= deadline {
+                        return Err(WorkerError::Io(std::io::Error::new(
+                            std::io::ErrorKind::TimedOut,
+                            format!(
+                                "timed out after {:?} waiting for manifest lock {}",
+                                MANIFEST_LOCK_TIMEOUT,
+                                lock_path.display()
+                            ),
+                        )));
+                    }
+                    std::thread::sleep(MANIFEST_LOCK_POLL);
+                }
+                Err(error) => return Err(error.into()),
+            }
+        }
+    }
+}
+
+/// The `.lock` sibling path for a manifest. Kept alongside the manifest so the lock
+/// scope is the exact file being mutated (per-file, not global).
+fn manifest_lock_path(manifest_path: &Path) -> PathBuf {
+    let mut name = manifest_path
+        .file_name()
+        .map(std::ffi::OsString::from)
+        .unwrap_or_default();
+    name.push(".lock");
+    manifest_path.with_file_name(name)
+}
+
+/// Blocking sibling of [`write_json_value`]: atomic temp-write + rename. Used inside
+/// the manifest lock's critical section (which is already off the async runtime).
+fn write_json_value_blocking(path: &Path, value: &Value) -> WorkerResult<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut output = serde_json::to_vec_pretty(value)?;
+    output.push(b'\n');
+    let tmp_path = path.with_extension(format!(
+        "{}.tmp",
+        path.extension()
+            .and_then(|extension| extension.to_str())
+            .unwrap_or("json")
+    ));
+    let mut file = std::fs::File::create(&tmp_path)?;
+    file.write_all(&output)?;
+    file.sync_all()?;
+    std::fs::rename(&tmp_path, path)?;
+    Ok(())
 }
 
 pub(crate) async fn write_json_value(path: &Path, value: &Value) -> WorkerResult<()> {
@@ -78,4 +201,107 @@ pub(crate) async fn write_json_value(path: &Path, value: &Value) -> WorkerResult
     tokio::fs::write(&tmp_path, output).await?;
     tokio::fs::rename(tmp_path, path).await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(id: &str) -> serde_json::Map<String, Value> {
+        let mut map = serde_json::Map::new();
+        map.insert("id".to_owned(), json!(id));
+        map.insert("name".to_owned(), json!(format!("name-{id}")));
+        map
+    }
+
+    async fn read_ids(path: &Path, collection_key: &str) -> Vec<String> {
+        let payload = tokio::fs::read_to_string(path)
+            .await
+            .expect("read manifest");
+        let manifest: Value =
+            serde_json::from_str(&strip_jsonc_comments(&payload)).expect("parse manifest");
+        manifest
+            .get(collection_key)
+            .and_then(Value::as_array)
+            .expect("collection array")
+            .iter()
+            .filter_map(|item| item.get("id").and_then(Value::as_str).map(str::to_owned))
+            .collect()
+    }
+
+    /// Two concurrent upserts to the same manifest must BOTH survive. Without the
+    /// cross-process lock, the read→merge→rename interleaves and one entry is lost
+    /// (F-041 / sc-8843). The flock guard serializes the RMW even across threads
+    /// (and, in the real deployment, across the separate utility-worker processes).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_upserts_all_survive() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("user.loras.jsonc");
+
+        // Many concurrent writers, each a distinct id, all racing the same file. If
+        // the lock is missing this loses entries essentially every run.
+        const WRITERS: usize = 24;
+        let mut handles = Vec::with_capacity(WRITERS);
+        for index in 0..WRITERS {
+            let path = path.clone();
+            handles.push(tokio::spawn(async move {
+                upsert_manifest_entry(&path, "loras", entry(&format!("lora-{index}"))).await
+            }));
+        }
+        for handle in handles {
+            handle.await.expect("join").expect("upsert");
+        }
+
+        let mut ids = read_ids(&path, "loras").await;
+        ids.sort();
+        let mut expected: Vec<String> = (0..WRITERS).map(|i| format!("lora-{i}")).collect();
+        expected.sort();
+        assert_eq!(ids, expected, "every concurrent upsert must persist");
+    }
+
+    /// Upserting an existing id merges fields and preserves the original createdAt,
+    /// and the lock path is unaffected by repeated calls.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn upsert_merges_and_preserves_created_at() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("user.models.jsonc");
+
+        let mut first = entry("m1");
+        first.insert("createdAt".to_owned(), json!("2020-01-01"));
+        first.insert("keep".to_owned(), json!("original"));
+        upsert_manifest_entry(&path, "models", first)
+            .await
+            .expect("first upsert");
+
+        let mut second = entry("m1");
+        second.insert("createdAt".to_owned(), json!("2099-12-31"));
+        second.insert("name".to_owned(), json!("renamed"));
+        upsert_manifest_entry(&path, "models", second)
+            .await
+            .expect("second upsert");
+
+        let payload = tokio::fs::read_to_string(&path).await.expect("read");
+        let manifest: Value = serde_json::from_str(&strip_jsonc_comments(&payload)).expect("parse");
+        let models = manifest["models"].as_array().expect("array");
+        assert_eq!(models.len(), 1, "same id must not duplicate");
+        let m1 = &models[0];
+        assert_eq!(m1["createdAt"], json!("2020-01-01"), "createdAt preserved");
+        assert_eq!(m1["name"], json!("renamed"), "incoming fields win");
+        assert_eq!(m1["keep"], json!("original"), "prior fields retained");
+    }
+
+    /// A lock timeout surfaces a clear error rather than silently skipping the write.
+    #[tokio::test]
+    async fn missing_id_errors_before_lock() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("user.loras.jsonc");
+        let mut bad = serde_json::Map::new();
+        bad.insert("name".to_owned(), json!("no-id"));
+        let err = upsert_manifest_entry(&path, "loras", bad)
+            .await
+            .expect_err("missing id must error");
+        assert!(matches!(err, WorkerError::InvalidPayload(_)));
+        // Nothing should have been written.
+        assert!(!path.exists(), "no manifest written for invalid payload");
+    }
 }


### PR DESCRIPTION
## Problem (F-041 / sc-8843)

`upsert_manifest_entry` (`crates/sceneworks-worker/src/manifest.rs`) is an unlocked read-modify-write of `user.loras.jsonc` / `user.models.jsonc`, but the default utility pool is **4 separate processes**. Two concurrent install jobs interleave — each reads the old file, merges its own entry, and the second `rename` overwrites the first. Result: a freshly downloaded LoRA/model **vanishes from the manifest** and shows "not installed" despite the completed job.

An in-process `Mutex` cannot fix this because the racers are separate OS processes, not threads.

## Fix

Wrap the entire read→merge→write(rename) in a **cross-process advisory exclusive file lock** (`fs2` flock — already the workspace's file-lock choice, used by `apps/rust-api`) on a `<manifest>.lock` sibling of the manifest file.

- Blocking critical section runs on a `spawn_blocking` thread (flock is synchronous).
- Lock acquisition retries to a **30s deadline**, then returns a clear `TimedOut` error rather than silently skipping the write.
- Atomic temp+rename write is preserved.
- Covers **both** manifest files and **both** worker call sites (`model_jobs.rs:1771`, `:2113`).

### API-side cross-writer coverage

The API (`apps/rust-api/src/manifest.rs`) writes the **same** `user.*.jsonc` files from a separate process and previously serialized only via an in-process `AsyncMutex`. `mutate_manifest_entries` now also takes the **same** sibling `.lock` across its load→merge→save, closing the worker↔API race (not just worker↔worker). All API write paths funnel through `mutate_manifest_entries`, so this one seam covers them.

## Tests

- `concurrent_upserts_all_survive` — 24 racing writers to one manifest, asserts **every** entry persists (fails ~every run without the lock).
- `upsert_merges_and_preserves_created_at` — same-id merge keeps original `createdAt`, incoming fields win.
- `missing_id_errors_before_lock` — invalid payload errors before any write.

`cargo test -p sceneworks-worker` (498 pass), `npm run rust:check` (fmt+clippy+build+tests), and `cargo check -p sceneworks-worker --no-default-features --features backend-candle --all-targets` all green.

Story: https://app.shortcut.com/trefry/story/8843

🤖 Generated with [Claude Code](https://claude.com/claude-code)