### PR TITLE
refactor(web): single assetMatchesCharacter predicate with superset semantics (sc-8857)

### DIFF
--- a/apps/web/src/characterMembership.js
+++ b/apps/web/src/characterMembership.js
@@ -1,0 +1,46 @@
+// Single source of truth for the "does this asset belong to this character?"
+// predicate (sc-8857). Previously this logic was triplicated across the
+// Image-Edit source picker (AssetPicker), the dataset add dialog
+// (DatasetAddDialog), and the asset detail-panel linker (assetPanels) — and the
+// copies had already drifted: only AssetPicker consulted `approvedReferences`,
+// so an asset promoted to a character's *approved* reference list (a stronger
+// membership signal than a plain reference) matched in the picker but silently
+// failed to match in the other two surfaces.
+//
+// An asset belongs to a character when ANY of the following hold:
+//   - it was generated for the character (recipe.normalizedSettings.characterId),
+//   - it was generated referencing the character
+//     (metadata.characterReferences[].characterId), or
+//   - it is in the character's approved-reference OR reference list.
+//
+// The membership-list check is a superset: `approvedReferences` ∪ `references`.
+// A reference entry may be shaped `{ assetId }` or `{ id }`, so both are honored.
+
+// The set of asset ids the character explicitly references, unioning the
+// approved-reference and plain-reference lists.
+export function characterAssetIds(character) {
+  return new Set(
+    [
+      ...(character?.approvedReferences ?? []),
+      ...(character?.references ?? []),
+    ]
+      .map((reference) => reference?.assetId ?? reference?.id)
+      .filter(Boolean),
+  );
+}
+
+// True when `asset` belongs to the character identified by `characterId`.
+// `character` (optional) supplies the reference lists for the membership-list
+// check; without it, only the recipe/metadata signals are consulted.
+export function assetMatchesCharacter(asset, characterId, character = null) {
+  if (!characterId) {
+    return false;
+  }
+  if (asset?.recipe?.normalizedSettings?.characterId === characterId) {
+    return true;
+  }
+  if ((asset?.metadata?.characterReferences ?? []).some((reference) => reference?.characterId === characterId)) {
+    return true;
+  }
+  return Boolean(asset?.id) && characterAssetIds(character).has(asset.id);
+}

--- a/apps/web/src/characterMembership.test.js
+++ b/apps/web/src/characterMembership.test.js
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { assetMatchesCharacter, characterAssetIds } from "./characterMembership.js";
+
+const CHARACTER_ID = "char_1";
+
+// A character whose approved-reference list and plain-reference list point at
+// distinct assets, so tests can prove the predicate consults BOTH (superset).
+const CHARACTER = {
+  id: CHARACTER_ID,
+  approvedReferences: [{ assetId: "asset_approved" }],
+  references: [{ assetId: "asset_reference" }, { id: "asset_reference_alt_shape" }],
+};
+
+describe("assetMatchesCharacter", () => {
+  it("matches an asset only in approvedReferences (superset semantics)", () => {
+    expect(assetMatchesCharacter({ id: "asset_approved" }, CHARACTER_ID, CHARACTER)).toBe(true);
+  });
+
+  it("matches an asset only in references", () => {
+    expect(assetMatchesCharacter({ id: "asset_reference" }, CHARACTER_ID, CHARACTER)).toBe(true);
+  });
+
+  it("honors both { assetId } and { id } reference shapes", () => {
+    expect(assetMatchesCharacter({ id: "asset_reference_alt_shape" }, CHARACTER_ID, CHARACTER)).toBe(true);
+  });
+
+  it("matches via recipe.normalizedSettings.characterId without any reference list", () => {
+    const asset = { id: "asset_recipe", recipe: { normalizedSettings: { characterId: CHARACTER_ID } } };
+    expect(assetMatchesCharacter(asset, CHARACTER_ID, null)).toBe(true);
+  });
+
+  it("matches via metadata.characterReferences[].characterId without any reference list", () => {
+    const asset = { id: "asset_meta", metadata: { characterReferences: [{ characterId: CHARACTER_ID }] } };
+    expect(assetMatchesCharacter(asset, CHARACTER_ID, null)).toBe(true);
+  });
+
+  it("rejects a non-member asset", () => {
+    expect(assetMatchesCharacter({ id: "asset_other" }, CHARACTER_ID, CHARACTER)).toBe(false);
+  });
+
+  it("rejects when characterId is missing", () => {
+    expect(assetMatchesCharacter({ id: "asset_approved" }, "", CHARACTER)).toBe(false);
+    expect(assetMatchesCharacter({ id: "asset_approved" }, undefined, CHARACTER)).toBe(false);
+  });
+
+  it("does not match a list entry when the asset has no id", () => {
+    // A reference-less asset must not accidentally match via `undefined === undefined`.
+    expect(assetMatchesCharacter({}, CHARACTER_ID, CHARACTER)).toBe(false);
+  });
+
+  it("does not match a different character's recipe/metadata", () => {
+    const asset = {
+      id: "asset_other_char",
+      recipe: { normalizedSettings: { characterId: "char_2" } },
+      metadata: { characterReferences: [{ characterId: "char_2" }] },
+    };
+    expect(assetMatchesCharacter(asset, CHARACTER_ID, CHARACTER)).toBe(false);
+  });
+});
+
+describe("characterAssetIds", () => {
+  it("unions approvedReferences and references and drops empty ids", () => {
+    const ids = characterAssetIds({
+      approvedReferences: [{ assetId: "a" }, { id: "b" }, {}],
+      references: [{ assetId: "c" }],
+    });
+    expect(ids).toEqual(new Set(["a", "b", "c"]));
+  });
+
+  it("tolerates a null/undefined character", () => {
+    expect(characterAssetIds(null)).toEqual(new Set());
+    expect(characterAssetIds(undefined)).toEqual(new Set());
+  });
+});

--- a/apps/web/src/components/AssetPicker.jsx
+++ b/apps/web/src/components/AssetPicker.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { AssetThumbnail, assetCanRenderAsImage, assetCanRenderAsVideo } from "./assetMedia.jsx";
+import { assetMatchesCharacter } from "../characterMembership.js";
 import { Modal } from "./Modal.jsx";
 
 const categoryOptions = [
@@ -151,30 +152,6 @@ function activeProjectVideoAsset(asset, projectId) {
     !asset?.status?.trashed &&
     !asset?.status?.rejected
   );
-}
-
-function characterAssetIds(character) {
-  return new Set(
-    [
-      ...(character?.approvedReferences ?? []),
-      ...(character?.references ?? []),
-    ]
-      .map((reference) => reference?.assetId ?? reference?.id)
-      .filter(Boolean),
-  );
-}
-
-function assetMatchesCharacter(asset, characterId, character) {
-  if (!characterId) {
-    return false;
-  }
-  if (asset?.recipe?.normalizedSettings?.characterId === characterId) {
-    return true;
-  }
-  if ((asset?.metadata?.characterReferences ?? []).some((reference) => reference?.characterId === characterId)) {
-    return true;
-  }
-  return characterAssetIds(character).has(asset?.id);
 }
 
 function filterPickerAssets(assets, query, searchIndex) {

--- a/apps/web/src/components/DatasetAddDialog.character.test.jsx
+++ b/apps/web/src/components/DatasetAddDialog.character.test.jsx
@@ -1,0 +1,79 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DatasetAddDialog } from "./DatasetAddDialog.jsx";
+
+// sc-8857 regression: the Character tab must surface an asset that is only in a
+// character's `approvedReferences` list (not its plain `references`). Before the
+// shared `assetMatchesCharacter` predicate, this dialog checked `references`
+// only, so approved-reference-only assets silently failed to appear here even
+// though the Image-Edit source picker matched them.
+
+const approvedOnlyAsset = {
+  id: "asset-approved",
+  projectId: "project-1",
+  displayName: "Approved Reference",
+  type: "image",
+  status: {},
+  file: { path: "assets/images/approved.png", mimeType: "image/png" },
+};
+const nonMemberAsset = {
+  id: "asset-other",
+  projectId: "project-1",
+  displayName: "Unrelated",
+  type: "image",
+  status: {},
+  file: { path: "assets/images/other.png", mimeType: "image/png" },
+};
+
+const character = {
+  id: "char-1",
+  name: "Mira",
+  approvedReferences: [{ assetId: "asset-approved" }],
+  references: [],
+};
+
+let container;
+let root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+function characterCards() {
+  return [...document.body.querySelectorAll(".dataset-add-card span")].map((el) => el.textContent);
+}
+
+describe("DatasetAddDialog Character tab (sc-8857)", () => {
+  it("surfaces an approvedReferences-only asset and hides non-members", () => {
+    act(() => {
+      root.render(
+        <DatasetAddDialog
+          assets={[approvedOnlyAsset, nonMemberAsset]}
+          characters={[character]}
+          onAdd={vi.fn()}
+          onClose={vi.fn()}
+          onImport={vi.fn()}
+        />,
+      );
+    });
+
+    // Switch to the Character source tab.
+    const characterTab = [...document.body.querySelectorAll('[role="tab"]')].find(
+      (tab) => tab.textContent === "Character",
+    );
+    act(() => characterTab.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+
+    const cards = characterCards();
+    expect(cards).toContain("Approved Reference");
+    expect(cards).not.toContain("Unrelated");
+  });
+});

--- a/apps/web/src/components/DatasetAddDialog.jsx
+++ b/apps/web/src/components/DatasetAddDialog.jsx
@@ -1,24 +1,8 @@
 import React, { useMemo, useState } from "react";
 import { isLibraryAsset } from "../constants.js";
+import { assetMatchesCharacter } from "../characterMembership.js";
 import { AssetThumbnail, assetCanRenderAsImage } from "./assetMedia.jsx";
 import { Modal } from "./Modal.jsx";
-
-// An asset belongs to a character when it was generated in association with it
-// (recipe.normalizedSettings.characterId) or generated referencing it
-// (metadata.characterReferences[].characterId). Mirrors the per-character
-// gallery filter so the Character tab surfaces the same images.
-export function assetMatchesCharacter(asset, characterId, character = null) {
-  if (!characterId) {
-    return false;
-  }
-  if (asset?.recipe?.normalizedSettings?.characterId === characterId) {
-    return true;
-  }
-  if ((asset?.metadata?.characterReferences ?? []).some((reference) => reference?.characterId === characterId)) {
-    return true;
-  }
-  return (character?.references ?? []).some((reference) => (reference?.assetId ?? reference?.id) === asset?.id);
-}
 
 function assetTitle(asset) {
   return asset?.displayName ?? asset?.title ?? asset?.name ?? asset?.id ?? "Untitled asset";

--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { isAbortError } from "../api.js";
+import { assetMatchesCharacter } from "../characterMembership.js";
 import { saveAssetAs, revealAsset } from "../assetActions.js";
 import { isDesktop } from "../runtime.js";
 import { AssetMedia, assetCanRenderAsVideo, assetUrl, suppressThumbnailContextMenu } from "./assetMedia.jsx";
@@ -209,20 +210,6 @@ export function assetSupportsCharacterLink(asset) {
   );
 }
 
-function assetLinkedToCharacter(asset, character) {
-  const characterId = character?.id;
-  if (!asset?.id || !characterId) {
-    return false;
-  }
-  if (asset.recipe?.normalizedSettings?.characterId === characterId) {
-    return true;
-  }
-  if ((asset.metadata?.characterReferences ?? []).some((reference) => reference?.characterId === characterId)) {
-    return true;
-  }
-  return (character.references ?? []).some((reference) => (reference?.assetId ?? reference?.id) === asset.id);
-}
-
 function CharacterAssetLinker({ asset, characters = [], onMoveToCharacter }) {
   const availableCharacters = React.useMemo(
     () => characters.filter((character) => !character?.archived),
@@ -248,7 +235,7 @@ function CharacterAssetLinker({ asset, characters = [], onMoveToCharacter }) {
   }
 
   const selectedCharacter = availableCharacters.find((character) => character.id === characterId) ?? null;
-  const alreadyLinked = assetLinkedToCharacter(asset, selectedCharacter);
+  const alreadyLinked = assetMatchesCharacter(asset, selectedCharacter?.id, selectedCharacter);
 
   async function submit(event) {
     event.preventDefault();

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -11,7 +11,7 @@ import {
   editableLora,
 } from "./characterPanels.jsx";
 import { CompactSelector } from "../components/CompactSelector.jsx";
-import { assetMatchesCharacter } from "../components/DatasetAddDialog.jsx";
+import { assetMatchesCharacter } from "../characterMembership.js";
 import { extractFamilies } from "../presetUtils.js";
 import { loadStudioSettings, useStudioSettingsWriter } from "../hooks/useStudioSettings.js";
 import { useAppContext } from "../context/AppContext.js";


### PR DESCRIPTION
## Summary

`[F-055]` — the "does this asset belong to this character?" predicate was **triplicated** across `AssetPicker.jsx`, `DatasetAddDialog.jsx`, and `assetPanels.jsx`, and the copies had **already drifted**:

- `AssetPicker` checked `approvedReferences` **and** `references` (superset).
- `DatasetAddDialog` and `assetPanels` checked **only** `references`.

The recipe/metadata membership signals were byte-identical in all three.

### Impact of the drift (the bug)
An asset present only in a character's `approvedReferences` list matched in the Image-Edit source picker but **silently failed to match** in the dataset add dialog and the asset detail-panel linker. An approved reference is a *stronger* membership signal than a plain reference, so it should match everywhere.

### Fix
- New `apps/web/src/characterMembership.js` exports one `assetMatchesCharacter(asset, characterId, character)` with **superset semantics**: matches if the asset is in `approvedReferences` ∪ `references`, or via `recipe.normalizedSettings.characterId`, or via `metadata.characterReferences[].characterId`.
- Imported in all three sites (`AssetPicker`, `DatasetAddDialog`, `assetPanels`) plus `CharacterStudio` (which imported the old export), deleting the local copies.

### Behavior change (intended, per finding)
**The dataset add dialog and the detail-panel character linker now correctly match `approvedReferences`-only assets** — previously they missed them. This aligns all three surfaces with the picker.

## Tests
- `src/characterMembership.test.js` — approvedReferences-only, references-only, both `{ assetId }`/`{ id }` shapes, recipe-matched, metadata-matched all match; non-member, missing `characterId`, and id-less asset all rejected; `characterAssetIds` unions both lists.
- `src/components/DatasetAddDialog.character.test.jsx` — consumer-level regression: an `approvedReferences`-only asset now appears in the Character tab, non-members do not.
- Full web suite green: **64 files / 1052 tests pass**. ESLint: 0 errors (pre-existing hook-deps warnings only, none in touched files).

Story: https://app.shortcut.com/trefry/story/8857

🤖 Generated with [Claude Code](https://claude.com/claude-code)