### PR TITLE
fix(release): scope signing secrets, loopback web dev server, pin wheel hashes (sc-8864)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,17 +43,10 @@ jobs:
     # Self-hosted macOS 26.2 runner; same-repo only — never run fork code.
     if: ${{ github.repository == 'SceneWorks/SceneWorks' }}
     runs-on: [self-hosted, macOS, ARM64, nax]
-    env:
-      APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-      APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-      APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
-      APPLE_API_KEY_PATH: ${{ secrets.APPLE_API_KEY_PATH }}
-      # Minisign keypair for the in-app auto-updater (sc-1355): signs the
-      # `.app.tar.gz` updater payload so the shipped app can verify it against
-      # plugins.updater.pubkey. Only needed when createUpdaterArtifacts is on (set
-      # via --config below), so other CI lanes / local builds don't require it.
-      TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-      TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+    # Signing/notarization secrets are scoped to the specific steps that consume
+    # them (the bundle build + the DMG staple) — NOT set at job level — so that
+    # `npm ci` (postinstall scripts) and every crate build.rs never see the
+    # updater signing key or the Apple credentials (sc-8864).
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
@@ -82,11 +75,29 @@ jobs:
       # signing key. Passed as a file, not inline JSON, so the same invocation is
       # quoting-safe under PowerShell on the Windows runner too.
       - name: Build, sign & notarize the desktop bundle
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_PATH: ${{ secrets.APPLE_API_KEY_PATH }}
+          # Minisign keypair for the in-app auto-updater (sc-1355): signs the
+          # `.app.tar.gz` updater payload so the shipped app can verify it against
+          # plugins.updater.pubkey. Only needed when createUpdaterArtifacts is on
+          # (set via --config below), so scoped to this step (sc-8864).
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: npm --prefix apps/desktop run build -- --config updater.release.conf.json
 
       # Tauri staples the .app but not the wrapping .dmg — staple the DMG so the
       # downloaded artifact verifies offline (shared script; same as `release:mac`).
       - name: Staple the DMG
+        env:
+          # staple-dmg.mjs re-submits the DMG container to the notary, so it needs
+          # the same App Store Connect API key Tauri used (NOT the signing identity
+          # or the updater key). Scoped here rather than job-wide (sc-8864).
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_PATH: ${{ secrets.APPLE_API_KEY_PATH }}
         run: node apps/desktop/scripts/staple-dmg.mjs
 
       # Create a DRAFT release with the already-stapled DMG attached (review before
@@ -151,11 +162,9 @@ jobs:
     env:
       # compute_80 PTX the driver JITs forward to sm_120 — one binary covers
       # Ampere->Blackwell (sc-3676); build-sidecar.mjs defaults this too.
+      # (Build-time constant, not a secret — safe at job level.) The updater
+      # signing key is scoped to the bundle step below, not here (sc-8864).
       CUDA_COMPUTE_CAP: "80"
-      # Same minisign keypair as the macos job — signs the NSIS updater payload so
-      # the shipped app verifies it against plugins.updater.pubkey (sc-1355).
-      TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-      TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -199,6 +208,13 @@ jobs:
       # NSIS `-setup.exe` updater payload (+ `.sig`) for the in-app updater (sc-1355).
       # Passed as a file (not inline JSON) so it survives PowerShell quoting here.
       - name: Build Windows candle installers (NSIS + MSI)
+        env:
+          # Same minisign keypair as the macos job — signs the NSIS updater
+          # payload so the shipped app verifies it against plugins.updater.pubkey
+          # (sc-1355). Scoped to this step so `npm ci` / build.rs never see it
+          # (sc-8864).
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: npm --prefix apps/desktop run build -- --bundles nsis,msi --config updater.release.conf.json
       # Upload to the draft release the macos job created. The user ships the MSI
       # (per desktop-windows.yml); the NSIS .exe is attached too as an alternative.

--- a/apps/desktop/scripts/stage-ffmpeg.py
+++ b/apps/desktop/scripts/stage-ffmpeg.py
@@ -12,8 +12,12 @@ imageio-ffmpeg.
 We stage the *exact* binary the desktop runs today: imageio-ffmpeg's bundled
 `ffmpeg-macos-aarch64-vX` (an evermeet.cx GPLv3 static build). The macOS arm64
 imageio-ffmpeg wheel is platform-tagged (`py3-none-macosx_*_arm64`) and bundles
-the binary at `imageio_ffmpeg/binaries/ffmpeg-*`, so we pip-download that wheel
-(a zip) and extract it. Pinned to a known version so the bundle is deterministic.
+the binary at `imageio_ffmpeg/binaries/ffmpeg-*`, so we download that wheel (a
+zip) from a pinned PyPI CDN URL, verify its sha256, then extract the binary.
+Pinned URL+sha256 (not just a version) so a compromised PyPI/CDN can't flow a
+malicious binary into the signed+notarized release — mirrors the
+cuda_provision.rs first-run downloader (sc-8864). Bump SHA256 in lockstep with
+the version.
 
 LICENSING: the extracted ffmpeg is GPLv3 (configured `--enable-gpl` +
 `--enable-libx264/x265`, which the worker's libx264 mp4 encode requires — an
@@ -24,17 +28,31 @@ USAGE: python3 stage-ffmpeg.py <dest-binary-path>
 """
 from __future__ import annotations
 
-import glob
+import hashlib
+import io
 import os
-import subprocess
 import sys
-import tempfile
+import urllib.request
 import zipfile
 
 # Pin to the version the desktop venv currently resolves (imageio-ffmpeg 0.6.0 →
 # ffmpeg 7.1 macos-aarch64). Bump in lockstep with requirements-mlx.txt so the
 # bundled binary matches what dev/pre-bundle runs.
 IMAGEIO_FFMPEG_VERSION = "0.6.0"
+
+# Pinned macOS arm64 wheel: URL on the PyPI CDN (files.pythonhosted.org) plus the
+# sha256 of the wheel, verified after download and BEFORE extraction. This is the
+# `py3-none-macosx_11_0_arm64` wheel — the only arm64 build the desktop targets.
+# The sha256 was resolved from the PyPI JSON API and confirmed by downloading the
+# wheel and running `shasum -a 256` (sc-8864). Update URL+SHA256 together on any
+# version bump; a mismatch fails the build loudly rather than shipping an
+# unverified binary into a signed release.
+WHEEL_URL = (
+    "https://files.pythonhosted.org/packages/40/5c/"
+    "f3d8a657d362cc93b81aab8feda487317da5b5d31c0e1fdfd5e986e55d17/"
+    "imageio_ffmpeg-0.6.0-py3-none-macosx_11_0_arm64.whl"
+)
+WHEEL_SHA256 = "b1ae3173414b5fc5f538a726c4e48ea97edc0d2cdc11f103afee655c463fa742"
 
 
 def main() -> int:
@@ -43,33 +61,31 @@ def main() -> int:
         return 2
     dest = sys.argv[1]
 
-    with tempfile.TemporaryDirectory() as tmp:
-        # Let pip pick the wheel matching this (macOS arm64) build host; the
-        # binary is bundled inside the platform-tagged wheel.
-        subprocess.run(
-            [
-                sys.executable, "-m", "pip", "download",
-                f"imageio-ffmpeg=={IMAGEIO_FFMPEG_VERSION}",
-                "--only-binary=:all:", "--no-deps", "-d", tmp,
-            ],
-            check=True,
+    # Download the pinned wheel into memory, then verify its sha256 before we
+    # trust any byte of it. Fail loudly on mismatch (never extract).
+    with urllib.request.urlopen(WHEEL_URL) as resp:  # noqa: S310 (pinned https URL)
+        data = resp.read()
+    digest = hashlib.sha256(data).hexdigest()
+    if digest != WHEEL_SHA256:
+        print(
+            "stage-ffmpeg: sha256 mismatch for "
+            f"{WHEEL_URL}\n  expected {WHEEL_SHA256}\n  got      {digest}",
+            file=sys.stderr,
         )
-        wheels = glob.glob(os.path.join(tmp, "imageio_ffmpeg-*.whl"))
-        if not wheels:
-            print("stage-ffmpeg: no imageio-ffmpeg wheel downloaded", file=sys.stderr)
+        return 1
+
+    with zipfile.ZipFile(io.BytesIO(data)) as zf:
+        bins = [
+            n for n in zf.namelist()
+            if "imageio_ffmpeg/binaries/ffmpeg" in n and not n.endswith("/")
+        ]
+        if not bins:
+            print("stage-ffmpeg: wheel has no ffmpeg binary", file=sys.stderr)
             return 1
-        with zipfile.ZipFile(wheels[0]) as zf:
-            bins = [
-                n for n in zf.namelist()
-                if "imageio_ffmpeg/binaries/ffmpeg" in n and not n.endswith("/")
-            ]
-            if not bins:
-                print("stage-ffmpeg: wheel has no ffmpeg binary", file=sys.stderr)
-                return 1
-            os.makedirs(os.path.dirname(dest), exist_ok=True)
-            with zf.open(bins[0]) as src, open(dest, "wb") as out:
-                out.write(src.read())
-        os.chmod(dest, 0o755)
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+        with zf.open(bins[0]) as src, open(dest, "wb") as out:
+            out.write(src.read())
+    os.chmod(dest, 0o755)
     print(f"stage-ffmpeg: staged {dest} (imageio-ffmpeg {IMAGEIO_FFMPEG_VERSION})")
     return 0
 

--- a/apps/desktop/scripts/stage-onnxruntime.py
+++ b/apps/desktop/scripts/stage-onnxruntime.py
@@ -5,26 +5,72 @@ The Rust worker links `ort` with `load-dynamic`, so it dlopens onnxruntime at
 runtime from `ORT_DYLIB_PATH` (set by the desktop `setup.rs`). For a packaged,
 Python-free Mac we must bundle that dylib. The macOS arm64 onnxruntime PyPI wheel
 ships exactly the CoreML-enabled `libonnxruntime.<ver>.dylib` the Python rtmlib path
-uses (and that ort 2.0.0-rc.12's ORT API 24 accepts), so we pip-download that wheel
-(a zip) and extract its `capi/libonnxruntime*.dylib`.
+uses (and that ort 2.0.0-rc.12's ORT API 24 accepts), so we download that wheel (a
+zip) from a pinned PyPI CDN URL, verify its sha256, and extract its
+`capi/libonnxruntime*.dylib`.
 
-Pinned to a known-compatible onnxruntime so the bundle is deterministic. Invoked by
+onnxruntime wheels are CPython-ABI-tagged (cp312/cp313/cp314), so unlike
+imageio-ffmpeg's single `py3-none` wheel we pin a small URL+sha256 table keyed by
+the build host's interpreter tag and verify against the matching entry. Pinning
+URL+sha256 (not just a version) keeps a compromised PyPI/CDN from flowing a
+malicious dylib into the signed+notarized release — mirrors cuda_provision.rs
+(sc-8864). Bump the table in lockstep with the `ort` crate. Invoked by
 build-sidecar.mjs on macOS only.
 
 USAGE: python3 stage-onnxruntime.py <dest-dylib-path>
 """
 from __future__ import annotations
 
-import glob
+import hashlib
+import io
 import os
-import subprocess
 import sys
-import tempfile
+import urllib.request
 import zipfile
 
 # ORT 2.0.0-rc.12 requests ONNX Runtime API 24 (>= onnxruntime 1.24); 1.26.0 is the
 # version validated in the sc-3487 spike. Bump in lockstep with the `ort` crate.
 ONNXRUNTIME_VERSION = "1.26.0"
+
+# Pinned macOS arm64 wheels keyed by CPython ABI tag. Each entry is the PyPI CDN
+# (files.pythonhosted.org) URL plus the sha256 of the wheel, verified after
+# download and BEFORE extraction. onnxruntime ships one wheel per interpreter, so
+# we select the entry matching the build host's `python3` and pin all supported
+# tags. The sha256s were resolved from the PyPI JSON API and confirmed by
+# downloading each wheel and running `shasum -a 256` (sc-8864). Update URL+SHA256
+# together on any version bump; a mismatch fails the build loudly rather than
+# shipping an unverified dylib into a signed release.
+WHEELS: dict[str, dict[str, str]] = {
+    "cp312": {
+        "url": (
+            "https://files.pythonhosted.org/packages/81/b1/"
+            "d111b1df656761f980d9e298a60039a9cb66036b1d039e777537743d0ac3/"
+            "onnxruntime-1.26.0-cp312-cp312-macosx_14_0_arm64.whl"
+        ),
+        "sha256": "05b028781b322ad74b57ce5b50aa5280bb1fe96ceec334628ade681e0b24c1ac",
+    },
+    "cp313": {
+        "url": (
+            "https://files.pythonhosted.org/packages/cf/a2/"
+            "c801242685e0ce48a4ca51dfafbb588765e0446397e123be53ba5598f3f5/"
+            "onnxruntime-1.26.0-cp313-cp313-macosx_14_0_arm64.whl"
+        ),
+        "sha256": "ccce19c5f771b8268902f77d9fed9e88f9499465d6780808faa6611a789d33f0",
+    },
+    "cp314": {
+        "url": (
+            "https://files.pythonhosted.org/packages/40/89/"
+            "17546c1c20f6bfc3ae41c22152378a26edfea918af3129e2139dcd7c99f3/"
+            "onnxruntime-1.26.0-cp314-cp314-macosx_14_0_arm64.whl"
+        ),
+        "sha256": "33a791f31432a3af1a96db5e54818b37aba5e5eefc2e6af5794c10a9118a9993",
+    },
+}
+
+
+def _abi_tag() -> str:
+    """CPython ABI tag for the running interpreter, e.g. `cp312`."""
+    return f"cp{sys.version_info.major}{sys.version_info.minor}"
 
 
 def main() -> int:
@@ -33,30 +79,43 @@ def main() -> int:
         return 2
     dest = sys.argv[1]
 
-    with tempfile.TemporaryDirectory() as tmp:
-        # Let pip pick the wheel matching this (macOS arm64) build host.
-        subprocess.run(
-            [
-                sys.executable, "-m", "pip", "download",
-                f"onnxruntime=={ONNXRUNTIME_VERSION}",
-                "--only-binary=:all:", "--no-deps", "-d", tmp,
-            ],
-            check=True,
+    tag = _abi_tag()
+    wheel = WHEELS.get(tag)
+    if wheel is None:
+        print(
+            f"stage-onnxruntime: no pinned onnxruntime {ONNXRUNTIME_VERSION} wheel "
+            f"for interpreter {tag} — add its URL+sha256 to WHEELS "
+            f"(have: {', '.join(sorted(WHEELS))})",
+            file=sys.stderr,
         )
-        wheels = glob.glob(os.path.join(tmp, "onnxruntime-*.whl"))
-        if not wheels:
-            print("stage-onnxruntime: no onnxruntime wheel downloaded", file=sys.stderr)
+        return 1
+
+    # Download the pinned wheel into memory, then verify its sha256 before we
+    # trust any byte of it. Fail loudly on mismatch (never extract).
+    with urllib.request.urlopen(wheel["url"]) as resp:  # noqa: S310 (pinned https URL)
+        data = resp.read()
+    digest = hashlib.sha256(data).hexdigest()
+    if digest != wheel["sha256"]:
+        print(
+            "stage-onnxruntime: sha256 mismatch for "
+            f"{wheel['url']}\n  expected {wheel['sha256']}\n  got      {digest}",
+            file=sys.stderr,
+        )
+        return 1
+
+    with zipfile.ZipFile(io.BytesIO(data)) as zf:
+        dylibs = [n for n in zf.namelist() if n.endswith(".dylib") and "libonnxruntime" in n]
+        if not dylibs:
+            print("stage-onnxruntime: wheel has no libonnxruntime dylib", file=sys.stderr)
             return 1
-        with zipfile.ZipFile(wheels[0]) as zf:
-            dylibs = [n for n in zf.namelist() if n.endswith(".dylib") and "libonnxruntime" in n]
-            if not dylibs:
-                print("stage-onnxruntime: wheel has no libonnxruntime dylib", file=sys.stderr)
-                return 1
-            os.makedirs(os.path.dirname(dest), exist_ok=True)
-            with zf.open(dylibs[0]) as src, open(dest, "wb") as out:
-                out.write(src.read())
-        os.chmod(dest, 0o755)
-    print(f"stage-onnxruntime: staged {dest} (onnxruntime {ONNXRUNTIME_VERSION})")
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+        with zf.open(dylibs[0]) as src, open(dest, "wb") as out:
+            out.write(src.read())
+    os.chmod(dest, 0o755)
+    print(
+        f"stage-onnxruntime: staged {dest} "
+        f"(onnxruntime {ONNXRUNTIME_VERSION}, {tag})"
+    )
     return 0
 
 

--- a/apps/desktop/scripts/stage-onnxruntime.py
+++ b/apps/desktop/scripts/stage-onnxruntime.py
@@ -9,7 +9,7 @@ uses (and that ort 2.0.0-rc.12's ORT API 24 accepts), so we download that wheel 
 zip) from a pinned PyPI CDN URL, verify its sha256, and extract its
 `capi/libonnxruntime*.dylib`.
 
-onnxruntime wheels are CPython-ABI-tagged (cp312/cp313/cp314), so unlike
+onnxruntime wheels are CPython-ABI-tagged (cp311/cp312/cp313/cp314), so unlike
 imageio-ffmpeg's single `py3-none` wheel we pin a small URL+sha256 table keyed by
 the build host's interpreter tag and verify against the matching entry. Pinning
 URL+sha256 (not just a version) keeps a compromised PyPI/CDN from flowing a
@@ -41,6 +41,14 @@ ONNXRUNTIME_VERSION = "1.26.0"
 # together on any version bump; a mismatch fails the build loudly rather than
 # shipping an unverified dylib into a signed release.
 WHEELS: dict[str, dict[str, str]] = {
+    "cp311": {
+        "url": (
+            "https://files.pythonhosted.org/packages/d4/81/"
+            "29a9eb470994a75eb7b3ccf32be314d7c66675a00ac7b50294816cc2db27/"
+            "onnxruntime-1.26.0-cp311-cp311-macosx_14_0_arm64.whl"
+        ),
+        "sha256": "ee1109ef4ef27cad90e823399e61e03b3c6c7bfe0fb820b4baf3678c15be8b3c",
+    },
     "cp312": {
         "url": (
             "https://files.pythonhosted.org/packages/81/b1/"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,7 +149,11 @@ services:
     environment:
       VITE_API_BASE_URL: http://localhost:${SCENEWORKS_API_PORT:-8010}
     ports:
-      - "${SCENEWORKS_WEB_PORT:-5173}:5173"
+      # Bind to loopback by default so a plain `docker compose up` never exposes
+      # the Vite dev server (with /@fs/ file serving) to the LAN — mirrors the
+      # api service's publish-host pattern (sc-8864). Set SCENEWORKS_WEB_PUBLISH_HOST=0.0.0.0
+      # to opt into LAN access deliberately.
+      - "${SCENEWORKS_WEB_PUBLISH_HOST:-127.0.0.1}:${SCENEWORKS_WEB_PORT:-5173}:5173"
     volumes:
       - ./apps/web:/app
       - /app/node_modules


### PR DESCRIPTION
Closes [sc-8864](https://app.shortcut.com/trefry/story/8864) — [F-062] Restrict release secrets from job-wide env; bind the Docker web dev server to loopback; verify staged wheel hashes.

Three independent release/deploy-surface hardening fixes.

## (a) `release.yml` — scope signing secrets to the steps that need them
Previously `TAURI_SIGNING_*` and `APPLE_*` were set at **job-level `env:`**, so they were in the environment of `npm ci` (postinstall scripts) and every crate `build.rs`. A compromised npm/crates dependency could read the updater signing key or the Apple credentials. Now each secret is set only on the step that consumes it:

| Secret | Now scoped to |
|---|---|
| `APPLE_SIGNING_IDENTITY` | macos → **Build, sign & notarize the desktop bundle** (codesign) |
| `APPLE_API_ISSUER` / `APPLE_API_KEY` / `APPLE_API_KEY_PATH` | macos → **Build, sign & notarize** (tauri notarize) **and** **Staple the DMG** (staple-dmg.mjs re-submits the DMG to the notary — verified it reads exactly these three) |
| `TAURI_SIGNING_PRIVATE_KEY` / `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | macos → **Build, sign & notarize** (updater `.app.tar.gz.sig`); windows → **Build Windows candle installers** (NSIS updater `.sig`) |

The macos job-level `env:` block is removed entirely; the windows job-level `env:` keeps only `CUDA_COMPUTE_CAP` (a non-secret build constant). The auto-updater (sc-1355) signing still works: `TAURI_SIGNING_*` still reaches both bundle steps that emit the updater payloads. `GITHUB_TOKEN` was already step-scoped and is unchanged. **After the change, `npm ci` / rust-toolchain / build.rs steps have no signing secrets in their environment.**

## (b) `docker-compose.yml` — bind the `web` dev server to loopback
The `web` service published `"${SCENEWORKS_WEB_PORT:-5173}:5173"` with no host-IP prefix (0.0.0.0), LAN-exposing an unauthenticated Vite dev server (with `/@fs/` file serving). `api` already correctly defaults to `127.0.0.1` via `SCENEWORKS_API_PUBLISH_HOST`.

- **Before:** `- "${SCENEWORKS_WEB_PORT:-5173}:5173"`
- **After:** `- "${SCENEWORKS_WEB_PUBLISH_HOST:-127.0.0.1}:${SCENEWORKS_WEB_PORT:-5173}:5173"`

Mirrors the `api` pattern; set `SCENEWORKS_WEB_PUBLISH_HOST=0.0.0.0` to opt into LAN access. `web` was the only 0.0.0.0 drift — the only two `ports:` blocks are `api` (already loopback) and `web` (now fixed).

## (c) `stage-ffmpeg.py` / `stage-onnxruntime.py` — pin wheel URL + sha256
These codesigned+notarized binaries were `pip download`ed by version pin only, no integrity check — a PyPI/CDN compromise could flow a malicious binary into a signed release. Now each downloads the wheel from a **pinned `files.pythonhosted.org` URL** and **verifies sha256 before extraction**, failing loudly on mismatch (mirrors `apps/desktop/src/cuda_provision.rs`).

**Exact pins (macOS arm64):**

- **imageio-ffmpeg 0.6.0** — `.../imageio_ffmpeg-0.6.0-py3-none-macosx_11_0_arm64.whl`
  sha256 `b1ae3173414b5fc5f538a726c4e48ea97edc0d2cdc11f103afee655c463fa742`
- **onnxruntime 1.26.0** (per-ABI table, selected by the build host's `python3`). The table pins **every** `macosx_*_arm64` wheel onnxruntime 1.26.0 publishes (cp311/cp312/cp313/cp314), so it is a strict superset of what `pip download` could have auto-selected on the macOS arm64 release platform:
  - cp311 `onnxruntime-1.26.0-cp311-cp311-macosx_14_0_arm64.whl` — `ee1109ef4ef27cad90e823399e61e03b3c6c7bfe0fb820b4baf3678c15be8b3c`
  - cp312 `onnxruntime-1.26.0-cp312-cp312-macosx_14_0_arm64.whl` — `05b028781b322ad74b57ce5b50aa5280bb1fe96ceec334628ade681e0b24c1ac`
  - cp313 `onnxruntime-1.26.0-cp313-cp313-macosx_14_0_arm64.whl` — `ccce19c5f771b8268902f77d9fed9e88f9499465d6780808faa6611a789d33f0`
  - cp314 `onnxruntime-1.26.0-cp314-cp314-macosx_14_0_arm64.whl` — `33a791f31432a3af1a96db5e54818b37aba5e5eefc2e6af5794c10a9118a9993`

onnxruntime wheels are CPython-ABI-tagged (unlike imageio-ffmpeg's single `py3-none` wheel), so a small ABI-keyed URL+sha256 table replaces `pip`'s host-based selection. **How computed:** resolved URLs+digests from the PyPI JSON API, then downloaded each wheel and ran `shasum -a 256` — all four onnxruntime wheels match. **cp311 added** in a follow-up commit after review flagged that omitting it (table pinned only cp312–314) was a coverage regression vs `pip download` on a cp311 runner; its digest was likewise confirmed by an independent `shasum -a 256` of the downloaded wheel.

## Validation
- `python -m py_compile` both staging scripts: pass.
- YAML parse of `release.yml` + `docker-compose.yml` (PyYAML `safe_load`): pass. `docker compose config`: pass.
- Ran both staging scripts end-to-end: they download the pinned URL, verify sha256, and extract valid arm64 Mach-O binaries (ffmpeg executable + libonnxruntime.dylib).
- Tampered the expected sha256 and confirmed the script returns non-zero and does **not** write the output file (fail-loud path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
