### PR TITLE
refactor(worker): shared run_batched_analysis_job scaffold (sc-8836)

### DIFF
--- a/crates/sceneworks-worker/src/analysis_jobs_common.rs
+++ b/crates/sceneworks-worker/src/analysis_jobs_common.rs
@@ -1,0 +1,233 @@
+//! Shared scaffold for the batched dataset-analysis jobs (sc-8836, F-034).
+//!
+//! Both `dataset_analysis` (CLIP embeddings, [`dataset_analysis_jobs`]) and `dataset_face_analysis`
+//! (SCRFD + ArcFace, [`face_analysis_jobs`]) embed every image of a training dataset, stream per-item
+//! progress off a `spawn_blocking` model loop, then POST the resulting records to a rust-api sidecar.
+//! The orchestration around that — the `CancelJoinGuard` bound to the blocking task, the `select!`
+//! stream loop that scales per-item progress into `0.12..0.90` while polling cancel on the interval
+//! tick, the saving update, and the sidecar POST — was a byte-for-byte structural clone in both
+//! modules. This module owns it once, parameterized by the two things that legitimately differ: the
+//! per-run [`AnalysisJobConfig`] strings/messages and the caller-spawned blocking task that produces
+//! the records.
+//!
+//! Each module keeps its own item parsing (the item shape differs), its own model loading (CLIP loads
+//! through the `gen_core` registry inside the blocking task; the face stack stages a weights bundle
+//! first), and its own record → sidecar-payload fold (the record fields differ) supplied as
+//! `records_payload`. Everything else — the cancel/heartbeat handling reconciled in sc-8835 (F-035) —
+//! lives here so a future analysis job re-stamps a config, not ~400 lines of scaffold, and the cancel
+//! handling can only ever be fixed in one place.
+
+#![cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+
+use super::*;
+
+use gen_core::CancelFlag;
+
+/// Per-item progress scaling shared by every batched analysis job: item `index` (0-based) of `total`
+/// maps to `0.12 + 0.78 * ((index + 1) / total)`, leaving `0.04/0.08` for prepare/load and `0.94/1.0`
+/// for save/complete. Extracted so the one magic ramp is defined (and unit-tested) once (sc-8836).
+pub(crate) fn item_progress(index: usize, total: usize) -> f64 {
+    0.12 + 0.78 * ((index + 1) as f64 / total.max(1) as f64)
+}
+
+/// Build a batched-analysis-job [`ProgressRequest`] with the shared field defaults. Every stage of both
+/// analysis jobs stamped these identical constructors (`analysis_progress` / `face_progress`); this is
+/// the one copy (sc-8836).
+pub(crate) fn analysis_progress(
+    status: JobStatus,
+    stage: ProgressStage,
+    progress: f64,
+    message: &str,
+    result: Option<JsonObject>,
+    backend: &str,
+) -> ProgressRequest {
+    ProgressRequest {
+        status,
+        stage,
+        progress: number_from_f64(progress),
+        message: message.to_owned(),
+        error: None,
+        result,
+        eta_seconds: None,
+        peak_gpu_memory_pct: None,
+        peak_gpu_load_pct: None,
+        backend: Some(backend.to_owned()),
+        worker_id: None,
+        extra: BTreeMap::new(),
+    }
+}
+
+/// The per-run knobs the shared [`run_batched_analysis_job`] scaffold needs: the sidecar endpoint +
+/// embedding space, the cancel message, the saving-stage message, and the per-item progress-message
+/// builder. Everything that differs between the CLIP and face analysis jobs (beyond the item shape,
+/// the model loading, and the record fold) is expressed here.
+pub(crate) struct AnalysisJobConfig<'a> {
+    /// The `.../training/datasets/{dataset_id}/<endpoint_suffix>` sidecar path segment
+    /// (`analysis-embeddings` for CLIP, `face-embeddings` for the face stack).
+    pub endpoint_suffix: &'a str,
+    /// The stable embedding-space tag POSTed alongside the records (guards the sidecar ingest merge).
+    pub space: &'a str,
+    /// The user-facing cancel message both the in-loop poll and the blocking task raise.
+    pub cancel_message: &'a str,
+    /// Saving-stage status message (e.g. "Saving embeddings.").
+    pub saving_message: &'a str,
+    /// Progress-line message for item `index` (0-based) of `total` (e.g. "Analyzed image 3 of 10.").
+    /// `Send + Sync` so the enclosing job future stays `Send` (rust-api `tokio::spawn`s the loop).
+    pub item_message: &'a (dyn Fn(usize, usize) -> String + Send + Sync),
+}
+
+/// Drive one batched dataset-analysis job to completion once its records-producing blocking task is
+/// spawned. Owns the shared scaffold (sc-8836): binds `blocking` to `cancel` via a [`CancelJoinGuard`],
+/// runs the `select!` stream loop that scales per-item progress into `0.12..0.90` and polls cancel on
+/// each heartbeat tick, joins the records on clean exit, POSTs them (folded through `records_payload`)
+/// to the sidecar, and emits the completed update built by `completed`. The caller has already parsed
+/// items, emitted the preparing/loading progress, created the `(tx, rx)` pair, and spawned `blocking`
+/// (whose per-item `tx.blocking_send(index)` drives `rx`).
+///
+/// The per-item `index` a producer sends (0-based) is reported through [`item_progress`]. Returns the
+/// joined records so the caller can derive its completed-result fields (e.g. a with-face count).
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn run_batched_analysis_job<R, P, C>(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    cfg: &AnalysisJobConfig<'_>,
+    total: usize,
+    backend: &str,
+    cancel: CancelFlag,
+    mut rx: tokio::sync::mpsc::Receiver<usize>,
+    blocking: tokio::task::JoinHandle<WorkerResult<Vec<R>>>,
+    records_payload: P,
+    completed: C,
+) -> WorkerResult<Vec<R>>
+where
+    P: FnOnce(&[R]) -> Vec<Value>,
+    C: FnOnce(&[R], Value) -> ProgressRequest,
+{
+    // Bind the blocking analysis task to its cancel flag (sc-8804, F-003): every `update_job`/
+    // `heartbeat` `?` below returns early on a transient POST failure or a 409 (stale-sweep reclaim);
+    // on that early return this guard trips `cancel` and aborts the analysis thread instead of leaving
+    // it running on a job nobody is consuming. `cancel` is kept alongside (it's `Clone`) for the
+    // in-loop cancel poll; the guard drives only the drop-time teardown.
+    let mut guard = CancelJoinGuard::new(cancel.clone(), blocking);
+    let mut interval = tokio::time::interval(progress_report_interval(settings));
+    interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    // Run the stream loop capturing its Result so any `?`-error path performs the explicit awaited
+    // bounded-join teardown BEFORE returning, instead of drop-and-run (sc-8804, F-003).
+    let loop_result: WorkerResult<()> = async {
+        loop {
+            tokio::select! {
+                event = rx.recv() => {
+                    match event {
+                        Some(index) => {
+                            update_job(
+                                api,
+                                &job.id,
+                                analysis_progress(
+                                    JobStatus::Running,
+                                    ProgressStage::Running,
+                                    item_progress(index, total),
+                                    &(cfg.item_message)(index, total),
+                                    None,
+                                    backend,
+                                ),
+                            )
+                            .await?;
+                        }
+                        None => break,
+                    }
+                }
+                _ = interval.tick() => {
+                    heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+                    match check_cancel(api, &job.id, cfg.cancel_message).await {
+                        Ok(()) => {}
+                        Err(WorkerError::Canceled(_)) => cancel.cancel(),
+                        Err(error) => return Err(error),
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+    .await;
+    if let Err(error) = loop_result {
+        guard.cancel_and_join().await;
+        return Err(error);
+    }
+
+    // Loop exited cleanly (channel closed) — reclaim the handle (disarming the drop-guard) and join.
+    let records = guard
+        .into_handle()
+        .await
+        .map_err(|error| task_join_error("dataset analysis task join", error))??;
+
+    update_job(
+        api,
+        &job.id,
+        analysis_progress(
+            JobStatus::Saving,
+            ProgressStage::Saving,
+            0.94,
+            cfg.saving_message,
+            None,
+            backend,
+        ),
+    )
+    .await?;
+    let project_id = required_payload_string(&job.payload, "projectId")?;
+    let dataset_id = required_payload_string(&job.payload, "datasetId")?;
+    let items_payload = records_payload(&records);
+    let stored: Value = api
+        .post_json(
+            &format!(
+                "/api/v1/projects/{project_id}/training/datasets/{dataset_id}/{}",
+                cfg.endpoint_suffix
+            ),
+            &json!({ "space": cfg.space, "items": items_payload }),
+        )
+        .await?;
+    update_job(api, &job.id, completed(&records, stored)).await?;
+    Ok(records)
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn item_progress_scales_into_the_running_band() {
+        // The shared per-item ramp: first of 10 lands just above the 0.12 floor, last lands at 0.90.
+        let total = 10;
+        assert!((item_progress(0, total) - (0.12 + 0.78 * 0.1)).abs() < 1e-12);
+        assert!((item_progress(total - 1, total) - 0.90).abs() < 1e-12);
+        // Monotonic across the batch.
+        for i in 1..total {
+            assert!(item_progress(i, total) > item_progress(i - 1, total));
+        }
+    }
+
+    #[test]
+    fn item_progress_guards_a_zero_total() {
+        // A degenerate `total == 0` must not divide by zero (callers reject empty item lists upstream,
+        // but the ramp stays total-safe regardless).
+        assert!(item_progress(0, 0).is_finite());
+    }
+
+    #[test]
+    fn analysis_progress_stamps_backend_and_number() {
+        let request = analysis_progress(
+            JobStatus::Running,
+            ProgressStage::Running,
+            0.5,
+            "half",
+            None,
+            "mlx",
+        );
+        assert_eq!(request.message, "half");
+        assert_eq!(request.backend.as_deref(), Some("mlx"));
+        assert!(request.result.is_none());
+    }
+}

--- a/crates/sceneworks-worker/src/analysis_jobs_common.rs
+++ b/crates/sceneworks-worker/src/analysis_jobs_common.rs
@@ -17,18 +17,21 @@
 //! lives here so a future analysis job re-stamps a config, not ~400 lines of scaffold, and the cancel
 //! handling can only ever be fixed in one place.
 
-#![cfg(any(
+use super::*;
+
+#[cfg(any(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
-
-use super::*;
-
 use gen_core::CancelFlag;
 
 /// Per-item progress scaling shared by every batched analysis job: item `index` (0-based) of `total`
 /// maps to `0.12 + 0.78 * ((index + 1) / total)`, leaving `0.04/0.08` for prepare/load and `0.94/1.0`
 /// for save/complete. Extracted so the one magic ramp is defined (and unit-tested) once (sc-8836).
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 pub(crate) fn item_progress(index: usize, total: usize) -> f64 {
     0.12 + 0.78 * ((index + 1) as f64 / total.max(1) as f64)
 }
@@ -36,6 +39,10 @@ pub(crate) fn item_progress(index: usize, total: usize) -> f64 {
 /// Build a batched-analysis-job [`ProgressRequest`] with the shared field defaults. Every stage of both
 /// analysis jobs stamped these identical constructors (`analysis_progress` / `face_progress`); this is
 /// the one copy (sc-8836).
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 pub(crate) fn analysis_progress(
     status: JobStatus,
     stage: ProgressStage,
@@ -64,6 +71,10 @@ pub(crate) fn analysis_progress(
 /// embedding space, the cancel message, the saving-stage message, and the per-item progress-message
 /// builder. Everything that differs between the CLIP and face analysis jobs (beyond the item shape,
 /// the model loading, and the record fold) is expressed here.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 pub(crate) struct AnalysisJobConfig<'a> {
     /// The `.../training/datasets/{dataset_id}/<endpoint_suffix>` sidecar path segment
     /// (`analysis-embeddings` for CLIP, `face-embeddings` for the face stack).
@@ -74,6 +85,10 @@ pub(crate) struct AnalysisJobConfig<'a> {
     pub cancel_message: &'a str,
     /// Saving-stage status message (e.g. "Saving embeddings.").
     pub saving_message: &'a str,
+    /// The `task_join_error` label if the blocking analysis task panics — kept per-run so each job
+    /// preserves its original distinct diagnostic string (`"dataset analysis task join"` for CLIP,
+    /// `"dataset face analysis task join"` for the face stack).
+    pub join_error_label: &'a str,
     /// Progress-line message for item `index` (0-based) of `total` (e.g. "Analyzed image 3 of 10.").
     /// `Send + Sync` so the enclosing job future stays `Send` (rust-api `tokio::spawn`s the loop).
     pub item_message: &'a (dyn Fn(usize, usize) -> String + Send + Sync),
@@ -89,6 +104,10 @@ pub(crate) struct AnalysisJobConfig<'a> {
 ///
 /// The per-item `index` a producer sends (0-based) is reported through [`item_progress`]. Returns the
 /// joined records so the caller can derive its completed-result fields (e.g. a with-face count).
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_batched_analysis_job<R, P, C>(
     api: &ApiClient,
@@ -162,7 +181,7 @@ where
     let records = guard
         .into_handle()
         .await
-        .map_err(|error| task_join_error("dataset analysis task join", error))??;
+        .map_err(|error| task_join_error(cfg.join_error_label, error))??;
 
     update_job(
         api,

--- a/crates/sceneworks-worker/src/dataset_analysis_jobs.rs
+++ b/crates/sceneworks-worker/src/dataset_analysis_jobs.rs
@@ -129,9 +129,11 @@ pub(crate) async fn run_dataset_analysis_job(
     .await?;
 
     let cancel = CancelFlag::new();
-    let (tx, mut rx) = tokio::sync::mpsc::channel::<usize>(64);
+    let (tx, rx) = tokio::sync::mpsc::channel::<usize>(64);
     let blocking_cancel = cancel.clone();
-    let blocking_items = items.clone();
+    // Move (not clone) the items into the blocking task: `total` is already captured above, so the
+    // async body needs nothing from `items` afterward — matching the face-analysis job (sc-8836).
+    let blocking_items = items;
     let job_id = job.id.clone();
     let blocking =
         tokio::task::spawn_blocking(move || -> WorkerResult<Vec<AnalysisEmbeddingRecord>> {
@@ -211,99 +213,39 @@ pub(crate) async fn run_dataset_analysis_job(
             Ok(out)
         });
 
-    // Bind the blocking analysis task to its cancel flag (sc-8804, F-003): every `update_job`/
-    // `heartbeat` `?` below returns early on a transient POST failure or a 409 (stale-sweep
-    // reclaim); on that early return this guard trips `cancel` and aborts the analysis thread
-    // instead of leaving it running on a job nobody is consuming. `cancel` is kept alongside (it's
-    // `Clone`) for the in-loop cancel poll; the guard drives only the drop-time teardown.
-    let mut guard = CancelJoinGuard::new(cancel.clone(), blocking);
-    let mut interval = tokio::time::interval(progress_report_interval(settings));
-    interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
-    // Run the stream loop capturing its Result so any `?`-error path performs the explicit awaited
-    // bounded-join teardown BEFORE returning, instead of drop-and-run (sc-8804, F-003).
-    let loop_result: WorkerResult<()> = async {
-        loop {
-            tokio::select! {
-                event = rx.recv() => {
-                    match event {
-                        Some(index) => {
-                            let progress = 0.12 + 0.78 * ((index + 1) as f64 / total as f64);
-                            update_job(
-                                api,
-                                &job.id,
-                                analysis_progress(
-                                    JobStatus::Running,
-                                    ProgressStage::Running,
-                                    progress,
-                                    &format!("Analyzed image {} of {}.", index + 1, total),
-                                    None,
-                                    backend,
-                                ),
-                            )
-                            .await?;
-                        }
-                        None => break,
-                    }
-                }
-                _ = interval.tick() => {
-                    heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
-                    match check_cancel(api, &job.id, CANCEL_MESSAGE).await {
-                        Ok(()) => {}
-                        Err(WorkerError::Canceled(_)) => cancel.cancel(),
-                        Err(error) => return Err(error),
-                    }
-                }
-            }
-        }
-        Ok(())
-    }
-    .await;
-    if let Err(error) = loop_result {
-        guard.cancel_and_join().await;
-        return Err(error);
-    }
-
-    // Loop exited cleanly (channel closed) — reclaim the handle (disarming the drop-guard) and join.
-    let embeddings = guard
-        .into_handle()
-        .await
-        .map_err(|error| task_join_error("dataset analysis task join", error))??;
-
-    update_job(
+    // Hand the spawned blocking task to the shared scaffold (sc-8836, F-034): it owns the
+    // `CancelJoinGuard`, the per-item progress select loop (with the sc-8835 cancel/heartbeat
+    // handling), the saving update, and the sidecar POST. Only the endpoint/space/messages and the
+    // record → payload fold differ here.
+    let dataset_id = required_payload_string(&job.payload, "datasetId")?.to_owned();
+    let cfg = AnalysisJobConfig {
+        endpoint_suffix: "analysis-embeddings",
+        space: EMBEDDING_SPACE,
+        cancel_message: CANCEL_MESSAGE,
+        saving_message: "Saving embeddings.",
+        item_message: &|index, total| format!("Analyzed image {} of {}.", index + 1, total),
+    };
+    run_batched_analysis_job(
         api,
-        &job.id,
-        analysis_progress(
-            JobStatus::Saving,
-            ProgressStage::Saving,
-            0.94,
-            "Saving embeddings.",
-            None,
-            backend,
-        ),
-    )
-    .await?;
-    let project_id = required_payload_string(&job.payload, "projectId")?;
-    let dataset_id = required_payload_string(&job.payload, "datasetId")?;
-    let records = analysis_embedding_records_payload(&embeddings);
-    let stored: Value = api
-        .post_json(
-            &format!(
-                "/api/v1/projects/{project_id}/training/datasets/{dataset_id}/analysis-embeddings"
-            ),
-            &json!({ "space": EMBEDDING_SPACE, "items": records }),
-        )
-        .await?;
-    update_job(
-        api,
-        &job.id,
-        analysis_progress(
-            JobStatus::Completed,
-            ProgressStage::Completed,
-            1.0,
-            &format!("Embedded {} training item(s).", embeddings.len()),
-            Some(analysis_result(dataset_id, embeddings.len(), stored)),
-            backend,
-        ),
+        settings,
+        job,
+        &cfg,
+        total,
+        backend,
+        cancel,
+        rx,
+        blocking,
+        analysis_embedding_records_payload,
+        |embeddings, stored| {
+            analysis_progress(
+                JobStatus::Completed,
+                ProgressStage::Completed,
+                1.0,
+                &format!("Embedded {} training item(s).", embeddings.len()),
+                Some(analysis_result(&dataset_id, embeddings.len(), stored)),
+                backend,
+            )
+        },
     )
     .await?;
     Ok(())
@@ -431,34 +373,6 @@ fn load_analysis_image(path: &Path) -> WorkerResult<Image> {
         height: decoded.height(),
         pixels: decoded.into_raw(),
     })
-}
-
-#[cfg(any(
-    target_os = "macos",
-    all(not(target_os = "macos"), feature = "backend-candle")
-))]
-fn analysis_progress(
-    status: JobStatus,
-    stage: ProgressStage,
-    progress: f64,
-    message: &str,
-    result: Option<JsonObject>,
-    backend: &str,
-) -> ProgressRequest {
-    ProgressRequest {
-        status,
-        stage,
-        progress: number_from_f64(progress),
-        message: message.to_owned(),
-        error: None,
-        result,
-        eta_seconds: None,
-        peak_gpu_memory_pct: None,
-        peak_gpu_load_pct: None,
-        backend: Some(backend.to_owned()),
-        worker_id: None,
-        extra: BTreeMap::new(),
-    }
 }
 
 #[cfg(any(

--- a/crates/sceneworks-worker/src/dataset_analysis_jobs.rs
+++ b/crates/sceneworks-worker/src/dataset_analysis_jobs.rs
@@ -223,6 +223,7 @@ pub(crate) async fn run_dataset_analysis_job(
         space: EMBEDDING_SPACE,
         cancel_message: CANCEL_MESSAGE,
         saving_message: "Saving embeddings.",
+        join_error_label: "dataset analysis task join",
         item_message: &|index, total| format!("Analyzed image {} of {}.", index + 1, total),
     };
     run_batched_analysis_job(

--- a/crates/sceneworks-worker/src/face_analysis_jobs.rs
+++ b/crates/sceneworks-worker/src/face_analysis_jobs.rs
@@ -295,6 +295,7 @@ pub(crate) async fn run_dataset_face_analysis_job(
         space: FACE_EMBEDDING_SPACE,
         cancel_message: CANCEL_MESSAGE,
         saving_message: "Saving face records.",
+        join_error_label: "dataset face analysis task join",
         item_message: &|index, total| format!("Analyzed face {} of {}.", index + 1, total),
     };
     run_batched_analysis_job(

--- a/crates/sceneworks-worker/src/face_analysis_jobs.rs
+++ b/crates/sceneworks-worker/src/face_analysis_jobs.rs
@@ -238,7 +238,7 @@ pub(crate) async fn run_dataset_face_analysis_job(
     update_job(
         api,
         &job.id,
-        face_progress(
+        analysis_progress(
             JobStatus::Preparing,
             ProgressStage::Preparing,
             0.04,
@@ -256,7 +256,7 @@ pub(crate) async fn run_dataset_face_analysis_job(
     update_job(
         api,
         &job.id,
-        face_progress(
+        analysis_progress(
             JobStatus::LoadingModel,
             ProgressStage::LoadingModel,
             0.08,
@@ -268,7 +268,7 @@ pub(crate) async fn run_dataset_face_analysis_job(
     .await?;
 
     let cancel = CancelFlag::new();
-    let (tx, mut rx) = tokio::sync::mpsc::channel::<usize>(64);
+    let (tx, rx) = tokio::sync::mpsc::channel::<usize>(64);
     let blocking_cancel = cancel.clone();
     let blocking_items = items;
     let job_id = job.id.clone();
@@ -285,103 +285,43 @@ pub(crate) async fn run_dataset_face_analysis_job(
         Ok(records)
     });
 
-    // Bind the blocking face-analysis task to its cancel flag (sc-8804, F-003): every `update_job`/
-    // `heartbeat` `?` below returns early on a transient POST failure or a 409 (stale-sweep
-    // reclaim); on that early return this guard trips `cancel` and aborts the analysis thread
-    // instead of leaving it running on a job nobody is consuming. `cancel` is kept alongside (it's
-    // `Clone`) for the in-loop cancel poll; the guard drives only the drop-time teardown.
-    let mut guard = CancelJoinGuard::new(cancel.clone(), blocking);
-    let mut interval = tokio::time::interval(progress_report_interval(settings));
-    interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
-    // Run the stream loop capturing its Result so any `?`-error path performs the explicit awaited
-    // bounded-join teardown BEFORE returning, instead of drop-and-run (sc-8804, F-003).
-    let loop_result: WorkerResult<()> = async {
-        loop {
-            tokio::select! {
-                event = rx.recv() => {
-                    match event {
-                        Some(index) => {
-                            let progress = 0.12 + 0.78 * ((index + 1) as f64 / total as f64);
-                            update_job(
-                                api,
-                                &job.id,
-                                face_progress(
-                                    JobStatus::Running,
-                                    ProgressStage::Running,
-                                    progress,
-                                    &format!("Analyzed face {} of {}.", index + 1, total),
-                                    None,
-                                    backend,
-                                ),
-                            )
-                            .await?;
-                        }
-                        None => break,
-                    }
-                }
-                _ = interval.tick() => {
-                    heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
-                    match check_cancel(api, &job.id, CANCEL_MESSAGE).await {
-                        Ok(()) => {}
-                        Err(WorkerError::Canceled(_)) => cancel.cancel(),
-                        Err(error) => return Err(error),
-                    }
-                }
-            }
-        }
-        Ok(())
-    }
-    .await;
-    if let Err(error) = loop_result {
-        guard.cancel_and_join().await;
-        return Err(error);
-    }
-
-    // Loop exited cleanly (channel closed) — reclaim the handle (disarming the drop-guard) and join.
-    let records = guard
-        .into_handle()
-        .await
-        .map_err(|error| task_join_error("dataset face analysis task join", error))??;
-
-    update_job(
+    // Hand the spawned blocking task to the shared scaffold (sc-8836, F-034): it owns the
+    // `CancelJoinGuard`, the per-item progress select loop (with the sc-8835 cancel/heartbeat
+    // handling), the saving update, and the sidecar POST. Only the endpoint/space/messages and the
+    // record → payload fold differ here.
+    let dataset_id = required_payload_string(&job.payload, "datasetId")?.to_owned();
+    let cfg = AnalysisJobConfig {
+        endpoint_suffix: "face-embeddings",
+        space: FACE_EMBEDDING_SPACE,
+        cancel_message: CANCEL_MESSAGE,
+        saving_message: "Saving face records.",
+        item_message: &|index, total| format!("Analyzed face {} of {}.", index + 1, total),
+    };
+    run_batched_analysis_job(
         api,
-        &job.id,
-        face_progress(
-            JobStatus::Saving,
-            ProgressStage::Saving,
-            0.94,
-            "Saving face records.",
-            None,
-            backend,
-        ),
-    )
-    .await?;
-    let project_id = required_payload_string(&job.payload, "projectId")?;
-    let dataset_id = required_payload_string(&job.payload, "datasetId")?;
-    let payload = face_records_payload(&records);
-    let stored: Value = api
-        .post_json(
-            &format!(
-                "/api/v1/projects/{project_id}/training/datasets/{dataset_id}/face-embeddings"
-            ),
-            &json!({ "space": FACE_EMBEDDING_SPACE, "items": payload }),
-        )
-        .await?;
-    let with_face = records.iter().filter(|r| !r.embedding.is_empty()).count();
-    update_job(
-        api,
-        &job.id,
-        face_progress(
-            JobStatus::Completed,
-            ProgressStage::Completed,
-            1.0,
-            &format!(
-                "Analyzed {} image(s); {with_face} with a face.",
-                records.len()
-            ),
-            Some(face_result(dataset_id, records.len(), with_face, stored)),
-            backend,
-        ),
+        settings,
+        job,
+        &cfg,
+        total,
+        backend,
+        cancel,
+        rx,
+        blocking,
+        face_records_payload,
+        |records, stored| {
+            let with_face = records.iter().filter(|r| !r.embedding.is_empty()).count();
+            analysis_progress(
+                JobStatus::Completed,
+                ProgressStage::Completed,
+                1.0,
+                &format!(
+                    "Analyzed {} image(s); {with_face} with a face.",
+                    records.len()
+                ),
+                Some(face_result(&dataset_id, records.len(), with_face, stored)),
+                backend,
+            )
+        },
     )
     .await?;
     Ok(())
@@ -499,34 +439,6 @@ fn load_face_image(path: &Path) -> WorkerResult<Image> {
         height: decoded.height(),
         pixels: decoded.into_raw(),
     })
-}
-
-#[cfg(any(
-    target_os = "macos",
-    all(not(target_os = "macos"), feature = "backend-candle")
-))]
-fn face_progress(
-    status: JobStatus,
-    stage: ProgressStage,
-    progress: f64,
-    message: &str,
-    result: Option<JsonObject>,
-    backend: &str,
-) -> ProgressRequest {
-    ProgressRequest {
-        status,
-        stage,
-        progress: number_from_f64(progress),
-        message: message.to_owned(),
-        error: None,
-        result,
-        eta_seconds: None,
-        peak_gpu_memory_pct: None,
-        peak_gpu_load_pct: None,
-        backend: Some(backend.to_owned()),
-        worker_id: None,
-        extra: BTreeMap::new(),
-    }
 }
 
 #[cfg(any(

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -107,6 +107,10 @@ mod training_jobs;
 use training_jobs::*;
 mod caption_jobs;
 use caption_jobs::*;
+// The shared scaffold both dataset-analysis jobs route through (sc-8836, F-034) — the `CancelJoinGuard`
+// select loop, per-item progress ramp, and sidecar POST extracted out of the two near-duplicate modules.
+mod analysis_jobs_common;
+use analysis_jobs_common::*;
 mod dataset_analysis_jobs;
 use dataset_analysis_jobs::*;
 mod face_analysis_jobs;

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -109,7 +109,17 @@ mod caption_jobs;
 use caption_jobs::*;
 // The shared scaffold both dataset-analysis jobs route through (sc-8836, F-034) — the `CancelJoinGuard`
 // select loop, per-item progress ramp, and sidecar POST extracted out of the two near-duplicate modules.
+// Gated to the same lanes as its only callers (the real `run_*_analysis_job` in the two modules below);
+// on the parity lane those fall back to no-op stubs, so the scaffold has no consumer and must not compile.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 mod analysis_jobs_common;
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 use analysis_jobs_common::*;
 mod dataset_analysis_jobs;
 use dataset_analysis_jobs::*;


### PR DESCRIPTION
## What

Extracts the near-duplicate scaffold shared by the two batched dataset-analysis jobs (F-034 from the 2026-07-01 code review) into `crates/sceneworks-worker/src/analysis_jobs_common.rs::run_batched_analysis_job`, and routes both `dataset_analysis_jobs.rs` (CLIP embeddings) and `face_analysis_jobs.rs` (SCRFD + ArcFace) through it.

Story: https://app.shortcut.com/trefry/story/8836

## Parameterized

`run_batched_analysis_job` owns the shared orchestration — the `CancelJoinGuard` bound to the blocking task, the `select!` stream loop with the per-item `0.12 + 0.78 * ((index+1)/total)` progress ramp, the cancel/heartbeat poll, the saving update, and the sidecar POST. It takes:

- an `AnalysisJobConfig` (endpoint suffix, embedding space, cancel message, saving message, per-item progress-message closure),
- the caller-spawned records-producing `JoinHandle` + its `rx`/`CancelFlag`,
- a `records_payload` fold (`&[R] -> Vec<Value>`) and a `completed` builder (`&[R], stored -> ProgressRequest`).

Each module keeps its legitimately-different parts: item parsing (the item shapes differ — CLIP carries caption text/hash, face does not), model loading (CLIP loads through the `gen_core` registry inside the blocking task; the face stack stages a weights bundle first), and its record → sidecar-payload fold.

## Drift fixed (called out in the finding)

- **`items.clone()` removed** — `dataset_analysis` now *moves* the items into the blocking task (as `face_analysis` already did); `total` is captured beforehand so the async body needs nothing from `items` after.
- **Three `*_progress` constructors → one** shared `analysis_progress`.
- **Cancel handling unified** — post-sc-8835 (F-035) both modules already had identical cancel/heartbeat handling; it now lives once in the scaffold, so it can only ever be fixed in one place. No cancellation behavior changed.
- `AnalysisJobConfig`'s message closure is `Send + Sync` so the worker-loop future stays `Send` (rust-api `tokio::spawn`s it).

## Training decision

The F-034 title says "(and training)". `training_jobs.rs` (2751 lines) is a materially different shape — a `TrainEvent` enum channel, no per-item progress ramp, no sidecar-records fold — so folding it would balloon the change and distort the analysis-only seam. Filed as a precise follow-up: **sc-9541** (relates-to sc-8836), rather than forced in here.

## Tests

- Existing oracle tests in both modules pass unchanged (item parsing, records payloads, face funnel/fraction).
- Added focused unit tests for the shared logic: `item_progress` scaling (band + monotonic + zero-total guard) and the shared `analysis_progress` constructor.

## Verification

- macOS default-features build: green.
- backend-candle parity lane (`cargo check -p sceneworks-worker --no-default-features --features backend-candle --all-targets`): green.
- `npm run rust:check` (fmt --check + clippy -D warnings + 525 tests + build): green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)