### PR TITLE
fix(release): re-align root+web versions to shipped 0.5.1 + CI assert (sc-8865)

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sceneworks/web",
-  "version": "0.4.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sceneworks/web",
-      "version": "0.4.0",
+      "version": "0.5.1",
       "dependencies": {
         "konva": "^9.3.22",
         "react": "18.3.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sceneworks/web",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.5.1",
   "type": "module",
   "scripts": {
     "dev": "vite --host 0.0.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sceneworks",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.5.1",
   "description": "Local AI image and video generation studio runtime skeleton.",
   "license": "SEE LICENSE IN LICENSE",
   "scripts": {

--- a/scripts/check-scaffold.mjs
+++ b/scripts/check-scaffold.mjs
@@ -195,6 +195,30 @@ async function assertBuiltinPromptGuides() {
   }
 }
 
+async function assertVersionsAligned() {
+  // sync-version.mjs's contract is that one root `npm version` bumps every
+  // product-version field atomically (root + web + desktop package.json and
+  // tauri.conf.json), so the git tag can never drift from the shipped version.
+  // Assert the invariant here: if these four diverge, a root `npm version patch`
+  // can emit a tag BELOW the version users already run — the Tauri auto-updater
+  // (sc-1355) compares against latest.json and would then serve no update.
+  const versionSources = [
+    { path: "package.json", version: JSON.parse(await readFile(path.join(root, "package.json"), "utf8")).version },
+    { path: "apps/web/package.json", version: JSON.parse(await readFile(path.join(root, "apps/web/package.json"), "utf8")).version },
+    { path: "apps/desktop/package.json", version: JSON.parse(await readFile(path.join(root, "apps/desktop/package.json"), "utf8")).version },
+    { path: "apps/desktop/tauri.conf.json", version: JSON.parse(await readFile(path.join(root, "apps/desktop/tauri.conf.json"), "utf8")).version },
+  ];
+  const reference = versionSources[0].version;
+  const mismatched = versionSources.filter((source) => source.version !== reference);
+  if (mismatched.length) {
+    const detail = versionSources.map((source) => `${source.path}=${source.version}`).join(", ");
+    throw new Error(
+      `Product version fields are not aligned: ${detail}. Run one root ` +
+        `\`npm version <x.y.z>\` (which invokes scripts/sync-version.mjs) so all four move together.`,
+    );
+  }
+}
+
 async function assertCharacterImageTuningSurface() {
   // Catch the sc-2017 picker UX mismatch at build time: a model that opts out
   // of the IP-Adapter Reference-strength slider via `ui.hideReferenceStrength`
@@ -239,6 +263,7 @@ await assertContains("README.md", "SCENEWORKS_ACCESS_TOKEN");
 await assertManifestSchemasParse();
 await assertManifestSchemaReferences();
 await assertManifestRootsMatchSchemas();
+await assertVersionsAligned();
 await assertBuiltinPromptGuides();
 await assertCharacterImageTuningSurface();
 

--- a/scripts/check-scaffold.mjs
+++ b/scripts/check-scaffold.mjs
@@ -208,6 +208,15 @@ async function assertVersionsAligned() {
     { path: "apps/desktop/package.json", version: JSON.parse(await readFile(path.join(root, "apps/desktop/package.json"), "utf8")).version },
     { path: "apps/desktop/tauri.conf.json", version: JSON.parse(await readFile(path.join(root, "apps/desktop/tauri.conf.json"), "utf8")).version },
   ];
+  // Scope of this assert: four-way ALIGNMENT only. Using versionSources[0]
+  // (root package.json) purely as the equality reference means we verify all
+  // four fields are equal, NOT that the version moved upward. A hypothetical
+  // synchronized all-four-down edit would pass this check. That's deliberate:
+  // upward-DIRECTION is owned by scripts/sync-version.mjs, whose only mutation
+  // path is `npm version`, and `npm version` never moves a version down. There
+  // is no committed floor to compare against here — these four files ARE the
+  // version sources — so a hardcoded baseline would be a rot-prone footgun
+  // rather than a real guard. Alignment is the invariant this file owns.
   const reference = versionSources[0].version;
   const mismatched = versionSources.filter((source) => source.version !== reference);
   if (mismatched.length) {


### PR DESCRIPTION
## sc-8865 — [F-063] Fix version drift between root, web, and desktop packages

Story: https://app.shortcut.com/trefry/story/8865

### Problem
`scripts/sync-version.mjs`'s contract is that one root `npm version` bumps all four product-version fields atomically, but the tree was already skewed and nothing in CI asserted the invariant:

| File | Before | After |
| --- | --- | --- |
| `package.json` | 0.4.0 | **0.5.1** |
| `apps/web/package.json` | 0.4.0 | **0.5.1** |
| `apps/desktop/package.json` | 0.5.1 | 0.5.1 |
| `apps/desktop/tauri.conf.json` | 0.5.1 | 0.5.1 |

The next root `npm version patch` would have produced **0.4.1** — a tag/version *below* what shipped users run. The Tauri auto-updater (sc-1355) compares the running version against `latest.json`'s version, so it would serve **no update** and release bookkeeping would diverge.

### Fix
- **Direction is UP (updater-safe):** re-align root + `apps/web` to the highest shipped version (**0.5.1**, from desktop). Nothing is moved down; no version is invented.
- `apps/web` bumped via `npm version 0.5.1 --no-git-tag-version --allow-same-version` (exactly what `sync-version.mjs` runs) so `package.json` and `package-lock.json` move in lockstep. The lock diff is **version-only** — no dependency updates.
- Add `assertVersionsAligned()` to `scripts/check-scaffold.mjs`, which reads all four version strings and throws if they diverge. It runs via `npm run check` in `.github/workflows/check.yml`, so CI now fails on any future drift.

### Testing
- `npm run check` **passes** on the aligned tree.
- Temporarily skewed root to 0.4.1 → `assertVersionsAligned()` **fails** with a clear message, then reverted.
- Lock diff verified version-only (no dep churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)