### PR TITLE
feat(app): send deleted LoRAs/models and purged assets to the OS trash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4281,7 +4281,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4622,7 +4622,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5687,6 +5687,7 @@ dependencies = [
  "tempfile",
  "tracing",
  "tracing-subscriber",
+ "trash",
  "url",
 ]
 
@@ -5761,6 +5762,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "trash",
  "uuid",
 ]
 
@@ -6582,7 +6584,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -6664,7 +6666,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -6863,7 +6865,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -6888,7 +6890,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -7437,6 +7439,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "trash"
+version = "5.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7602e0c7d66ec2d92a8c917219fbc7894039efa2063b9064260110828a356f46"
+dependencies = [
+ "chrono",
+ "libc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "once_cell",
+ "percent-encoding",
+ "scopeguard",
+ "urlencoding",
+ "windows 0.56.0",
+]
+
+[[package]]
 name = "tray-icon"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7684,6 +7704,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "urlpattern"
@@ -8040,10 +8066,10 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
 ]
 
 [[package]]
@@ -8064,7 +8090,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -8112,7 +8138,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8134,6 +8160,16 @@ dependencies = [
  "raw-window-handle",
  "windows-sys 0.59.0",
  "windows-version",
+]
+
+[[package]]
+name = "windows"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
+dependencies = [
+ "windows-core 0.56.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8160,12 +8196,24 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
+dependencies = [
+ "windows-implement 0.56.0",
+ "windows-interface 0.56.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -8177,8 +8225,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -8197,9 +8245,31 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8237,6 +8307,15 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8765,7 +8844,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,11 @@ license-file = "LICENSE"
 [workspace.dependencies]
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
+# Cross-platform "send to the OS trash" (Windows Recycle Bin / macOS Trash / Linux
+# XDG trash). Used so deleting a LoRA/model or purging an asset is recoverable from
+# the operating system's trash instead of an irreversible unlink. Pinned once here so
+# the api (sync helper) and core (project store purge) resolve the same version.
+trash = "5"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/apps/rust-api/Cargo.toml
+++ b/apps/rust-api/Cargo.toml
@@ -24,6 +24,8 @@ serde_json = "1.0"
 tokio = { version = "1.40", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tracing = { workspace = true }
+# Move deleted LoRA/model artifacts to the OS trash (recoverable) rather than unlinking them.
+trash = { workspace = true }
 tokio-util = { version = "0.7", features = ["io"] }
 tower-http = { version = "0.6", features = ["cors"] }
 uuid = { version = "1.11", features = ["v4"] }

--- a/apps/rust-api/src/assets.rs
+++ b/apps/rust-api/src/assets.rs
@@ -296,10 +296,12 @@ pub(crate) async fn delete_asset(
 pub(crate) async fn purge_asset(
     State(state): State<AppState>,
     Path((project_id, asset_id)): Path<(String, String)>,
+    Query(query): Query<AssetPurgeQuery>,
 ) -> Result<Json<sceneworks_core::project_store::AssetMutationResult>, ApiError> {
+    let permanent = query.permanent.unwrap_or(false);
     Ok(Json(
         project_call(state, move |store| {
-            store.purge_asset(&project_id, &asset_id)
+            store.purge_asset(&project_id, &asset_id, permanent)
         })
         .await?,
     ))

--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -126,6 +126,17 @@ pub(crate) struct LorasQuery {
 pub(crate) struct CatalogDeleteQuery {
     pub(crate) project_id: Option<String>,
     pub(crate) scope: Option<String>,
+    /// When true, permanently unlink the artifacts instead of moving them to the OS
+    /// trash. The UI only sets this on the second call after a "move to trash" failure
+    /// prompts the user to confirm a permanent delete. Defaults to false (trash first).
+    pub(crate) permanent: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AssetPurgeQuery {
+    /// See `CatalogDeleteQuery::permanent` — false trashes the media/sidecar, true unlinks.
+    pub(crate) permanent: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -1916,11 +1916,51 @@ fn unique_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
     unique
 }
 
+/// Result of attempting to remove a batch of SceneWorks-owned artifact paths.
+#[derive(Default)]
+struct ArtifactRemoval {
+    /// Paths successfully moved to the OS trash (or permanently unlinked).
+    removed_paths: Vec<String>,
+    /// Paths left in place because they are not inside a SceneWorks-owned root
+    /// (e.g. a shared Hugging Face cache blob referenced by another model).
+    retained_paths: Vec<String>,
+    /// Owned paths that could NOT be moved to the OS trash (recycle bin disabled,
+    /// unsupported volume, item too large, …). Nothing was deleted for these, so the
+    /// caller can prompt the user before falling back to a permanent delete.
+    trash_failed_paths: Vec<String>,
+}
+
+/// Move a single path to the operating-system trash (Windows Recycle Bin / macOS
+/// Trash / Linux XDG trash). `trash::delete` is blocking, so it runs on the blocking
+/// pool to avoid stalling the async runtime.
+async fn move_path_to_os_trash(path: PathBuf) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || trash::delete(&path))
+        .await
+        .map_err(|error| format!("trash task failed: {error}"))?
+        .map_err(|error| error.to_string())
+}
+
+/// Remove a batch of artifact paths, moving each SceneWorks-owned path to the OS
+/// trash unless `permanent` is set (then unlink it). Paths outside the allowed roots
+/// are retained. A trash failure is non-fatal: the path is recorded in
+/// `trash_failed_paths` so the caller can offer a permanent-delete confirmation.
+async fn remove_owned_artifacts(
+    paths: Vec<PathBuf>,
+    allowed_roots: &[PathBuf],
+    permanent: bool,
+) -> Result<ArtifactRemoval, ApiError> {
+    let mut removal = ArtifactRemoval::default();
+    for path in paths {
+        remove_owned_artifact_path(path, allowed_roots, permanent, &mut removal).await?;
+    }
+    Ok(removal)
+}
+
 async fn remove_owned_artifact_path(
     path: PathBuf,
     allowed_roots: &[PathBuf],
-    removed_paths: &mut Vec<String>,
-    retained_paths: &mut Vec<String>,
+    permanent: bool,
+    removal: &mut ArtifactRemoval,
 ) -> Result<(), ApiError> {
     let metadata = match tokio::fs::symlink_metadata(&path).await {
         Ok(metadata) => metadata,
@@ -1948,25 +1988,40 @@ async fn remove_owned_artifact_path(
         }
     }
     if !owned {
-        retained_paths.push(path.display().to_string());
+        removal.retained_paths.push(path.display().to_string());
         return Ok(());
     }
-    if metadata.is_dir() {
-        tokio::fs::remove_dir_all(&path).await.map_err(|error| {
-            ApiError::internal(format!(
-                "Failed to remove artifact directory {}: {error}",
-                path.display()
-            ))
-        })?;
-    } else {
-        tokio::fs::remove_file(&path).await.map_err(|error| {
-            ApiError::internal(format!(
-                "Failed to remove artifact file {}: {error}",
-                path.display()
-            ))
-        })?;
+    if permanent {
+        if metadata.is_dir() {
+            tokio::fs::remove_dir_all(&path).await.map_err(|error| {
+                ApiError::internal(format!(
+                    "Failed to remove artifact directory {}: {error}",
+                    path.display()
+                ))
+            })?;
+        } else {
+            tokio::fs::remove_file(&path).await.map_err(|error| {
+                ApiError::internal(format!(
+                    "Failed to remove artifact file {}: {error}",
+                    path.display()
+                ))
+            })?;
+        }
+        removal.removed_paths.push(path.display().to_string());
+        return Ok(());
     }
-    removed_paths.push(path.display().to_string());
+    match move_path_to_os_trash(path.clone()).await {
+        Ok(()) => removal.removed_paths.push(path.display().to_string()),
+        Err(error) => {
+            tracing::warn!(
+                event = "artifact_trash_failed",
+                path = %path.display(),
+                error = %error,
+                "Failed to move artifact to the OS trash; awaiting permanent-delete confirmation"
+            );
+            removal.trash_failed_paths.push(path.display().to_string());
+        }
+    }
     Ok(())
 }
 

--- a/apps/rust-api/src/loras.rs
+++ b/apps/rust-api/src/loras.rs
@@ -182,24 +182,43 @@ pub(crate) async fn delete_lora(
         ),
         _ => return Err(ApiError::bad_request("Unsupported LoRA scope")),
     };
+    let permanent = query.permanent.unwrap_or(false);
+    // Peek (not remove) the manifest entry so a failed move-to-trash leaves the
+    // catalog intact for the client's permanent-delete confirmation prompt.
+    let manifest_entry = if let Some(manifest_path) = manifest_path.as_deref() {
+        load_manifest_entries(&state, manifest_path, "loras")
+            .await?
+            .into_iter()
+            .find(|entry| entry.get("id").and_then(Value::as_str) == Some(lora_id.as_str()))
+    } else {
+        None
+    };
+    let cleanup_source = manifest_entry.as_ref().unwrap_or(&lora);
+    let removal = remove_owned_artifacts(
+        lora_artifact_paths(cleanup_source, &default_root),
+        &allowed_roots,
+        permanent,
+    )
+    .await?;
+    if !permanent && !removal.trash_failed_paths.is_empty() {
+        return Ok(Json(json!({
+            "id": lora_id,
+            "kind": "lora",
+            "scope": scope,
+            "trashUnavailable": true,
+            "trashFailedPaths": removal.trash_failed_paths,
+            "removedManifestEntry": false,
+            "removedLocalArtifacts": !removal.removed_paths.is_empty(),
+            "removedPaths": removal.removed_paths,
+            "retainedPaths": removal.retained_paths,
+        })));
+    }
     let removed_entry = if let Some(manifest_path) = manifest_path.as_deref() {
         remove_catalog_manifest_entry(&state, manifest_path, "loras", &lora_id).await?
     } else {
         None
     };
-    let cleanup_source = removed_entry.as_ref().unwrap_or(&lora);
-    let mut removed_paths = Vec::new();
-    let mut retained_paths = Vec::new();
-    for path in lora_artifact_paths(cleanup_source, &default_root) {
-        remove_owned_artifact_path(
-            path,
-            &allowed_roots,
-            &mut removed_paths,
-            &mut retained_paths,
-        )
-        .await?;
-    }
-    if removed_entry.is_none() && removed_paths.is_empty() {
+    if removed_entry.is_none() && removal.removed_paths.is_empty() {
         return Err(ApiError::bad_request(
             "Built-in LoRA catalog entries are read-only unless local files are installed",
         ));
@@ -215,10 +234,11 @@ pub(crate) async fn delete_lora(
         "id": lora_id,
         "kind": "lora",
         "scope": scope,
+        "trashed": !permanent,
         "removedManifestEntry": removed_entry.is_some(),
-        "removedLocalArtifacts": !removed_paths.is_empty(),
-        "removedPaths": removed_paths,
-        "retainedPaths": retained_paths,
+        "removedLocalArtifacts": !removal.removed_paths.is_empty(),
+        "removedPaths": removal.removed_paths,
+        "retainedPaths": removal.retained_paths,
         "warnings": warnings,
         "policy": policy,
     })))

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -384,7 +384,9 @@ pub(crate) async fn create_model_convert_job(
 pub(crate) async fn delete_model(
     State(state): State<AppState>,
     Path(model_id): Path<String>,
+    Query(query): Query<CatalogDeleteQuery>,
 ) -> Result<Json<Value>, ApiError> {
+    let permanent = query.permanent.unwrap_or(false);
     let catalog = model_catalog(&state).await?;
     let model = catalog
         .into_iter()
@@ -398,25 +400,40 @@ pub(crate) async fn delete_model(
         .config_dir
         .join("manifests")
         .join("user.models.jsonc");
-    let removed_entry =
-        remove_catalog_manifest_entry(&state, &manifest_path, "models", &model_id).await?;
-    let cleanup_source = removed_entry.as_ref().unwrap_or(&model);
-    let mut removed_paths = Vec::new();
-    let mut retained_paths = Vec::new();
+    // Peek (not remove) the manifest entry so that if moving the files to the OS
+    // trash fails we can leave the catalog untouched and prompt for confirmation.
+    let manifest_entry = load_manifest_entries(&state, &manifest_path, "models")
+        .await?
+        .into_iter()
+        .find(|entry| entry.get("id").and_then(Value::as_str) == Some(model_id.as_str()));
+    let cleanup_source = manifest_entry.as_ref().unwrap_or(&model);
     let allowed_roots = vec![
         state.settings.data_dir.join("models"),
         huggingface_hub_cache_dir(&state.settings.data_dir),
     ];
-    for path in model_artifact_paths(cleanup_source, &state.settings.data_dir) {
-        remove_owned_artifact_path(
-            path,
-            &allowed_roots,
-            &mut removed_paths,
-            &mut retained_paths,
-        )
-        .await?;
+    let removal = remove_owned_artifacts(
+        model_artifact_paths(cleanup_source, &state.settings.data_dir),
+        &allowed_roots,
+        permanent,
+    )
+    .await?;
+    // Some owned files could not reach the OS trash and nothing was permanently
+    // deleted. Leave the registry entry in place and ask the client to confirm.
+    if !permanent && !removal.trash_failed_paths.is_empty() {
+        return Ok(Json(json!({
+            "id": model_id,
+            "kind": "model",
+            "trashUnavailable": true,
+            "trashFailedPaths": removal.trash_failed_paths,
+            "removedManifestEntry": false,
+            "removedLocalArtifacts": !removal.removed_paths.is_empty(),
+            "removedPaths": removal.removed_paths,
+            "retainedPaths": removal.retained_paths,
+        })));
     }
-    if removed_entry.is_none() && removed_paths.is_empty() {
+    let removed_entry =
+        remove_catalog_manifest_entry(&state, &manifest_path, "models", &model_id).await?;
+    if removed_entry.is_none() && removal.removed_paths.is_empty() {
         return Err(ApiError::bad_request(
             "Built-in model catalog entries are read-only unless local files are installed",
         ));
@@ -430,10 +447,11 @@ pub(crate) async fn delete_model(
     Ok(Json(json!({
         "id": model_id,
         "kind": "model",
+        "trashed": !permanent,
         "removedManifestEntry": removed_entry.is_some(),
-        "removedLocalArtifacts": !removed_paths.is_empty(),
-        "removedPaths": removed_paths,
-        "retainedPaths": retained_paths,
+        "removedLocalArtifacts": !removal.removed_paths.is_empty(),
+        "removedPaths": removal.removed_paths,
+        "retainedPaths": removal.retained_paths,
         "warnings": warnings,
         "policy": policy,
     })))

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -1087,10 +1087,12 @@ async fn project_and_asset_routes_persist_contract_state() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(reindex["assets"], 2);
 
+    // permanent=true exercises the deterministic hard-delete path; the default
+    // (move-to-OS-trash) is environment-dependent and validated manually.
     let (status, purged) = request(
         app,
         "DELETE",
-        &format!("/api/v1/projects/{project_id}/assets/{asset_id}/purge"),
+        &format!("/api/v1/projects/{project_id}/assets/{asset_id}/purge?permanent=true"),
         Value::Null,
     )
     .await;
@@ -7178,10 +7180,12 @@ async fn catalog_delete_routes_remove_manifest_entries_and_owned_artifacts() {
     .expect("user presets writes");
 
     let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    // permanent=true keeps the assertions deterministic (the default move-to-OS-trash
+    // path depends on the host having a usable recycle bin/trash).
     let (model_status, model_delete) = request(
         app.clone(),
         "DELETE",
-        "/api/v1/models/delete_me",
+        "/api/v1/models/delete_me?permanent=true",
         Value::Null,
     )
     .await;
@@ -7199,7 +7203,7 @@ async fn catalog_delete_routes_remove_manifest_entries_and_owned_artifacts() {
     let (lora_status, lora_delete) = request(
         app.clone(),
         "DELETE",
-        "/api/v1/loras/delete_style?scope=global",
+        "/api/v1/loras/delete_style?scope=global&permanent=true",
         Value::Null,
     )
     .await;

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -2135,7 +2135,18 @@ export function App() {
   const purgeAsset = useCallback(
     async (asset) => {
       try {
-        await apiFetch(`/api/v1/projects/${asset.projectId}/assets/${asset.id}/purge`, token, { method: "DELETE" });
+        let result = await apiFetch(`/api/v1/projects/${asset.projectId}/assets/${asset.id}/purge`, token, { method: "DELETE" });
+        // The purge first tries the OS trash (recoverable). If that fails nothing was
+        // removed; confirm before falling back to a permanent delete.
+        if (result?.status === "trash_unavailable") {
+          const proceed = typeof window.confirm !== "function" ||
+            window.confirm("Cannot move to trash. Continue to permanently delete.");
+          if (!proceed) {
+            setError("");
+            return;
+          }
+          result = await apiFetch(`/api/v1/projects/${asset.projectId}/assets/${asset.id}/purge?permanent=true`, token, { method: "DELETE" });
+        }
         setAssets((items) => items.filter((item) => item.id !== asset.id));
         setSelectedAssetId((current) => (current === asset.id ? null : current));
         setError("");

--- a/apps/web/src/hooks/useModelsAndLoras.js
+++ b/apps/web/src/hooks/useModelsAndLoras.js
@@ -10,6 +10,14 @@ function uploadLimitLabel(bytes) {
   return Number.isInteger(gib) ? `${gib}GB` : `${gib.toFixed(1)}GB`;
 }
 
+// A delete first tries to move the artifacts to the OS trash (Recycle Bin / Trash).
+// When that fails the API removes nothing and returns `trashUnavailable`; the user is
+// then asked whether to fall back to a permanent delete. Returns true to proceed.
+export const TRASH_UNAVAILABLE_CONFIRM = "Cannot move to trash. Continue to permanently delete.";
+function confirmPermanentDelete() {
+  return typeof window.confirm !== "function" || window.confirm(TRASH_UNAVAILABLE_CONFIRM);
+}
+
 // Owns the model + LoRA catalogs and their import/download/convert/delete actions.
 // Extracted from App.jsx (sc-1651). Models and LoRAs are coupled (a LoRA delete/
 // import re-pulls both via the lora overlay), so they share one hook. App keeps the
@@ -60,9 +68,19 @@ export function useModelsAndLoras({
 
   const deleteModel = useCallback(
     async (model) => {
-      const result = await apiFetch(`/api/v1/models/${encodeURIComponent(model.id)}`, token, {
+      let result = await apiFetch(`/api/v1/models/${encodeURIComponent(model.id)}`, token, {
         method: "DELETE",
       });
+      if (result?.trashUnavailable) {
+        if (!confirmPermanentDelete()) {
+          return { cancelled: true };
+        }
+        result = await apiFetch(
+          `/api/v1/models/${encodeURIComponent(model.id)}?permanent=true`,
+          token,
+          { method: "DELETE" },
+        );
+      }
       if (result.removedManifestEntry) {
         setModels((items) => items.filter((item) => item.id !== model.id));
       }
@@ -83,9 +101,20 @@ export function useModelsAndLoras({
       params.set("projectId", activeProject.id);
     }
     const query = params.toString() ? `?${params.toString()}` : "";
-    const result = await apiFetch(`/api/v1/loras/${encodeURIComponent(lora.id)}${query}`, token, {
+    let result = await apiFetch(`/api/v1/loras/${encodeURIComponent(lora.id)}${query}`, token, {
       method: "DELETE",
     });
+    if (result?.trashUnavailable) {
+      if (!confirmPermanentDelete()) {
+        return { cancelled: true };
+      }
+      params.set("permanent", "true");
+      result = await apiFetch(
+        `/api/v1/loras/${encodeURIComponent(lora.id)}?${params.toString()}`,
+        token,
+        { method: "DELETE" },
+      );
+    }
     if (result.removedManifestEntry) {
       setLoras((items) => items.filter((item) => item.id !== lora.id || item.scope !== lora.scope));
     }

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -765,7 +765,11 @@ export function ModelManagerScreen() {
     setDeleteMessage({ tone: "neutral", text: "" });
     try {
       const result = await onDeleteModel(model);
-      setDeleteMessage({ tone: "success", text: deleteResultText(result, model.name ?? model.id) });
+      if (result?.cancelled) {
+        setDeleteMessage({ tone: "neutral", text: "" });
+      } else {
+        setDeleteMessage({ tone: "success", text: deleteResultText(result, model.name ?? model.id) });
+      }
     } catch (err) {
       setDeleteMessage({ tone: "error", text: err.message });
     } finally {
@@ -784,7 +788,11 @@ export function ModelManagerScreen() {
     setDeleteMessage({ tone: "neutral", text: "" });
     try {
       const result = await onDeleteLora(lora);
-      setDeleteMessage({ tone: "success", text: deleteResultText(result, lora.name ?? lora.id) });
+      if (result?.cancelled) {
+        setDeleteMessage({ tone: "neutral", text: "" });
+      } else {
+        setDeleteMessage({ tone: "success", text: deleteResultText(result, lora.name ?? lora.id) });
+      }
     } catch (err) {
       setDeleteMessage({ tone: "error", text: err.message });
     } finally {

--- a/crates/sceneworks-core/Cargo.toml
+++ b/crates/sceneworks-core/Cargo.toml
@@ -25,6 +25,8 @@ imagesize = "0.13"
 sha2 = "0.10"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+# Purge sends asset media/sidecars to the OS trash (recoverable) instead of unlinking.
+trash = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.13"

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -2257,10 +2257,15 @@ impl ProjectStore {
         })
     }
 
+    /// Permanently remove a (usually already-trashed) asset. With `permanent = false`
+    /// the on-disk media/sidecar are moved to the OS trash (recoverable); if that move
+    /// fails nothing is deleted and the result carries `status = "trash_unavailable"`
+    /// so the caller can prompt the user to confirm a permanent delete (`permanent = true`).
     pub fn purge_asset(
         &self,
         project_id: &str,
         asset_id: &str,
+        permanent: bool,
     ) -> ProjectStoreResult<AssetMutationResult> {
         let (project_path, _project_guard) = self.lock_project(project_id)?;
         let sidecar_path = self.find_asset_sidecar(&project_path, asset_id)?;
@@ -2271,20 +2276,53 @@ impl ProjectStore {
                 .and_then(Value::as_str)
                 .unwrap_or_default(),
         );
+        let trash_dir = project_path.join("trash");
+        let asset_trash_dir = sidecar_path
+            .parent()
+            .filter(|parent| {
+                parent.file_name().and_then(|name| name.to_str()) == Some(asset_id)
+                    && parent.parent() == Some(trash_dir.as_path())
+            })
+            .map(Path::to_path_buf);
+        if !permanent {
+            // Move the asset's footprint to the OS trash rather than unlinking it. When
+            // the asset already lives in `trash/<id>/`, trash that directory in one shot;
+            // otherwise trash the media file and sidecar directly.
+            let targets: Vec<PathBuf> = if let Some(dir) = asset_trash_dir.clone() {
+                vec![dir]
+            } else {
+                let mut targets = Vec::new();
+                if media_path.exists() && media_path.is_file() {
+                    targets.push(media_path.clone());
+                }
+                if sidecar_path.exists() {
+                    targets.push(sidecar_path.clone());
+                }
+                targets
+            };
+            if !targets.is_empty() && trash::delete_all(&targets).is_err() {
+                // Nothing was removed; let the caller confirm a permanent delete.
+                return Ok(AssetMutationResult {
+                    id: asset_id.to_owned(),
+                    status: "trash_unavailable".to_owned(),
+                });
+            }
+            CharacterStore::new(&self.data_dir, project_path.clone())
+                .remove_asset_references(asset_id)?;
+            purge_asset_record(&project_path, asset_id)?;
+            return Ok(AssetMutationResult {
+                id: asset_id.to_owned(),
+                status: "purged".to_owned(),
+            });
+        }
         CharacterStore::new(&self.data_dir, project_path.clone())
             .remove_asset_references(asset_id)?;
         if media_path.exists() && media_path.is_file() {
             fs::remove_file(media_path)?;
         }
         fs::remove_file(&sidecar_path).ok();
-        let trash_dir = project_path.join("trash");
-        if sidecar_path.parent().is_some_and(|parent| {
-            parent.file_name().and_then(|name| name.to_str()) == Some(asset_id)
-                && parent.parent() == Some(trash_dir.as_path())
-        }) {
-            if let Some(parent) = sidecar_path.parent() {
-                fs::remove_dir_all(parent).ok();
-            }
+        if let Some(parent) = asset_trash_dir {
+            fs::remove_dir_all(parent).ok();
         }
         purge_asset_record(&project_path, asset_id)?;
         Ok(AssetMutationResult {
@@ -5072,7 +5110,7 @@ mod tests {
             Err(ProjectStoreError::BadRequest(_))
         ));
         assert!(matches!(
-            store.purge_asset(&project.id, evil),
+            store.purge_asset(&project.id, evil, true),
             Err(ProjectStoreError::BadRequest(_))
         ));
         // The traversal target is untouched.

--- a/crates/sceneworks-core/tests/character_store.rs
+++ b/crates/sceneworks-core/tests/character_store.rs
@@ -398,7 +398,7 @@ fn purge_asset_removes_character_references_and_look_ids() {
         .expect("look creates");
 
     store
-        .purge_asset(&project.id, &asset_id)
+        .purge_asset(&project.id, &asset_id, true)
         .expect("asset purges");
 
     let character = store


### PR DESCRIPTION
## Why

Deleting a LoRA or model from the Models page, or purging an asset, used to `unlink`/`remove_dir_all` the files immediately and irreversibly. Reported after a 6-hour-trained LoRA was lost to a single accidental click.

## What

Deletes and purges now move the on-disk artifacts to the **operating-system trash** (Windows Recycle Bin / macOS Trash / Linux XDG trash) via the [`trash`](https://crates.io/crates/trash) crate, so the files are recoverable from the OS.

Covered flows:
- **Delete model** and **delete LoRA** (Models page) — shared `remove_owned_artifacts` helper.
- **Purge asset** (empties the app-level trash into the OS trash).

### Fallback when the OS trash is unavailable

Some paths can't be trashed (recycle bin disabled, network/unsupported volume, item exceeds the bin). In that case the API **removes nothing** — the manifest entry / DB record is left intact — and signals the client (`trashUnavailable` for model/LoRA, `status: "trash_unavailable"` for assets). The UI then prompts:

> Cannot move to trash. Continue to permanently delete.

On **Continue** it re-issues the request with `?permanent=true` for the original irreversible delete; on **Cancel** nothing is deleted and the catalog is untouched.

### Notes / trade-offs

- Model/LoRA deletes now **peek** the manifest entry and only drop it *after* the files are handled, so a cancelled fallback can't leave an orphaned entry.
- The confirmation reuses `window.confirm` (consistent with the existing delete confirmation), so the buttons are the browser-native **OK / Cancel** rather than literally "Continue / Cancel". Happy to swap in a custom modal if exact labels are wanted.
- The existing app-level asset trash (delete → `trash/` folder → purge) is unchanged; only the final purge now empties to the OS trash.

## Testing

- `cargo clippy` clean; `cargo test` — core lib 351, rust-api lib 160, `character_store` 9 — all pass.
- Web `vitest` — 66 files / 1089 tests pass; `vite build` OK.
- The default move-to-OS-trash path is environment-dependent, so the automated delete/purge tests pin `?permanent=true` to stay deterministic; the trash path is validated manually on Windows (Recycle Bin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
