### PR TITLE
fix(worker): thread PuLID/LTX aux weights via LoadSpec, drop job-time env mutation (sc-8827)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c43ec8f319da84d78e32898f5839cba93fbd6e2#7c43ec8f319da84d78e32898f5839cba93fbd6e2"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c43ec8f319da84d78e32898f5839cba93fbd6e2#7c43ec8f319da84d78e32898f5839cba93fbd6e2"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -494,7 +494,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c43ec8f319da84d78e32898f5839cba93fbd6e2#7c43ec8f319da84d78e32898f5839cba93fbd6e2"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -508,7 +508,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c43ec8f319da84d78e32898f5839cba93fbd6e2#7c43ec8f319da84d78e32898f5839cba93fbd6e2"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c43ec8f319da84d78e32898f5839cba93fbd6e2#7c43ec8f319da84d78e32898f5839cba93fbd6e2"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c43ec8f319da84d78e32898f5839cba93fbd6e2#7c43ec8f319da84d78e32898f5839cba93fbd6e2"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -542,7 +542,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c43ec8f319da84d78e32898f5839cba93fbd6e2#7c43ec8f319da84d78e32898f5839cba93fbd6e2"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -559,7 +559,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c43ec8f319da84d78e32898f5839cba93fbd6e2#7c43ec8f319da84d78e32898f5839cba93fbd6e2"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c43ec8f319da84d78e32898f5839cba93fbd6e2#7c43ec8f319da84d78e32898f5839cba93fbd6e2"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -587,7 +587,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c43ec8f319da84d78e32898f5839cba93fbd6e2#7c43ec8f319da84d78e32898f5839cba93fbd6e2"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -599,7 +599,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c43ec8f319da84d78e32898f5839cba93fbd6e2#7c43ec8f319da84d78e32898f5839cba93fbd6e2"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -609,7 +609,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c43ec8f319da84d78e32898f5839cba93fbd6e2#7c43ec8f319da84d78e32898f5839cba93fbd6e2"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -623,7 +623,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c43ec8f319da84d78e32898f5839cba93fbd6e2#7c43ec8f319da84d78e32898f5839cba93fbd6e2"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -637,7 +637,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c43ec8f319da84d78e32898f5839cba93fbd6e2#7c43ec8f319da84d78e32898f5839cba93fbd6e2"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -650,7 +650,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c43ec8f319da84d78e32898f5839cba93fbd6e2#7c43ec8f319da84d78e32898f5839cba93fbd6e2"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -662,13 +662,12 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c43ec8f319da84d78e32898f5839cba93fbd6e2#7c43ec8f319da84d78e32898f5839cba93fbd6e2"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
  "candle-gen-face",
  "candle-gen-flux",
- "candle-gen-sdxl",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-transformers",
  "rand 0.9.4",
@@ -679,7 +678,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c43ec8f319da84d78e32898f5839cba93fbd6e2#7c43ec8f319da84d78e32898f5839cba93fbd6e2"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -692,7 +691,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c43ec8f319da84d78e32898f5839cba93fbd6e2#7c43ec8f319da84d78e32898f5839cba93fbd6e2"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -703,7 +702,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c43ec8f319da84d78e32898f5839cba93fbd6e2#7c43ec8f319da84d78e32898f5839cba93fbd6e2"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -718,7 +717,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c43ec8f319da84d78e32898f5839cba93fbd6e2#7c43ec8f319da84d78e32898f5839cba93fbd6e2"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -735,7 +734,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c43ec8f319da84d78e32898f5839cba93fbd6e2#7c43ec8f319da84d78e32898f5839cba93fbd6e2"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -746,6 +745,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_distr 0.5.1",
  "safetensors 0.7.0",
+ "serde_json",
  "tokenizers 0.22.2",
  "tracing",
 ]
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c43ec8f319da84d78e32898f5839cba93fbd6e2#7c43ec8f319da84d78e32898f5839cba93fbd6e2"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -764,7 +764,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c43ec8f319da84d78e32898f5839cba93fbd6e2#7c43ec8f319da84d78e32898f5839cba93fbd6e2"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -777,7 +777,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c43ec8f319da84d78e32898f5839cba93fbd6e2#7c43ec8f319da84d78e32898f5839cba93fbd6e2"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -788,7 +788,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c43ec8f319da84d78e32898f5839cba93fbd6e2#7c43ec8f319da84d78e32898f5839cba93fbd6e2"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7c43ec8f319da84d78e32898f5839cba93fbd6e2#7c43ec8f319da84d78e32898f5839cba93fbd6e2"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -3598,7 +3598,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3611,7 +3611,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
 dependencies = [
  "image",
  "inventory",
@@ -3625,7 +3625,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
 dependencies = [
  "image",
  "inventory",
@@ -3639,7 +3639,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3653,7 +3653,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3664,7 +3664,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3673,7 +3673,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3682,7 +3682,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3696,7 +3696,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3709,7 +3709,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3722,7 +3722,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3734,7 +3734,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3744,7 +3744,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
 dependencies = [
  "image",
  "inventory",
@@ -3757,7 +3757,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
 dependencies = [
  "image",
  "inventory",
@@ -3771,7 +3771,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
 dependencies = [
  "image",
  "inventory",
@@ -3785,7 +3785,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
 dependencies = [
  "image",
  "inventory",
@@ -3797,7 +3797,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3808,7 +3808,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3820,7 +3820,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3832,7 +3832,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3841,7 +3841,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3850,7 +3850,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3860,7 +3860,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3872,7 +3872,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
 dependencies = [
  "image",
  "inventory",
@@ -3887,7 +3887,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
 dependencies = [
  "image",
  "inventory",
@@ -3901,7 +3901,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3912,7 +3912,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3924,7 +3924,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3935,7 +3935,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
 dependencies = [
  "image",
  "inventory",
@@ -3949,7 +3949,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
 dependencies = [
  "image",
  "inventory",
@@ -4280,7 +4280,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5714,7 +5714,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
 dependencies = [
  "core-llm",
  "inventory",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -494,7 +494,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -508,7 +508,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -542,7 +542,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -559,7 +559,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -582,13 +582,12 @@ dependencies = [
  "rand_distr 0.5.1",
  "safetensors 0.7.0",
  "serde_json",
- "tokenizers 0.22.2",
 ]
 
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -600,7 +599,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -610,7 +609,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -624,7 +623,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -638,7 +637,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -651,7 +650,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -663,7 +662,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -680,7 +679,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -693,7 +692,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -704,7 +703,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -719,7 +718,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -736,7 +735,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -754,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -765,7 +764,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -778,7 +777,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -789,7 +788,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -802,7 +801,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4b636790e8d8d92814d19e201afcc1e3726dadf1#4b636790e8d8d92814d19e201afcc1e3726dadf1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c#d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -3599,7 +3598,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=330d339e0d93e7fc9136f7b915f3cbeeb544c701#330d339e0d93e7fc9136f7b915f3cbeeb544c701"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3612,7 +3611,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=330d339e0d93e7fc9136f7b915f3cbeeb544c701#330d339e0d93e7fc9136f7b915f3cbeeb544c701"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
 dependencies = [
  "image",
  "inventory",
@@ -3626,7 +3625,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=330d339e0d93e7fc9136f7b915f3cbeeb544c701#330d339e0d93e7fc9136f7b915f3cbeeb544c701"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
 dependencies = [
  "image",
  "inventory",
@@ -3640,7 +3639,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=330d339e0d93e7fc9136f7b915f3cbeeb544c701#330d339e0d93e7fc9136f7b915f3cbeeb544c701"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3654,7 +3653,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=330d339e0d93e7fc9136f7b915f3cbeeb544c701#330d339e0d93e7fc9136f7b915f3cbeeb544c701"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3665,7 +3664,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=330d339e0d93e7fc9136f7b915f3cbeeb544c701#330d339e0d93e7fc9136f7b915f3cbeeb544c701"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3674,7 +3673,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=330d339e0d93e7fc9136f7b915f3cbeeb544c701#330d339e0d93e7fc9136f7b915f3cbeeb544c701"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3683,7 +3682,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=330d339e0d93e7fc9136f7b915f3cbeeb544c701#330d339e0d93e7fc9136f7b915f3cbeeb544c701"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3697,7 +3696,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=330d339e0d93e7fc9136f7b915f3cbeeb544c701#330d339e0d93e7fc9136f7b915f3cbeeb544c701"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3710,7 +3709,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=330d339e0d93e7fc9136f7b915f3cbeeb544c701#330d339e0d93e7fc9136f7b915f3cbeeb544c701"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3723,7 +3722,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=330d339e0d93e7fc9136f7b915f3cbeeb544c701#330d339e0d93e7fc9136f7b915f3cbeeb544c701"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3735,7 +3734,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=330d339e0d93e7fc9136f7b915f3cbeeb544c701#330d339e0d93e7fc9136f7b915f3cbeeb544c701"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3745,7 +3744,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=330d339e0d93e7fc9136f7b915f3cbeeb544c701#330d339e0d93e7fc9136f7b915f3cbeeb544c701"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
 dependencies = [
  "image",
  "inventory",
@@ -3758,7 +3757,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=330d339e0d93e7fc9136f7b915f3cbeeb544c701#330d339e0d93e7fc9136f7b915f3cbeeb544c701"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
 dependencies = [
  "image",
  "inventory",
@@ -3772,7 +3771,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=330d339e0d93e7fc9136f7b915f3cbeeb544c701#330d339e0d93e7fc9136f7b915f3cbeeb544c701"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
 dependencies = [
  "image",
  "inventory",
@@ -3786,7 +3785,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=330d339e0d93e7fc9136f7b915f3cbeeb544c701#330d339e0d93e7fc9136f7b915f3cbeeb544c701"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
 dependencies = [
  "image",
  "inventory",
@@ -3798,7 +3797,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=330d339e0d93e7fc9136f7b915f3cbeeb544c701#330d339e0d93e7fc9136f7b915f3cbeeb544c701"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3809,7 +3808,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=330d339e0d93e7fc9136f7b915f3cbeeb544c701#330d339e0d93e7fc9136f7b915f3cbeeb544c701"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3821,7 +3820,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=330d339e0d93e7fc9136f7b915f3cbeeb544c701#330d339e0d93e7fc9136f7b915f3cbeeb544c701"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3833,7 +3832,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=330d339e0d93e7fc9136f7b915f3cbeeb544c701#330d339e0d93e7fc9136f7b915f3cbeeb544c701"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3842,7 +3841,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=330d339e0d93e7fc9136f7b915f3cbeeb544c701#330d339e0d93e7fc9136f7b915f3cbeeb544c701"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3851,7 +3850,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=330d339e0d93e7fc9136f7b915f3cbeeb544c701#330d339e0d93e7fc9136f7b915f3cbeeb544c701"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3861,7 +3860,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=330d339e0d93e7fc9136f7b915f3cbeeb544c701#330d339e0d93e7fc9136f7b915f3cbeeb544c701"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3873,7 +3872,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=330d339e0d93e7fc9136f7b915f3cbeeb544c701#330d339e0d93e7fc9136f7b915f3cbeeb544c701"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
 dependencies = [
  "image",
  "inventory",
@@ -3888,7 +3887,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=330d339e0d93e7fc9136f7b915f3cbeeb544c701#330d339e0d93e7fc9136f7b915f3cbeeb544c701"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
 dependencies = [
  "image",
  "inventory",
@@ -3902,7 +3901,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=330d339e0d93e7fc9136f7b915f3cbeeb544c701#330d339e0d93e7fc9136f7b915f3cbeeb544c701"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3913,7 +3912,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=330d339e0d93e7fc9136f7b915f3cbeeb544c701#330d339e0d93e7fc9136f7b915f3cbeeb544c701"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3925,7 +3924,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=330d339e0d93e7fc9136f7b915f3cbeeb544c701#330d339e0d93e7fc9136f7b915f3cbeeb544c701"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3936,7 +3935,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=330d339e0d93e7fc9136f7b915f3cbeeb544c701#330d339e0d93e7fc9136f7b915f3cbeeb544c701"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
 dependencies = [
  "image",
  "inventory",
@@ -3950,7 +3949,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=330d339e0d93e7fc9136f7b915f3cbeeb544c701#330d339e0d93e7fc9136f7b915f3cbeeb544c701"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
 dependencies = [
  "image",
  "inventory",
@@ -5715,7 +5714,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=330d339e0d93e7fc9136f7b915f3cbeeb544c701#330d339e0d93e7fc9136f7b915f3cbeeb544c701"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8239cc12d6d934df870dc3036e2c3580d8492359#8239cc12d6d934df870dc3036e2c3580d8492359"
 dependencies = [
  "core-llm",
  "inventory",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -477,7 +477,15 @@ sceneworks-core = { path = "../sceneworks-core" }
 # LOCKSTEP (candle-gen #266, sc-9123: adds the same cancel param to the candle `vqa`/`decode_text`/
 # `Qwen3Backbone::generate` AND re-pins candle-gen's own gen-core cc9a8c1 -> 330d339, byte-identical)
 # so `--features backend-candle` resolves the SINGLE gen-core rev 330d339.
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d339e0d93e7fc9136f7b915f3cbeeb544c701" }
+# Rev 330d339 -> 8239cc1 (sc-8827, mlx-gen #637): ADDITIVE gen-core LoadSpec fields — `identity`
+# (IdentityWeights: encoder/eva/face_dir, the PuLID seam) and `text_encoder` (the LTX Gemma-dir seam),
+# both `Default = None`. Lets the worker feed PuLID-FLUX / LTX their aux weight paths on the LoadSpec
+# instead of mutating process-global env vars (PULID_* / LTX_GEMMA_DIR) at job time on the
+# multithreaded tokio runtime (F-025 UB). Bumps EVERY mlx-gen crate + gen-core 330d339 -> 8239cc1. The
+# candle-gen pin below moves to d1c1d0a IN LOCKSTEP (candle-gen #301: consumes `text_encoder` in the
+# LTX provider AND re-pins candle-gen's own gen-core 330d339 -> 8239cc1) so `--features backend-candle`
+# resolves the SINGLE gen-core rev 8239cc1. mlx-rs + mlx-llm pins unchanged.
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -829,7 +837,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d339e0d93e7fc9136f7b915f3cbeeb544c701" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -845,23 +853,23 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d339e0d9
 # exactly this rev, so the worker MUST match (a different rev would compile pmetal-mlx-sys twice). This
 # rebuilds MLX from source. Paired with mlx-llm `6c052ba` below (mlx-llm#45 carries the same fork pin).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d339e0d93e7fc9136f7b915f3cbeeb544c701" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d339e0d93e7fc9136f7b915f3cbeeb544c701" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d339e0d93e7fc9136f7b915f3cbeeb544c701" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
 # Krea 2 Turbo (native MLX, Krea 2 Community License; epic 7565, sc-7572). Same git rev as mlx-gen.
 # Self-registers `krea_2_turbo` (Qwen3-VL-4B TE + 28-block single-stream DiT + Qwen-Image VAE; CFG-free
 # rectified-flow few-step) via inventory only when force-linked (`use mlx_gen_krea as _;` in
 # image_jobs.rs). Loads the packed Q8/Q4 turnkey subdir (krea_model_subdir; the loader auto-detects the
 # packed quant, so the resolved `spec.quantize` is a no-op on it). Depends on mlx-gen-qwen-image for the
 # shared `AutoencoderKLQwenImage` VAE.
-mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d339e0d93e7fc9136f7b915f3cbeeb544c701" }
+mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
 # Stable Diffusion 3.5 provider (native MLX, Stability AI Community License; epic 7841, sc-7871). Same
 # git rev as mlx-gen so MLX builds once. Self-registers `sd3_5_large` (true-CFG, 28 steps / guidance 3.5)
 # + `sd3_5_large_turbo` (ADD-distilled few-step, CFG-off) + `sd3_5_medium` (MMDiT-X, true-CFG, 40 steps /
@@ -869,7 +877,7 @@ mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d33
 # (`use mlx_gen_sd3 as _;` in image_jobs.rs). All three carry a `sd3_5_*_quant` converter. Reuses the SDXL
 # CLIP encoder (×2), the FLUX T5-XXL encoder, and the Z-Image 16-ch VAE — its `quantize_sd3_dir` converter
 # is wired in model_jobs.rs for the `sd3_5_{large,large_turbo,medium}_quant` install-time conversions.
-mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d339e0d93e7fc9136f7b915f3cbeeb544c701" }
+mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
 # SANA 1600M provider (native MLX, NVIDIA non-commercial license; epic 8485, sc-8489). Same git rev as
 # mlx-gen so MLX builds once. Self-registers `sana_1600m` (Image/t2i, true-CFG, 32× DC-AE divisor,
 # mac_only) via `register_generators!` into the gen-core inventory — surfaces only when force-linked
@@ -877,59 +885,59 @@ mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d339
 # conditioning (sc-8488); the `SanaPipeline` composes SanaTextEncoder -> SanaTransformer (Linear DiT) ->
 # DC-AE f32 decoder and exposes the `from_snapshot`/`from_weights` weight-load entrypoints the generic
 # generator-cache load path drives.
-mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d339e0d93e7fc9136f7b915f3cbeeb544c701" }
+mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d339e0d93e7fc9136f7b915f3cbeeb544c701" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d339e0d93e7fc9136f7b915f3cbeeb544c701" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d339e0d93e7fc9136f7b915f3cbeeb544c701" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d339e0d93e7fc9136f7b915f3cbeeb544c701" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
 # CLIP ViT-L/14 image embedder for the Dataset Doctor analysis job (epic 6529 P2, sc-6535).
 # Self-registers `clip_vit_l14` (gen_core::ImageEmbedder) via inventory only when force-linked
 # (`use mlx_gen_clip as _;` in dataset_analysis_jobs.rs). Reuses mlx-gen-sdxl's CLIP body → same rev.
-mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d339e0d93e7fc9136f7b915f3cbeeb544c701" }
+mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d339e0d93e7fc9136f7b915f3cbeeb544c701" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d339e0d93e7fc9136f7b915f3cbeeb544c701" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d339e0d93e7fc9136f7b915f3cbeeb544c701" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d339e0d93e7fc9136f7b915f3cbeeb544c701" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d339e0d93e7fc9136f7b915f3cbeeb544c701" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d339e0d93e7fc9136f7b915f3cbeeb544c701" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d339e0d93e7fc9136f7b915f3cbeeb544c701" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -938,19 +946,19 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d33
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d339e0d93e7fc9136f7b915f3cbeeb544c701" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d339e0d93e7fc9136f7b915f3cbeeb544c701" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
 # Depth Anything V2 (DINOv2 ViT-S/14 + DPT) native-MLX monocular depth estimator (epic 8236,
 # sc-8242). A plain utility crate (NOT a self-registering generation provider): an arbitrary RGB
 # image → a normalized single-channel depth control image, the AUTO depth source for the
 # Fun-Controlnet-Union depth tier (`ControlKind::Depth`) — sibling of the CPU canny/pose
 # preprocessors, but neural so it is macOS-gated (MLX). Consumed by the worker `depth` module /
 # the shared strict-control driver (sc-8243). Same mlx-rs pin as every other mlx-gen crate.
-mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d339e0d93e7fc9136f7b915f3cbeeb544c701" }
+mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -959,7 +967,7 @@ mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d3
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d339e0d93e7fc9136f7b915f3cbeeb544c701" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -967,7 +975,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d339e0d93e7fc9136f7b915f3cbeeb544c701" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -978,7 +986,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d339e0d93e7fc9136f7b915f3cbeeb544c701" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -989,7 +997,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d3
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d339e0d93e7fc9136f7b915f3cbeeb544c701" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -1011,7 +1019,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d33
 # a Metal large-tensor limit, not precision). New `VAE_SAFE_DECODE_EDGE_PX=1536` forces decode tiling on
 # a CORRECTNESS cap independent of the memory budget (image + video), so a 2048² upscale that fits memory
 # still tiles. Real-weight 1024→2048 pixel-cosine vs the mflux reference 0.9524 → 0.9974.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d339e0d93e7fc9136f7b915f3cbeeb544c701" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -1022,7 +1030,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d339e0d93e7fc9136f7b915f3cbeeb544c701" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
 # The unified LLM engine (epic 7153, sc-7158): the macOS `prompt_refine` job now runs through
 # mlx-llm's generic `mlx-llama` provider (a `core_llm::TextLlm`) resolved model-first via
 # `gen_core::core_llm::load_for_model`, RETIRING the bespoke `mlx-gen-prompt-refine` hand-rolled
@@ -1054,7 +1062,7 @@ mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "7041411f395e43
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d339e0d93e7fc9136f7b915f3cbeeb544c701" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -1397,15 +1405,15 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "330d
 # backend-candle` still resolves the SINGLE gen-core rev 330d339 (the skew gate). ALL candle-gen-*
 # rev lines move together. This is the post-squash main rev — the old branch-head pin 7b7e86a was
 # orphaned by the squash-merge and is no longer reachable.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1413,17 +1421,17 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1433,7 +1441,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1441,21 +1449,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1464,17 +1472,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1483,7 +1491,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1516,7 +1524,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1525,12 +1533,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1538,7 +1546,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1547,7 +1555,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1555,7 +1563,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1569,7 +1577,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1596,7 +1604,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1607,7 +1615,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4b636790e8d8d92814d19e201afcc1e3726dadf1", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -477,15 +477,15 @@ sceneworks-core = { path = "../sceneworks-core" }
 # LOCKSTEP (candle-gen #266, sc-9123: adds the same cancel param to the candle `vqa`/`decode_text`/
 # `Qwen3Backbone::generate` AND re-pins candle-gen's own gen-core cc9a8c1 -> 330d339, byte-identical)
 # so `--features backend-candle` resolves the SINGLE gen-core rev 330d339.
-# Rev 330d339 -> 8239cc1 (sc-8827, mlx-gen #637): ADDITIVE gen-core LoadSpec fields — `identity`
+# Rev 330d339 -> b520a0e7 (sc-8827, mlx-gen #637): ADDITIVE gen-core LoadSpec fields — `identity`
 # (IdentityWeights: encoder/eva/face_dir, the PuLID seam) and `text_encoder` (the LTX Gemma-dir seam),
 # both `Default = None`. Lets the worker feed PuLID-FLUX / LTX their aux weight paths on the LoadSpec
 # instead of mutating process-global env vars (PULID_* / LTX_GEMMA_DIR) at job time on the
-# multithreaded tokio runtime (F-025 UB). Bumps EVERY mlx-gen crate + gen-core 330d339 -> 8239cc1. The
-# candle-gen pin below moves to d1c1d0a IN LOCKSTEP (candle-gen #301: consumes `text_encoder` in the
-# LTX provider AND re-pins candle-gen's own gen-core 330d339 -> 8239cc1) so `--features backend-candle`
-# resolves the SINGLE gen-core rev 8239cc1. mlx-rs + mlx-llm pins unchanged.
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
+# multithreaded tokio runtime (F-025 UB). Bumps EVERY mlx-gen crate + gen-core 330d339 -> b520a0e7. The
+# candle-gen pin below moves to 7c43ec8f IN LOCKSTEP (candle-gen #301: consumes `text_encoder` in the
+# LTX provider AND re-pins candle-gen's own gen-core 330d339 -> b520a0e7) so `--features backend-candle`
+# resolves the SINGLE gen-core rev b520a0e7. mlx-rs + mlx-llm pins unchanged.
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -837,7 +837,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -853,23 +853,23 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d
 # exactly this rev, so the worker MUST match (a different rev would compile pmetal-mlx-sys twice). This
 # rebuilds MLX from source. Paired with mlx-llm `6c052ba` below (mlx-llm#45 carries the same fork pin).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
 # Krea 2 Turbo (native MLX, Krea 2 Community License; epic 7565, sc-7572). Same git rev as mlx-gen.
 # Self-registers `krea_2_turbo` (Qwen3-VL-4B TE + 28-block single-stream DiT + Qwen-Image VAE; CFG-free
 # rectified-flow few-step) via inventory only when force-linked (`use mlx_gen_krea as _;` in
 # image_jobs.rs). Loads the packed Q8/Q4 turnkey subdir (krea_model_subdir; the loader auto-detects the
 # packed quant, so the resolved `spec.quantize` is a no-op on it). Depends on mlx-gen-qwen-image for the
 # shared `AutoencoderKLQwenImage` VAE.
-mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
+mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
 # Stable Diffusion 3.5 provider (native MLX, Stability AI Community License; epic 7841, sc-7871). Same
 # git rev as mlx-gen so MLX builds once. Self-registers `sd3_5_large` (true-CFG, 28 steps / guidance 3.5)
 # + `sd3_5_large_turbo` (ADD-distilled few-step, CFG-off) + `sd3_5_medium` (MMDiT-X, true-CFG, 40 steps /
@@ -877,7 +877,7 @@ mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc
 # (`use mlx_gen_sd3 as _;` in image_jobs.rs). All three carry a `sd3_5_*_quant` converter. Reuses the SDXL
 # CLIP encoder (×2), the FLUX T5-XXL encoder, and the Z-Image 16-ch VAE — its `quantize_sd3_dir` converter
 # is wired in model_jobs.rs for the `sd3_5_{large,large_turbo,medium}_quant` install-time conversions.
-mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
+mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
 # SANA 1600M provider (native MLX, NVIDIA non-commercial license; epic 8485, sc-8489). Same git rev as
 # mlx-gen so MLX builds once. Self-registers `sana_1600m` (Image/t2i, true-CFG, 32× DC-AE divisor,
 # mac_only) via `register_generators!` into the gen-core inventory — surfaces only when force-linked
@@ -885,59 +885,59 @@ mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc1
 # conditioning (sc-8488); the `SanaPipeline` composes SanaTextEncoder -> SanaTransformer (Linear DiT) ->
 # DC-AE f32 decoder and exposes the `from_snapshot`/`from_weights` weight-load entrypoints the generic
 # generator-cache load path drives.
-mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
+mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
 # CLIP ViT-L/14 image embedder for the Dataset Doctor analysis job (epic 6529 P2, sc-6535).
 # Self-registers `clip_vit_l14` (gen_core::ImageEmbedder) via inventory only when force-linked
 # (`use mlx_gen_clip as _;` in dataset_analysis_jobs.rs). Reuses mlx-gen-sdxl's CLIP body → same rev.
-mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
+mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -946,19 +946,19 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
 # Depth Anything V2 (DINOv2 ViT-S/14 + DPT) native-MLX monocular depth estimator (epic 8236,
 # sc-8242). A plain utility crate (NOT a self-registering generation provider): an arbitrary RGB
 # image → a normalized single-channel depth control image, the AUTO depth source for the
 # Fun-Controlnet-Union depth tier (`ControlKind::Depth`) — sibling of the CPU canny/pose
 # preprocessors, but neural so it is macOS-gated (MLX). Consumed by the worker `depth` module /
 # the shared strict-control driver (sc-8243). Same mlx-rs pin as every other mlx-gen crate.
-mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
+mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -967,7 +967,7 @@ mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239c
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -975,7 +975,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -986,7 +986,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -997,7 +997,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239c
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -1019,7 +1019,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc
 # a Metal large-tensor limit, not precision). New `VAE_SAFE_DECODE_EDGE_PX=1536` forces decode tiling on
 # a CORRECTNESS cap independent of the memory budget (image + video), so a 2048² upscale that fits memory
 # still tiles. Real-weight 1024→2048 pixel-cosine vs the mflux reference 0.9524 → 0.9974.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -1030,7 +1030,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "823
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
 # The unified LLM engine (epic 7153, sc-7158): the macOS `prompt_refine` job now runs through
 # mlx-llm's generic `mlx-llama` provider (a `core_llm::TextLlm`) resolved model-first via
 # `gen_core::core_llm::load_for_model`, RETIRING the bespoke `mlx-gen-prompt-refine` hand-rolled
@@ -1062,7 +1062,7 @@ mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "7041411f395e43
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239cc12d6d934df870dc3036e2c3580d8492359" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -1405,15 +1405,15 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8239
 # backend-candle` still resolves the SINGLE gen-core rev 330d339 (the skew gate). ALL candle-gen-*
 # rev lines move together. This is the post-squash main rev — the old branch-head pin 7b7e86a was
 # orphaned by the squash-merge and is no longer reachable.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c43ec8f319da84d78e32898f5839cba93fbd6e2", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c43ec8f319da84d78e32898f5839cba93fbd6e2", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c43ec8f319da84d78e32898f5839cba93fbd6e2", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c43ec8f319da84d78e32898f5839cba93fbd6e2", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c43ec8f319da84d78e32898f5839cba93fbd6e2", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1421,17 +1421,17 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c43ec8f319da84d78e32898f5839cba93fbd6e2", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c43ec8f319da84d78e32898f5839cba93fbd6e2", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c43ec8f319da84d78e32898f5839cba93fbd6e2", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1441,7 +1441,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c43ec8f319da84d78e32898f5839cba93fbd6e2", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1449,21 +1449,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c43ec8f319da84d78e32898f5839cba93fbd6e2", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c43ec8f319da84d78e32898f5839cba93fbd6e2", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c43ec8f319da84d78e32898f5839cba93fbd6e2", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c43ec8f319da84d78e32898f5839cba93fbd6e2", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1472,17 +1472,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c43ec8f319da84d78e32898f5839cba93fbd6e2", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c43ec8f319da84d78e32898f5839cba93fbd6e2", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c43ec8f319da84d78e32898f5839cba93fbd6e2", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1491,7 +1491,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c43ec8f319da84d78e32898f5839cba93fbd6e2", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1524,7 +1524,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c43ec8f319da84d78e32898f5839cba93fbd6e2", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1533,12 +1533,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c43ec8f319da84d78e32898f5839cba93fbd6e2", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c43ec8f319da84d78e32898f5839cba93fbd6e2", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1546,7 +1546,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c43ec8f319da84d78e32898f5839cba93fbd6e2", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1555,7 +1555,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c43ec8f319da84d78e32898f5839cba93fbd6e2", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1563,7 +1563,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c43ec8f319da84d78e32898f5839cba93fbd6e2", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1577,7 +1577,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c43ec8f319da84d78e32898f5839cba93fbd6e2", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1604,7 +1604,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c43ec8f319da84d78e32898f5839cba93fbd6e2", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1615,7 +1615,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "d1c1d0ad072b9fa4087d6e9d44f47decfb62eb1c", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7c43ec8f319da84d78e32898f5839cba93fbd6e2", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -34,6 +34,10 @@ use gen_core::{
     AdapterKind, AdapterSpec, CancelFlag, Conditioning, GenerationOutput, GenerationRequest,
     Generator, Image, LoadSpec, Progress, Quant, WeightsSource,
 };
+// `IdentityWeights` (the PuLID-FLUX `LoadSpec::identity` seam, sc-8827) is used only by the macOS MLX
+// PuLID path (`image_jobs/pulid.rs`); gate it so the candle lane's `-D warnings` sees no unused import.
+#[cfg(target_os = "macos")]
+use gen_core::IdentityWeights;
 // `AdapterKind` (LoRA/LoKr classification) was MLX-only until sc-5126: the candle Lens lane is the
 // first candle family to take LoRA/LoKr, so it now classifies adapters too and the import moved into
 // the shared block above. `ControlKind` (ControlNet conditioning) was MLX-only until sc-8304: the candle

--- a/crates/sceneworks-worker/src/image_jobs/pulid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/pulid.rs
@@ -180,36 +180,17 @@ fn pulid_weights_env_preset() -> Option<PulidWeights> {
     })
 }
 
-struct EnvRestore {
-    values: [(&'static str, Option<std::ffi::OsString>); 3],
-}
-
-impl Drop for EnvRestore {
-    fn drop(&mut self) {
-        for (key, value) in &self.values {
-            match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
-            }
-        }
+/// Build the engine's identity-weight seam from the resolved cache paths (sc-8827). The `pulid_flux`
+/// loader reads the PuLID adapter + EVA tower + native face stack from `LoadSpec::identity`, so the
+/// worker threads the paths through the spec instead of mutating the process-global `PULID_*` env vars
+/// at job time on the multithreaded tokio runtime (the old `set_var`/`remove_var` seam was unsound —
+/// F-025). The paths travel with the `LoadSpec` into the spawned load task, no env involved.
+fn pulid_identity_weights(weights: &PulidWeights) -> IdentityWeights {
+    IdentityWeights {
+        encoder: Some(WeightsSource::File(weights.adapter.clone())),
+        eva: Some(WeightsSource::File(weights.eva.clone())),
+        face_dir: Some(WeightsSource::Dir(weights.face_dir.clone())),
     }
-}
-
-fn set_pulid_weight_env(weights: &PulidWeights) -> EnvRestore {
-    let guard = EnvRestore {
-        values: [
-            ("PULID_FLUX_WEIGHTS", std::env::var_os("PULID_FLUX_WEIGHTS")),
-            ("PULID_EVA_WEIGHTS", std::env::var_os("PULID_EVA_WEIGHTS")),
-            (
-                "PULID_FACE_WEIGHTS_DIR",
-                std::env::var_os("PULID_FACE_WEIGHTS_DIR"),
-            ),
-        ],
-    };
-    std::env::set_var("PULID_FLUX_WEIGHTS", &weights.adapter);
-    std::env::set_var("PULID_EVA_WEIGHTS", &weights.eva);
-    std::env::set_var("PULID_FACE_WEIGHTS_DIR", &weights.face_dir);
-    guard
 }
 
 /// Resolve all PuLID-FLUX engine weight inputs, downloading the converted bundle + the PuLID
@@ -325,11 +306,11 @@ async fn generate_pulid_flux_stream(
     )?;
 
     let weights = ensure_pulid_weights(api, settings, job).await?;
-    // Feed the engine's weight seam from the resolved cache paths (the `pulid_flux` loader resolves
-    // the PuLID adapter + EVA + face stack from these env vars). Keep them scoped to this async job:
-    // the generator load happens inside the spawned stream task, so they must stay live through
-    // `consume_gen_events`, then `EnvRestore` removes/restores them before the next job.
-    let _pulid_env = set_pulid_weight_env(&weights);
+    // Feed the engine's weight seam from the resolved cache paths on the `LoadSpec` (the `pulid_flux`
+    // loader resolves the PuLID adapter + EVA + face stack from `LoadSpec::identity`, sc-8827). The
+    // paths ride the spec into the spawned load task — no process-global env mutation (the old
+    // `PULID_*` `set_var`/`remove_var` seam was unsound on the multithreaded runtime, F-025).
+    let identity = pulid_identity_weights(&weights);
 
     let steps = pulid_steps(request);
     let guidance = pulid_guidance(request);
@@ -402,7 +383,10 @@ async fn generate_pulid_flux_stream(
     let likeness_source = face_stack_dir.as_ref().map(|_| reference.clone());
     let likeness_source_ref = reference_id.to_owned();
 
-    let spec = load_spec(flux_base, quant, Vec::new(), None);
+    let mut spec = load_spec(flux_base, quant, Vec::new(), None);
+    // PuLID identity sub-model paths ride the spec (sc-8827) — the `pulid_flux` loader reads them from
+    // `LoadSpec::identity` instead of the process-global `PULID_*` env vars.
+    spec.identity = Some(identity);
     let (cancel, rx, blocking) = start_cached_gen_stream(
         job.id.clone(),
         PULID_ENGINE_ID,

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -1000,6 +1000,34 @@ fn bernini_image_i2i_real_weights_generates_one_image() {
     );
 }
 
+/// sc-8827 (F-025): the worker feeds the PuLID-FLUX engine its adapter / EVA / face-stack paths on
+/// `LoadSpec::identity` instead of mutating the process-global `PULID_*` env vars at job time. This
+/// asserts the mapping `PulidWeights -> IdentityWeights` (encoder=File(adapter), eva=File(eva),
+/// face_dir=Dir(face_dir)) so the paths now travel via config, not env. Non-ignored (no weights /
+/// device needed).
+#[cfg(target_os = "macos")]
+#[test]
+fn pulid_identity_weights_maps_paths_onto_loadspec_not_env() {
+    let weights = PulidWeights {
+        adapter: PathBuf::from("/cache/pulid-flux-mlx/pulid_flux_v0.9.1.safetensors"),
+        eva: PathBuf::from("/cache/pulid-flux-mlx/eva02_clip_l_336.safetensors"),
+        face_dir: PathBuf::from("/cache/pulid-flux-mlx"),
+    };
+    let id = pulid_identity_weights(&weights);
+    assert!(
+        matches!(id.encoder, Some(WeightsSource::File(ref p)) if *p == weights.adapter),
+        "adapter path rides identity.encoder as a File source"
+    );
+    assert!(
+        matches!(id.eva, Some(WeightsSource::File(ref p)) if *p == weights.eva),
+        "eva path rides identity.eva as a File source"
+    );
+    assert!(
+        matches!(id.face_dir, Some(WeightsSource::Dir(ref p)) if *p == weights.face_dir),
+        "face_dir rides identity.face_dir as a Dir source"
+    );
+}
+
 /// sc-3344 parity gate (worker path): drive the native `pulid_flux` registry generator through the
 /// SAME load seam the worker uses (`load_engine` → `gen_core::load("pulid_flux")` with the engine's
 /// env-var weight resolution filled from local caches) and confirm it produces an identity-preserving

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -2417,6 +2417,11 @@ struct VideoGenInput {
     conditioning_fps: Option<u32>,
     // SeedVR2 input pre-blur (sc-4816); `None` on the other models.
     softness: Option<f32>,
+    // LTX-only external Gemma-3 text-encoder snapshot dir (sc-8827): rides `LoadSpec::text_encoder` so
+    // the LTX provider locates its Gemma encoder from the spec instead of the process-global
+    // `$LTX_GEMMA_DIR` env var (the old `set_var` seam was unsound on the multithreaded runtime,
+    // F-025). `None` on every other model (they bundle their TE) and when no override resolves.
+    text_encoder_dir: Option<PathBuf>,
 }
 
 #[cfg(any(
@@ -2454,6 +2459,7 @@ impl Default for VideoGenInput {
             decode_chunk_size: None,
             conditioning_fps: None,
             softness: None,
+            text_encoder_dir: None,
         }
     }
 }
@@ -2475,6 +2481,11 @@ fn video_load_spec(input: &VideoGenInput) -> LoadSpec {
         // PiD super-resolving decode (epic 7840) is an image-only latent-space swap; video
         // providers have no PiD backbone, so never request it.
         pid: None,
+        // Video providers are not face-ID models — no identity sub-model weights.
+        identity: None,
+        // LTX's external Gemma-3 text encoder rides the spec (sc-8827); `None` ⇒ the provider's
+        // `$LTX_GEMMA_DIR` / `<root>/text_encoder` fallback.
+        text_encoder: input.text_encoder_dir.clone().map(WeightsSource::Dir),
     }
 }
 
@@ -2550,19 +2561,7 @@ fn run_loaded_video_generation(
 
 #[cfg(all(target_os = "macos", test))]
 fn load_video_generation_for_tests(input: &VideoGenInput) -> WorkerResult<Box<dyn Generator>> {
-    let spec = LoadSpec {
-        weights: WeightsSource::Dir(input.model_dir.clone()),
-        quantize: input.quant,
-        precision: Precision::Bf16,
-        control: None,
-        // MultiControlNet (sc-3378) is image-only; video providers ignore it.
-        extra_controls: Vec::new(),
-        ip_adapter: None,
-        adapters: input.adapters.clone(),
-        // PiD super-resolving decode (epic 7840) is an image-only latent-space swap; video
-        // providers have no PiD backbone, so never request it.
-        pid: None,
-    };
+    let spec = video_load_spec(input);
     gen_core::load(input.engine_id, &spec)
         .map_err(|error| WorkerError::Engine(format!("video load failed: {error}")))
 }
@@ -3052,19 +3051,19 @@ fn candle_video_snapshot_dir(settings: &Settings, repo: &str) -> WorkerResult<Pa
     })
 }
 
-/// Point the candle LTX provider at the Gemma-3-12B encoder snapshot via `LTX_GEMMA_DIR` (the env var
-/// the provider reads; it otherwise falls back to `<checkpoint>/text_encoder`). Best-effort: if the
-/// Gemma snapshot isn't in the HF cache we leave `LTX_GEMMA_DIR` unset so the provider tries its
-/// `<root>/text_encoder` fallback and emits its own clear "set LTX_GEMMA_DIR …" error. The worker runs
-/// video jobs sequentially, so the process-global env set is race-free.
+/// Resolve the Gemma-3-12B encoder snapshot dir for the candle LTX provider (sc-8827). Returns the
+/// HF-cache snapshot path so the caller can thread it onto `LoadSpec::text_encoder` — no more mutating
+/// the process-global `$LTX_GEMMA_DIR` at job time on the multithreaded runtime (the old `set_var`
+/// seam was unsound, F-025). Honors an explicit operator `$LTX_GEMMA_DIR` (returns `None` so the
+/// provider reads the env override itself). Best-effort: if the Gemma snapshot isn't in the HF cache
+/// we return `None` so the provider tries its `<root>/text_encoder` fallback and emits its own clear
+/// "set LTX_GEMMA_DIR …" error.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-fn ensure_ltx_gemma_dir(settings: &Settings) {
+fn resolve_ltx_gemma_dir(settings: &Settings) -> Option<PathBuf> {
     if std::env::var_os("LTX_GEMMA_DIR").is_some() {
-        return; // honor an explicit operator override.
+        return None; // honor an explicit operator override (the provider reads the env var).
     }
-    if let Some(dir) = huggingface_snapshot_dir(&settings.data_dir, CANDLE_LTX_GEMMA_REPO) {
-        std::env::set_var("LTX_GEMMA_DIR", dir);
-    }
+    huggingface_snapshot_dir(&settings.data_dir, CANDLE_LTX_GEMMA_REPO)
 }
 
 /// Raw-settings recorded on a candle video asset (mirrors `wan_raw_settings`, trimmed to the
@@ -3150,11 +3149,14 @@ async fn generate_candle_video(
     let adapter = candle_video_adapter_label(engine_id);
     let repo = candle_video_repo(request, engine_id);
     let model_dir = candle_video_snapshot_dir(settings, &repo)?;
-    // ltx needs the separate Gemma-3-12B encoder (its only conditioning input).
+    // ltx needs the separate Gemma-3-12B encoder (its only conditioning input). Resolve its snapshot
+    // dir here and thread it onto the LoadSpec below (sc-8827) instead of mutating `$LTX_GEMMA_DIR`.
     let is_ltx = engine_id == "ltx_2_3_distilled";
-    if is_ltx {
-        ensure_ltx_gemma_dir(settings);
-    }
+    let ltx_gemma_dir = if is_ltx {
+        resolve_ltx_gemma_dir(settings)
+    } else {
+        None
+    };
     // Wan 14B I2V conditions on a source image (`Conditioning::Reference`); every other candle video
     // engine is txt2video-only (empty conditioning).
     let conditioning =
@@ -3234,6 +3236,8 @@ async fn generate_candle_video(
         steps,
         guidance,
         seed: resolve_video_seed(request) as u64,
+        // ltx's Gemma-3 encoder dir rides the LoadSpec (sc-8827); `None` for wan (bundled TE).
+        text_encoder_dir: ltx_gemma_dir,
         ..VideoGenInput::default()
     };
     let raw_settings = candle_video_raw_settings(request, &repo);
@@ -4953,20 +4957,19 @@ fn bundled_ltx_gemma_dir(model_dir: &Path) -> Option<PathBuf> {
     gemma.is_dir().then_some(gemma)
 }
 
-/// Point the engine at the Gemma-3 text encoder bundled beside the resolved LTX dir (sc-5608).
-/// Setting `$LTX_GEMMA_DIR` (the var [`mlx-gen-ltx`'s `resolve_gemma_dir`] honors on every OS) makes
-/// a fresh install self-contained — no separate `mlx-community/gemma` download. Best-effort +
-/// non-destructive: honors an explicit operator `$LTX_GEMMA_DIR`, and skips when no bundled `gemma/`
-/// sibling exists ([`bundled_ltx_gemma_dir`]). The worker runs video jobs sequentially, so the env
-/// set is race-free.
+/// Resolve the Gemma-3 text encoder bundled beside the resolved LTX dir (sc-5608), returning it so the
+/// caller can thread it onto `LoadSpec::text_encoder` (sc-8827) — a fresh install is self-contained (no
+/// separate `mlx-community/gemma` download) without mutating the process-global `$LTX_GEMMA_DIR` at job
+/// time on the multithreaded runtime (the old `set_var` seam was unsound, F-025). Best-effort +
+/// non-destructive: returns `None` when an explicit operator `$LTX_GEMMA_DIR` is set (the provider
+/// reads the env var itself), and `None` when no bundled `gemma/` sibling exists
+/// ([`bundled_ltx_gemma_dir`]) so the provider falls back to the HF-cache gemma snapshot.
 #[cfg(target_os = "macos")]
-fn ensure_bundled_ltx_gemma_dir(model_dir: &Path) {
+fn resolve_bundled_ltx_gemma_dir(model_dir: &Path) -> Option<PathBuf> {
     if std::env::var_os("LTX_GEMMA_DIR").is_some() {
-        return; // honor an explicit operator override.
+        return None; // honor an explicit operator override (the provider reads the env var).
     }
-    if let Some(gemma) = bundled_ltx_gemma_dir(model_dir) {
-        std::env::set_var("LTX_GEMMA_DIR", gemma);
-    }
+    bundled_ltx_gemma_dir(model_dir)
 }
 
 /// On-demand fetch of the bundle's `q8/` subdir (sc-5679). The macOS default download is lean
@@ -5523,8 +5526,9 @@ async fn generate_ltx(
     ensure_ltx_q8_present(api, settings, job, request).await?;
     let model_dir = resolve_ltx_model_dir(settings, request)?;
     // When the resolved dir is the SceneWorks bundle subdir, its sibling `gemma/` is the text
-    // encoder — point the engine at it (sc-5608) before load. No-op for legacy/local conversions.
-    ensure_bundled_ltx_gemma_dir(&model_dir);
+    // encoder — thread it onto the LoadSpec (sc-8827, was `$LTX_GEMMA_DIR`). `None` for legacy/local
+    // conversions (no bundled sibling) ⇒ the engine falls back to the HF-cache gemma snapshot.
+    let text_encoder_dir = resolve_bundled_ltx_gemma_dir(&model_dir);
     let input = VideoGenInput {
         sampler: None,
         scheduler: None,
@@ -5548,6 +5552,7 @@ async fn generate_ltx(
         use_uncensored_enhancer: advanced::bool(&request.advanced, "useUncensoredEnhancer"),
         enhance_max_tokens,
         enhance_temperature,
+        text_encoder_dir,
         ..VideoGenInput::default()
     };
     generate_video(api, settings, job, backend, input).await
@@ -8775,6 +8780,38 @@ mod tests {
         let _ = std::fs::remove_dir_all(&bare);
     }
 
+    /// sc-8827 (F-025): the LTX Gemma-encoder dir rides `LoadSpec::text_encoder` (via
+    /// `VideoGenInput::text_encoder_dir`) instead of the process-global `$LTX_GEMMA_DIR`. This asserts
+    /// the path flows through `video_load_spec` onto the spec — `None` maps to `None` (env/`<root>`
+    /// fallback in the provider), a dir maps to `Some(WeightsSource::Dir(..))`.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    #[test]
+    fn video_load_spec_threads_text_encoder_dir() {
+        let base = VideoGenInput {
+            engine_id: "ltx_2_3",
+            model_dir: PathBuf::from("/models/ltx/q4"),
+            ..VideoGenInput::default()
+        };
+        // No override → text_encoder None (the provider reads its env/`<root>` fallback).
+        assert!(
+            video_load_spec(&base).text_encoder.is_none(),
+            "no text_encoder_dir ⇒ no spec override"
+        );
+        // An explicit gemma dir rides the spec as a Dir source.
+        let gemma = PathBuf::from("/models/ltx/gemma");
+        let with_te = VideoGenInput {
+            text_encoder_dir: Some(gemma.clone()),
+            ..base
+        };
+        assert!(
+            matches!(video_load_spec(&with_te).text_encoder, Some(WeightsSource::Dir(ref p)) if *p == gemma),
+            "text_encoder_dir rides LoadSpec::text_encoder as a Dir source"
+        );
+    }
+
     /// Q8 opt-in detection (sc-5679): `advanced.mlxQuantize: 8` (int or string) → true; absent / Q4
     /// → false. Drives both the resolve quant preference and the on-demand q8 fetch.
     #[cfg(target_os = "macos")]
@@ -9409,9 +9446,9 @@ mod tests {
             eprintln!("skipping ltx_real_weights_with_audio: no complete LTX snapshot found");
             return;
         };
-        // The bundle ships gemma beside the q4/q8 dir; point the engine at it (matches the worker
-        // path) so the smoke needs no separate mlx-community/gemma snapshot in the HF cache.
-        ensure_bundled_ltx_gemma_dir(&model_dir);
+        // The bundle ships gemma beside the q4/q8 dir; thread it onto the LoadSpec (matches the worker
+        // path, sc-8827) so the smoke needs no separate mlx-community/gemma snapshot in the HF cache.
+        let text_encoder_dir = resolve_bundled_ltx_gemma_dir(&model_dir);
         let input = VideoGenInput {
             sampler: None,
             scheduler: None,
@@ -9423,6 +9460,7 @@ mod tests {
             frames: 9,
             fps: 24,
             seed: 7,
+            text_encoder_dir,
             ..VideoGenInput::default()
         };
         let cancel = CancelFlag::new();


### PR DESCRIPTION
## Problem (F-025, sc-8827)

`set_pulid_weight_env` (image_jobs/pulid.rs) and `ensure_ltx_gemma_dir` / `ensure_bundled_ltx_gemma_dir` (video_jobs.rs) called `std::env::set_var`/`remove_var` on the multithreaded tokio runtime **at job time** to feed the PuLID-FLUX and LTX-2.3 loaders their auxiliary weight paths (`PULID_FLUX_WEIGHTS` / `PULID_EVA_WEIGHTS` / `PULID_FACE_WEIGHTS_DIR`, `LTX_GEMMA_DIR`). `set_var` on a live multithreaded program is unsound (POSIX UB if any other thread — reqwest/DNS, HF_HOME reads, linked C/ObjC — reads env concurrently) and `unsafe` in Rust 2024. The PuLID `EnvRestore` RAII restore additionally raced the spawned stream-load task by design (the load runs inside a `tokio::spawn`ed task while the guard's `Drop` fires on the async caller).

## Fix

Thread the paths through the loader's `LoadSpec` instead (additive engine seams landed in mlx-gen #637 / candle-gen #301):

- **PuLID** (`pulid_flux`, macOS/MLX): new `pulid_identity_weights` maps the resolved `PulidWeights` onto `LoadSpec::identity` (`IdentityWeights { encoder, eva, face_dir }`). The spec carries the paths into the spawned load task — no env. Deleted `EnvRestore` + `set_pulid_weight_env`.
- **LTX** (candle + MLX): `resolve_ltx_gemma_dir` / `resolve_bundled_ltx_gemma_dir` now **return** the Gemma-encoder dir, threaded onto `LoadSpec::text_encoder` via a new `VideoGenInput::text_encoder_dir`. Both honor an explicit operator `$LTX_GEMMA_DIR` by returning `None` (the provider reads the env var itself).

**Zero job-time `set_var`/`remove_var` remain for these seams.** The engines still honor the historical env vars as a load-time **fallback**, so operator overrides and the `#[ignore]`d real-weight tests keep working unchanged.

## Pins

- gen-core + every `mlx-gen-*` crate `330d339` -> `8239cc1` (mlx-gen #637).
- every `candle-gen-*` crate `4b63679` -> `d1c1d0a` (candle-gen #301).
- `check-gen-core-skew.sh` resolves ONE gen-core rev on both the macOS and `--features backend-candle` graphs.

## Tests

- `pulid_identity_weights_maps_paths_onto_loadspec_not_env` — proves the PuLID paths ride `LoadSpec::identity` (not env).
- `video_load_spec_threads_text_encoder_dir` — proves the LTX Gemma dir rides `LoadSpec::text_encoder`.
- Existing pulid/ltx/video tests are the oracle — all green. `cargo fmt --all --check` + `clippy --all-targets -D warnings` clean on the macOS + candle-parity lanes; 524 worker lib tests pass.

## Merge order

**mlx-gen #637 → candle-gen #301 → this PR.** This PR's pins already point at the engine branches' final revs; it must merge last (after both engine PRs land on their mains at those SHAs).

Story: https://app.shortcut.com/trefry/story/8827

🤖 Generated with [Claude Code](https://claude.com/claude-code)