### PR TITLE
refactor(web): extract shared pollJobToCompletion helper (sc-8856)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { apiFetch, eventUrl, isAbortError, setMediaTicket } from "./api.js";
+import { pollJobToCompletion } from "./pollJob.js";
 import { Icon } from "./components/Icons.jsx";
 import { Logo } from "./components/Logo.jsx";
 import { StatusDot } from "./components/StatusDot.jsx";
@@ -93,23 +94,6 @@ function parseSseJson(event, label) {
     console.warn(`Ignoring malformed ${label} SSE event`, err);
     return null;
   }
-}
-
-function abortableDelay(ms, signal) {
-  if (signal?.aborted) {
-    return Promise.reject(new DOMException("Aborted", "AbortError"));
-  }
-  return new Promise((resolve, reject) => {
-    const timer = window.setTimeout(resolve, ms);
-    signal?.addEventListener(
-      "abort",
-      () => {
-        window.clearTimeout(timer);
-        reject(new DOMException("Aborted", "AbortError"));
-      },
-      { once: true },
-    );
-  });
 }
 
 // sc-4198: notice kind for a job-failure banner. LoRA import/train failures get
@@ -1683,33 +1667,24 @@ export function App() {
   // independent (no activeProject gate); throws on failure so the studio can surface
   // the message inline without clobbering the original prompt.
   const refinePrompt = useCallback(
-    async ({ prompt, modelId, workflow, guide, signal }) => {
-      const created = await apiFetch("/api/v1/prompts/refine", token, {
-        method: "POST",
-        signal,
-        body: JSON.stringify({ prompt, modelId, workflow, guide }),
-      });
-      const jobId = created?.id;
-      if (!jobId) {
-        throw new Error("Could not start prompt refinement.");
-      }
-      const deadline = Date.now() + 120000;
-      while (Date.now() < deadline) {
-        await abortableDelay(1000, signal);
-        const job = await apiFetch(`/api/v1/jobs/${jobId}`, token, { signal });
-        if (job.status === "completed") {
+    ({ prompt, modelId, workflow, guide, signal }) =>
+      pollJobToCompletion({
+        createPath: "/api/v1/prompts/refine",
+        body: { prompt, modelId, workflow, guide },
+        deadlineMs: 120000,
+        resolveResult: (job) => {
           const refined = job.result?.refinedPrompt;
           if (!refined) {
             throw new Error("Refinement returned an empty prompt.");
           }
           return refined;
-        }
-        if (job.status === "failed" || job.status === "canceled" || job.status === "interrupted") {
-          throw new Error(job.message || job.error || "Prompt refinement failed.");
-        }
-      }
-      throw new Error("Prompt refinement timed out. Is the refinement runtime running?");
-    },
+        },
+        signal,
+        token,
+        startError: "Could not start prompt refinement.",
+        failureError: "Prompt refinement failed.",
+        timeoutError: "Prompt refinement timed out. Is the refinement runtime running?",
+      }),
     [token],
   );
 
@@ -1718,33 +1693,24 @@ export function App() {
   // returns a JSON caption string (the caller parses + validates it). Reuses the refine job's
   // poll-to-completion contract; captions can take longer, so the deadline is generous.
   const magicPrompt = useCallback(
-    async ({ prompt, modelId, aspectRatio, guide, signal }) => {
-      const created = await apiFetch("/api/v1/prompts/refine", token, {
-        method: "POST",
-        signal,
-        body: JSON.stringify({ prompt, modelId, task: "magic_prompt", aspectRatio, guide }),
-      });
-      const jobId = created?.id;
-      if (!jobId) {
-        throw new Error("Could not start magic-prompt.");
-      }
-      const deadline = Date.now() + 180000;
-      while (Date.now() < deadline) {
-        await abortableDelay(1000, signal);
-        const job = await apiFetch(`/api/v1/jobs/${jobId}`, token, { signal });
-        if (job.status === "completed") {
+    ({ prompt, modelId, aspectRatio, guide, signal }) =>
+      pollJobToCompletion({
+        createPath: "/api/v1/prompts/refine",
+        body: { prompt, modelId, task: "magic_prompt", aspectRatio, guide },
+        deadlineMs: 180000,
+        resolveResult: (job) => {
           const caption = job.result?.refinedPrompt;
           if (!caption) {
             throw new Error("Magic-prompt returned an empty caption.");
           }
           return caption;
-        }
-        if (job.status === "failed" || job.status === "canceled" || job.status === "interrupted") {
-          throw new Error(job.message || job.error || "Magic-prompt failed.");
-        }
-      }
-      throw new Error("Magic-prompt timed out. Is the refinement runtime running?");
-    },
+        },
+        signal,
+        token,
+        startError: "Could not start magic-prompt.",
+        failureError: "Magic-prompt failed.",
+        timeoutError: "Magic-prompt timed out. Is the refinement runtime running?",
+      }),
     [token],
   );
 
@@ -1756,33 +1722,24 @@ export function App() {
   // the returned JSON with `parseVisionCaption` (aspect_ratio stripped, bboxes KEPT). C1: the image is
   // consumed only to produce the caption — it is NEVER passed to generation as img2img conditioning.
   const imageCaption = useCallback(
-    async ({ sourceAssetId, projectId, model, signal }) => {
-      const created = await apiFetch("/api/v1/prompts/refine", token, {
-        method: "POST",
-        signal,
-        body: JSON.stringify({ task: "image_caption", sourceAssetId, projectId, model }),
-      });
-      const jobId = created?.id;
-      if (!jobId) {
-        throw new Error("Could not start image captioning.");
-      }
-      const deadline = Date.now() + 180000;
-      while (Date.now() < deadline) {
-        await abortableDelay(1000, signal);
-        const job = await apiFetch(`/api/v1/jobs/${jobId}`, token, { signal });
-        if (job.status === "completed") {
+    ({ sourceAssetId, projectId, model, signal }) =>
+      pollJobToCompletion({
+        createPath: "/api/v1/prompts/refine",
+        body: { task: "image_caption", sourceAssetId, projectId, model },
+        deadlineMs: 180000,
+        resolveResult: (job) => {
           const caption = job.result?.refinedPrompt;
           if (!caption) {
             throw new Error("Image captioning returned an empty caption.");
           }
           return caption;
-        }
-        if (job.status === "failed" || job.status === "canceled" || job.status === "interrupted") {
-          throw new Error(job.message || job.error || "Image captioning failed.");
-        }
-      }
-      throw new Error("Image captioning timed out. Is the captioning runtime running?");
-    },
+        },
+        signal,
+        token,
+        startError: "Could not start image captioning.",
+        failureError: "Image captioning failed.",
+        timeoutError: "Image captioning timed out. Is the captioning runtime running?",
+      }),
     [token],
   );
 
@@ -1793,39 +1750,24 @@ export function App() {
   // text the caller drops into the prompt box. C1: the image is consumed only to produce the prompt — it
   // is NEVER passed to generation as img2img conditioning.
   const imageDescribe = useCallback(
-    async ({ sourceAssetId, projectId, model, captionStyle, signal }) => {
-      const created = await apiFetch("/api/v1/prompts/refine", token, {
-        method: "POST",
-        signal,
-        body: JSON.stringify({
-          task: "image_describe",
-          sourceAssetId,
-          projectId,
-          model,
-          captionStyle,
-        }),
-      });
-      const jobId = created?.id;
-      if (!jobId) {
-        throw new Error("Could not start image description.");
-      }
-      const deadline = Date.now() + 180000;
-      while (Date.now() < deadline) {
-        await abortableDelay(1000, signal);
-        const job = await apiFetch(`/api/v1/jobs/${jobId}`, token, { signal });
-        if (job.status === "completed") {
+    ({ sourceAssetId, projectId, model, captionStyle, signal }) =>
+      pollJobToCompletion({
+        createPath: "/api/v1/prompts/refine",
+        body: { task: "image_describe", sourceAssetId, projectId, model, captionStyle },
+        deadlineMs: 180000,
+        resolveResult: (job) => {
           const description = job.result?.refinedPrompt;
           if (!description) {
             throw new Error("Image description returned empty text.");
           }
           return description;
-        }
-        if (job.status === "failed" || job.status === "canceled" || job.status === "interrupted") {
-          throw new Error(job.message || job.error || "Image description failed.");
-        }
-      }
-      throw new Error("Image description timed out. Is the captioning runtime running?");
-    },
+        },
+        signal,
+        token,
+        startError: "Could not start image description.",
+        failureError: "Image description failed.",
+        timeoutError: "Image description timed out. Is the captioning runtime running?",
+      }),
     [token],
   );
 
@@ -1837,34 +1779,25 @@ export function App() {
   // via `classifyLikeness` / `LikenessBadge`. Non-fatal end to end: a no-face / non-frontal candidate
   // is an honest detected:false result (NOT an error); only a hard failure throws.
   const compareFaceLikeness = useCallback(
-    async ({ sourceAssetId, candidateAssetId, projectId, signal }) => {
-      const created = await apiFetch("/api/v1/face-likeness/compare", token, {
-        method: "POST",
-        signal,
-        body: JSON.stringify({ sourceAssetId, candidateAssetId, projectId }),
-      });
-      const jobId = created?.id;
-      if (!jobId) {
-        throw new Error("Could not start the likeness compare.");
-      }
-      const deadline = Date.now() + 180000;
-      while (Date.now() < deadline) {
-        await abortableDelay(1000, signal);
-        const job = await apiFetch(`/api/v1/jobs/${jobId}`, token, { signal });
-        if (job.status === "completed") {
+    ({ sourceAssetId, candidateAssetId, projectId, signal }) =>
+      pollJobToCompletion({
+        createPath: "/api/v1/face-likeness/compare",
+        body: { sourceAssetId, candidateAssetId, projectId },
+        deadlineMs: 180000,
+        resolveResult: (job) => {
           // A completed compare always carries a result block (a detected:false N/A is a valid,
           // non-error outcome). Surface the whole block so the UI can band/N-A it.
           if (!job.result) {
             throw new Error("Likeness compare returned no result.");
           }
           return job.result;
-        }
-        if (job.status === "failed" || job.status === "canceled" || job.status === "interrupted") {
-          throw new Error(job.message || job.error || "Likeness compare failed.");
-        }
-      }
-      throw new Error("Likeness compare timed out. Is the worker running?");
-    },
+        },
+        signal,
+        token,
+        startError: "Could not start the likeness compare.",
+        failureError: "Likeness compare failed.",
+        timeoutError: "Likeness compare timed out. Is the worker running?",
+      }),
     [token],
   );
 

--- a/apps/web/src/pollJob.js
+++ b/apps/web/src/pollJob.js
@@ -1,0 +1,73 @@
+import { apiFetch } from "./api.js";
+
+// Resolve after `ms`, or reject with an AbortError if `signal` fires (or is already
+// aborted). Shared by the poll-to-completion runners so a caller's AbortController
+// cancels the in-flight 1s wait immediately rather than after the timer elapses.
+export function abortableDelay(ms, signal) {
+  if (signal?.aborted) {
+    return Promise.reject(new DOMException("Aborted", "AbortError"));
+  }
+  return new Promise((resolve, reject) => {
+    const timer = window.setTimeout(resolve, ms);
+    signal?.addEventListener(
+      "abort",
+      () => {
+        window.clearTimeout(timer);
+        reject(new DOMException("Aborted", "AbortError"));
+      },
+      { once: true },
+    );
+  });
+}
+
+// Shared POST-a-job-then-poll-until-terminal runner (sc-8856). Five App.jsx callbacks
+// (refinePrompt / magicPrompt / imageCaption / imageDescribe / compareFaceLikeness) all
+// enqueue a worker job via a POST, then `while (Date.now() < deadline)` of
+// `abortableDelay(1000)` + `GET /jobs/:id` until the job reaches a terminal status. This
+// centralises that mechanism while keeping every per-caller variation explicit:
+//   - createPath   : the enqueue endpoint (e.g. "/api/v1/prompts/refine").
+//   - body         : the JSON body object to POST (stringified here).
+//   - deadlineMs    : the caller's own poll deadline (refine=120s, the rest=180s).
+//   - resolveResult : (job) => value — invoked once the job is "completed"; each caller
+//                     extracts + validates its own result field here and throws its own
+//                     "empty result" error, so the completion semantics stay per-caller.
+//   - startError / failureError / timeoutError : the caller's own messages for a missing
+//                     job id, a failed/canceled/interrupted terminal state, and a deadline
+//                     timeout respectively.
+// Terminal-status handling ("completed" vs failed/canceled/interrupted) and the 1s poll
+// interval are identical across all five callers, so they live here; everything that
+// varied stays a parameter. Throws on any non-success path; the `signal` cancels both the
+// POST/GET fetches and the inter-poll delay.
+export async function pollJobToCompletion({
+  createPath,
+  body,
+  deadlineMs,
+  resolveResult,
+  signal,
+  token,
+  startError,
+  failureError,
+  timeoutError,
+}) {
+  const created = await apiFetch(createPath, token, {
+    method: "POST",
+    signal,
+    body: JSON.stringify(body),
+  });
+  const jobId = created?.id;
+  if (!jobId) {
+    throw new Error(startError);
+  }
+  const deadline = Date.now() + deadlineMs;
+  while (Date.now() < deadline) {
+    await abortableDelay(1000, signal);
+    const job = await apiFetch(`/api/v1/jobs/${jobId}`, token, { signal });
+    if (job.status === "completed") {
+      return resolveResult(job);
+    }
+    if (job.status === "failed" || job.status === "canceled" || job.status === "interrupted") {
+      throw new Error(job.message || job.error || failureError);
+    }
+  }
+  throw new Error(timeoutError);
+}

--- a/apps/web/src/pollJob.test.js
+++ b/apps/web/src/pollJob.test.js
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { apiFetch } from "./api.js";
+import { pollJobToCompletion } from "./pollJob.js";
+
+vi.mock("./api.js", () => ({
+  apiFetch: vi.fn(),
+}));
+
+// pollJobToCompletion (sc-8856) is the shared POST-then-poll-until-terminal runner behind the
+// five App.jsx callbacks (refinePrompt / magicPrompt / imageCaption / imageDescribe /
+// compareFaceLikeness). These tests pin the mechanism that was previously copy-pasted five times:
+// it POSTs the create endpoint, polls GET /jobs/:id on a 1s cadence, and honours each caller's own
+// resolve/terminal/timeout semantics. Fake timers advance the inter-poll abortableDelay(1000).
+
+// Drive apiFetch as: first call (the POST) returns `created`; every subsequent call (a GET
+// /jobs/:id poll) returns the next status object from `pollResponses` (last one repeats).
+function stubApi({ created, pollResponses }) {
+  let pollIdx = 0;
+  apiFetch.mockImplementation(async (path, _token, options) => {
+    if (options?.method === "POST") {
+      return created;
+    }
+    const idx = Math.min(pollIdx, pollResponses.length - 1);
+    pollIdx += 1;
+    return pollResponses[idx];
+  });
+}
+
+// Await a promise while flushing the fake-timer queue, so the internal abortableDelay(1000) waits
+// resolve and the poll loop advances without real wall-clock time.
+async function runWithTimers(promise) {
+  const settled = promise.then(
+    (value) => ({ ok: true, value }),
+    (error) => ({ ok: false, error }),
+  );
+  // Advance well past several 1s poll intervals; the loop settles as soon as a terminal status
+  // (or the deadline) is reached.
+  for (let i = 0; i < 200; i += 1) {
+    await vi.advanceTimersByTimeAsync(1000);
+  }
+  return settled;
+}
+
+const baseArgs = {
+  createPath: "/api/v1/prompts/refine",
+  body: { prompt: "dog" },
+  deadlineMs: 120000,
+  resolveResult: (job) => {
+    const refined = job.result?.refinedPrompt;
+    if (!refined) {
+      throw new Error("Refinement returned an empty prompt.");
+    }
+    return refined;
+  },
+  token: "tok",
+  startError: "Could not start prompt refinement.",
+  failureError: "Prompt refinement failed.",
+  timeoutError: "Prompt refinement timed out. Is the refinement runtime running?",
+};
+
+describe("pollJobToCompletion (sc-8856)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    apiFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("POSTs the create endpoint with the stringified body and the token", async () => {
+    stubApi({
+      created: { id: "job-1" },
+      pollResponses: [{ status: "completed", result: { refinedPrompt: "rewritten" } }],
+    });
+
+    const settled = await runWithTimers(pollJobToCompletion({ ...baseArgs }));
+
+    expect(settled).toEqual({ ok: true, value: "rewritten" });
+    const postCall = apiFetch.mock.calls.find(([, , opts]) => opts?.method === "POST");
+    expect(postCall[0]).toBe("/api/v1/prompts/refine");
+    expect(postCall[1]).toBe("tok");
+    expect(postCall[2].body).toBe(JSON.stringify({ prompt: "dog" }));
+  });
+
+  it("polls GET /jobs/:id until completed and returns the caller's resolved result", async () => {
+    stubApi({
+      created: { id: "job-9" },
+      pollResponses: [
+        { status: "queued" },
+        { status: "running" },
+        { status: "completed", result: { refinedPrompt: "final prompt" } },
+      ],
+    });
+
+    const settled = await runWithTimers(pollJobToCompletion({ ...baseArgs }));
+
+    expect(settled).toEqual({ ok: true, value: "final prompt" });
+    const getCalls = apiFetch.mock.calls.filter(([, , opts]) => opts?.method !== "POST");
+    expect(getCalls.every(([path]) => path === "/api/v1/jobs/job-9")).toBe(true);
+    // queued + running + completed = three polls.
+    expect(getCalls.length).toBe(3);
+  });
+
+  it("throws the caller's startError when the POST returns no job id", async () => {
+    stubApi({ created: {}, pollResponses: [] });
+
+    const settled = await runWithTimers(pollJobToCompletion({ ...baseArgs }));
+
+    expect(settled.ok).toBe(false);
+    expect(settled.error.message).toBe("Could not start prompt refinement.");
+  });
+
+  it("lets the caller's resolveResult throw on an empty completed result", async () => {
+    stubApi({
+      created: { id: "job-2" },
+      pollResponses: [{ status: "completed", result: {} }],
+    });
+
+    const settled = await runWithTimers(pollJobToCompletion({ ...baseArgs }));
+
+    expect(settled.ok).toBe(false);
+    expect(settled.error.message).toBe("Refinement returned an empty prompt.");
+  });
+
+  it.each(["failed", "canceled", "interrupted"])(
+    "throws the failureError on a %s terminal status",
+    async (status) => {
+      stubApi({ created: { id: "job-3" }, pollResponses: [{ status }] });
+
+      const settled = await runWithTimers(pollJobToCompletion({ ...baseArgs }));
+
+      expect(settled.ok).toBe(false);
+      expect(settled.error.message).toBe("Prompt refinement failed.");
+    },
+  );
+
+  it("prefers the job's own message/error over the generic failureError", async () => {
+    stubApi({
+      created: { id: "job-4" },
+      pollResponses: [{ status: "failed", message: "runtime exploded" }],
+    });
+
+    const settled = await runWithTimers(pollJobToCompletion({ ...baseArgs }));
+
+    expect(settled.ok).toBe(false);
+    expect(settled.error.message).toBe("runtime exploded");
+  });
+
+  it("throws the timeoutError once the deadline passes with no terminal status", async () => {
+    // deadlineMs 3s => the loop gets ~2 polls before Date.now() crosses the deadline.
+    stubApi({ created: { id: "job-5" }, pollResponses: [{ status: "running" }] });
+
+    const settled = await runWithTimers(
+      pollJobToCompletion({ ...baseArgs, deadlineMs: 3000 }),
+    );
+
+    expect(settled.ok).toBe(false);
+    expect(settled.error.message).toBe(
+      "Prompt refinement timed out. Is the refinement runtime running?",
+    );
+  });
+
+  it("aborts the inter-poll delay when the signal fires", async () => {
+    stubApi({ created: { id: "job-6" }, pollResponses: [{ status: "running" }] });
+    const controller = new AbortController();
+
+    const promise = pollJobToCompletion({ ...baseArgs, signal: controller.signal });
+    const settled = promise.then(
+      (value) => ({ ok: true, value }),
+      (error) => ({ ok: false, error }),
+    );
+    controller.abort();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    const result = await settled;
+    expect(result.ok).toBe(false);
+    expect(result.error.name).toBe("AbortError");
+  });
+
+  it("rejects immediately when the signal is already aborted", async () => {
+    stubApi({ created: { id: "job-7" }, pollResponses: [{ status: "running" }] });
+    const controller = new AbortController();
+    controller.abort();
+
+    const settled = await runWithTimers(
+      pollJobToCompletion({ ...baseArgs, signal: controller.signal }),
+    );
+
+    expect(settled.ok).toBe(false);
+    expect(settled.error.name).toBe("AbortError");
+  });
+});


### PR DESCRIPTION
## sc-8856 — [F-054] Five copy-pasted poll-to-completion loops in App.jsx

Story: https://app.shortcut.com/trefry/story/8856

### Problem
Five callbacks in `apps/web/src/App.jsx` (`refinePrompt`, `magicPrompt`, `imageCaption`, `imageDescribe`, `compareFaceLikeness`) each repeated the identical ~30-line "POST a job, then `while (Date.now() < deadline)` of `abortableDelay(1000)` + `GET /jobs/:id` until terminal" pattern, varying only in endpoint, deadline, and result field — ~150 lines of drift-prone duplication. Any fix (new terminal status, backoff, cancellation edge) had to be applied five times by hand, exactly as happened when `interrupted` was added to each copy.

### Fix (option a — extract shared helper)
Chose the lower-risk in-scope dedup: extracted one `pollJobToCompletion({ createPath, body, deadlineMs, resolveResult, signal, token, startError, failureError, timeoutError })` into the new `apps/web/src/pollJob.js` (with the module-private `abortableDelay` moved alongside it), and routed all five callbacks through it. The SSE-primary option (b) was rejected for this story: it's a bigger behavior change (subscription lifecycle, POST-jobId-vs-SSE-arrival race, fallback logic) and out of scope for a dedup chore.

Every per-caller variation stays an explicit parameter, so behavior is byte-for-byte preserved.

### Per-callback parity table

| Callback | createPath | deadlineMs | poll interval | result field | terminal statuses |
|---|---|---|---|---|---|
| `refinePrompt` | `/api/v1/prompts/refine` | 120000 | `abortableDelay(1000)` | `job.result?.refinedPrompt` (throw if empty) | done / failed / canceled / interrupted |
| `magicPrompt` | `/api/v1/prompts/refine` (`task:"magic_prompt"`) | 180000 | `abortableDelay(1000)` | `job.result?.refinedPrompt` (throw if empty) | done / failed / canceled / interrupted |
| `imageCaption` | `/api/v1/prompts/refine` (`task:"image_caption"`) | 180000 | `abortableDelay(1000)` | `job.result?.refinedPrompt` (throw if empty) | done / failed / canceled / interrupted |
| `imageDescribe` | `/api/v1/prompts/refine` (`task:"image_describe"`) | 180000 | `abortableDelay(1000)` | `job.result?.refinedPrompt` (throw if empty) | done / failed / canceled / interrupted |
| `compareFaceLikeness` | `/api/v1/face-likeness/compare` | 180000 | `abortableDelay(1000)` | `job.result` (whole block; throw if absent) | done / failed / canceled / interrupted |

Each caller keeps its own start/failure/timeout error strings and its own `resolveResult` (empty-result throw). Terminal-status handling (`job.message || job.error || failureError`), the 1s cadence, and abort/signal wiring are shared in the helper.

### Tests
- New `apps/web/src/pollJob.test.js` unit-tests the previously-untested loop: resolves on `completed` with the caller's result; caller `resolveResult` throws on empty; `failed`/`canceled`/`interrupted` → `failureError`; `job.message` preferred over generic; deadline timeout; signal abort (mid-wait and already-aborted). 11 tests.
- The five callbacks' existing tests mock them as props (component/App-level), so they pass unchanged as the behavior oracle.
- Full web suite: **1100 passed (67 files)**. ESLint: **0 errors, 49 warnings** (parity with main; new files add 0 warnings).

### Scope
Minimal coherent change: extract the helper + route the 5 callbacks. No broader App.jsx restructuring (that god-component lives under F-052/F-053). Net ~150 lines of duplication removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)