### PR TITLE
fix(worker): clamp person-detect sourceTimestamp to clip duration (sc-8831)

### DIFF
--- a/crates/sceneworks-worker/src/media_jobs.rs
+++ b/crates/sceneworks-worker/src/media_jobs.rs
@@ -345,6 +345,19 @@ pub(crate) async fn run_person_detect_job(
     Ok(())
 }
 
+/// The largest seek (seconds) a person-detect frame extraction will ever accept.
+const PERSON_DETECT_MAX_TIMESTAMP_SECONDS: f64 = 3600.0;
+
+/// Clamp the requested `sourceTimestamp` into a seek that lands inside the source clip.
+///
+/// The upper bound is `min(duration, 3600)`, not `max(duration, 3600)`: a timestamp past the
+/// end of a short clip is pulled back to the clip's duration so `ffmpeg -ss` still produces a
+/// frame, instead of sailing past the end and failing with a generic "no frame output" error
+/// (sc-8831). The 3600s ceiling only ever tightens the bound for absurdly long clips.
+fn person_detect_source_timestamp(timestamp: f64, duration: f64) -> f64 {
+    timestamp.clamp(0.0, duration.min(PERSON_DETECT_MAX_TIMESTAMP_SECONDS))
+}
+
 pub(crate) async fn run_person_detect(
     api: &ApiClient,
     settings: &Settings,
@@ -373,12 +386,14 @@ pub(crate) async fn run_person_detect(
         .get("duration")
         .map_or(6.0, |value| value_f64(value, 6.0))
         .clamp(0.0, 3600.0);
-    let timestamp = payload_f64(
-        &job.payload,
-        "sourceTimestamp",
-        if duration > 0.0 { duration * 0.25 } else { 0.0 },
-    )
-    .clamp(0.0, duration.max(3600.0));
+    let timestamp = person_detect_source_timestamp(
+        payload_f64(
+            &job.payload,
+            "sourceTimestamp",
+            if duration > 0.0 { duration * 0.25 } else { 0.0 },
+        ),
+        duration,
+    );
 
     let frames_dir = project_path.join("assets").join("frames");
     tokio::fs::create_dir_all(&frames_dir).await?;
@@ -2680,6 +2695,48 @@ mod frame_seek_tests {
         // A clip shorter than the guard clamps to 0 rather than a negative seek.
         assert_eq!(frame_seek_timestamp(0.1, 0.1), 0.0);
         assert_eq!(frame_seek_timestamp(0.0, 0.0), 0.0);
+    }
+}
+
+#[cfg(test)]
+mod person_detect_timestamp_tests {
+    use super::*;
+
+    #[test]
+    fn timestamp_past_short_clip_end_is_clamped_to_duration_not_3600() {
+        // sc-8831: a request past the end of a 5s clip must land at the clip's duration so
+        // ffmpeg -ss still pulls a frame — the old `duration.max(3600.0)` upper bound left
+        // this at 999.0 (>=3600 ceiling), which produced a generic "no frame output" failure.
+        let clamped = person_detect_source_timestamp(999.0, 5.0);
+        assert_eq!(
+            clamped, 5.0,
+            "out-of-range seek clamps to the clip duration"
+        );
+        assert!(
+            clamped < PERSON_DETECT_MAX_TIMESTAMP_SECONDS,
+            "clamp must not float up to the 3600s ceiling for a short clip"
+        );
+    }
+
+    #[test]
+    fn in_range_timestamp_passes_through_unchanged() {
+        assert_eq!(person_detect_source_timestamp(2.5, 5.0), 2.5);
+        assert_eq!(person_detect_source_timestamp(0.0, 5.0), 0.0);
+        assert_eq!(person_detect_source_timestamp(5.0, 5.0), 5.0);
+    }
+
+    #[test]
+    fn negative_timestamp_clamps_to_zero() {
+        assert_eq!(person_detect_source_timestamp(-3.0, 5.0), 0.0);
+    }
+
+    #[test]
+    fn very_long_clip_is_capped_at_the_3600s_ceiling() {
+        // The 3600s ceiling only tightens the bound for absurdly long clips.
+        assert_eq!(
+            person_detect_source_timestamp(5000.0, 7200.0),
+            PERSON_DETECT_MAX_TIMESTAMP_SECONDS
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

`run_person_detect` clamped the requested `sourceTimestamp` with `.clamp(0.0, duration.max(3600.0))`. Because `max` was used, the upper bound was **always** `>= 3600` and never the clip's actual duration. A timestamp past the end of a short clip therefore passed validation, `ffmpeg -ss` produced no frame, and the job failed with a generic "no frame output" error instead of a valid seek.

## Fix

- Extracted the clamp into a pure helper `person_detect_source_timestamp(timestamp, duration)` that uses `duration.min(3600.0)` as the upper bound. An out-of-range request is now pulled back to the clip's duration (ffmpeg still gets a decodable seek); the 3600s ceiling only ever tightens the bound for absurdly long clips.
- The codebase pattern for `sourceTimestamp` is to **clamp into range** (see the sibling `frame_seek_timestamp` guard and the `duration` clamp), so `min()` is the correct fix — no separate rejection path is warranted.
- Audited the other `.max(...)` uses in `media_jobs.rs`: the rest are floor guards (`max(1.0)` / `max(0.0)` / `max(0.1)`), not upper clamps. Line 381 was the only defective bound.

## Tests

New non-gated `person_detect_timestamp_tests` module:
- `timestamp_past_short_clip_end_is_clamped_to_duration_not_3600` — the regression: `person_detect_source_timestamp(999.0, 5.0) == 5.0` and stays below the 3600s ceiling.
- `in_range_timestamp_passes_through_unchanged`
- `negative_timestamp_clamps_to_zero`
- `very_long_clip_is_capped_at_the_3600s_ceiling`

Verified:
- `cargo test -p sceneworks-worker` — green (499 integration + 630 lib incl. the 4 new)
- `npm run rust:check` — green (fmt + clippy + build)
- `cargo check -p sceneworks-worker --no-default-features --features backend-candle --all-targets` — green

Story: https://app.shortcut.com/trefry/story/8831

🤖 Generated with [Claude Code](https://claude.com/claude-code)