### PR TITLE
fix(worker): confine payload-supplied control/PiD weight filenames (sc-8821)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -2263,7 +2263,7 @@ async fn generate_stream(
     // Per-generation PiD decode (epic 7840, sc-7849): resolve the PiD checkpoint + Gemma for this
     // model's latent space when `advanced.usePid` is set and the snapshots are cached; otherwise keep
     // the native VAE. `use_pid` and `spec.pid` stay in lockstep (the engine rejects a mismatch).
-    let pid_weights = resolve_pid_weights(request, &settings.data_dir, &request.model);
+    let pid_weights = resolve_pid_weights(request, &settings.data_dir, &request.model)?;
     let use_pid = pid_weights.is_some();
     let mut spec = load_spec(weights_dir, quant, adapters, flux_ip_dir);
     if let Some(pid) = pid_weights {

--- a/crates/sceneworks-worker/src/image_jobs/flux1_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux1_control.rs
@@ -35,7 +35,8 @@ fn flux1_dev_control_available(request: &ImageRequest, settings: &Settings) -> b
 
 /// The (repo, filename) of the FLUX.1-dev control weights — `advanced.controlWeights.{repo,filename}`
 /// overrides, else the Shakker Union-Pro-2.0 default (parity with the FLUX.2 / Z-Image resolvers).
-fn flux1_control_repo_file(request: &ImageRequest) -> (String, String) {
+/// The payload filename must be a plain component (sc-8821 / F-019).
+fn flux1_control_repo_file(request: &ImageRequest) -> WorkerResult<(String, String)> {
     let cw = request
         .advanced
         .get("controlWeights")
@@ -48,15 +49,18 @@ fn flux1_control_repo_file(request: &ImageRequest) -> (String, String) {
             .unwrap_or(default)
             .to_owned()
     };
-    (
+    Ok((
         // Default repo from the shared strict-control table (single source of truth); the file stays
         // engine-specific.
         pick(
             "repo",
             strict_control_default_repo(FLUX1_DEV_CONTROL_ENGINE_ID),
         ),
-        pick("filename", FLUX1_CONTROL_FILE),
-    )
+        safe_weight_filename(
+            &pick("filename", FLUX1_CONTROL_FILE),
+            "advanced.controlWeights.filename",
+        )?,
+    ))
 }
 
 /// Resolve the Shakker Union-Pro-2.0 checkpoint the engine loads, downloading on first use. Order: an
@@ -69,7 +73,7 @@ async fn ensure_flux1_control_weights(
     job: &JobSnapshot,
     request: &ImageRequest,
 ) -> WorkerResult<PathBuf> {
-    let (repo, file) = flux1_control_repo_file(request);
+    let (repo, file) = flux1_control_repo_file(request)?;
     if let Ok(p) = std::env::var("SCENEWORKS_CONTROLNET_FLUX1") {
         let p = PathBuf::from(p);
         if p.is_file() {

--- a/crates/sceneworks-worker/src/image_jobs/flux1_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux1_control_candle.rs
@@ -125,7 +125,8 @@ fn flux1_control_candle_guidance(request: &ImageRequest) -> f32 {
 
 /// The (repo, filename) of the control weights — `advanced.controlWeights.{repo,filename}` overrides,
 /// else the Shakker Union-Pro-2.0 default (parity with the MLX `flux1_control_repo_file`).
-fn flux1_control_candle_repo_file(request: &ImageRequest) -> (String, String) {
+/// The payload filename must be a plain component (sc-8821 / F-019).
+fn flux1_control_candle_repo_file(request: &ImageRequest) -> WorkerResult<(String, String)> {
     let cw = request
         .advanced
         .get("controlWeights")
@@ -138,10 +139,13 @@ fn flux1_control_candle_repo_file(request: &ImageRequest) -> (String, String) {
             .unwrap_or(default)
             .to_owned()
     };
-    (
+    Ok((
         pick("repo", FLUX1_CONTROL_CANDLE_REPO),
-        pick("filename", FLUX1_CONTROL_CANDLE_FILE),
-    )
+        safe_weight_filename(
+            &pick("filename", FLUX1_CONTROL_CANDLE_FILE),
+            "advanced.controlWeights.filename",
+        )?,
+    ))
 }
 
 /// Resolve the Shakker Union-Pro-2.0 weight **file** the `Flux1DevControl` provider loads, downloading on
@@ -155,7 +159,7 @@ async fn ensure_flux1_control_candle_weights(
     job: &JobSnapshot,
     request: &ImageRequest,
 ) -> WorkerResult<PathBuf> {
-    let (repo, file) = flux1_control_candle_repo_file(request);
+    let (repo, file) = flux1_control_candle_repo_file(request)?;
     if let Ok(p) = std::env::var("SCENEWORKS_CONTROLNET_FLUX1") {
         let p = PathBuf::from(p);
         if p.is_file() {

--- a/crates/sceneworks-worker/src/image_jobs/flux2.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2.rs
@@ -617,7 +617,8 @@ fn flux2_dev_control_available(request: &ImageRequest, settings: &Settings) -> b
 
 /// The (repo, filename) of the FLUX.2-dev control weights — `advanced.controlWeights.{repo,filename}`
 /// overrides, else the `-2602` Fun-Controlnet-Union default (parity with the Z-Image resolver).
-fn flux2_control_repo_file(request: &ImageRequest) -> (String, String) {
+/// The payload filename must be a plain component (sc-8821 / F-019).
+fn flux2_control_repo_file(request: &ImageRequest) -> WorkerResult<(String, String)> {
     let cw = request
         .advanced
         .get("controlWeights")
@@ -630,15 +631,18 @@ fn flux2_control_repo_file(request: &ImageRequest) -> (String, String) {
             .unwrap_or(default)
             .to_owned()
     };
-    (
+    Ok((
         // Default repo from the shared strict-control table (single source of truth); the file stays
         // engine-specific.
         pick(
             "repo",
             strict_control_default_repo(FLUX2_DEV_CONTROL_ENGINE_ID),
         ),
-        pick("filename", FLUX2_CONTROL_FILE),
-    )
+        safe_weight_filename(
+            &pick("filename", FLUX2_CONTROL_FILE),
+            "advanced.controlWeights.filename",
+        )?,
+    ))
 }
 
 /// Resolve the Fun-Controlnet-Union checkpoint the engine loads, downloading on first use. Order: an
@@ -651,7 +655,7 @@ async fn ensure_flux2_control_weights(
     job: &JobSnapshot,
     request: &ImageRequest,
 ) -> WorkerResult<PathBuf> {
-    let (repo, file) = flux2_control_repo_file(request);
+    let (repo, file) = flux2_control_repo_file(request)?;
     if let Ok(p) = std::env::var("SCENEWORKS_CONTROLNET_FLUX2") {
         let p = PathBuf::from(p);
         if p.is_file() {

--- a/crates/sceneworks-worker/src/image_jobs/flux2_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2_control_candle.rs
@@ -124,7 +124,8 @@ fn flux2_control_candle_guidance(request: &ImageRequest) -> f32 {
 
 /// The (repo, filename) of the control weights — `advanced.controlWeights.{repo,filename}` overrides,
 /// else the Fun-Controlnet-Union `-2602` default (parity with the MLX `flux2_control_repo_file`).
-fn flux2_control_candle_repo_file(request: &ImageRequest) -> (String, String) {
+/// The payload filename must be a plain component (sc-8821 / F-019).
+fn flux2_control_candle_repo_file(request: &ImageRequest) -> WorkerResult<(String, String)> {
     let cw = request
         .advanced
         .get("controlWeights")
@@ -137,10 +138,13 @@ fn flux2_control_candle_repo_file(request: &ImageRequest) -> (String, String) {
             .unwrap_or(default)
             .to_owned()
     };
-    (
+    Ok((
         pick("repo", FLUX2_CONTROL_CANDLE_REPO),
-        pick("filename", FLUX2_CONTROL_CANDLE_FILE),
-    )
+        safe_weight_filename(
+            &pick("filename", FLUX2_CONTROL_CANDLE_FILE),
+            "advanced.controlWeights.filename",
+        )?,
+    ))
 }
 
 /// Resolve the Fun-Controlnet-Union weight **file** the `Flux2Control` provider loads, downloading on
@@ -154,7 +158,7 @@ async fn ensure_flux2_control_candle_weights(
     job: &JobSnapshot,
     request: &ImageRequest,
 ) -> WorkerResult<PathBuf> {
-    let (repo, file) = flux2_control_candle_repo_file(request);
+    let (repo, file) = flux2_control_candle_repo_file(request)?;
     if let Ok(p) = std::env::var("SCENEWORKS_CONTROLNET_FLUX2") {
         let p = PathBuf::from(p);
         if p.is_file() {

--- a/crates/sceneworks-worker/src/image_jobs/instantid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/instantid.rs
@@ -607,7 +607,7 @@ async fn generate_instantid_stream(
     // `with_pid`. The candle InstantID lane has no PiD decode yet (sc-8373), so this is macOS-only —
     // `use_pid` never reaches the candle engine (whose `InstantIdRequest` has no such field).
     #[cfg(target_os = "macos")]
-    let pid_weights = resolve_pid_weights(request, &settings.data_dir, &request.model);
+    let pid_weights = resolve_pid_weights(request, &settings.data_dir, &request.model)?;
     #[cfg(target_os = "macos")]
     let use_pid = pid_weights.is_some();
     // Load the xinsir OpenPose ControlNet only for pose mode (it is the MultiControlNet second

--- a/crates/sceneworks-worker/src/image_jobs/kolors_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/kolors_control.rs
@@ -116,7 +116,8 @@ fn kolors_control_guidance(request: &ImageRequest) -> f32 {
 
 /// The (repo, filename) of the ControlNet weights — `advanced.controlWeights.{repo,filename}` overrides,
 /// else the Kolors-ControlNet-Pose default (parity with the MLX `resolve_control_weights_for`).
-fn kolors_control_repo_file(request: &ImageRequest) -> (String, String) {
+/// The payload filename must be a plain component (sc-8821 / F-019).
+fn kolors_control_repo_file(request: &ImageRequest) -> WorkerResult<(String, String)> {
     let cw = request.advanced.get("controlWeights").and_then(Value::as_object);
     let pick = |key: &str, default: &str| {
         cw.and_then(|m| m.get(key))
@@ -126,10 +127,13 @@ fn kolors_control_repo_file(request: &ImageRequest) -> (String, String) {
             .unwrap_or(default)
             .to_owned()
     };
-    (
+    Ok((
         pick("repo", KOLORS_CONTROL_REPO),
-        pick("filename", KOLORS_CONTROL_FILE),
-    )
+        safe_weight_filename(
+            &pick("filename", KOLORS_CONTROL_FILE),
+            "advanced.controlWeights.filename",
+        )?,
+    ))
 }
 
 /// Resolve the Kolors ControlNet weight **file** the `KolorsControl` provider loads, downloading on first
@@ -141,7 +145,7 @@ async fn ensure_kolors_control_weights(
     job: &JobSnapshot,
     request: &ImageRequest,
 ) -> WorkerResult<PathBuf> {
-    let (repo, file) = kolors_control_repo_file(request);
+    let (repo, file) = kolors_control_repo_file(request)?;
     if let Ok(p) = std::env::var("SCENEWORKS_CONTROLNET_KOLORS") {
         let p = PathBuf::from(p);
         if p.is_file() {

--- a/crates/sceneworks-worker/src/image_jobs/pid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/pid.rs
@@ -104,29 +104,33 @@ fn pid_requested(request: &ImageRequest) -> bool {
 
 /// Resolve the per-generation PiD decoder weights for `model`, or `None` to keep the native VAE decode.
 ///
-/// Returns `None` whenever ANY of: the request did not opt in (`advanced.usePid` unset/false); the
+/// Returns `Ok(None)` whenever ANY of: the request did not opt in (`advanced.usePid` unset/false); the
 /// model has no PiD backbone (non-eligible → silently ignore the toggle); or the PiD checkpoint / Gemma
 /// snapshot is not cached under `data_dir` yet (provisioning is sc-7852). The checkpoint repo+filename
 /// and the Gemma repo default to the turnkey convention and may be overridden via
-/// `advanced.pidCheckpoint` (`{repo, filename}`) / `advanced.pidGemma` (repo string).
+/// `advanced.pidCheckpoint` (`{repo, filename}`) / `advanced.pidGemma` (repo string). An override
+/// filename that is not a plain component is an error (sc-8821 / F-019 — a `../…` filename must not
+/// escape the snapshot).
 ///
 /// The caller sets BOTH `LoadSpec::with_pid(checkpoint, gemma)` and `GenerationRequest.use_pid = true`
-/// exactly when this returns `Some` — never one without the other (the engine rejects that).
+/// exactly when this returns `Ok(Some)` — never one without the other (the engine rejects that).
 fn resolve_pid_weights(
     request: &ImageRequest,
     data_dir: &Path,
     model: &str,
-) -> Option<gen_core::PidWeights> {
+) -> WorkerResult<Option<gen_core::PidWeights>> {
     if !pid_requested(request) {
-        return None;
+        return Ok(None);
     }
-    let backbone = pid_backbone_for(model)?;
+    let Some(backbone) = pid_backbone_for(model) else {
+        return Ok(None);
+    };
     let (default_repo, default_file) = match backbone {
         "qwenimage" => (PID_QWENIMAGE_REPO, PID_QWENIMAGE_FILE),
         "flux" => (PID_FLUX_REPO, PID_FLUX_FILE),
         "flux2" => (PID_FLUX2_REPO, PID_FLUX2_FILE),
         "sdxl" => (PID_SDXL_REPO, PID_SDXL_FILE),
-        _ => return None,
+        _ => return Ok(None),
     };
 
     let ckpt_cfg = request
@@ -139,12 +143,15 @@ fn resolve_pid_weights(
         .map(str::trim)
         .filter(|s| !s.is_empty())
         .unwrap_or(default_repo);
-    let filename = ckpt_cfg
-        .and_then(|c| c.get("filename"))
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .unwrap_or(default_file);
+    let filename = safe_weight_filename(
+        ckpt_cfg
+            .and_then(|c| c.get("filename"))
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or(default_file),
+        "advanced.pidCheckpoint.filename",
+    )?;
     let gemma_repo = request
         .advanced
         .get("pidGemma")
@@ -154,15 +161,20 @@ fn resolve_pid_weights(
         .unwrap_or(PID_GEMMA_REPO);
 
     // Both snapshots must be cached, or fall through to the native VAE (no partial/half-loaded PiD).
-    let checkpoint = huggingface_snapshot_dir(data_dir, repo)?.join(filename);
+    let Some(snapshot) = huggingface_snapshot_dir(data_dir, repo) else {
+        return Ok(None);
+    };
+    let checkpoint = snapshot.join(filename);
     if !checkpoint.exists() {
-        return None;
+        return Ok(None);
     }
-    let gemma = huggingface_snapshot_dir(data_dir, gemma_repo)?;
-    Some(gen_core::PidWeights {
+    let Some(gemma) = huggingface_snapshot_dir(data_dir, gemma_repo) else {
+        return Ok(None);
+    };
+    Ok(Some(gen_core::PidWeights {
         checkpoint: WeightsSource::File(checkpoint),
         gemma: WeightsSource::Dir(gemma),
-    })
+    }))
 }
 
 #[cfg(all(target_os = "macos", test))]
@@ -217,7 +229,9 @@ mod pid_tests {
     fn resolve_returns_none_without_opt_in() {
         let dir = tempfile::tempdir().unwrap();
         let req = request("qwen_image", json!({}));
-        assert!(resolve_pid_weights(&req, dir.path(), &req.model).is_none());
+        assert!(resolve_pid_weights(&req, dir.path(), &req.model)
+            .expect("plain default filename resolves")
+            .is_none());
     }
 
     #[test]
@@ -225,7 +239,9 @@ mod pid_tests {
         let dir = tempfile::tempdir().unwrap();
         // SenseNova is autoregressive (no VAE latent) → no PiD backbone, toggle ignored.
         let req = request("sensenova_u1_8b", json!({ "usePid": true }));
-        assert!(resolve_pid_weights(&req, dir.path(), &req.model).is_none());
+        assert!(resolve_pid_weights(&req, dir.path(), &req.model)
+            .expect("plain default filename resolves")
+            .is_none());
     }
 
     #[test]
@@ -236,9 +252,39 @@ mod pid_tests {
         for model in ["qwen_image", "flux_dev", "flux2_dev", "sdxl"] {
             let req = request(model, json!({ "usePid": true }));
             assert!(
-                resolve_pid_weights(&req, dir.path(), &req.model).is_none(),
+                resolve_pid_weights(&req, dir.path(), &req.model)
+                    .expect("plain default filename resolves")
+                    .is_none(),
                 "{model} should resolve None when its checkpoint is not cached"
             );
         }
+    }
+
+    /// sc-8821 / F-019: a payload `pidCheckpoint.filename` that is not a plain component (traversal,
+    /// absolute, sub-path) is REJECTED with an `InvalidPayload` pointing at the field — never joined
+    /// under the snapshot. A plain override filename still resolves (Ok).
+    #[test]
+    fn resolve_rejects_traversal_pid_checkpoint_filenames() {
+        let dir = tempfile::tempdir().unwrap();
+        for filename in ["../../etc/hosts", "/etc/hosts", "sub/dir.safetensors", ".."] {
+            let req = request(
+                "qwen_image",
+                json!({ "usePid": true, "pidCheckpoint": { "filename": filename } }),
+            );
+            let error = resolve_pid_weights(&req, dir.path(), &req.model)
+                .expect_err("unsafe pidCheckpoint.filename must be rejected");
+            assert!(
+                error.to_string().contains("advanced.pidCheckpoint.filename"),
+                "error should point at the offending field: {error}"
+            );
+        }
+        // A plain override filename passes validation (snapshot absent → Ok(None), native VAE).
+        let req = request(
+            "qwen_image",
+            json!({ "usePid": true, "pidCheckpoint": { "filename": "custom.safetensors" } }),
+        );
+        assert!(resolve_pid_weights(&req, dir.path(), &req.model)
+            .expect("plain override filename resolves")
+            .is_none());
     }
 }

--- a/crates/sceneworks-worker/src/image_jobs/qwen.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen.rs
@@ -16,7 +16,10 @@ fn qwen_control_available(request: &ImageRequest, settings: &Settings) -> bool {
         && matches!(resolve_weights_dir(request, settings), Ok(Some(_)))
 }
 
-fn resolve_qwen_control_weights(request: &ImageRequest, settings: &Settings) -> Option<PathBuf> {
+fn resolve_qwen_control_weights(
+    request: &ImageRequest,
+    settings: &Settings,
+) -> WorkerResult<Option<PathBuf>> {
     // Default repo from the shared strict-control table (single source of truth); the file stays
     // engine-specific.
     resolve_control_weights_for(
@@ -150,7 +153,7 @@ async fn generate_qwen_control_stream(
         .ok_or_else(|| WorkerError::InvalidPayload("Qwen model row missing".to_owned()))?;
     let weights_dir = resolve_weights_dir(request, settings)?
         .ok_or_else(|| WorkerError::InvalidPayload("Qwen-Image weights not found".to_owned()))?;
-    let control_weights = resolve_qwen_control_weights(request, settings).ok_or_else(|| {
+    let control_weights = resolve_qwen_control_weights(request, settings)?.ok_or_else(|| {
         WorkerError::InvalidPayload(format!(
             "Qwen strict-pose control weights not found (download {QWEN_CONTROL_REPO})."
         ))
@@ -220,7 +223,7 @@ async fn generate_qwen_control_stream(
     // Per-generation PiD decode (epic 7840, sc-7849): the strict-pose control engine shares the
     // `qwenimage` latent space, so route its decode through PiD when `advanced.usePid` is set and the
     // snapshots are cached; otherwise native VAE. `use_pid` and `spec.pid` stay in lockstep.
-    let pid_weights = resolve_pid_weights(request, &settings.data_dir, &request.model);
+    let pid_weights = resolve_pid_weights(request, &settings.data_dir, &request.model)?;
     let use_pid = pid_weights.is_some();
     let mut spec = qwen_control_spec(weights_dir, control_weights, quant, adapters);
     if let Some(pid) = pid_weights {
@@ -755,7 +758,7 @@ async fn generate_qwen_edit_stream(
     // Per-generation PiD decode (epic 7840, sc-7849): Qwen-Image-Edit shares the `qwenimage` latent
     // space, so route its decode through PiD when `advanced.usePid` is set and the snapshots are
     // cached; otherwise native VAE. `use_pid` and `spec.pid` stay in lockstep.
-    let pid_weights = resolve_pid_weights(request, &settings.data_dir, &request.model);
+    let pid_weights = resolve_pid_weights(request, &settings.data_dir, &request.model)?;
     let use_pid = pid_weights.is_some();
     let mut spec = load_spec(weights_dir, quant, adapters, None);
     if let Some(pid) = pid_weights {

--- a/crates/sceneworks-worker/src/image_jobs/qwen_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_control.rs
@@ -121,7 +121,8 @@ fn qwen_control_guidance(request: &ImageRequest) -> f32 {
 
 /// The (repo, filename) of the ControlNet weights — `advanced.controlWeights.{repo,filename}` overrides,
 /// else the 2512-Fun-Controlnet-Union default (parity with the MLX `resolve_control_weights_for`).
-fn qwen_control_repo_file(request: &ImageRequest) -> (String, String) {
+/// The payload filename must be a plain component (sc-8821 / F-019).
+fn qwen_control_repo_file(request: &ImageRequest) -> WorkerResult<(String, String)> {
     let cw = request.advanced.get("controlWeights").and_then(Value::as_object);
     let pick = |key: &str, default: &str| {
         cw.and_then(|m| m.get(key))
@@ -131,10 +132,13 @@ fn qwen_control_repo_file(request: &ImageRequest) -> (String, String) {
             .unwrap_or(default)
             .to_owned()
     };
-    (
+    Ok((
         pick("repo", QWEN_CONTROL_REPO),
-        pick("filename", QWEN_CONTROL_FILE),
-    )
+        safe_weight_filename(
+            &pick("filename", QWEN_CONTROL_FILE),
+            "advanced.controlWeights.filename",
+        )?,
+    ))
 }
 
 /// Resolve the 2512-Fun-Controlnet-Union weight **file** the `QwenFunControl` provider loads (sc-8350),
@@ -146,7 +150,7 @@ async fn ensure_qwen_control_weights(
     job: &JobSnapshot,
     request: &ImageRequest,
 ) -> WorkerResult<PathBuf> {
-    let (repo, file) = qwen_control_repo_file(request);
+    let (repo, file) = qwen_control_repo_file(request)?;
     if let Ok(p) = std::env::var("SCENEWORKS_CONTROLNET_QWEN") {
         let p = PathBuf::from(p);
         if p.is_file() {

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -2629,8 +2629,9 @@ fn sc3031_ab_dump_pose() {
     let weights = resolve_weights_dir(&req, &settings)
         .expect("z-image weights resolve")
         .expect("z-image weights in HF cache");
-    let control_weights =
-        resolve_control_weights(&req, &settings).expect("Fun-Controlnet-Union weights");
+    let control_weights = resolve_control_weights(&req, &settings)
+        .expect("control-weights filename resolves")
+        .expect("Fun-Controlnet-Union weights");
     let (quant, _bits) = resolve_quant(&req);
     let zimage = mlx_model("z_image_turbo").expect("z-image model row");
     let steps = resolve_steps(&req, &zimage);
@@ -3185,7 +3186,8 @@ fn flux2_control_scale_defaults_and_clamps() {
 #[cfg(target_os = "macos")]
 #[test]
 fn flux2_control_repo_file_defaults_and_overrides() {
-    let (repo, file) = flux2_control_repo_file(&request(json!({ "projectId": "p" })));
+    let (repo, file) =
+        flux2_control_repo_file(&request(json!({ "projectId": "p" }))).expect("defaults resolve");
     // The default repo now comes from the shared strict-control table (single source of truth).
     assert_eq!(
         repo,
@@ -3197,9 +3199,64 @@ fn flux2_control_repo_file_defaults_and_overrides() {
     let (repo, file) = flux2_control_repo_file(&request(json!({
         "projectId": "p",
         "advanced": { "controlWeights": { "repo": "me/custom", "filename": "x.safetensors" } }
-    })));
+    })))
+    .expect("plain override filename resolves");
     assert_eq!(repo, "me/custom");
     assert_eq!(file, "x.safetensors");
+}
+
+/// sc-8821 / F-019: a payload `controlWeights.filename` that is not a plain component (traversal,
+/// absolute, sub-path) is REJECTED with an `InvalidPayload` pointing at the field — never joined
+/// under the HF snapshot / app cache — on every MLX control resolver (the shared
+/// `resolve_control_weights_for` behind the Z-Image/Qwen wrappers, plus the FLUX.1/FLUX.2
+/// `*_control_repo_file` pair).
+#[cfg(target_os = "macos")]
+#[test]
+fn mlx_control_weight_filenames_reject_traversal() {
+    let settings = Settings::from_env();
+    for filename in ["../../etc/hosts", "/etc/hosts", "sub/x.safetensors", ".."] {
+        let req = request(json!({
+            "projectId": "p",
+            "advanced": { "controlWeights": { "filename": filename } }
+        }));
+        for (label, error) in [
+            (
+                "z-image turbo",
+                resolve_control_weights(&req, &settings).expect_err("z-image turbo rejects"),
+            ),
+            (
+                "z-image base",
+                resolve_base_control_weights(&req, &settings).expect_err("z-image base rejects"),
+            ),
+            (
+                "qwen",
+                resolve_qwen_control_weights(&req, &settings).expect_err("qwen rejects"),
+            ),
+            (
+                "flux2",
+                flux2_control_repo_file(&req).expect_err("flux2 rejects"),
+            ),
+            (
+                "flux1",
+                flux1_control_repo_file(&req).expect_err("flux1 rejects"),
+            ),
+        ] {
+            assert!(
+                error
+                    .to_string()
+                    .contains("advanced.controlWeights.filename"),
+                "{label} error should point at the offending field for {filename:?}: {error}"
+            );
+        }
+    }
+    // A plain filename still passes validation on the Option-returning resolvers (whether it maps to
+    // Some or None then depends only on the local HF cache, not on confinement).
+    let plain = request(json!({
+        "projectId": "p",
+        "advanced": { "controlWeights": { "filename": "custom.safetensors" } }
+    }));
+    assert!(resolve_control_weights(&plain, &settings).is_ok());
+    assert!(resolve_qwen_control_weights(&plain, &settings).is_ok());
 }
 
 #[cfg(target_os = "macos")]
@@ -7308,7 +7365,7 @@ fn candle_control_providers_resolve_models_and_repos() {
     assert!(!is_flux1_control_model("flux_schnell"));
     assert!(!is_flux1_control_model("flux2_dev"));
     let flux1 = request(json!({ "projectId": "p", "model": "flux_dev" }));
-    let (f1_repo, f1_file) = flux1_control_candle_repo_file(&flux1);
+    let (f1_repo, f1_file) = flux1_control_candle_repo_file(&flux1).expect("defaults resolve");
     assert_eq!(f1_repo, "Shakker-Labs/FLUX.1-dev-ControlNet-Union-Pro-2.0");
     assert_eq!(f1_file, "diffusion_pytorch_model.safetensors");
     assert_eq!(
@@ -7319,7 +7376,7 @@ fn candle_control_providers_resolve_models_and_repos() {
     // sc-8350 — qwen InstantX → 2512-Fun: the default control repo + base repo are the 2512-Fun row, NOT
     // the retired InstantX `Qwen-Image-ControlNet-Union`.
     let qwen = request(json!({ "projectId": "p", "model": "qwen_image" }));
-    let (q_repo, _q_file) = qwen_control_repo_file(&qwen);
+    let (q_repo, _q_file) = qwen_control_repo_file(&qwen).expect("defaults resolve");
     assert_eq!(q_repo, "alibaba-pai/Qwen-Image-2512-Fun-Controlnet-Union");
     assert_eq!(QWEN_CONTROL_DEFAULT_REPO, "Qwen/Qwen-Image-2512");
     assert_ne!(q_repo, "InstantX/Qwen-Image-ControlNet-Union");
@@ -7340,8 +7397,8 @@ fn candle_control_providers_resolve_models_and_repos() {
         zimage_control_base_default_repo(&base.model),
         "Tongyi-MAI/Z-Image"
     );
-    let (turbo_ctrl_repo, _) = zimage_control_repo_file(&turbo);
-    let (base_ctrl_repo, _) = zimage_control_repo_file(&base);
+    let (turbo_ctrl_repo, _) = zimage_control_repo_file(&turbo).expect("defaults resolve");
+    let (base_ctrl_repo, _) = zimage_control_repo_file(&base).expect("defaults resolve");
     assert_eq!(
         turbo_ctrl_repo,
         "alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1"
@@ -7364,6 +7421,57 @@ fn candle_control_providers_resolve_models_and_repos() {
         "projectId": "p", "model": "z_image", "advanced": { "guidanceScale": 6.5 }
     }));
     assert_eq!(zimage_control_guidance(&base_g), 6.5);
+}
+
+/// sc-8821 / F-019: a payload `controlWeights.filename` that is not a plain component (traversal,
+/// absolute, sub-path) is REJECTED with an `InvalidPayload` pointing at the field — never joined
+/// under the HF snapshot / app cache — on every candle control resolver. A plain override filename
+/// still resolves.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn candle_control_weight_filenames_reject_traversal() {
+    for filename in ["../../etc/hosts", "/etc/hosts", "sub/x.safetensors", ".."] {
+        let req = request(json!({
+            "projectId": "p",
+            "advanced": { "controlWeights": { "filename": filename } }
+        }));
+        for (label, error) in [
+            (
+                "qwen",
+                qwen_control_repo_file(&req).expect_err("qwen rejects"),
+            ),
+            (
+                "kolors",
+                kolors_control_repo_file(&req).expect_err("kolors rejects"),
+            ),
+            (
+                "z-image",
+                zimage_control_repo_file(&req).expect_err("z-image rejects"),
+            ),
+            (
+                "flux2",
+                flux2_control_candle_repo_file(&req).expect_err("flux2 rejects"),
+            ),
+            (
+                "flux1",
+                flux1_control_candle_repo_file(&req).expect_err("flux1 rejects"),
+            ),
+        ] {
+            assert!(
+                error
+                    .to_string()
+                    .contains("advanced.controlWeights.filename"),
+                "{label} error should point at the offending field for {filename:?}: {error}"
+            );
+        }
+    }
+    let plain = request(json!({
+        "projectId": "p",
+        "advanced": { "controlWeights": { "repo": "me/custom", "filename": "x.safetensors" } }
+    }));
+    let (repo, file) = kolors_control_repo_file(&plain).expect("plain override filename resolves");
+    assert_eq!(repo, "me/custom");
+    assert_eq!(file, "x.safetensors");
 }
 
 /// The trait routes each provider: each lane's `CandleStrictControl` impl reports the right engine id

--- a/crates/sceneworks-worker/src/image_jobs/zimage.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage.rs
@@ -36,14 +36,16 @@ fn zimage_base_control_available(request: &ImageRequest, settings: &Settings) ->
 }
 
 /// Resolve the Fun-Controlnet-Union checkpoint (`advanced.controlWeights.{repo,filename}`
-/// else defaults) to a single `.safetensors` in the HF cache. `None` when absent (the
-/// model-download flow fetches it ahead of generation, like base weights).
+/// else defaults) to a single `.safetensors` in the HF cache. `Ok(None)` when absent (the
+/// model-download flow fetches it ahead of generation, like base weights); `Err` when the
+/// payload filename is not a plain component (sc-8821 / F-019 — a `../…` filename must not
+/// escape the snapshot).
 fn resolve_control_weights_for(
     request: &ImageRequest,
     settings: &Settings,
     default_repo: &'static str,
     default_file: &'static str,
-) -> Option<PathBuf> {
+) -> WorkerResult<Option<PathBuf>> {
     let control = request
         .advanced
         .get("controlWeights")
@@ -58,16 +60,24 @@ fn resolve_control_weights_for(
             .to_owned()
     };
     let repo = str_field("repo", default_repo);
-    let filename = str_field("filename", default_file);
-    let snapshot = huggingface_snapshot_dir(&settings.data_dir, &repo)?;
+    let filename = safe_weight_filename(
+        &str_field("filename", default_file),
+        "advanced.controlWeights.filename",
+    )?;
+    let Some(snapshot) = huggingface_snapshot_dir(&settings.data_dir, &repo) else {
+        return Ok(None);
+    };
     let path = snapshot.join(filename);
-    path.exists().then_some(path)
+    Ok(path.exists().then_some(path))
 }
 
 /// Resolve the Z-Image Fun-Controlnet-Union checkpoint. The default repo comes from the shared
 /// strict-control table (single source of truth — `STRICT_CONTROL_ENGINES`); the file default stays
 /// engine-specific.
-fn resolve_control_weights(request: &ImageRequest, settings: &Settings) -> Option<PathBuf> {
+fn resolve_control_weights(
+    request: &ImageRequest,
+    settings: &Settings,
+) -> WorkerResult<Option<PathBuf>> {
     resolve_control_weights_for(
         request,
         settings,
@@ -79,7 +89,10 @@ fn resolve_control_weights(request: &ImageRequest, settings: &Settings) -> Optio
 /// Resolve the **base** Z-Image Fun-Controlnet-Union checkpoint (sc-8251). The default repo comes from
 /// the shared strict-control table (single source of truth — `STRICT_CONTROL_ENGINES`); the file
 /// default stays engine-specific.
-fn resolve_base_control_weights(request: &ImageRequest, settings: &Settings) -> Option<PathBuf> {
+fn resolve_base_control_weights(
+    request: &ImageRequest,
+    settings: &Settings,
+) -> WorkerResult<Option<PathBuf>> {
     resolve_control_weights_for(
         request,
         settings,
@@ -238,7 +251,7 @@ async fn generate_zimage_control_stream(
 
     let weights_dir = resolve_weights_dir(request, settings)?
         .ok_or_else(|| WorkerError::InvalidPayload("Z-Image weights not found".to_owned()))?;
-    let control_weights = resolve_control_weights(request, settings).ok_or_else(|| {
+    let control_weights = resolve_control_weights(request, settings)?.ok_or_else(|| {
         WorkerError::InvalidPayload(format!(
             "Z-Image strict-pose control weights not found (download {ZIMAGE_CONTROL_REPO})."
         ))
@@ -490,7 +503,7 @@ async fn generate_zimage_base_control_stream(
         .ok_or_else(|| WorkerError::InvalidPayload("z-image base model row missing".to_owned()))?;
     let weights_dir = resolve_weights_dir(request, settings)?
         .ok_or_else(|| WorkerError::InvalidPayload("Z-Image base weights not found".to_owned()))?;
-    let control_weights = resolve_base_control_weights(request, settings).ok_or_else(|| {
+    let control_weights = resolve_base_control_weights(request, settings)?.ok_or_else(|| {
         WorkerError::InvalidPayload(format!(
             "Z-Image base strict-control weights not found (download {ZIMAGE_BASE_CONTROL_REPO})."
         ))

--- a/crates/sceneworks-worker/src/image_jobs/zimage_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage_control.rs
@@ -156,7 +156,8 @@ fn zimage_control_guidance(request: &ImageRequest) -> f32 {
 /// The (repo, filename) of the ControlNet weights — `advanced.controlWeights.{repo,filename}` overrides,
 /// else the model's Fun-Controlnet-Union default: the Turbo 8-step variant, or the base
 /// (full-CFG) variant for the base `z_image` model (sc-8379). Parity with the MLX `resolve_control_weights`.
-fn zimage_control_repo_file(request: &ImageRequest) -> (String, String) {
+/// The payload filename must be a plain component (sc-8821 / F-019).
+fn zimage_control_repo_file(request: &ImageRequest) -> WorkerResult<(String, String)> {
     let (default_repo, default_file) = if is_zimage_base_model(&request.model) {
         (ZIMAGE_CTRL_BASE_REPO, ZIMAGE_CTRL_BASE_FILE)
     } else {
@@ -171,10 +172,13 @@ fn zimage_control_repo_file(request: &ImageRequest) -> (String, String) {
             .unwrap_or(default)
             .to_owned()
     };
-    (
+    Ok((
         pick("repo", default_repo),
-        pick("filename", default_file),
-    )
+        safe_weight_filename(
+            &pick("filename", default_file),
+            "advanced.controlWeights.filename",
+        )?,
+    ))
 }
 
 /// Resolve the Fun-Controlnet-Union weight **file** the `ZImageControl` provider loads, downloading on
@@ -186,7 +190,7 @@ async fn ensure_zimage_control_weights(
     job: &JobSnapshot,
     request: &ImageRequest,
 ) -> WorkerResult<PathBuf> {
-    let (repo, file) = zimage_control_repo_file(request);
+    let (repo, file) = zimage_control_repo_file(request)?;
     if let Ok(p) = std::env::var("SCENEWORKS_CONTROLNET_ZIMAGE") {
         let p = PathBuf::from(p);
         if p.is_file() {

--- a/crates/sceneworks-worker/src/paths.rs
+++ b/crates/sceneworks-worker/src/paths.rs
@@ -36,6 +36,30 @@ pub(crate) fn safe_join(base: &Path, relative: &str) -> WorkerResult<PathBuf> {
     Ok(target)
 }
 
+/// Confine a payload-supplied weight *filename* that is joined under a resolved HF
+/// snapshot / app-cache directory (sc-8821 / F-019): `advanced.controlWeights.filename`
+/// on every strict-control lane and `advanced.pidCheckpoint.filename` on the PiD
+/// decoder. The repo half of those overrides is already sanitized
+/// (`safe_repo_dir_name` slugs separators into `--`), but the filename was joined
+/// raw, so a `../../…` (or absolute) filename escaped the snapshot and loaded an
+/// arbitrary readable file as weights — reachable over the LAN jobs API (epic 4484),
+/// the same primitive `normalize_app_managed_lora_path` closes for LoRA paths. A
+/// weight file inside an HF repo snapshot is always a single plain path component,
+/// so require exactly that: no separators (`/` or `\`), no `..`/`.`, not absolute.
+pub(crate) fn safe_weight_filename(filename: &str, label: &str) -> WorkerResult<String> {
+    let filename = filename.trim();
+    let mut components = Path::new(filename).components();
+    let single_normal = matches!(components.next(), Some(std::path::Component::Normal(_)))
+        && components.next().is_none();
+    if single_normal && !filename.contains('/') && !filename.contains('\\') {
+        Ok(filename.to_owned())
+    } else {
+        Err(WorkerError::InvalidPayload(format!(
+            "{label} must be a plain filename (no path separators or '..'): {filename}"
+        )))
+    }
+}
+
 pub(crate) fn normalize_absolute_path(path: &Path) -> WorkerResult<PathBuf> {
     let mut output = if path.is_absolute() {
         PathBuf::new()

--- a/crates/sceneworks-worker/src/paths.rs
+++ b/crates/sceneworks-worker/src/paths.rs
@@ -46,6 +46,14 @@ pub(crate) fn safe_join(base: &Path, relative: &str) -> WorkerResult<PathBuf> {
 /// the same primitive `normalize_app_managed_lora_path` closes for LoRA paths. A
 /// weight file inside an HF repo snapshot is always a single plain path component,
 /// so require exactly that: no separators (`/` or `\`), no `..`/`.`, not absolute.
+///
+/// Callers all live in `image_jobs` lanes gated macOS or off-Mac + `backend-candle`
+/// (`image_jobs/{*_control,pid,*_candle}`), so the bare (non-macOS, non-candle) lib
+/// build has none — silence dead_code only there, like `decode_image_any`.
+#[cfg_attr(
+    all(not(target_os = "macos"), not(feature = "backend-candle")),
+    allow(dead_code)
+)]
 pub(crate) fn safe_weight_filename(filename: &str, label: &str) -> WorkerResult<String> {
     let filename = filename.trim();
     let mut components = Path::new(filename).components();

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -2990,6 +2990,46 @@ fn lora_paths_resolve_symlinks_before_root_check() {
     assert!(error.to_string().contains("LoRA path must be inside"));
 }
 
+// sc-8821 / F-019: payload-supplied weight filenames (`advanced.controlWeights.filename`,
+// `advanced.pidCheckpoint.filename`) are joined under a resolved HF snapshot / app-cache
+// dir, so they must be a single plain path component — traversal, absolute paths, and
+// sub-paths are rejected before any join.
+#[test]
+fn weight_filenames_are_confined_to_plain_components() {
+    // Plain filenames pass through (trimmed).
+    assert_eq!(
+        super::safe_weight_filename("model.safetensors", "advanced.controlWeights.filename")
+            .expect("plain filename accepted"),
+        "model.safetensors"
+    );
+    assert_eq!(
+        super::safe_weight_filename("  model.safetensors  ", "advanced.controlWeights.filename")
+            .expect("surrounding whitespace trimmed"),
+        "model.safetensors"
+    );
+
+    for unsafe_name in [
+        "../../etc/hosts",
+        "..",
+        ".",
+        "",
+        "/etc/hosts",
+        "sub/dir.safetensors",
+        "..\\..\\secrets.safetensors",
+        "sub\\dir.safetensors",
+        "model.safetensors/",
+    ] {
+        let error = super::safe_weight_filename(unsafe_name, "advanced.controlWeights.filename")
+            .expect_err("non-plain filename rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("advanced.controlWeights.filename"),
+            "error names the offending field for {unsafe_name:?}: {error}"
+        );
+    }
+}
+
 // sc-8803 / F-002: LoRA/model import *source* paths are client-supplied over the
 // unauthenticated jobs API; the worker must confine them before copying (or, for
 // uploads, moving) the file into an app-listable directory.


### PR DESCRIPTION
## What / why

sc-8821 / F-019 (security, Medium — code review 2026-07-01): every strict-control lane and the PiD decoder take `advanced.controlWeights.filename` / `advanced.pidCheckpoint.filename` straight from the job payload and `snapshot.join(filename)` it with only an existence check. A `../../…` (or absolute) filename escapes the HF snapshot and loads an arbitrary readable local file as weights — reachable over the epic-4484 LAN jobs API, bypassing the confinement the crate already enforces for LoRA/model paths. The repo half of the same overrides was never exposed (`safe_repo_dir_name` slugs separators), the filename was the gap.

## Fix

New shared helper `safe_weight_filename(filename, label)` in `crates/sceneworks-worker/src/paths.rs` (next to the existing `safe_join` / `ensure_path_under` confinement idiom): a payload weight filename must be a single plain path component — no `/` or `\`, no `..`/`.`, not absolute — else `WorkerError::InvalidPayload` naming the offending field. Every resolver that joins a payload filename under a snapshot/app-cache dir now routes through it and became fallible (`WorkerResult`), so a crafted filename fails the job loudly instead of being joined:

**MLX lane (macOS):**
- `image_jobs/zimage.rs` — `resolve_control_weights_for` (the shared resolver behind `resolve_control_weights`, `resolve_base_control_weights`, and qwen's `resolve_qwen_control_weights`)
- `image_jobs/flux2.rs` — `flux2_control_repo_file`
- `image_jobs/flux1_control.rs` — `flux1_control_repo_file`
- `image_jobs/pid.rs` — `resolve_pid_weights` (`advanced.pidCheckpoint.filename`; also protects the download-cache `dst` join in the ensure paths)

**Candle lane (Windows/CUDA + Linux parity):**
- `image_jobs/qwen_control.rs` — `qwen_control_repo_file`
- `image_jobs/kolors_control.rs` — `kolors_control_repo_file`
- `image_jobs/zimage_control.rs` — `zimage_control_repo_file`
- `image_jobs/flux2_control_candle.rs` — `flux2_control_candle_repo_file`
- `image_jobs/flux1_control_candle.rs` — `flux1_control_candle_repo_file`

The `ensure_*_control_weights` download paths also joined the same filename into `<data>/cache/controlnet-*/<file>` (an arbitrary-write-location primitive on top of the read one); they now consume the validated filename.

Defaults always pass validation, so the error only ever fires on a payload override — no behavior change for normal jobs.

## Tests

- `src/tests.rs::weight_filenames_are_confined_to_plain_components` — helper unit test: plain names pass (trimmed), traversal / absolute / sub-path / backslash / dot / empty rejected with the field name in the error.
- `src/image_jobs/tests.rs::mlx_control_weight_filenames_reject_traversal` (macOS) — all five MLX resolvers reject `../../etc/hosts`, `/etc/hosts`, `sub/x.safetensors`, `..` with an error naming `advanced.controlWeights.filename`; a plain override still resolves.
- `src/image_jobs/tests.rs::candle_control_weight_filenames_reject_traversal` (candle lane) — same matrix across all five candle resolvers.
- `src/image_jobs/pid.rs::resolve_rejects_traversal_pid_checkpoint_filenames` — traversal `pidCheckpoint.filename` rejected naming `advanced.pidCheckpoint.filename`; plain override still resolves.
- Existing resolver default/override tests updated for the now-fallible signatures.

## Verification

- `npm run rust:check` (cargo fmt --check + clippy -D warnings + cargo test + cargo build) — green on macOS.
- `cargo check -p sceneworks-worker --no-default-features --features backend-candle --all-targets` — green on macOS. The `not(target_os = "macos")` candle control lanes cannot compile locally (Linux candle pulls cudarc/nvcc); covered by the CI Linux parity lane.

## Scope notes

Related-but-separate path findings stay on their own stories: sc-8877 (F-075 canonicalize-before-check), sc-8842 (F-040 dataset-upscale), sc-8875 (F-073 pose paths), sc-8876 (F-074 sidecar mask).

Shortcut: https://app.shortcut.com/trefry/story/8821

🤖 Generated with [Claude Code](https://claude.com/claude-code)
