### PR TITLE
feat(worker): per-frame cancel/progress in candle SAM3 propagate (sc-8972)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a9a6f0b011fb1549f5938148b6045db84d606a24#a9a6f0b011fb1549f5938148b6045db84d606a24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a9a6f0b011fb1549f5938148b6045db84d606a24#a9a6f0b011fb1549f5938148b6045db84d606a24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -494,7 +494,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a9a6f0b011fb1549f5938148b6045db84d606a24#a9a6f0b011fb1549f5938148b6045db84d606a24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -508,7 +508,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a9a6f0b011fb1549f5938148b6045db84d606a24#a9a6f0b011fb1549f5938148b6045db84d606a24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a9a6f0b011fb1549f5938148b6045db84d606a24#a9a6f0b011fb1549f5938148b6045db84d606a24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a9a6f0b011fb1549f5938148b6045db84d606a24#a9a6f0b011fb1549f5938148b6045db84d606a24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -542,7 +542,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a9a6f0b011fb1549f5938148b6045db84d606a24#a9a6f0b011fb1549f5938148b6045db84d606a24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -559,7 +559,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a9a6f0b011fb1549f5938148b6045db84d606a24#a9a6f0b011fb1549f5938148b6045db84d606a24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -573,11 +573,10 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a9a6f0b011fb1549f5938148b6045db84d606a24#a9a6f0b011fb1549f5938148b6045db84d606a24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
- "candle-transformers",
  "inventory",
  "rand 0.9.4",
  "rand_distr 0.5.1",
@@ -589,7 +588,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a9a6f0b011fb1549f5938148b6045db84d606a24#a9a6f0b011fb1549f5938148b6045db84d606a24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -601,7 +600,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a9a6f0b011fb1549f5938148b6045db84d606a24#a9a6f0b011fb1549f5938148b6045db84d606a24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -611,7 +610,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a9a6f0b011fb1549f5938148b6045db84d606a24#a9a6f0b011fb1549f5938148b6045db84d606a24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -625,11 +624,10 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a9a6f0b011fb1549f5938148b6045db84d606a24#a9a6f0b011fb1549f5938148b6045db84d606a24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
- "candle-transformers",
  "inventory",
  "rand 0.9.4",
  "rand_distr 0.5.1",
@@ -640,7 +638,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a9a6f0b011fb1549f5938148b6045db84d606a24#a9a6f0b011fb1549f5938148b6045db84d606a24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -653,7 +651,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a9a6f0b011fb1549f5938148b6045db84d606a24#a9a6f0b011fb1549f5938148b6045db84d606a24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -665,7 +663,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a9a6f0b011fb1549f5938148b6045db84d606a24#a9a6f0b011fb1549f5938148b6045db84d606a24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -682,22 +680,20 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a9a6f0b011fb1549f5938148b6045db84d606a24#a9a6f0b011fb1549f5938148b6045db84d606a24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
 dependencies = [
  "candle-gen",
- "candle-transformers",
  "inventory",
  "rand 0.9.4",
  "rand_distr 0.5.1",
  "safetensors 0.7.0",
  "serde_json",
- "tokenizers 0.22.2",
 ]
 
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a9a6f0b011fb1549f5938148b6045db84d606a24#a9a6f0b011fb1549f5938148b6045db84d606a24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -708,7 +704,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a9a6f0b011fb1549f5938148b6045db84d606a24#a9a6f0b011fb1549f5938148b6045db84d606a24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -723,7 +719,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a9a6f0b011fb1549f5938148b6045db84d606a24#a9a6f0b011fb1549f5938148b6045db84d606a24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -740,7 +736,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a9a6f0b011fb1549f5938148b6045db84d606a24#a9a6f0b011fb1549f5938148b6045db84d606a24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -758,7 +754,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a9a6f0b011fb1549f5938148b6045db84d606a24#a9a6f0b011fb1549f5938148b6045db84d606a24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -769,7 +765,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a9a6f0b011fb1549f5938148b6045db84d606a24#a9a6f0b011fb1549f5938148b6045db84d606a24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -782,7 +778,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a9a6f0b011fb1549f5938148b6045db84d606a24#a9a6f0b011fb1549f5938148b6045db84d606a24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -793,7 +789,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a9a6f0b011fb1549f5938148b6045db84d606a24#a9a6f0b011fb1549f5938148b6045db84d606a24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -806,7 +802,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a9a6f0b011fb1549f5938148b6045db84d606a24#a9a6f0b011fb1549f5938148b6045db84d606a24"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -8116,7 +8112,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -494,7 +494,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -508,7 +508,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -542,7 +542,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -559,7 +559,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -588,7 +588,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -600,7 +600,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -610,7 +610,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -624,7 +624,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -638,7 +638,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -651,7 +651,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -663,7 +663,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -680,7 +680,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -693,7 +693,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -704,7 +704,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -719,7 +719,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -736,7 +736,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -754,7 +754,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -765,7 +765,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -778,7 +778,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -789,7 +789,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -802,7 +802,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659#7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1386,8 +1386,8 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d
 # backend-candle` resolves the SINGLE gen-core rev 330d339. Moving to main head also picks up the
 # same-day candle-gen PRs #262-#267 (incl. the candle-core c1e6756 re-pin the old branch pin had
 # deliberately excluded). ALL candle-gen-* rev lines move together.
-# Bumped `a9a6f0b` -> `7b7e86a` (sc-8972): candle-gen PR #274 branch head (based on candle-gen main
-# cb29e59) — `Sam3VideoModel::propagate` gains `cancel: Option<&CancelFlag>` + per-frame `progress`
+# Bumped `a9a6f0b` -> `4b63679` (sc-8972): candle-gen PR #274 SQUASH-merged to candle-gen main as
+# 4b636790 — `Sam3VideoModel::propagate` gains `cancel: Option<&CancelFlag>` + per-frame `progress`
 # (checked before each frame, typed `CandleError::Canceled` on trip; the candle sibling of
 # mlx-gen-sam3's gen-core d8038beb video cancel contract), which `person_segment_sam3_candle` now
 # threads so a user cancel stops mid-clip instead of only at the coarse worker seams. Also picks up
@@ -1395,17 +1395,17 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d
 # image_seed/seeded-noise hoist — all source-only for the worker's surface). candle-gen's OWN
 # gen-core pin is UNCHANGED at 330d339 (= this worker's mlx-gen pin above), so `--features
 # backend-candle` still resolves the SINGLE gen-core rev 330d339 (the skew gate). ALL candle-gen-*
-# rev lines move together. Re-pin to the #274 squash-merge main rev once it lands (candle-gen merges
-# are squash — this branch rev gets orphaned).
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
+# rev lines move together. This is the post-squash main rev — the old branch-head pin 7b7e86a was
+# orphaned by the squash-merge and is no longer reachable.
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1413,17 +1413,17 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1433,7 +1433,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1441,21 +1441,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1464,17 +1464,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1483,7 +1483,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1516,7 +1516,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1525,12 +1525,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1538,7 +1538,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e8
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1547,7 +1547,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1555,7 +1555,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1569,7 +1569,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1596,7 +1596,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1607,7 +1607,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1386,15 +1386,26 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d
 # backend-candle` resolves the SINGLE gen-core rev 330d339. Moving to main head also picks up the
 # same-day candle-gen PRs #262-#267 (incl. the candle-core c1e6756 re-pin the old branch pin had
 # deliberately excluded). ALL candle-gen-* rev lines move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a9a6f0b011fb1549f5938148b6045db84d606a24", features = ["cuda"], optional = true }
+# Bumped `a9a6f0b` -> `7b7e86a` (sc-8972): candle-gen PR #274 branch head (based on candle-gen main
+# cb29e59) — `Sam3VideoModel::propagate` gains `cancel: Option<&CancelFlag>` + per-frame `progress`
+# (checked before each frame, typed `CandleError::Canceled` on trip; the candle sibling of
+# mlx-gen-sam3's gen-core d8038beb video cancel contract), which `person_segment_sam3_candle` now
+# threads so a user cancel stops mid-clip instead of only at the coarse worker seams. Also picks up
+# the intervening candle-gen main PRs #268/#269/#271 (dep pruning, boogu q4 packed-tier load, the
+# image_seed/seeded-noise hoist — all source-only for the worker's surface). candle-gen's OWN
+# gen-core pin is UNCHANGED at 330d339 (= this worker's mlx-gen pin above), so `--features
+# backend-candle` still resolves the SINGLE gen-core rev 330d339 (the skew gate). ALL candle-gen-*
+# rev lines move together. Re-pin to the #274 squash-merge main rev once it lands (candle-gen merges
+# are squash — this branch rev gets orphaned).
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a9a6f0b011fb1549f5938148b6045db84d606a24", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a9a6f0b011fb1549f5938148b6045db84d606a24", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a9a6f0b011fb1549f5938148b6045db84d606a24", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a9a6f0b011fb1549f5938148b6045db84d606a24", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1402,17 +1413,17 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a9a6f0b011fb1549f5938148b6045db84d606a24", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a9a6f0b011fb1549f5938148b6045db84d606a24", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a9a6f0b011fb1549f5938148b6045db84d606a24", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1422,7 +1433,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a9a6f0b011fb1549f5938148b6045db84d606a24", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1430,21 +1441,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a9a6f0b011fb1549f5938148b6045db84d606a24", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a9a6f0b011fb1549f5938148b6045db84d606a24", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a9a6f0b011fb1549f5938148b6045db84d606a24", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a9a6f0b011fb1549f5938148b6045db84d606a24", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1453,17 +1464,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a9a6f0b011fb1549f5938148b6045db84d606a24", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a9a6f0b011fb1549f5938148b6045db84d606a24", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a9a6f0b011fb1549f5938148b6045db84d606a24", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1472,7 +1483,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a9a6f0b011fb1549f5938148b6045db84d606a24", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1505,7 +1516,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a9a6f0b011fb1549f5938148b6045db84d606a24", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1514,12 +1525,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a9a6f0b011fb1549f5938148b6045db84d606a24", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a9a6f0b011fb1549f5938148b6045db84d606a24", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1527,7 +1538,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a9a6f
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a9a6f0b011fb1549f5938148b6045db84d606a24", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1536,7 +1547,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a9a6f0b011fb1549f5938148b6045db84d606a24", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1544,7 +1555,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a9a6f0b011fb1549f5938148b6045db84d606a24", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1558,7 +1569,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a9a6f0b011fb1549f5938148b6045db84d606a24", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1585,7 +1596,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a9a6f0b011fb1549f5938148b6045db84d606a24", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1596,7 +1607,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a9a6f0b011fb1549f5938148b6045db84d606a24", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7b7e86ab2d7dcfcb1d583f834ed249cbdf6cc659", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/media_jobs.rs
+++ b/crates/sceneworks-worker/src/media_jobs.rs
@@ -1176,8 +1176,9 @@ async fn segment_assembly_frames(
         Err(_) => return Ok("degraded"),
     };
     // Keepalive + user cancel across the blocking segment step (sc-8390 / sc-8807), mirroring the
-    // macOS twin. The pinned candle-gen-sam3 propagate takes no cancel/progress params yet
-    // (sc-8972), so the tripped flag stops at the coarse seams (cold parse / model build) only.
+    // macOS twin: the keepalive's cancel poll trips `cancel`, which the engine's per-frame
+    // propagate contract (sc-8972, the candle sibling of gen-core d8038beb) observes between
+    // frames — not just at the coarse seams (cold parse / model build).
     let cancel = gen_core::CancelFlag::new();
     let flag = cancel.clone();
     let outcome = run_blocking_with_heartbeat(
@@ -1194,6 +1195,9 @@ async fn segment_assembly_frames(
                 clip_paths,
                 anchors,
                 Some(flag),
+                Some(Box::new(|frame, total| {
+                    tracing::debug!(event = "sam3_propagate_progress", frame, total);
+                })),
             )
         }),
     )

--- a/crates/sceneworks-worker/src/person_segment_sam3_candle.rs
+++ b/crates/sceneworks-worker/src/person_segment_sam3_candle.rs
@@ -33,12 +33,15 @@ use crate::{Settings, WorkerError, WorkerResult};
 /// of `person_segment::CANCEL_MESSAGE` (Mac-only, so duplicated like the other shared helpers).
 pub(crate) const CANCEL_MESSAGE: &str = "Person segmentation canceled by user.";
 
+/// Per-propagated-frame progress callback `(frame_index, total_frames)` — the candle sibling of
+/// `person_segment::SegmentProgress` (Mac-only, so duplicated like the other shared helpers).
+pub(crate) type SegmentProgress = Box<dyn FnMut(usize, usize) + Send>;
+
 /// Bail out with [`WorkerError::Canceled`] when the threaded flag has been tripped — the coarse
 /// cancel seam guarding frame decode, the cold multi-GB checkpoint parse, and model build/quantize
-/// (sc-8807). Unlike the MLX twin, this is the ONLY cancel granularity on the candle lane: the
-/// pinned `candle-gen-sam3` `Sam3VideoModel::propagate` does not yet take the gen-core d8038beb
-/// `cancel`/`progress` params, so a tripped flag cannot stop mid-propagate (per-frame cancel +
-/// progress need the upstream candle-gen API bump — tracked in sc-8972).
+/// (sc-8807). The same flag is also threaded into `Sam3VideoModel::propagate`'s per-frame cancel
+/// contract (sc-8972, the candle sibling of gen-core d8038beb), so a tripped flag stops the clip
+/// between propagated frames too.
 fn check_segment_canceled(cancel: Option<&CancelFlag>) -> WorkerResult<()> {
     if cancel.is_some_and(CancelFlag::is_cancelled) {
         return Err(WorkerError::Canceled(CANCEL_MESSAGE.to_owned()));
@@ -276,15 +279,18 @@ fn mask_to_frame(mask_logits: &[f32], grid: usize, width: u32, height: u32) -> V
 /// fallback). The checkpoint parses once and is cached process-wide; run under `spawn_blocking` (image
 /// decode + GPU inference are blocking).
 ///
-/// `cancel` is the user-cancel flag (sc-8807), checked at the coarse phase boundaries (frame decode,
-/// cold checkpoint parse, model build/quantize). Per-frame cancel + progress inside the propagate
-/// loop need the candle-gen-sam3 API bump (sc-8972) — see [`check_segment_canceled`].
+/// `cancel` is the user-cancel flag (sc-8807): checked at the coarse phase boundaries here (frame
+/// decode, cold checkpoint parse, model build/quantize) and threaded into the engine's per-frame
+/// propagate cancel contract (sc-8972, the candle sibling of gen-core d8038beb), so a tripped flag
+/// stops the clip between frames with [`WorkerError::Canceled`]. `progress` is invoked
+/// `(frame_index, total_frames)` after each propagated frame.
 pub(crate) fn segment_track_blocking(
     model_path: PathBuf,
     tokenizer_path: PathBuf,
     clip_frame_paths: Vec<PathBuf>,
     anchors: Vec<Option<BoxNorm>>,
     cancel: Option<CancelFlag>,
+    mut progress: Option<SegmentProgress>,
 ) -> WorkerResult<Vec<Vec<u8>>> {
     assert_eq!(
         clip_frame_paths.len(),
@@ -317,8 +323,8 @@ pub(crate) fn segment_track_blocking(
         frames.push(input_tensor(&img, &device)?);
     }
 
-    // Guard the cold multi-GB checkpoint parse + model build — the last cancel seam before the
-    // (currently uncancellable, sc-8972) propagate loop.
+    // Guard the cold multi-GB checkpoint parse + model build — the engine only observes the flag
+    // once propagation starts.
     check_segment_canceled(cancel.as_ref())?;
 
     // Cached checkpoint; recover from a poisoned lock by dropping the cached weights and reloading.
@@ -352,11 +358,23 @@ pub(crate) fn segment_track_blocking(
         .map_err(|e| WorkerError::Engine(format!("sam3 tokenize: {e}")))?;
     check_segment_canceled(cancel.as_ref())?;
 
-    // The pinned candle-gen-sam3 `propagate` takes no `cancel`/`progress` yet (unlike the MLX twin,
-    // gen-core d8038beb); per-frame cancel + progress land with the upstream API bump (sc-8972).
+    // candle-gen-sam3 `propagate` takes `cancel` + per-frame `progress` (sc-8972, the candle
+    // sibling of the MLX video per-step cancel contract, gen-core d8038beb). Thread the caller's
+    // flag/callback so a user cancel stops between frames and each frame reports progress.
     let outputs = model
-        .propagate(&frames, &input_ids, &text_mask)
-        .map_err(|e| WorkerError::Engine(format!("sam3 propagate: {e}")))?;
+        .propagate(
+            &frames,
+            &input_ids,
+            &text_mask,
+            cancel.as_ref(),
+            progress
+                .as_deref_mut()
+                .map(|cb| cb as &mut dyn FnMut(usize, usize)),
+        )
+        .map_err(|e| match e {
+            candle_gen::CandleError::Canceled => WorkerError::Canceled(CANCEL_MESSAGE.to_owned()),
+            e => WorkerError::Engine(format!("sam3 propagate: {e}")),
+        })?;
 
     // Associate SAM3's identities to the selected track, then emit that object's per-frame mask.
     let Some(selected) = select_object(&outputs, &anchors) else {
@@ -418,13 +436,15 @@ fn mask_centroid_x(mask_logits: &[f32], grid: usize) -> Option<f64> {
 /// process-wide; a fresh `Sam3VideoModel` is built per call (clean tracking state). Run under
 /// `spawn_blocking` (GPU inference is blocking).
 ///
-/// `cancel` follows [`segment_track_blocking`] (sc-8807): coarse checks only until the
-/// candle-gen-sam3 propagate API bump (sc-8972).
+/// `cancel`/`progress` follow [`segment_track_blocking`] (sc-8807): coarse checks around the cold
+/// checkpoint parse + model build, the engine's per-frame cancel between frames (sc-8972), and a
+/// `(frame_index, total_frames)` callback after each propagated frame.
 pub(crate) fn segment_all_persons_in_memory(
     model_path: &Path,
     tokenizer_path: &Path,
     frames: &[image::RgbImage],
     cancel: Option<CancelFlag>,
+    mut progress: Option<SegmentProgress>,
 ) -> WorkerResult<AllPersonMasks> {
     check_segment_canceled(cancel.as_ref())?;
     let first = frames.first().ok_or_else(|| {
@@ -446,8 +466,8 @@ pub(crate) fn segment_all_persons_in_memory(
         .map(|f| input_tensor(f, &device))
         .collect::<WorkerResult<Vec<_>>>()?;
 
-    // Guard the cold multi-GB checkpoint parse + model build — the last cancel seam before the
-    // (currently uncancellable, sc-8972) propagate loop.
+    // Guard the cold multi-GB checkpoint parse + model build — the engine only observes the flag
+    // once propagation starts.
     check_segment_canceled(cancel.as_ref())?;
 
     // Cached checkpoint; recover from a poisoned lock by dropping + reloading (mirrors
@@ -481,10 +501,22 @@ pub(crate) fn segment_all_persons_in_memory(
         .map_err(|e| WorkerError::Engine(format!("sam3 tokenize: {e}")))?;
     check_segment_canceled(cancel.as_ref())?;
 
-    // No `cancel`/`progress` on the pinned candle-gen-sam3 propagate yet (sc-8972).
+    // candle-gen-sam3 `propagate` takes `cancel` + per-frame `progress` (sc-8972). Thread the
+    // caller's flag/callback (mirrors `segment_track_blocking`).
     let outputs = model
-        .propagate(&tensors, &input_ids, &text_mask)
-        .map_err(|e| WorkerError::Engine(format!("sam3 propagate: {e}")))?;
+        .propagate(
+            &tensors,
+            &input_ids,
+            &text_mask,
+            cancel.as_ref(),
+            progress
+                .as_deref_mut()
+                .map(|cb| cb as &mut dyn FnMut(usize, usize)),
+        )
+        .map_err(|e| match e {
+            candle_gen::CandleError::Canceled => WorkerError::Canceled(CANCEL_MESSAGE.to_owned()),
+            e => WorkerError::Engine(format!("sam3 propagate: {e}")),
+        })?;
 
     // Paint order: each object's centroid-x in the FIRST frame it appears, ascending (tie-break on
     // first-seen frame, then object id, so repeated runs agree). Shared with the MLX module.
@@ -569,6 +601,7 @@ mod tests {
             vec![PathBuf::from("/nonexistent/frame.png")],
             vec![Some((0.1, 0.1, 0.5, 0.5))],
             Some(cancel.clone()),
+            None,
         );
         assert!(
             matches!(track, Err(WorkerError::Canceled(_))),
@@ -580,6 +613,7 @@ mod tests {
             Path::new("/nonexistent/tokenizer.json"),
             &frames,
             Some(cancel),
+            None,
         );
         assert!(
             matches!(all, Err(WorkerError::Canceled(_))),

--- a/crates/sceneworks-worker/src/scail2_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/scail2_gpu_smoke.rs
@@ -116,6 +116,7 @@ fn scail2_candle_gpu_smoke() {
         &sam3_tok,
         std::slice::from_ref(&ref_rgb),
         None,
+        None,
     )
     .expect("sam3 reference segmentation");
     let ref_bg = if replacement {
@@ -144,6 +145,7 @@ fn scail2_candle_gpu_smoke() {
         &sam3_model,
         &sam3_tok,
         &driving_rgb,
+        None,
         None,
     )
     .expect("sam3 driving segmentation");

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -4185,8 +4185,7 @@ mod stub_fallback_gate {
 // wiring relies on, with a stand-in blocking task in place of the real (weights-requiring)
 // propagate: (a) the worker heartbeat is pinged while the task runs, (b) the API cancel poll
 // trips the threaded `CancelFlag`, and (c) the terminal `Canceled` is posted whether the task
-// honors the flag itself (the MLX per-frame cancel contract) or runs to completion first (the
-// candle coarse-seam lane, sc-8972).
+// honors the flag itself or completes before the flag is tripped.
 // ---------------------------------------------------------------------------
 
 #[derive(Clone)]
@@ -4296,8 +4295,8 @@ async fn keepalive_posts_terminal_canceled_when_the_task_honors_the_flag() {
     );
 }
 
-/// The candle lane (coarse seams only until sc-8972): the compute cannot observe the flag
-/// mid-propagate and runs to completion — the keepalive still posts the terminal `Canceled` with
+/// A task that completes before the flag is observed: the compute finishes and returns `Ok`
+/// before it sees the tripped flag — the keepalive still posts the terminal `Canceled` with
 /// its own cancel copy and returns `WorkerError::Canceled`.
 #[tokio::test]
 async fn keepalive_cancels_the_job_even_when_the_task_cannot_observe_the_flag() {
@@ -4311,7 +4310,7 @@ async fn keepalive_cancels_the_job_even_when_the_task_cannot_observe_the_flag() 
     let wait_flag = flag.clone();
     let task = tokio::task::spawn_blocking(move || -> super::WorkerResult<u32> {
         // Wait until the keepalive has tripped the flag (so `canceled` is set before we return),
-        // then finish successfully — the uncancellable-compute shape.
+        // then finish successfully — the completes-before-observing-the-flag shape.
         let start = std::time::Instant::now();
         while !wait_flag.is_cancelled() && start.elapsed() < Duration::from_secs(30) {
             std::thread::sleep(Duration::from_millis(10));

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -3539,10 +3539,10 @@ async fn resolve_candle_scail2_conditioning(
         .ok_or_else(|| WorkerError::InvalidPayload("scail2 driving frame is malformed".into()))?;
 
     // Segment + paint the reference mask (animation keeps the reference's world → white background).
-    // Both SAM3 passes run under `run_blocking_with_heartbeat` (sc-8390 / sc-8807) so the cold
-    // multi-GB checkpoint parse + per-frame propagation never trip the API's 90s stale-sweep. The
-    // pinned candle-gen-sam3 propagate takes no cancel/progress params yet (sc-8972), so the
-    // tripped flag stops at the coarse seams (cold parse / model build) only.
+    // Both SAM3 passes run under `run_blocking_with_heartbeat` (sc-8390 / sc-8807): the cold
+    // multi-GB checkpoint parse + per-frame propagation can exceed the API's 90s stale-sweep, and
+    // the keepalive's cancel poll trips `cancel`, which the engine's per-frame propagate contract
+    // (sc-8972, the candle sibling of gen-core d8038beb) observes between frames.
     let scail2_cancel_message = "SCAIL-2 canceled during person segmentation.";
     let cancel = gen_core::CancelFlag::new();
     let flag = cancel.clone();
@@ -3560,6 +3560,7 @@ async fn resolve_candle_scail2_conditioning(
                 &rt,
                 std::slice::from_ref(&ref_rgb),
                 Some(flag),
+                None,
             )?;
             crate::scail2_masks::paint_reference_mask(&masks, crate::scail2_masks::BG_WHITE)
         }),
@@ -3582,6 +3583,9 @@ async fn resolve_candle_scail2_conditioning(
                 &sam_tokenizer,
                 &driving_rgb,
                 Some(flag),
+                Some(Box::new(|frame, total| {
+                    tracing::debug!(event = "scail2_sam3_propagate_progress", frame, total);
+                })),
             )?;
             Ok(crate::scail2_masks::paint_driving_masks(
                 &masks,
@@ -3737,7 +3741,8 @@ async fn resolve_candle_scail2_replace_conditioning(
                 WorkerError::InvalidPayload("scail2 reference image is malformed".into())
             })?;
     // Heartbeat keepalive + user cancel across the cold SAM3 parse + single-frame propagate
-    // (sc-8390 / sc-8807); coarse cancel seams only until the candle-gen-sam3 API bump (sc-8972).
+    // (sc-8390 / sc-8807); the engine's per-frame propagate contract (sc-8972) observes the
+    // tripped flag between frames, beyond the coarse seams (cold parse / model build).
     let cancel = gen_core::CancelFlag::new();
     let flag = cancel.clone();
     let ref_mask = run_blocking_with_heartbeat(
@@ -3753,6 +3758,7 @@ async fn resolve_candle_scail2_replace_conditioning(
                 &sam_tokenizer,
                 std::slice::from_ref(&ref_rgb),
                 Some(flag),
+                None,
             )?;
             crate::scail2_masks::paint_reference_mask(&masks, crate::scail2_masks::BG_BLACK)
         }),


### PR DESCRIPTION
Shortcut: [sc-8972](https://app.shortcut.com/trefry/story/8972) — follow-up to sc-8807 (F-006). Pairs with candle-gen PR SceneWorks/candle-gen#274 (**merge that first**, then re-pin — see Merge order).

## Why
The MLX SAM2/SAM3 propagate paths thread a real `CancelFlag` + per-frame progress into the engine (gen-core d8038beb contract). The candle lane got the sc-8807 heartbeat keepalive and a threaded flag, but the pinned `candle-gen-sam3` `Sam3VideoModel::propagate` took NO `cancel`/`progress` params — a user cancel only took effect at the coarse worker seams (frame decode / cold checkpoint parse / model build+quantize), never between propagated frames of a clip.

## What
- **Pin bump (all 26 candle-gen-\* rev lines together)**: `a9a6f0b` → `7b7e86a` (candle-gen PR #274 branch head, based on candle-gen main `cb29e59`). `propagate` now takes `cancel: Option<&CancelFlag>` + `progress: Option<&mut dyn FnMut(usize, usize)>` (per-frame check, typed `CandleError::Canceled` on trip — mirrors mlx-gen-sam3 exactly). candle-gen's own gen-core pin is **unchanged at 330d339** (= this worker's mlx-gen pin), so `--features backend-candle` still resolves ONE gen-core rev. Lock regenerated via `cargo update -p candle-gen` — delta is the rev flip + candle-gen #268's dep-pruning fallout only.
- **`person_segment_sam3_candle.rs`**: `segment_track_blocking` / `segment_all_persons_in_memory` gain `Option<SegmentProgress>` (local twin of `person_segment::SegmentProgress` — that module is Mac-only), thread `cancel.as_ref()` + the callback into `propagate`, and map the typed `Canceled` → `WorkerError::Canceled(CANCEL_MESSAGE)`, exactly like the MLX twin `person_segment_sam3.rs`. Coarse-seam-only comments citing sc-8972 removed.
- **Call sites**: `media_jobs.rs` candle `segment_assembly_frames` passes the same debug-progress callback as the macOS twin; `video_jobs.rs` candle SCAIL-2 conditioning resolvers pass `None` (single ref frame) / debug-progress (driving clip), mirroring the MLX resolvers; `scail2_gpu_smoke.rs` real-weight smoke updated.

## Tests / verification
- Worker `pre_tripped_cancel_short_circuits_both_video_paths` updated to the new signatures (still pins the coarse seam ordering); the typed-Canceled propagate mapping is pinned upstream by candle-gen #274's new unit test.
- `npm run rust:check` green (fmt + clippy + tests + build).
- `./scripts/check-gen-core-skew.sh` green on the default lane AND `--features backend-candle` — single gen-core rev 330d339 on both.
- `cargo check -p sceneworks-worker --no-default-features --features backend-candle --all-targets` green on macOS. The `cfg(not(macos))` candle modules can't compile locally (cudarc build script needs nvcc) — the Linux parity lane is the compile gate for those; all changed `not(macos)` call sites (incl. the test-only `scail2_gpu_smoke`) were swept by hand.

## Merge order
1. Merge candle-gen PR SceneWorks/candle-gen#274 (squash).
2. Re-pin this branch's 26 candle-gen rev lines from branch head `7b7e86a` to the resulting candle-gen **main** rev (the branch rev gets orphaned by the squash), `cargo update -p candle-gen`, re-run the skew script.
3. Merge this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)