### PR TITLE
fix(web): keep WebView2 shell painting through native file dialogs (sc-9261)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1052,6 +1052,112 @@ export function App() {
       .catch(() => setSetupCompleted(true));
   }, []);
 
+  // Desktop (WebView2 / Windows) only: opening a native file dialog from an
+  // `<input type="file">` can strand the composited app shell painted blank.
+  // When the modal dialog takes the foreground it disables the owner window and
+  // Chromium stops presenting the promoted DirectComposition layers (`.sidebar`,
+  // `.topbar`, `.workspace`); it does NOT restore them from ordinary window
+  // messages (resize / minimize-restore) — only an internally-scheduled frame
+  // recovers it, which is why disabling `CalculateNativeWinOcclusion` alone
+  // doesn't help. So while a file picker is pending we pump a cheap, sub-pixel
+  // transform on `.app` every frame to keep WebView2 presenting *during* the
+  // dialog (not just after it closes, which was the visibly-flashing stopgap),
+  // then do a final promote/demote once focus returns to guarantee recovery.
+  // No-op off the desktop shell and on macOS WebKit, which never drops layers.
+  useEffect(() => {
+    if (!isDesktopShell) {
+      return undefined;
+    }
+
+    let pumping = false;
+    let rafId = 0;
+    let timerId = 0;
+    let deadlineId = 0;
+    let phase = false;
+
+    const shell = () => document.querySelector(".app");
+
+    const tick = () => {
+      const el = shell();
+      if (el instanceof HTMLElement) {
+        // The transform stays established the whole time (so `.app` never
+        // toggles its containing-block status under any fixed child), but the
+        // sub-pixel value changes each frame to force a fresh present. `.app`
+        // fills the viewport at the origin, so the shift is imperceptible.
+        phase = !phase;
+        el.style.transform = phase ? "translate3d(0.02px, 0, 0)" : "translate3d(0, 0, 0)";
+      }
+      if (pumping) {
+        rafId = requestAnimationFrame(tick);
+      }
+    };
+
+    const stop = () => {
+      if (!pumping) {
+        return;
+      }
+      pumping = false;
+      cancelAnimationFrame(rafId);
+      window.clearInterval(timerId);
+      window.clearTimeout(deadlineId);
+      const el = shell();
+      if (el instanceof HTMLElement) {
+        // Promote-then-demote across two frames, then drop the inline transform
+        // we borrowed, leaving the stylesheet in control again.
+        requestAnimationFrame(() => {
+          el.style.transform = "translateZ(0)";
+          requestAnimationFrame(() => {
+            el.style.transform = "";
+          });
+        });
+      }
+    };
+
+    const start = () => {
+      if (pumping) {
+        return;
+      }
+      pumping = true;
+      rafId = requestAnimationFrame(tick);
+      // rAF is throttled while the window is occluded/deactivated — exactly our
+      // failure window — so drive a timer fallback alongside it.
+      timerId = window.setInterval(tick, 32);
+      // Safety valve: never pump forever if a focus/change edge is missed.
+      deadlineId = window.setTimeout(stop, 60000);
+    };
+
+    const onClick = (event) => {
+      const target = event.target;
+      if (target instanceof HTMLInputElement && target.type === "file") {
+        start();
+      }
+    };
+
+    // Only stop when visibility *returns*: opening the dialog can itself flip
+    // the document to hidden, which must not tear down the pump we just armed.
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") {
+        stop();
+      }
+    };
+
+    // The dialog closing restores focus / flips visibility back and (on select)
+    // fires `change`; any of those edges ends the pump. Capture phase so the
+    // click arms before the input's own handler opens the dialog.
+    document.addEventListener("click", onClick, true);
+    window.addEventListener("focus", stop);
+    document.addEventListener("visibilitychange", onVisibility);
+    document.addEventListener("change", stop, true);
+
+    return () => {
+      stop();
+      document.removeEventListener("click", onClick, true);
+      window.removeEventListener("focus", stop);
+      document.removeEventListener("visibilitychange", onVisibility);
+      document.removeEventListener("change", stop, true);
+    };
+  }, []);
+
   useEffect(() => {
     if (!ready) {
       return;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -753,8 +753,11 @@ button:focus-visible {
   gap: var(--gap-3);
   padding: 12px 22px;
   border-bottom: 1px solid var(--border);
-  background: color-mix(in oklch, var(--bg) 92%, transparent);
-  backdrop-filter: blur(10px);
+  /* No `backdrop-filter` here: a blur promotes the topbar to its own
+     DirectComposition layer, which WebView2 can strand blank when a native
+     file dialog steals the foreground (sc-9261). A near-opaque solid keeps the
+     layered look without the extra composited layer. */
+  background: color-mix(in oklch, var(--bg) 97%, transparent);
   position: sticky;
   top: 0;
   z-index: 5;
@@ -7560,8 +7563,11 @@ details[open] > summary.lora-scope-group-heading::before,
   display: grid;
   place-items: center;
   padding: 24px;
-  background: rgba(15, 23, 42, 0.55);
-  backdrop-filter: blur(6px);
+  /* No `backdrop-filter`: the blur makes this body-portaled backdrop its own
+     composited layer, so under the WebView2 file-dialog blank (sc-9261) the
+     modal itself can go blank instead of surviving in the root layer. A darker
+     scrim preserves the dimming without promoting the layer. */
+  background: rgba(15, 23, 42, 0.72);
 }
 
 .preview-modal {


### PR DESCRIPTION
## Problem (sc-9261)

On **Windows desktop only**, opening a native file dialog from an `<input type="file">` (Models → Import LoRA/model → **Choose**) blanks the whole app and it stays blank on select or cancel. macOS is unaffected.

## Root cause (re-diagnosed on-device)

Reproduced live on the installed 0.5.1 build with instrumentation:

- **#1042's flag is applied but insufficient.** The running WebView2 processes carry `--disable-features=…,CalculateNativeWinOcclusion` (the env var is *merged* into Tauri/wry's args, not ignored), yet the app still fully blanks. So occlusion tracking is not the whole cause.
- **The entire window blanks**, not just `.workspace` — the shell has three independently-promoted composited layers (`.sidebar` and `.workspace` scroll containers, `.topbar` `backdrop-filter`), and they drop together.
- **The blank does not self-recover.** After the dialog closes it stays black; resize and minimize/restore don't fix it. Only an *internally-scheduled* frame (DOM/rAF) forces WebView2 to re-present. That's why the earlier focus-return nudge (#1028) worked at all, and why external window messages don't.

Mechanism: the modal dialog disables + deactivates the webview's owner window; Chromium stops presenting the promoted DirectComposition layers and won't rebuild them from window messages. Windows-only because macOS WKWebView keeps its CoreAnimation layers composited and `NSOpenPanel` doesn't disable the owner window.

## Changes (flag-free, complementary)

1. **Repaint pump during the dialog** (`App.jsx`, desktop-shell-only): while a file picker is pending, pump a sub-pixel transform on `.app` every frame (rAF + timer fallback for when rAF is throttled while occluded) so the webview keeps presenting *during* the dialog — not just after it closes, which was the visibly-flashing stopgap. Armed on a file-input click (capture phase), disarmed on focus/visibility return or `change`, with a 60s safety valve. No-op on web and macOS.
2. **Shed two composited layers** (`styles.css`): drop `backdrop-filter` from `.topbar` and the shared `.modal-backdrop`, compensated with more opaque backgrounds. Fewer promoted layers = less surface for WebView2 to strand. (Also de-risks routing the picker through the shared modal, whose backdrop was itself promoted by the blur.)

The #1042 occlusion flag is intentionally **kept** as harmless defense-in-depth.

## Verification

- `npm run lint` — 0 errors (pre-existing warnings only), `npm test` — 992 passing, `npm run build` — clean.
- ⚠️ **Needs a Windows desktop rebuild to verify on-device** — the bug is WebView2-specific and does not reproduce on web or macOS.

## Note on overlap

Supersedes the approach on `claude/sc-9261-restore-upload`, which reverts #1042 and adds a focus-return-only nudge (the stopgap that flashes blank *during* the dialog). This PR keeps painting throughout instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)