### PR TITLE
chore(worker): extract shared plan_edit_batch + stage_likeness for edit streams (sc-8826)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -2063,6 +2063,37 @@ fn parse_poses(request: &ImageRequest) -> Vec<PoseInput> {
         .collect()
 }
 
+/// Stage the antelopev2 face stack for identity-likeness scoring (epic 4406), collapsing the
+/// warn-and-`None` staging block duplicated across every scored image lane (F-024, sc-8826). When
+/// `should_stage` is false the stack is never fetched and this is `None`; when true it downloads the
+/// shared InstantID bundle (a no-op if already cached) and returns its dir. Staging is **non-fatal**:
+/// a download failure logs `warn_message` and yields `None`, so the scorer is simply skipped and the
+/// generation still renders (no scores). `warn_message` is the per-lane phrasing (e.g. the
+/// `character_image` edit streams vs. the `pose-set` control lanes) so the log line is unchanged from
+/// the hand-written blocks this replaces.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+async fn stage_likeness(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    should_stage: bool,
+    warn_message: &'static str,
+) -> Option<PathBuf> {
+    if !should_stage {
+        return None;
+    }
+    match ensure_face_stack_dir(api, settings, job).await {
+        Ok(dir) => Some(dir),
+        Err(error) => {
+            tracing::warn!(error = %error, "{warn_message}");
+            None
+        }
+    }
+}
+
 /// The per-angle continuation clause appended to the user's prompt (parity with
 /// `character_studio_angles.ANGLE_PROMPT_AUGMENTS`). Unknown angle → empty.
 #[cfg(any(
@@ -2405,16 +2436,14 @@ async fn generate_stream(
     // which also resolves the CURRENT job's reference (so changing it changes the scored source) and is
     // non-fatal. The `!Send` scorer is built ONCE inside the closure and reused across the N outputs.
     let likeness_source = resolve_character_image_likeness_source(request, settings, project_path);
-    let face_stack_dir = match &likeness_source {
-        Some(_) => match ensure_face_stack_dir(api, settings, job).await {
-            Ok(dir) => Some(dir),
-            Err(error) => {
-                tracing::warn!(error = %error, "character_image face-stack staging failed; likeness scores omitted");
-                None
-            }
-        },
-        None => None,
-    };
+    let face_stack_dir = stage_likeness(
+        api,
+        settings,
+        job,
+        likeness_source.is_some(),
+        "character_image face-stack staging failed; likeness scores omitted",
+    )
+    .await;
     // Keep the source only if the face stack staged (otherwise no scorer can be built).
     let likeness_source = face_stack_dir.as_ref().and(likeness_source);
 

--- a/crates/sceneworks-worker/src/image_jobs/candle_strict_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/candle_strict_control.rs
@@ -128,17 +128,14 @@ async fn run_candle_strict_control<P: CandleStrictControl>(
     // `!Send` scorer is built ONCE in the load closure on the blocking thread (source embedded once,
     // reused across all poses).
     let likeness_source = resolve_control_identity_source(request, settings, project_path);
-    let face_stack_dir = if likeness_source.is_some() {
-        match ensure_face_stack_dir(api, settings, job).await {
-            Ok(dir) => Some(dir),
-            Err(error) => {
-                tracing::warn!(error = %error, "pose-set face-stack staging failed; likeness scores omitted");
-                None
-            }
-        }
-    } else {
-        None
-    };
+    let face_stack_dir = stage_likeness(
+        api,
+        settings,
+        job,
+        likeness_source.is_some(),
+        "pose-set face-stack staging failed; likeness scores omitted",
+    )
+    .await;
     let likeness_source_ref = likeness_source.as_ref().map(|(_, id)| id.clone());
 
     let engine_label = provider.engine_label();

--- a/crates/sceneworks-worker/src/image_jobs/flux1_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux1_control.rs
@@ -286,17 +286,14 @@ async fn generate_flux1_dev_control_stream(
     // (missing reference / failure → no scorer → scores omitted, set still renders). The `!Send` scorer
     // is built ONCE in the closure (source embedded once, reused across all poses).
     let likeness_source = resolve_control_identity_source(request, settings, project_path);
-    let face_stack_dir = if likeness_source.is_some() {
-        match ensure_face_stack_dir(api, settings, job).await {
-            Ok(dir) => Some(dir),
-            Err(error) => {
-                tracing::warn!(error = %error, "pose-set face-stack staging failed; likeness scores omitted");
-                None
-            }
-        }
-    } else {
-        None
-    };
+    let face_stack_dir = stage_likeness(
+        api,
+        settings,
+        job,
+        likeness_source.is_some(),
+        "pose-set face-stack staging failed; likeness scores omitted",
+    )
+    .await;
 
     let prompt = request.prompt.clone();
     let (width, height) = (request.width, request.height);

--- a/crates/sceneworks-worker/src/image_jobs/flux2.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2.rs
@@ -26,6 +26,101 @@ fn flux2_grouping(request: &ImageRequest) -> Flux2Grouping {
     Flux2Grouping::Plain
 }
 
+/// The per-iteration plan shared by every native edit stream (FLUX.2 / Qwen-Edit / SenseNova-U1,
+/// F-024 sc-8826): the `(seeds, prompts, pose_inputs)` grouping expansion, the
+/// `angleSet`/`poseLibrary` raw-settings stamping, and the identity-likeness gate. Built once by
+/// [`plan_edit_batch`] and consumed by all three lanes so a change to the plain-With-Character gate
+/// (sc-4411) lands in exactly one place.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+struct EditBatch {
+    /// Per-iteration seed (shared across an angle/pose set, per-image on the plain path).
+    seeds: Vec<i64>,
+    /// Per-iteration prompt (angle/pose augment on the set paths, the base prompt on plain).
+    prompts: Vec<String>,
+    /// Full `PoseInput`s (keypoints + hands + face) for the pose tier; `None` for angles/plain.
+    pose_inputs: Option<Vec<PoseInput>>,
+    /// The lane's base raw settings with `angleSet`/`poseLibrary` stamped per grouping.
+    raw_settings: JsonObject,
+    /// Whether this generation is identity-likeness scored (epic 4406): a Character-Studio angle
+    /// set, a pose-library set, OR a plain With-Character `character_image` job (sc-4411). Drives
+    /// the [`stage_likeness`] call each lane makes with `references[0]` as the scored source.
+    score_likeness: bool,
+}
+
+/// Build the [`EditBatch`] for a native edit stream from its resolved `grouping` and its
+/// lane-specific `raw_settings` (the per-lane `*_edit_raw_settings` output — the ONLY per-stream
+/// input, so the grouping/stamping/gating logic stays identical across FLUX.2 / Qwen / SenseNova).
+///
+/// Grouping expansion (parity with the `Mlx*Adapter` decision):
+/// - `Poses(n)`: shared seed, one `augment_prompt_for_pose` prompt per pose, full `PoseInput`s kept
+///   so whole-body poses thread hand/face articulation into the skeleton (sc-6702 / sc-6599).
+/// - `Angles`: shared seed so noise-derived attributes (hair, lighting) stay constant across angles
+///   — only the head pose changes (sc-2050 InstantID strategy) — with a per-angle prompt augment.
+/// - `Plain`: `count` independent per-image seeds, the base prompt each.
+///
+/// Likeness gate (epic 4406, sc-4409 angles / sc-4410 poses / sc-4411 plain With-Character): the
+/// generator-agnostic post-pass applies to EVERY character_image generation. `character_set` covers
+/// the angle + pose sets; `plain_with_character` is a `character_image` job (so NOT an `edit_image`,
+/// whose `Plain` grouping also lands here but carries a `sourceAssetId`, not an identity reference)
+/// whose `Plain` grouping is the general subject-variation case — for that lane the scored reference
+/// is `references[0]`, which for a `character_image` job IS the `referenceAssetId` (first in the
+/// lane's `*_edit_reference_ids`). `score_likeness` covers all three.
+#[cfg(target_os = "macos")]
+fn plan_edit_batch(
+    request: &ImageRequest,
+    grouping: &Flux2Grouping,
+    mut raw_settings: JsonObject,
+) -> EditBatch {
+    let set_seed = resolve_seed(request, 0);
+    let (seeds, prompts, pose_inputs): (Vec<i64>, Vec<String>, Option<Vec<PoseInput>>) =
+        match grouping {
+            Flux2Grouping::Poses(count) => {
+                let poses = parse_poses(request);
+                let prompts = vec![augment_prompt_for_pose(&request.prompt); *count];
+                (vec![set_seed; *count], prompts, Some(poses))
+            }
+            Flux2Grouping::Angles => {
+                let prompts = CHARACTER_ANGLE_SET_ORDER
+                    .iter()
+                    .map(|angle| augment_prompt_for_angle(&request.prompt, angle))
+                    .collect();
+                (
+                    vec![set_seed; CHARACTER_ANGLE_SET_ORDER.len()],
+                    prompts,
+                    None,
+                )
+            }
+            Flux2Grouping::Plain => {
+                let count = request.count as usize;
+                let seeds = (0..count).map(|index| resolve_seed(request, index)).collect();
+                (seeds, vec![request.prompt.clone(); count], None)
+            }
+        };
+
+    match grouping {
+        Flux2Grouping::Angles => {
+            raw_settings.insert("angleSet".to_owned(), Value::Bool(true));
+        }
+        Flux2Grouping::Poses(_) => {
+            raw_settings.insert("poseLibrary".to_owned(), Value::Bool(true));
+        }
+        Flux2Grouping::Plain => {}
+    }
+
+    let character_set = matches!(grouping, Flux2Grouping::Angles | Flux2Grouping::Poses(_));
+    let plain_with_character =
+        matches!(grouping, Flux2Grouping::Plain) && request.mode == "character_image";
+    let score_likeness = character_set || plain_with_character;
+
+    EditBatch {
+        seeds,
+        prompts,
+        pose_inputs,
+        raw_settings,
+        score_likeness,
+    }
+}
+
 /// True when the FLUX.2 Image-Edit source should be pre-fitted to W×H (parity with the
 /// `MlxFlux2Adapter` fit gate): `edit_image` mode, a source asset, no character
 /// `referenceAssetId`, and a non-`stretch` fit mode. The Character-Studio reference
@@ -378,96 +473,50 @@ async fn generate_flux2_edit_stream(
 
     // sc-3030 per-iteration grouping: a Character-Studio angle set (11 shared-seed,
     // per-angle prompt) / best-effort pose tier (one per pose, shared seed, each a
-    // `[skeleton, reference]` set) / else the plain per-image reference path.
+    // `[skeleton, reference]` set) / else the plain per-image reference path. The grouping
+    // expansion, angleSet/poseLibrary stamping, and the identity-likeness gate (incl. the sc-4411
+    // plain-With-Character case) are the shared `plan_edit_batch` builder (F-024 sc-8826). The
+    // whole-body pose PoseInputs thread their hand/face articulation into the skeleton below
+    // (sc-6702). Identity-likeness scoring (epic 4406, sc-4409 angles / sc-4410 poses / sc-4411
+    // plain With-Character) applies to EVERY character_image generation on this FLUX.2 edit lane,
+    // which produces the FINAL image directly (no face-restore pass), so scoring the generated
+    // image scores what the user sees.
     let grouping = flux2_grouping(request);
-    let set_seed = resolve_seed(request, 0);
-    let (seeds, prompts, pose_inputs): (
-        Vec<i64>,
-        Vec<String>,
-        Option<Vec<PoseInput>>,
-    ) = match &grouping {
-        Flux2Grouping::Poses(count) => {
-            // Shared seed so only the pose changes across the set (Python parity).
-            // Keep the full PoseInput (keypoints + hands + face) so whole-body poses
-            // thread their hand/face articulation into the skeleton below (sc-6702).
-            let poses = parse_poses(request);
-            let prompts = vec![augment_prompt_for_pose(&request.prompt); *count];
-            (vec![set_seed; *count], prompts, Some(poses))
-        }
-        Flux2Grouping::Angles => {
-            // Shared seed so noise-derived attributes (hair, lighting) stay constant
-            // across angles — only the head pose changes (sc-2050 InstantID strategy).
-            let prompts = CHARACTER_ANGLE_SET_ORDER
-                .iter()
-                .map(|angle| augment_prompt_for_angle(&request.prompt, angle))
-                .collect();
-            (
-                vec![set_seed; CHARACTER_ANGLE_SET_ORDER.len()],
-                prompts,
-                None,
-            )
-        }
-        Flux2Grouping::Plain => {
-            let count = request.count as usize;
-            let seeds = (0..count)
-                .map(|index| resolve_seed(request, index))
-                .collect();
-            (seeds, vec![request.prompt.clone(); count], None)
-        }
-    };
+    let EditBatch {
+        seeds,
+        prompts,
+        pose_inputs,
+        raw_settings,
+        score_likeness,
+    } = plan_edit_batch(
+        request,
+        &grouping,
+        flux2_edit_raw_settings(
+            request,
+            &repo,
+            engine_id,
+            steps,
+            quant_bits,
+            guidance,
+            references.len(),
+        ),
+    );
     let total = seeds.len();
 
-    let mut raw_settings = flux2_edit_raw_settings(
-        request,
-        &repo,
-        engine_id,
-        steps,
-        quant_bits,
-        guidance,
-        references.len(),
-    );
-    match grouping {
-        Flux2Grouping::Angles => {
-            raw_settings.insert("angleSet".to_owned(), Value::Bool(true));
-        }
-        Flux2Grouping::Poses(_) => {
-            raw_settings.insert("poseLibrary".to_owned(), Value::Bool(true));
-        }
-        Flux2Grouping::Plain => {}
-    }
-
-    // Identity-likeness scoring (epic 4406, sc-4409 angles / sc-4410 poses / sc-4411 plain
-    // With-Character): the generator-agnostic post-pass applies to EVERY character_image generation, not
-    // just InstantID-routed ones — a Character-Studio angle set, a pose-library set, OR a plain
-    // With-Character generation on a FLUX.2 edit model is scored through the same shared seam. The FLUX.2
-    // edit path produces the FINAL image directly (no face-restore pass on this lane), so scoring the
-    // generated image scores what the user sees. The PLAIN case (sc-4411) is scored only when this is a
-    // `character_image` job with a character `referenceAssetId` (NOT an `edit_image` job, whose `Plain`
-    // grouping also lands here but carries the `sourceAssetId`, not an identity reference). The angle +
-    // pose sets keep their existing scoring; this just adds the plain `character_image` case so the
-    // common With-Character generation is scored too — `score_likeness` covers all three. Stage the
-    // antelopev2 face stack (same bundle InstantID uses; a no-op if already cached) and capture the
-    // source identity reference + its asset id; the `!Send` scorer is built ONCE inside the
-    // generator-worker closure below and reused across all outputs. Staging is non-fatal (a failure → no
-    // scorer → scores omitted, the generation still renders).
-    let character_set = matches!(grouping, Flux2Grouping::Angles | Flux2Grouping::Poses(_));
-    // Plain With-Character: a `character_image` job (so NOT an `edit_image`) whose `Plain` grouping is the
-    // general subject-variation case (sc-4411). For this lane the scored reference is `references[0]` —
-    // for a character_image job that IS the `referenceAssetId` (it is first in `flux2_edit_reference_ids`).
-    let plain_with_character =
-        matches!(grouping, Flux2Grouping::Plain) && request.mode == "character_image";
-    let score_likeness = character_set || plain_with_character;
-    let face_stack_dir = if score_likeness {
-        match ensure_face_stack_dir(api, settings, job).await {
-            Ok(dir) => Some(dir),
-            Err(error) => {
-                tracing::warn!(error = %error, "character_image face-stack staging failed; likeness scores omitted");
-                None
-            }
-        }
-    } else {
-        None
-    };
+    // Stage the antelopev2 face stack (same bundle InstantID uses; a no-op if already cached) and
+    // capture the source identity reference + its asset id; the `!Send` scorer is built ONCE inside
+    // the generator-worker closure below and reused across all outputs. Staging is non-fatal (a
+    // failure → no scorer → scores omitted, the generation still renders). The scored reference is
+    // `references[0]` — for a character_image job that IS the `referenceAssetId` (first in
+    // `flux2_edit_reference_ids`).
+    let face_stack_dir = stage_likeness(
+        api,
+        settings,
+        job,
+        score_likeness,
+        "character_image face-stack staging failed; likeness scores omitted",
+    )
+    .await;
     let likeness_source = (score_likeness && face_stack_dir.is_some()).then(|| references[0].clone());
     let likeness_source_ref = reference_ids.first().cloned();
 
@@ -919,17 +968,14 @@ async fn generate_flux2_dev_control_stream(
     // set still renders). The `!Send` scorer is built ONCE in the closure (source embedded once, reused
     // across all poses).
     let likeness_source = resolve_control_identity_source(request, settings, project_path);
-    let face_stack_dir = if likeness_source.is_some() {
-        match ensure_face_stack_dir(api, settings, job).await {
-            Ok(dir) => Some(dir),
-            Err(error) => {
-                tracing::warn!(error = %error, "pose-set face-stack staging failed; likeness scores omitted");
-                None
-            }
-        }
-    } else {
-        None
-    };
+    let face_stack_dir = stage_likeness(
+        api,
+        settings,
+        job,
+        likeness_source.is_some(),
+        "pose-set face-stack staging failed; likeness scores omitted",
+    )
+    .await;
 
     let prompt = request.prompt.clone();
     let (width, height) = (request.width, request.height);

--- a/crates/sceneworks-worker/src/image_jobs/flux_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux_ipadapter.rs
@@ -262,17 +262,14 @@ async fn generate_candle_flux_ipadapter_stream(
     // reused across the N outputs (source embedded once). Staging is non-fatal (failure → scores omitted).
     let score_likeness =
         resolve_character_image_likeness_source(request, settings, project_path).is_some();
-    let face_stack_dir = if score_likeness {
-        match ensure_face_stack_dir(api, settings, job).await {
-            Ok(dir) => Some(dir),
-            Err(error) => {
-                tracing::warn!(error = %error, "character_image face-stack staging failed; likeness scores omitted");
-                None
-            }
-        }
-    } else {
-        None
-    };
+    let face_stack_dir = stage_likeness(
+        api,
+        settings,
+        job,
+        score_likeness,
+        "character_image face-stack staging failed; likeness scores omitted",
+    )
+    .await;
     let likeness_source = face_stack_dir.as_ref().map(|_| reference.clone());
     let likeness_source_ref = reference_id.to_owned();
 

--- a/crates/sceneworks-worker/src/image_jobs/kolors.rs
+++ b/crates/sceneworks-worker/src/image_jobs/kolors.rs
@@ -380,13 +380,14 @@ async fn generate_kolors_control_stream(
     // closure (source embedded once, reused across all poses — the caching AC). This lane produces the
     // FINAL image directly (no face-restore pass), so scoring the generated image scores what the user
     // sees.
-    let face_stack_dir = match ensure_face_stack_dir(api, settings, job).await {
-        Ok(dir) => Some(dir),
-        Err(error) => {
-            tracing::warn!(error = %error, "pose-set face-stack staging failed; likeness scores omitted");
-            None
-        }
-    };
+    let face_stack_dir = stage_likeness(
+        api,
+        settings,
+        job,
+        true,
+        "pose-set face-stack staging failed; likeness scores omitted",
+    )
+    .await;
     let likeness_source_ref = reference_id.to_owned();
 
     let prompt = request.prompt.clone();

--- a/crates/sceneworks-worker/src/image_jobs/kolors_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/kolors_ipadapter.rs
@@ -226,17 +226,14 @@ async fn generate_candle_kolors_ipadapter_stream(
     // outputs (source embedded once). Staging is non-fatal (failure → scores omitted).
     let score_likeness =
         resolve_character_image_likeness_source(request, settings, project_path).is_some();
-    let face_stack_dir = if score_likeness {
-        match ensure_face_stack_dir(api, settings, job).await {
-            Ok(dir) => Some(dir),
-            Err(error) => {
-                tracing::warn!(error = %error, "character_image face-stack staging failed; likeness scores omitted");
-                None
-            }
-        }
-    } else {
-        None
-    };
+    let face_stack_dir = stage_likeness(
+        api,
+        settings,
+        job,
+        score_likeness,
+        "character_image face-stack staging failed; likeness scores omitted",
+    )
+    .await;
     let likeness_source = face_stack_dir.as_ref().map(|_| reference.clone());
     let likeness_source_ref = reference_id.to_owned();
 

--- a/crates/sceneworks-worker/src/image_jobs/pulid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/pulid.rs
@@ -391,13 +391,14 @@ async fn generate_pulid_flux_stream(
     // (source embedded once — the caching AC). The source is the CURRENT job's `referenceAssetId`, so
     // changing the reference changes the scored source. Staging is non-fatal (failure → no scorer →
     // scores omitted, generation still renders).
-    let face_stack_dir = match ensure_face_stack_dir(api, settings, job).await {
-        Ok(dir) => Some(dir),
-        Err(error) => {
-            tracing::warn!(error = %error, "PuLID-FLUX face-stack staging failed; likeness scores omitted");
-            None
-        }
-    };
+    let face_stack_dir = stage_likeness(
+        api,
+        settings,
+        job,
+        true,
+        "PuLID-FLUX face-stack staging failed; likeness scores omitted",
+    )
+    .await;
     let likeness_source = face_stack_dir.as_ref().map(|_| reference.clone());
     let likeness_source_ref = reference_id.to_owned();
 

--- a/crates/sceneworks-worker/src/image_jobs/pulid_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/pulid_candle.rs
@@ -265,17 +265,14 @@ async fn generate_candle_pulid_stream(
     // non-fatal (failure → no scorer → scores omitted, generation still renders).
     let score_likeness =
         resolve_character_image_likeness_source(request, settings, project_path).is_some();
-    let face_stack_dir = if score_likeness {
-        match ensure_face_stack_dir(api, settings, job).await {
-            Ok(dir) => Some(dir),
-            Err(error) => {
-                tracing::warn!(error = %error, "PuLID-FLUX face-stack staging failed; likeness scores omitted");
-                None
-            }
-        }
-    } else {
-        None
-    };
+    let face_stack_dir = stage_likeness(
+        api,
+        settings,
+        job,
+        score_likeness,
+        "PuLID-FLUX face-stack staging failed; likeness scores omitted",
+    )
+    .await;
     let likeness_source = face_stack_dir.as_ref().map(|_| reference.clone());
     let likeness_source_ref = reference_id.to_owned();
 

--- a/crates/sceneworks-worker/src/image_jobs/qwen.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen.rs
@@ -204,17 +204,14 @@ async fn generate_qwen_control_stream(
     // + face-stack staging are non-fatal; the `!Send` scorer is built ONCE in the closure (source
     // embedded once, reused across poses).
     let likeness_source = resolve_control_identity_source(request, settings, project_path);
-    let face_stack_dir = if likeness_source.is_some() {
-        match ensure_face_stack_dir(api, settings, job).await {
-            Ok(dir) => Some(dir),
-            Err(error) => {
-                tracing::warn!(error = %error, "pose-set face-stack staging failed; likeness scores omitted");
-                None
-            }
-        }
-    } else {
-        None
-    };
+    let face_stack_dir = stage_likeness(
+        api,
+        settings,
+        job,
+        likeness_source.is_some(),
+        "pose-set face-stack staging failed; likeness scores omitted",
+    )
+    .await;
 
     let prompt = request.prompt.clone();
     let (width, height) = (request.width, request.height);
@@ -650,64 +647,29 @@ async fn generate_qwen_edit_stream(
             .collect::<WorkerResult<Vec<_>>>()?;
     }
 
-    // Per-iteration grouping (shared with the FLUX.2 edit path): a Character-Studio angle
-    // set (11 shared-seed, per-angle prompt) / best-effort pose tier (one per pose, shared
-    // seed, each a `[reference, skeleton]` set) / else the plain per-image reference path.
+    // Per-iteration grouping (shared with the FLUX.2 edit path via `plan_edit_batch`, F-024
+    // sc-8826): a Character-Studio angle set (11 shared-seed, per-angle prompt) / best-effort pose
+    // tier (one per pose, shared seed, each a `[reference, skeleton]` set) / else the plain
+    // per-image reference path. The whole-body pose PoseInputs thread their hand/face articulation
+    // into the skeleton below (sc-6599). The builder also stamps angleSet/poseLibrary and computes
+    // the identity-likeness gate (incl. the sc-4411 plain-With-Character case). Scoring (epic 4406,
+    // sc-4409 angles / sc-4410 poses / sc-4411 plain With-Character) is generator-agnostic — Qwen-Edit
+    // produces the FINAL image directly (no face-restore pass), so scoring the generated image scores
+    // what the user sees.
     let grouping = flux2_grouping(request);
-    let set_seed = resolve_seed(request, 0);
-    let (seeds, prompts, pose_inputs): (
-        Vec<i64>,
-        Vec<String>,
-        Option<Vec<PoseInput>>,
-    ) = match &grouping {
-        Flux2Grouping::Poses(count) => {
-            // Shared seed so only the pose changes across the set (Python parity).
-            // Keep the full PoseInput (keypoints + hands + face) so whole-body poses
-            // thread their hand/face articulation into the skeleton below (sc-6599).
-            let poses = parse_poses(request);
-            let prompts = vec![augment_prompt_for_pose(&request.prompt); *count];
-            (vec![set_seed; *count], prompts, Some(poses))
-        }
-        Flux2Grouping::Angles => {
-            // Shared seed so noise-derived attributes (hair, lighting) stay constant
-            // across angles — only the head pose changes.
-            let prompts = CHARACTER_ANGLE_SET_ORDER
-                .iter()
-                .map(|angle| augment_prompt_for_angle(&request.prompt, angle))
-                .collect();
-            (
-                vec![set_seed; CHARACTER_ANGLE_SET_ORDER.len()],
-                prompts,
-                None,
-            )
-        }
-        Flux2Grouping::Plain => {
-            let count = request.count as usize;
-            let seeds = (0..count)
-                .map(|index| resolve_seed(request, index))
-                .collect();
-            (seeds, vec![request.prompt.clone(); count], None)
-        }
-    };
+    let EditBatch {
+        seeds,
+        prompts,
+        pose_inputs,
+        mut raw_settings,
+        score_likeness,
+    } = plan_edit_batch(
+        request,
+        &grouping,
+        qwen_edit_raw_settings(request, &repo, steps, quant_bits, guidance, references.len()),
+    );
     let total = seeds.len();
 
-    let mut raw_settings = qwen_edit_raw_settings(
-        request,
-        &repo,
-        steps,
-        quant_bits,
-        guidance,
-        references.len(),
-    );
-    match grouping {
-        Flux2Grouping::Angles => {
-            raw_settings.insert("angleSet".to_owned(), Value::Bool(true));
-        }
-        Flux2Grouping::Poses(_) => {
-            raw_settings.insert("poseLibrary".to_owned(), Value::Bool(true));
-        }
-        Flux2Grouping::Plain => {}
-    }
     // Record the Lightning recipe for telemetry/A-B parity (matches the Python `distillLora`
     // key format `repo/file`); absent on the production multi-step variants.
     if let Some(distill) = &lightning {
@@ -721,34 +683,19 @@ async fn generate_qwen_edit_stream(
         );
     }
 
-    // Identity-likeness scoring (epic 4406, sc-4409 angles / sc-4410 poses / sc-4411 plain
-    // With-Character): generator-agnostic — a Character-Studio angle set, a pose-library set, OR a plain
-    // With-Character generation on Qwen-Edit is scored through the same shared seam as InstantID /
-    // FLUX.2. The Qwen edit path produces the FINAL image directly (no face-restore pass on this lane),
-    // so scoring the generated image scores what the user sees. The PLAIN case (sc-4411) is scored only
-    // when this is a `character_image` job with a character `referenceAssetId` (NOT an `edit_image` job,
-    // whose `Plain` grouping also lands here but carries `sourceAssetId`, not an identity reference).
-    // Stage the antelopev2 face stack (shared bundle, no-op if cached) and capture the source identity
-    // reference + asset id; the `!Send` scorer is built ONCE in the closure and reused across all
-    // outputs. Staging is non-fatal (failure → no scorer → scores omitted, generation still renders).
-    let character_set = matches!(grouping, Flux2Grouping::Angles | Flux2Grouping::Poses(_));
-    // Plain With-Character (sc-4411): a `character_image` job (so NOT an `edit_image`) whose `Plain`
-    // grouping is the general subject-variation case. The scored reference is `references[0]` — for a
-    // character_image job that IS the `referenceAssetId` (first in `flux2_edit_reference_ids`).
-    let plain_with_character =
-        matches!(grouping, Flux2Grouping::Plain) && request.mode == "character_image";
-    let score_likeness = character_set || plain_with_character;
-    let face_stack_dir = if score_likeness {
-        match ensure_face_stack_dir(api, settings, job).await {
-            Ok(dir) => Some(dir),
-            Err(error) => {
-                tracing::warn!(error = %error, "character_image face-stack staging failed; likeness scores omitted");
-                None
-            }
-        }
-    } else {
-        None
-    };
+    // Stage the antelopev2 face stack (shared bundle, no-op if cached) and capture the source
+    // identity reference + asset id; the `!Send` scorer is built ONCE in the closure and reused
+    // across all outputs. Staging is non-fatal (failure → no scorer → scores omitted, generation
+    // still renders). The scored reference is `references[0]` — for a character_image job that IS
+    // the `referenceAssetId` (first in `qwen_edit_reference_ids`).
+    let face_stack_dir = stage_likeness(
+        api,
+        settings,
+        job,
+        score_likeness,
+        "character_image face-stack staging failed; likeness scores omitted",
+    )
+    .await;
     let likeness_source = (score_likeness && face_stack_dir.is_some()).then(|| references[0].clone());
     let likeness_source_ref = reference_ids.first().cloned();
 

--- a/crates/sceneworks-worker/src/image_jobs/sdxl.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl.rs
@@ -398,16 +398,14 @@ async fn generate_sdxl_advanced_stream(
         matches!(sub_mode, SdxlSubMode::Ip).then(|| {
             resolve_character_image_likeness_source(request, settings, project_path)
         });
-    let face_stack_dir = match likeness {
-        Some(Some(_)) => match ensure_face_stack_dir(api, settings, job).await {
-            Ok(dir) => Some(dir),
-            Err(error) => {
-                tracing::warn!(error = %error, "character_image face-stack staging failed; likeness scores omitted");
-                None
-            }
-        },
-        _ => None,
-    };
+    let face_stack_dir = stage_likeness(
+        api,
+        settings,
+        job,
+        matches!(likeness, Some(Some(_))),
+        "character_image face-stack staging failed; likeness scores omitted",
+    )
+    .await;
     let likeness_source = match (&face_stack_dir, likeness.flatten()) {
         (Some(_), Some((image, asset_id))) => Some((image, asset_id)),
         _ => None,

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
@@ -230,17 +230,14 @@ async fn generate_candle_sdxl_ipadapter_stream(
     // AC). Staging is non-fatal (failure → no scorer → scores omitted, generation still renders).
     let score_likeness =
         resolve_character_image_likeness_source(request, settings, project_path).is_some();
-    let face_stack_dir = if score_likeness {
-        match ensure_face_stack_dir(api, settings, job).await {
-            Ok(dir) => Some(dir),
-            Err(error) => {
-                tracing::warn!(error = %error, "character_image face-stack staging failed; likeness scores omitted");
-                None
-            }
-        }
-    } else {
-        None
-    };
+    let face_stack_dir = stage_likeness(
+        api,
+        settings,
+        job,
+        score_likeness,
+        "character_image face-stack staging failed; likeness scores omitted",
+    )
+    .await;
     let likeness_source = face_stack_dir.as_ref().map(|_| reference.clone());
     let likeness_source_ref = reference_id.to_owned();
 

--- a/crates/sceneworks-worker/src/image_jobs/sensenova.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sensenova.rs
@@ -201,75 +201,54 @@ async fn generate_sensenova_edit_stream(
     let conditioning = build_edit_conditioning(&references);
 
     // Per-iteration grouping: a Character-Studio angle set (11 shared-seed, per-angle prompt) or the
-    // plain per-image reference path. SenseNova has no pose tier (excluded by `sensenova_mlx_eligible`).
+    // plain per-image reference path. SenseNova has no pose tier (excluded by `sensenova_mlx_eligible`),
+    // so reject a Poses grouping before routing through the shared `plan_edit_batch` builder (F-024
+    // sc-8826). The builder stamps angleSet (poseLibrary is unreachable here) and computes the
+    // identity-likeness gate (incl. the sc-4411 plain-With-Character case). Scoring (epic 4406, sc-4409
+    // angles / sc-4411 plain With-Character) is generator-agnostic — SenseNova-U1 produces the FINAL
+    // image directly (no face-restore pass), so scoring the generated image scores what the user sees.
     let grouping = flux2_grouping(request);
-    let set_seed = resolve_seed(request, 0);
-    let (seeds, prompts): (Vec<i64>, Vec<String>) = match &grouping {
-        Flux2Grouping::Angles => {
-            // Shared seed so noise-derived attributes stay constant across angles.
-            let prompts = CHARACTER_ANGLE_SET_ORDER
-                .iter()
-                .map(|angle| augment_prompt_for_angle(&request.prompt, angle))
-                .collect();
-            (vec![set_seed; CHARACTER_ANGLE_SET_ORDER.len()], prompts)
-        }
-        Flux2Grouping::Plain => {
-            let count = request.count as usize;
-            let seeds = (0..count)
-                .map(|index| resolve_seed(request, index))
-                .collect();
-            (seeds, vec![request.prompt.clone(); count])
-        }
-        Flux2Grouping::Poses(_) => {
-            // Unreachable: strict pose is excluded by `sensenova_mlx_eligible` (no ControlNet).
-            return Err(WorkerError::InvalidPayload(
-                "SenseNova-U1 has no strict-pose (ControlNet) path".to_owned(),
-            ));
-        }
-    };
+    if matches!(grouping, Flux2Grouping::Poses(_)) {
+        // Unreachable: strict pose is excluded by `sensenova_mlx_eligible` (no ControlNet).
+        return Err(WorkerError::InvalidPayload(
+            "SenseNova-U1 has no strict-pose (ControlNet) path".to_owned(),
+        ));
+    }
+    let EditBatch {
+        seeds,
+        prompts,
+        pose_inputs: _,
+        raw_settings,
+        score_likeness,
+    } = plan_edit_batch(
+        request,
+        &grouping,
+        sensenova_edit_raw_settings(
+            request,
+            &repo,
+            steps,
+            quant_bits,
+            guidance,
+            img_cfg,
+            timestep_shift,
+            references.len(),
+        ),
+    );
     let total = seeds.len();
 
-    let mut raw_settings = sensenova_edit_raw_settings(
-        request,
-        &repo,
-        steps,
-        quant_bits,
-        guidance,
-        img_cfg,
-        timestep_shift,
-        references.len(),
-    );
-    if matches!(grouping, Flux2Grouping::Angles) {
-        raw_settings.insert("angleSet".to_owned(), Value::Bool(true));
-    }
-
-    // Identity-likeness scoring (epic 4406, sc-4409 angles / sc-4411 plain With-Character): generator-
-    // agnostic — a Character-Studio angle set OR a plain With-Character generation on SenseNova-U1 is
-    // scored through the same shared seam as InstantID / FLUX.2 / Qwen (SenseNova has no pose tier). The
-    // PLAIN case (sc-4411) is scored only when this is a `character_image` job with a character
-    // `referenceAssetId` (NOT an `edit_image` job, whose `Plain` grouping also lands here but carries
-    // `sourceAssetId`, not an identity reference). Stage the antelopev2 face stack (shared bundle, no-op
-    // if cached) and capture the source identity reference + asset id; the `!Send` scorer is built ONCE
-    // in the closure and reused across all outputs. Staging is non-fatal (failure → no scorer → scores
-    // omitted, generation still renders).
-    let angle_set = matches!(grouping, Flux2Grouping::Angles);
-    // Plain With-Character (sc-4411): a `character_image` job (so NOT an `edit_image`) whose `Plain`
-    // grouping is the general subject-variation case. The scored reference is `references[0]` — for a
-    // character_image job that IS the `referenceAssetId` (first in `qwen_edit_reference_ids`).
-    let plain_with_character =
-        matches!(grouping, Flux2Grouping::Plain) && request.mode == "character_image";
-    let score_likeness = angle_set || plain_with_character;
-    let face_stack_dir = if score_likeness {
-        match ensure_face_stack_dir(api, settings, job).await {
-            Ok(dir) => Some(dir),
-            Err(error) => {
-                tracing::warn!(error = %error, "character_image face-stack staging failed; likeness scores omitted");
-                None
-            }
-        }
-    } else {
-        None
-    };
+    // Stage the antelopev2 face stack (shared bundle, no-op if cached) and capture the source
+    // identity reference + asset id; the `!Send` scorer is built ONCE in the closure and reused
+    // across all outputs. Staging is non-fatal (failure → no scorer → scores omitted, generation
+    // still renders). The scored reference is `references[0]` — for a character_image job that IS the
+    // `referenceAssetId` (first in `qwen_edit_reference_ids`).
+    let face_stack_dir = stage_likeness(
+        api,
+        settings,
+        job,
+        score_likeness,
+        "character_image face-stack staging failed; likeness scores omitted",
+    )
+    .await;
     let likeness_source = (score_likeness && face_stack_dir.is_some()).then(|| references[0].clone());
     let likeness_source_ref = reference_ids.first().cloned();
 

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -4106,6 +4106,72 @@ fn flux2_grouping_poses_over_angles_over_plain() {
     assert!(matches!(flux2_grouping(&edit), Flux2Grouping::Plain));
 }
 
+/// `plan_edit_batch` (F-024 sc-8826) is the shared grouping/stamping/gating builder for the FLUX.2 /
+/// Qwen / SenseNova edit streams. Angles → 11 shared-seed per-angle prompts, no poses, `angleSet`
+/// stamped, scored. Pose set → n shared-seed pose prompts WITH `PoseInput`s, `poseLibrary` stamped,
+/// scored. Plain `character_image` → per-image seeds, no stamp, scored (sc-4411). Plain `edit_image`
+/// → per-image seeds, no stamp, NOT scored (the `Plain` grouping that carries a `sourceAssetId`, not
+/// an identity reference). The lane's base `raw_settings` pass through untouched.
+#[cfg(target_os = "macos")]
+#[test]
+fn plan_edit_batch_expands_and_gates_per_grouping() {
+    let base_settings = || {
+        let mut map = JsonObject::new();
+        map.insert("laneKey".to_owned(), json!("kept"));
+        map
+    };
+
+    // Angles: 11 shared seeds, per-angle prompts, no pose inputs, angleSet stamped, scored.
+    let angles = request(json!({
+        "projectId": "p", "mode": "character_image", "referenceAssetId": "ref",
+        "advanced": { "angleSet": true, "seed": 7 }
+    }));
+    let batch = plan_edit_batch(&angles, &flux2_grouping(&angles), base_settings());
+    assert_eq!(batch.seeds.len(), CHARACTER_ANGLE_SET_ORDER.len());
+    assert_eq!(batch.prompts.len(), CHARACTER_ANGLE_SET_ORDER.len());
+    assert!(batch.seeds.iter().all(|&s| s == batch.seeds[0]));
+    assert!(batch.pose_inputs.is_none());
+    assert_eq!(batch.raw_settings.get("angleSet"), Some(&Value::Bool(true)));
+    assert!(batch.raw_settings.get("poseLibrary").is_none());
+    assert_eq!(batch.raw_settings.get("laneKey"), Some(&json!("kept")));
+    assert!(batch.score_likeness);
+
+    // Pose set: n shared seeds, pose inputs present, poseLibrary stamped, scored.
+    let poses = request(json!({
+        "projectId": "p", "mode": "character_image", "referenceAssetId": "ref",
+        "advanced": { "seed": 7, "poses": [{ "id": "a" }, { "id": "b" }] }
+    }));
+    let batch = plan_edit_batch(&poses, &flux2_grouping(&poses), base_settings());
+    assert_eq!(batch.seeds.len(), 2);
+    assert!(batch.seeds.iter().all(|&s| s == batch.seeds[0]));
+    assert_eq!(batch.pose_inputs.as_ref().map(Vec::len), Some(2));
+    assert_eq!(
+        batch.raw_settings.get("poseLibrary"),
+        Some(&Value::Bool(true))
+    );
+    assert!(batch.raw_settings.get("angleSet").is_none());
+    assert!(batch.score_likeness);
+
+    // Plain character_image: per-image seeds, no stamp, scored (sc-4411 plain With-Character).
+    let plain_char = request(json!({
+        "projectId": "p", "mode": "character_image", "referenceAssetId": "ref", "count": 3
+    }));
+    let batch = plan_edit_batch(&plain_char, &flux2_grouping(&plain_char), base_settings());
+    assert_eq!(batch.seeds.len(), 3);
+    assert!(batch.pose_inputs.is_none());
+    assert!(batch.raw_settings.get("angleSet").is_none());
+    assert!(batch.raw_settings.get("poseLibrary").is_none());
+    assert!(batch.score_likeness);
+
+    // Plain edit_image: per-image seeds, NOT scored (Plain grouping without an identity reference).
+    let plain_edit = request(json!({
+        "projectId": "p", "mode": "edit_image", "sourceAssetId": "src", "count": 2
+    }));
+    let batch = plan_edit_batch(&plain_edit, &flux2_grouping(&plain_edit), base_settings());
+    assert_eq!(batch.seeds.len(), 2);
+    assert!(!batch.score_likeness);
+}
+
 /// Minimal valid safetensors (8-byte LE header length + JSON header). No `networkType`, so
 /// `classify_adapter` reports `Lora`; the resolver only reads the header, so empty tensors are fine.
 #[cfg(any(

--- a/crates/sceneworks-worker/src/image_jobs/zimage.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage.rs
@@ -298,17 +298,14 @@ async fn generate_zimage_control_stream(
     // omitted, the set still renders. The `!Send` scorer is built ONCE inside the closure (source
     // embedded once, reused across all poses — the caching AC).
     let likeness_source = resolve_control_identity_source(request, settings, project_path);
-    let face_stack_dir = if likeness_source.is_some() {
-        match ensure_face_stack_dir(api, settings, job).await {
-            Ok(dir) => Some(dir),
-            Err(error) => {
-                tracing::warn!(error = %error, "pose-set face-stack staging failed; likeness scores omitted");
-                None
-            }
-        }
-    } else {
-        None
-    };
+    let face_stack_dir = stage_likeness(
+        api,
+        settings,
+        job,
+        likeness_source.is_some(),
+        "pose-set face-stack staging failed; likeness scores omitted",
+    )
+    .await;
 
     let prompt = request.prompt.clone();
     let (width, height) = (request.width, request.height);
@@ -554,17 +551,14 @@ async fn generate_zimage_base_control_stream(
     // closure (source embedded once, reused across all poses — the caching AC). This is the base mirror
     // of the identical block in `generate_zimage_control_stream` (sc-8822 closed the copy-paste gap).
     let likeness_source = resolve_control_identity_source(request, settings, project_path);
-    let face_stack_dir = if likeness_source.is_some() {
-        match ensure_face_stack_dir(api, settings, job).await {
-            Ok(dir) => Some(dir),
-            Err(error) => {
-                tracing::warn!(error = %error, "pose-set face-stack staging failed; likeness scores omitted");
-                None
-            }
-        }
-    } else {
-        None
-    };
+    let face_stack_dir = stage_likeness(
+        api,
+        settings,
+        job,
+        likeness_source.is_some(),
+        "pose-set face-stack staging failed; likeness scores omitted",
+    )
+    .await;
 
     let prompt = request.prompt.clone();
     let (width, height) = (request.width, request.height);

--- a/crates/sceneworks-worker/src/image_jobs/zimage_identity_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage_identity_candle.rs
@@ -186,16 +186,14 @@ async fn generate_candle_zimage_identity_stream(
     // img2img init uses (decoded raw, not fit — better for face detection). All non-fatal: a missing
     // reference / staging failure → no scorer → scores omitted, the generation still renders.
     let likeness_source = resolve_character_image_likeness_source(request, settings, project_path);
-    let face_stack_dir = match &likeness_source {
-        Some(_) => match ensure_face_stack_dir(api, settings, job).await {
-            Ok(dir) => Some(dir),
-            Err(error) => {
-                tracing::warn!(error = %error, "With-Character (z-image identity) face-stack staging failed; likeness scores omitted");
-                None
-            }
-        },
-        None => None,
-    };
+    let face_stack_dir = stage_likeness(
+        api,
+        settings,
+        job,
+        likeness_source.is_some(),
+        "With-Character (z-image identity) face-stack staging failed; likeness scores omitted",
+    )
+    .await;
     // Keep the source only if the face stack staged (otherwise no scorer can be built).
     let likeness_source = face_stack_dir.as_ref().and(likeness_source);
 


### PR DESCRIPTION
## Summary

[F-024, sc-8826] The ~90-line grouping + likeness-gating block was near-verbatim triplicated across the FLUX.2, Qwen-Edit, and SenseNova-U1 edit streams (comments included), so a fix to the sc-4411 plain-With-Character gate had to be re-applied three times with three chances to drift. This is a behavior-preserving dedup.

Story: https://app.shortcut.com/trefry/story/8826

## What was extracted

**`plan_edit_batch(request, grouping, raw_settings) -> EditBatch`** (in `flux2.rs`, macOS-gated alongside `Flux2Grouping`): owns the `(seeds, prompts, pose_inputs)` grouping expansion, the `angleSet`/`poseLibrary` raw-settings stamping, and the `character_set` / `plain_with_character` / `score_likeness` identity-likeness gate (epic 4406, sc-4409/4410/4411). Returns an `EditBatch` intermediate the three streams destructure.

**`async fn stage_likeness(api, settings, job, should_stage, warn_message) -> Option<PathBuf>`** (in `base.rs`, compiled on both build lanes): folds the warn-and-`None` antelopev2 face-stack staging block.

## Parameterized vs shared

The **only** per-stream input to `plan_edit_batch` is the lane's already-built `*_edit_raw_settings` map (`flux2_edit_raw_settings` / `qwen_edit_raw_settings` / `sensenova_edit_raw_settings`), so the grouping/stamping/gating logic is now byte-identical across the three lanes:
- **FLUX.2 & Qwen** consume all three groupings (Angles / Poses / Plain); Qwen additionally mutates the returned `raw_settings` to stamp its Lightning `sampler`/`distillLora` keys.
- **SenseNova** has no pose tier: it keeps its own `Poses` rejection guard (returns `InvalidPayload`) **before** calling the shared builder, then ignores the `pose_inputs` field. Its prior `angle_set` (Angles-only) gate is equivalent to `character_set` (Angles|Poses) here because Poses is unreachable past the guard.

## stage_likeness fold count

**15 of 15** warn-and-`None` staging sites folded — the 3 edit streams plus the FLUX.2/Qwen strict-control paths, `flux1_control`, `zimage` (x2), `kolors`, `pulid`, the ipadapter trio (`flux`/`sdxl`/`kolors`), `sdxl`, `base`, `candle_strict_control`, `zimage_identity_candle`, `pulid_candle`. Per-lane warn phrasing (`character_image ...` / `pose-set ...` / `PuLID-FLUX ...` / `With-Character (z-image identity) ...`) is preserved via the `warn_message` parameter; each varied gate shape (`if score_likeness`, `if likeness_source.is_some()`, `match &likeness_source { Some(_) => ... }`, `match likeness { Some(Some(_)) => ... }`, unconditional) collapses to a single bool argument. The remaining `ensure_face_stack_dir` callers use `?`-propagation (not warn-and-None) and are correctly out of scope.

## Behavior preservation

- Existing `image_jobs::tests` oracle suite (78 tests incl. `flux2_grouping_poses_over_angles_over_plain` and `character_image_likeness_source_gates_to_plain_with_character`) passes **unchanged**.
- Added a focused `plan_edit_batch_expands_and_gates_per_grouping` unit test covering all four grouping/gate shapes (Angles → 11 shared seeds + `angleSet` + scored; Poses → n + `PoseInput`s + `poseLibrary` + scored; Plain `character_image` → scored per sc-4411; Plain `edit_image` → not scored) plus `raw_settings` passthrough.
- Verified on **both** build lanes: macOS default-features and `--no-default-features --features backend-candle` (clippy `-D warnings` + `--all-targets` on each), plus full `npm run rust:check` (fmt --check + clippy + test + build) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)