### PR TITLE
fix(tests): merge snapshots on UPDATE_SNAPSHOTS instead of clobbering (sc-8862)

### DIFF
--- a/tests/test_rust_api_contract_snapshot_merge.py
+++ b/tests/test_rust_api_contract_snapshot_merge.py
@@ -1,0 +1,97 @@
+"""Unit tests for the snapshot writer's merge behavior (sc-8862).
+
+These are deliberately *not* marked ``parity`` — they exercise the pure
+``write_updated_snapshots`` merge logic without spinning up the Rust API, so
+they run in the default CI lane (``-m "not e2e and not parity"``) and guard
+against the regression where a filtered ``UPDATE_SNAPSHOTS=1`` run clobbered
+every untouched snapshot.
+"""
+
+from __future__ import annotations
+
+import json
+
+import test_rust_api_contract_snapshots as mod
+
+
+def _write_snapshots(path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def test_filtered_update_preserves_untouched_snapshots(monkeypatch, tmp_path):
+    snapshot_path = tmp_path / "snapshots.json"
+    # Pre-existing on-disk snapshots, as if written by a prior full run.
+    _write_snapshots(
+        snapshot_path,
+        {
+            "character contract": {"kind": "character"},
+            "timeline contract": {"kind": "timeline"},
+            "worker contract": {"kind": "worker"},
+        },
+    )
+
+    # Simulate `UPDATE_SNAPSHOTS=1 pytest -k character`: only the character
+    # label is accumulated during the run.
+    monkeypatch.setattr(mod, "SNAPSHOT_PATH", snapshot_path)
+    monkeypatch.setattr(mod, "UPDATE_SNAPSHOTS", True)
+    monkeypatch.setattr(
+        mod,
+        "UPDATED_SNAPSHOTS",
+        {"character contract": {"kind": "character", "rev": 2}},
+    )
+
+    mod.write_updated_snapshots()
+
+    result = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    # Touched label is updated in place.
+    assert result["character contract"] == {"kind": "character", "rev": 2}
+    # Untouched labels are preserved rather than clobbered.
+    assert result["timeline contract"] == {"kind": "timeline"}
+    assert result["worker contract"] == {"kind": "worker"}
+
+
+def test_first_ever_generation_starts_from_empty(monkeypatch, tmp_path):
+    # No file on disk yet: the writer must create it from the run's labels.
+    snapshot_path = tmp_path / "nested" / "snapshots.json"
+    assert not snapshot_path.exists()
+
+    monkeypatch.setattr(mod, "SNAPSHOT_PATH", snapshot_path)
+    monkeypatch.setattr(mod, "UPDATE_SNAPSHOTS", True)
+    monkeypatch.setattr(mod, "UPDATED_SNAPSHOTS", {"only label": {"kind": "only"}})
+
+    mod.write_updated_snapshots()
+
+    result = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    assert result == {"only label": {"kind": "only"}}
+
+
+def test_writer_is_noop_when_update_disabled(monkeypatch, tmp_path):
+    snapshot_path = tmp_path / "snapshots.json"
+    _write_snapshots(snapshot_path, {"existing": {"kind": "existing"}})
+
+    monkeypatch.setattr(mod, "SNAPSHOT_PATH", snapshot_path)
+    monkeypatch.setattr(mod, "UPDATE_SNAPSHOTS", False)
+    monkeypatch.setattr(mod, "UPDATED_SNAPSHOTS", {"new": {"kind": "new"}})
+
+    mod.write_updated_snapshots()
+
+    # Unchanged: the writer returns early when UPDATE_SNAPSHOTS is off.
+    result = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    assert result == {"existing": {"kind": "existing"}}
+
+
+def test_output_is_sorted_and_stable(monkeypatch, tmp_path):
+    snapshot_path = tmp_path / "snapshots.json"
+    _write_snapshots(snapshot_path, {"zeta": {"kind": "z"}})
+
+    monkeypatch.setattr(mod, "SNAPSHOT_PATH", snapshot_path)
+    monkeypatch.setattr(mod, "UPDATE_SNAPSHOTS", True)
+    monkeypatch.setattr(mod, "UPDATED_SNAPSHOTS", {"alpha": {"kind": "a"}})
+
+    mod.write_updated_snapshots()
+
+    text = snapshot_path.read_text(encoding="utf-8")
+    # Keys are sorted for clean diffs: alpha before zeta, trailing newline.
+    assert text.index('"alpha"') < text.index('"zeta"')
+    assert text.endswith("}\n")

--- a/tests/test_rust_api_contract_snapshots.py
+++ b/tests/test_rust_api_contract_snapshots.py
@@ -56,9 +56,21 @@ CLAIM_WORKER_RE = re.compile(r"\bclaim-worker-[a-z]\b")
 def write_updated_snapshots() -> None:
     if not UPDATE_SNAPSHOTS:
         return
+    # Merge into the existing on-disk snapshots rather than serializing only the
+    # labels touched this run. Otherwise a filtered update (e.g.
+    # `UPDATE_SNAPSHOTS=1 pytest -k character`) would clobber every untouched
+    # snapshot, since UPDATED_SNAPSHOTS only accumulates labels asserted during
+    # this run (sc-8862). snapshots() returns {} when the file does not yet
+    # exist, so first-ever generation still works.
+    #
+    # Note: because this merge preserves all pre-existing labels, intentionally
+    # REMOVING a snapshot must be done by editing snapshots.json manually — a
+    # filtered UPDATE_SNAPSHOTS run will never delete stale entries.
+    merged = snapshots()
+    merged.update(UPDATED_SNAPSHOTS)
     SNAPSHOT_PATH.parent.mkdir(parents=True, exist_ok=True)
     SNAPSHOT_PATH.write_text(
-        json.dumps(UPDATED_SNAPSHOTS, indent=2, sort_keys=True) + "\n",
+        json.dumps(merged, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
 


### PR DESCRIPTION
## Summary

Fixes **sc-8862 [F-060]**: `UPDATE_SNAPSHOTS=1` on a filtered run clobbered all untouched snapshots.

`write_updated_snapshots` (registered via `atexit`) rewrote `tests/fixtures/rust_api_contract_snapshots/snapshots.json` wholesale from `UPDATED_SNAPSHOTS`, which only accumulates labels asserted during that run. So `UPDATE_SNAPSHOTS=1 pytest -k character` silently dropped every non-character snapshot — surfacing later as confusing "Missing snapshot" failures on the next full run, or getting committed.

## Fix

Load the existing on-disk snapshots first, `.update()` them with the run's `UPDATED_SNAPSHOTS`, and write the **merged** dict. Edge cases handled:
- **First-ever generation** — `snapshots()` returns `{}` when the file does not exist, so generation from scratch still works.
- **Intentional deletion** — merge-preserves-all means deletions must be manual; documented in a code comment.
- **Deterministic ordering** — retains `sort_keys=True` + trailing newline for clean diffs.

## Tests

Adds `tests/test_rust_api_contract_snapshot_merge.py` — a **non-parity** self-test module (so it runs in the default CI lane `-m "not e2e and not parity"`) that drives `write_updated_snapshots` against a temp `snapshots.json` via monkeypatch and asserts:
- a filtered update preserves untouched labels (the regression);
- first-ever generation starts from `{}`;
- the writer is a no-op when `UPDATE_SNAPSHOTS` is off;
- output is key-sorted and stable.

Local run (CI lane, `pytest 9.0.2` per check.yml): `536 passed, 9 skipped, 17 deselected`. New module: `4 passed`.

Story: https://app.shortcut.com/trefry/story/8862

🤖 Generated with [Claude Code](https://claude.com/claude-code)