### PR TITLE
refactor(worker): share fit/letterbox geometry across candle edit lanes (sc-8824)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -6,22 +6,19 @@
 // broke the candle build because video_jobs.rs / the candle edit handlers call it). No `#[cfg]` here:
 // availability follows base.rs's own include cfg, which matches the callers'.
 
-/// Where a `src_w`×`src_h` image lands when contained (long edge fits) and centered in
-/// a `width`×`height` box: `(new_w, new_h, left, top)`. Parity with Python `_contain_box`
-/// (shared by the pad fit so the kept region lines up). Integer-divides the offsets.
-fn contain_box(src_w: u32, src_h: u32, width: u32, height: u32) -> (u32, u32, u32, u32) {
-    let ratio = (width as f32 / src_w as f32).min(height as f32 / src_h as f32);
-    let new_w = ((src_w as f32 * ratio).round() as u32).max(1);
-    let new_h = ((src_h as f32 * ratio).round() as u32).max(1);
-    (new_w, new_h, (width - new_w) / 2, (height - new_h) / 2)
-}
-
 /// Resize an RGB image to exactly `width`×`height` honoring `mode` without distorting it
 /// (parity with Python `fit_image`, RGB path only — no inpaint mask exists on the MLX
 /// FLUX.2 edit path, so `outpaint` degrades to `pad` geometry):
 ///   - `crop`:    scale to COVER (short edge fits), center-crop the overflow.
 ///   - `pad`/`outpaint`: scale to CONTAIN (long edge fits), center on a black canvas.
 ///   - `stretch`: legacy non-aspect-preserving resize.
+///
+/// The pad/outpaint arm's contain geometry is the engine's [`gen_core::imageops::contain_box`]
+/// (sc-8824) — the SINGLE source of truth shared with the outpaint mask
+/// ([`gen_core::imageops::outpaint_border_mask`] calls the same `contain_box`), so the letterboxed
+/// kept-rect and the mask's keep-rect are pixel-identical. It rounds half-to-even in f64 (matching
+/// Python `round`) and returns i32 offsets; the old local copy rounded half-away-from-zero in f32,
+/// which could disagree by a pixel at an exact `.5` and desync fit vs. mask on outpaint edges.
 fn fit_rgb(source: &image::RgbImage, width: u32, height: u32, mode: &str) -> image::RgbImage {
     use image::imageops::FilterType::Lanczos3;
     let width = width.max(1);
@@ -39,10 +36,12 @@ fn fit_rgb(source: &image::RgbImage, width: u32, height: u32, mode: &str) -> ima
             let top = (new_h - height) / 2;
             image::imageops::crop_imm(&resized, left, top, width, height).to_image()
         }
-        // "pad" / "outpaint": contain + center on a black canvas (letterbox).
+        // "pad" / "outpaint": contain + center on a black canvas (letterbox). The engine's
+        // `contain_box` is the shared geometry the outpaint mask also uses, so fit + mask agree.
         _ => {
-            let (new_w, new_h, left, top) = contain_box(src_w, src_h, width, height);
-            let resized = image::imageops::resize(source, new_w, new_h, Lanczos3);
+            let (new_w, new_h, left, top) =
+                gen_core::imageops::contain_box(src_w, src_h, width, height);
+            let resized = image::imageops::resize(source, new_w.max(1), new_h.max(1), Lanczos3);
             let mut canvas = image::RgbImage::from_pixel(width, height, image::Rgb([0, 0, 0]));
             image::imageops::overlay(&mut canvas, &resized, left as i64, top as i64);
             canvas

--- a/crates/sceneworks-worker/src/image_jobs/flux2_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2_edit_candle.rs
@@ -175,56 +175,10 @@ fn flux2_edit_candle_reference_ids(request: &ImageRequest) -> Vec<String> {
     Vec::new()
 }
 
-/// Resize an RGB image to exactly `width`×`height` honoring `mode` without distorting it (the candle
-/// FLUX.2 twin of the macOS `fit_rgb`): `crop` covers + center-crops, `pad`/`outpaint` contain +
-/// letterbox on black, `stretch` is the legacy non-aspect resize. The Image-Edit source is pre-fitted so
-/// an off-aspect edit doesn't stretch; the provider re-resizes to the render size internally.
-fn flux2_edit_fit_rgb(
-    source: &image::RgbImage,
-    width: u32,
-    height: u32,
-    mode: &str,
-) -> image::RgbImage {
-    use image::imageops::FilterType::Lanczos3;
-    let width = width.max(1);
-    let height = height.max(1);
-    let (src_w, src_h) = (source.width(), source.height());
-    match mode {
-        "stretch" => image::imageops::resize(source, width, height, Lanczos3),
-        "crop" => {
-            let ratio = (width as f32 / src_w as f32).max(height as f32 / src_h as f32);
-            let new_w = width.max((src_w as f32 * ratio).ceil() as u32);
-            let new_h = height.max((src_h as f32 * ratio).ceil() as u32);
-            let resized = image::imageops::resize(source, new_w, new_h, Lanczos3);
-            let left = (new_w - width) / 2;
-            let top = (new_h - height) / 2;
-            image::imageops::crop_imm(&resized, left, top, width, height).to_image()
-        }
-        // "pad" / "outpaint": contain + center on a black canvas (letterbox).
-        _ => {
-            let (new_w, new_h, left, top) =
-                gen_core::imageops::contain_box(src_w, src_h, width, height);
-            let resized = image::imageops::resize(source, new_w.max(1), new_h.max(1), Lanczos3);
-            let mut canvas = image::RgbImage::from_pixel(width, height, image::Rgb([0, 0, 0]));
-            image::imageops::overlay(&mut canvas, &resized, left as i64, top as i64);
-            canvas
-        }
-    }
-}
-
-/// Fit an engine [`Image`] (RGB8) to `width`×`height` by `mode` via [`flux2_edit_fit_rgb`].
-fn flux2_edit_fit_image(source: Image, width: u32, height: u32, mode: &str) -> WorkerResult<Image> {
-    let rgb =
-        image::RgbImage::from_raw(source.width, source.height, source.pixels).ok_or_else(|| {
-            WorkerError::InvalidPayload("FLUX.2 edit image buffer size mismatch".to_owned())
-        })?;
-    let fitted = flux2_edit_fit_rgb(&rgb, width, height, mode);
-    Ok(Image {
-        width: fitted.width(),
-        height: fitted.height(),
-        pixels: fitted.into_raw(),
-    })
-}
+// Fit/letterbox geometry is the SHARED `fit_engine_image` (base.rs), not a per-lane twin (sc-8824):
+// the same helper the macOS FLUX.2 edit lane and the candle Z-Image edit lane use. Its pad/outpaint
+// arm rides `gen_core::imageops::contain_box`, so an off-aspect Image-Edit source letterboxes with
+// exactly the geometry any outpaint mask would, with no per-lane rounding drift.
 
 /// Flat telemetry recorded on candle FLUX.2 edit assets (parity with the macOS FLUX.2 edit recipe keys).
 fn flux2_edit_candle_raw_settings(
@@ -276,7 +230,7 @@ fn load_flux2_edit_references(
         let fitted = if request.fit_mode == "stretch" {
             source
         } else {
-            flux2_edit_fit_image(source, width, height, &request.fit_mode)?
+            fit_engine_image(source, width, height, &request.fit_mode)?
         };
         references.push(fitted);
     }

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_edit_candle.rs
@@ -140,75 +140,11 @@ fn sdxl_edit_candle_guidance(request: &ImageRequest) -> f32 {
     )
 }
 
-/// Resize an RGB image to exactly `width`×`height` honoring `mode` without distorting it (the candle twin
-/// of the macOS `fit_rgb`): `crop` covers + center-crops, `pad`/`outpaint` contains + letterboxes on a
-/// black canvas (the kept rect aligns with [`gen_core::imageops::contain_box`]), `stretch` is the legacy
-/// non-aspect resize. The candle `SdxlEdit` provider re-resizes to the render size internally, but pre-
-/// fitting here is what honors `fit_mode` (the provider only stretches).
-fn sdxl_edit_fit_rgb(
-    source: &image::RgbImage,
-    width: u32,
-    height: u32,
-    mode: &str,
-) -> image::RgbImage {
-    use image::imageops::FilterType::Lanczos3;
-    let width = width.max(1);
-    let height = height.max(1);
-    let (src_w, src_h) = (source.width(), source.height());
-    match mode {
-        "stretch" => image::imageops::resize(source, width, height, Lanczos3),
-        "crop" => {
-            let ratio = (width as f32 / src_w as f32).max(height as f32 / src_h as f32);
-            // Ceil so the scaled image always fully covers the target before cropping.
-            let new_w = width.max((src_w as f32 * ratio).ceil() as u32);
-            let new_h = height.max((src_h as f32 * ratio).ceil() as u32);
-            let resized = image::imageops::resize(source, new_w, new_h, Lanczos3);
-            let left = (new_w - width) / 2;
-            let top = (new_h - height) / 2;
-            image::imageops::crop_imm(&resized, left, top, width, height).to_image()
-        }
-        // "pad" / "outpaint": contain + center on a black canvas (letterbox).
-        _ => {
-            let (new_w, new_h, left, top) =
-                gen_core::imageops::contain_box(src_w, src_h, width, height);
-            let resized = image::imageops::resize(source, new_w.max(1), new_h.max(1), Lanczos3);
-            let mut canvas = image::RgbImage::from_pixel(width, height, image::Rgb([0, 0, 0]));
-            image::imageops::overlay(&mut canvas, &resized, left as i64, top as i64);
-            canvas
-        }
-    }
-}
-
-/// Fit an engine [`Image`] (RGB8) to `width`×`height` by `mode` via [`sdxl_edit_fit_rgb`].
-fn sdxl_edit_fit_image(source: Image, width: u32, height: u32, mode: &str) -> WorkerResult<Image> {
-    let rgb =
-        image::RgbImage::from_raw(source.width, source.height, source.pixels).ok_or_else(|| {
-            WorkerError::InvalidPayload("SDXL edit image buffer size mismatch".to_owned())
-        })?;
-    let fitted = sdxl_edit_fit_rgb(&rgb, width, height, mode);
-    Ok(Image {
-        width: fitted.width(),
-        height: fitted.height(),
-        pixels: fitted.into_raw(),
-    })
-}
-
-/// Composite `source` contained (long edge fits) + centered on a black `width`×`height` canvas (the
-/// candle twin of the macOS `sdxl_outpaint_canvas`), using the engine's [`gen_core::imageops::contain_box`]
-/// so the padded source lines up pixel-for-pixel with [`gen_core::imageops::outpaint_border_mask`].
-fn sdxl_edit_outpaint_canvas(source: &image::RgbImage, width: u32, height: u32) -> Image {
-    use image::imageops::FilterType::Lanczos3;
-    let (new_w, new_h, left, top) =
-        gen_core::imageops::contain_box(source.width(), source.height(), width, height);
-    let resized = image::imageops::resize(source, new_w.max(1), new_h.max(1), Lanczos3);
-    let mut canvas = image::RgbImage::from_pixel(width, height, image::Rgb([0, 0, 0]));
-    image::imageops::overlay(&mut canvas, &resized, left as i64, top as i64);
-    Image {
-        width,
-        height,
-        pixels: canvas.into_raw(),
-    }
-}
+// Fit/letterbox geometry is the SHARED `fit_engine_image` (base.rs) — the same helper the macOS
+// SDXL edit lane and the candle Z-Image edit lane use — rather than a per-lane twin (sc-8824). Its
+// pad/outpaint arm and `gen_core::imageops::outpaint_border_mask` both call
+// `gen_core::imageops::contain_box`, so the letterboxed source and the outpaint mask stay pixel-
+// aligned with no per-lane rounding drift.
 
 /// Flat telemetry recorded on candle SDXL edit assets (the sub-mode + strength that drove it; parity with
 /// the macOS SDXL advanced recipe keys).
@@ -302,12 +238,12 @@ async fn generate_candle_sdxl_edit_stream(
     // internally, so the source/mask only need to be at `width`×`height` with aligned geometry.
     let (gen_source, gen_mask, mode_tag): (Image, Option<Image>, &str) = match mode {
         SdxlEditCandleMode::Edit => (
-            sdxl_edit_fit_image(source, width, height, &request.fit_mode)?,
+            fit_engine_image(source, width, height, &request.fit_mode)?,
             None,
             "edit",
         ),
         SdxlEditCandleMode::Inpaint => {
-            let src = sdxl_edit_fit_image(source, width, height, &request.fit_mode)?;
+            let src = fit_engine_image(source, width, height, &request.fit_mode)?;
             let mask_id = request
                 .mask_asset_id
                 .as_deref()
@@ -322,19 +258,16 @@ async fn generate_candle_sdxl_edit_stream(
                 mask_id,
                 project_path,
             )?;
-            let mask = sdxl_edit_fit_image(mask, width, height, &request.fit_mode)?;
+            let mask = fit_engine_image(mask, width, height, &request.fit_mode)?;
             (src, Some(mask), "inpaint")
         }
         SdxlEditCandleMode::Outpaint => {
             // Pad the source onto the render canvas; the white border is the region to regenerate.
-            let src_rgb = image::RgbImage::from_raw(source.width, source.height, source.pixels)
-                .ok_or_else(|| {
-                    WorkerError::InvalidPayload(
-                        "SDXL outpaint source buffer size mismatch".to_owned(),
-                    )
-                })?;
-            let (src_w, src_h) = (src_rgb.width(), src_rgb.height());
-            let canvas = sdxl_edit_outpaint_canvas(&src_rgb, width, height);
+            // Fit + mask MUST share `gen_core::imageops::contain_box` (sc-8824): `fit_engine_image`'s
+            // "outpaint"/pad arm and `outpaint_border_mask` both call it, so the kept rect and the
+            // mask's keep rect are pixel-identical.
+            let (src_w, src_h) = (source.width, source.height);
+            let canvas = fit_engine_image(source, width, height, "outpaint")?;
             // White = regenerate (the padded border), black = keep (the centered source).
             let mut mask = gen_core::imageops::outpaint_border_mask(src_w, src_h, width, height);
             if non_empty(&request.mask_asset_id) {
@@ -347,7 +280,7 @@ async fn generate_candle_sdxl_edit_stream(
                     mask_id,
                     project_path,
                 )?;
-                let user_mask = sdxl_edit_fit_image(user_mask, width, height, "pad")?;
+                let user_mask = fit_engine_image(user_mask, width, height, "pad")?;
                 mask = gen_core::imageops::union_masks(&mask, &user_mask).map_err(|error| {
                     WorkerError::Engine(format!("SDXL outpaint mask union failed: {error}"))
                 })?;

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -4043,10 +4043,18 @@ fn character_image_likeness_source_gates_to_plain_with_character() {
 #[cfg(target_os = "macos")]
 #[test]
 fn contain_box_centers_the_contained_rect() {
+    // `fit_rgb`'s pad arm now rides the engine's `contain_box` (sc-8824), the same geometry the
+    // outpaint mask uses — so assert against it directly (i32 offsets).
     // Wide source contained in a square: full width, centered vertically.
-    assert_eq!(contain_box(100, 50, 50, 50), (50, 25, 0, 12));
+    assert_eq!(
+        gen_core::imageops::contain_box(100, 50, 50, 50),
+        (50, 25, 0, 12)
+    );
     // Tall source: full height, centered horizontally.
-    assert_eq!(contain_box(50, 100, 50, 50), (25, 50, 12, 0));
+    assert_eq!(
+        gen_core::imageops::contain_box(50, 100, 50, 50),
+        (25, 50, 12, 0)
+    );
 }
 
 #[cfg(target_os = "macos")]
@@ -4076,6 +4084,60 @@ fn fit_rgb_crop_pad_stretch_produce_exact_dims_and_geometry() {
     // stretch → exact target dims (aspect not preserved).
     let stretched = fit_rgb(&source, 40, 30, "stretch");
     assert_eq!((stretched.width(), stretched.height()), (40, 30));
+}
+
+/// sc-8824: the whole point of sharing the fit geometry is that the letterboxed source (`fit_rgb`
+/// pad/outpaint arm) and the outpaint mask's keep-region use the SAME `gen_core::imageops::contain_box`,
+/// so the kept rect and the mask's keep rect are pixel-identical. This runs on BOTH the macOS and
+/// candle lanes (both compile `fit_rgb` + the shared geometry) — it's the divergence guard: were
+/// `fit_rgb` to round differently from the mask (the old local f32 `.round()` copy could, at an exact
+/// `.5`), the black-content rect below would drift off the mask's keep rect and this would fail.
+#[cfg(any(target_os = "macos", feature = "backend-candle"))]
+#[test]
+fn fit_pad_content_rect_matches_outpaint_mask_keep_rect() {
+    // Odd dims + aspect ratios that stress rounding (incl. a `.5`-boundary contain, e.g. 101→…).
+    let cases: &[(u32, u32, u32, u32)] = &[
+        (100, 50, 50, 50),   // wide → vertical bars
+        (50, 100, 50, 50),   // tall → horizontal bars
+        (101, 37, 64, 64),   // odd source into a square
+        (33, 100, 71, 40),   // odd everything, non-square target
+        (3, 2, 1024, 1024),  // extreme upscale (large `.round()` surface)
+        (1024, 768, 91, 91), // downscale into a small odd square
+    ];
+    for &(src_w, src_h, w, h) in cases {
+        // The mask's keep rect (black pixels) is driven by the engine's `contain_box`.
+        let (new_w, new_h, left, top) = gen_core::imageops::contain_box(src_w, src_h, w, h);
+        // Fit a solid-white source: the letterboxed content lands exactly on the contained rect,
+        // everything else is the black canvas.
+        let source = image::RgbImage::from_pixel(src_w, src_h, image::Rgb([255, 255, 255]));
+        let padded = fit_rgb(&source, w, h, "outpaint");
+        assert_eq!((padded.width(), padded.height()), (w, h));
+        // Every pixel INSIDE the contained rect is white (kept content); every pixel OUTSIDE is
+        // black (the regenerate border). If fit and `contain_box` disagreed by a pixel, an edge
+        // row/col would flip color and this would fail — that's the drift the dedup removes.
+        for y in 0..h as i32 {
+            for x in 0..w as i32 {
+                let inside =
+                    x >= left && x < left + new_w as i32 && y >= top && y < top + new_h as i32;
+                let px = padded.get_pixel(x as u32, y as u32);
+                if inside {
+                    assert_ne!(
+                        px,
+                        &image::Rgb([0, 0, 0]),
+                        "kept-rect pixel ({x},{y}) is black for {src_w}x{src_h}->{w}x{h} \
+                         (fit vs mask contain_box drift)"
+                    );
+                } else {
+                    assert_eq!(
+                        px,
+                        &image::Rgb([0, 0, 0]),
+                        "border pixel ({x},{y}) is not black for {src_w}x{src_h}->{w}x{h} \
+                         (fit vs mask contain_box drift)"
+                    );
+                }
+            }
+        }
+    }
 }
 
 // --- Qwen-Image-Edit path (sc-3397) ---

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -4095,13 +4095,21 @@ fn fit_rgb_crop_pad_stretch_produce_exact_dims_and_geometry() {
 #[cfg(any(target_os = "macos", feature = "backend-candle"))]
 #[test]
 fn fit_pad_content_rect_matches_outpaint_mask_keep_rect() {
-    // Odd dims + aspect ratios that stress rounding (incl. a `.5`-boundary contain, e.g. 101→…).
+    // Odd dims + aspect ratios that stress rounding. The FIRST case is the divergence guard: it
+    // lands the contained width on an EXACT half — `(1,4,50,50)` → ratio `min(50/1, 50/4) = 12.5`,
+    // so `new_w = 1*12.5 = 12.5`. `contain_box`'s round-half-to-even (floor 12 is even) yields
+    // `new_w = 12` (`left = 19`), whereas the OLD local f32 `.round()` (half-away-from-zero) yields
+    // `new_w = 13` (`left = 18`). Those disagree by a whole column, so the white kept-rect below
+    // would land off the mask's keep rect and this test would FAIL if the old rounding came back —
+    // that's the drift the dedup fixes, and none of the other cases below actually hit it (they all
+    // round identically under both rules). `new_h = 4*12.5 = 50.0` is exact (no bar on that axis).
     let cases: &[(u32, u32, u32, u32)] = &[
-        (100, 50, 50, 50),   // wide → vertical bars
-        (50, 100, 50, 50),   // tall → horizontal bars
-        (101, 37, 64, 64),   // odd source into a square
-        (33, 100, 71, 40),   // odd everything, non-square target
-        (3, 2, 1024, 1024),  // extreme upscale (large `.round()` surface)
+        (1, 4, 50, 50),     // EXACT `.5` contain: half-even (12) vs old half-away (13) DIVERGE
+        (100, 50, 50, 50),  // wide → vertical bars
+        (50, 100, 50, 50),  // tall → horizontal bars
+        (101, 37, 64, 64),  // odd source into a square
+        (33, 100, 71, 40),  // odd everything, non-square target
+        (3, 2, 1024, 1024), // extreme upscale (large `.round()` surface)
         (1024, 768, 91, 91), // downscale into a small odd square
     ];
     for &(src_w, src_h, w, h) in cases {


### PR DESCRIPTION
## What & why

**sc-8824 [F-022]** — the candle SDXL-edit and FLUX.2-edit lanes each reimplemented the shared fit/letterbox geometry, and the copies had drifted in a way that risks a **1px fit-vs-mask misalignment on outpaint edges**.

`base.rs` `fit_rgb`'s pad/outpaint arm used a **local** `contain_box`:
- ratio + rounding in **f32**, `round()` = half-away-from-zero
- integer-divided **u32** offsets

The per-lane twins (`sdxl_edit_fit_rgb`/`_image`, `flux2_edit_fit_rgb`/`_image`, `sdxl_edit_outpaint_canvas`) already used **`gen_core::imageops::contain_box`**:
- ratio + rounding in **f64**, `round_half_even` (matches Python `round`)
- **i32** offsets (no u32 underflow)

The outpaint mask (`gen_core::imageops::outpaint_border_mask`) **also** calls the engine's `contain_box` internally. So `base.rs`'s local copy could disagree with the mask by a pixel at an exact `.5` boundary — the letterboxed kept-rect drifting off the mask's keep-rect.

## The contain_box convergence (which rounding was kept, and why)

Converged **all three** on **`gen_core::imageops::contain_box`** — the round-half-to-even / f64 / i32-offset one — as the single source of truth:

- It is the **same** `contain_box` the outpaint mask uses, so fit + mask are now guaranteed pixel-identical (the whole point of the dedup).
- gen_core's own doc comment names half-to-even "for pixel-geometry parity with the worker's `_contain_box`" and matches Python `round` — i.e. it is the intended/reference rounding; the worker's local f32 `.round()` copy was the drifted one.

## Changes
- `base.rs`: delete the local `contain_box`; `fit_rgb`'s pad/outpaint arm now calls `gen_core::imageops::contain_box`.
- `sdxl_edit_candle.rs`: delete `sdxl_edit_fit_rgb`/`sdxl_edit_fit_image`/`sdxl_edit_outpaint_canvas`; route all fit calls through the shared `fit_engine_image`; the outpaint canvas is `fit_engine_image(.., "outpaint")` (same contain + black-canvas composite).
- `flux2_edit_candle.rs`: delete `flux2_edit_fit_rgb`/`flux2_edit_fit_image`; route through `fit_engine_image` — exactly as `zimage_edit_candle.rs` already does.

Net −52 lines; three implementations collapse to one.

## Tests (added first)
- `contain_box_centers_the_contained_rect` repointed at `gen_core::imageops::contain_box` (i32 offsets).
- **New** `fit_pad_content_rect_matches_outpaint_mask_keep_rect` — a both-lane (`macos` + `backend-candle`) characterization test over odd dims and rounding-sensitive aspect ratios (`101x37`, `33x100`, `3x2→1024`, …). Fits a solid-white source and asserts the letterboxed content rect is **pixel-identical** to the outpaint mask's keep rect. Would fail on any fit-vs-mask `contain_box` divergence.

## Verification
- `cargo test -p sceneworks-worker` → 496 passed, 0 failed (macOS)
- `cargo test -p sceneworks-worker --no-default-features -F backend-candle` → 496 passed, 0 failed
- `cargo check -p sceneworks-worker --no-default-features --features backend-candle --all-targets` → clean
- `npm run rust:check` (fmt + clippy -D warnings + test + build) → clean
- `check-gen-core-skew.sh --features backend-candle` → one gen-core rev (no pin change)

Story: https://app.shortcut.com/trefry/story/8824

🤖 Generated with [Claude Code](https://claude.com/claude-code)