### PR TITLE
fix(web): purge AI-op scratch/result assets across ImageEditor unmount (sc-8850)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -39,6 +39,7 @@ import {
   restrictFoldedToScope,
 } from "./assetVariants.js";
 import { buildWorkersById } from "./workers.js";
+import { createEditorScratchRegistry } from "./editorScratch.js";
 import { isDesktop as isDesktopShell, tauriInvoke } from "./runtime.js";
 
 // Desktop (Tauri) shell detection (unified helper, epic 4484 story 6). The first-run
@@ -584,6 +585,9 @@ export function App() {
   const generatedAssetRefreshesRef = useRef(new Map());
   const refreshDataRef = useRef(null);
   const refreshAssetsRef = useRef(null);
+  // Latest purgeAsset, held in a ref so the App-level scratch-op survivor (sc-8850) can
+  // purge orphaned scratch/result assets from the SSE handler without re-subscribing.
+  const purgeAssetRef = useRef(null);
   const refreshCharactersRef = useRef(null);
   const refreshLorasRef = useRef(null);
   const refreshPresetsRef = useRef(null);
@@ -601,6 +605,34 @@ export function App() {
       if (leaveGuardRef.current === guard) leaveGuardRef.current = null;
     };
   }, []);
+  // In-flight Image-Editor AI-op scratch registry (sc-8850). The editor stages an
+  // ephemeral scratch asset per AI op and normally loads the result back + purges
+  // everything itself. But navigating away mid-job unmounts the editor, so that
+  // in-component purge never runs. This registry lives in App (survives the unmount) and
+  // purges the tracked scratch/mask + result assets whenever such a job terminates and
+  // the editor is no longer claiming it. It calls purgeAsset through a ref so it stays
+  // stable across renders. See editorScratch.js for the full survivor behaviour.
+  const editorScratchRegistryRef = useRef(null);
+  if (!editorScratchRegistryRef.current) {
+    editorScratchRegistryRef.current = createEditorScratchRegistry({
+      purgeAsset: (asset) => purgeAssetRef.current?.(asset),
+    });
+  }
+  const editorScratchRegistry = editorScratchRegistryRef.current;
+  // Latest jobs list, so the claim-release sweep can read it without re-subscribing.
+  const jobsRef = useRef([]);
+  const trackEditorScratchOp = useCallback(
+    (jobId, assets) => editorScratchRegistry.track(jobId, assets),
+    [editorScratchRegistry],
+  );
+  const releaseEditorScratchOp = useCallback(
+    (jobId, resultJob = null) => editorScratchRegistry.release(jobId, resultJob),
+    [editorScratchRegistry],
+  );
+  const registerEditorScratchClaim = useCallback(
+    (getClaimedIds) => editorScratchRegistry.registerClaim(getClaimedIds, () => jobsRef.current),
+    [editorScratchRegistry],
+  );
   const navTo = useCallback((viewId) => {
     if (viewId === activeViewRef.current) return;
     const guard = leaveGuardRef.current;
@@ -1232,6 +1264,16 @@ export function App() {
       events?.close();
     };
   }, [access.authRequired, ready, token]);
+
+  // Survivor sweep for orphaned Image-Editor scratch ops (sc-8850). Runs on every `jobs`
+  // change (SSE ticks, initial load, etc.): purges the scratch + result assets of any
+  // tracked editor AI-op whose job has terminated and whose editor is no longer claiming
+  // it (unmounted mid-job). The editor's own in-component watcher handles the mounted
+  // case and releases its claim; this catches everything the unmounted editor left behind.
+  useEffect(() => {
+    jobsRef.current = jobs;
+    editorScratchRegistry.sweep(jobs);
+  }, [jobs, editorScratchRegistry]);
 
   async function refreshData() {
     const fetchInitial = async (label, path, fallback, optional = false) => {
@@ -1957,6 +1999,10 @@ export function App() {
     },
     [token],
   );
+  // Keep the ref current for the App-level scratch-op survivor (sc-8850), which purges
+  // from the SSE/sweep path without re-subscribing. Assigned here (after purgeAsset is
+  // defined) rather than in the hoisted ref block above, which runs before this const.
+  purgeAssetRef.current = purgeAsset;
 
   const importAsset = useCallback(
     async (file, options = {}) => {
@@ -2164,6 +2210,10 @@ export function App() {
     // Navigation
     setActiveView,
     registerLeaveGuard,
+    // Image-Editor scratch-op survivor coordination (sc-8850)
+    trackEditorScratchOp,
+    releaseEditorScratchOp,
+    registerEditorScratchClaim,
     // Characters
     characters,
     createCharacter,
@@ -2204,7 +2254,8 @@ export function App() {
     refreshTrainingDatasets, loadTrainingDataset, loadTrainingDatasetReadiness, setTrainingDatasetItemQualityAck, createTrainingDataset, uploadTrainingDatasetItem,
     updateTrainingDataset, batchRenameTrainingDataset, writeTrainingDatasetCaptionSidecars,
     createTrainingDatasetCaptionJob, createTrainingDatasetUpscaleJob, createTrainingDatasetAnalysisJob, createTrainingDatasetFaceAnalysisJob, smartCropTrainingDataset, stripExifTrainingDataset, createTrainingJob, trainingPresets, trainingPresetsError,
-    trainingTargets, trainingTargetsError, setActiveView, registerLeaveGuard, characters,
+    trainingTargets, trainingTargetsError, setActiveView, registerLeaveGuard,
+    trackEditorScratchOp, releaseEditorScratchOp, registerEditorScratchClaim, characters,
     createCharacter, updateCharacter, archiveCharacter, unarchiveCharacter, listArchivedCharacters,
     addCharacterReference, updateCharacterReference,
     removeCharacterReference, createCharacterLook, updateCharacterLook, deleteCharacterLook,

--- a/apps/web/src/editorScratch.js
+++ b/apps/web/src/editorScratch.js
@@ -1,0 +1,120 @@
+// Survivor-side registry + helpers for purging Image-Editor AI-op scratch/result assets
+// when the editor is no longer around to do it itself (sc-8850).
+//
+// The Image Editor stages the working bitmap as an ephemeral "scratch" asset, runs a
+// worker job against it, loads the result back, then purges scratch + result so only
+// Save (sc-2434) ever lands a Library asset. That purge used to live entirely in an
+// in-component effect — which never fires if the user navigates away mid-job and the
+// editor unmounts (starting an AI op doesn't set `dirty`, so the leave guard wasn't even
+// registered). The result was silently lost AND the scratch upload + result asset
+// permanently orphaned in the Library.
+//
+// The fix keeps this registry at the App level (it outlives the editor). While the editor
+// is mounted it "claims" the jobIds it is tracking and owns loading the result back into
+// the canvas, then releases the op (which purges). If the editor unmounts first, it never
+// releases; the survivor sweep then purges the tracked scratch/mask + result assets the
+// moment the job reaches a terminal status (or right after the claim is dropped, for an op
+// that had already terminated). Either way nothing is orphaned.
+//
+// The registry is a plain factory (no React) so the full survivor behaviour — including
+// "purges after the editor unmounts" — is unit-testable without mounting App.
+
+import { terminalStatuses } from "./jobTypes.js";
+
+// A terminal job's result assets as `{ id, projectId }` purge descriptors. Handles the
+// two result shapes the worker emits (`result.assets` full objects, `result.assetIds`
+// bare ids) and falls back to the job's projectId when a bare id carries none.
+export function resultAssetsToPurge(job) {
+  if (!job) return [];
+  const projectFallback = job.projectId ?? null;
+  const assets = job.result?.assets;
+  if (Array.isArray(assets) && assets.length) {
+    return assets
+      .filter((asset) => asset && asset.id)
+      .map((asset) => ({ id: asset.id, projectId: asset.projectId ?? projectFallback }));
+  }
+  const assetIds = job.result?.assetIds;
+  if (Array.isArray(assetIds) && assetIds.length) {
+    return assetIds.filter(Boolean).map((id) => ({ id, projectId: projectFallback }));
+  }
+  return [];
+}
+
+// The full set of assets to purge for a completed editor scratch op: the tracked scratch
+// source + mask (from the registry entry) plus the job's result assets. De-duped by asset
+// id. `entry.assets` is the array of scratch/mask asset objects the editor staged.
+export function scratchOpAssetsToPurge(entry, job) {
+  const out = [];
+  const seen = new Set();
+  const push = (asset) => {
+    if (!asset || !asset.id || seen.has(asset.id)) return;
+    seen.add(asset.id);
+    out.push(asset);
+  };
+  for (const asset of entry?.assets ?? []) push(asset);
+  for (const asset of resultAssetsToPurge(job)) push(asset);
+  return out;
+}
+
+// The App-level scratch-op registry. `purgeAsset(asset)` performs the actual DELETE and
+// may return a promise; failures are swallowed (best-effort cleanup). `isTerminal` is
+// injectable for tests but defaults to the shared terminal-status set.
+export function createEditorScratchRegistry({ purgeAsset, isTerminal = (status) => terminalStatuses.has(status) }) {
+  const ops = new Map(); // jobId -> { assets }
+  let claimGetter = null; // () => Set<jobId> the mounted editor is actively tracking
+
+  function purgeOp(jobId, job) {
+    const entry = ops.get(jobId);
+    if (!entry) return; // idempotent: whoever purges first wins
+    ops.delete(jobId);
+    for (const asset of scratchOpAssetsToPurge(entry, job)) {
+      if (asset?.id && asset?.projectId) {
+        try {
+          purgeAsset(asset)?.catch?.(() => {});
+        } catch {
+          // best-effort cleanup
+        }
+      }
+    }
+  }
+
+  return {
+    // Editor starts an AI op: remember its scratch/mask assets so they can be purged even
+    // if the editor unmounts before its own watcher runs.
+    track(jobId, assets) {
+      if (!jobId) return;
+      ops.set(jobId, { assets: (assets ?? []).filter(Boolean) });
+    },
+    // Editor's in-component watcher loaded the result back into the canvas — hand the
+    // purge (scratch + mask + result) to the registry so there's a single purge path.
+    release(jobId, job) {
+      purgeOp(jobId, job);
+    },
+    // The mounted editor registers a getter for the jobIds it is actively tracking. On
+    // unmount the returned unregister clears the claim AND sweeps once, so an op that had
+    // already terminated while claimed (and was therefore skipped) is not orphaned.
+    registerClaim(getClaimedIds, getJobs) {
+      claimGetter = getClaimedIds;
+      return () => {
+        if (claimGetter === getClaimedIds) claimGetter = null;
+        this.sweep(getJobs?.() ?? []);
+      };
+    },
+    // Purge every tracked op whose job is terminal and which the editor is no longer
+    // claiming (unmounted or already released). Runs on each jobs tick and post-unmount.
+    sweep(jobsList) {
+      if (ops.size === 0) return;
+      const claimed = claimGetter ? claimGetter() : null;
+      for (const jobId of [...ops.keys()]) {
+        if (claimed && claimed.has(jobId)) continue; // editor still owns this op
+        const job = jobsList?.find((item) => item.id === jobId);
+        if (!job || !isTerminal(job.status)) continue;
+        purgeOp(jobId, job);
+      }
+    },
+    // Test/introspection helper.
+    _size() {
+      return ops.size;
+    },
+  };
+}

--- a/apps/web/src/editorScratch.test.js
+++ b/apps/web/src/editorScratch.test.js
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  resultAssetsToPurge,
+  scratchOpAssetsToPurge,
+  createEditorScratchRegistry,
+} from "./editorScratch.js";
+
+const scratchAsset = { id: "scratch-1", projectId: "project-1" };
+const maskAsset = { id: "mask-1", projectId: "project-1" };
+const completedJob = (extra = {}) => ({
+  id: "job-1",
+  projectId: "project-1",
+  status: "completed",
+  result: { assets: [{ id: "result-1", projectId: "project-1" }] },
+  ...extra,
+});
+
+describe("resultAssetsToPurge (sc-8850)", () => {
+  it("reads full result.assets objects", () => {
+    expect(resultAssetsToPurge(completedJob())).toEqual([{ id: "result-1", projectId: "project-1" }]);
+  });
+
+  it("falls back to the job's projectId for bare result.assetIds", () => {
+    const job = { id: "j", projectId: "project-9", status: "completed", result: { assetIds: ["a", "b"] } };
+    expect(resultAssetsToPurge(job)).toEqual([
+      { id: "a", projectId: "project-9" },
+      { id: "b", projectId: "project-9" },
+    ]);
+  });
+
+  it("returns [] for a job with no result assets (e.g. a failed job)", () => {
+    expect(resultAssetsToPurge({ id: "j", status: "failed", result: {} })).toEqual([]);
+    expect(resultAssetsToPurge(null)).toEqual([]);
+  });
+});
+
+describe("scratchOpAssetsToPurge (sc-8850)", () => {
+  it("combines tracked scratch/mask with the job's result assets, de-duped", () => {
+    const entry = { assets: [scratchAsset, maskAsset, scratchAsset] };
+    expect(scratchOpAssetsToPurge(entry, completedJob())).toEqual([
+      scratchAsset,
+      maskAsset,
+      { id: "result-1", projectId: "project-1" },
+    ]);
+  });
+
+  it("purges the scratch even when the job failed (no result)", () => {
+    const entry = { assets: [scratchAsset] };
+    expect(scratchOpAssetsToPurge(entry, { id: "job-1", status: "failed", result: {} })).toEqual([scratchAsset]);
+  });
+});
+
+describe("createEditorScratchRegistry survivor sweep (sc-8850)", () => {
+  function setup() {
+    const purgeAsset = vi.fn().mockResolvedValue(undefined);
+    const registry = createEditorScratchRegistry({ purgeAsset });
+    return { purgeAsset, registry };
+  }
+
+  it("does NOT purge while the editor still claims the in-flight op", () => {
+    const { purgeAsset, registry } = setup();
+    registry.track("job-1", [scratchAsset]);
+    // Editor mounted and actively tracking job-1.
+    registry.registerClaim(() => new Set(["job-1"]), () => [completedJob()]);
+    // The job terminates, but the mounted editor owns loading the result back first.
+    registry.sweep([completedJob()]);
+    expect(purgeAsset).not.toHaveBeenCalled();
+  });
+
+  it("purges scratch + result when a claimed op is released (editor loaded the result)", () => {
+    const { purgeAsset, registry } = setup();
+    registry.track("job-1", [scratchAsset]);
+    registry.registerClaim(() => new Set(["job-1"]), () => [completedJob()]);
+    registry.release("job-1", completedJob());
+    expect(purgeAsset).toHaveBeenCalledWith(scratchAsset);
+    expect(purgeAsset).toHaveBeenCalledWith({ id: "result-1", projectId: "project-1" });
+    expect(registry._size()).toBe(0);
+  });
+
+  it("purges an op whose job terminates AFTER the editor unmounts (result lands late)", () => {
+    const { purgeAsset, registry } = setup();
+    registry.track("job-1", [scratchAsset, maskAsset]);
+    let jobs = [{ id: "job-1", status: "running", projectId: "project-1" }]; // still running at unmount
+    const unregister = registry.registerClaim(() => new Set(["job-1"]), () => jobs);
+    // Editor unmounts mid-job — claim cleared; sweep runs but the job isn't terminal yet.
+    unregister();
+    expect(purgeAsset).not.toHaveBeenCalled();
+    expect(registry._size()).toBe(1);
+    // The job completes later; the App-level jobs tick sweeps it — nothing orphaned.
+    jobs = [completedJob()];
+    registry.sweep(jobs);
+    expect(purgeAsset).toHaveBeenCalledWith(scratchAsset);
+    expect(purgeAsset).toHaveBeenCalledWith(maskAsset);
+    expect(purgeAsset).toHaveBeenCalledWith({ id: "result-1", projectId: "project-1" });
+    expect(registry._size()).toBe(0);
+  });
+
+  it("purges an op that had ALREADY terminated when the editor unmounts (claim-release sweep)", () => {
+    const { purgeAsset, registry } = setup();
+    registry.track("job-1", [scratchAsset]);
+    const jobs = [completedJob()];
+    // Editor claimed the op right up to unmount, so the periodic sweep skipped it while
+    // claimed. The unregister sweep must catch it now that the claim is gone.
+    const unregister = registry.registerClaim(() => new Set(["job-1"]), () => jobs);
+    unregister();
+    expect(purgeAsset).toHaveBeenCalledWith(scratchAsset);
+    expect(purgeAsset).toHaveBeenCalledWith({ id: "result-1", projectId: "project-1" });
+    expect(registry._size()).toBe(0);
+  });
+
+  it("purges scratch even for a FAILED op after unmount (no silent orphan)", () => {
+    const { purgeAsset, registry } = setup();
+    registry.track("job-1", [scratchAsset]);
+    const jobs = [{ id: "job-1", status: "failed", projectId: "project-1", result: {} }];
+    registry.registerClaim(() => new Set(), () => jobs)(); // register then immediately unregister
+    expect(purgeAsset).toHaveBeenCalledWith(scratchAsset);
+    expect(registry._size()).toBe(0);
+  });
+
+  it("is idempotent — a second sweep after purge does nothing", () => {
+    const { purgeAsset, registry } = setup();
+    registry.track("job-1", [scratchAsset]);
+    registry.sweep([completedJob()]); // no claim registered → purges immediately
+    expect(purgeAsset).toHaveBeenCalledTimes(2); // scratch + result
+    registry.sweep([completedJob()]);
+    expect(purgeAsset).toHaveBeenCalledTimes(2); // entry already gone
+  });
+});

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -125,6 +125,17 @@ const UPCOMING_TOOLS = [];
 // (image_jobs/flux2.rs). The working image takes one slot, so the editor allows up to 3 user refs.
 export const MAX_EDIT_REFERENCES = 4;
 
+// The leave-guard prompt shown before navigating away from the editor, or null when it's
+// safe to leave silently (sc-2434 / sc-8850). Unsaved edits win the message. Crucially the
+// guard also fires while an AI op is in flight — starting one does NOT set `dirty` (its
+// result only lands on success), so without this branch the user could silently abandon a
+// running edit (losing the result and, before the App survivor sweep, orphaning scratch).
+export function leaveGuardMessage({ dirty, aiOpPending }) {
+  if (dirty) return "You have unsaved edits in the Image Editor. Leave and discard them?";
+  if (aiOpPending) return "An image edit is still running. Leave and abandon it?";
+  return null;
+}
+
 // Compose the multi-reference edit's `referenceAssetIds`: the working image (staged as the scratch
 // source) FIRST so it anchors the edit, then the user's reference images — trimmed, de-duped, and
 // capped at `max` total. The worker prefers a non-empty `referenceAssetIds` list over `sourceAssetId`
@@ -761,6 +772,12 @@ export function ImageEditor() {
     importAsset,
     purgeAsset,
     registerLeaveGuard,
+    // App-level scratch-op survivor coordination (sc-8850). The editor stages an ephemeral
+    // scratch asset per AI op; these let App purge it (and the result) even if the user
+    // navigates away mid-job and this component unmounts before its own watcher can run.
+    trackEditorScratchOp,
+    releaseEditorScratchOp,
+    registerEditorScratchClaim,
     imageModels,
     editorLaunch = null,
     clearEditorLaunch,
@@ -2318,6 +2335,10 @@ export function ImageEditor() {
           body: JSON.stringify(buildBody(scratch, maskScratch)),
         });
         if (!job?.id) throw new Error("The job was not created.");
+        // Register the scratch op with App so its scratch/mask (and later result) assets
+        // are purged even if the user navigates away mid-job and this editor unmounts
+        // before the completion watcher below runs (sc-8850).
+        trackEditorScratchOp?.(job.id, [scratch, maskScratch]);
         setAiOp({
           jobId: job.id,
           scratch,
@@ -2338,7 +2359,7 @@ export function ImageEditor() {
         setStatus({ loading: false, error: `Could not start ${label}: ${err.message || err}` });
       }
     },
-    [working, aiOp, activeProject, workingImageToFile, activeLayerToFile, confirmFlatten, importAsset, token, purgeAsset],
+    [working, aiOp, activeProject, workingImageToFile, activeLayerToFile, confirmFlatten, importAsset, token, purgeAsset, trackEditorScratchOp],
   );
 
   function runUpscale() {
@@ -2533,7 +2554,7 @@ export function ImageEditor() {
     if (!aiOp?.jobId) return;
     const job = jobs?.find((item) => item.id === aiOp.jobId);
     if (!job || !terminalStatuses.has(job.status)) return;
-    const { scratch, maskScratch, source, edit, onComplete, writeBack, targetLayerId } = aiOp;
+    const { jobId, source, edit, onComplete, writeBack, targetLayerId } = aiOp;
     setAiOp(null); // stop tracking immediately so this can't re-enter on the next jobs tick
     const resultAsset = job.status === "completed" ? job.result?.assets?.[0] ?? null : null;
     (async () => {
@@ -2567,12 +2588,14 @@ export function ImageEditor() {
       } catch (err) {
         setStatus({ loading: false, error: err.message || "The operation failed." });
       } finally {
-        if (scratch) purgeAsset(scratch).catch(() => {});
-        if (maskScratch) purgeAsset(maskScratch).catch(() => {});
-        if (resultAsset) purgeAsset(resultAsset).catch(() => {});
+        // Hand the purge to App (sc-8850): it owns the scratch registry, so it purges the
+        // scratch + mask + result assets through the single survivor path. This also drops
+        // the registry entry so the App-level sweep won't double-purge. The result is
+        // loaded into the canvas above BEFORE this releases it — intermediates never persist.
+        releaseEditorScratchOp?.(jobId, job);
       }
     })();
-  }, [aiOp, jobs, installWorkingImage, replaceLayerImage, purgeAsset, checkpoint]);
+  }, [aiOp, jobs, installWorkingImage, replaceLayerImage, releaseEditorScratchOp, checkpoint]);
 
   // ── Save / export (sc-2434) ───────────────────────────────────────────────
   // Persist the working image as a NEW Library asset, never overwriting the
@@ -2632,25 +2655,42 @@ export function ImageEditor() {
     );
   }
 
-  // Warn before leaving with unsaved edits: a browser unload (close/refresh) and an
-  // in-app navigation away (the App nav consults this guard, sc-2434).
+  // Warn before leaving with unsaved edits OR an in-flight AI op (sc-2434 / sc-8850): a
+  // browser unload (close/refresh) and an in-app navigation away (the App nav consults
+  // this guard). Starting an AI op does NOT set `dirty` — its result only lands on
+  // success — so the guard must also fire while `aiOp` is non-null, otherwise the user
+  // can silently navigate away and abandon the running op (losing the result and, before
+  // the App-level survivor sweep, orphaning the scratch upload).
+  const aiOpPending = Boolean(aiOp);
   useEffect(() => {
-    if (!dirty) return undefined;
+    const message = leaveGuardMessage({ dirty, aiOpPending });
+    if (!message) return undefined;
     const onBeforeUnload = (event) => {
       event.preventDefault();
       event.returnValue = "";
     };
     window.addEventListener("beforeunload", onBeforeUnload);
     const unregister = registerLeaveGuard?.(
-      () =>
-        typeof window.confirm !== "function" ||
-        window.confirm("You have unsaved edits in the Image Editor. Leave and discard them?"),
+      () => typeof window.confirm !== "function" || window.confirm(message),
     );
     return () => {
       window.removeEventListener("beforeunload", onBeforeUnload);
       if (typeof unregister === "function") unregister();
     };
-  }, [dirty, registerLeaveGuard]);
+  }, [dirty, aiOpPending, registerLeaveGuard]);
+
+  // Claim the in-flight AI op's jobId with App so its survivor sweep (sc-8850) knows this
+  // editor is alive and owns loading the result back before the scratch/result assets are
+  // purged. The getter reads live `aiOp` via the ref, so the claim registration itself is
+  // stable — it only unregisters (and triggers App's post-unmount sweep) when this editor
+  // unmounts. An op that completes after this unmount is then purged by App, not lost here.
+  useEffect(() => {
+    if (!registerEditorScratchClaim) return undefined;
+    return registerEditorScratchClaim(() => {
+      const id = aiOpRef.current?.jobId;
+      return id ? new Set([id]) : new Set();
+    });
+  }, [registerEditorScratchClaim]);
 
   const activeAiJob = aiOp ? jobs?.find((item) => item.id === aiOp.jobId) : null;
 

--- a/apps/web/src/screens/ImageEditor.test.jsx
+++ b/apps/web/src/screens/ImageEditor.test.jsx
@@ -72,6 +72,7 @@ import {
   MASK_PREVIEW_RGBA,
   editReferenceIds,
   MAX_EDIT_REFERENCES,
+  leaveGuardMessage,
 } from "./ImageEditor.jsx";
 import { verifyCaption, serializeCaption, ELEMENT_KEY_ORDER_OBJ } from "../ideogramCaption.js";
 
@@ -91,7 +92,10 @@ function baseContext(overrides = {}) {
     jobs: [],
     importAsset: vi.fn(),
     purgeAsset: vi.fn(),
-    registerLeaveGuard: vi.fn(),
+    registerLeaveGuard: vi.fn(() => () => {}),
+    trackEditorScratchOp: vi.fn(),
+    releaseEditorScratchOp: vi.fn(),
+    registerEditorScratchClaim: vi.fn(() => () => {}),
     imageModels: [],
     ...overrides,
   };
@@ -262,6 +266,60 @@ describe("ImageEditor scaffold", () => {
       expect(fetchSpy).not.toHaveBeenCalled();
       expect(clearEditorLaunch).toHaveBeenCalledTimes(1);
     });
+  });
+});
+
+// sc-8850: an in-flight AI op imports the working bitmap as a real "scratch" asset and
+// (on success) loads the result back, then purges both. Navigating away mid-op unmounts
+// the editor, so its in-component purge never fires. Two halves guard against orphans:
+// (a) the leave guard fires while an AI op is pending — even though starting one does NOT
+// set `dirty` — so the user is warned before abandoning it; and (b) App owns a scratch
+// registry that survives the unmount and purges the scratch/result via the claim it
+// registers. These tests cover both halves at the editor seam.
+describe("in-flight AI-op scratch survival (sc-8850)", () => {
+  it("leaveGuardMessage warns while an AI op is pending even when NOT dirty", () => {
+    // The regression: the guard was gated only on `dirty`, so a running AI op (which never
+    // sets dirty) left the editor unguarded and silently abandonable.
+    expect(leaveGuardMessage({ dirty: false, aiOpPending: false })).toBeNull();
+    expect(leaveGuardMessage({ dirty: false, aiOpPending: true })).toBe(
+      "An image edit is still running. Leave and abandon it?",
+    );
+    // Unsaved edits still take precedence over the AI-op wording.
+    expect(leaveGuardMessage({ dirty: true, aiOpPending: false })).toContain("unsaved edits");
+    expect(leaveGuardMessage({ dirty: true, aiOpPending: true })).toContain("unsaved edits");
+  });
+
+  it("registers a survivor claim with App on mount and drops it on unmount", async () => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    const unregister = vi.fn();
+    const registerEditorScratchClaim = vi.fn(() => unregister);
+    const context = baseContext({ registerEditorScratchClaim });
+
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <ImageEditor />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+
+    // The editor claims its in-flight ops with App so the survivor sweep knows it is the
+    // owner while mounted. The claim is a getter; with no op pending it reports an empty set.
+    expect(registerEditorScratchClaim).toHaveBeenCalledTimes(1);
+    const claimGetter = registerEditorScratchClaim.mock.calls[0][0];
+    expect(typeof claimGetter).toBe("function");
+    expect([...claimGetter()]).toEqual([]);
+
+    // Unmounting (the App-mounts-only-active navigation, which caused the orphan bug)
+    // releases the claim so App can sweep any op the editor left behind.
+    await act(async () => root.unmount());
+    expect(unregister).toHaveBeenCalledTimes(1);
+    container.remove();
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes [sc-8850](https://app.shortcut.com/trefry/story/8850) (F-048, Bug, Medium). An in-flight Image-Editor AI op imports the working bitmap as a real project "scratch" asset and relied on a completion effect in `ImageEditor.jsx` to load the result back and purge scratch + result. That effect only ran while the editor was mounted, and the leave guard was registered only when `dirty` — but starting an AI op doesn't set `dirty`. Navigating away mid-job unmounts the editor, so the result was silently lost and the scratch upload + result asset were permanently orphaned in the Library (accumulating junk assets + disk on every occurrence).

## Both halves of the finding

**(a) Leave guard while an AI op is pending.** The guard now fires on `dirty || aiOpPending`, warning the user before they abandon a running edit. Extracted a pure `leaveGuardMessage({ dirty, aiOpPending })` helper (unsaved edits still win the wording).

**(b) A survivor purge that outlives the unmount.** New App-level scratch registry (`editorScratch.js` `createEditorScratchRegistry`) lives above the screen tree, so it survives the editor unmounting:
- The editor `track`s each scratch op (scratch + optional mask assets) when the job starts.
- While mounted, the editor registers a `claim` for its in-flight jobId so it still owns loading the result back into the canvas, then `release`s the op (single purge path).
- App's `sweep` runs on every `jobs` tick (SSE) and right after the claim is dropped on unmount. It purges the tracked scratch/mask + the job's result assets whenever such a job is terminal and the editor no longer claims it.

This covers the tricky cases the finding calls out: the job completing **after** the unmount (swept on the next jobs tick) and a job already terminal **at** unmount (swept immediately when the claim is released). The purge is idempotent (whoever purges first wins) and best-effort.

## Tests

- `editorScratch.test.js` — pure helpers (`resultAssetsToPurge`, `scratchOpAssetsToPurge`) + the full survivor state machine: no purge while claimed, purge on release, purge after unmount for a late-completing job, purge for an already-terminal op via the claim-release sweep, scratch purged even for a failed op, and idempotency.
- `ImageEditor.test.jsx` — the leave guard warns while an AI op is pending even when not dirty (the regression), and the editor registers its survivor claim on mount and drops it on unmount.

Full web suite green: **1015 passed**. Lint: 0 errors (16 pre-existing unrelated `setError`/exhaustive-deps warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)