### PR TITLE
chore(worker): dedup steps/guidance resolver into shared advanced-or-manifest helpers (sc-8825)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -877,6 +877,69 @@ fn resolve_advanced_or_manifest_f32(
     advanced::f32_clamped(&request.advanced, key, manifest_default, range)
 }
 
+/// Closure-default twin of [`resolve_advanced_or_manifest_u32`] (sc-8825). Identical mechanism —
+/// `advanced[key]` → manifest `[key]` (parsed, clamped to `range`) — except the fallback is a
+/// per-lane `default_fn` closure evaluated **only** when both advanced and manifest are absent (and,
+/// like the const twin, returned **unclamped**). This covers the lanes whose default is model-dependent
+/// (`flux_ipadapter` variant steps, `qwen_edit_candle`/`zimage_control` per-variant steps) rather than a
+/// bare constant. Every caller passes its OWN `range`/`default_fn`, so per-lane bounds stay byte-for-byte.
+///
+/// Unlike the const twins (which have macOS-live callers in `pulid.rs`/`instantid.rs`), these variants
+/// are only *called* by the candle-exclusive lanes, so the macOS non-test lib build has no caller —
+/// hence the gate is `candle-lane OR test` (the sc-8825 unit tests exercise it on both build lanes).
+#[cfg(any(
+    all(not(target_os = "macos"), feature = "backend-candle"),
+    test
+))]
+fn resolve_advanced_or_manifest_u32_with(
+    request: &ImageRequest,
+    key: &str,
+    default_fn: impl FnOnce() -> u32,
+    range: std::ops::RangeInclusive<u32>,
+) -> u32 {
+    let parse = |value: &Value| {
+        value
+            .as_u64()
+            .or_else(|| value.as_str()?.trim().parse().ok())
+    };
+    request
+        .advanced
+        .get(key)
+        .and_then(parse)
+        .or_else(|| request.model_manifest_entry.get(key).and_then(parse))
+        .map(|value| value.clamp(*range.start() as u64, *range.end() as u64) as u32)
+        .unwrap_or_else(default_fn)
+}
+
+/// Closure-default twin of [`resolve_advanced_or_manifest_f32`] (sc-8825). Identical mechanism —
+/// manifest `[key]` supplies the effective default (else the per-lane `default_fn` closure, evaluated
+/// only when the manifest key is absent), then [`advanced::f32_clamped`] reads `advanced[key]` (falling
+/// back to that default) and clamps to `range`. Covers `flux_ipadapter`, whose guidance fallback is a
+/// per-variant fn. Each caller passes its OWN `range`/`default_fn`. Gated `candle-lane OR test` for the
+/// same reason as the u32 twin: no macOS non-test caller, but the sc-8825 tests exercise it on both lanes.
+#[cfg(any(
+    all(not(target_os = "macos"), feature = "backend-candle"),
+    test
+))]
+fn resolve_advanced_or_manifest_f32_with(
+    request: &ImageRequest,
+    key: &str,
+    default_fn: impl FnOnce() -> f32,
+    range: std::ops::RangeInclusive<f32>,
+) -> f32 {
+    let manifest_default = request
+        .model_manifest_entry
+        .get(key)
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .map(|value| value as f32)
+        .unwrap_or_else(default_fn);
+    advanced::f32_clamped(&request.advanced, key, manifest_default, range)
+}
+
 /// True for a TRUE-CFG family whose engine reads the CFG scale from `true_cfg` (with a real
 /// negative prompt) and **rejects** the distilled `guidance` scalar — i.e. Chroma (epic 3531),
 /// uniquely identified by `supports_guidance=false` + `supports_negative_prompt=true`. The

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -815,6 +815,68 @@ fn resolve_guidance(request: &ImageRequest, model: &ResolvedModel) -> Option<f32
     Some(scale)
 }
 
+/// Resolve an unsigned advanced knob with a manifest fallback (sc-8825). The single mechanism the
+/// bespoke edit/adapter/control lanes (`*_edit_candle.rs`, `sdxl_ipadapter.rs`, `kolors_*.rs`,
+/// `qwen_control.rs`, `instantid.rs`, `pulid.rs`) had each re-implemented as an inline parse closure:
+/// `advanced[key]` (JSON uint OR numeric string) → the manifest `[key]` (same parse) → `default`.
+/// The parsed **advanced-or-manifest** value is clamped to `range`; the `default` is returned
+/// **unclamped** (it is a trusted per-lane constant, and clamping it would silently change a lane
+/// whose default sits outside its own historical range). Each caller passes its OWN `range`/`default`,
+/// so the drifting steps bounds (1..=80 / 1..=50 / 1..=100) are preserved byte-for-byte — this is a
+/// dedup-of-mechanism refactor, not a policy change.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn resolve_advanced_or_manifest_u32(
+    request: &ImageRequest,
+    key: &str,
+    default: u32,
+    range: std::ops::RangeInclusive<u32>,
+) -> u32 {
+    let parse = |value: &Value| {
+        value
+            .as_u64()
+            .or_else(|| value.as_str()?.trim().parse().ok())
+    };
+    request
+        .advanced
+        .get(key)
+        .and_then(parse)
+        .or_else(|| request.model_manifest_entry.get(key).and_then(parse))
+        .map(|value| value.clamp(*range.start() as u64, *range.end() as u64) as u32)
+        .unwrap_or(default)
+}
+
+/// Resolve a float advanced knob with a manifest fallback (sc-8825). The guidance twin of
+/// [`resolve_advanced_or_manifest_u32`]: the manifest `[key]` (JSON float OR numeric string) supplies
+/// the effective default (else the per-lane `default`), then [`advanced::f32_clamped`] reads
+/// `advanced[key]` — falling back to that manifest default — and clamps the result to `range`. Unlike
+/// the u32 twin, the resolved value here is always clamped (matching the historical `f32_clamped`
+/// call, which clamps the manifest/default fallback too). Each caller passes its OWN `range`/`default`.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn resolve_advanced_or_manifest_f32(
+    request: &ImageRequest,
+    key: &str,
+    default: f32,
+    range: std::ops::RangeInclusive<f32>,
+) -> f32 {
+    let manifest_default = request
+        .model_manifest_entry
+        .get(key)
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .map(|value| value as f32)
+        .unwrap_or(default);
+    advanced::f32_clamped(&request.advanced, key, manifest_default, range)
+}
+
 /// True for a TRUE-CFG family whose engine reads the CFG scale from `true_cfg` (with a real
 /// negative prompt) and **rejects** the distilled `guidance` scalar — i.e. Chroma (epic 3531),
 /// uniquely identified by `supports_guidance=false` + `supports_negative_prompt=true`. The

--- a/crates/sceneworks-worker/src/image_jobs/flux1_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux1_control_candle.rs
@@ -88,37 +88,16 @@ fn flux1_control_candle_available(request: &ImageRequest, settings: &Settings) -
 
 /// Resolve denoise steps: `advanced.steps` (clamped 1..=50) → manifest `steps` → default (25).
 fn flux1_control_candle_steps(request: &ImageRequest) -> u32 {
-    let parse = |value: &Value| {
-        value
-            .as_u64()
-            .or_else(|| value.as_str()?.trim().parse().ok())
-    };
-    request
-        .advanced
-        .get("steps")
-        .and_then(parse)
-        .or_else(|| request.model_manifest_entry.get("steps").and_then(parse))
-        .map(|steps| steps.clamp(1, 50) as u32)
-        .unwrap_or(FLUX1_CONTROL_CANDLE_DEFAULT_STEPS)
+    resolve_advanced_or_manifest_u32(request, "steps", FLUX1_CONTROL_CANDLE_DEFAULT_STEPS, 1..=50)
 }
 
 /// Resolve embedded guidance: `advanced.guidanceScale` → manifest `guidanceScale` → default (3.5),
 /// clamped. dev rides this scalar on the transformer's guidance embedder (no true-CFG).
 fn flux1_control_candle_guidance(request: &ImageRequest) -> f32 {
-    let manifest_default = request
-        .model_manifest_entry
-        .get("guidanceScale")
-        .and_then(|value| {
-            value
-                .as_f64()
-                .or_else(|| value.as_str()?.trim().parse().ok())
-        })
-        .map(|value| value as f32)
-        .unwrap_or(FLUX1_CONTROL_CANDLE_DEFAULT_GUIDANCE);
-    advanced::f32_clamped(
-        &request.advanced,
+    resolve_advanced_or_manifest_f32(
+        request,
         "guidanceScale",
-        manifest_default,
+        FLUX1_CONTROL_CANDLE_DEFAULT_GUIDANCE,
         0.0..=30.0,
     )
 }

--- a/crates/sceneworks-worker/src/image_jobs/flux2_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2_control_candle.rs
@@ -87,37 +87,16 @@ fn flux2_control_candle_available(request: &ImageRequest, settings: &Settings) -
 
 /// Resolve denoise steps: `advanced.steps` (clamped 1..=50) → manifest `steps` → default (28).
 fn flux2_control_candle_steps(request: &ImageRequest) -> u32 {
-    let parse = |value: &Value| {
-        value
-            .as_u64()
-            .or_else(|| value.as_str()?.trim().parse().ok())
-    };
-    request
-        .advanced
-        .get("steps")
-        .and_then(parse)
-        .or_else(|| request.model_manifest_entry.get("steps").and_then(parse))
-        .map(|steps| steps.clamp(1, 50) as u32)
-        .unwrap_or(FLUX2_CONTROL_CANDLE_DEFAULT_STEPS)
+    resolve_advanced_or_manifest_u32(request, "steps", FLUX2_CONTROL_CANDLE_DEFAULT_STEPS, 1..=50)
 }
 
 /// Resolve embedded guidance: `advanced.guidanceScale` → manifest `guidanceScale` → default (4.0),
 /// clamped. dev rides this scalar on the transformer's guidance embedder (no true-CFG).
 fn flux2_control_candle_guidance(request: &ImageRequest) -> f32 {
-    let manifest_default = request
-        .model_manifest_entry
-        .get("guidanceScale")
-        .and_then(|value| {
-            value
-                .as_f64()
-                .or_else(|| value.as_str()?.trim().parse().ok())
-        })
-        .map(|value| value as f32)
-        .unwrap_or(FLUX2_CONTROL_CANDLE_DEFAULT_GUIDANCE);
-    advanced::f32_clamped(
-        &request.advanced,
+    resolve_advanced_or_manifest_f32(
+        request,
         "guidanceScale",
-        manifest_default,
+        FLUX2_CONTROL_CANDLE_DEFAULT_GUIDANCE,
         0.0..=30.0,
     )
 }

--- a/crates/sceneworks-worker/src/image_jobs/flux2_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2_edit_candle.rs
@@ -115,39 +115,13 @@ fn flux2_edit_candle_available(request: &ImageRequest, settings: &Settings) -> b
 /// Resolve denoise steps: `advanced.steps` (clamped 1..=50) → manifest `steps` → the family default
 /// (klein 4 / dev 28).
 fn flux2_edit_candle_steps(request: &ImageRequest, default: u32) -> u32 {
-    let parse = |value: &Value| {
-        value
-            .as_u64()
-            .or_else(|| value.as_str()?.trim().parse().ok())
-    };
-    request
-        .advanced
-        .get("steps")
-        .and_then(parse)
-        .or_else(|| request.model_manifest_entry.get("steps").and_then(parse))
-        .map(|steps| steps.clamp(1, 50) as u32)
-        .unwrap_or(default)
+    resolve_advanced_or_manifest_u32(request, "steps", default, 1..=50)
 }
 
 /// Resolve guidance: `advanced.guidanceScale` → manifest `guidanceScale` → the family default
 /// (klein 1.0 / dev 4.0), clamped.
 fn flux2_edit_candle_guidance(request: &ImageRequest, default: f32) -> f32 {
-    let manifest_default = request
-        .model_manifest_entry
-        .get("guidanceScale")
-        .and_then(|value| {
-            value
-                .as_f64()
-                .or_else(|| value.as_str()?.trim().parse().ok())
-        })
-        .map(|value| value as f32)
-        .unwrap_or(default);
-    advanced::f32_clamped(
-        &request.advanced,
-        "guidanceScale",
-        manifest_default,
-        0.0..=30.0,
-    )
+    resolve_advanced_or_manifest_f32(request, "guidanceScale", default, 0.0..=30.0)
 }
 
 /// Reference asset ids for a FLUX.2 edit, in order. The multi-image picker (sc-6211) sends the plural

--- a/crates/sceneworks-worker/src/image_jobs/flux_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux_ipadapter.rs
@@ -102,36 +102,20 @@ fn flux_ipadapter_available(request: &ImageRequest, settings: &Settings) -> bool
 
 /// Resolve denoise steps: `advanced.steps` (clamped 1..=100) → manifest `steps` → variant default.
 fn flux_ipadapter_steps(request: &ImageRequest) -> u32 {
-    let parse = |value: &Value| {
-        value
-            .as_u64()
-            .or_else(|| value.as_str()?.trim().parse().ok())
-    };
-    request
-        .advanced
-        .get("steps")
-        .and_then(parse)
-        .or_else(|| request.model_manifest_entry.get("steps").and_then(parse))
-        .map(|steps| steps.clamp(1, 100) as u32)
-        .unwrap_or_else(|| flux_ipadapter_default_steps(&request.model))
+    resolve_advanced_or_manifest_u32_with(
+        request,
+        "steps",
+        || flux_ipadapter_default_steps(&request.model),
+        1..=100,
+    )
 }
 
 /// Resolve guidance: `advanced.guidanceScale` → manifest `guidanceScale` → variant default, clamped.
 fn flux_ipadapter_guidance(request: &ImageRequest) -> f32 {
-    let manifest_default = request
-        .model_manifest_entry
-        .get("guidanceScale")
-        .and_then(|value| {
-            value
-                .as_f64()
-                .or_else(|| value.as_str()?.trim().parse().ok())
-        })
-        .map(|value| value as f32)
-        .unwrap_or_else(|| flux_ipadapter_default_guidance(&request.model));
-    advanced::f32_clamped(
-        &request.advanced,
+    resolve_advanced_or_manifest_f32_with(
+        request,
         "guidanceScale",
-        manifest_default,
+        || flux_ipadapter_default_guidance(&request.model),
         0.0..=30.0,
     )
 }

--- a/crates/sceneworks-worker/src/image_jobs/instantid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/instantid.rs
@@ -192,37 +192,16 @@ fn builtin_angle_presets() -> Vec<sceneworks_core::project_store::ResolvedAngleP
 /// Resolve InstantID denoise steps: `advanced.steps` (clamped 1..=80) → manifest `steps` →
 /// the torch-parity default (30).
 fn instantid_steps(request: &ImageRequest) -> u32 {
-    let parse = |value: &Value| {
-        value
-            .as_u64()
-            .or_else(|| value.as_str()?.trim().parse().ok())
-    };
-    request
-        .advanced
-        .get("steps")
-        .and_then(parse)
-        .or_else(|| request.model_manifest_entry.get("steps").and_then(parse))
-        .map(|steps| steps.clamp(1, 80) as u32)
-        .unwrap_or(INSTANTID_DEFAULT_STEPS)
+    resolve_advanced_or_manifest_u32(request, "steps", INSTANTID_DEFAULT_STEPS, 1..=80)
 }
 
 /// Resolve InstantID guidance: `advanced.guidanceScale` → manifest `guidanceScale` → the
 /// RealVisXL-tuned default (3.0). Clamped to a sane CFG range.
 fn instantid_guidance(request: &ImageRequest) -> f32 {
-    let manifest_default = request
-        .model_manifest_entry
-        .get("guidanceScale")
-        .and_then(|value| {
-            value
-                .as_f64()
-                .or_else(|| value.as_str()?.trim().parse().ok())
-        })
-        .map(|value| value as f32)
-        .unwrap_or(INSTANTID_DEFAULT_GUIDANCE);
-    advanced::f32_clamped(
-        &request.advanced,
+    resolve_advanced_or_manifest_f32(
+        request,
         "guidanceScale",
-        manifest_default,
+        INSTANTID_DEFAULT_GUIDANCE,
         0.0..=30.0,
     )
 }

--- a/crates/sceneworks-worker/src/image_jobs/kolors_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/kolors_control.rs
@@ -80,36 +80,15 @@ fn kolors_control_available(request: &ImageRequest, settings: &Settings) -> bool
 
 /// Resolve denoise steps: `advanced.steps` (clamped 1..=80) → manifest `steps` → default (50).
 fn kolors_control_steps(request: &ImageRequest) -> u32 {
-    let parse = |value: &Value| {
-        value
-            .as_u64()
-            .or_else(|| value.as_str()?.trim().parse().ok())
-    };
-    request
-        .advanced
-        .get("steps")
-        .and_then(parse)
-        .or_else(|| request.model_manifest_entry.get("steps").and_then(parse))
-        .map(|steps| steps.clamp(1, 80) as u32)
-        .unwrap_or(KOLORS_CONTROL_DEFAULT_STEPS)
+    resolve_advanced_or_manifest_u32(request, "steps", KOLORS_CONTROL_DEFAULT_STEPS, 1..=80)
 }
 
 /// Resolve guidance: `advanced.guidanceScale` → manifest `guidanceScale` → default (5.0), clamped.
 fn kolors_control_guidance(request: &ImageRequest) -> f32 {
-    let manifest_default = request
-        .model_manifest_entry
-        .get("guidanceScale")
-        .and_then(|value| {
-            value
-                .as_f64()
-                .or_else(|| value.as_str()?.trim().parse().ok())
-        })
-        .map(|value| value as f32)
-        .unwrap_or(KOLORS_CONTROL_DEFAULT_GUIDANCE);
-    advanced::f32_clamped(
-        &request.advanced,
+    resolve_advanced_or_manifest_f32(
+        request,
         "guidanceScale",
-        manifest_default,
+        KOLORS_CONTROL_DEFAULT_GUIDANCE,
         0.0..=30.0,
     )
 }

--- a/crates/sceneworks-worker/src/image_jobs/kolors_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/kolors_ipadapter.rs
@@ -86,36 +86,15 @@ fn kolors_ipadapter_available(request: &ImageRequest, settings: &Settings) -> bo
 
 /// Resolve denoise steps: `advanced.steps` (clamped 1..=80) → manifest `steps` → default (50).
 fn kolors_ipadapter_steps(request: &ImageRequest) -> u32 {
-    let parse = |value: &Value| {
-        value
-            .as_u64()
-            .or_else(|| value.as_str()?.trim().parse().ok())
-    };
-    request
-        .advanced
-        .get("steps")
-        .and_then(parse)
-        .or_else(|| request.model_manifest_entry.get("steps").and_then(parse))
-        .map(|steps| steps.clamp(1, 80) as u32)
-        .unwrap_or(KOLORS_IPADAPTER_DEFAULT_STEPS)
+    resolve_advanced_or_manifest_u32(request, "steps", KOLORS_IPADAPTER_DEFAULT_STEPS, 1..=80)
 }
 
 /// Resolve guidance: `advanced.guidanceScale` → manifest `guidanceScale` → default (5.0), clamped.
 fn kolors_ipadapter_guidance(request: &ImageRequest) -> f32 {
-    let manifest_default = request
-        .model_manifest_entry
-        .get("guidanceScale")
-        .and_then(|value| {
-            value
-                .as_f64()
-                .or_else(|| value.as_str()?.trim().parse().ok())
-        })
-        .map(|value| value as f32)
-        .unwrap_or(KOLORS_IPADAPTER_DEFAULT_GUIDANCE);
-    advanced::f32_clamped(
-        &request.advanced,
+    resolve_advanced_or_manifest_f32(
+        request,
         "guidanceScale",
-        manifest_default,
+        KOLORS_IPADAPTER_DEFAULT_GUIDANCE,
         0.0..=30.0,
     )
 }

--- a/crates/sceneworks-worker/src/image_jobs/pulid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/pulid.rs
@@ -94,34 +94,13 @@ fn pulid_flux_available(request: &ImageRequest, settings: &Settings) -> bool {
 
 /// Resolve PuLID denoise steps: `advanced.steps` (clamped 1..=80) → manifest `steps` → 30.
 fn pulid_steps(request: &ImageRequest) -> u32 {
-    let parse = |value: &Value| {
-        value
-            .as_u64()
-            .or_else(|| value.as_str()?.trim().parse().ok())
-    };
-    request
-        .advanced
-        .get("steps")
-        .and_then(parse)
-        .or_else(|| request.model_manifest_entry.get("steps").and_then(parse))
-        .map(|steps| steps.clamp(1, 80) as u32)
-        .unwrap_or(PULID_DEFAULT_STEPS)
+    resolve_advanced_or_manifest_u32(request, "steps", PULID_DEFAULT_STEPS, 1..=80)
 }
 
 /// Resolve PuLID guidance: `advanced.guidanceScale` → manifest `guidanceScale` → 4.0 (the FLUX.1-dev
 /// guidance-distilled CFG; the engine's fake-CFG single forward consumes it).
 fn pulid_guidance(request: &ImageRequest) -> f32 {
-    let manifest_default = request
-        .model_manifest_entry
-        .get("guidanceScale")
-        .and_then(|value| {
-            value
-                .as_f64()
-                .or_else(|| value.as_str()?.trim().parse().ok())
-        })
-        .map(|value| value as f32)
-        .unwrap_or(PULID_DEFAULT_GUIDANCE);
-    advanced::f32_clamped(&request.advanced, "guidanceScale", manifest_default, 0.0..=30.0)
+    resolve_advanced_or_manifest_f32(request, "guidanceScale", PULID_DEFAULT_GUIDANCE, 0.0..=30.0)
 }
 
 /// The PuLID identity-strength knob → the reference conditioning's `strength` (the engine reads

--- a/crates/sceneworks-worker/src/image_jobs/pulid_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/pulid_candle.rs
@@ -86,34 +86,13 @@ fn pulid_candle_available(request: &ImageRequest, settings: &Settings) -> bool {
 
 /// Resolve PuLID denoise steps: `advanced.steps` (clamped 1..=80) → manifest `steps` → 30.
 fn pulid_candle_steps(request: &ImageRequest) -> u32 {
-    let parse = |value: &Value| {
-        value
-            .as_u64()
-            .or_else(|| value.as_str()?.trim().parse().ok())
-    };
-    request
-        .advanced
-        .get("steps")
-        .and_then(parse)
-        .or_else(|| request.model_manifest_entry.get("steps").and_then(parse))
-        .map(|steps| steps.clamp(1, 80) as u32)
-        .unwrap_or(PULID_CANDLE_DEFAULT_STEPS)
+    resolve_advanced_or_manifest_u32(request, "steps", PULID_CANDLE_DEFAULT_STEPS, 1..=80)
 }
 
 /// Resolve PuLID guidance: `advanced.guidanceScale` → manifest `guidanceScale` → 4.0 (the FLUX.1-dev
 /// guidance-distilled CFG the distilled single forward consumes).
 fn pulid_candle_guidance(request: &ImageRequest) -> f32 {
-    let manifest_default = request
-        .model_manifest_entry
-        .get("guidanceScale")
-        .and_then(|value| {
-            value
-                .as_f64()
-                .or_else(|| value.as_str()?.trim().parse().ok())
-        })
-        .map(|value| value as f32)
-        .unwrap_or(PULID_CANDLE_DEFAULT_GUIDANCE);
-    advanced::f32_clamped(&request.advanced, "guidanceScale", manifest_default, 0.0..=30.0)
+    resolve_advanced_or_manifest_f32(request, "guidanceScale", PULID_CANDLE_DEFAULT_GUIDANCE, 0.0..=30.0)
 }
 
 /// The PuLID identity-strength knob → the provider's `id_weight` (0.0 = the no-id ablation = plain

--- a/crates/sceneworks-worker/src/image_jobs/qwen_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_control.rs
@@ -85,36 +85,15 @@ fn qwen_control_available(request: &ImageRequest, settings: &Settings) -> bool {
 
 /// Resolve denoise steps: `advanced.steps` (clamped 1..=100) → manifest `steps` → default (30).
 fn qwen_control_steps(request: &ImageRequest) -> u32 {
-    let parse = |value: &Value| {
-        value
-            .as_u64()
-            .or_else(|| value.as_str()?.trim().parse().ok())
-    };
-    request
-        .advanced
-        .get("steps")
-        .and_then(parse)
-        .or_else(|| request.model_manifest_entry.get("steps").and_then(parse))
-        .map(|steps| steps.clamp(1, 100) as u32)
-        .unwrap_or(QWEN_CONTROL_DEFAULT_STEPS)
+    resolve_advanced_or_manifest_u32(request, "steps", QWEN_CONTROL_DEFAULT_STEPS, 1..=100)
 }
 
 /// Resolve guidance: `advanced.guidanceScale` → manifest `guidanceScale` → default (4.0), clamped.
 fn qwen_control_guidance(request: &ImageRequest) -> f32 {
-    let manifest_default = request
-        .model_manifest_entry
-        .get("guidanceScale")
-        .and_then(|value| {
-            value
-                .as_f64()
-                .or_else(|| value.as_str()?.trim().parse().ok())
-        })
-        .map(|value| value as f32)
-        .unwrap_or(QWEN_CONTROL_DEFAULT_GUIDANCE);
-    advanced::f32_clamped(
-        &request.advanced,
+    resolve_advanced_or_manifest_f32(
+        request,
         "guidanceScale",
-        manifest_default,
+        QWEN_CONTROL_DEFAULT_GUIDANCE,
         0.0..=30.0,
     )
 }

--- a/crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs
@@ -116,41 +116,26 @@ fn qwen_edit_candle_available(request: &ImageRequest, settings: &Settings) -> bo
 /// Resolve denoise steps: `advanced.steps` (clamped 1..=50) → manifest `steps` → family default
 /// (Lightning → 4, else 30).
 fn qwen_edit_candle_steps(request: &ImageRequest) -> u32 {
-    let default = if is_qwen_edit_lightning(&request.model) {
-        QWEN_EDIT_CANDLE_LIGHTNING_STEPS
-    } else {
-        QWEN_EDIT_CANDLE_DEFAULT_STEPS
-    };
-    let parse = |value: &Value| {
-        value
-            .as_u64()
-            .or_else(|| value.as_str()?.trim().parse().ok())
-    };
-    request
-        .advanced
-        .get("steps")
-        .and_then(parse)
-        .or_else(|| request.model_manifest_entry.get("steps").and_then(parse))
-        .map(|steps| steps.clamp(1, 50) as u32)
-        .unwrap_or(default)
+    resolve_advanced_or_manifest_u32_with(
+        request,
+        "steps",
+        || {
+            if is_qwen_edit_lightning(&request.model) {
+                QWEN_EDIT_CANDLE_LIGHTNING_STEPS
+            } else {
+                QWEN_EDIT_CANDLE_DEFAULT_STEPS
+            }
+        },
+        1..=50,
+    )
 }
 
 /// Resolve guidance: `advanced.guidanceScale` → manifest `guidanceScale` → default (4.0), clamped.
 fn qwen_edit_candle_guidance(request: &ImageRequest) -> f32 {
-    let manifest_default = request
-        .model_manifest_entry
-        .get("guidanceScale")
-        .and_then(|value| {
-            value
-                .as_f64()
-                .or_else(|| value.as_str()?.trim().parse().ok())
-        })
-        .map(|value| value as f32)
-        .unwrap_or(QWEN_EDIT_CANDLE_DEFAULT_GUIDANCE);
-    advanced::f32_clamped(
-        &request.advanced,
+    resolve_advanced_or_manifest_f32(
+        request,
         "guidanceScale",
-        manifest_default,
+        QWEN_EDIT_CANDLE_DEFAULT_GUIDANCE,
         0.0..=30.0,
     )
 }

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_edit_candle.rs
@@ -106,36 +106,15 @@ fn sdxl_edit_candle_available(request: &ImageRequest, settings: &Settings) -> bo
 
 /// Resolve denoise steps: `advanced.steps` (clamped 1..=80) → manifest `steps` → default (30).
 fn sdxl_edit_candle_steps(request: &ImageRequest) -> u32 {
-    let parse = |value: &Value| {
-        value
-            .as_u64()
-            .or_else(|| value.as_str()?.trim().parse().ok())
-    };
-    request
-        .advanced
-        .get("steps")
-        .and_then(parse)
-        .or_else(|| request.model_manifest_entry.get("steps").and_then(parse))
-        .map(|steps| steps.clamp(1, 80) as u32)
-        .unwrap_or(SDXL_EDIT_CANDLE_DEFAULT_STEPS)
+    resolve_advanced_or_manifest_u32(request, "steps", SDXL_EDIT_CANDLE_DEFAULT_STEPS, 1..=80)
 }
 
 /// Resolve guidance: `advanced.guidanceScale` → manifest `guidanceScale` → default (5.0), clamped.
 fn sdxl_edit_candle_guidance(request: &ImageRequest) -> f32 {
-    let manifest_default = request
-        .model_manifest_entry
-        .get("guidanceScale")
-        .and_then(|value| {
-            value
-                .as_f64()
-                .or_else(|| value.as_str()?.trim().parse().ok())
-        })
-        .map(|value| value as f32)
-        .unwrap_or(SDXL_EDIT_CANDLE_DEFAULT_GUIDANCE);
-    advanced::f32_clamped(
-        &request.advanced,
+    resolve_advanced_or_manifest_f32(
+        request,
         "guidanceScale",
-        manifest_default,
+        SDXL_EDIT_CANDLE_DEFAULT_GUIDANCE,
         0.0..=30.0,
     )
 }

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
@@ -84,37 +84,16 @@ fn sdxl_ipadapter_available(request: &ImageRequest, settings: &Settings) -> bool
 
 /// Resolve denoise steps: `advanced.steps` (clamped 1..=80) → manifest `steps` → default (30).
 fn sdxl_ipadapter_steps(request: &ImageRequest) -> u32 {
-    let parse = |value: &Value| {
-        value
-            .as_u64()
-            .or_else(|| value.as_str()?.trim().parse().ok())
-    };
-    request
-        .advanced
-        .get("steps")
-        .and_then(parse)
-        .or_else(|| request.model_manifest_entry.get("steps").and_then(parse))
-        .map(|steps| steps.clamp(1, 80) as u32)
-        .unwrap_or(SDXL_IPADAPTER_DEFAULT_STEPS)
+    resolve_advanced_or_manifest_u32(request, "steps", SDXL_IPADAPTER_DEFAULT_STEPS, 1..=80)
 }
 
 /// Resolve guidance: `advanced.guidanceScale` → manifest `guidanceScale` → the reference-tuned default
 /// (5.0), clamped to a sane CFG range.
 fn sdxl_ipadapter_guidance(request: &ImageRequest) -> f32 {
-    let manifest_default = request
-        .model_manifest_entry
-        .get("guidanceScale")
-        .and_then(|value| {
-            value
-                .as_f64()
-                .or_else(|| value.as_str()?.trim().parse().ok())
-        })
-        .map(|value| value as f32)
-        .unwrap_or(SDXL_IPADAPTER_DEFAULT_GUIDANCE);
-    advanced::f32_clamped(
-        &request.advanced,
+    resolve_advanced_or_manifest_f32(
+        request,
         "guidanceScale",
-        manifest_default,
+        SDXL_IPADAPTER_DEFAULT_GUIDANCE,
         0.0..=30.0,
     )
 }

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -172,6 +172,152 @@ fn steps_default_is_family_default_and_clamps() {
     );
 }
 
+// The shared advanced→manifest→default resolvers the bespoke edit/adapter/control lanes call
+// (sc-8825). Gated identically to the resolvers themselves so they compile on the macOS AND
+// backend-candle lanes. These lock the four behaviors the per-lane inline closures had:
+// advanced wins, manifest is the fallback, absent → the (unclamped) default, and the
+// advanced-or-manifest value is clamped to the caller's range while garbage parses to the default.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+#[test]
+fn resolve_advanced_or_manifest_u32_precedence_and_clamp() {
+    // advanced present wins and is clamped to the caller's range.
+    assert_eq!(
+        resolve_advanced_or_manifest_u32(
+            &request(json!({ "projectId": "p", "advanced": { "steps": 12 } })),
+            "steps",
+            30,
+            1..=80,
+        ),
+        12
+    );
+    assert_eq!(
+        resolve_advanced_or_manifest_u32(
+            &request(json!({ "projectId": "p", "advanced": { "steps": 200 } })),
+            "steps",
+            30,
+            1..=80,
+        ),
+        80
+    );
+    assert_eq!(
+        resolve_advanced_or_manifest_u32(
+            &request(json!({ "projectId": "p", "advanced": { "steps": 0 } })),
+            "steps",
+            30,
+            1..=80,
+        ),
+        1
+    );
+    // A numeric string parses just like a JSON int.
+    assert_eq!(
+        resolve_advanced_or_manifest_u32(
+            &request(json!({ "projectId": "p", "advanced": { "steps": "24" } })),
+            "steps",
+            30,
+            1..=100,
+        ),
+        24
+    );
+    // advanced absent → manifest fallback (also clamped).
+    assert_eq!(
+        resolve_advanced_or_manifest_u32(
+            &request(json!({ "projectId": "p", "modelManifestEntry": { "steps": 200 } })),
+            "steps",
+            30,
+            1..=100,
+        ),
+        100
+    );
+    // Both absent → the default, returned UNCLAMPED (the distilled 4-step default survives a 1..=50
+    // range — clamping the default here would be a behavior change).
+    assert_eq!(
+        resolve_advanced_or_manifest_u32(&request(json!({ "projectId": "p" })), "steps", 4, 1..=50,),
+        4
+    );
+    // Un-parseable advanced → NOT a fallback to manifest (matches the inline closures: a present-but-
+    // garbage advanced value fails the parse and the closure moves on to manifest, then default).
+    assert_eq!(
+        resolve_advanced_or_manifest_u32(
+            &request(json!({ "projectId": "p", "advanced": { "steps": "abc" } })),
+            "steps",
+            30,
+            1..=80,
+        ),
+        30
+    );
+}
+
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+#[test]
+fn resolve_advanced_or_manifest_f32_precedence_and_clamp() {
+    // advanced present wins and is clamped to the caller's range.
+    assert_eq!(
+        resolve_advanced_or_manifest_f32(
+            &request(json!({ "projectId": "p", "advanced": { "guidanceScale": 7.5 } })),
+            "guidanceScale",
+            5.0,
+            0.0..=30.0,
+        ),
+        7.5
+    );
+    assert_eq!(
+        resolve_advanced_or_manifest_f32(
+            &request(json!({ "projectId": "p", "advanced": { "guidanceScale": 99.0 } })),
+            "guidanceScale",
+            5.0,
+            0.0..=30.0,
+        ),
+        30.0
+    );
+    // A numeric string parses just like a JSON float.
+    assert_eq!(
+        resolve_advanced_or_manifest_f32(
+            &request(json!({ "projectId": "p", "advanced": { "guidanceScale": "2.5" } })),
+            "guidanceScale",
+            5.0,
+            0.0..=30.0,
+        ),
+        2.5
+    );
+    // advanced absent → manifest fallback (also clamped).
+    assert_eq!(
+        resolve_advanced_or_manifest_f32(
+            &request(json!({ "projectId": "p", "modelManifestEntry": { "guidanceScale": 99.0 } })),
+            "guidanceScale",
+            5.0,
+            0.0..=30.0,
+        ),
+        30.0
+    );
+    // Both absent → the per-lane default.
+    assert_eq!(
+        resolve_advanced_or_manifest_f32(
+            &request(json!({ "projectId": "p" })),
+            "guidanceScale",
+            4.0,
+            0.0..=30.0,
+        ),
+        4.0
+    );
+    // Un-parseable advanced → the f32 reader falls back to the manifest default (here the lane
+    // default 5.0), then clamps — matching the historical `f32_clamped` call.
+    assert_eq!(
+        resolve_advanced_or_manifest_f32(
+            &request(json!({ "projectId": "p", "advanced": { "guidanceScale": "abc" } })),
+            "guidanceScale",
+            5.0,
+            0.0..=30.0,
+        ),
+        5.0
+    );
+}
+
 #[cfg(target_os = "macos")]
 #[test]
 fn mlx_model_table_maps_known_families() {

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -318,6 +318,181 @@ fn resolve_advanced_or_manifest_f32_precedence_and_clamp() {
     );
 }
 
+// The closure-default twins (sc-8825) the model-dependent-default lanes call
+// (`flux_ipadapter`, `qwen_edit_candle`/`zimage_control` per-variant steps). Same
+// precedence/clamp contract as the const twins, PLUS: the `default_fn` fires ONLY when both
+// advanced and manifest are absent (a present advanced/manifest value must short-circuit it).
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+#[test]
+fn resolve_advanced_or_manifest_u32_with_precedence_clamp_and_lazy_default() {
+    use std::cell::Cell;
+
+    // advanced present wins, clamped — default_fn NOT invoked.
+    let called = Cell::new(false);
+    assert_eq!(
+        resolve_advanced_or_manifest_u32_with(
+            &request(json!({ "projectId": "p", "advanced": { "steps": 200 } })),
+            "steps",
+            || {
+                called.set(true);
+                25
+            },
+            1..=100,
+        ),
+        100
+    );
+    assert!(
+        !called.get(),
+        "default_fn must not fire when advanced is present"
+    );
+
+    // manifest fallback wins, clamped — default_fn NOT invoked.
+    let called = Cell::new(false);
+    assert_eq!(
+        resolve_advanced_or_manifest_u32_with(
+            &request(json!({ "projectId": "p", "modelManifestEntry": { "steps": 0 } })),
+            "steps",
+            || {
+                called.set(true);
+                25
+            },
+            1..=100,
+        ),
+        1
+    );
+    assert!(
+        !called.get(),
+        "default_fn must not fire when manifest supplies the value"
+    );
+
+    // Both absent → default_fn IS invoked, its value returned UNCLAMPED (distilled 4 survives 1..=50).
+    let called = Cell::new(false);
+    assert_eq!(
+        resolve_advanced_or_manifest_u32_with(
+            &request(json!({ "projectId": "p" })),
+            "steps",
+            || {
+                called.set(true);
+                4
+            },
+            1..=50,
+        ),
+        4
+    );
+    assert!(
+        called.get(),
+        "default_fn must fire when advanced and manifest are both absent"
+    );
+
+    // Un-parseable advanced → falls through to the (here absent) manifest, then default_fn.
+    let called = Cell::new(false);
+    assert_eq!(
+        resolve_advanced_or_manifest_u32_with(
+            &request(json!({ "projectId": "p", "advanced": { "steps": "abc" } })),
+            "steps",
+            || {
+                called.set(true);
+                30
+            },
+            1..=80,
+        ),
+        30
+    );
+    assert!(called.get(), "garbage advanced falls through to default_fn");
+}
+
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+#[test]
+fn resolve_advanced_or_manifest_f32_with_precedence_clamp_and_lazy_default() {
+    use std::cell::Cell;
+
+    // NOTE: the f32 variant's `default_fn` supplies the MANIFEST fallback (which `f32_clamped` then
+    // treats as the reader default), so — matching the original inline `manifest.get(..).unwrap_or_else`
+    // — it fires whenever the MANIFEST key is absent, INDEPENDENTLY of whether advanced is present. This
+    // differs from the u32 twin (whose closure is the whole-chain fallback and fires only when BOTH are
+    // absent). These asserts lock that preserved semantic.
+
+    // advanced present wins and is clamped; manifest absent so default_fn still runs to build the
+    // (discarded) manifest fallback — byte-identical to the pre-fold inline code.
+    let called = Cell::new(false);
+    assert_eq!(
+        resolve_advanced_or_manifest_f32_with(
+            &request(json!({ "projectId": "p", "advanced": { "guidanceScale": 99.0 } })),
+            "guidanceScale",
+            || {
+                called.set(true);
+                3.5
+            },
+            0.0..=30.0,
+        ),
+        30.0
+    );
+    assert!(
+        called.get(),
+        "f32 default_fn builds the manifest fallback whenever the manifest key is absent"
+    );
+
+    // manifest supplies the effective default (clamped) — default_fn NOT invoked.
+    let called = Cell::new(false);
+    assert_eq!(
+        resolve_advanced_or_manifest_f32_with(
+            &request(json!({ "projectId": "p", "modelManifestEntry": { "guidanceScale": 99.0 } })),
+            "guidanceScale",
+            || {
+                called.set(true);
+                3.5
+            },
+            0.0..=30.0,
+        ),
+        30.0
+    );
+    assert!(
+        !called.get(),
+        "default_fn must not fire when manifest supplies the value"
+    );
+
+    // Both absent → default_fn IS invoked (variant default), then f32_clamped applies.
+    let called = Cell::new(false);
+    assert_eq!(
+        resolve_advanced_or_manifest_f32_with(
+            &request(json!({ "projectId": "p" })),
+            "guidanceScale",
+            || {
+                called.set(true);
+                3.5
+            },
+            0.0..=30.0,
+        ),
+        3.5
+    );
+    assert!(
+        called.get(),
+        "default_fn must fire when advanced and manifest are both absent"
+    );
+
+    // Un-parseable advanced → the f32 reader falls back to the (default_fn) fallback, then clamps.
+    let called = Cell::new(false);
+    assert_eq!(
+        resolve_advanced_or_manifest_f32_with(
+            &request(json!({ "projectId": "p", "advanced": { "guidanceScale": "abc" } })),
+            "guidanceScale",
+            || {
+                called.set(true);
+                3.5
+            },
+            0.0..=30.0,
+        ),
+        3.5
+    );
+    assert!(called.get(), "garbage advanced falls through to default_fn");
+}
+
 #[cfg(target_os = "macos")]
 #[test]
 fn mlx_model_table_maps_known_families() {

--- a/crates/sceneworks-worker/src/image_jobs/zimage_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage_control.rs
@@ -116,23 +116,18 @@ fn zimage_control_available(request: &ImageRequest, settings: &Settings) -> bool
 /// Resolve denoise steps: `advanced.steps` (clamped 1..=50) → manifest `steps` → model default (Turbo 8,
 /// base 50; sc-8379). The base undistilled model runs the longer schedule for its real-CFG quality.
 fn zimage_control_steps(request: &ImageRequest) -> u32 {
-    let parse = |value: &Value| {
-        value
-            .as_u64()
-            .or_else(|| value.as_str()?.trim().parse().ok())
-    };
-    let default = if is_zimage_base_model(&request.model) {
-        ZIMAGE_CTRL_BASE_DEFAULT_STEPS
-    } else {
-        ZIMAGE_CTRL_DEFAULT_STEPS
-    };
-    request
-        .advanced
-        .get("steps")
-        .and_then(parse)
-        .or_else(|| request.model_manifest_entry.get("steps").and_then(parse))
-        .map(|steps| steps.clamp(1, 50) as u32)
-        .unwrap_or(default)
+    resolve_advanced_or_manifest_u32_with(
+        request,
+        "steps",
+        || {
+            if is_zimage_base_model(&request.model) {
+                ZIMAGE_CTRL_BASE_DEFAULT_STEPS
+            } else {
+                ZIMAGE_CTRL_DEFAULT_STEPS
+            }
+        },
+        1..=50,
+    )
 }
 
 /// Resolve the base-mode (sc-8680) classifier-free guidance scale: `advanced.guidanceScale` → manifest
@@ -140,17 +135,12 @@ fn zimage_control_steps(request: &ImageRequest) -> u32 {
 /// `z_image` control path (real CFG); Turbo ignores it (guidance-distilled). Mirrors
 /// `kolors_control_guidance`.
 fn zimage_control_guidance(request: &ImageRequest) -> f32 {
-    let manifest_default = request
-        .model_manifest_entry
-        .get("guidanceScale")
-        .and_then(|value| {
-            value
-                .as_f64()
-                .or_else(|| value.as_str()?.trim().parse().ok())
-        })
-        .map(|value| value as f32)
-        .unwrap_or(ZIMAGE_CTRL_BASE_DEFAULT_GUIDANCE);
-    advanced::f32_clamped(&request.advanced, "guidanceScale", manifest_default, 0.0..=30.0)
+    resolve_advanced_or_manifest_f32(
+        request,
+        "guidanceScale",
+        ZIMAGE_CTRL_BASE_DEFAULT_GUIDANCE,
+        0.0..=30.0,
+    )
 }
 
 /// The (repo, filename) of the ControlNet weights — `advanced.controlWeights.{repo,filename}` overrides,

--- a/crates/sceneworks-worker/src/image_jobs/zimage_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage_edit_candle.rs
@@ -73,18 +73,7 @@ fn zimage_edit_candle_available(request: &ImageRequest, settings: &Settings) -> 
 
 /// Resolve denoise steps: `advanced.steps` (clamped 1..=50) → manifest `steps` → default (4, distilled).
 fn zimage_edit_candle_steps(request: &ImageRequest) -> u32 {
-    let parse = |value: &Value| {
-        value
-            .as_u64()
-            .or_else(|| value.as_str()?.trim().parse().ok())
-    };
-    request
-        .advanced
-        .get("steps")
-        .and_then(parse)
-        .or_else(|| request.model_manifest_entry.get("steps").and_then(parse))
-        .map(|steps| steps.clamp(1, 50) as u32)
-        .unwrap_or(ZIMAGE_EDIT_CANDLE_DEFAULT_STEPS)
+    resolve_advanced_or_manifest_u32(request, "steps", ZIMAGE_EDIT_CANDLE_DEFAULT_STEPS, 1..=50)
 }
 
 /// Load the source asset (required for an edit) — mirrors the MLX `resolve_zimage_edit_init` source load.


### PR DESCRIPTION
## sc-8825 — [F-023] steps/guidance resolver cloned ~9 times across bespoke lanes

Story: https://app.shortcut.com/trefry/story/8825

### What
The `advanced → manifest → per-lane default → clamp` mechanism for `steps` and `guidanceScale` was re-implemented as an inline parse closure in each of the bespoke edit/adapter/control lanes. The steps clamp bounds had already drifted (`1..=80` / `1..=50` / `1..=100`) with no shared source of truth, and every new lane added two more copies.

### Change
- Added `resolve_advanced_or_manifest_u32(request, key, default, range)` and `resolve_advanced_or_manifest_f32(request, key, default, range)` next to `resolve_steps` in `base.rs`, both `#[cfg]`-gated identically (macOS + `backend-candle`).
- **Closure-default variants (adversarial-review follow-up):** added `resolve_advanced_or_manifest_u32_with(request, key, default_fn: impl FnOnce() -> u32, range)` and `resolve_advanced_or_manifest_f32_with(..., default_fn: impl FnOnce() -> f32, ...)` for the lanes whose default is model-dependent (a branch or a per-variant fn, not a bare constant). These take the fallback as a lazily-evaluated closure instead of a const. They are gated `candle-lane OR test` (their only real callers are candle-exclusive lanes, so the macOS non-test lib has no caller).
- Routed **all 15 lanes** through them, **each passing its own captured range/default(_fn)** — behavior is byte-identical per lane.
- The helpers preserve the subtly different semantics of the originals:
  - **u32 (steps):** advanced-or-manifest value is clamped; the per-lane `default`/`default_fn` result is returned **unclamped** (a trusted constant — clamping it would silently move a lane whose default sits outside its own range, e.g. distilled 4-step under `1..=50`). The `_with` closure is the whole-chain fallback → fires only when **both** advanced and manifest are absent.
  - **f32 (guidance):** matches the historical `advanced::f32_clamped(advanced, key, manifest_default, range)` composition — the manifest/default fallback is clamped too. The `_with` closure supplies the **manifest** fallback → fires whenever the **manifest key** is absent (independent of advanced), exactly as the original inline `manifest.get(..).unwrap_or_else(default_fn)`.
- Unit tests for all four helpers (advanced-present → clamp low/high, advanced-absent → manifest, both-absent → default, numeric-string parse, garbage-parse → default; and for the `_with` twins, that `default_fn` fires only at the correct precedence tier). Existing per-lane oracle tests pass unchanged.

### Behavior-parity table (no range or default changed)

**Originally folded (9):**

| Lane | steps range | steps default | guidance range | guidance default |
|------|-------------|---------------|----------------|------------------|
| `sdxl_edit_candle` | `1..=80` | 30 | `0.0..=30.0` | 5.0 |
| `sdxl_ipadapter` | `1..=80` | 30 | `0.0..=30.0` | 5.0 |
| `kolors_ipadapter` | `1..=80` | 50 | `0.0..=30.0` | 5.0 |
| `kolors_control` | `1..=80` | 50 | `0.0..=30.0` | 5.0 |
| `qwen_control` | `1..=100` | 30 | `0.0..=30.0` | 4.0 |
| `flux2_edit_candle` | `1..=50` | 4 (klein) / 28 (dev) | `0.0..=30.0` | 1.0 (klein) / 4.0 (dev) |
| `instantid` | `1..=80` | 30 | `0.0..=30.0` | 3.0 |
| `pulid` | `1..=80` | 30 | `0.0..=30.0` | 4.0 |
| `zimage_edit_candle` | `1..=50` | 4 | — (distilled, no guidance) | — |

**Newly folded (6 — adversarial-review scope gap):**

| Lane | helper(s) | steps range | steps default | guidance range | guidance default |
|------|-----------|-------------|---------------|----------------|------------------|
| `flux2_control_candle` | u32 / f32 (const) | `1..=50` | 28 | `0.0..=30.0` | 4.0 |
| `flux1_control_candle` | u32 / f32 (const) | `1..=50` | 25 | `0.0..=30.0` | 3.5 |
| `pulid_candle` | u32 / f32 (const) | `1..=80` | 30 | `0.0..=30.0` | 4.0 |
| `qwen_edit_candle` | **u32_with** / f32 (const) | `1..=50` | 4 (lightning) / 30 | `0.0..=30.0` | 4.0 |
| `flux_ipadapter` | **u32_with / f32_with** | `1..=100` | 4 (schnell) / 25 (dev) | `0.0..=30.0` | 0.0 (schnell) / 3.5 (dev) |
| `zimage_control` | **u32_with** / f32 (const) | `1..=50` | 8 (turbo) / 50 (base) | `0.0..=30.0` | 4.0 |

The drifting steps bounds (`1..=100` on qwen_control, `1..=50` / `1..=80` elsewhere) are **deliberately preserved** — they map to real per-model step ceilings (Qwen's higher schedule, the distilled 4-step families). No genuine-bug drift was found.

After this fold, **no `image_jobs/` lane carries the inline steps/guidance clone** (swept the whole dir). `video_jobs.rs`'s SVD resolver is a separate `VideoRequest`-typed lane, out of this story's scope.

### Verification
- macOS default-features: `cargo check/clippy/test -p sceneworks-worker --all-targets` — green (521 passed, 0 failed).
- Candle parity lane: `cargo check/clippy/test -p sceneworks-worker --no-default-features --features backend-candle --all-targets` — green (521 passed, 0 failed; exercises the candle lanes that call the folded helpers + their oracle tests).
- `npm run rust:check` (workspace fmt + clippy `-D warnings` + test + build) — green.
- Both new closure-variant tests + all affected per-lane oracle tests (incl. `zimage_control` per-variant steps/guidance) pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
