### PR TITLE
perf(api): compute model/lora catalog once per job-create request (sc-8819)

### DIFF
--- a/apps/rust-api/src/generation.rs
+++ b/apps/rust-api/src/generation.rs
@@ -18,7 +18,11 @@ pub(crate) async fn create_image_job(
     if payload.recipe_preset_id.is_none() {
         job_payload.remove("recipePresetId");
     }
-    apply_recipe_preset_to_image_payload(&state, &payload, &mut job_payload).await?;
+    // One request-scoped catalog snapshot threaded through preset expansion + LoRA
+    // validation so the per-model/per-LoRA filesystem install-state probes run once per
+    // job-create instead of 2–3× (sc-8819, F-017).
+    let catalogs = JobCatalogSnapshot::default();
+    apply_recipe_preset_to_image_payload(&state, &payload, &mut job_payload, &catalogs).await?;
     // Ideogram 4 headless/API parity (sc-6519): auto-expand a plain prompt into a rich JSON caption
     // via the magic-prompt utility model — the same separate prompt_refine job the web runs (sc-6501)
     // — and rewrite the job's prompt before it dispatches, so a direct/headless plain-text job escapes
@@ -27,8 +31,14 @@ pub(crate) async fn create_image_job(
     crate::ideogram::rich_auto_caption_for_ideogram(&state, &mut job_payload).await;
     let model_manifest_entry = resolve_model_manifest_entry(&state, &payload.model).await?;
     job_payload.insert("modelManifestEntry".to_owned(), model_manifest_entry);
-    validate_job_lora_compatibility(&state, Some(&payload.project_id), &mut job_payload, false)
-        .await?;
+    validate_job_lora_compatibility_with(
+        &state,
+        Some(&payload.project_id),
+        &mut job_payload,
+        false,
+        Some(&catalogs),
+    )
+    .await?;
     if payload.seed.is_none() {
         let count = job_payload
             .get("count")
@@ -141,10 +151,60 @@ pub(crate) fn validate_interleave_job(payload: &InterleaveJobRequest) -> Result<
     Ok(())
 }
 
+/// Request-scoped, lazily-memoized snapshot of the model and LoRA catalogs (sc-8819,
+/// F-017). A single preset-backed `POST /image/jobs` (or `/video/jobs`) fans out into
+/// `recipe_preset_catalog`, `merge_preset_loras_into_payload`, and
+/// `validate_job_lora_compatibility`, each of which formerly re-assembled
+/// `model_catalog`/`lora_catalog` from scratch — re-running the per-model install-state
+/// probes (recursive HF-cache walks, `model_is_installed`, `mlx_catalog_status`) 2–3×
+/// over the whole catalog per submit. Threading one snapshot through those seams makes
+/// each catalog's filesystem probing run exactly once per job-create.
+///
+/// This is deliberately request-scoped rather than a shared TTL cache: the snapshot lives
+/// only for the duration of one job-create, so there is no staleness window and the
+/// catalog contents seen by preset expansion and by LoRA validation are guaranteed
+/// identical. It memoizes per `project_id` (constant within a single job-create), so both
+/// the `project_id`-scoped and the `None` (no-project) catalog reads are covered.
+#[derive(Default)]
+pub(crate) struct JobCatalogSnapshot {
+    models: tokio::sync::OnceCell<Vec<Value>>,
+    loras_by_project: tokio::sync::Mutex<HashMap<Option<String>, Arc<Vec<Value>>>>,
+}
+
+impl JobCatalogSnapshot {
+    /// The model catalog, built once per request and reused thereafter. Identical output
+    /// to a direct `model_catalog(state)` call.
+    pub(crate) async fn models(&self, state: &AppState) -> Result<&[Value], ApiError> {
+        let models = self
+            .models
+            .get_or_try_init(|| async { model_catalog(state).await })
+            .await?;
+        Ok(models.as_slice())
+    }
+
+    /// The LoRA catalog for `project_id`, built once per (request, project) and reused
+    /// thereafter. Identical output to a direct `lora_catalog(state, project_id)` call.
+    pub(crate) async fn loras(
+        &self,
+        state: &AppState,
+        project_id: Option<&str>,
+    ) -> Result<Arc<Vec<Value>>, ApiError> {
+        let key = project_id.map(str::to_owned);
+        let mut guard = self.loras_by_project.lock().await;
+        if let Some(existing) = guard.get(&key) {
+            return Ok(existing.clone());
+        }
+        let loras = Arc::new(lora_catalog(state, project_id).await?);
+        guard.insert(key, loras.clone());
+        Ok(loras)
+    }
+}
+
 pub(crate) async fn apply_recipe_preset_to_image_payload(
     state: &AppState,
     payload: &ImageJobRequest,
     job_payload: &mut JsonObject,
+    snapshot: &JobCatalogSnapshot,
 ) -> Result<(), ApiError> {
     let Some(preset_id) = payload.recipe_preset_id.as_deref() else {
         return Ok(());
@@ -152,7 +212,8 @@ pub(crate) async fn apply_recipe_preset_to_image_payload(
     if payload.project_id.is_empty() {
         return Err(ApiError::bad_request("projectId is required"));
     }
-    let presets = recipe_preset_catalog(state, Some(&payload.project_id)).await?;
+    let presets =
+        recipe_preset_catalog_with(state, Some(&payload.project_id), Some(snapshot)).await?;
     let preset = presets
         .iter()
         .find(|item| item.get("id").and_then(Value::as_str) == Some(preset_id))
@@ -177,8 +238,15 @@ pub(crate) async fn apply_recipe_preset_to_image_payload(
         "stylePreset".to_owned(),
         Value::String(preset_id.to_owned()),
     );
-    merge_preset_loras_into_payload(state, &payload.project_id, preset_id, preset, job_payload)
-        .await
+    merge_preset_loras_into_payload(
+        state,
+        &payload.project_id,
+        preset_id,
+        preset,
+        job_payload,
+        Some(snapshot),
+    )
+    .await
 }
 
 /// Prepend a preset's declared LoRAs to whatever LoRAs the client already sent,
@@ -191,8 +259,14 @@ pub(crate) async fn merge_preset_loras_into_payload(
     preset_id: &str,
     preset: &Value,
     job_payload: &mut JsonObject,
+    snapshot: Option<&JobCatalogSnapshot>,
 ) -> Result<(), ApiError> {
-    let loras = lora_catalog(state, Some(project_id)).await?;
+    // Reuse the request-scoped LoRA catalog snapshot when threaded (sc-8819), else build
+    // fresh. Both paths see identical catalog contents.
+    let loras = match snapshot {
+        Some(snapshot) => snapshot.loras(state, Some(project_id)).await?,
+        None => Arc::new(lora_catalog(state, Some(project_id)).await?),
+    };
     let existing_lora_ids = job_payload
         .get("loras")
         .and_then(Value::as_array)
@@ -282,6 +356,7 @@ pub(crate) async fn apply_recipe_preset_to_video_payload(
     state: &AppState,
     payload: &VideoJobRequest,
     job_payload: &mut JsonObject,
+    snapshot: &JobCatalogSnapshot,
 ) -> Result<(), ApiError> {
     let Some(preset_id) = payload.recipe_preset_id.as_deref() else {
         return Ok(());
@@ -289,7 +364,8 @@ pub(crate) async fn apply_recipe_preset_to_video_payload(
     if payload.project_id.is_empty() {
         return Err(ApiError::bad_request("projectId is required"));
     }
-    let presets = recipe_preset_catalog(state, Some(&payload.project_id)).await?;
+    let presets =
+        recipe_preset_catalog_with(state, Some(&payload.project_id), Some(snapshot)).await?;
     let preset = presets
         .iter()
         .find(|item| item.get("id").and_then(Value::as_str) == Some(preset_id))
@@ -307,8 +383,15 @@ pub(crate) async fn apply_recipe_preset_to_video_payload(
             job_payload.insert("model".to_owned(), Value::String(model.to_owned()));
         }
     }
-    merge_preset_loras_into_payload(state, &payload.project_id, preset_id, preset, job_payload)
-        .await
+    merge_preset_loras_into_payload(
+        state,
+        &payload.project_id,
+        preset_id,
+        preset,
+        job_payload,
+        Some(snapshot),
+    )
+    .await
 }
 
 pub(crate) async fn create_video_job(
@@ -330,15 +413,25 @@ pub(crate) async fn create_video_job(
     if payload.recipe_preset_id.is_none() {
         job_payload.remove("recipePresetId");
     }
-    apply_recipe_preset_to_video_payload(&state, &payload, &mut job_payload).await?;
+    // One request-scoped catalog snapshot threaded through preset expansion + LoRA
+    // validation so the per-model/per-LoRA filesystem install-state probes run once per
+    // job-create instead of 2–3× (sc-8819, F-017).
+    let catalogs = JobCatalogSnapshot::default();
+    apply_recipe_preset_to_video_payload(&state, &payload, &mut job_payload, &catalogs).await?;
     // Resolve the model manifest entry here so the GPU worker never re-parses
     // builtin/user.models.jsonc itself — Rust owns manifest parsing/merging
     // (story 1653). An unknown model resolves to {}, matching the worker's
     // existing fallback to the model's default repo.
     let model_manifest_entry = resolve_model_manifest_entry(&state, &payload.model).await?;
     job_payload.insert("modelManifestEntry".to_owned(), model_manifest_entry);
-    validate_job_lora_compatibility(&state, Some(&payload.project_id), &mut job_payload, false)
-        .await?;
+    validate_job_lora_compatibility_with(
+        &state,
+        Some(&payload.project_id),
+        &mut job_payload,
+        false,
+        Some(&catalogs),
+    )
+    .await?;
     let job = create_generation_job(
         state,
         job_type,

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -174,6 +174,44 @@ thread_local! {
 static TEST_MAX_MODEL_UPLOAD_BYTES: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 
+// sc-8819 (F-017): count how many times the model/LoRA catalogs are assembled (which
+// each trigger the whole per-model filesystem install-state probe sweep) so a test can
+// assert a preset job-create builds each catalog once, not 2–3×. Thread-local, and the
+// counter is bumped on the caller's async task thread (before the catalog's inner
+// `spawn_blocking`), so under the `#[tokio::test]` current-thread runtime the count is
+// observed on the test thread and is immune to parallel tests on sibling threads.
+#[cfg(test)]
+thread_local! {
+    static TEST_MODEL_CATALOG_BUILDS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static TEST_LORA_CATALOG_BUILDS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(crate) fn test_reset_catalog_build_counters() {
+    TEST_MODEL_CATALOG_BUILDS.with(|cell| cell.set(0));
+    TEST_LORA_CATALOG_BUILDS.with(|cell| cell.set(0));
+}
+
+#[cfg(test)]
+pub(crate) fn test_model_catalog_builds() -> usize {
+    TEST_MODEL_CATALOG_BUILDS.with(std::cell::Cell::get)
+}
+
+#[cfg(test)]
+pub(crate) fn test_lora_catalog_builds() -> usize {
+    TEST_LORA_CATALOG_BUILDS.with(std::cell::Cell::get)
+}
+
+#[cfg(test)]
+pub(crate) fn test_note_model_catalog_build() {
+    TEST_MODEL_CATALOG_BUILDS.with(|cell| cell.set(cell.get() + 1));
+}
+
+#[cfg(test)]
+pub(crate) fn test_note_lora_catalog_build() {
+    TEST_LORA_CATALOG_BUILDS.with(|cell| cell.set(cell.get() + 1));
+}
+
 #[derive(Debug, Clone)]
 pub struct Settings {
     pub app_version: String,

--- a/apps/rust-api/src/loras.rs
+++ b/apps/rust-api/src/loras.rs
@@ -228,6 +228,10 @@ pub(crate) async fn lora_catalog(
     state: &AppState,
     project_id: Option<&str>,
 ) -> Result<Vec<Value>, ApiError> {
+    // sc-8819 (F-017): observe full-catalog assembly (the per-LoRA FS install-state probe
+    // sweep) so a test can assert it runs once per job-create.
+    #[cfg(test)]
+    crate::test_note_lora_catalog_build();
     let manifest_dir = state.settings.config_dir.join("manifests");
     let builtin =
         load_manifest_entries(state, &manifest_dir.join("builtin.loras.jsonc"), "loras").await?;
@@ -759,6 +763,21 @@ pub(crate) async fn validate_job_lora_compatibility(
     job_payload: &mut JsonObject,
     allow_inline_loras: bool,
 ) -> Result<(), ApiError> {
+    validate_job_lora_compatibility_with(state, project_id, job_payload, allow_inline_loras, None)
+        .await
+}
+
+/// `validate_job_lora_compatibility` with an optional caller-supplied catalog snapshot
+/// (sc-8819). When `snapshot` is `Some`, the model and LoRA catalogs it exposes are reused
+/// instead of re-running the per-model/per-LoRA filesystem install-state probes; the
+/// validation result is identical to the `None` path.
+pub(crate) async fn validate_job_lora_compatibility_with(
+    state: &AppState,
+    project_id: Option<&str>,
+    job_payload: &mut JsonObject,
+    allow_inline_loras: bool,
+    snapshot: Option<&JobCatalogSnapshot>,
+) -> Result<(), ApiError> {
     let Some(loras) = job_payload
         .get("loras")
         .and_then(Value::as_array)
@@ -772,15 +791,21 @@ pub(crate) async fn validate_job_lora_compatibility(
         .and_then(Value::as_str)
         .ok_or_else(|| ApiError::bad_request("Model is required for LoRA compatibility"))?;
     let model_id = model_id.to_owned();
-    let models = model_catalog(state).await?;
-    let catalog_loras = lora_catalog(state, project_id).await?;
+    let models = match snapshot {
+        Some(snapshot) => Arc::new(snapshot.models(state).await?.to_vec()),
+        None => Arc::new(model_catalog(state).await?),
+    };
+    let catalog_loras = match snapshot {
+        Some(snapshot) => snapshot.loras(state, project_id).await?,
+        None => Arc::new(lora_catalog(state, project_id).await?),
+    };
     // sc-4202 (F-API-3): validate_lora_specs_for_model reads safetensors headers off
     // disk (validate_lora_safetensors_header) inline. Run it on the blocking pool so a
     // slow/network volume can't stall a tokio worker thread on the job-creation path.
     let normalized = tokio::task::spawn_blocking(move || {
         validate_lora_specs_for_model(
-            &models,
-            &catalog_loras,
+            models.as_slice(),
+            catalog_loras.as_slice(),
             &model_id,
             &loras,
             allow_inline_loras,

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -1155,6 +1155,10 @@ async fn model_catalog_inner(
     state: &AppState,
     estimate_sizes: bool,
 ) -> Result<Vec<Value>, ApiError> {
+    // sc-8819 (F-017): observe full-catalog assembly (the per-model FS install-state probe
+    // sweep) so a test can assert it runs once per job-create.
+    #[cfg(test)]
+    crate::test_note_model_catalog_build();
     let manifest_dir = state.settings.config_dir.join("manifests");
     let builtin =
         load_manifest_entries(state, &manifest_dir.join("builtin.models.jsonc"), "models").await?;

--- a/apps/rust-api/src/recipe_presets.rs
+++ b/apps/rust-api/src/recipe_presets.rs
@@ -232,6 +232,18 @@ pub(crate) async fn recipe_preset_catalog(
     state: &AppState,
     project_id: Option<&str>,
 ) -> Result<Vec<Value>, ApiError> {
+    recipe_preset_catalog_with(state, project_id, None).await
+}
+
+/// `recipe_preset_catalog` with an optional caller-supplied model catalog snapshot
+/// (sc-8819). When `snapshot` is `Some`, the model catalog it exposes is reused instead
+/// of re-running the per-model filesystem install-state probes; the resulting presets are
+/// byte-for-byte identical to the `None` path.
+pub(crate) async fn recipe_preset_catalog_with(
+    state: &AppState,
+    project_id: Option<&str>,
+    snapshot: Option<&JobCatalogSnapshot>,
+) -> Result<Vec<Value>, ApiError> {
     let manifest_dir = state.settings.config_dir.join("manifests");
     let builtin_manifest = manifest_dir.join("builtin.recipe-presets.jsonc");
     let user_manifest = manifest_dir.join("user.recipe-presets.jsonc");
@@ -245,7 +257,16 @@ pub(crate) async fn recipe_preset_catalog(
         .into_iter()
         .map(|preset| normalize_recipe_preset_entry(preset, "global", &user_manifest))
         .collect::<Result<Vec<_>, _>>()?;
-    let models = model_catalog(state).await?;
+    // Reuse the request-scoped model catalog snapshot when the caller threaded one
+    // (sc-8819), else build a fresh catalog exactly as before.
+    let owned_models;
+    let models: &[Value] = match snapshot {
+        Some(snapshot) => snapshot.models(state).await?,
+        None => {
+            owned_models = model_catalog(state).await?;
+            &owned_models
+        }
+    };
     let mut presets = merge_entries_by_id(builtin, user);
     if let Some(project_id) = project_id {
         let project_path = project_path_for_id(state.clone(), project_id).await?;
@@ -258,7 +279,7 @@ pub(crate) async fn recipe_preset_catalog(
         presets = merge_entries_by_id(presets, project_presets);
     }
     for preset in presets.iter_mut() {
-        finalize_recipe_preset_entry(preset, &models)?;
+        finalize_recipe_preset_entry(preset, models)?;
     }
     presets.sort_by(|left, right| {
         let left_key = (

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -5099,6 +5099,159 @@ async fn video_jobs_expand_recipe_presets_server_side() {
 }
 
 #[tokio::test]
+async fn preset_image_job_builds_each_catalog_once() {
+    // sc-8819 (F-017): a preset-backed POST /image/jobs fans out into recipe_preset_catalog,
+    // merge_preset_loras_into_payload, and validate_job_lora_compatibility. Before the fix
+    // each re-assembled model_catalog/lora_catalog from scratch, re-running the whole
+    // per-model/per-LoRA filesystem install-state probe sweep 2× each. The request-scoped
+    // JobCatalogSnapshot threads one snapshot through those seams so each catalog is built
+    // exactly once per job-create — assert that here.
+    std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        r#"
+        {
+          "schemaVersion": 1,
+          "models": [
+            {
+              "id": "img-model",
+              "name": "Img Model",
+              "family": "z-image",
+              "type": "image",
+              "adapter": "z_image",
+              "capabilities": ["text_to_image"],
+              "downloads": [
+                { "provider": "huggingface", "repo": "owner/img", "files": ["*.safetensors"], "default": true }
+              ],
+              "paths": {},
+              "defaults": {},
+              "limits": {},
+              "loraCompatibility": { "families": ["z-image"] },
+              "ui": { "label": "Img" }
+            }
+          ]
+        }
+        "#,
+    )
+    .expect("builtin models writes");
+    std::fs::write(
+        config_dir.join("user.models.jsonc"),
+        r#"{ "schemaVersion": 1, "models": [] }"#,
+    )
+    .expect("user models writes");
+    std::fs::write(
+        config_dir.join("builtin.loras.jsonc"),
+        r#"
+        {
+          "schemaVersion": 1,
+          "loras": [
+            {
+              "id": "style-lora",
+              "name": "Style LoRA",
+              "family": "z-image",
+              "triggerWords": ["style"],
+              "compatibility": { "families": ["z-image"] },
+              "source": { "provider": "local", "path": "loras/style.safetensors" }
+            }
+          ]
+        }
+        "#,
+    )
+    .expect("builtin loras writes");
+    std::fs::write(
+        config_dir.join("user.loras.jsonc"),
+        r#"{ "schemaVersion": 1, "loras": [] }"#,
+    )
+    .expect("user loras writes");
+    std::fs::write(
+        config_dir.join("builtin.recipe-presets.jsonc"),
+        r#"
+        {
+          "schemaVersion": 1,
+          "presets": [
+            {
+              "id": "dream_style",
+              "name": "Dream Style",
+              "workflow": "text_to_image",
+              "model": "img-model",
+              "defaults": { "count": 1, "resolution": "1024x1024", "negativePrompt": "blur" },
+              "prompt": { "prefix": "cinematic", "suffix": "high detail" },
+              "loras": [{ "id": "style-lora", "weight": 0.5 }]
+            }
+          ]
+        }
+        "#,
+    )
+    .expect("builtin recipe presets writes");
+    std::fs::write(
+        config_dir.join("user.recipe-presets.jsonc"),
+        r#"{ "schemaVersion": 1, "presets": [] }"#,
+    )
+    .expect("user recipe presets writes");
+    let lora_dir = temp_dir.path().join("data/loras");
+    std::fs::create_dir_all(&lora_dir).expect("lora dir creates");
+    write_test_safetensors(&lora_dir.join("style.safetensors"));
+
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Image Preset Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id").to_owned();
+
+    // Reset the probe counters immediately before the job-create so project setup /
+    // seeding above doesn't count against it.
+    crate::test_reset_catalog_build_counters();
+    let (status, image_job) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/image/jobs",
+        json!({
+            "projectId": project_id,
+            "mode": "text_to_image",
+            "prompt": "a fox",
+            "model": "img-model",
+            "count": 1,
+            "width": 1024,
+            "height": 1024,
+            "recipePresetId": "dream_style"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "job created: {image_job:?}");
+
+    // Correctness preserved: preset prompt folded in, preset LoRA merged, and it validated.
+    assert_eq!(
+        image_job["payload"]["prompt"],
+        "cinematic, a fox, high detail"
+    );
+    assert_eq!(image_job["payload"]["loras"][0]["id"], "style-lora");
+    assert_eq!(
+        image_job["payload"]["advanced"]["recipePresetId"],
+        "dream_style"
+    );
+
+    // The heart of sc-8819: each catalog's full FS-probe assembly ran exactly once for the
+    // whole request, not 2–3× as before the snapshot was threaded through.
+    assert_eq!(
+        crate::test_model_catalog_builds(),
+        1,
+        "model catalog should be assembled once per preset job-create"
+    );
+    assert_eq!(
+        crate::test_lora_catalog_builds(),
+        1,
+        "lora catalog should be assembled once per preset job-create"
+    );
+}
+
+#[tokio::test]
 async fn lora_download_endpoint_queues_hf_download_for_builtin_lora() {
     // sc-5944: built-in LoRAs gain an explicit Download (mirrors model download). A
     // catalog LoRA with a Hugging Face source queues a `lora_download` job carrying the


### PR DESCRIPTION
## sc-8819 — [F-017] Model/LoRA catalogs re-assembled (with filesystem probing) several times per job-create request

### Problem
A single preset-backed `POST /image/jobs` (or `/video/jobs`) fanned out into `recipe_preset_catalog`, `merge_preset_loras_into_payload`, and `validate_job_lora_compatibility`. Each of those re-assembled `model_catalog`/`lora_catalog` from scratch — re-running the per-model/per-LoRA install-state probes (recursive HF-cache walks, `model_is_installed`, `mlx_catalog_status`, per-variant/MLX field probes) **2× each** per submit, over the whole catalog. Job-create latency scaled with catalog size × HF-cache-tree size and hammered the blocking pool under batch submission.

### Fix — request-scoped snapshot threading (not TTL)
Introduced a `JobCatalogSnapshot` (in `generation.rs`) that lazily memoizes the model catalog (`OnceCell`) and the LoRA catalog per project. `create_image_job`/`create_video_job` build one snapshot and thread it through the preset-expansion and LoRA-validation seams:

- `recipe_preset_catalog` → new `recipe_preset_catalog_with(..., snapshot)`
- `merge_preset_loras_into_payload(..., snapshot)`
- `validate_job_lora_compatibility` → new `validate_job_lora_compatibility_with(..., snapshot)`

Each catalog's full filesystem-probe assembly now runs **exactly once** per job-create instead of 2–3×.

**Snapshot vs TTL:** chose request-scoped threading over a short-TTL cache. The snapshot lives only for the duration of one submit, so there is **no staleness window** and preset expansion + LoRA validation are guaranteed to see identical catalog contents (the story's stated preference). A TTL cache would add a staleness surface and could let validation disagree with an expansion done a moment earlier. All existing callers keep the original functions (the `_with` variants default `snapshot = None` → build fresh), so validation semantics and outputs are unchanged.

`resolve_model_manifest_entry` was left as-is: it only re-parses the (already mtime-cached) manifests plus a tiny `mlx_catalog_status`, not the full catalog probe sweep.

### Tests
- New `preset_image_job_builds_each_catalog_once`: instruments a thread-local build counter in `model_catalog_inner`/`lora_catalog` (test-only, mirrors the existing `TEST_MAX_MODEL_UPLOAD_BYTES` pattern) and asserts a preset-backed image job-create builds each catalog **once**, while still folding in the preset prompt, merging the preset LoRA, and validating.
- Full `npm run rust:check` green (fmt --all --check, clippy --all-targets -D warnings, workspace `cargo test`, build). rust-api suite: 160 passed / 0 failed.

https://app.shortcut.com/trefry/story/8819

🤖 Generated with [Claude Code](https://claude.com/claude-code)