### PR TITLE
fix(worker): crash-safe finalize_converted_dir + kill hf child on error (sc-8837)

### DIFF
--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -1220,15 +1220,66 @@ fn relink_to_blob(link: &Path) {
 /// replacing any stale directory there. On error the final location is left
 /// untouched (the caller removes the temp dir), so a complete `final_dir` only ever
 /// appears after a fully successful conversion.
+///
+/// sc-8837 (F-035): the previous implementation `remove_dir_all(final_dir)` *before*
+/// renaming the temp dir in, so a rename failure — or a crash in the window between
+/// the delete and the rename — left the user with no model at all after minutes of
+/// conversion work. Instead we move any existing `final_dir` ASIDE to a sibling backup
+/// first, rename temp → final, and only then delete the backup. If anything fails after
+/// the aside move, we RESTORE the backup back to `final_dir`, honoring the doc's promise
+/// that on error the previously working model is left untouched.
 pub(crate) async fn finalize_converted_dir(temp_dir: &Path, final_dir: &Path) -> WorkerResult<()> {
-    if final_dir.exists() {
-        tokio::fs::remove_dir_all(final_dir).await?;
-    }
     if let Some(parent) = final_dir.parent() {
         tokio::fs::create_dir_all(parent).await?;
     }
-    tokio::fs::rename(temp_dir, final_dir).await?;
+
+    // Move any stale install aside instead of destroying it, so a later failure can
+    // restore it. The backup lives next to `final_dir` (same filesystem) so the move is
+    // an atomic rename and the restore is equally cheap and safe.
+    let backup_dir: Option<PathBuf> = if final_dir.exists() {
+        let backup = converted_dir_backup_path(final_dir);
+        // A leftover backup from a prior interrupted finalize would block the aside move;
+        // clear it first (best effort — a stale backup is never the working install).
+        let _ = tokio::fs::remove_dir_all(&backup).await;
+        tokio::fs::rename(final_dir, &backup).await?;
+        Some(backup)
+    } else {
+        None
+    };
+
+    // Promote the freshly converted dir into place. On any failure, restore the stale
+    // install so the user keeps the previously working model.
+    if let Err(error) = tokio::fs::rename(temp_dir, final_dir).await {
+        if let Some(backup) = backup_dir {
+            // Best effort: the working install is the priority, so ignore restore errors
+            // (there is nothing more we can do) but surface the original failure.
+            let _ = tokio::fs::remove_dir_all(final_dir).await;
+            let _ = tokio::fs::rename(&backup, final_dir).await;
+        }
+        return Err(error.into());
+    }
+
+    // Success: the new install is in place; drop the stale backup (best effort — a
+    // leftover backup is harmless and never mistaken for the live install).
+    if let Some(backup) = backup_dir {
+        let _ = tokio::fs::remove_dir_all(&backup).await;
+    }
     Ok(())
+}
+
+/// Sibling backup path used to move a stale converted dir aside during finalize
+/// (sc-8837). Kept next to `final_dir` so the aside/restore moves are atomic renames on
+/// the same filesystem rather than cross-device copies.
+fn converted_dir_backup_path(final_dir: &Path) -> PathBuf {
+    let name = final_dir
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "model".to_string());
+    let suffix = format!(".{name}.finalize-backup-{}", std::process::id());
+    match final_dir.parent() {
+        Some(parent) => parent.join(suffix),
+        None => PathBuf::from(suffix),
+    }
 }
 
 pub(crate) async fn download_model_with_hf_cli(

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -309,6 +309,119 @@ async fn finalize_converted_dir_promotes_atomically_and_replaces_stale() {
     assert!(!temp_dir2.exists());
 }
 
+/// sc-8837 (F-035): when a previously working install exists and the temp→final
+/// promotion fails, the ORIGINAL install must survive — the crash-safe finalize moves
+/// the stale install aside rather than destroying it first, then restores it on failure.
+/// We inject the rename failure by pointing at a `temp_dir` that does not exist (the aside
+/// move of the stale install succeeds, then the temp→final rename fails ENOENT).
+#[tokio::test]
+async fn finalize_converted_dir_restores_stale_install_on_rename_failure() {
+    let temp = tempdir().expect("tempdir");
+    let root = temp.path();
+    let final_dir = root.join("mlx").join("model");
+    std::fs::create_dir_all(&final_dir).expect("final dir");
+    std::fs::write(final_dir.join("weights.safetensors"), b"OLD-BUT-WORKING")
+        .expect("seed old install");
+
+    // Intentionally never created, so the temp→final rename fails after the stale aside.
+    let temp_dir = root.join("mlx").join(".model.converting-jobX");
+
+    let error = finalize_converted_dir(&temp_dir, &final_dir)
+        .await
+        .expect_err("a missing temp dir must make the promotion fail");
+    assert!(
+        matches!(error, WorkerError::Io(_)),
+        "expected an IO rename error, got {error:?}"
+    );
+
+    // The previously working model is left untouched (its contents survived).
+    assert!(
+        final_dir.join("weights.safetensors").is_file(),
+        "the original install must survive a failed finalize"
+    );
+    assert_eq!(
+        std::fs::read(final_dir.join("weights.safetensors")).expect("read restored"),
+        b"OLD-BUT-WORKING",
+        "restored install must have the original contents"
+    );
+    // No leftover backup dir next to the install.
+    let leftovers: Vec<_> = std::fs::read_dir(final_dir.parent().expect("parent"))
+        .expect("read parent")
+        .flatten()
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .filter(|name| name.contains("finalize-backup"))
+        .collect();
+    assert!(
+        leftovers.is_empty(),
+        "no backup dir should remain after restore, found {leftovers:?}"
+    );
+}
+
+/// sc-8837: the happy path replaces an existing install with the new contents and
+/// leaves no backup dir behind (crash-safe aside is cleaned up on success).
+#[tokio::test]
+async fn finalize_converted_dir_replaces_existing_install_leaves_no_backup() {
+    let temp = tempdir().expect("tempdir");
+    let root = temp.path();
+    let final_dir = root.join("mlx").join("model");
+    std::fs::create_dir_all(&final_dir).expect("final dir");
+    std::fs::write(final_dir.join("weights.safetensors"), b"OLD").expect("seed old");
+    let temp_dir = root.join("mlx").join(".model.converting-jobY");
+    std::fs::create_dir_all(&temp_dir).expect("temp dir");
+    std::fs::write(temp_dir.join("weights.safetensors"), b"NEW").expect("seed new");
+
+    finalize_converted_dir(&temp_dir, &final_dir)
+        .await
+        .expect("finalize should succeed");
+
+    assert_eq!(
+        std::fs::read(final_dir.join("weights.safetensors")).expect("read new"),
+        b"NEW",
+        "final dir must hold the freshly converted contents"
+    );
+    assert!(
+        !temp_dir.exists(),
+        "temp dir must have been moved into place"
+    );
+    let leftovers: Vec<_> = std::fs::read_dir(final_dir.parent().expect("parent"))
+        .expect("read parent")
+        .flatten()
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .filter(|name| name.contains("finalize-backup"))
+        .collect();
+    assert!(
+        leftovers.is_empty(),
+        "no backup dir should remain on success, found {leftovers:?}"
+    );
+}
+
+/// sc-8837: the first-install case (no prior `final_dir`, nested parent) promotes the
+/// temp dir into place without needing anything to move aside.
+#[tokio::test]
+async fn finalize_converted_dir_first_install_succeeds() {
+    let temp = tempdir().expect("tempdir");
+    let root = temp.path();
+    let final_dir = root.join("mlx").join("installed").join("model");
+    let temp_dir = root.join("mlx").join(".model.converting-jobZ");
+    std::fs::create_dir_all(&temp_dir).expect("temp dir");
+    std::fs::write(temp_dir.join("weights.safetensors"), b"FRESH").expect("seed fresh");
+
+    assert!(!final_dir.exists());
+    finalize_converted_dir(&temp_dir, &final_dir)
+        .await
+        .expect("first install should succeed");
+
+    assert_eq!(
+        std::fs::read(final_dir.join("weights.safetensors")).expect("read fresh"),
+        b"FRESH",
+        "first install must land the converted contents"
+    );
+    assert!(
+        !temp_dir.exists(),
+        "temp dir must have been moved into place"
+    );
+}
+
 #[test]
 fn download_progress_payload_matches_python_shape() {
     let payload = download_progress_payload(


### PR DESCRIPTION
## sc-8837 — [F-035] Crash-safe `finalize_converted_dir` + kill hf child on error

### The data-loss bug (primary fix)
`finalize_converted_dir` ran `remove_dir_all(final_dir)` **before** renaming the freshly converted temp dir into place. A rename failure — or a crash in the window between the delete and the rename — destroyed the previously working install, contradicting the function's own doc ("on error the final location is left untouched"). Re-converting an already-installed model could leave the user with **no model at all** after minutes of conversion work.

### Fix
Crash-safe promotion:
1. Move any existing `final_dir` **aside** to a same-filesystem sibling backup (atomic rename) instead of destroying it.
2. Rename temp → final.
3. On success, delete the backup.
4. On **any** failure after the aside move, **restore** the backup back to `final_dir` — so the previously working model always survives.

First-install (no prior `final_dir`) and nested-parent cases are handled. The aside/restore renames stay on the same filesystem so they're atomic; a cross-device `temp → final` rename still fails loudly but leaves the restored install intact (the restore guarantee holds).

### kill_on_drop — already done by F-003
`kill_on_drop(true)` on the `hf` CLI child (plus an explicit `child.kill()` on the cancel arm) was **already added by F-003 (sc-8804)** at `model_jobs.rs:1298`. No change needed there; left as-is.

### Tests (`crates/sceneworks-worker/src/tests.rs`)
- `finalize_converted_dir_restores_stale_install_on_rename_failure` — inject a rename failure (missing temp dir); assert the ORIGINAL install contents survive and no backup dir is left behind.
- `finalize_converted_dir_replaces_existing_install_leaves_no_backup` — success path replaces contents, no leftover backup.
- `finalize_converted_dir_first_install_succeeds` — no prior `final_dir` (nested parent) promotes cleanly.

### Validation
- `cargo test -p sceneworks-worker` — 505 passed, 0 failed (135 ignored, real-weights).
- `npm run rust:check` — clean (fmt + clippy + build).
- `cargo check -p sceneworks-worker --no-default-features --features backend-candle --all-targets` — clean.

Story: https://app.shortcut.com/trefry/story/8837

🤖 Generated with [Claude Code](https://claude.com/claude-code)
