### PR TITLE
refactor(web): unify job-result-asset resolvers and upscale-engine table (sc-8853)

### DIFF
--- a/apps/web/src/jobResultAssets.js
+++ b/apps/web/src/jobResultAssets.js
@@ -1,0 +1,101 @@
+// Single source of truth for "resolve a job's produced asset records against the
+// live catalog" (sc-8853). Four near-identical copies had drifted across
+// ImageStudio (image, batch-slot ordered), VideoStudio (video), QueueScreen
+// (type-agnostic small-row) and characterPanels (image, catalog-only). Unifying
+// here keeps a worker result-contract change — batch-slot ordering, the
+// assetIds/assets/generationSetId fallbacks — a one-place edit.
+//
+// The resolution strategy: a job reports its outputs three ways, tried in order.
+//   1. `result.assetIds` — the worker emits these in batch-slot order, so the
+//      array order IS the review-slot order (preserve it verbatim).
+//   2. `result.assets` — the embedded asset records (used before the catalog has
+//      caught up); merged against the catalog so a saved record wins once known.
+//   3. `result.generationSetId` — every catalog asset tagged with the set. This
+//      is the streaming path (partial outputs surface as each image is saved) and
+//      is the only branch that needs an explicit batch-index sort, since the
+//      catalog is not inherently slot-ordered.
+
+// Best-effort batch-slot index for an asset, used to order the generationSetId
+// fallback back into worker-emitted slot order. Prefers explicit `batchIndex`
+// fields, then a `_NNNN` filename suffix, then a trailing `#N` in the display
+// name; unknown assets sort last (Infinity).
+export function assetBatchIndex(asset) {
+  const candidates = [
+    asset?.batchIndex,
+    asset?.recipe?.batchIndex,
+    asset?.recipe?.normalizedSettings?.batchIndex,
+    asset?.lineage?.batchIndex,
+  ];
+  for (const candidate of candidates) {
+    const value = Number(candidate);
+    if (Number.isFinite(value)) {
+      return value;
+    }
+  }
+  const basename = String(asset?.file?.path ?? "").split(/[\\/]/).pop() ?? "";
+  const fileMatch = basename.match(/_(\d{4})\.[^.]+$/);
+  if (fileMatch) {
+    return Number(fileMatch[1]) - 1;
+  }
+  const nameMatch = String(asset?.displayName ?? "").match(/#(\d+)\s*$/);
+  return nameMatch ? Number(nameMatch[1]) - 1 : Number.POSITIVE_INFINITY;
+}
+
+// Resolve a job's produced assets against the live `assets` catalog.
+//
+// Options (each call site opts into the behavior it historically had):
+//   - `type`             — only keep assets of this media type ("image" |
+//                          "video"). Omit for the type-agnostic queue small-row,
+//                          which shows whatever a job produced.
+//   - `sortByBatchIndex` — sort the `generationSetId` fallback into batch-slot
+//                          order. Only the image lane needs this; the assetIds
+//                          branch is already slot-ordered by the worker, so this
+//                          flag never applies there.
+//   - `mergeResultAssets`— consult `result.assets` and let an embedded record
+//                          stand in for a not-yet-catalogued asset. The image,
+//                          video and queue lanes do this; characterPanels reads
+//                          the catalog only (a partial-output stream where only
+//                          catalog membership matters), so it passes `false`.
+export function resolveJobResultAssets(job, assets, options = {}) {
+  const { type, sortByBatchIndex = false, mergeResultAssets = true } = options;
+  const list = Array.isArray(assets) ? assets : [];
+  if (!job?.result) return [];
+
+  const catalogById = new Map(list.map((asset) => [asset.id, asset]));
+  const ofType = (asset) => (type ? asset?.type === type : Boolean(asset));
+
+  if (mergeResultAssets) {
+    // An embedded record wins only until the catalog knows the id; a catalogued
+    // asset (fuller record) then takes over.
+    const resultAssets = (Array.isArray(job.result.assets) ? job.result.assets : []).filter((asset) =>
+      type ? asset?.type === type : true,
+    );
+    const resultById = new Map(resultAssets.map((asset) => [asset.id, catalogById.get(asset.id) ?? asset]));
+
+    const assetIds = job.result.assetIds ?? [];
+    if (assetIds.length) {
+      // assetIds already carry batch-slot order — never re-sort this branch.
+      return assetIds.map((id) => resultById.get(id) ?? catalogById.get(id)).filter(ofType);
+    }
+    if (resultAssets.length) {
+      return resultAssets.map((asset) => catalogById.get(asset.id) ?? asset);
+    }
+  } else {
+    // Catalog-only path (characterPanels): an id not yet in the catalog is
+    // dropped, so a parallel job's newer set never masks this job's partials.
+    const assetIds = job.result.assetIds ?? [];
+    if (assetIds.length) {
+      return assetIds.map((id) => catalogById.get(id)).filter(ofType);
+    }
+  }
+
+  if (job.result.generationSetId) {
+    const inSet = list.filter(
+      (asset) => ofType(asset) && asset.generationSetId === job.result.generationSetId,
+    );
+    return sortByBatchIndex
+      ? inSet.sort((left, right) => assetBatchIndex(left) - assetBatchIndex(right))
+      : inSet;
+  }
+  return [];
+}

--- a/apps/web/src/jobResultAssets.test.js
+++ b/apps/web/src/jobResultAssets.test.js
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "vitest";
+import { resolveJobResultAssets, assetBatchIndex } from "./jobResultAssets.js";
+
+// Characterization tests (sc-8853): these lock in the CURRENT behavior of the
+// four resolver copies this module replaces, proving the unification is
+// behavior-preserving per call site. The option combos map to the old helpers:
+//   ImageStudio.jobResultAssets      → { type:"image", sortByBatchIndex:true, mergeResultAssets:true }
+//   VideoStudio.jobVideoResultAssets → { type:"video", mergeResultAssets:true }
+//   QueueScreen.resolveJobAssets     → { mergeResultAssets:true } (type-agnostic)
+//   characterPanels.jobImageAssets   → { type:"image", mergeResultAssets:false }
+
+const imageOpts = { type: "image", sortByBatchIndex: true, mergeResultAssets: true };
+const videoOpts = { type: "video", mergeResultAssets: true };
+const queueOpts = { mergeResultAssets: true };
+const characterOpts = { type: "image", mergeResultAssets: false };
+
+function img(id, extra = {}) {
+  return { id, type: "image", ...extra };
+}
+function vid(id, extra = {}) {
+  return { id, type: "video", ...extra };
+}
+
+describe("resolveJobResultAssets — assetIds branch", () => {
+  it("preserves worker-emitted assetIds order (slot order), image lane", () => {
+    const catalog = [img("b"), img("a"), img("c")];
+    const job = { result: { assetIds: ["a", "b", "c"] } };
+    expect(resolveJobResultAssets(job, catalog, imageOpts).map((a) => a.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("does NOT re-sort assetIds even when sortByBatchIndex is on", () => {
+    // assetIds already carry slot order; a mismatched batchIndex must not reorder.
+    const catalog = [img("a", { batchIndex: 5 }), img("b", { batchIndex: 0 })];
+    const job = { result: { assetIds: ["a", "b"] } };
+    expect(resolveJobResultAssets(job, catalog, imageOpts).map((a) => a.id)).toEqual(["a", "b"]);
+  });
+
+  it("filters assetIds to the requested type (image)", () => {
+    const catalog = [img("a"), vid("v")];
+    const job = { result: { assetIds: ["a", "v"] } };
+    expect(resolveJobResultAssets(job, catalog, imageOpts).map((a) => a.id)).toEqual(["a"]);
+  });
+
+  it("video lane keeps only video assets", () => {
+    const catalog = [img("a"), vid("v")];
+    const job = { result: { assetIds: ["v", "a"] } };
+    expect(resolveJobResultAssets(job, catalog, videoOpts).map((a) => a.id)).toEqual(["v"]);
+  });
+
+  it("queue lane keeps any truthy asset (type-agnostic)", () => {
+    const catalog = [img("a"), vid("v")];
+    const job = { result: { assetIds: ["a", "v"] } };
+    expect(resolveJobResultAssets(job, catalog, queueOpts).map((a) => a.id)).toEqual(["a", "v"]);
+  });
+
+  it("merge lanes fall back to the embedded result record when not yet catalogued", () => {
+    const catalog = []; // catalog has not caught up
+    const job = { result: { assetIds: ["a"], assets: [img("a", { pending: true })] } };
+    const out = resolveJobResultAssets(job, catalog, imageOpts);
+    expect(out.map((a) => a.id)).toEqual(["a"]);
+    expect(out[0].pending).toBe(true);
+  });
+
+  it("catalog record wins over the embedded record once known (merge lanes)", () => {
+    const catalog = [img("a", { saved: true })];
+    const job = { result: { assetIds: ["a"], assets: [img("a", { pending: true })] } };
+    expect(resolveJobResultAssets(job, catalog, imageOpts)[0].saved).toBe(true);
+  });
+
+  it("character lane is catalog-only: a not-yet-catalogued id is dropped", () => {
+    const catalog = []; // no embedded-record fallback for characterPanels
+    const job = { result: { assetIds: ["a"], assets: [img("a")] } };
+    expect(resolveJobResultAssets(job, catalog, characterOpts)).toEqual([]);
+  });
+
+  it("character lane resolves catalogued ids", () => {
+    const catalog = [img("a"), vid("v")];
+    const job = { result: { assetIds: ["a", "v"] } };
+    expect(resolveJobResultAssets(job, catalog, characterOpts).map((a) => a.id)).toEqual(["a"]);
+  });
+});
+
+describe("resolveJobResultAssets — result.assets branch (merge lanes)", () => {
+  it("image lane maps embedded records through the catalog", () => {
+    const catalog = [img("a", { saved: true })];
+    const job = { result: { assets: [img("a"), img("b")] } };
+    const out = resolveJobResultAssets(job, catalog, imageOpts);
+    expect(out.map((a) => a.id)).toEqual(["a", "b"]);
+    expect(out[0].saved).toBe(true); // catalog record substituted
+  });
+
+  it("queue lane keeps embedded records of any type", () => {
+    const job = { result: { assets: [img("a"), vid("v")] } };
+    expect(resolveJobResultAssets(job, [], queueOpts).map((a) => a.id)).toEqual(["a", "v"]);
+  });
+
+  it("character lane never consults result.assets (returns [])", () => {
+    const job = { result: { assets: [img("a")] } };
+    expect(resolveJobResultAssets(job, [], characterOpts)).toEqual([]);
+  });
+});
+
+describe("resolveJobResultAssets — generationSetId branch", () => {
+  it("image lane sorts the set by batch index", () => {
+    const catalog = [
+      img("late", { generationSetId: "g1", batchIndex: 2 }),
+      img("first", { generationSetId: "g1", batchIndex: 0 }),
+      img("mid", { generationSetId: "g1", batchIndex: 1 }),
+      img("other", { generationSetId: "g2", batchIndex: 0 }),
+    ];
+    const job = { result: { generationSetId: "g1" } };
+    expect(resolveJobResultAssets(job, catalog, imageOpts).map((a) => a.id)).toEqual(["first", "mid", "late"]);
+  });
+
+  it("video lane does NOT sort the set (catalog order preserved)", () => {
+    const catalog = [
+      vid("b", { generationSetId: "g1", batchIndex: 2 }),
+      vid("a", { generationSetId: "g1", batchIndex: 0 }),
+    ];
+    const job = { result: { generationSetId: "g1" } };
+    expect(resolveJobResultAssets(job, catalog, videoOpts).map((a) => a.id)).toEqual(["b", "a"]);
+  });
+
+  it("queue lane keeps any type in the set, unsorted", () => {
+    const catalog = [
+      img("i", { generationSetId: "g1" }),
+      vid("v", { generationSetId: "g1" }),
+      img("x", { generationSetId: "g2" }),
+    ];
+    const job = { result: { generationSetId: "g1" } };
+    expect(resolveJobResultAssets(job, catalog, queueOpts).map((a) => a.id)).toEqual(["i", "v"]);
+  });
+
+  it("character lane filters the set to images, unsorted", () => {
+    const catalog = [
+      img("i", { generationSetId: "g1" }),
+      vid("v", { generationSetId: "g1" }),
+    ];
+    const job = { result: { generationSetId: "g1" } };
+    expect(resolveJobResultAssets(job, catalog, characterOpts).map((a) => a.id)).toEqual(["i"]);
+  });
+});
+
+describe("resolveJobResultAssets — empty / guard cases", () => {
+  it("returns [] when the job has no result", () => {
+    expect(resolveJobResultAssets({}, [img("a")], imageOpts)).toEqual([]);
+    expect(resolveJobResultAssets(null, [img("a")], queueOpts)).toEqual([]);
+  });
+
+  it("returns [] when a non-array catalog is passed", () => {
+    const job = { result: { generationSetId: "g1" } };
+    expect(resolveJobResultAssets(job, undefined, imageOpts)).toEqual([]);
+  });
+});
+
+describe("assetBatchIndex", () => {
+  it("prefers explicit batchIndex fields in order", () => {
+    expect(assetBatchIndex({ batchIndex: 3 })).toBe(3);
+    expect(assetBatchIndex({ recipe: { batchIndex: 4 } })).toBe(4);
+    expect(assetBatchIndex({ recipe: { normalizedSettings: { batchIndex: 5 } } })).toBe(5);
+    expect(assetBatchIndex({ lineage: { batchIndex: 6 } })).toBe(6);
+  });
+
+  it("falls back to a _NNNN filename suffix (0-based)", () => {
+    expect(assetBatchIndex({ file: { path: "/x/img_0003.png" } })).toBe(2);
+  });
+
+  it("falls back to a trailing #N in the display name (0-based)", () => {
+    expect(assetBatchIndex({ displayName: "Scene #4" })).toBe(3);
+  });
+
+  it("sorts unknown assets last", () => {
+    expect(assetBatchIndex({})).toBe(Number.POSITIVE_INFINITY);
+  });
+});

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -4,7 +4,7 @@ import { Stage, Layer, Image as KonvaImage, Line, Rect, Transformer } from "reac
 import { apiFetch } from "../api.js";
 import { terminalStatuses } from "../jobTypes.js";
 import { useAppContext } from "../context/AppContext.js";
-import { DEFAULT_MAC_CAPABILITIES, macFeatureBlock, macUpscaleEngineBlocked } from "../macGating.js";
+import { DEFAULT_MAC_CAPABILITIES, macFeatureBlock } from "../macGating.js";
 import { assetUrl, assetCanRenderAsImage } from "../components/assetMedia.jsx";
 import { DatasetAddDialog } from "../components/DatasetAddDialog.jsx";
 import { FitModeControl, effectiveFitMode } from "../components/FitModeControl.jsx";
@@ -54,10 +54,13 @@ import {
   buildUpscaleJobBody,
   detailCapableModels,
   editCapableModels,
-  UPSCALE_ENGINES,
   upscaleEngineHasSoftness,
   upscaleFactorsForEngine,
 } from "../imageJobs.js";
+import {
+  availableUpscaleEngines as upscaleEnginesForPlatform,
+  useUpscaleEngineFallback,
+} from "../upscaleEngines.js";
 
 export {
   buildDetailJobBody,
@@ -846,19 +849,17 @@ export function ImageEditor() {
   // SeedVR2 detail/softness knob (0..1, sc-4815) — only meaningful for the seedvr2 engine.
   const [upscaleSoftness, setUpscaleSoftness] = useState(0);
   // Engines offered in the picker; AuraSR is dropped on every platform (sc-3668 / sc-5499).
-  const availableUpscaleEngines = UPSCALE_ENGINES.filter(
-    (entry) => !macUpscaleEngineBlocked(macCapabilities, entry.key),
-  );
+  const availableUpscaleEngines = upscaleEnginesForPlatform(macCapabilities);
   // If the selected engine got gated out (e.g. a stale saved AuraSR selection), fall back to the
-  // default real-esrgan engine (the guaranteed-available cross-platform upscaler) so the tool stays usable.
-  useEffect(() => {
-    if (macUpscaleEngineBlocked(macCapabilities, upscaleEngine)) {
-      setUpscaleEngine("real-esrgan");
-      if (!upscaleFactorsForEngine("real-esrgan").includes(upscaleFactor)) {
-        setUpscaleFactor(upscaleFactorsForEngine("real-esrgan")[0]);
-      }
-    }
-  }, [macCapabilities, upscaleEngine, upscaleFactor]);
+  // default real-esrgan engine (the guaranteed-available cross-platform upscaler) so the tool stays
+  // usable. Shared with ImageStudio via the single fallback hook (sc-8853).
+  useUpscaleEngineFallback({
+    macCapabilities,
+    upscaleEngine,
+    setUpscaleEngine,
+    upscaleFactor,
+    setUpscaleFactor,
+  });
 
   // Color grade (sc-2439): non-destructive −1..1 adjustments previewed live via a
   // Konva filter, baked into the working image on Apply.

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -118,9 +118,15 @@ import {
   macBlockedModels,
   macGatingActive,
   macModelFeatureBlock,
-  macUpscaleEngineBlocked,
 } from "../macGating.js";
 import { loadStudioSettings, useStudioSettingsWriter } from "../hooks/useStudioSettings.js";
+import { resolveJobResultAssets } from "../jobResultAssets.js";
+import {
+  availableUpscaleEngines as upscaleEnginesForPlatform,
+  upscaleEngineHasSoftness,
+  upscaleFactorsForEngine,
+  useUpscaleEngineFallback,
+} from "../upscaleEngines.js";
 import { FitModeControl, effectiveFitMode } from "../components/FitModeControl.jsx";
 import {
   GUIDANCE_METHOD_LABELS,
@@ -155,20 +161,6 @@ function preferredResolution(model, options) {
     : options.includes("1024x1024")
       ? "1024x1024"
       : options[0];
-}
-
-const UPSCALE_ENGINES = [
-  { id: "real-esrgan", label: "Real-ESRGAN", factors: [2, 4] },
-  // SeedVR2: one-step diffusion upscaler (native MLX on Mac / candle off-Mac, epic 4811 / sc-5928 /
-  // sc-5160) with a detail/softness control; shown on every GPU platform via imageUpscaleSeedvr2.
-  { id: "seedvr2", label: "SeedVR2", factors: [2, 4], softness: true },
-  // AuraSR is kept only for graceful fallback of a stale saved selection — hidden on every platform
-  // (dropped, sc-3668 / sc-5499) via macUpscaleEngineBlocked.
-  { id: "aura-sr", label: "AuraSR", factors: [4] },
-];
-
-function upscaleEngineHasSoftness(engineId) {
-  return Boolean(UPSCALE_ENGINES.find((engine) => engine.id === engineId)?.softness);
 }
 
 function formatResolutionLabel(value) {
@@ -224,53 +216,15 @@ function recipeLoraWeight(lora) {
   return finiteRecipeNumber(lora?.weight) ?? undefined;
 }
 
+// Image Studio review slots: images in worker-emitted batch-slot order (sc-8853;
+// the generationSetId fallback is the only branch needing an explicit sort).
 function jobResultAssets(job, assets) {
-  const catalogById = new Map(assets.map((asset) => [asset.id, asset]));
-  const resultAssets = (job.result?.assets ?? []).filter((asset) => asset?.type === "image");
-  const resultById = new Map(resultAssets.map((asset) => [asset.id, catalogById.get(asset.id) ?? asset]));
-  const assetIds = job.result?.assetIds ?? [];
-  if (assetIds.length) {
-    // The worker emits assetIds in batch-slot order, so preserve this array order when filling review slots.
-    return assetIds
-      .map((id) => resultById.get(id) ?? catalogById.get(id))
-      .filter((asset) => asset?.type === "image");
-  }
-  if (resultAssets.length) {
-    return resultAssets.map((asset) => catalogById.get(asset.id) ?? asset);
-  }
-  if (job.result?.generationSetId) {
-    return assets
-      .filter((asset) => asset.type === "image" && asset.generationSetId === job.result.generationSetId)
-      .sort((left, right) => assetBatchIndex(left) - assetBatchIndex(right));
-  }
-  return [];
+  return resolveJobResultAssets(job, assets, { type: "image", sortByBatchIndex: true });
 }
 
 function jobExpectedCount(job, completedCount) {
   const expected = Number(job.result?.expectedCount ?? job.result?.count ?? job.payload?.count);
   return Number.isFinite(expected) && expected > 0 ? Math.max(expected, completedCount) : completedCount;
-}
-
-function assetBatchIndex(asset) {
-  const candidates = [
-    asset?.batchIndex,
-    asset?.recipe?.batchIndex,
-    asset?.recipe?.normalizedSettings?.batchIndex,
-    asset?.lineage?.batchIndex,
-  ];
-  for (const candidate of candidates) {
-    const value = Number(candidate);
-    if (Number.isFinite(value)) {
-      return value;
-    }
-  }
-  const basename = String(asset?.file?.path ?? "").split(/[\\/]/).pop() ?? "";
-  const fileMatch = basename.match(/_(\d{4})\.[^.]+$/);
-  if (fileMatch) {
-    return Number(fileMatch[1]) - 1;
-  }
-  const nameMatch = String(asset?.displayName ?? "").match(/#(\d+)\s*$/);
-  return nameMatch ? Number(nameMatch[1]) - 1 : Number.POSITIVE_INFINITY;
 }
 
 export function ImageStudio() {
@@ -524,24 +478,23 @@ export function ImageStudio() {
 
   function handleUpscaleEngineChange(nextEngine) {
     setUpscaleEngine(nextEngine);
-    const option = UPSCALE_ENGINES.find((candidate) => candidate.id === nextEngine);
-    if (option && !option.factors.includes(upscaleFactor)) {
-      setUpscaleFactor(option.factors[0]);
+    const factors = upscaleFactorsForEngine(nextEngine);
+    if (!factors.includes(upscaleFactor)) {
+      setUpscaleFactor(factors[0]);
     }
   }
 
   // Engines offered in the picker; AuraSR is dropped on every platform (sc-3668 / sc-5499).
-  const availableUpscaleEngines = UPSCALE_ENGINES.filter(
-    (engine) => !macUpscaleEngineBlocked(macCapabilities, engine.id),
-  );
+  const availableUpscaleEngines = upscaleEnginesForPlatform(macCapabilities);
   // If a restored/saved engine is gated out (e.g. a stale saved AuraSR selection), fall back to the
-  // default real-esrgan engine so the user never submits an aura-sr job the native workers refuse.
-  useEffect(() => {
-    if (!macUpscaleEngineBlocked(macCapabilities, upscaleEngine)) return;
-    setUpscaleEngine("real-esrgan");
-    const factors = UPSCALE_ENGINES.find((engine) => engine.id === "real-esrgan")?.factors ?? [2, 4];
-    if (!factors.includes(upscaleFactor)) setUpscaleFactor(factors[0]);
-  }, [macCapabilities, upscaleEngine, upscaleFactor]);
+  // default real-esrgan engine so the user never submits an aura-sr job the native workers refuse (sc-8853).
+  useUpscaleEngineFallback({
+    macCapabilities,
+    upscaleEngine,
+    setUpscaleEngine,
+    upscaleFactor,
+    setUpscaleFactor,
+  });
 
   useEffect(() => {
     if (mode === "edit_image" && selectedAssetEditableSourceId) {
@@ -2331,7 +2284,7 @@ export function ImageStudio() {
                 <label>
                   Scale
                   <select disabled={!upscaleEnabled} onChange={(event) => setUpscaleFactor(Number(event.target.value))} value={upscaleFactor}>
-                    {(UPSCALE_ENGINES.find((engine) => engine.id === upscaleEngine)?.factors ?? [2, 4]).map((factor) => (
+                    {upscaleFactorsForEngine(upscaleEngine).map((factor) => (
                       <option key={factor} value={factor}>
                         {factor}x
                       </option>
@@ -2342,7 +2295,7 @@ export function ImageStudio() {
                   Engine
                   <select disabled={!upscaleEnabled} onChange={(event) => handleUpscaleEngineChange(event.target.value)} value={upscaleEngine}>
                     {availableUpscaleEngines.map((engine) => (
-                      <option key={engine.id} value={engine.id}>
+                      <option key={engine.key} value={engine.key}>
                         {engine.label}
                       </option>
                     ))}

--- a/apps/web/src/screens/QueueScreen.jsx
+++ b/apps/web/src/screens/QueueScreen.jsx
@@ -3,6 +3,7 @@ import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
 import { terminalStatuses } from "../constants.js";
 import { GPU_REQUIRED_JOB_TYPES, NON_GPU_JOB_TYPES } from "../jobTypes.js";
 import { useAppContext } from "../context/AppContext.js";
+import { resolveJobResultAssets } from "../jobResultAssets.js";
 
 function formatJobType(type) {
   return String(type ?? "job").replaceAll("_", " ");
@@ -302,22 +303,8 @@ function thumbnailVariantForJob(job) {
 }
 
 // Resolve a job's produced asset records against the live catalog. Generic over
-// image/video so the queue's small-row works for both. Matches the resolution
-// strategy used by ImageStudio.jobResultAssets / VideoStudio.jobVideoResultAssets.
+// image/video so the queue's small-row works for both (sc-8853): type-agnostic
+// (no media-type filter), catalog order for the generationSetId fallback.
 function resolveJobAssets(job, assets) {
-  if (!job?.result) return [];
-  const catalogById = new Map((assets ?? []).map((asset) => [asset.id, asset]));
-  const resultAssets = Array.isArray(job.result.assets) ? job.result.assets : [];
-  const resultById = new Map(resultAssets.map((asset) => [asset.id, catalogById.get(asset.id) ?? asset]));
-  const assetIds = job.result.assetIds ?? [];
-  if (assetIds.length) {
-    return assetIds.map((id) => resultById.get(id) ?? catalogById.get(id)).filter(Boolean);
-  }
-  if (resultAssets.length) {
-    return resultAssets.map((asset) => catalogById.get(asset.id) ?? asset);
-  }
-  if (job.result.generationSetId) {
-    return (assets ?? []).filter((asset) => asset.generationSetId === job.result.generationSetId);
-  }
-  return [];
+  return resolveJobResultAssets(job, assets);
 }

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -9,6 +9,7 @@ import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
 import { PromptGuideModal } from "../components/PromptGuideModal.jsx";
 import { RefinePromptControl } from "../components/RefinePromptControl.jsx";
 import { VideoUpscalePanel } from "./VideoUpscalePanel.jsx";
+import { resolveJobResultAssets } from "../jobResultAssets.js";
 
 const MOTIONS = [
   "static",
@@ -44,22 +45,10 @@ function formatPlaybackTime(seconds) {
 
 // Resolve a video job's result assets against the live catalog so the
 // WorkerProgressCard video-player variant can play the finished clip (sc-2089).
-// Mirrors the image-side `jobResultAssets` helper in ImageStudio.jsx.
+// Shares the unified resolver (sc-8853); the video lane keeps the generationSetId
+// fallback in catalog order (no batch-slot sort — that is image-only).
 function jobVideoResultAssets(job, assets) {
-  const catalogById = new Map(assets.map((asset) => [asset.id, asset]));
-  const resultAssets = (job.result?.assets ?? []).filter((asset) => asset?.type === "video");
-  const resultById = new Map(resultAssets.map((asset) => [asset.id, catalogById.get(asset.id) ?? asset]));
-  const assetIds = job.result?.assetIds ?? [];
-  if (assetIds.length) {
-    return assetIds.map((id) => resultById.get(id) ?? catalogById.get(id)).filter((asset) => asset?.type === "video");
-  }
-  if (resultAssets.length) {
-    return resultAssets.map((asset) => catalogById.get(asset.id) ?? asset);
-  }
-  if (job.result?.generationSetId) {
-    return assets.filter((asset) => asset.type === "video" && asset.generationSetId === job.result.generationSetId);
-  }
-  return [];
+  return resolveJobResultAssets(job, assets, { type: "video" });
 }
 import {
   applyPresetDefault,

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -12,6 +12,7 @@ import { CharacterAdvancedOptions, useCharacterAdvancedOptions } from "../compon
 import { KeypointCollectionField } from "../components/KeypointCollectionField.jsx";
 import { usePoseLibrary, useUserPoseLoader } from "../poseLibrary.js";
 import { extractFamilies } from "../presetUtils.js";
+import { resolveJobResultAssets } from "../jobResultAssets.js";
 
 // Curated negative prompts seeded into the advanced panel for each Character
 // Studio flow (sc-3857). These are the baseline the editable Negative prompt
@@ -31,15 +32,12 @@ const POSE_LIBRARY_NEGATIVE_PROMPT =
 // recent generation set) is what lets pose / angle previews stream in as each
 // image is saved — otherwise a parallel job's newer generation set hides this
 // job's partial outputs from latestAssets and nothing surfaces in the card.
+//
+// Catalog-only resolution (sc-8853, `mergeResultAssets: false`): an id not yet in
+// the catalog is intentionally dropped rather than backfilled from an embedded
+// result record, which is what keeps this streaming/partial-output behavior.
 function jobImageAssets(job, assets) {
-  if (!job?.result || !Array.isArray(assets)) return [];
-  const byId = new Map(assets.map((asset) => [asset.id, asset]));
-  const ids = job.result.assetIds ?? [];
-  if (ids.length) return ids.map((id) => byId.get(id)).filter((asset) => asset?.type === "image");
-  if (job.result.generationSetId) {
-    return assets.filter((asset) => asset?.type === "image" && asset.generationSetId === job.result.generationSetId);
-  }
-  return [];
+  return resolveJobResultAssets(job, assets, { type: "image", mergeResultAssets: false });
 }
 
 // True when the job was started from the Angle Set form (advanced.angleSet)

--- a/apps/web/src/upscaleEngines.js
+++ b/apps/web/src/upscaleEngines.js
@@ -1,0 +1,50 @@
+// Single source of truth for the upscale-engine table + its stale-selection
+// fallback (sc-8853). The table lived twice — here-adjacent in imageJobs.js
+// (keyed `key`) and copy-pasted into ImageStudio (keyed `id`) — and the
+// "gated-out engine falls back to real-esrgan" effect was copy-pasted into
+// both ImageStudio and ImageEditor. Unifying here means adding/gating an engine
+// is a one-place edit.
+//
+// The canonical shape keys on `key` (imageJobs.js already exported it that way
+// and ImageEditor reads `entry.key`); the former ImageStudio `.id` consumers
+// were migrated to `.key`.
+//
+// This module owns the React hook; imageJobs.js re-exports the pure table +
+// helpers so its React/Konva-free contract (and existing importers) are
+// unchanged.
+import { useEffect } from "react";
+import { UPSCALE_ENGINES, upscaleFactorsForEngine } from "./imageJobs.js";
+import { macUpscaleEngineBlocked } from "./macGating.js";
+
+export { UPSCALE_ENGINES, upscaleFactorsForEngine, upscaleEngineHasSoftness } from "./imageJobs.js";
+
+// The guaranteed-available cross-platform upscaler; the fallback target when a
+// saved/selected engine is gated out on this platform.
+export const DEFAULT_UPSCALE_ENGINE = "real-esrgan";
+
+// The engines offered in the picker on this platform (AuraSR is dropped
+// everywhere, SeedVR2 is platform-intrinsic) — filters the shared table so both
+// studios build the dropdown identically.
+export function availableUpscaleEngines(macCapabilities) {
+  return UPSCALE_ENGINES.filter((engine) => !macUpscaleEngineBlocked(macCapabilities, engine.key));
+}
+
+// If the currently-selected upscale engine is gated out on this platform (e.g. a
+// stale saved AuraSR selection restored from settings), snap it back to the
+// default engine and clamp the factor to one the default supports — so the user
+// never submits a job the native workers refuse. Shared by ImageStudio and
+// ImageEditor, which previously each copy-pasted this effect.
+export function useUpscaleEngineFallback({
+  macCapabilities,
+  upscaleEngine,
+  setUpscaleEngine,
+  upscaleFactor,
+  setUpscaleFactor,
+}) {
+  useEffect(() => {
+    if (!macUpscaleEngineBlocked(macCapabilities, upscaleEngine)) return;
+    setUpscaleEngine(DEFAULT_UPSCALE_ENGINE);
+    const factors = upscaleFactorsForEngine(DEFAULT_UPSCALE_ENGINE);
+    if (!factors.includes(upscaleFactor)) setUpscaleFactor(factors[0]);
+  }, [macCapabilities, upscaleEngine, upscaleFactor, setUpscaleEngine, setUpscaleFactor]);
+}

--- a/apps/web/src/upscaleEngines.test.jsx
+++ b/apps/web/src/upscaleEngines.test.jsx
@@ -1,0 +1,119 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, it, expect, vi } from "vitest";
+import {
+  UPSCALE_ENGINES,
+  upscaleFactorsForEngine,
+  upscaleEngineHasSoftness,
+  availableUpscaleEngines,
+  useUpscaleEngineFallback,
+  DEFAULT_UPSCALE_ENGINE,
+} from "./upscaleEngines.js";
+
+// sc-8853: the upscale table + gating hook are now single-sourced. These lock in
+// the canonical `key` shape and the stale-selection fallback both studios share.
+
+// Minimal hook harness (this project has no @testing-library/react — existing
+// tests drive react-dom/client directly, mirrored here).
+let container = null;
+let root = null;
+afterEach(() => {
+  if (root) act(() => root.unmount());
+  root = null;
+  container = null;
+});
+function renderHook(props) {
+  container = document.createElement("div");
+  function Harness() {
+    useUpscaleEngineFallback(props);
+    return null;
+  }
+  act(() => {
+    root = createRoot(container);
+    root.render(<Harness />);
+  });
+}
+
+describe("UPSCALE_ENGINES table (canonical key shape)", () => {
+  it("keys every engine on `key` (not the old ImageStudio `id`)", () => {
+    for (const engine of UPSCALE_ENGINES) {
+      expect(engine.key).toBeTruthy();
+      expect(engine.id).toBeUndefined();
+      expect(engine.label).toBeTruthy();
+      expect(Array.isArray(engine.factors)).toBe(true);
+    }
+  });
+
+  it("exposes the three known engines", () => {
+    expect(UPSCALE_ENGINES.map((e) => e.key)).toEqual(["real-esrgan", "seedvr2", "aura-sr"]);
+  });
+
+  it("resolves factors per engine key, defaulting to [2,4]", () => {
+    expect(upscaleFactorsForEngine("real-esrgan")).toEqual([2, 4]);
+    expect(upscaleFactorsForEngine("aura-sr")).toEqual([4]);
+    expect(upscaleFactorsForEngine("nonexistent")).toEqual([2, 4]);
+  });
+
+  it("reports softness only for seedvr2", () => {
+    expect(upscaleEngineHasSoftness("seedvr2")).toBe(true);
+    expect(upscaleEngineHasSoftness("real-esrgan")).toBe(false);
+    expect(upscaleEngineHasSoftness("aura-sr")).toBe(false);
+  });
+});
+
+describe("availableUpscaleEngines", () => {
+  it("drops aura-sr and seedvr2 when their capabilities are absent", () => {
+    const caps = { features: {} };
+    expect(availableUpscaleEngines(caps).map((e) => e.key)).toEqual(["real-esrgan"]);
+  });
+
+  it("keeps seedvr2 when the platform supports it", () => {
+    const caps = { features: { imageUpscaleSeedvr2: { supported: true } } };
+    expect(availableUpscaleEngines(caps).map((e) => e.key)).toEqual(["real-esrgan", "seedvr2"]);
+  });
+});
+
+describe("useUpscaleEngineFallback", () => {
+  it("snaps a gated-out engine back to the default and clamps the factor", () => {
+    const setUpscaleEngine = vi.fn();
+    const setUpscaleFactor = vi.fn();
+    renderHook({
+        macCapabilities: { features: {} }, // aura-sr gated out
+        upscaleEngine: "aura-sr",
+        setUpscaleEngine,
+        upscaleFactor: 4, // aura-sr's factor, not supported by real-esrgan? it is (2,4)
+        setUpscaleFactor,
+      });
+    expect(setUpscaleEngine).toHaveBeenCalledWith(DEFAULT_UPSCALE_ENGINE);
+    // factor 4 IS valid for real-esrgan, so it is not re-clamped.
+    expect(setUpscaleFactor).not.toHaveBeenCalled();
+  });
+
+  it("clamps the factor when the current one is invalid for the default engine", () => {
+    const setUpscaleEngine = vi.fn();
+    const setUpscaleFactor = vi.fn();
+    renderHook({
+        macCapabilities: { features: {} },
+        upscaleEngine: "aura-sr",
+        setUpscaleEngine,
+        upscaleFactor: 3, // not in real-esrgan factors [2,4]
+        setUpscaleFactor,
+      });
+    expect(setUpscaleEngine).toHaveBeenCalledWith(DEFAULT_UPSCALE_ENGINE);
+    expect(setUpscaleFactor).toHaveBeenCalledWith(2);
+  });
+
+  it("does nothing when the selected engine is allowed", () => {
+    const setUpscaleEngine = vi.fn();
+    const setUpscaleFactor = vi.fn();
+    renderHook({
+        macCapabilities: { features: { imageUpscaleSeedvr2: { supported: true } } },
+        upscaleEngine: "seedvr2",
+        setUpscaleEngine,
+        upscaleFactor: 2,
+        setUpscaleFactor,
+      });
+    expect(setUpscaleEngine).not.toHaveBeenCalled();
+    expect(setUpscaleFactor).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## [F-051] sc-8853 — unify the four job→result-asset resolvers and the two upscale-engine tables

Dedup of two drifted patterns in `apps/web`.

### Problem
- Four near-identical "resolve a job's produced assets against the live catalog" copies: `ImageStudio.jobResultAssets`, `VideoStudio.jobVideoResultAssets`, `QueueScreen.resolveJobAssets`, `characterPanels.jobImageAssets`. **Only the image one carried batch-slot ordering** on the `generationSetId` fallback.
- `UPSCALE_ENGINES` existed twice with **already-drifted shapes** (`imageJobs.js` keyed `key`, `ImageStudio` keyed `id`), plus a copy-pasted stale-selection fallback effect in both `ImageStudio` and `ImageEditor`.

### Fix — unify to a superset that preserves each lane
**`src/jobResultAssets.js`** — one `resolveJobResultAssets(job, assets, { type, sortByBatchIndex, mergeResultAssets })`:

| Call site | type | sortByBatchIndex | mergeResultAssets |
|---|---|---|---|
| ImageStudio | `image` | **true** (kept) | true |
| VideoStudio | `video` | false | true |
| QueueScreen | — (any) | false | true |
| characterPanels | `image` | false | **false** (catalog-only) |

- **Batch-index ordering preserved** for the image lane only — it is an opt-in flag applied *only* to the `generationSetId` fallback (the `assetIds` branch is already worker slot-ordered and is never re-sorted).
- **characterPanels stays catalog-only** (`mergeResultAssets:false`): a not-yet-catalogued id is dropped rather than backfilled from an embedded record — exactly the streaming/partial-output behavior it relied on.
- Queue stays type-agnostic (no media-type filter).

**`src/upscaleEngines.js`** — re-exports the single `UPSCALE_ENGINES` table (canonical **`key`** shape) + pure helpers from `imageJobs.js`, and owns the shared `availableUpscaleEngines()` + `useUpscaleEngineFallback()` hook.
- **key/id drift reconciled to `key`**: `imageJobs.js`/`ImageEditor` already used `.key`, so `ImageStudio`'s `.id` consumers (picker options, factor lookup, change handler) were migrated to `.key`/the shared helpers. Removed the `ImageStudio` duplicate table.
- Both `ImageStudio` and `ImageEditor` copy-pasted fallback effects replaced by the single `useUpscaleEngineFallback` hook.
- `imageJobs.js` keeps its React/Konva-free contract untouched (the hook lives in the new module and imports the pure table from it).

### Tests
- **Characterization tests first** (`jobResultAssets.test.js`, 22 cases): lock each lane's current output — image batch-index sort on the genSet branch, video/queue no sort, assetIds slot-order never re-sorted, type filters, the embedded-record merge vs the character catalog-only drop, `assetBatchIndex` fallbacks.
- `upscaleEngines.test.jsx` (9 cases): canonical `key` shape, factor/softness helpers, `availableUpscaleEngines` gating, and the fallback hook (snap-to-default, factor clamp, no-op when allowed).
- Full web suite green: **64 files / 1071 tests passed** (no snapshot changes). Pre-existing `react-hooks/exhaustive-deps` warnings only, 0 errors, unrelated to this change.

Story: https://app.shortcut.com/trefry/story/8853

🤖 Generated with [Claude Code](https://claude.com/claude-code)