### PR TITLE
perf(web): split monolithic AppContext into live + static providers (sc-8855)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -30,7 +30,7 @@ import { useTraining } from "./hooks/useTraining.js";
 import { useModelsAndLoras } from "./hooks/useModelsAndLoras.js";
 import { usePersonTracks } from "./hooks/usePersonTracks.js";
 import { useTimelines } from "./hooks/useTimelines.js";
-import { AppContext } from "./context/AppContext.js";
+import { AppStaticContext, AppLiveContext } from "./context/AppContext.js";
 import { DEFAULT_MAC_CAPABILITIES } from "./macGating.js";
 import { ACCENTS, DEFAULT_ACCENT, isAccentId } from "./accents.js";
 import {
@@ -2170,9 +2170,35 @@ export function App() {
   // entries actually changes, instead of being a fresh ~120-key literal on every App
   // render (SSE job/worker/queue ticks re-render App continuously). The actions above
   // and the data-hook actions are useCallback-stable, so this holds across renders
-  // that don't change data. NOTE: this dependency array must mirror the object below —
-  // every value referenced here is a dependency.
-  const appContextValue = useMemo(() => ({
+  // that don't change data.
+  //
+  // sc-8855 (F-053): split into TWO memoized values behind two providers.
+  //   - appLiveValue: the high-churn fields derived from the SSE-updated jobs/workers
+  //     state (jobs/filteredJobs/*LocalJobs/visibleWorkers/workersById/personReadiness/
+  //     gpuOptions). These change identity on nearly every tick.
+  //   - appStaticValue: everything else (actions/catalogs/project/presets/characters/
+  //     training/timelines/models). Its dependency array MUST NOT reference jobs or
+  //     workersById (or anything derived from them) — that exclusion is the whole point:
+  //     cold-only consumers reading via useAppStatic() no longer re-render on job ticks.
+  // NOTE: each dependency array must mirror the corresponding object below.
+  const appLiveValue = useMemo(() => ({
+    // Jobs / queue (high-churn — new identity per SSE tick)
+    jobs,
+    filteredJobs,
+    imageLocalJobs,
+    videoLocalJobs,
+    documentLocalJobs,
+    // Workers / GPU (high-churn — new identity per worker SSE tick)
+    visibleWorkers,
+    workersById,
+    personReadiness,
+    gpuOptions,
+  }), [
+    jobs, filteredJobs, imageLocalJobs, videoLocalJobs, documentLocalJobs,
+    visibleWorkers, workersById, personReadiness, gpuOptions,
+  ]);
+
+  const appStaticValue = useMemo(() => ({
     activeProject,
     mediaAssets,
     setPreviewAsset: openPreview,
@@ -2199,21 +2225,17 @@ export function App() {
     updateAssetStatus,
     updateAssetTags,
     latestImageAssets,
-    // Jobs / queue
-    jobs,
+    // Job actions (creation/control — stable callbacks, NOT the churning jobs list)
     jobAction,
     createVqaJob,
     createInterleaveJob,
     // Queue screen (sc-1651 Phase B batch 2)
     createPlaceholderJob,
-    filteredJobs,
     jobPrompt,
     setJobPrompt,
     projectFilter,
     setProjectFilter,
     projects,
-    visibleWorkers,
-    workersById,
     // Generation studios (sc-1651 Phase B batch 3)
     createVideoJob,
     createVideoUpscaleJob,
@@ -2226,9 +2248,6 @@ export function App() {
     latestVideoAssets,
     recentImageAssets,
     recentVideoAssets,
-    videoLocalJobs,
-    imageLocalJobs,
-    documentLocalJobs,
     studioLaunch,
     // sc-8730: Image Editor launch channel + the two Edit paths. sendAssetToImageEditor
     // routes to the editor canvas (FullscreenPreview Edit button); sendAssetToImageEdit
@@ -2240,7 +2259,6 @@ export function App() {
     rememberLocalGenerationJob,
     // Person tracks (Video Studio + Replace Person)
     personTracks,
-    personReadiness,
     createPersonDetectionJob,
     createPersonTrackJob,
     saveTrackCorrections,
@@ -2258,7 +2276,6 @@ export function App() {
     createModelConvertJob,
     createLoraImportJob,
     createModelImportJob,
-    gpuOptions,
     requestedGpu,
     setRequestedGpu,
     // Presets
@@ -2330,15 +2347,15 @@ export function App() {
     createTimeline, saveTimeline, exportTimeline, extractTimelineFrame, queueTimelineVideoJob,
     assets, selectedAsset, setSelectedAssetId, deleteAsset, purgeAsset, moveAssetToLibrary, importAsset,
     updateAssetStatus, updateAssetTags, latestImageAssets,
-    jobs, jobAction, createVqaJob, createInterleaveJob, createPlaceholderJob, filteredJobs,
-    jobPrompt, setJobPrompt, projectFilter, setProjectFilter, projects, visibleWorkers, workersById,
+    jobAction, createVqaJob, createInterleaveJob, createPlaceholderJob,
+    jobPrompt, setJobPrompt, projectFilter, setProjectFilter, projects,
     createVideoJob, createVideoUpscaleJob, createImageJob, refinePrompt, magicPrompt, imageCaption, imageDescribe, compareFaceLikeness, latestVideoAssets, recentImageAssets,
-    recentVideoAssets, videoLocalJobs, imageLocalJobs, documentLocalJobs, studioLaunch,
+    recentVideoAssets, studioLaunch,
     editorLaunch, clearEditorLaunch, sendAssetToImageEditor, sendAssetToImageEdit,
-    rememberLocalGenerationJob, personTracks, personReadiness, createPersonDetectionJob,
+    rememberLocalGenerationJob, personTracks, createPersonDetectionJob,
     createPersonTrackJob, saveTrackCorrections, imageModels, videoModels, models, macCapabilities,
     loras, deleteLora, deleteModel, createModelDownloadJob, createLoraDownloadJob, createModelConvertJob,
-    createLoraImportJob, createModelImportJob, gpuOptions, requestedGpu, setRequestedGpu,
+    createLoraImportJob, createModelImportJob, requestedGpu, setRequestedGpu,
     presets, createPreset, updatePreset, deletePreset, duplicatePreset, token, authenticated,
     trainingDatasets, trainingDatasetsProjectId, trainingDatasetsError, loadingTrainingDatasets,
     refreshTrainingDatasets, loadTrainingDataset, loadTrainingDatasetReadiness, setTrainingDatasetItemQualityAck, createTrainingDataset, uploadTrainingDatasetItem,
@@ -2354,7 +2371,8 @@ export function App() {
   ]);
 
   return (
-    <AppContext.Provider value={appContextValue}>
+    <AppStaticContext.Provider value={appStaticValue}>
+    <AppLiveContext.Provider value={appLiveValue}>
     <main className="app">
       <aside className="sidebar" aria-label="Primary">
         <div className="brand">
@@ -2607,6 +2625,7 @@ export function App() {
         />
       ) : null}
     </main>
-    </AppContext.Provider>
+    </AppLiveContext.Provider>
+    </AppStaticContext.Provider>
   );
 }

--- a/apps/web/src/components/WorkerProgressCard.jsx
+++ b/apps/web/src/components/WorkerProgressCard.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { actionStatuses, terminalStatuses } from "../jobTypes.js";
 import { formatSeconds, liveElapsedSeconds, percent } from "../formatting.js";
-import { useAppContext } from "../context/AppContext.js";
+import { useAppLive } from "../context/AppContext.js";
 import { deriveWorkerHardware, findWorkerForJob, liveMeters } from "../workers.js";
 import { AssetMedia, AssetThumbnail, assetUrl, posterUrl, suppressThumbnailContextMenu } from "./assetMedia.jsx";
 import { LikenessBadge } from "./LikenessBadge.jsx";
@@ -398,7 +398,7 @@ export function WorkerProgressCard({
   expectedThumbnailCount,
   onThumbnailClick,
 }) {
-  const { workersById, visibleWorkers } = useAppContext();
+  const { workersById, visibleWorkers } = useAppLive();
   const worker = useMemo(() => {
     if (job.workerId && workersById?.get) {
       const direct = workersById.get(job.workerId);

--- a/apps/web/src/context/AppContext.js
+++ b/apps/web/src/context/AppContext.js
@@ -1,15 +1,92 @@
-import { createContext, useContext } from "react";
+import { createContext, useContext, useMemo } from "react";
 
 // Shared app data/actions provider (sc-1651 Phase B). App composes the per-domain
 // hooks (Phase A) and exposes the primitives here so screens read what they need via
 // useAppContext() instead of receiving dozens of drilled props. Screens build any
 // screen-specific wrappers (e.g. send-to-studio with a mode) from these primitives.
+//
+// sc-8855 (F-053): the single monolithic context re-rendered EVERY consumer on every
+// SSE tick, because jobs/workers change identity continuously and that gave the one
+// combined value a new identity each tick. Split into two providers:
+//   - AppLiveContext  — high-churn fields derived from jobs/workers (change per SSE tick)
+//   - AppStaticContext — low-churn actions/catalogs/project/presets/characters/training
+// A consumer that reads ONLY static fields subscribes via useAppStatic() and no longer
+// re-renders on job/worker ticks. Consumers that read live fields (or both) use
+// useAppContext(), the backward-compatible combined hook that merges both contexts so
+// every existing destructure keeps working with no field loss.
+//
+// AppContext (the legacy combined context) is retained as a THIRD provider that carries a
+// pre-merged flat value. App does NOT use it (App renders the two split providers), but
+// tests and any external code that render a single <AppContext.Provider value={merged}>
+// keep working: each hook below falls back to the legacy combined value when its split
+// context is absent. This is what makes the split backward compatible.
+
+// The keys carried by the high-churn (live) context. Derived from the SSE-updated
+// `jobs`/`workers` state, so they change identity on virtually every tick. Kept here so
+// App can build the two value objects from one source of truth.
+export const LIVE_CONTEXT_KEYS = Object.freeze([
+  "jobs",
+  "filteredJobs",
+  "imageLocalJobs",
+  "videoLocalJobs",
+  "documentLocalJobs",
+  "visibleWorkers",
+  "workersById",
+  "personReadiness",
+  "gpuOptions",
+]);
+
+export const AppStaticContext = createContext(null);
+export const AppLiveContext = createContext(null);
+
+// Legacy combined context. Feeds a single flat value (static + live merged). App renders
+// the two split providers instead; this exists so a lone <AppContext.Provider value={…}>
+// (existing tests, external callers) still satisfies every hook via the fallbacks below.
 export const AppContext = createContext(null);
 
-export function useAppContext() {
-  const value = useContext(AppContext);
-  if (value === null) {
-    throw new Error("useAppContext must be used within an <AppContext.Provider>");
+export function useAppStatic() {
+  const split = useContext(AppStaticContext);
+  const combined = useContext(AppContext);
+  const value = split ?? combined;
+  if (value === null || value === undefined) {
+    throw new Error("useAppStatic must be used within an <AppStaticContext.Provider> or <AppContext.Provider>");
   }
   return value;
+}
+
+export function useAppLive() {
+  const split = useContext(AppLiveContext);
+  const combined = useContext(AppContext);
+  const value = split ?? combined;
+  if (value === null || value === undefined) {
+    throw new Error("useAppLive must be used within an <AppLiveContext.Provider> or <AppContext.Provider>");
+  }
+  return value;
+}
+
+// Backward-compatible combined hook: merges the two split contexts into the flat shape
+// the monolithic context used to expose. Consumers that read live fields (or a mix of
+// live + static) keep using this and lose no field. Consumers that read only static
+// fields should switch to useAppStatic() so they stop re-rendering on job/worker ticks.
+//
+// Reading the live context here still subscribes the caller to it, so a useAppContext()
+// consumer re-renders on ticks exactly as before — intentional (no behavior change for
+// those callers). The win is that cold-only callers opt out via useAppStatic().
+//
+// When only the legacy combined <AppContext.Provider> is present (tests), both split
+// contexts are null and we return the combined value directly.
+export function useAppContext() {
+  const staticValue = useContext(AppStaticContext);
+  const liveValue = useContext(AppLiveContext);
+  const combined = useContext(AppContext);
+  const merged = useMemo(() => {
+    if (staticValue === null && liveValue === null) {
+      return combined;
+    }
+    return { ...(combined ?? {}), ...(staticValue ?? {}), ...(liveValue ?? {}) };
+  }, [staticValue, liveValue, combined]);
+  if (merged === null || merged === undefined) {
+    throw new Error("useAppContext must be used within the App context providers");
+  }
+  return merged;
 }

--- a/apps/web/src/keypointLibrary.js
+++ b/apps/web/src/keypointLibrary.js
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { API_BASE_URL, apiFetch, withMediaTicket } from "./api.js";
-import { useAppContext } from "./context/AppContext.js";
+import { useAppStatic } from "./context/AppContext.js";
 
 // The reserved global project that holds user-created keypoint (face-angle) preset assets
 // (epic 4422, sc-4434). Mirrors crates/sceneworks-core::GLOBAL_KEYPOINTS_PROJECT_ID; hidden
@@ -90,7 +90,7 @@ export async function deleteKeypointCollection(token, collectionId) {
 // Load the preset list (built-in 11 + user) once per token. Best-effort: a fetch failure
 // surfaces via `error`; built-ins always come back from the API so the list is rarely empty.
 export function useKeypointPresets() {
-  const { token } = useAppContext();
+  const { token } = useAppStatic();
   const [state, setState] = useState({ presets: [], loading: true, error: "" });
   const reload = useCallback(
     async (signal) => {
@@ -116,7 +116,7 @@ export function useKeypointPresets() {
 // Load the collection list (built-in default + user collections). Used by the Collections tab
 // and by the per-generation override picker in Character Studio's angle set.
 export function useKeypointCollections() {
-  const { token } = useAppContext();
+  const { token } = useAppStatic();
   const [state, setState] = useState({ collections: [], loading: true, error: "" });
   const reload = useCallback(
     async (signal) => {

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -29,7 +29,7 @@ import { QueueScreen } from "./screens/QueueScreen.jsx";
 import { ReplacePersonPanel } from "./screens/ReplacePersonPanel.jsx";
 import { VideoStudio } from "./screens/VideoStudio.jsx";
 import { TrainingDataSetsLibrary, TrainingStudio } from "./screens/TrainingStudio.jsx";
-import { AppContext } from "./context/AppContext.js";
+import { AppContext, AppStaticContext, AppLiveContext } from "./context/AppContext.js";
 import { qualityChoices, GPU_REQUIRED_JOB_TYPES, errorStatuses } from "./jobTypes.js";
 
 // sc-1651 Phase B: screens converted to useAppContext() read their data from the
@@ -641,20 +641,23 @@ describe("SceneWorks app shell", () => {
     expect(queueChip()?.textContent).toContain("Queue 2");
   });
 
-  // sc-8811 regression (F-009): appContextValue must keep its identity across an App
-  // re-render that touches none of its entries. Before the fix, refreshData /
+  // sc-8811 regression (F-009): the STATIC context value must keep its identity across an
+  // App re-render that touches none of its entries. Before the fix, refreshData /
   // refreshDataWithLoraOverlay were plain per-render declarations passed into
   // useModelsAndLoras, so deleteModel/deleteLora — and therefore the whole memoized
   // context value — got a fresh identity on EVERY App render (each SSE tick, each
   // keystroke), silently defeating the sc-4194 memoization and re-rendering every
   // useAppContext consumer. A queue.updated event only changes queueSummary, which is
   // not part of the context value, so the provider value identity must survive it.
-  it("keeps appContextValue identity stable across an unrelated re-render (sc-8811)", async () => {
+  //
+  // sc-8855 (F-053): App now renders TWO providers (AppStaticContext + AppLiveContext).
+  // This asserts the STATIC value's identity, which must survive an unrelated re-render.
+  it("keeps the static context value identity stable across an unrelated re-render (sc-8811/sc-8855)", async () => {
     const providedValues = [];
-    const OriginalProvider = AppContext.Provider;
+    const OriginalProvider = AppStaticContext.Provider;
     // Swap in a recording pass-through provider so the test can observe the exact
-    // value identities App feeds the context on each committed render.
-    AppContext.Provider = function RecordingProvider({ value, children }) {
+    // static-value identities App feeds the context on each committed render.
+    AppStaticContext.Provider = function RecordingProvider({ value, children }) {
       providedValues.push(value);
       return <OriginalProvider value={value}>{children}</OriginalProvider>;
     };
@@ -670,7 +673,7 @@ describe("SceneWorks app shell", () => {
       expect(before).toBeTruthy();
 
       // Pure queue.updated (no workers array, no job.updated): re-renders App via
-      // setQueueSummary without changing anything appContextValue depends on.
+      // setQueueSummary without changing anything the static value depends on.
       await act(async () => {
         FakeEventSource.instances[0].listeners["queue.updated"]({
           data: JSON.stringify({ counts: { active: 2, queued: 2 }, activeJobs: [{ id: "job-a" }] }),
@@ -682,7 +685,64 @@ describe("SceneWorks app shell", () => {
       expect(providedValues.length).toBeGreaterThan(countBefore); // the event really re-rendered App
       expect(after).toBe(before); // identity preserved → consumer tree memoization holds
     } finally {
-      AppContext.Provider = OriginalProvider;
+      AppStaticContext.Provider = OriginalProvider;
+    }
+  });
+
+  // sc-8855 (F-053): a job/worker SSE tick must NOT change the STATIC context value's
+  // identity — that is the whole point of the split. The LIVE value's identity DOES
+  // change (it carries the churning jobs/workers fields), but static-only consumers
+  // (Settings, Presets, Logs, pose/keypoint pickers) subscribe to the static value and
+  // therefore skip re-render on every tick. We record both provider values and assert the
+  // static identity is preserved across a job.updated + workers.snapshot tick while the
+  // live identity changes.
+  it("static context value identity survives a job/worker SSE tick; live value changes (sc-8855)", async () => {
+    const staticValues = [];
+    const liveValues = [];
+    const OriginalStatic = AppStaticContext.Provider;
+    const OriginalLive = AppLiveContext.Provider;
+    AppStaticContext.Provider = function RecordingStatic({ value, children }) {
+      staticValues.push(value);
+      return <OriginalStatic value={value}>{children}</OriginalStatic>;
+    };
+    AppLiveContext.Provider = function RecordingLive({ value, children }) {
+      liveValues.push(value);
+      return <OriginalLive value={value}>{children}</OriginalLive>;
+    };
+    try {
+      root = createRoot(container);
+      await act(async () => {
+        root.render(<App />);
+      });
+      await settle();
+
+      const staticBefore = staticValues[staticValues.length - 1];
+      const liveBefore = liveValues[liveValues.length - 1];
+      expect(staticBefore).toBeTruthy();
+      expect(liveBefore).toBeTruthy();
+
+      // A real job tick: job.updated changes the jobs list (LIVE), which must not touch
+      // the static value's identity.
+      await act(async () => {
+        FakeEventSource.instances[0].listeners["job.updated"]({
+          data: JSON.stringify({ id: "job-churn", status: "running", type: "image", projectId: "p1" }),
+        });
+      });
+      await settle();
+
+      const staticAfter = staticValues[staticValues.length - 1];
+      const liveAfter = liveValues[liveValues.length - 1];
+      // Static identity preserved: cold-only consumers do NOT re-render on the tick.
+      expect(staticAfter).toBe(staticBefore);
+      // Live identity changed: the jobs field really churned.
+      expect(liveAfter).not.toBe(liveBefore);
+      // And the static value never carried the churning live keys.
+      for (const key of ["jobs", "workersById", "visibleWorkers", "filteredJobs", "gpuOptions"]) {
+        expect(staticAfter).not.toHaveProperty(key);
+      }
+    } finally {
+      AppStaticContext.Provider = OriginalStatic;
+      AppLiveContext.Provider = OriginalLive;
     }
   });
 

--- a/apps/web/src/poseLibrary.js
+++ b/apps/web/src/poseLibrary.js
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { apiFetch } from "./api.js";
 import { assetUrl } from "./components/assetMedia.jsx";
-import { useAppContext } from "./context/AppContext.js";
+import { useAppStatic } from "./context/AppContext.js";
 
 // The reserved global project that holds user-created pose assets (epic 2282). Mirrors
 // crates/sceneworks-core::GLOBAL_POSES_PROJECT_ID. Hidden from the project switcher;
@@ -98,7 +98,7 @@ export async function loadPoseLibrary({ loadUserPoses } = {}) {
 // `PoseLibraryPicker` (so it appears in the grid). Best-effort: any fetch failure
 // is swallowed by `loadPoseLibrary`, degrading to the built-in library (sc-2287).
 export function useUserPoseLoader() {
-  const { token } = useAppContext();
+  const { token } = useAppStatic();
   return useCallback(async () => {
     const items = await apiFetch(`/api/v1/projects/${GLOBAL_POSES_PROJECT_ID}/assets`, token);
     return (Array.isArray(items) ? items : [])

--- a/apps/web/src/screens/EditorScreen.jsx
+++ b/apps/web/src/screens/EditorScreen.jsx
@@ -11,7 +11,7 @@ import {
   trackItems,
   transitionOptions,
 } from "../timeline.js";
-import { useAppContext } from "../context/AppContext.js";
+import { useAppStatic } from "../context/AppContext.js";
 
 export function EditorScreen() {
   const {
@@ -30,7 +30,7 @@ export function EditorScreen() {
     setActiveTimeline,
     setSelectedTimelineId,
     timelines,
-  } = useAppContext();
+  } = useAppStatic();
   const assets = mediaAssets;
   const onPreview = setPreviewAsset;
   const onSendImage = (asset) => sendAssetToImage(asset, "edit_image");

--- a/apps/web/src/screens/KeyPointLibraryScreen.jsx
+++ b/apps/web/src/screens/KeyPointLibraryScreen.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { apiFetch } from "../api.js";
-import { useAppContext } from "../context/AppContext.js";
+import { useAppContext, useAppStatic } from "../context/AppContext.js";
 import { terminalStatuses } from "../jobTypes.js";
 import { KpsOverlay } from "../components/KpsOverlay.jsx";
 import { DatasetAddDialog } from "../components/DatasetAddDialog.jsx";
@@ -336,7 +336,7 @@ function KeypointCapturePanel({ hidden, onSaved }) {
 // --- Collections tab --------------------------------------------------------
 
 function KeypointCollectionsPanel({ hidden, presets, collections, collectionsLoading, onChanged }) {
-  const { token } = useAppContext();
+  const { token } = useAppStatic();
   const [name, setName] = useState("");
   const [orderedIds, setOrderedIds] = useState([]);
   const [editingId, setEditingId] = useState(null);
@@ -566,7 +566,7 @@ async function postExtractJob(token, requestedGpu, sourcePath) {
 
 export function KeyPointLibraryScreen() {
   const [activeTab, setActiveTab] = useState("library");
-  const { token } = useAppContext();
+  const { token } = useAppStatic();
   const { presets, loading: presetsLoading, error: presetsError, reload: reloadPresets } = useKeypointPresets();
   const {
     collections,

--- a/apps/web/src/screens/LogsScreen.jsx
+++ b/apps/web/src/screens/LogsScreen.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { apiFetch } from "../api.js";
-import { useAppContext } from "../context/AppContext.js";
+import { useAppStatic } from "../context/AppContext.js";
 import { isDesktop, tauriInvoke } from "../runtime.js";
 
 // In-app Logs viewer (sc-3452). Shows the current session's activity — most
@@ -64,7 +64,7 @@ async function fetchLogs(token, { afterSeq, limit, source, level }) {
 }
 
 export function LogsScreen() {
-  const { token } = useAppContext();
+  const { token } = useAppStatic();
   const [entries, setEntries] = useState([]);
   const [source, setSource] = useState("");
   const [level, setLevel] = useState("");

--- a/apps/web/src/screens/PoseLibraryScreen.jsx
+++ b/apps/web/src/screens/PoseLibraryScreen.jsx
@@ -3,7 +3,7 @@ import { API_BASE_URL, apiFetch, isAbortError, withMediaTicket } from "../api.js
 import { AssetDetail, AssetGrid, FullscreenPreview, emptyTrash } from "../components/assetPanels.jsx";
 import { AssetThumbnail } from "../components/assetMedia.jsx";
 import { DatasetAddDialog } from "../components/DatasetAddDialog.jsx";
-import { useAppContext } from "../context/AppContext.js";
+import { useAppContext, useAppStatic } from "../context/AppContext.js";
 import { DEFAULT_MAC_CAPABILITIES, macFeatureBlock } from "../macGating.js";
 import { terminalStatuses } from "../jobTypes.js";
 import { GLOBAL_POSES_PROJECT_ID } from "../poseLibrary.js";
@@ -417,7 +417,7 @@ function PoseCreatePanel({ hidden, categories, onSaved, existingPoses }) {
 }
 
 export function PoseLibraryScreen() {
-  const { token, macCapabilities = DEFAULT_MAC_CAPABILITIES } = useAppContext();
+  const { token, macCapabilities = DEFAULT_MAC_CAPABILITIES } = useAppStatic();
   // Mac UI gating (sc-3486): photo→skeleton pose detection runs on Python onnxruntime (DWPose),
   // with no in-process Rust path yet (sc-3487), so the Create tab is disabled on a gated Mac.
   const macPoseDetectBlock = macFeatureBlock(macCapabilities, "poseFromPhoto");

--- a/apps/web/src/screens/PresetManagerScreen.jsx
+++ b/apps/web/src/screens/PresetManagerScreen.jsx
@@ -10,7 +10,7 @@ import {
   workflowModelType,
   workflowModes,
 } from "../presetUtils.js";
-import { useAppContext } from "../context/AppContext.js";
+import { useAppStatic } from "../context/AppContext.js";
 import { qualityChoices } from "../jobTypes.js";
 
 const workflowCards = [
@@ -119,7 +119,7 @@ export function PresetManagerScreen() {
     updatePreset,
     videoModels,
     setActiveView,
-  } = useAppContext();
+  } = useAppStatic();
   const onOpenModels = () => setActiveView("Models");
   const models = useMemo(() => [...imageModels, ...videoModels], [imageModels, videoModels]);
   const [selectedPresetId, setSelectedPresetId] = useState(presets.find((preset) => preset.scope !== "builtin")?.id ?? "");


### PR DESCRIPTION
## sc-8855 — [F-053] Monolithic AppContext re-renders every consumer on any data tick

Story: https://app.shortcut.com/trefry/story/8855

### Problem
A single `AppContext` carried jobs/workers/queue **and** all actions/catalogs/project/presets/characters/training/timelines/models. Because `jobs` and `workersById` change identity on every SSE tick, the combined memoized value got a fresh identity each tick and re-rendered **every** consumer — including static-only screens (Settings/Presets, Logs, Editor, pose/keypoint pickers) that read no live field. `React.memo` on screens was defeated because the context read invalidated them.

### Approach — split into two contexts (Option A)
Chose the surgical, dependency-free split over `use-context-selector` (which would add a dependency and change every consumer's read pattern — higher blast radius).

- **`AppLiveContext`** — high-churn fields derived from the SSE `jobs`/`workers` state: `jobs`, `filteredJobs`, `imageLocalJobs`, `videoLocalJobs`, `documentLocalJobs`, `visibleWorkers`, `workersById`, `personReadiness`, `gpuOptions`.
- **`AppStaticContext`** — everything else. Its `useMemo` deps **exclude** `jobs`/`workersById` (and everything derived from them), so its identity survives a job/worker tick. That exclusion is the churn fix.

Three hooks:
- `useAppStatic()` — static-only consumers; **skip re-render on job/worker ticks**.
- `useAppLive()` — live-only consumers.
- `useAppContext()` — backward-compatible combined hook (merges both); live+static consumers keep working with **no field loss**.

The legacy `AppContext` is retained as a standalone combined provider and each hook falls back to it, so existing tests that render a single `<AppContext.Provider value={merged}>` pass unchanged.

### Consumer routing table
| Routing | Hook | Consumers |
|---|---|---|
| static-only | `useAppStatic` | PresetManagerScreen, EditorScreen, LogsScreen, poseLibrary, keypointLibrary, PoseLibraryScreen (settings picker), KeyPointLibraryScreen (2 sub-pickers) |
| live-only | `useAppLive` | WorkerProgressCard |
| live + static | `useAppContext` (unchanged) | assetBatch, LibraryScreen, QueueScreen, ModelManagerScreen, ImageStudio, VideoStudio, DocumentStudio, CharacterStudio, TrainingStudio, ImageEditor, PoseLibraryScreen/KeyPointLibraryScreen main lists |

Every consumer still receives exactly the fields it did before — no field dropped. Mixed consumers stay on the combined hook (safe default).

### Churn fix / tests
- New test: the **static** provider value's identity survives a `job.updated` tick while the **live** value's identity changes, and the static value never carries the churning live keys (`jobs`/`workersById`/`visibleWorkers`/`filteredJobs`/`gpuOptions`).
- Updated the sc-8811 identity test to observe the static provider (App now renders two providers instead of one).
- Full web suite: **1101 passed / 67 files**. ESLint: **0 errors**, warning count at parity with main (0 new; the 2 warnings on touched files are pre-existing `exhaustive-deps` in unrelated `useEffect`s). `vite build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)