### PR TITLE
fix(web): guard SSE project-scoped refreshes against stale project switches (sc-8858)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -696,7 +696,7 @@ export function App() {
     updateCharacterLora,
     detachCharacterLora,
     createCharacterTestJob,
-  } = useCharacters({ token, activeProject, setError, requestedGpu, setActiveView });
+  } = useCharacters({ token, activeProject, activeProjectRef, setError, requestedGpu, setActiveView });
 
   const {
     presets,
@@ -765,6 +765,7 @@ export function App() {
   } = useModelsAndLoras({
     token,
     activeProject,
+    activeProjectRef,
     setError,
     setJobs,
     setActiveView,
@@ -779,7 +780,7 @@ export function App() {
     createPersonDetectionJob,
     createPersonTrackJob,
     saveTrackCorrections,
-  } = usePersonTracks({ token, activeProject, setError, requestedGpu, setActiveView });
+  } = usePersonTracks({ token, activeProject, activeProjectRef, setError, requestedGpu, setActiveView });
 
   const {
     timelines,
@@ -1454,6 +1455,13 @@ export function App() {
     }
     try {
       const items = await apiFetch(`/api/v1/projects/${projectId}/assets?includeRejected=true&includeTrashed=true`, token, { signal });
+      // sc-8858: an SSE-triggered refresh for the just-active project can resolve
+      // after the user switches away; committing then would clobber the new
+      // project's assets with the old one's. Drop the stale response — mirrors
+      // refreshTimelines' guard (useTimelines.js).
+      if (activeProjectRef.current?.id && activeProjectRef.current.id !== projectId) {
+        return;
+      }
       setAssets(items);
       const defaultAsset = items.find((asset) => !asset.status?.trashed && !asset.status?.rejected) ?? items[0] ?? null;
       setSelectedAssetId((current) => current ?? defaultAsset?.id ?? null);

--- a/apps/web/src/hooks/projectScopedRefreshStaleGuard.test.jsx
+++ b/apps/web/src/hooks/projectScopedRefreshStaleGuard.test.jsx
@@ -1,0 +1,200 @@
+// sc-8858 (F-056): SSE-triggered, project-scoped refreshers must drop a stale
+// response — one whose fetch was fired for project A but resolves AFTER the user
+// switched the active project to B. Committing it would clobber B's state with A's
+// data. refreshTimelines already guards exactly this
+// (`activeProjectRef.current.id !== projectId → return`, useTimelines.js); these
+// tests assert the same guard now holds for the other project-scoped refreshers:
+// characters, loras (useModelsAndLoras), and person-tracks. The assets refresh
+// (App.jsx) shares the identical guard mechanism — it reads the same
+// `activeProjectRef` — and is exercised by the same shape here at the hook layer.
+import React, { useState } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useCharacters } from "./useCharacters.js";
+import { useModelsAndLoras } from "./useModelsAndLoras.js";
+import { usePersonTracks } from "./usePersonTracks.js";
+
+// Controllable fetch: each apiFetch call parks its resolver so a test can resolve
+// project A's response AFTER the active project has switched to B.
+const pendingResolvers = [];
+vi.mock("../api.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    apiFetch: vi.fn(
+      () =>
+        new Promise((resolve) => {
+          pendingResolvers.push(resolve);
+        }),
+    ),
+  };
+});
+
+async function settle() {
+  await act(async () => {
+    for (let i = 0; i < 4; i += 1) {
+      await Promise.resolve();
+    }
+  });
+}
+
+// Each hook exposes a project-scoped `refresh*` plus a `set*`/state pair. activeProjectRef
+// mirrors the *currently active* project (mutated by the test to simulate a switch),
+// independent of the projectId the refresh was fired for.
+const CASES = [
+  { name: "useCharacters.refreshCharacters", hook: useCharacters, refreshKey: "refreshCharacters", stateKey: "characters" },
+  { name: "useModelsAndLoras.refreshLoras", hook: useModelsAndLoras, refreshKey: "refreshLoras", stateKey: "loras" },
+  { name: "usePersonTracks.refreshPersonTracks", hook: usePersonTracks, refreshKey: "refreshPersonTracks", stateKey: "personTracks" },
+];
+
+describe.each(CASES)("$name stale-project guard (sc-8858)", ({ hook, refreshKey, stateKey }) => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    pendingResolvers.length = 0;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    container.remove();
+  });
+
+  // Renders the hook, exposing its live api and a way to force a re-render so committed
+  // state re-reads. activeProjectRef is a plain mutable ref the test flips mid-flight.
+  function mount(activeProjectRef) {
+    let latest = null;
+    function Harness() {
+      const [, setN] = useState(0);
+      latest = {
+        api: hook({
+          token: "tok",
+          activeProject: activeProjectRef.current,
+          activeProjectRef,
+          setError: () => {},
+          setJobs: () => {},
+          requestedGpu: "auto",
+          setActiveView: () => {},
+          refreshData: async () => {},
+          refreshDataWithLoraOverlay: async () => {},
+        }),
+        rerender: () => setN((n) => n + 1),
+      };
+      return null;
+    }
+    root = createRoot(container);
+    act(() => root.render(<Harness />));
+    return () => latest;
+  }
+
+  it("does NOT commit a response for project A after the active project switched to B", async () => {
+    const activeProjectRef = { current: { id: "A", name: "A" } };
+    const get = mount(activeProjectRef);
+
+    // Fire the refresh for project A (as an SSE job.updated for A would).
+    let pending;
+    act(() => {
+      pending = get().api[refreshKey]("A");
+    });
+
+    // User switches to project B while A's fetch is still in flight.
+    activeProjectRef.current = { id: "B", name: "B" };
+
+    // A's response resolves — it must be dropped, not committed.
+    await act(async () => {
+      pendingResolvers[0]([{ id: "from-A" }]);
+      await pending;
+    });
+    await settle();
+
+    expect(get().api[stateKey]).toEqual([]);
+  });
+
+  it("DOES commit a response for the still-active project", async () => {
+    const activeProjectRef = { current: { id: "A", name: "A" } };
+    const get = mount(activeProjectRef);
+
+    let pending;
+    act(() => {
+      pending = get().api[refreshKey]("A");
+    });
+
+    // Active project unchanged — the response is current and must land.
+    await act(async () => {
+      pendingResolvers[0]([{ id: "from-A" }]);
+      await pending;
+    });
+    await settle();
+
+    expect(get().api[stateKey]).toEqual([{ id: "from-A" }]);
+  });
+});
+
+// refreshLoras also serves a *global* (projectId undefined) fetch — the LoRA catalog
+// with no project scope. That path is not project-scoped, so it must still commit even
+// when activeProjectRef points at some project.
+describe("useModelsAndLoras.refreshLoras global (no project) still commits (sc-8858)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    pendingResolvers.length = 0;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    container.remove();
+  });
+
+  it("commits a global (no-project) refresh even when a project later becomes active", async () => {
+    // No active project → refreshLoras() resolves projectId to undefined, i.e. the
+    // unscoped global catalog fetch. The guard must NOT drop this even if a project
+    // becomes active mid-flight, because the fetch was never project-scoped.
+    const activeProjectRef = { current: null };
+    let latest = null;
+    function Harness() {
+      const [, setN] = useState(0);
+      latest = {
+        api: useModelsAndLoras({
+          token: "tok",
+          activeProject: activeProjectRef.current,
+          activeProjectRef,
+          setError: () => {},
+          setJobs: () => {},
+          setActiveView: () => {},
+          refreshData: async () => {},
+          refreshDataWithLoraOverlay: async () => {},
+        }),
+        rerender: () => setN((n) => n + 1),
+      };
+      return null;
+    }
+    root = createRoot(container);
+    act(() => root.render(<Harness />));
+
+    let pending;
+    act(() => {
+      // No project active → global loras fetch (projectId undefined).
+      pending = latest.api.refreshLoras();
+    });
+
+    // A project becomes active while the global fetch is in flight — must still commit.
+    activeProjectRef.current = { id: "B", name: "B" };
+
+    await act(async () => {
+      pendingResolvers[0]([{ id: "global-lora" }]);
+      await pending;
+    });
+    await settle();
+
+    expect(latest.api.loras).toEqual([{ id: "global-lora" }]);
+  });
+});

--- a/apps/web/src/hooks/useCharacters.js
+++ b/apps/web/src/hooks/useCharacters.js
@@ -10,7 +10,7 @@ import { apiFetch, isAbortError } from "../api.js";
 // sc-4194: every returned action is wrapped in useCallback so its identity is stable
 // across App's SSE-driven re-renders, which lets appContextValue memoize instead of
 // rebuilding (and changing identity) on every job.updated tick.
-export function useCharacters({ token, activeProject, setError, requestedGpu, setActiveView }) {
+export function useCharacters({ token, activeProject, activeProjectRef, setError, requestedGpu, setActiveView }) {
   const [characters, setCharacters] = useState([]);
 
   const refreshCharacters = useCallback(
@@ -20,6 +20,13 @@ export function useCharacters({ token, activeProject, setError, requestedGpu, se
       }
       try {
         const items = await apiFetch(`/api/v1/projects/${projectId}/characters`, token, { signal });
+        // sc-8858: an SSE-triggered refresh for the just-active project can resolve
+        // after the user switches away; committing then would clobber the new
+        // project's roster with the old one's. Drop the stale response — mirrors
+        // refreshTimelines' guard (useTimelines.js).
+        if (activeProjectRef?.current?.id && activeProjectRef.current.id !== projectId) {
+          return;
+        }
         setCharacters(items);
         setError("");
       } catch (err) {
@@ -27,7 +34,7 @@ export function useCharacters({ token, activeProject, setError, requestedGpu, se
         setError(err.message);
       }
     },
-    [token, activeProject, setError],
+    [token, activeProject, activeProjectRef, setError],
   );
 
   const withCharacterApi = useCallback(

--- a/apps/web/src/hooks/useModelsAndLoras.js
+++ b/apps/web/src/hooks/useModelsAndLoras.js
@@ -23,6 +23,7 @@ function uploadLimitLabel(bytes) {
 export function useModelsAndLoras({
   token,
   activeProject,
+  activeProjectRef,
   setError,
   setJobs,
   setActiveView,
@@ -39,6 +40,14 @@ export function useModelsAndLoras({
       try {
         const query = projectId ? `?projectId=${encodeURIComponent(projectId)}` : "";
         const items = await apiFetch(`/api/v1/loras${query}`, token, { signal });
+        // sc-8858: an SSE-triggered refresh for a specific project can resolve after
+        // the user switches away; committing then would clobber the new project's
+        // LoRA overlay with the old one's. Drop the stale response — mirrors
+        // refreshTimelines' guard (useTimelines.js). Only project-scoped refreshes
+        // are guarded; a global refresh (projectId undefined) still commits.
+        if (projectId && activeProjectRef?.current?.id && activeProjectRef.current.id !== projectId) {
+          return;
+        }
         setLoras(items);
         setError("");
       } catch (err) {
@@ -46,7 +55,7 @@ export function useModelsAndLoras({
         setError(err.message);
       }
     },
-    [token, activeProject, setError],
+    [token, activeProject, activeProjectRef, setError],
   );
 
   const deleteModel = useCallback(

--- a/apps/web/src/hooks/usePersonTracks.js
+++ b/apps/web/src/hooks/usePersonTracks.js
@@ -6,7 +6,7 @@ import { apiFetch, isAbortError } from "../api.js";
 // (loaded by the project-load effect, not the bulk refreshData), so the hook just
 // takes the shared concerns it needs; detection/track jobs surface live via the SSE
 // job stream (the create endpoints publish job.updated), so no post-create refetch.
-export function usePersonTracks({ token, activeProject, setError, requestedGpu, setActiveView }) {
+export function usePersonTracks({ token, activeProject, activeProjectRef, setError, requestedGpu, setActiveView }) {
   const [personTracks, setPersonTracks] = useState([]);
 
   // sc-4194: every action is wrapped in useCallback so its identity is stable
@@ -18,6 +18,13 @@ export function usePersonTracks({ token, activeProject, setError, requestedGpu, 
       }
       try {
         const items = await apiFetch(`/api/v1/projects/${projectId}/person-tracks`, token, { signal });
+        // sc-8858: an SSE-triggered refresh for the just-active project can resolve
+        // after the user switches away; committing then would clobber the new
+        // project's tracks with the old one's. Drop the stale response — mirrors
+        // refreshTimelines' guard (useTimelines.js).
+        if (activeProjectRef?.current?.id && activeProjectRef.current.id !== projectId) {
+          return;
+        }
         setPersonTracks(items);
         setError("");
       } catch (err) {
@@ -25,7 +32,7 @@ export function usePersonTracks({ token, activeProject, setError, requestedGpu, 
         setError(err.message);
       }
     },
-    [token, activeProject, setError],
+    [token, activeProject, activeProjectRef, setError],
   );
 
   const createPersonDetectionJob = useCallback(


### PR DESCRIPTION
## sc-8858 — [F-056] SSE-triggered project-scoped refreshes lack the stale-response guard

Story: https://app.shortcut.com/trefry/story/8858

### Problem
The SSE `job.updated` handler fires `refreshAssets` / `refreshCharacters` / `refreshLoras` / `refreshPersonTracks` with the completed job's `projectId`. Each committed `setX(items)` unconditionally after the fetch. A refresh in flight for project **A** whose response resolves **after** the user switches to project **B** would overwrite B's `assets` / `characters` / `loras` / `personTracks` with A's data. `refreshTimelines` already guards exactly this hazard (`activeProjectRef.current?.id !== projectId → return`), proving the pattern; the other four setters lacked it.

### Fix
Mirror `refreshTimelines`' guard (useTimelines.js) in the four remaining project-scoped refreshers: after the `await` and before committing `setX(items)`, drop the response if `activeProjectRef.current?.id` no longer matches the `projectId` the refresh was fired for.

- `useCharacters.refreshCharacters`, `useModelsAndLoras.refreshLoras`, `usePersonTracks.refreshPersonTracks` — threaded `activeProjectRef` in (assets' `refreshAssets` lives in App.jsx and already had it).
- `refreshLoras` guards only project-scoped fetches; a **global** (`projectId` undefined) catalog refresh still commits.
- Normal (still-active) refresh path is unchanged.

### Tests
New `apps/web/src/hooks/projectScopedRefreshStaleGuard.test.jsx` (7 tests, jsdom):
- For each of characters / loras / person-tracks: a refresh fired for A that resolves **after** the switch to B does **not** commit; a refresh for the still-active project **does** commit. (Assets shares the identical `activeProjectRef` mechanism.)
- A global (no-project) loras refresh still commits even when a project becomes active mid-flight.

Verified the 3 stale-drop assertions fail with the guard reverted (they catch the regression) and pass with it. Full web suite green: **62 files / 1034 tests pass**, including the existing `hookStability` test now receiving the real `activeProjectRef`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)