### PR TITLE
fix(web): build user-pose preview URLs through assetUrl (sc-8859)

### DIFF
--- a/apps/web/src/poseLibrary.js
+++ b/apps/web/src/poseLibrary.js
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { apiFetch } from "./api.js";
+import { assetUrl } from "./components/assetMedia.jsx";
 import { useAppContext } from "./context/AppContext.js";
 
 // The reserved global project that holds user-created pose assets (epic 2282). Mirrors
@@ -50,10 +51,17 @@ export function loadBuiltinPoses() {
 }
 
 // Map a reserved-project type:"pose" asset into a pose record the picker understands.
-// The asset's `pose` field carries keypoints/hands/face/category; `url` is the rendered
-// skeleton preview. Built by the DWPose detector + Create tab (sc-2285/sc-2287).
+// The asset's `pose` field carries keypoints/hands/face/category; the rendered skeleton
+// preview is resolved through the shared `assetUrl` helper. Built by the DWPose detector
+// + Create tab (sc-2285/sc-2287).
 export function poseAssetToRecord(asset) {
   const pose = asset?.pose ?? {};
+  // Route the preview through the shared asset-URL helper so it gets the API_BASE_URL
+  // prefix (split-origin / Vite dev), the correct /api/v1/projects/:id/files/ route,
+  // and the short-lived media ticket in remote-auth mode (sc-8810/sc-8859). The raw
+  // asset already carries `url` + `projectId` + `file.path` (asset_index injects `url`),
+  // which is exactly the shape assetUrl consumes; `""` when unresolvable.
+  const previewUrl = assetUrl(asset) || undefined;
   return {
     id: asset.id,
     label: asset.displayName || asset.id,
@@ -64,7 +72,7 @@ export function poseAssetToRecord(asset) {
     tags: asset.tags ?? [],
     source: "user",
     assetId: asset.id,
-    previewUrl: asset.url ?? (asset.file?.path ? `/${asset.file.path}` : undefined),
+    previewUrl,
   };
 }
 

--- a/apps/web/src/poseLibrary.test.jsx
+++ b/apps/web/src/poseLibrary.test.jsx
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { API_BASE_URL, setMediaTicket } from "./api.js";
 import { loadBuiltinPoses, loadPoseLibrary, poseAssetToRecord } from "./poseLibrary.js";
 
 const BUILTIN = {
@@ -14,6 +15,7 @@ function mockBuiltinFetch() {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  setMediaTicket("");
 });
 
 describe("poseLibrary", () => {
@@ -28,7 +30,9 @@ describe("poseLibrary", () => {
     const record = poseAssetToRecord({
       id: "asset_pose_1",
       displayName: "Arm Raised",
+      projectId: "project_global_poses",
       url: "/api/v1/projects/project_global_poses/files/assets/poses/asset_pose_1.png",
+      file: { path: "assets/poses/asset_pose_1.png", mimeType: "image/png" },
       tags: ["dynamic"],
       pose: { category: "dance", keypoints: [[0.4, 0.2]], hands: [[], []], face: [] },
     });
@@ -41,6 +45,46 @@ describe("poseLibrary", () => {
     });
     expect(record.keypoints).toEqual([[0.4, 0.2]]);
     expect(record.previewUrl).toContain("/files/assets/poses/");
+  });
+
+  // sc-8859 (F-057): the preview must be built through the shared assetUrl helper so
+  // it carries the API_BASE_URL prefix — bare `asset.url` 404s under Vite dev / any
+  // split-origin (VITE_API_BASE_URL) deployment, and the old raw-path fallback omitted
+  // the /api/v1/projects/:id/files/ route entirely.
+  it("builds previewUrl through assetUrl (API_BASE_URL-prefixed, not a bare relative path)", () => {
+    const record = poseAssetToRecord({
+      id: "asset_pose_1",
+      displayName: "Arm Raised",
+      projectId: "project_global_poses",
+      url: "/api/v1/projects/project_global_poses/files/assets/poses/asset_pose_1.png",
+      file: { path: "assets/poses/asset_pose_1.png", mimeType: "image/png" },
+      pose: { category: "dance", keypoints: [[0.4, 0.2]] },
+    });
+    expect(record.previewUrl).toBe(
+      `${API_BASE_URL}/api/v1/projects/project_global_poses/files/assets/poses/asset_pose_1.png`,
+    );
+    // API_BASE_URL is non-empty under the test/dev config, so the URL is absolute
+    // rather than a bare relative path that would resolve against the dev origin.
+    expect(API_BASE_URL).not.toBe("");
+    expect(record.previewUrl.startsWith(API_BASE_URL)).toBe(true);
+  });
+
+  // sc-8859: in remote-auth mode assetUrl (sc-8810) appends a short-lived media
+  // ticket so the element-driven <img> preview authenticates. The pose preview must
+  // inherit that ticket by riding the shared helper.
+  it("carries the media ticket in remote-auth mode (sc-8810)", () => {
+    setMediaTicket("t0ken");
+    const record = poseAssetToRecord({
+      id: "asset_pose_1",
+      displayName: "Arm Raised",
+      projectId: "project_global_poses",
+      url: "/api/v1/projects/project_global_poses/files/assets/poses/asset_pose_1.png",
+      file: { path: "assets/poses/asset_pose_1.png", mimeType: "image/png" },
+      pose: { category: "dance", keypoints: [[0.4, 0.2]] },
+    });
+    expect(record.previewUrl).toBe(
+      `${API_BASE_URL}/api/v1/projects/project_global_poses/files/assets/poses/asset_pose_1.png?ticket=t0ken`,
+    );
   });
 
   it("merges built-in + injected user poses (categories + byId)", async () => {


### PR DESCRIPTION
## sc-8859 — [F-057] User-pose preview URLs skip API_BASE_URL, breaking on split-origin deployments

**Story:** https://app.shortcut.com/trefry/story/8859

### Problem
`poseAssetToRecord` (`apps/web/src/poseLibrary.js`) set `previewUrl` to the bare API-relative `asset.url`, with a `/${asset.file.path}` fallback. `asset.url` is the same API-relative path every other consumer prefixes with `API_BASE_URL`, and the raw-path fallback omitted the `/api/v1/projects/:id/files/` route prefix entirely.

Impact: in Vite dev and any split-origin deployment (`VITE_API_BASE_URL` set), user pose thumbnails 404. The raw-path fallback was broken on every deployment. Only the embedded same-origin desktop build rendered them.

### Fix
Route the preview through the shared `assetUrl` helper (`components/assetMedia.jsx`) instead of the bare `asset.url` / raw-path fallback. This gives the preview:
- the `API_BASE_URL` prefix (fixes split-origin / Vite dev),
- the correct `/api/v1/projects/:id/files/` route,
- **and** the short-lived media ticket in remote-auth mode (sc-8810 / F-008).

The raw pose asset already carries `url` + `projectId` + `file.path` (`asset_index` injects `url`), which is exactly the shape `assetUrl` consumes — no shape mapping needed. `assetUrl` returns `""` when unresolvable, coalesced back to `undefined`.

### Scope
- Only one pose-preview producer had the bug (`poseLibrary.js:67`); grep for sibling `asset.url` / `file.path` preview construction in poseLibrary/PoseLibrary turned up no other occurrences.

### Tests
`apps/web/src/poseLibrary.test.jsx`:
- previewUrl is built via `assetUrl`, `API_BASE_URL`-prefixed (absolute, not a bare relative path) for a split-origin config.
- previewUrl carries the media ticket when one is set (remote-auth mode).
- Existing `poseAssetToRecord` case updated to the full asset shape.

Full web suite green: 1027 passed / 61 files (`npm test`, `--environment jsdom`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)