### PR TITLE
fix(web): don't let a failing media-ticket mint block all data loading (sc-9063)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -555,7 +555,13 @@ export function App() {
     });
   }, []);
   const dismissNoticeKind = useCallback((kind) => {
-    setNotices((current) => current.filter((notice) => notice.kind !== kind));
+    setNotices((current) => {
+      // Bail to the same array when nothing matches — callers run this on hot
+      // paths (e.g. every media-ticket refresh), and returning a fresh array
+      // would force a no-op re-render of the whole app each time.
+      const next = current.filter((notice) => notice.kind !== kind);
+      return next.length === current.length ? current : next;
+    });
   }, []);
   // Back-compat: the existing setError(msg)/setError("") call sites map onto the
   // "general" notice kind — a truthy message replaces it, "" dismisses only it.
@@ -834,6 +840,14 @@ export function App() {
 
   useEffect(() => {
     if (!authenticated || !accessResolved) {
+      // Lock/logout stops the mint loop (cleanup above cleared the backoff timer),
+      // so drop the settled gate: the next unlock must re-run sc-8810's
+      // mint-before-data ordering rather than ride a stale mediaReady/
+      // mediaTicketFailed, and the "Retrying in the background" notice must not
+      // linger on the lock screen while no retry is actually running.
+      setMediaReady(false);
+      setMediaTicketFailed(false);
+      dismissNoticeKind("media-ticket");
       return undefined;
     }
     if (!access.authRequired) {

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -824,7 +824,13 @@ export function App() {
   // stored (mediaReady), otherwise thumbnails rendered in the gap would 401 and
   // stick as "deleted" placeholders. When auth is off this resolves immediately.
   const [mediaReady, setMediaReady] = useState(false);
-  const ready = authenticated && mediaReady;
+  // sc-9063 (F-008 follow-up): a persistently failing mint must not blank the whole
+  // app. `ready` waits for the first mint attempt to SETTLE (success or failure),
+  // not for a success: once a mint fails, lists/metadata load anyway — media
+  // degrades to placeholders and recovers when a retry lands — and a "media-ticket"
+  // notice tells the user why media is broken while the backoff keeps retrying.
+  const [mediaTicketFailed, setMediaTicketFailed] = useState(false);
+  const ready = authenticated && (mediaReady || mediaTicketFailed);
 
   useEffect(() => {
     if (!authenticated || !accessResolved) {
@@ -849,6 +855,8 @@ export function App() {
         }
         setMediaTicket(response.ticket);
         setMediaReady(true);
+        setMediaTicketFailed(false);
+        dismissNoticeKind("media-ticket");
         attempt = 0;
         const ttlMs = Math.max(15, Number(response.expiresInSeconds) || 0) * 1000;
         timer = window.setTimeout(acquire, Math.max(5000, Math.floor(ttlMs / 3)));
@@ -856,6 +864,11 @@ export function App() {
         if (closed) {
           return;
         }
+        setMediaTicketFailed(true);
+        pushNotice(
+          "media-ticket",
+          "media authorization: couldn't obtain a media ticket, so thumbnails, previews, and downloads may fail to load. Retrying in the background.",
+        );
         const delay = Math.min(30000, 1000 * 2 ** attempt);
         attempt += 1;
         timer = window.setTimeout(acquire, delay);
@@ -868,7 +881,7 @@ export function App() {
         window.clearTimeout(timer);
       }
     };
-  }, [access.authRequired, accessResolved, authenticated, token]);
+  }, [access.authRequired, accessResolved, authenticated, token, pushNotice, dismissNoticeKind]);
   const imageModels = useMemo(() => {
     const items = models.filter((model) => model.type === "image" && model.installState !== "missing");
     return items.length || models.length ? items : fallbackModels.filter((model) => model.type === "image");
@@ -1234,7 +1247,8 @@ export function App() {
 
   useEffect(() => {
     // Gated on `ready` (not just `authenticated`): SSE job updates carry assets whose
-    // thumbnails render immediately, so the media ticket must exist first (sc-8810).
+    // thumbnails render immediately, so the media-ticket mint must have settled first
+    // (sc-8810; sc-9063 lets a failed mint through — media degrades, data flows).
     if (!ready) {
       return undefined;
     }

--- a/apps/web/src/components/assetMedia.jsx
+++ b/apps/web/src/components/assetMedia.jsx
@@ -85,6 +85,12 @@ export function MissingMedia({ className = "" }) {
 // source fails to load (the file is gone), rather than leaving a broken image.
 function ImageThumb({ src, className }) {
   const [failed, setFailed] = React.useState(false);
+  // sc-9063: a load failure is per-URL, not per-asset. When the src changes —
+  // e.g. a media ticket finally arrives after a mint failure degraded thumbnails
+  // to the placeholder — retry the load instead of sticking on the marker.
+  React.useEffect(() => {
+    setFailed(false);
+  }, [src]);
   if (failed) {
     return <MissingMedia className={className} />;
   }
@@ -111,6 +117,11 @@ export function AssetThumbnail({ asset, className = "" }) {
 function VideoPoster({ asset, className }) {
   const [failed, setFailed] = React.useState(false);
   const poster = posterUrl(asset);
+  // Same per-URL retry as ImageThumb (sc-9063): a new poster URL (fresh media
+  // ticket) clears a stale failure so the placeholder isn't permanent.
+  React.useEffect(() => {
+    setFailed(false);
+  }, [poster]);
   if (!poster) {
     return <span className={className} onContextMenu={suppressThumbnailContextMenu}>{asset.type ?? "video"}</span>;
   }

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App, ErrorBoundary, eventUrl } from "./main.jsx";
 import { AssetPickerField, CharacterImportDialog } from "./components/AssetPicker.jsx";
+import { getMediaTicket, setMediaTicket } from "./api.js";
 import { assetUrl } from "./components/assetMedia.jsx";
 import {
   AssetDetail,
@@ -835,6 +836,150 @@ describe("SceneWorks app shell", () => {
     expect(requests.filter((request) => request.path.endsWith("/jobs/events/ticket")).length).toBe(1);
     expect(FakeEventSource.instances.length).toBe(1);
     expect(FakeEventSource.instances[0].url).toContain("ticket=stream-ticket");
+  });
+
+  // sc-9063 (follow-up to sc-8810 / F-008): a media-ticket mint that keeps failing
+  // in remote-auth mode must not block ALL data loading. `ready` waits for the
+  // first mint attempt to SETTLE, not to succeed: on failure the lists/metadata
+  // still load (thumbnails degrade to placeholders), a distinct notice names the
+  // media-ticket problem, and the notice clears once a backoff retry lands.
+  describe("media-ticket mint failure (sc-9063)", () => {
+    function mockRemoteAuthFetch({ requests = [], mint }) {
+      global.fetch = vi.fn((url, options = {}) => {
+        const path = new URL(url).pathname;
+        requests.push({ path, method: options.method ?? "GET" });
+        if (path.endsWith("/health")) {
+          return Promise.resolve(response({ status: "ok", authRequired: true }));
+        }
+        if (path.endsWith("/access")) {
+          return Promise.resolve(response({ authRequired: true }));
+        }
+        if (path.endsWith("/auth/verify")) {
+          return Promise.resolve(response({ ok: true }));
+        }
+        if (path.endsWith("/jobs/events/ticket")) {
+          return Promise.resolve(response({ ticket: "stream-ticket" }));
+        }
+        if (path.endsWith("/files/ticket")) {
+          return Promise.resolve(
+            mint()
+              ? response({ ticket: "media-ticket-1", expiresInSeconds: 300 })
+              : errorResponse(500, "mint exploded"),
+          );
+        }
+        if (path.endsWith("/projects")) {
+          return Promise.resolve(response([{ id: "project-default", name: "Default Project" }]));
+        }
+        return Promise.resolve(response([]));
+      });
+      return requests;
+    }
+
+    afterEach(() => {
+      setMediaTicket("");
+    });
+
+    it("still loads core data and shows a media-ticket notice when the mint persistently fails", async () => {
+      window.localStorage.setItem("sceneworks-token", "remote-token");
+      const requests = mockRemoteAuthFetch({ mint: () => false });
+
+      root = createRoot(container);
+      await act(async () => {
+        root.render(<App />);
+      });
+      await settle();
+
+      // The mint was attempted and failed…
+      expect(requests.some((request) => request.path.endsWith("/files/ticket"))).toBe(true);
+      expect(getMediaTicket()).toBe("");
+      // …but core data still loads (pre-sc-9063 the whole app stayed empty).
+      expect(requests.some((request) => request.path.endsWith("/projects"))).toBe(true);
+      // And a distinct notice names the media-ticket problem.
+      const noticeTexts = [...document.body.querySelectorAll(".notice.error")].map((node) => node.textContent);
+      expect(noticeTexts.some((text) => text.includes("media ticket"))).toBe(true);
+    });
+
+    it("clears the media-ticket notice once a backoff retry succeeds", async () => {
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      try {
+        window.localStorage.setItem("sceneworks-token", "remote-token");
+        let mintOk = false;
+        mockRemoteAuthFetch({ mint: () => mintOk });
+
+        root = createRoot(container);
+        await act(async () => {
+          root.render(<App />);
+        });
+        await settle();
+
+        expect(getMediaTicket()).toBe("");
+        const failedTexts = [...document.body.querySelectorAll(".notice.error")].map((node) => node.textContent);
+        expect(failedTexts.some((text) => text.includes("media ticket"))).toBe(true);
+
+        // The first backoff retry fires after 1s; let it succeed this time.
+        mintOk = true;
+        await act(async () => {
+          vi.advanceTimersByTime(1000);
+        });
+        await settle();
+
+        expect(getMediaTicket()).toBe("media-ticket-1");
+        const remainingTexts = [...document.body.querySelectorAll(".notice.error")].map((node) => node.textContent);
+        expect(remainingTexts.some((text) => text.includes("media ticket"))).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("still gates the initial data load on a successful mint (sc-8810 unchanged)", async () => {
+      window.localStorage.setItem("sceneworks-token", "remote-token");
+      const requests = mockRemoteAuthFetch({ mint: () => true });
+
+      root = createRoot(container);
+      await act(async () => {
+        root.render(<App />);
+      });
+      await settle();
+
+      expect(getMediaTicket()).toBe("media-ticket-1");
+      const mintIndex = requests.findIndex((request) => request.path.endsWith("/files/ticket"));
+      const projectsIndex = requests.findIndex((request) => request.path.endsWith("/projects"));
+      expect(mintIndex).toBeGreaterThanOrEqual(0);
+      expect(projectsIndex).toBeGreaterThan(mintIndex);
+      expect(document.body.querySelectorAll(".notice.error").length).toBe(0);
+    });
+
+    it("leaves auth-off (desktop/loopback) mode untouched: no mint, data loads, no notice", async () => {
+      const requests = [];
+      global.fetch = vi.fn((url, options = {}) => {
+        const path = new URL(url).pathname;
+        requests.push({ path, method: options.method ?? "GET" });
+        if (path.endsWith("/health")) {
+          return Promise.resolve(response({ status: "ok", authRequired: false }));
+        }
+        if (path.endsWith("/access")) {
+          return Promise.resolve(response({ authRequired: false }));
+        }
+        if (path.endsWith("/jobs/events/ticket")) {
+          return Promise.resolve(response({ ticket: "stream-ticket" }));
+        }
+        if (path.endsWith("/projects")) {
+          return Promise.resolve(response([{ id: "project-default", name: "Default Project" }]));
+        }
+        return Promise.resolve(response([]));
+      });
+
+      root = createRoot(container);
+      await act(async () => {
+        root.render(<App />);
+      });
+      await settle();
+
+      expect(requests.some((request) => request.path.endsWith("/files/ticket"))).toBe(false);
+      expect(requests.some((request) => request.path.endsWith("/projects"))).toBe(true);
+      expect(getMediaTicket()).toBe("");
+      expect(document.body.querySelectorAll(".notice.error").length).toBe(0);
+    });
   });
 
   it("gates the studios behind workspace creation when no projects exist", async () => {

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -949,6 +949,89 @@ describe("SceneWorks app shell", () => {
       expect(document.body.querySelectorAll(".notice.error").length).toBe(0);
     });
 
+    it("lock resets the settled gate and clears the notice; unlock waits for the new mint", async () => {
+      window.localStorage.setItem("sceneworks-token", "remote-token");
+      // Mint behavior across the phases: fail on mount, then hang after unlock so
+      // we can observe the gap between re-login and the new mint settling.
+      let mintBehavior = "fail";
+      let releaseMint = null;
+      const requests = [];
+      global.fetch = vi.fn((url, options = {}) => {
+        const path = new URL(url).pathname;
+        requests.push({ path, method: options.method ?? "GET" });
+        if (path.endsWith("/health")) {
+          return Promise.resolve(response({ status: "ok", authRequired: true }));
+        }
+        if (path.endsWith("/access")) {
+          return Promise.resolve(response({ authRequired: true }));
+        }
+        if (path.endsWith("/auth/verify")) {
+          return Promise.resolve(response({ ok: true }));
+        }
+        if (path.endsWith("/jobs/events/ticket")) {
+          return Promise.resolve(response({ ticket: "stream-ticket" }));
+        }
+        if (path.endsWith("/files/ticket")) {
+          if (mintBehavior === "fail") {
+            return Promise.resolve(errorResponse(500, "mint exploded"));
+          }
+          return new Promise((resolve) => {
+            releaseMint = () => resolve(response({ ticket: "media-ticket-2", expiresInSeconds: 300 }));
+          });
+        }
+        if (path.endsWith("/projects")) {
+          return Promise.resolve(response([{ id: "project-default", name: "Default Project" }]));
+        }
+        return Promise.resolve(response([]));
+      });
+
+      root = createRoot(container);
+      await act(async () => {
+        root.render(<App />);
+      });
+      await settle();
+
+      // sc-9063 baseline: mint failed, data loaded anyway, notice is up.
+      expect(requests.some((request) => request.path.endsWith("/projects"))).toBe(true);
+      const failedTexts = [...document.body.querySelectorAll(".notice.error")].map((node) => node.textContent);
+      expect(failedTexts.some((text) => text.includes("media ticket"))).toBe(true);
+
+      // Lock: the gate returns and the failure state must not leak onto it — the
+      // "Retrying in the background" notice clears (the backoff was stopped by the
+      // mint effect's cleanup, so the message would be a lie).
+      await act(async () => {
+        buttonInside(document.body, "Lock").click();
+      });
+      await settle();
+      expect(document.body.querySelector("#token")).not.toBeNull();
+      expect(document.body.querySelectorAll(".notice.error").length).toBe(0);
+
+      // Unlock while the new mint hangs: mediaTicketFailed was reset on lock, so
+      // `ready` must wait for the NEW mint to settle — no data load in the gap
+      // (sc-8810's mint-before-data ordering applies to re-login too).
+      mintBehavior = "pending";
+      const requestCountAtUnlock = requests.length;
+      await changeField(document.body.querySelector("#token"), "remote-token");
+      await act(async () => {
+        buttonInside(document.body, "Unlock").click();
+      });
+      await settle();
+      const afterUnlock = requests.slice(requestCountAtUnlock);
+      expect(afterUnlock.some((request) => request.path.endsWith("/files/ticket"))).toBe(true);
+      expect(afterUnlock.some((request) => request.path.endsWith("/projects"))).toBe(false);
+
+      // The new mint settles: data loads with the fresh ticket already in place.
+      await act(async () => {
+        releaseMint();
+      });
+      await settle();
+      expect(getMediaTicket()).toBe("media-ticket-2");
+      expect(
+        requests.slice(requestCountAtUnlock).some((request) => request.path.endsWith("/projects")),
+      ).toBe(true);
+      expect(document.body.querySelectorAll(".notice.error").length).toBe(0);
+    });
+
     it("leaves auth-off (desktop/loopback) mode untouched: no mint, data loads, no notice", async () => {
       const requests = [];
       global.fetch = vi.fn((url, options = {}) => {

--- a/apps/web/src/mediaTicket.test.jsx
+++ b/apps/web/src/mediaTicket.test.jsx
@@ -7,7 +7,7 @@ import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { API_BASE_URL, getMediaTicket, setMediaTicket, withMediaTicket } from "./api.js";
-import { assetUrl, posterUrl } from "./components/assetMedia.jsx";
+import { AssetThumbnail, assetUrl, posterUrl } from "./components/assetMedia.jsx";
 import { AssetDetail } from "./components/assetPanels.jsx";
 import { keypointSourceImageUrl } from "./keypointLibrary.js";
 
@@ -84,6 +84,49 @@ describe("asset URL producers carry the media ticket", () => {
     setMediaTicket("t0ken");
     const url = keypointSourceImageUrl("assets/keypoints/asset_x.png");
     expect(url).toContain("/files/assets/keypoints/asset_x.png?ticket=t0ken");
+  });
+});
+
+// sc-9063: when the media-ticket mint fails, data loads anyway and un-ticketed
+// thumbnails 401 into the "deleted" placeholder. The placeholder must be
+// per-URL, not permanent — once a retried mint lands and the src gains the
+// ticket query param, the thumbnail retries instead of sticking on the marker.
+describe("thumbnail placeholders retry when the media URL changes (sc-9063)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it("recovers from the deleted-asset marker once a ticketed URL arrives", async () => {
+    setMediaTicket("");
+    await act(async () => root.render(<AssetThumbnail asset={imageAsset} />));
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+
+    // Un-ticketed URL 401s in remote-auth mode → thumbnail degrades to the marker.
+    await act(async () => {
+      img.dispatchEvent(new window.Event("error"));
+    });
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.querySelector(".asset-thumb-missing")).not.toBeNull();
+
+    // A mint retry lands: the ticketed src is a new URL, so the thumb retries.
+    setMediaTicket("late-ticket");
+    await act(async () => root.render(<AssetThumbnail asset={{ ...imageAsset }} />));
+    const retried = container.querySelector("img");
+    expect(retried).not.toBeNull();
+    expect(retried.src).toContain("ticket=late-ticket");
+    expect(container.querySelector(".asset-thumb-missing")).toBeNull();
   });
 });
 


### PR DESCRIPTION
Story: https://app.shortcut.com/trefry/story/9063

Follow-up to sc-8810 (F-008, PR #1057). That change gated `ready = authenticated && mediaReady`, so if `POST /api/v1/files/ticket` persistently failed in remote-auth mode the app loaded **no data at all** — a total outage instead of just broken media.

## What changed

**Decouple data loading from mint success.** `ready` now waits for the first mint attempt to *settle* (success or failure). On failure, lists/metadata load anyway; media degrades to placeholders while the existing exponential backoff keeps retrying unchanged. The sc-8810 success path is preserved: with a working mint, the initial load still waits for the ticket so first-paint thumbnails never 401.

**Surface the failure.** A distinct `media-ticket` notice in the existing notices band names the problem ("media authorization: couldn't obtain a media ticket…") and clears automatically on the first successful mint.

**Per-URL placeholder recovery.** `ImageThumb`/`VideoPoster` reset their failed state when the src changes, so thumbnails that degraded to the "deleted" marker during the outage retry and recover once a ticketed URL arrives — the marker is no longer permanent.

**Desktop/loopback + auth-off untouched.** With `authRequired: false` there is still no mint attempt, `mediaReady` resolves immediately, and no notice can appear.

**Review follow-ups (87163c31).** (1) Lock/logout now resets `mediaReady`/`mediaTicketFailed` and dismisses the `media-ticket` notice, so re-login after a failed mint re-runs sc-8810's mint-before-data ordering instead of riding a stale `mediaTicketFailed`, and the "Retrying in the background" notice no longer lingers on the lock screen while the backoff is stopped. (2) `dismissNoticeKind` bails out to the same array when no notice of that kind exists — the mint success path calls it every ticket refresh, and the unconditional `filter()` forced a no-op re-render of the app root each cycle.

## Tests

- `main.test.jsx` (new `media-ticket mint failure (sc-9063)` block): persistent mint failure → `/projects` still loads + media-ticket notice visible; backoff retry succeeds → notice clears + ticket stored; sc-8810 mint-before-data ordering still pinned; auth-off mode makes no mint call and shows no notice; lock→unlock clears the notice on lock and holds data loading until the new mint settles.
- `mediaTicket.test.jsx`: deleted-asset marker recovers to a retried `<img>` once the ticketed URL arrives.
- Correction to the earlier claim here: of the 5 original tests, only 3 fail without the fix (persistent-failure, retry-clears-notice, thumbnail recovery); the sc-8810-ordering and auth-off tests are regression pins that pass either way. The new lock→unlock test is verified to fail without the follow-up fix.
- Full web suite 1089/1089 green; eslint 0 errors (49 warnings, identical to main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
