### PR TITLE
fix(web): serialize ImageEditor undo/redo to prevent redo-stack corruption (sc-8852)

### DIFF
--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -750,6 +750,36 @@ export function historyRedo(history, present, limit = HISTORY_LIMIT) {
 export const canUndo = (history) => history.past.length > 0;
 export const canRedo = (history) => history.future.length > 0;
 
+// Serialize a single undo/redo step so a rapid second invocation can't race a
+// restore that is still in flight (sc-8852). Restoring is async — each changed
+// layer is decoded via `blobToImage` before the working stack is re-installed —
+// so without a guard a key-repeat Cmd-Z would run `step()` again while the first
+// restore is mid-flight, capturing the STALE working state as "present" and
+// pushing a duplicate onto the redo (`future`) branch. Both undo AND redo route
+// through here and share one `guardRef`: while a restore is in flight, any
+// further undo/redo is ignored (the finding's simplest fix — holding Cmd-Z steps
+// back predictably rather than dropping-then-jumping). The guard is set BEFORE
+// the reducer step runs and cleared in a `finally`, so a mid-restore error can't
+// wedge undo/redo forever. Returns true when a step actually ran.
+//   - guardRef:     a mutable ref-like `{ current: boolean }` shared by undo/redo.
+//   - step:         () => ({ history, restore }) — the pure reducer step, called
+//                   only once we hold the guard, capturing the live "present".
+//   - commitHistory:(nextHistory) => void — install the new history + sync flags.
+//   - restore:      async (snapshot) => void — the async snapshot re-install.
+export async function runGuardedRestore({ guardRef, step, commitHistory, restore }) {
+  if (guardRef.current) return false;
+  guardRef.current = true;
+  try {
+    const { history: next, restore: target } = step();
+    if (!target) return false;
+    commitHistory(next);
+    await restore(target);
+    return true;
+  } finally {
+    guardRef.current = false;
+  }
+}
+
 // Revoke the object URLs of a set of live layers (sc-6117). Undo snapshots hold
 // only blobs (no URLs), so the only URLs that ever need revoking are the live
 // ones, when their layer is evicted — on delete, on a session replace, and on
@@ -973,6 +1003,12 @@ export function ImageEditor() {
   // The stacks live in a ref for synchronous reads inside the commit handlers; the
   // can-undo/redo flags are mirrored into state so the toolbar buttons re-render.
   const historyRef = useRef(emptyHistory());
+  // Serializes undo/redo (sc-8852): a restore is async (it decodes changed layers
+  // via blobToImage before re-installing the stack), so a rapid second Cmd-Z would
+  // otherwise race the in-flight restore and corrupt the redo branch. Shared by
+  // both undo() and redo() via runGuardedRestore — set while restoring, cleared in
+  // a finally so a mid-restore error can't wedge history forever.
+  const isRestoringRef = useRef(false);
   const [historyFlags, setHistoryFlags] = useState({ canUndo: false, canRedo: false });
   // Live mirror of the working document for synchronous reads inside the commit
   // handlers (a checkpoint captures the pre-operation stack; restore reuses the
@@ -1217,20 +1253,28 @@ export function ImageEditor() {
 
   const undo = useCallback(async () => {
     if (aiOpRef.current || !workingRef.current) return;
-    const { history: next, restore } = historyUndo(historyRef.current, captureSnapshot());
-    if (!restore) return;
-    historyRef.current = next;
-    syncHistoryFlags();
-    await restoreSnapshot(restore);
+    await runGuardedRestore({
+      guardRef: isRestoringRef,
+      step: () => historyUndo(historyRef.current, captureSnapshot()),
+      commitHistory: (next) => {
+        historyRef.current = next;
+        syncHistoryFlags();
+      },
+      restore: restoreSnapshot,
+    });
   }, [captureSnapshot, restoreSnapshot, syncHistoryFlags]);
 
   const redo = useCallback(async () => {
     if (aiOpRef.current || !workingRef.current) return;
-    const { history: next, restore } = historyRedo(historyRef.current, captureSnapshot());
-    if (!restore) return;
-    historyRef.current = next;
-    syncHistoryFlags();
-    await restoreSnapshot(restore);
+    await runGuardedRestore({
+      guardRef: isRestoringRef,
+      step: () => historyRedo(historyRef.current, captureSnapshot()),
+      commitHistory: (next) => {
+        historyRef.current = next;
+        syncHistoryFlags();
+      },
+      restore: restoreSnapshot,
+    });
   }, [captureSnapshot, restoreSnapshot, syncHistoryFlags]);
 
   // ── Keyboard shortcuts (sc-6111) ───────────────────────────────────────────

--- a/apps/web/src/screens/ImageEditor.test.jsx
+++ b/apps/web/src/screens/ImageEditor.test.jsx
@@ -66,6 +66,7 @@ import {
   historyRedo,
   canUndo,
   canRedo,
+  runGuardedRestore,
   buildSegmentJobBody,
   rectToSegmentBox,
   tintMaskRgbaInPlace,
@@ -1137,6 +1138,188 @@ describe("undo/redo history (sc-6106)", () => {
     const after = historyCheckpoint(h, A);
     expect(h).toEqual({ past: [], future: [] });
     expect(after).not.toBe(h);
+  });
+});
+
+// Serialized undo/redo restore guard (sc-8852). A restore is async (it decodes
+// changed layers via blobToImage before re-installing the working stack), so a
+// rapid second Cmd-Z must not race the in-flight restore and corrupt the redo
+// branch. These drive runGuardedRestore exactly as undo()/redo() wire it: a
+// mutable `historyRef` + a "present" marker that the (deferred) restore updates,
+// so a second call landing mid-restore would — without the guard — capture the
+// stale present and push a duplicate onto `future`.
+describe("serialized undo/redo restore (sc-8852)", () => {
+  const A = { id: "A" };
+  const B = { id: "B" };
+  const C = { id: "C" };
+
+  // Build a harness mirroring the component: undo()/redo() route through
+  // runGuardedRestore with a shared guard ref, a synchronous historyRef, a live
+  // "present" marker, and a controllable async restore whose promise resolution
+  // is deferred until the test releases it.
+  function makeHarness(initialHistory, initialPresent) {
+    const guardRef = { current: false };
+    const historyRef = { current: initialHistory };
+    const present = { current: initialPresent };
+    const restores = []; // { snapshot, resolve } for every restore that actually ran
+    let pending = null; // the deferred controller for the in-flight restore
+
+    const restore = (snapshot) =>
+      new Promise((resolve) => {
+        pending = {
+          snapshot,
+          resolve: () => {
+            // Mirror restoreSnapshot's effect: the restored snapshot becomes the
+            // new live "present" once the async work settles.
+            present.current = snapshot;
+            resolve();
+          },
+        };
+        restores.push(pending);
+      });
+
+    const undo = () =>
+      runGuardedRestore({
+        guardRef,
+        step: () => historyUndo(historyRef.current, present.current),
+        commitHistory: (next) => {
+          historyRef.current = next;
+        },
+        restore,
+      });
+
+    const redo = () =>
+      runGuardedRestore({
+        guardRef,
+        step: () => historyRedo(historyRef.current, present.current),
+        commitHistory: (next) => {
+          historyRef.current = next;
+        },
+        restore,
+      });
+
+    return {
+      guardRef,
+      historyRef,
+      present,
+      restores,
+      undo,
+      redo,
+      // Release the single in-flight restore (there is at most one under the guard).
+      releasePending: async () => {
+        const p = pending;
+        pending = null;
+        p.resolve();
+        // Let the awaiting runGuardedRestore run its finally + return.
+        await Promise.resolve();
+        await Promise.resolve();
+      },
+    };
+  }
+
+  it("two rapid undos step back exactly once — the second is ignored mid-restore", async () => {
+    // present is C, past=[A,B]; an undo→undo chain should land on B, not corrupt future.
+    const h = makeHarness({ past: [A, B], future: [] }, C);
+
+    const first = h.undo(); // starts restoring B, guard is now held
+    const second = h.undo(); // lands mid-restore → ignored, no second step()
+
+    // Exactly one restore was dispatched (the second call never ran step()).
+    expect(h.restores).toHaveLength(1);
+    expect(h.restores[0].snapshot).toBe(B);
+    // History advanced exactly one step: C parked on future, B popped from past.
+    expect(h.historyRef.current).toEqual({ past: [A], future: [C] });
+    expect(await second).toBe(false); // ignored invocation reports "no step ran"
+
+    await h.releasePending();
+    expect(await first).toBe(true);
+    // Guard released; no duplicate C pushed onto future.
+    expect(h.guardRef.current).toBe(false);
+    expect(h.historyRef.current).toEqual({ past: [A], future: [C] });
+    expect(h.present.current).toBe(B);
+  });
+
+  it("undo then redo returns to the same present", async () => {
+    const h = makeHarness({ past: [A, B], future: [] }, C);
+
+    const undoDone = h.undo();
+    await h.releasePending(); // restore B settles → present is B
+    await undoDone;
+    expect(h.present.current).toBe(B);
+    expect(h.historyRef.current).toEqual({ past: [A], future: [C] });
+
+    const redoDone = h.redo();
+    await h.releasePending(); // restore C settles → present is C again
+    await redoDone;
+    expect(h.present.current).toBe(C);
+    expect(h.historyRef.current).toEqual({ past: [A, B], future: [] });
+  });
+
+  it("clears the guard after a successful restore so the next undo runs", async () => {
+    const h = makeHarness({ past: [A, B], future: [] }, C);
+
+    const first = h.undo();
+    await h.releasePending();
+    await first;
+    expect(h.guardRef.current).toBe(false);
+
+    // A second, non-overlapping undo now proceeds (guard was released).
+    const second = h.undo();
+    expect(h.restores).toHaveLength(2);
+    expect(h.restores[1].snapshot).toBe(A);
+    await h.releasePending();
+    await second;
+    expect(h.present.current).toBe(A);
+    expect(h.historyRef.current).toEqual({ past: [], future: [B, C] });
+  });
+
+  it("clears the guard even when a restore throws so undo is not wedged forever", async () => {
+    const guardRef = { current: false };
+    const historyRef = { current: { past: [A, B], future: [] } };
+    let calls = 0;
+    const failingRestore = async () => {
+      calls += 1;
+      if (calls === 1) throw new Error("decode failed");
+    };
+    const undo = () =>
+      runGuardedRestore({
+        guardRef,
+        step: () => historyUndo(historyRef.current, C),
+        commitHistory: (next) => {
+          historyRef.current = next;
+        },
+        restore: failingRestore,
+      });
+
+    await expect(undo()).rejects.toThrow("decode failed");
+    // finally released the guard despite the throw.
+    expect(guardRef.current).toBe(false);
+    // A subsequent undo works — history is not wedged.
+    const ran = await undo();
+    expect(ran).toBe(true);
+    expect(calls).toBe(2);
+    expect(guardRef.current).toBe(false);
+  });
+
+  it("normal single undo/redo is unchanged and reports it ran", async () => {
+    const h = makeHarness({ past: [A], future: [] }, B);
+    const done = h.undo();
+    expect(h.restores).toHaveLength(1);
+    expect(h.restores[0].snapshot).toBe(A);
+    await h.releasePending();
+    expect(await done).toBe(true);
+    expect(h.historyRef.current).toEqual({ past: [], future: [B] });
+    expect(h.present.current).toBe(A);
+  });
+
+  it("a no-op undo on an exhausted stack releases the guard and reports false", async () => {
+    const h = makeHarness({ past: [], future: [] }, A);
+    expect(await h.undo()).toBe(false);
+    expect(h.restores).toHaveLength(0);
+    expect(h.guardRef.current).toBe(false);
+    // Redo likewise no-ops cleanly and leaves the guard free.
+    expect(await h.redo()).toBe(false);
+    expect(h.guardRef.current).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Bug (sc-8852 · [F-050], Medium)

`undo()` / `redo()` in `apps/web/src/screens/ImageEditor.jsx` pop the history ref synchronously but restore **asynchronously** (`await restoreSnapshot`, which decodes each changed layer via `blobToImage` before re-installing the working stack). A second key-repeat Cmd-Z arriving before the first restore resolves re-ran the reducer step against the still-stale `workingRef`, capturing it as "present" and pushing a **duplicate onto the redo (`future`) branch**. Holding Cmd-Z on large-layer sessions could then replay the wrong states and make an intermediate edit unreachable.

## Fix

- New exported pure helper `runGuardedRestore({ guardRef, step, commitHistory, restore })` that serializes a single undo/redo step behind a shared guard.
- Added `isRestoringRef` in the component; **both** `undo()` and `redo()` route through `runGuardedRestore` with it. While a restore is in flight, any further undo/redo is **ignored** (the finding's simplest fix — holding Cmd-Z steps back predictably rather than dropping-then-jumping).
- The guard is set **before** the reducer step runs (so a racing invocation never captures a stale present or pushes a duplicate) and cleared in a **`finally`** so a mid-restore error can't wedge history forever.
- Normal single-step undo/redo behavior is unchanged.

## Tests (vitest)

New `serialized undo/redo restore (sc-8852)` describe block, driving `runGuardedRestore` exactly as the component wires it (mutable historyRef + a "present" marker updated by a deferred/controllable restore):

- two rapid undos step back **exactly once** — the second is ignored mid-restore, no duplicate on `future`
- undo then redo returns to the same present
- guard cleared after a successful restore so the next undo runs
- guard cleared even when a restore **throws** (history not wedged forever)
- normal single undo/redo unchanged
- no-op undo/redo on an exhausted stack releases the guard cleanly

Full web suite green locally: 61 files / 1033 tests passing.

Story: https://app.shortcut.com/trefry/story/8852

🤖 Generated with [Claude Code](https://claude.com/claude-code)