### PR TITLE
refactor(worker): table-ize video/image dispatch + extract lane conditioning (sc-8828)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -638,295 +638,253 @@ pub(crate) async fn run_image_generate_job(
     // `ImageRoute::InstantId` arm) — checked first since `instantid_realvisxl` is not an inventory
     // `is_candle_engine` id.
     #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-    let handled = if settings.backend_candle_enabled && instantid_available(&request, settings) {
-        generate_instantid_stream(
-            api,
-            settings,
-            job,
-            &plan,
-            &project_path,
-            backend,
-            &mut asset_writes,
-        )
-        .await?;
-        true
-    } else if settings.backend_candle_enabled && sdxl_edit_candle_available(&request, settings) {
-        // SDXL img2img / inpaint / outpaint edit (sc-5487) — checked BEFORE `is_candle_engine` because
-        // `sdxl`/`realvisxl` ARE candle txt2img ids, so without this an `edit_image` job would be caught
-        // by the txt2img branch (which can't honor a source/mask). Disjoint from the IP-Adapter lane
-        // below (that one is reference-only and not `edit_image`).
-        generate_candle_sdxl_edit_stream(
-            api,
-            settings,
-            job,
-            &plan,
-            &project_path,
-            backend,
-            &mut asset_writes,
-        )
-        .await?;
-        true
-    } else if settings.backend_candle_enabled && flux2_edit_candle_available(&request, settings) {
-        // FLUX.2-klein reference / img2img edit (sc-5487) — checked BEFORE `is_candle_engine` because
-        // `flux2_klein_9b` IS a candle txt2img id, so without this an `edit_image` job would be caught by
-        // the txt2img branch (which can't honor a source reference). FLUX.2-klein has no torch path, so
-        // before this an off-Mac klein edit had no real lane (it deferred to a torch worker that lacks
-        // the model). Disjoint from the IP-Adapter / SDXL-edit lanes (different model family).
-        generate_candle_flux2_edit_stream(
-            api,
-            settings,
-            job,
-            &plan,
-            &project_path,
-            backend,
-            &mut asset_writes,
-        )
-        .await?;
-        true
-    } else if settings.backend_candle_enabled && qwen_edit_candle_available(&request, settings) {
-        // Qwen-Image-Edit reference / dual-latent edit (sc-5487) — checked BEFORE `is_candle_engine`.
-        // `qwen_image_edit` is its OWN model id (not the `qwen_image` candle txt2img id), so it would
-        // not be caught by the txt2img branch; routed here (grouped with the edit lanes) to the bespoke
-        // candle `QwenEdit` stream. Off-Mac this was a torch fallback; candle now serves it. Disjoint
-        // from the Qwen strict-pose control lane below (that one is `qwen_image` + `advanced.poses`).
-        generate_candle_qwen_edit_stream(
-            api,
-            settings,
-            job,
-            &plan,
-            &project_path,
-            backend,
-            &mut asset_writes,
-        )
-        .await?;
-        true
-    } else if settings.backend_candle_enabled && zimage_edit_candle_available(&request, settings) {
-        // Z-Image img2img / edit (sc-6595) — checked BEFORE `is_candle_engine` because `z_image_turbo` IS
-        // a candle txt2img id (and `z_image_edit` is a distinct id the txt2img branch doesn't know), so
-        // without this an `edit_image` job would be caught by the txt2img branch (which can't honor a
-        // source) or fall through entirely. Grouped with the other edit lanes; disjoint from the Z-Image
-        // strict-pose control lane below (that one is `advanced.poses`, not `edit_image`).
-        generate_candle_zimage_edit_stream(
-            api,
-            settings,
-            job,
-            &plan,
-            &project_path,
-            backend,
-            &mut asset_writes,
-        )
-        .await?;
-        true
-    } else if settings.backend_candle_enabled
-        && zimage_identity_candle_available(&request, settings)
-    {
-        // Z-Image identity-init for Image Studio "With Character" (sc-8409, epic 4406) — checked BEFORE
-        // `is_candle_engine` because `z_image_turbo` IS a candle txt2img id, so without this a
-        // `character_image` + `referenceAssetId` (+ `referenceStrength > 0`) job would be caught by the
-        // txt2img branch and silently drop the reference (carrying no identity, hence no score — the gap
-        // this story closes). The off-Mac sibling of the macOS generic lane's Z-Image identity img2img
-        // (`resolve_zimage_identity_init`); reuses the candle `ZImageEdit` engine with the identity
-        // `referenceAssetId` as the source-latent init + wires the sc-4411 face-likeness scorer. Disjoint
-        // from the Z-Image edit lane above (that one is `edit_image` + `sourceAssetId`) and the strict-pose
-        // control lane below (that one is `advanced.poses`, which this gate excludes). Mirrors the router's
-        // `zimage_identity_candle_eligible`.
-        generate_candle_zimage_identity_stream(
-            api,
-            settings,
-            job,
-            &plan,
-            &project_path,
-            backend,
-            &mut asset_writes,
-        )
-        .await?;
-        true
-    } else if settings.backend_candle_enabled && sdxl_ipadapter_available(&request, settings) {
-        // SDXL IP-Adapter-Plus reference conditioning (sc-5488) — checked BEFORE `is_candle_engine`
-        // because `sdxl`/`realvisxl` ARE candle txt2img ids, so without this a reference job would be
-        // caught by the txt2img branch and silently drop the reference.
-        generate_candle_sdxl_ipadapter_stream(
-            api,
-            settings,
-            job,
-            &plan,
-            &project_path,
-            backend,
-            &mut asset_writes,
-        )
-        .await?;
-        true
-    } else if settings.backend_candle_enabled && kolors_ipadapter_available(&request, settings) {
-        // Kolors IP-Adapter-Plus reference conditioning (sc-5488) — checked BEFORE `is_candle_engine`
-        // because `kolors` IS a candle txt2img id, so without this a reference job would be caught by
-        // the txt2img branch and silently drop the reference (the SDXL IP reasoning, for Kolors).
-        generate_candle_kolors_ipadapter_stream(
-            api,
-            settings,
-            job,
-            &plan,
-            &project_path,
-            backend,
-            &mut asset_writes,
-        )
-        .await?;
-        true
-    } else if settings.backend_candle_enabled && flux_ipadapter_available(&request, settings) {
-        // FLUX XLabs IP-Adapter reference conditioning (sc-5872) — checked BEFORE `is_candle_engine`
-        // because `flux_dev`/`flux_schnell` ARE candle txt2img ids, so without this a reference job
-        // would be caught by the txt2img branch and silently drop the reference (the SDXL/Kolors IP
-        // reasoning, for FLUX).
-        generate_candle_flux_ipadapter_stream(
-            api,
-            settings,
-            job,
-            &plan,
-            &project_path,
-            backend,
-            &mut asset_writes,
-        )
-        .await?;
-        true
-    } else if settings.backend_candle_enabled && pulid_candle_available(&request, settings) {
-        // PuLID-FLUX face identity (sc-5492) — `pulid_flux_dev` is its OWN model id (not a candle
-        // txt2img id), so it would never be caught by the `is_candle_engine` branch below; routed here
-        // (grouped with the reference/identity lanes) to the bespoke candle `PulidFlux` stream. The
-        // distinct model id cleanly disambiguates it from the FLUX XLabs IP-Adapter lane above (both
-        // condition on a reference image, but that lane is `flux_dev`/`flux_schnell`).
-        generate_candle_pulid_stream(
-            api,
-            settings,
-            job,
-            &plan,
-            &project_path,
-            backend,
-            &mut asset_writes,
-        )
-        .await?;
-        true
-    } else if settings.backend_candle_enabled && qwen_control_available(&request, settings) {
-        // Qwen-Image strict-pose ControlNet (sc-5489) — checked BEFORE `is_candle_engine` because
-        // `qwen_image` IS a candle txt2img id, so without this a `advanced.poses` job would be caught
-        // by the txt2img branch and silently drop the poses (the IP-Adapter reasoning, for poses).
-        generate_candle_qwen_control_stream(
-            api,
-            settings,
-            job,
-            &plan,
-            &project_path,
-            backend,
-            &mut asset_writes,
-        )
-        .await?;
-        true
-    } else if settings.backend_candle_enabled && kolors_control_available(&request, settings) {
-        // Kolors strict-pose ControlNet (sc-5489) — checked BEFORE `is_candle_engine` because `kolors`
-        // IS a candle txt2img id, so without this a `advanced.poses` job would be caught by the txt2img
-        // branch and silently drop the poses (the Qwen-control reasoning, for the Kolors family).
-        generate_candle_kolors_control_stream(
-            api,
-            settings,
-            job,
-            &plan,
-            &project_path,
-            backend,
-            &mut asset_writes,
-        )
-        .await?;
-        true
-    } else if settings.backend_candle_enabled && zimage_control_available(&request, settings) {
-        // Z-Image strict-pose Fun-ControlNet (sc-5489) — checked BEFORE `is_candle_engine` because
-        // `z_image_turbo` IS a candle txt2img id, so without this a `advanced.poses` job would be caught
-        // by the txt2img branch and silently drop the poses (the Qwen/Kolors-control reasoning, for the
-        // Z-Image family — the last of the three strict-pose families).
-        generate_candle_zimage_control_stream(
-            api,
-            settings,
-            job,
-            &plan,
-            &project_path,
-            backend,
-            &mut asset_writes,
-        )
-        .await?;
-        true
-    } else if settings.backend_candle_enabled && flux2_control_candle_available(&request, settings)
-    {
-        // FLUX.2-dev strict-pose Fun-Controlnet-Union (sc-7736, epic 6564) — `flux2_dev` + `advanced.poses`
-        // is the bespoke candle `Flux2Control` lane (`generate_candle_flux2_control_stream`), NOT txt2img —
-        // the `is_candle_engine` txt2img branch below would silently drop the poses, and the no-pose-lane
-        // reject branch would reject them. Branch it out first (the qwen/kolors/z_image-control reasoning,
-        // for the FLUX.2-dev family — the 4th wired strict-pose family). Disjoint from the FLUX.2 edit lane
-        // above (that one is `edit_image` + a source; this is `advanced.poses`, not edit mode). Mirrors the
-        // router's `flux2_dev_control_candle_eligible`.
-        generate_candle_flux2_control_stream(
-            api,
-            settings,
-            job,
-            &plan,
-            &project_path,
-            backend,
-            &mut asset_writes,
-        )
-        .await?;
-        true
-    } else if settings.backend_candle_enabled && flux1_control_candle_available(&request, settings)
-    {
-        // FLUX.1-dev strict-control Shakker Union-Pro-2.0 (sc-8412, epic 8236) — `flux_dev` +
-        // `advanced.poses` is the bespoke candle `Flux1DevControl` lane
-        // (`generate_candle_flux1_control_stream`), NOT txt2img — the `is_candle_engine` txt2img branch
-        // below would silently drop the poses, and the no-pose-lane reject branch would reject them.
-        // Branch it out first (the qwen/kolors/z_image/flux2-control reasoning, for the FLUX.1-dev family —
-        // the 5th wired strict-control family). Disjoint from the FLUX XLabs IP-Adapter lane above (that
-        // one keys on a `referenceAssetId`; this is `advanced.poses`). Mirrors the router's
-        // `flux1_control_candle_eligible`.
-        generate_candle_flux1_control_stream(
-            api,
-            settings,
-            job,
-            &plan,
-            &project_path,
-            backend,
-            &mut asset_writes,
-        )
-        .await?;
-        true
-    } else if settings.backend_candle_enabled
-        && is_candle_engine(&request.model)
-        && !matches!(
-            request.model.as_str(),
-            "qwen_image" | "kolors" | "z_image_turbo" | "z_image" | "flux2_dev" | "flux_dev"
-        )
-        && request.mode != "edit_image"
-        && !pose_entries(&request).is_empty()
-    {
-        // No-silent-T2I (sc-5968): a strict-pose job on a candle model with NO pose lane (e.g. sdxl)
-        // must be REJECTED with a clear error, not silently rendered as plain txt2img (poses dropped)
-        // and not bounced to torch. The candle worker CLAIMS these (jobs_store
-        // `image_job_candle_pose_reject`) precisely to fail them loudly here, checked BEFORE the
-        // `is_candle_engine` txt2img branch below. SDXL identity-pose ships via InstantID; the wired
-        // candle pose families are qwen_image / kolors / z_image_turbo / z_image / flux2_dev / flux_dev.
-        return Err(WorkerError::InvalidPayload(format!(
-            "strict pose (advanced.poses) is not supported for model '{}' on the candle backend — \
-             refusing rather than silently generating an unconditioned image (wired candle pose \
-             families: qwen_image, kolors, z_image_turbo, z_image, flux2_dev, flux_dev; SDXL \
-             identity-pose runs via InstantID)",
-            request.model
-        )));
-    } else if settings.backend_candle_enabled && is_candle_engine(&request.model) {
-        generate_candle_stream(
-            api,
-            settings,
-            job,
-            &plan,
-            &project_path,
-            backend,
-            &mut asset_writes,
-        )
-        .await?;
-        true
-    } else {
-        false
+    let handled = match resolve_candle_image_route(&request, settings) {
+        Some(route) => {
+            match route {
+                // InstantID (sc-5491, epic 5480): the candle InstantID provider's bespoke path (the
+                // off-Mac sibling of the macOS `ImageRoute::InstantId` arm).
+                CandleImageRoute::InstantId => {
+                    generate_instantid_stream(
+                        api,
+                        settings,
+                        job,
+                        &plan,
+                        &project_path,
+                        backend,
+                        &mut asset_writes,
+                    )
+                    .await?;
+                }
+                // SDXL img2img / inpaint / outpaint edit (sc-5487) — diverted before the txt2img arm
+                // because `sdxl`/`realvisxl` ARE candle txt2img ids (an `edit_image` job would otherwise
+                // be caught there and lose the source/mask). Disjoint from the IP-Adapter lane.
+                CandleImageRoute::SdxlEdit => {
+                    generate_candle_sdxl_edit_stream(
+                        api,
+                        settings,
+                        job,
+                        &plan,
+                        &project_path,
+                        backend,
+                        &mut asset_writes,
+                    )
+                    .await?;
+                }
+                // FLUX.2-klein reference / img2img edit (sc-5487) — `flux2_klein_9b` IS a candle txt2img
+                // id, so an `edit_image` job must divert here first. No torch path for klein edit.
+                CandleImageRoute::Flux2Edit => {
+                    generate_candle_flux2_edit_stream(
+                        api,
+                        settings,
+                        job,
+                        &plan,
+                        &project_path,
+                        backend,
+                        &mut asset_writes,
+                    )
+                    .await?;
+                }
+                // Qwen-Image-Edit reference / dual-latent edit (sc-5487) — `qwen_image_edit` is its own
+                // model id, routed to the bespoke candle QwenEdit stream (disjoint from the qwen control
+                // lane, which is `qwen_image` + `advanced.poses`).
+                CandleImageRoute::QwenEdit => {
+                    generate_candle_qwen_edit_stream(
+                        api,
+                        settings,
+                        job,
+                        &plan,
+                        &project_path,
+                        backend,
+                        &mut asset_writes,
+                    )
+                    .await?;
+                }
+                // Z-Image img2img / edit (sc-6595) — `z_image_turbo` IS a candle txt2img id, so an
+                // `edit_image` job must divert here first (disjoint from the Z-Image control lane).
+                CandleImageRoute::ZimageEdit => {
+                    generate_candle_zimage_edit_stream(
+                        api,
+                        settings,
+                        job,
+                        &plan,
+                        &project_path,
+                        backend,
+                        &mut asset_writes,
+                    )
+                    .await?;
+                }
+                // Z-Image identity-init for Image Studio "With Character" (sc-8409, epic 4406) — the
+                // off-Mac sibling of the macOS generic lane's Z-Image identity img2img; reuses the candle
+                // ZImageEdit engine with the identity `referenceAssetId` as the source-latent init + wires
+                // the sc-4411 face-likeness scorer. Diverted before the txt2img arm (else the reference
+                // silently drops).
+                CandleImageRoute::ZimageIdentity => {
+                    generate_candle_zimage_identity_stream(
+                        api,
+                        settings,
+                        job,
+                        &plan,
+                        &project_path,
+                        backend,
+                        &mut asset_writes,
+                    )
+                    .await?;
+                }
+                // SDXL IP-Adapter-Plus reference conditioning (sc-5488) — diverted before the txt2img arm
+                // (else the reference silently drops on the shared `sdxl`/`realvisxl` txt2img id).
+                CandleImageRoute::SdxlIpAdapter => {
+                    generate_candle_sdxl_ipadapter_stream(
+                        api,
+                        settings,
+                        job,
+                        &plan,
+                        &project_path,
+                        backend,
+                        &mut asset_writes,
+                    )
+                    .await?;
+                }
+                // Kolors IP-Adapter-Plus reference conditioning (sc-5488).
+                CandleImageRoute::KolorsIpAdapter => {
+                    generate_candle_kolors_ipadapter_stream(
+                        api,
+                        settings,
+                        job,
+                        &plan,
+                        &project_path,
+                        backend,
+                        &mut asset_writes,
+                    )
+                    .await?;
+                }
+                // FLUX XLabs IP-Adapter reference conditioning (sc-5872).
+                CandleImageRoute::FluxIpAdapter => {
+                    generate_candle_flux_ipadapter_stream(
+                        api,
+                        settings,
+                        job,
+                        &plan,
+                        &project_path,
+                        backend,
+                        &mut asset_writes,
+                    )
+                    .await?;
+                }
+                // PuLID-FLUX face identity (sc-5492) — `pulid_flux_dev` is its own model id (never an
+                // `is_candle_engine` txt2img id), routed to the bespoke candle PulidFlux stream.
+                CandleImageRoute::Pulid => {
+                    generate_candle_pulid_stream(
+                        api,
+                        settings,
+                        job,
+                        &plan,
+                        &project_path,
+                        backend,
+                        &mut asset_writes,
+                    )
+                    .await?;
+                }
+                // Qwen-Image strict-pose ControlNet (sc-5489) — diverted before the txt2img arm (else the
+                // poses silently drop on the shared `qwen_image` txt2img id).
+                CandleImageRoute::QwenControl => {
+                    generate_candle_qwen_control_stream(
+                        api,
+                        settings,
+                        job,
+                        &plan,
+                        &project_path,
+                        backend,
+                        &mut asset_writes,
+                    )
+                    .await?;
+                }
+                // Kolors strict-pose ControlNet (sc-5489).
+                CandleImageRoute::KolorsControl => {
+                    generate_candle_kolors_control_stream(
+                        api,
+                        settings,
+                        job,
+                        &plan,
+                        &project_path,
+                        backend,
+                        &mut asset_writes,
+                    )
+                    .await?;
+                }
+                // Z-Image strict-pose Fun-ControlNet (sc-5489).
+                CandleImageRoute::ZimageControl => {
+                    generate_candle_zimage_control_stream(
+                        api,
+                        settings,
+                        job,
+                        &plan,
+                        &project_path,
+                        backend,
+                        &mut asset_writes,
+                    )
+                    .await?;
+                }
+                // FLUX.2-dev strict-pose Fun-Controlnet-Union (sc-7736, epic 6564) — `flux2_dev` +
+                // `advanced.poses` is the bespoke candle Flux2Control lane, diverted before the txt2img arm.
+                CandleImageRoute::Flux2Control => {
+                    generate_candle_flux2_control_stream(
+                        api,
+                        settings,
+                        job,
+                        &plan,
+                        &project_path,
+                        backend,
+                        &mut asset_writes,
+                    )
+                    .await?;
+                }
+                // FLUX.1-dev strict-control Shakker Union-Pro-2.0 (sc-8412, epic 8236) — `flux_dev` +
+                // `advanced.poses` is the bespoke candle Flux1DevControl lane, diverted before the txt2img arm.
+                CandleImageRoute::Flux1Control => {
+                    generate_candle_flux1_control_stream(
+                        api,
+                        settings,
+                        job,
+                        &plan,
+                        &project_path,
+                        backend,
+                        &mut asset_writes,
+                    )
+                    .await?;
+                }
+                // No-silent-T2I (sc-5968): a strict-pose job on a candle model with NO pose lane (e.g.
+                // sdxl) must be REJECTED with a clear error, not silently rendered as plain txt2img (poses
+                // dropped) and not bounced to torch. The candle worker CLAIMS these (jobs_store
+                // `image_job_candle_pose_reject`) precisely to fail them loudly here. SDXL identity-pose
+                // ships via InstantID; the wired candle pose families are qwen_image / kolors /
+                // z_image_turbo / z_image / flux2_dev / flux_dev.
+                CandleImageRoute::PoseReject => {
+                    return Err(WorkerError::InvalidPayload(format!(
+                        "strict pose (advanced.poses) is not supported for model '{}' on the candle backend — \
+                         refusing rather than silently generating an unconditioned image (wired candle pose \
+                         families: qwen_image, kolors, z_image_turbo, z_image, flux2_dev, flux_dev; SDXL \
+                         identity-pose runs via InstantID)",
+                        request.model
+                    )));
+                }
+                // Plain candle txt2img (sc-3675, epic 3672): sdxl/realvisxl on the narrow txt2img lane.
+                CandleImageRoute::CandleTxt2Img => {
+                    generate_candle_stream(
+                        api,
+                        settings,
+                        job,
+                        &plan,
+                        &project_path,
+                        backend,
+                        &mut asset_writes,
+                    )
+                    .await?;
+                }
+            }
+            true
+        }
+        // Candle disabled (default) or no candle engine matched → stub exactly as before.
+        None => false,
     };
     #[cfg(not(any(
         target_os = "macos",

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -170,6 +170,116 @@ impl ImageRoute {
     }
 }
 
+/// The candle (Windows/CUDA/Linux) image engine a `run_image_generate_job` request routes to — the
+/// candle-lane sibling of [`ImageRoute`] (sc-8828, F-026). Each variant maps 1:1 to a bespoke candle
+/// stream handler with the uniform `(api, settings, job, &plan, &project_path, backend, &mut asset_writes)`
+/// signature; [`CandleImageRoute::PoseReject`] is the no-silent-T2I reject arm (sc-5968). Every arm is
+/// gated on `settings.backend_candle_enabled`; when off (default) the resolver returns `None` so the job
+/// falls through to the stub, exactly as before.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CandleImageRoute {
+    /// InstantID identity (sc-5491) — the off-Mac sibling of `ImageRoute::InstantId`. Checked first
+    /// because `instantid_realvisxl` is not an `is_candle_engine` txt2img id.
+    InstantId,
+    /// SDXL img2img / inpaint / outpaint edit (sc-5487).
+    SdxlEdit,
+    /// FLUX.2-klein reference / img2img edit (sc-5487).
+    Flux2Edit,
+    /// Qwen-Image-Edit reference / dual-latent edit (sc-5487).
+    QwenEdit,
+    /// Z-Image img2img / edit (sc-6595).
+    ZimageEdit,
+    /// Z-Image identity-init for Image Studio "With Character" (sc-8409).
+    ZimageIdentity,
+    /// SDXL IP-Adapter-Plus reference conditioning (sc-5488).
+    SdxlIpAdapter,
+    /// Kolors IP-Adapter-Plus reference conditioning (sc-5488).
+    KolorsIpAdapter,
+    /// FLUX XLabs IP-Adapter reference conditioning (sc-5872).
+    FluxIpAdapter,
+    /// PuLID-FLUX face identity (sc-5492).
+    Pulid,
+    /// Qwen-Image strict-pose ControlNet (sc-5489).
+    QwenControl,
+    /// Kolors strict-pose ControlNet (sc-5489).
+    KolorsControl,
+    /// Z-Image strict-pose Fun-ControlNet (sc-5489).
+    ZimageControl,
+    /// FLUX.2-dev strict-pose Fun-Controlnet-Union (sc-7736).
+    Flux2Control,
+    /// FLUX.1-dev strict-control Shakker Union-Pro-2.0 (sc-8412).
+    Flux1Control,
+    /// A strict-pose job on a candle model with NO pose lane → reject loudly, never silent T2I (sc-5968).
+    PoseReject,
+    /// A plain candle txt2img engine id → `generate_candle_stream`.
+    CandleTxt2Img,
+}
+
+/// Run the candle image dispatch predicate ladder ONCE and return the [`CandleImageRoute`] (or `None`
+/// when candle is disabled / no candle engine matches → the job stubs). Mirrors the historical inline
+/// `else if settings.backend_candle_enabled && <predicate>` ladder EXACTLY — same predicate order,
+/// same `backend_candle_enabled` gating, same handler per family — so routing is byte-identical
+/// (sc-8828). Pure decision: no I/O, no generation.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn resolve_candle_image_route(
+    request: &ImageRequest,
+    settings: &Settings,
+) -> Option<CandleImageRoute> {
+    if !settings.backend_candle_enabled {
+        return None;
+    }
+    // Order matches the historical ladder: the edit / reference / identity / control lanes are all
+    // checked BEFORE the generic `is_candle_engine` txt2img arm (they share candle txt2img model ids, so
+    // without diverting first they'd be silently rendered as plain txt2img, dropping the source / poses).
+    if instantid_available(request, settings) {
+        Some(CandleImageRoute::InstantId)
+    } else if sdxl_edit_candle_available(request, settings) {
+        Some(CandleImageRoute::SdxlEdit)
+    } else if flux2_edit_candle_available(request, settings) {
+        Some(CandleImageRoute::Flux2Edit)
+    } else if qwen_edit_candle_available(request, settings) {
+        Some(CandleImageRoute::QwenEdit)
+    } else if zimage_edit_candle_available(request, settings) {
+        Some(CandleImageRoute::ZimageEdit)
+    } else if zimage_identity_candle_available(request, settings) {
+        Some(CandleImageRoute::ZimageIdentity)
+    } else if sdxl_ipadapter_available(request, settings) {
+        Some(CandleImageRoute::SdxlIpAdapter)
+    } else if kolors_ipadapter_available(request, settings) {
+        Some(CandleImageRoute::KolorsIpAdapter)
+    } else if flux_ipadapter_available(request, settings) {
+        Some(CandleImageRoute::FluxIpAdapter)
+    } else if pulid_candle_available(request, settings) {
+        Some(CandleImageRoute::Pulid)
+    } else if qwen_control_available(request, settings) {
+        Some(CandleImageRoute::QwenControl)
+    } else if kolors_control_available(request, settings) {
+        Some(CandleImageRoute::KolorsControl)
+    } else if zimage_control_available(request, settings) {
+        Some(CandleImageRoute::ZimageControl)
+    } else if flux2_control_candle_available(request, settings) {
+        Some(CandleImageRoute::Flux2Control)
+    } else if flux1_control_candle_available(request, settings) {
+        Some(CandleImageRoute::Flux1Control)
+    } else if is_candle_engine(&request.model)
+        && !matches!(
+            request.model.as_str(),
+            "qwen_image" | "kolors" | "z_image_turbo" | "z_image" | "flux2_dev" | "flux_dev"
+        )
+        && request.mode != "edit_image"
+        && !pose_entries(request).is_empty()
+    {
+        // No-silent-T2I (sc-5968): a strict-pose job on a candle model with NO pose lane (e.g. sdxl) must
+        // be REJECTED, not silently rendered as plain txt2img. Checked BEFORE the txt2img arm below.
+        Some(CandleImageRoute::PoseReject)
+    } else if is_candle_engine(&request.model) {
+        Some(CandleImageRoute::CandleTxt2Img)
+    } else {
+        None
+    }
+}
+
 #[cfg(target_os = "macos")]
 fn grouped_edit_image_count(request: &ImageRequest) -> u32 {
     match flux2_grouping(request) {
@@ -2164,6 +2274,137 @@ fn augment_prompt_for_angle(base: &str, angle: &str) -> String {
     }
 }
 
+/// Per-family reference conditioning for the generic MLX lane (`generate_stream`), resolved once
+/// (constant across the generation set). Bundles the four values the family dispatch produces so the
+/// caller does one `resolve_generic_lane_conditioning(..)` call instead of the inline 5-way match —
+/// the historical place per-family drift bugs land (sc-8828, F-026). The families served:
+///  • Z-Image reference-identity img2img-init / edit-init (sc-3619 / epic 3529),
+///  • FLUX.1 XLabs IP-Adapter (epic 3621 — schnell + dev; `strength = ipAdapterScale`, real CFG via
+///    `trueCfgScale` on dev),
+///  • Kolors img2img (sc-4765) + IP-Adapter-Plus reference (sc-4767), and
+///  • Ideogram 4 img2img (Remix) + mask inpaint/outpaint (sc-6303).
+/// Every other family (plain t2i, Boogu multi-reference) resolves to the all-`None`/`Vec::new` default.
+#[cfg(target_os = "macos")]
+#[derive(Default)]
+struct LaneConditioning {
+    /// Single img2img-init / IP-Adapter reference image + strength (Z-Image, FLUX.1 IP, Kolors,
+    /// Ideogram) fed to the engine as `Conditioning::Reference`. `None` for plain t2i.
+    identity_init: Option<(Image, f32)>,
+    /// FLUX.1 / Kolors IP-Adapter weights directory threaded into the [`load_spec`]. `None` unless the
+    /// IP-Adapter reference path is active.
+    flux_ip_dir: Option<PathBuf>,
+    /// FLUX.1-dev reference path's real-CFG scale (`trueCfgScale`). `None` for distilled/guidance-scalar
+    /// families; the caller folds it into the effective `true_cfg` alongside the true-CFG-family scale.
+    flux_true_cfg: Option<f32>,
+    /// Ideogram 4 inpaint/outpaint mask (white = repaint) threaded to `generate_one` as
+    /// `Conditioning::Mask`. `None` for every other family / plain img2img.
+    ideogram_edit_mask: Option<Image>,
+}
+
+/// Resolve the [`LaneConditioning`] for `request` on the generic MLX lane. Mirrors the historical
+/// inline family dispatch EXACTLY — same predicate order, same per-family values — so routing is
+/// byte-identical (sc-8828). The strict-pose ControlNet / edit tiers divert earlier (in
+/// `resolve_image_route`), so only the reference/identity/img2img families reach here.
+#[cfg(target_os = "macos")]
+fn resolve_generic_lane_conditioning(
+    request: &ImageRequest,
+    settings: &Settings,
+    project_path: &Path,
+    has_reference: bool,
+) -> WorkerResult<LaneConditioning> {
+    if matches!(request.model.as_str(), "z_image_turbo" | "z_image_edit") {
+        // Z-Image base path: `edit_image` → img2img-edit (sourceAssetId + strength, epic 3529);
+        // otherwise the identity-init reference (referenceAssetId + referenceStrength, sc-3619).
+        // Both feed the engine's single `Reference` conditioning; only the source + strength
+        // keying differs. The strict-pose ControlNet tier diverts earlier (zimage_control_available).
+        let init = if request.mode == "edit_image" {
+            resolve_zimage_edit_init(request, settings, project_path)?
+        } else {
+            resolve_zimage_identity_init(request, settings, project_path)?
+        };
+        Ok(LaneConditioning {
+            identity_init: init,
+            ..Default::default()
+        })
+    } else if is_flux_model(&request.model) && has_reference && request.mode != "edit_image" {
+        let reference_id = request
+            .reference_asset_id
+            .as_deref()
+            .map(str::trim)
+            .unwrap_or_default()
+            .to_owned();
+        let image = load_reference_image(
+            &settings.data_dir,
+            &request.project_id,
+            &reference_id,
+            project_path,
+        )?;
+        let scale = advanced::f32_clamped(
+            &request.advanced,
+            "ipAdapterScale",
+            FLUX_IP_SCALE,
+            0.0..=1.0,
+        );
+        let ip_dir = resolve_flux_ip_adapter_dir(settings)?;
+        // Real CFG only on dev (schnell is distilled — no CFG).
+        let true_cfg = (request.model == "flux_dev").then(|| {
+            advanced::f32_clamped(
+                &request.advanced,
+                "trueCfgScale",
+                FLUX_IP_TRUE_CFG,
+                1.0..=10.0,
+            )
+        });
+        Ok(LaneConditioning {
+            identity_init: Some((image, scale)),
+            flux_ip_dir: Some(ip_dir),
+            flux_true_cfg: true_cfg,
+            ideogram_edit_mask: None,
+        })
+    } else if request.model == "kolors" && request.mode == "edit_image" {
+        // Kolors img2img (sc-4765): `sourceAssetId` + `strength` → the engine's `Reference`
+        // (img2img init, no IP-Adapter loaded). Kolors carries CFG through `guidance` + negative
+        // prompt (resolved above), not `true_cfg`.
+        let init = resolve_kolors_edit_init(request, settings, project_path)?;
+        Ok(LaneConditioning {
+            identity_init: init,
+            ..Default::default()
+        })
+    } else if request.model == "kolors" && has_reference {
+        // Kolors IP-Adapter-Plus reference (sc-4767): `referenceAssetId` → the IP image prompt at
+        // `ipAdapterScale`. `with_ip_adapter` makes the engine treat the `Reference` as the image
+        // prompt (decoupled cross-attn) rather than an img2img init.
+        let (image, scale) = resolve_kolors_ip_reference(request, settings, project_path)?;
+        let ip_dir = resolve_kolors_ip_adapter_dir(settings)?;
+        Ok(LaneConditioning {
+            identity_init: Some((image, scale)),
+            flux_ip_dir: Some(ip_dir),
+            flux_true_cfg: None,
+            ideogram_edit_mask: None,
+        })
+    } else if matches!(request.model.as_str(), "ideogram_4" | "ideogram_4_turbo")
+        && request.mode == "edit_image"
+    {
+        // Ideogram 4 img2img (Remix) + mask inpaint / outpaint (Edit), sc-6303: `sourceAssetId` →
+        // the engine's `Reference` (img2img init); a `maskAssetId` (inpaint) or `fit_mode ==
+        // "outpaint"` adds a `Conditioning::Mask` (white = repaint), threaded via `ideogram_edit_mask`.
+        // Works in both quality (`ideogram_4`) and turbo (same base + TurboTime LoRA). No IP-Adapter.
+        match resolve_ideogram_edit(request, settings, project_path)? {
+            Some((source, strength, mask)) => Ok(LaneConditioning {
+                identity_init: Some((source, strength)),
+                flux_ip_dir: None,
+                flux_true_cfg: None,
+                ideogram_edit_mask: mask,
+            }),
+            None => Ok(LaneConditioning::default()),
+        }
+    } else {
+        // Boogu instruction edit resolves its (1..5) references separately into `boogu_refs` below —
+        // it uses the `MultiReference`-capable path, not the single `identity_init` reference.
+        Ok(LaneConditioning::default())
+    }
+}
+
 /// Real MLX generation: load once on a blocking thread, generate each image, and
 /// stream step/decode/image events back to the async worker (which saves PNGs, emits
 /// `assetWrites`, and polls cancel). MLX runs entirely on the blocking thread (the
@@ -2304,86 +2545,16 @@ async fn generate_stream(
         .reference_asset_id
         .as_deref()
         .is_some_and(|id| !id.trim().is_empty());
-    // Ideogram 4 inpaint/outpaint mask (sc-6303), set by the ideogram edit branch below and threaded
-    // to `generate_one` as a `Conditioning::Mask`. `None` for every other family / plain img2img.
-    let mut ideogram_edit_mask: Option<Image> = None;
-    let (identity_init, flux_ip_dir, flux_true_cfg): (
-        Option<(Image, f32)>,
-        Option<PathBuf>,
-        Option<f32>,
-    ) = if matches!(request.model.as_str(), "z_image_turbo" | "z_image_edit") {
-        // Z-Image base path: `edit_image` → img2img-edit (sourceAssetId + strength, epic 3529);
-        // otherwise the identity-init reference (referenceAssetId + referenceStrength, sc-3619).
-        // Both feed the engine's single `Reference` conditioning; only the source + strength
-        // keying differs. The strict-pose ControlNet tier diverts earlier (zimage_control_available).
-        let init = if request.mode == "edit_image" {
-            resolve_zimage_edit_init(request, settings, project_path)?
-        } else {
-            resolve_zimage_identity_init(request, settings, project_path)?
-        };
-        (init, None, None)
-    } else if is_flux_model(&request.model) && has_reference && request.mode != "edit_image" {
-        let reference_id = request
-            .reference_asset_id
-            .as_deref()
-            .map(str::trim)
-            .unwrap_or_default()
-            .to_owned();
-        let image = load_reference_image(
-            &settings.data_dir,
-            &request.project_id,
-            &reference_id,
-            project_path,
-        )?;
-        let scale = advanced::f32_clamped(
-            &request.advanced,
-            "ipAdapterScale",
-            FLUX_IP_SCALE,
-            0.0..=1.0,
-        );
-        let ip_dir = resolve_flux_ip_adapter_dir(settings)?;
-        // Real CFG only on dev (schnell is distilled — no CFG).
-        let true_cfg = (request.model == "flux_dev").then(|| {
-            advanced::f32_clamped(
-                &request.advanced,
-                "trueCfgScale",
-                FLUX_IP_TRUE_CFG,
-                1.0..=10.0,
-            )
-        });
-        (Some((image, scale)), Some(ip_dir), true_cfg)
-    } else if request.model == "kolors" && request.mode == "edit_image" {
-        // Kolors img2img (sc-4765): `sourceAssetId` + `strength` → the engine's `Reference`
-        // (img2img init, no IP-Adapter loaded). Kolors carries CFG through `guidance` + negative
-        // prompt (resolved above), not `true_cfg`.
-        let init = resolve_kolors_edit_init(request, settings, project_path)?;
-        (init, None, None)
-    } else if request.model == "kolors" && has_reference {
-        // Kolors IP-Adapter-Plus reference (sc-4767): `referenceAssetId` → the IP image prompt at
-        // `ipAdapterScale`. `with_ip_adapter` makes the engine treat the `Reference` as the image
-        // prompt (decoupled cross-attn) rather than an img2img init.
-        let (image, scale) = resolve_kolors_ip_reference(request, settings, project_path)?;
-        let ip_dir = resolve_kolors_ip_adapter_dir(settings)?;
-        (Some((image, scale)), Some(ip_dir), None)
-    } else if matches!(request.model.as_str(), "ideogram_4" | "ideogram_4_turbo")
-        && request.mode == "edit_image"
-    {
-        // Ideogram 4 img2img (Remix) + mask inpaint / outpaint (Edit), sc-6303: `sourceAssetId` →
-        // the engine's `Reference` (img2img init); a `maskAssetId` (inpaint) or `fit_mode ==
-        // "outpaint"` adds a `Conditioning::Mask` (white = repaint), threaded via `ideogram_edit_mask`.
-        // Works in both quality (`ideogram_4`) and turbo (same base + TurboTime LoRA). No IP-Adapter.
-        match resolve_ideogram_edit(request, settings, project_path)? {
-            Some((source, strength, mask)) => {
-                ideogram_edit_mask = mask;
-                (Some((source, strength)), None, None)
-            }
-            None => (None, None, None),
-        }
-    } else {
-        // Boogu instruction edit resolves its (1..5) references separately into `boogu_refs` below —
-        // it uses the `MultiReference`-capable path, not the single `identity_init` reference.
-        (None, None, None)
-    };
+    // Per-family reference conditioning (Z-Image identity/edit-init, FLUX.1/Kolors IP-Adapter, Kolors
+    // img2img, Ideogram edit + mask), resolved once — same predicate order + per-family values as the
+    // historical inline 5-way match, now table-ized into one resolver (sc-8828, F-026). The strict-pose
+    // ControlNet / edit tiers divert earlier in `resolve_image_route`.
+    let LaneConditioning {
+        identity_init,
+        flux_ip_dir,
+        flux_true_cfg,
+        ideogram_edit_mask,
+    } = resolve_generic_lane_conditioning(request, settings, project_path, has_reference)?;
     // Boogu instruction edit (epic 6387, multi-reference sc-7645): resolve the 1..5 source references
     // (the Qwen3-VL vision tower reads each + they VAE-encode into the DiT spatial sequence); the prompt
     // is the edit instruction. Threaded to `generate_one` as `Conditioning::Reference` (one reference) /

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -4421,6 +4421,72 @@ fn image_route_count_follows_dispatch_order() {
     assert_eq!(route.image_count(&zimage_base_t2i, &settings), 4);
 }
 
+// sc-8828 (F-026): `resolve_candle_image_route` is the extracted candle dispatch decision — the
+// `else if settings.backend_candle_enabled && <predicate>` ladder pulled out of `run_image_generate_job`
+// into a table (the candle sibling of `resolve_image_route`/`ImageRoute`). Locks the flag gate + the
+// no-pose-lane reject + the plain txt2img arm (the branches that route on model id, not staged weights).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn candle_image_route_gates_on_flag_then_pose_reject_then_txt2img() {
+    let mut settings = Settings::from_env();
+
+    // Candle disabled (default) → None (the job stubs), regardless of model.
+    settings.backend_candle_enabled = false;
+    let sdxl_t2i = request(json!({ "projectId": "p", "model": "sdxl", "count": 1 }));
+    assert_eq!(resolve_candle_image_route(&sdxl_t2i, &settings), None);
+
+    settings.backend_candle_enabled = true;
+    // Plain sdxl t2i (no reference / no poses / no edit) → the generic candle txt2img lane.
+    assert_eq!(
+        resolve_candle_image_route(&sdxl_t2i, &settings),
+        Some(CandleImageRoute::CandleTxt2Img),
+    );
+
+    // A strict-pose job on sdxl (a candle engine with NO pose lane) → the loud reject, never silent T2I.
+    let sdxl_pose = request(json!({
+        "projectId": "p", "model": "sdxl", "count": 1,
+        "advanced": { "poses": [{ "id": "a" }] }
+    }));
+    assert_eq!(
+        resolve_candle_image_route(&sdxl_pose, &settings),
+        Some(CandleImageRoute::PoseReject),
+    );
+
+    // A non-candle model → None (stubs / MLX-only elsewhere).
+    let unknown = request(json!({ "projectId": "p", "model": "not_a_candle_engine", "count": 1 }));
+    assert_eq!(resolve_candle_image_route(&unknown, &settings), None);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn generic_lane_conditioning_defaults_when_no_reference() {
+    // The generic MLX lane's per-family conditioning resolver (sc-8828, F-026): a plain t2i job (no
+    // reference, no edit source) resolves to the all-`None` default for every family that reaches the
+    // generic lane — the Z-Image arm (via `resolve_zimage_identity_init` returning `None`), the Kolors
+    // arm, and the final Boogu/plain fall-through. No disk access; just proves the dispatch order picks
+    // the right arm and each yields the empty conditioning when its reference precondition is absent.
+    let dir = tempfile::tempdir().unwrap();
+    let mut settings = Settings::from_env();
+    settings.data_dir = dir.path().to_path_buf();
+    let project_path = dir.path();
+
+    for model in ["z_image_turbo", "kolors", "sdxl", "flux_dev"] {
+        let req = request(json!({
+            "projectId": "p", "model": model, "count": 1,
+        }));
+        // `has_reference == false` — the reference/IP-Adapter arms are all gated on it (or on an
+        // edit source), so every model falls through to the empty default.
+        let cond = resolve_generic_lane_conditioning(&req, &settings, project_path, false).unwrap();
+        assert!(
+            cond.identity_init.is_none()
+                && cond.flux_ip_dir.is_none()
+                && cond.flux_true_cfg.is_none()
+                && cond.ideogram_edit_mask.is_none(),
+            "plain t2i for '{model}' must resolve to the empty generic-lane conditioning"
+        );
+    }
+}
+
 #[cfg(target_os = "macos")]
 #[test]
 fn should_fit_edit_source_only_for_off_aspect_edit_image() {

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -147,6 +147,136 @@ struct AudioTrack {
     channels: u16,
 }
 
+/// The native (MLX) video engine a `run_video_generate_job` request routes to — the routing DECISION,
+/// separated from execution (sc-8828, F-026; mirrors the image lane's `ImageRoute`). `resolve_video_route`
+/// runs the predicate ladder ONCE and returns this; the caller `match`es to run the (non-uniformly-typed)
+/// generators. Preserves the historical predicate order + per-family engine exactly, so routing is
+/// byte-identical. `replace_person` (mode-gated, resolve-or-error) is three distinct variants — SCAIL-2,
+/// dual-expert Wan2.2 VACE-Fun, single-expert Wan-VACE — because each drives a different backend/checkpoint.
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum VideoRoute {
+    /// `replace_person` on a `scail2_*` model → SCAIL-2 cross-identity replacement (sc-5452). Carries the
+    /// resolved engine id.
+    ReplacePersonScail2(&'static str),
+    /// `replace_person` on `wan_2_2_vace_fun_14b` → the dual-expert Wan2.2 VACE-Fun engine (sc-3459).
+    ReplacePersonWanVaceFun,
+    /// `replace_person` on any other replace-capable model → single-expert Wan-VACE (sc-3521).
+    ReplacePersonWanVace,
+    /// `extend_clip` / `video_bridge` on `wan_2_2_ti2v_5b` (weights available) → native Wan-VACE
+    /// extend/bridge, falling back to the TI2V-5B keyframe path if the VACE snapshot is unprovisioned
+    /// (sc-3812). The fallback is an execution-time detail handled in the dispatch arm.
+    WanVaceExtendBridge,
+    /// Wan txt2video / i2v on a resolvable Wan model (sc-3034). Carries the resolved engine id.
+    Wan(&'static str),
+    /// LTX+audio (sc-3035). Carries the resolved engine id.
+    Ltx(&'static str),
+    /// Stable Video Diffusion. Carries the resolved engine id.
+    Svd(&'static str),
+    /// Bernini (epic 4699): Qwen2.5-VL planner + Wan2.2-T2V-A14B renderer. Carries the resolved engine id.
+    Bernini(&'static str),
+    /// SCAIL-2 standalone character animation (epic 5439). Carries the resolved engine id.
+    Scail2(&'static str),
+    /// No native engine matched (or weights unresolved) → the procedural stub, after
+    /// `ensure_video_engine_weights` fails a known-but-unprovisioned engine loudly (sc-4176).
+    Stub,
+}
+
+/// Run the native video dispatch predicate ladder ONCE and return the [`VideoRoute`]. Mirrors the
+/// historical inline ladder EXACTLY — same predicate order, same per-family engine — so routing is
+/// byte-identical (sc-8828). Pure decision: no I/O, no generation. `replace_person` is dispatched by
+/// mode first (resolve-or-error semantics live in the execution arms), then the engine-id/availability
+/// ladder for every other mode.
+#[cfg(target_os = "macos")]
+fn resolve_video_route(request: &VideoRequest, settings: &Settings) -> VideoRoute {
+    if request.mode == "replace_person" {
+        if let Some(engine_id) = scail2_engine_id(&request.model) {
+            VideoRoute::ReplacePersonScail2(engine_id)
+        } else if request.model == "wan_2_2_vace_fun_14b" {
+            VideoRoute::ReplacePersonWanVaceFun
+        } else {
+            VideoRoute::ReplacePersonWanVace
+        }
+    } else if matches!(request.mode.as_str(), "extend_clip" | "video_bridge")
+        && wan_engine_id(&request.model) == Some("wan2_2_ti2v_5b")
+        && wan_available(request, settings)
+    {
+        VideoRoute::WanVaceExtendBridge
+    } else if let Some(engine_id) =
+        wan_engine_id(&request.model).filter(|_| wan_available(request, settings))
+    {
+        VideoRoute::Wan(engine_id)
+    } else if let Some(engine_id) =
+        ltx_engine_id(&request.model).filter(|_| ltx_available(request, settings))
+    {
+        VideoRoute::Ltx(engine_id)
+    } else if let Some(engine_id) =
+        svd_engine_id(&request.model).filter(|_| svd_available(request, settings))
+    {
+        VideoRoute::Svd(engine_id)
+    } else if let Some(engine_id) =
+        bernini_engine_id(&request.model).filter(|_| bernini_available(request, settings))
+    {
+        VideoRoute::Bernini(engine_id)
+    } else if let Some(engine_id) =
+        scail2_engine_id(&request.model).filter(|_| scail2_available(request, settings))
+    {
+        VideoRoute::Scail2(engine_id)
+    } else {
+        VideoRoute::Stub
+    }
+}
+
+/// The candle (Windows/CUDA/Linux) video engine a `run_video_generate_job` request routes to — the
+/// candle-lane sibling of [`VideoRoute`] (sc-8828, F-026). Every arm is gated on
+/// `settings.backend_candle_enabled`; when that is off (default) the resolver returns
+/// [`CandleVideoRoute::Stub`] so routing is unchanged until parity is accepted. Conditioning shapes
+/// never reach the candle lane — the router's `video_job_is_candle_eligible` confines it — so this is
+/// a narrow replace/animate/extend/txt2video ladder.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CandleVideoRoute {
+    /// `replace_person` on a `scail2_*` model → candle SCAIL-2 replacement (sc-6837). Carries the id.
+    ReplacePersonScail2(&'static str),
+    /// `replace_person` on any other candle-VACE model → candle Wan-VACE replacement (sc-5494).
+    ReplacePersonWanVace,
+    /// `animate_character` on a `scail2_*` model → candle SCAIL-2 animation (sc-6837). Carries the id.
+    AnimateScail2(&'static str),
+    /// `extend_clip` / `video_bridge` → candle Wan-VACE extend/bridge (sc-5494).
+    WanVaceExtendBridge,
+    /// A candle txt2video engine id → `generate_candle_video` (sc-5097).
+    CandleVideo,
+    /// Candle disabled, or no candle engine matched → the procedural stub.
+    Stub,
+}
+
+/// Run the candle video dispatch predicate ladder ONCE and return the [`CandleVideoRoute`]. Mirrors the
+/// historical inline ladder EXACTLY — same predicate order + `backend_candle_enabled` gating — so
+/// routing is byte-identical (sc-8828). Pure decision: no I/O, no generation.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn resolve_candle_video_route(request: &VideoRequest, settings: &Settings) -> CandleVideoRoute {
+    if !settings.backend_candle_enabled {
+        return CandleVideoRoute::Stub;
+    }
+    if request.mode == "replace_person" {
+        match candle_scail2_engine_id(&request.model) {
+            Some(engine_id) => CandleVideoRoute::ReplacePersonScail2(engine_id),
+            None => CandleVideoRoute::ReplacePersonWanVace,
+        }
+    } else if request.mode == "animate_character"
+        && candle_scail2_engine_id(&request.model).is_some()
+    {
+        let engine_id = candle_scail2_engine_id(&request.model).expect("scail2 model");
+        CandleVideoRoute::AnimateScail2(engine_id)
+    } else if matches!(request.mode.as_str(), "extend_clip" | "video_bridge") {
+        CandleVideoRoute::WanVaceExtendBridge
+    } else if is_candle_video_engine(&request.model) {
+        CandleVideoRoute::CandleVideo
+    } else {
+        CandleVideoRoute::Stub
+    }
+}
+
 /// Dispatch handler for `JobType::VideoGenerate`: generate, encode, and stream a
 /// single video asset through the Rust GPU worker.
 pub(crate) async fn run_video_generate_job(
@@ -225,85 +355,155 @@ pub(crate) async fn run_video_generate_job(
     // procedural stub (a stubbed person-replace would be meaningless). It also reports the honest
     // `replacementStatus` the asset sidecar folds in (project_store::build_video_sidecar_parts).
     #[cfg(target_os = "macos")]
-    let (decoded, adapter, raw_settings, replacement_status) = if request.mode == "replace_person" {
-        // sc-5452: SCAIL-2 is a higher-quality cross-identity replacement backend behind the same
-        // YOLO11 → ByteTrack → SAM3 person-track pipeline. A `scail2_14b` person-replace job routes
-        // to SCAIL-2 (the tracked person's masks + the character reference → the engine's
-        // replacement conditioning, `replace_flag = true`); every other replace-capable model keeps
-        // native Wan-VACE (sc-3521). Routed by model id, not weight availability: like the Wan-VACE
-        // path, `generate_scail2_replace` resolves-or-errors loudly if the snapshot is unprovisioned
-        // (a person-replace must never silently degrade to a different backend or the stub). Both
-        // report the honest `replacementStatus` the asset sidecar folds in.
-        if let Some(engine_id) = scail2_engine_id(&request.model) {
-            let (decoded, status) = generate_scail2_replace(
-                api,
-                settings,
-                job,
-                &request,
-                &project_path,
-                engine_id,
-                backend,
-            )
-            .await?;
-            (
-                // The replace_person path doesn't resolve user LoRAs (sc-5452), so no lightning recipe.
-                decoded,
-                SCAIL2_ADAPTER,
-                scail2_raw_settings(&request, false),
-                Some(status),
-            )
-        } else if request.model == "wan_2_2_vace_fun_14b" {
-            // sc-3459: the native dual-expert Wan2.2 VACE-Fun engine (`wan2_2_vace_fun_14b`,
-            // mlx-gen sc-6604). Same replace_person conditioning as single-expert Wan-VACE, but the
-            // dual-expert snapshot + engine — `generate_wan_vace_fun` resolves-or-errors loudly,
-            // never falling back to the Wan2.1 `wan_vace` checkpoint.
-            let (decoded, status) =
-                generate_wan_vace_fun(api, settings, job, &request, &project_path, backend).await?;
-            (
-                decoded,
-                WAN_VACE_FUN_ADAPTER,
-                wan_vace_raw_settings(&request, "wan2_2_vace_fun_14b"),
-                Some(status),
-            )
-        } else {
-            let (decoded, status) =
-                generate_wan_vace(api, settings, job, &request, &project_path, backend).await?;
-            (
-                decoded,
-                WAN_VACE_ADAPTER,
-                wan_vace_raw_settings(&request, "wan_vace"),
-                Some(status),
-            )
-        }
-    } else if matches!(request.mode.as_str(), "extend_clip" | "video_bridge")
-        && wan_engine_id(&request.model) == Some("wan2_2_ti2v_5b")
-        && wan_available(&request, settings)
-    {
-        // sc-3812 (tier C): route Wan extend/bridge to native Wan-VACE for genuine motion
-        // continuity (the model attends to real source frames, not one boundary still). Falls
-        // back to the sc-3357 single-frame TI2V-5B keyframe path when the VACE snapshot is
-        // unprovisioned, so the mode keeps working on the weights the user already has. The
-        // engine substitution under the `wan_2_2` pick is recorded honestly in raw-settings.
-        match resolve_wan_vace_model_dir(settings) {
-            Ok(model_dir) => (
-                generate_wan_vace_extend_bridge(
+    let (decoded, adapter, raw_settings, replacement_status) =
+        match resolve_video_route(&request, settings) {
+            // sc-5452: SCAIL-2 is a higher-quality cross-identity replacement backend behind the same
+            // YOLO11 → ByteTrack → SAM3 person-track pipeline. A `scail2_14b` person-replace job routes
+            // to SCAIL-2 (the tracked person's masks + the character reference → the engine's
+            // replacement conditioning, `replace_flag = true`); every other replace-capable model keeps
+            // native Wan-VACE (sc-3521). Routed by model id, not weight availability: like the Wan-VACE
+            // path, `generate_scail2_replace` resolves-or-errors loudly if the snapshot is unprovisioned
+            // (a person-replace must never silently degrade to a different backend or the stub). Both
+            // report the honest `replacementStatus` the asset sidecar folds in.
+            VideoRoute::ReplacePersonScail2(engine_id) => {
+                let (decoded, status) = generate_scail2_replace(
                     api,
                     settings,
                     job,
                     &request,
                     &project_path,
+                    engine_id,
                     backend,
-                    model_dir,
+                )
+                .await?;
+                (
+                    // The replace_person path doesn't resolve user LoRAs (sc-5452), so no lightning recipe.
+                    decoded,
+                    SCAIL2_ADAPTER,
+                    scail2_raw_settings(&request, false),
+                    Some(status),
+                )
+            }
+            VideoRoute::ReplacePersonWanVaceFun => {
+                // sc-3459: the native dual-expert Wan2.2 VACE-Fun engine (`wan2_2_vace_fun_14b`,
+                // mlx-gen sc-6604). Same replace_person conditioning as single-expert Wan-VACE, but the
+                // dual-expert snapshot + engine — `generate_wan_vace_fun` resolves-or-errors loudly,
+                // never falling back to the Wan2.1 `wan_vace` checkpoint.
+                let (decoded, status) =
+                    generate_wan_vace_fun(api, settings, job, &request, &project_path, backend)
+                        .await?;
+                (
+                    decoded,
+                    WAN_VACE_FUN_ADAPTER,
+                    wan_vace_raw_settings(&request, "wan2_2_vace_fun_14b"),
+                    Some(status),
+                )
+            }
+            VideoRoute::ReplacePersonWanVace => {
+                let (decoded, status) =
+                    generate_wan_vace(api, settings, job, &request, &project_path, backend).await?;
+                (
+                    decoded,
+                    WAN_VACE_ADAPTER,
+                    wan_vace_raw_settings(&request, "wan_vace"),
+                    Some(status),
+                )
+            }
+            VideoRoute::WanVaceExtendBridge => {
+                // sc-3812 (tier C): route Wan extend/bridge to native Wan-VACE for genuine motion
+                // continuity (the model attends to real source frames, not one boundary still). Falls
+                // back to the sc-3357 single-frame TI2V-5B keyframe path when the VACE snapshot is
+                // unprovisioned, so the mode keeps working on the weights the user already has. The
+                // engine substitution under the `wan_2_2` pick is recorded honestly in raw-settings.
+                match resolve_wan_vace_model_dir(settings) {
+                    Ok(model_dir) => (
+                        generate_wan_vace_extend_bridge(
+                            api,
+                            settings,
+                            job,
+                            &request,
+                            &project_path,
+                            backend,
+                            model_dir,
+                        )
+                        .await?,
+                        WAN_VACE_ADAPTER,
+                        wan_vace_extend_raw_settings(&request),
+                        None,
+                    ),
+                    Err(_) => {
+                        let engine_id = "wan2_2_ti2v_5b";
+                        (
+                            generate_wan(
+                                api,
+                                settings,
+                                job,
+                                &request,
+                                &project_path,
+                                engine_id,
+                                backend,
+                            )
+                            .await?,
+                            WAN_ADAPTER,
+                            wan_raw_settings(&request, engine_id),
+                            None,
+                        )
+                    }
+                }
+            }
+            VideoRoute::Wan(engine_id) => (
+                generate_wan(
+                    api,
+                    settings,
+                    job,
+                    &request,
+                    &project_path,
+                    engine_id,
+                    backend,
                 )
                 .await?,
-                WAN_VACE_ADAPTER,
-                wan_vace_extend_raw_settings(&request),
+                WAN_ADAPTER,
+                wan_raw_settings(&request, engine_id),
                 None,
             ),
-            Err(_) => {
-                let engine_id = "wan2_2_ti2v_5b";
+            VideoRoute::Ltx(engine_id) => (
+                generate_ltx(
+                    api,
+                    settings,
+                    job,
+                    &request,
+                    &project_path,
+                    engine_id,
+                    backend,
+                )
+                .await?,
+                LTX_ADAPTER,
+                ltx_raw_settings(&request),
+                None,
+            ),
+            VideoRoute::Svd(engine_id) => (
+                generate_svd(
+                    api,
+                    settings,
+                    job,
+                    &request,
+                    &project_path,
+                    engine_id,
+                    backend,
+                )
+                .await?,
+                SVD_ADAPTER,
+                svd_raw_settings(&request),
+                None,
+            ),
+            VideoRoute::Bernini(engine_id) => {
+                // Bernini (epic 4699 / sc-4707 + sc-4703): the full Qwen2.5-VL planner + Wan2.2-T2V-A14B
+                // renderer. Serves text_to_video + the editing/reference video modes (video_to_video /
+                // reference_to_video / reference_video_to_video); `generate_bernini` maps the SceneWorks mode
+                // to the engine guidance task and resolves the source media into the planner conditioning.
+                // (t2i/i2i image companion = a separate image-typed catalog id, tracked under epic 4699.)
                 (
-                    generate_wan(
+                    generate_bernini(
                         api,
                         settings,
                         job,
@@ -313,133 +513,55 @@ pub(crate) async fn run_video_generate_job(
                         backend,
                     )
                     .await?,
-                    WAN_ADAPTER,
-                    wan_raw_settings(&request, engine_id),
+                    BERNINI_ADAPTER,
+                    bernini_raw_settings(&request),
                     None,
                 )
             }
-        }
-    } else if let Some(engine_id) =
-        wan_engine_id(&request.model).filter(|_| wan_available(&request, settings))
-    {
-        (
-            generate_wan(
-                api,
-                settings,
-                job,
-                &request,
-                &project_path,
-                engine_id,
-                backend,
-            )
-            .await?,
-            WAN_ADAPTER,
-            wan_raw_settings(&request, engine_id),
-            None,
-        )
-    } else if let Some(engine_id) =
-        ltx_engine_id(&request.model).filter(|_| ltx_available(&request, settings))
-    {
-        (
-            generate_ltx(
-                api,
-                settings,
-                job,
-                &request,
-                &project_path,
-                engine_id,
-                backend,
-            )
-            .await?,
-            LTX_ADAPTER,
-            ltx_raw_settings(&request),
-            None,
-        )
-    } else if let Some(engine_id) =
-        svd_engine_id(&request.model).filter(|_| svd_available(&request, settings))
-    {
-        (
-            generate_svd(
-                api,
-                settings,
-                job,
-                &request,
-                &project_path,
-                engine_id,
-                backend,
-            )
-            .await?,
-            SVD_ADAPTER,
-            svd_raw_settings(&request),
-            None,
-        )
-    } else if let Some(engine_id) =
-        bernini_engine_id(&request.model).filter(|_| bernini_available(&request, settings))
-    {
-        // Bernini (epic 4699 / sc-4707 + sc-4703): the full Qwen2.5-VL planner + Wan2.2-T2V-A14B
-        // renderer. Serves text_to_video + the editing/reference video modes (video_to_video /
-        // reference_to_video / reference_video_to_video); `generate_bernini` maps the SceneWorks mode
-        // to the engine guidance task and resolves the source media into the planner conditioning.
-        // (t2i/i2i image companion = a separate image-typed catalog id, tracked under epic 4699.)
-        (
-            generate_bernini(
-                api,
-                settings,
-                job,
-                &request,
-                &project_path,
-                engine_id,
-                backend,
-            )
-            .await?,
-            BERNINI_ADAPTER,
-            bernini_raw_settings(&request),
-            None,
-        )
-    } else if let Some(engine_id) =
-        scail2_engine_id(&request.model).filter(|_| scail2_available(&request, settings))
-    {
-        // SCAIL-2 (epic 5439 / sc-5448): Wan2.1-14B I2V character animation. `generate_scail2`
-        // segments the reference image + driving frames with native SAM3, paints the color-coded
-        // masks, and maps the SceneWorks mode to the engine task (animate_character → animation;
-        // replace_person → replacement is wired in sc-5452). No torch path (mac-only engine).
-        (
-            generate_scail2(
-                api,
-                settings,
-                job,
-                &request,
-                &project_path,
-                engine_id,
-                backend,
-            )
-            .await?,
-            SCAIL2_ADAPTER,
-            // Best-effort lightning detection for the asset's effective-recipe record (the adapter
-            // file is already resolved by generate_scail2 above; re-reading its header is cheap).
-            scail2_raw_settings(
-                &request,
-                scail2_adapters_have_lightning(
-                    &resolve_scail2_adapters(settings, &request).unwrap_or_default(),
-                ),
-            ),
-            None,
-        )
-    } else {
-        // An MLX-routed video model whose snapshot didn't resolve must fail
-        // loudly with the resolver's precise error instead of completing with
-        // procedural stub output (sc-4176, epic 3482 "unsupported jobs error
-        // loudly"). replace_person above already follows this rule; the stub
-        // remains only for ids outside the engine families (test models,
-        // not-yet-ported families).
-        ensure_video_engine_weights(&request, settings)?;
-        (
-            generate_stub_video(&request, seed),
-            STUB_ADAPTER,
-            stub_raw_settings(&request),
-            None,
-        )
-    };
+            VideoRoute::Scail2(engine_id) => {
+                // SCAIL-2 (epic 5439 / sc-5448): Wan2.1-14B I2V character animation. `generate_scail2`
+                // segments the reference image + driving frames with native SAM3, paints the color-coded
+                // masks, and maps the SceneWorks mode to the engine task (animate_character → animation;
+                // replace_person → replacement is wired in sc-5452). No torch path (mac-only engine).
+                (
+                    generate_scail2(
+                        api,
+                        settings,
+                        job,
+                        &request,
+                        &project_path,
+                        engine_id,
+                        backend,
+                    )
+                    .await?,
+                    SCAIL2_ADAPTER,
+                    // Best-effort lightning detection for the asset's effective-recipe record (the adapter
+                    // file is already resolved by generate_scail2 above; re-reading its header is cheap).
+                    scail2_raw_settings(
+                        &request,
+                        scail2_adapters_have_lightning(
+                            &resolve_scail2_adapters(settings, &request).unwrap_or_default(),
+                        ),
+                    ),
+                    None,
+                )
+            }
+            VideoRoute::Stub => {
+                // An MLX-routed video model whose snapshot didn't resolve must fail
+                // loudly with the resolver's precise error instead of completing with
+                // procedural stub output (sc-4176, epic 3482 "unsupported jobs error
+                // loudly"). replace_person above already follows this rule; the stub
+                // remains only for ids outside the engine families (test models,
+                // not-yet-ported families).
+                ensure_video_engine_weights(&request, settings)?;
+                (
+                    generate_stub_video(&request, seed),
+                    STUB_ADAPTER,
+                    stub_raw_settings(&request),
+                    None,
+                )
+            }
+        };
     // Windows/CUDA candle video lane (sc-5097): a real wan/ltx txt2video job runs through
     // `generate_candle_video` (the same neutral encode/mux path as MLX + the stub); anything the
     // candle lane doesn't serve stubs exactly as before. Gated on `backend_candle_enabled` (default
@@ -447,14 +569,14 @@ pub(crate) async fn run_video_generate_job(
     // `video_job_is_candle_eligible` confines the candle worker to txt2video.
     #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
     let (decoded, adapter, raw_settings, replacement_status) =
-        if settings.backend_candle_enabled && request.mode == "replace_person" {
+        match resolve_candle_video_route(&request, settings) {
             // sc-6837 (epic 6563): SCAIL-2 is a distinct cross-identity replacement backend (NOT Wan-VACE)
             // behind the same person-track pipeline. A `scail2_14b` replace_person job routes to the candle
             // SCAIL-2 engine (the character reference + the tracked person's color masks, `replace_flag`),
             // mirroring the macOS `generate_scail2_replace` dispatch; every other replace-capable model
             // keeps candle Wan-VACE. Routed by model id, not weight availability — `generate_candle_scail2_
             // replace` resolves-or-errors loudly (a person-replace must never silently degrade to a stub).
-            if let Some(engine_id) = candle_scail2_engine_id(&request.model) {
+            CandleVideoRoute::ReplacePersonScail2(engine_id) => {
                 let (decoded, status) = generate_candle_scail2_replace(
                     api,
                     settings,
@@ -472,7 +594,8 @@ pub(crate) async fn run_video_generate_job(
                     candle_scail2_raw_settings(&request, false),
                     Some(status),
                 )
-            } else {
+            }
+            CandleVideoRoute::ReplacePersonWanVace => {
                 // Candle Wan-VACE person replacement (sc-5494) — the candle equivalent of the MLX
                 // `wan_vace` path. The router (`video_request_candle_vace_eligible`) already confirmed the
                 // candle-VACE model + the source clip + person track before this job reached the candle
@@ -488,58 +611,55 @@ pub(crate) async fn run_video_generate_job(
                     Some(status),
                 )
             }
-        } else if settings.backend_candle_enabled
-            && request.mode == "animate_character"
-            && candle_scail2_engine_id(&request.model).is_some()
-        {
-            // sc-6837: SCAIL-2 standalone character animation — a reference character + a driving video →
-            // an animated clip. `generate_candle_scail2` segments the reference + driving frames with the
-            // candle SAM3 segmenter, paints the color-coded masks, and runs the `scail2_14b` engine
-            // (`animate_character` → engine task `animation`). The candle sibling of the macOS
-            // `generate_scail2`; resolves-or-errors loudly (no torch fallback — a distinct candle engine).
-            let engine_id = candle_scail2_engine_id(&request.model).expect("scail2 model");
-            let (decoded, adapter, raw_settings) = generate_candle_scail2(
-                api,
-                settings,
-                job,
-                &request,
-                &project_path,
-                engine_id,
-                backend,
-            )
-            .await?;
-            (decoded, adapter, raw_settings, None::<Value>)
-        } else if settings.backend_candle_enabled
-            && matches!(request.mode.as_str(), "extend_clip" | "video_bridge")
-        {
-            // Candle Wan-VACE extend/bridge (sc-5494): real source frames pinned at the kept positions +
-            // a generated span (the candle equivalent of the MLX `generate_wan_vace_extend_bridge`).
-            let decoded = generate_candle_wan_vace_extend_bridge(
-                api,
-                settings,
-                job,
-                &request,
-                &project_path,
-                backend,
-            )
-            .await?;
-            (
-                decoded,
-                CANDLE_WAN_VACE_ADAPTER,
-                wan_vace_extend_raw_settings(&request),
-                None::<Value>,
-            )
-        } else if settings.backend_candle_enabled && is_candle_video_engine(&request.model) {
-            let (decoded, adapter, raw_settings) =
-                generate_candle_video(api, settings, job, &request, &project_path, backend).await?;
-            (decoded, adapter, raw_settings, None::<Value>)
-        } else {
-            (
+            CandleVideoRoute::AnimateScail2(engine_id) => {
+                // sc-6837: SCAIL-2 standalone character animation — a reference character + a driving video →
+                // an animated clip. `generate_candle_scail2` segments the reference + driving frames with the
+                // candle SAM3 segmenter, paints the color-coded masks, and runs the `scail2_14b` engine
+                // (`animate_character` → engine task `animation`). The candle sibling of the macOS
+                // `generate_scail2`; resolves-or-errors loudly (no torch fallback — a distinct candle engine).
+                let (decoded, adapter, raw_settings) = generate_candle_scail2(
+                    api,
+                    settings,
+                    job,
+                    &request,
+                    &project_path,
+                    engine_id,
+                    backend,
+                )
+                .await?;
+                (decoded, adapter, raw_settings, None::<Value>)
+            }
+            CandleVideoRoute::WanVaceExtendBridge => {
+                // Candle Wan-VACE extend/bridge (sc-5494): real source frames pinned at the kept positions +
+                // a generated span (the candle equivalent of the MLX `generate_wan_vace_extend_bridge`).
+                let decoded = generate_candle_wan_vace_extend_bridge(
+                    api,
+                    settings,
+                    job,
+                    &request,
+                    &project_path,
+                    backend,
+                )
+                .await?;
+                (
+                    decoded,
+                    CANDLE_WAN_VACE_ADAPTER,
+                    wan_vace_extend_raw_settings(&request),
+                    None::<Value>,
+                )
+            }
+            CandleVideoRoute::CandleVideo => {
+                let (decoded, adapter, raw_settings) =
+                    generate_candle_video(api, settings, job, &request, &project_path, backend)
+                        .await?;
+                (decoded, adapter, raw_settings, None::<Value>)
+            }
+            CandleVideoRoute::Stub => (
                 generate_stub_video(&request, seed),
                 STUB_ADAPTER,
                 stub_raw_settings(&request),
                 None::<Value>,
-            )
+            ),
         };
     #[cfg(not(any(
         target_os = "macos",
@@ -2796,35 +2916,35 @@ async fn generate_video(
                     if canceled {
                         continue; // drain so the blocking sender never blocks.
                     }
-            if last_cancel.elapsed() >= Duration::from_secs(2) {
-                last_cancel = Instant::now();
-                if cancel_requested_peek(api, &job.id).await {
-                    begin_video_cancel(api, &job.id, &cancel, backend).await;
-                    canceled = true;
-                    continue;
-                }
-                heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
-            }
-            let (fraction, message) = match progress {
-                Progress::Step { current, total } => (
-                    0.25 + 0.30 * (current as f64 / total.max(1) as f64),
-                    format!("Generating frames — step {current}/{total}."),
-                ),
-                Progress::Decoding => (0.58, "Decoding frames.".to_owned()),
-            };
-            update_job(
-                api,
-                &job.id,
-                video_progress(
-                    JobStatus::Running,
-                    ProgressStage::Generating,
-                    fraction,
-                    &message,
-                    None,
-                    backend,
-                ),
-            )
-            .await?;
+                    if last_cancel.elapsed() >= Duration::from_secs(2) {
+                        last_cancel = Instant::now();
+                        if cancel_requested_peek(api, &job.id).await {
+                            begin_video_cancel(api, &job.id, &cancel, backend).await;
+                            canceled = true;
+                            continue;
+                        }
+                        heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+                    }
+                    let (fraction, message) = match progress {
+                        Progress::Step { current, total } => (
+                            0.25 + 0.30 * (current as f64 / total.max(1) as f64),
+                            format!("Generating frames — step {current}/{total}."),
+                        ),
+                        Progress::Decoding => (0.58, "Decoding frames.".to_owned()),
+                    };
+                    update_job(
+                        api,
+                        &job.id,
+                        video_progress(
+                            JobStatus::Running,
+                            ProgressStage::Generating,
+                            fraction,
+                            &message,
+                            None,
+                            backend,
+                        ),
+                    )
+                    .await?;
                 }
                 _ = interval.tick() => {
                     heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
@@ -6877,6 +6997,85 @@ mod tests {
 
     fn request(value: Value) -> VideoRequest {
         VideoRequest::from_payload(&value.as_object().cloned().unwrap())
+    }
+
+    // sc-8828 (F-026): `resolve_video_route` is the extracted native (MLX) dispatch decision — the
+    // predicate ladder pulled out of `run_video_generate_job`'s 4-tuple match. These lock the branches
+    // whose routing depends only on the mode + model id (not on staged weights), so a future family edit
+    // that reorders the ladder or mis-routes `replace_person` fails loudly here.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn video_route_replace_person_dispatches_by_model() {
+        let settings = Settings::from_env();
+
+        // `replace_person` on the SCAIL-2 model → the SCAIL-2 replacement backend (sc-5452), carrying
+        // the resolved engine id — NOT Wan-VACE.
+        let scail2 = request(json!({
+            "projectId": "p", "model": "scail2_14b", "mode": "replace_person",
+        }));
+        assert_eq!(
+            resolve_video_route(&scail2, &settings),
+            VideoRoute::ReplacePersonScail2("scail2_14b"),
+        );
+
+        // `replace_person` on the dual-expert Wan2.2 VACE-Fun model → its own variant (sc-3459), never
+        // the single-expert Wan-VACE checkpoint.
+        let vace_fun = request(json!({
+            "projectId": "p", "model": "wan_2_2_vace_fun_14b", "mode": "replace_person",
+        }));
+        assert_eq!(
+            resolve_video_route(&vace_fun, &settings),
+            VideoRoute::ReplacePersonWanVaceFun,
+        );
+
+        // `replace_person` on any other replace-capable model → single-expert Wan-VACE (sc-3521).
+        let other = request(json!({
+            "projectId": "p", "model": "wan_2_2_ti2v_5b", "mode": "replace_person",
+        }));
+        assert_eq!(
+            resolve_video_route(&other, &settings),
+            VideoRoute::ReplacePersonWanVace,
+        );
+
+        // An unknown model with no engine + no resolvable weights → the stub (the loud-fail path lives in
+        // the execution arm via `ensure_video_engine_weights`).
+        let unknown = request(json!({
+            "projectId": "p", "model": "definitely_not_a_video_engine", "mode": "text_to_video",
+        }));
+        assert_eq!(resolve_video_route(&unknown, &settings), VideoRoute::Stub);
+    }
+
+    // sc-8828 (F-026): the candle sibling — `resolve_candle_video_route`. Locks the `backend_candle_enabled`
+    // gate (off → Stub, so routing is unchanged until parity) + the mode/model dispatch.
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    #[test]
+    fn candle_video_route_gates_on_backend_flag_then_mode() {
+        let mut settings = Settings::from_env();
+
+        // Candle disabled (default) → always the stub, regardless of model/mode.
+        settings.backend_candle_enabled = false;
+        let scail2_replace = request(json!({
+            "projectId": "p", "model": "scail2_14b", "mode": "replace_person",
+        }));
+        assert_eq!(
+            resolve_candle_video_route(&scail2_replace, &settings),
+            CandleVideoRoute::Stub,
+        );
+
+        // Enabled: `replace_person` on the candle SCAIL-2 model → the SCAIL-2 replacement variant;
+        // any other replace-capable model → candle Wan-VACE.
+        settings.backend_candle_enabled = true;
+        assert_eq!(
+            resolve_candle_video_route(&scail2_replace, &settings),
+            CandleVideoRoute::ReplacePersonScail2(candle_scail2_engine_id("scail2_14b").unwrap()),
+        );
+        let extend = request(json!({
+            "projectId": "p", "model": "wan_2_2_ti2v_5b", "mode": "extend_clip",
+        }));
+        assert_eq!(
+            resolve_candle_video_route(&extend, &settings),
+            CandleVideoRoute::WanVaceExtendBridge,
+        );
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
## sc-8828 — [F-026] dispatch god functions in `run_video_generate_job` / `run_image_generate_job` / `generate_stream`

Behavior-preserving readability refactor. The generate-job dispatch functions mixed validation, `cfg`-gated multi-arm engine-dispatch ladders (the macOS video ladder alone was ~215 lines of 4-tuple returns), and result assembly, with per-family conditioning inlined into a 5-armed `match`. Table-ized per the finding's suggested fix (predicate → route enum, **mirroring the pre-existing macOS `ImageRoute`**) + extracted the generic-lane conditioning resolver.

### Before → after structure

| Function | Before | After |
|---|---|---|
| `run_video_generate_job` (macOS) | ~215-line `if request.mode == "replace_person" { … } else if … else { stub }` producing a 4-tuple | `match resolve_video_route(&request, settings)` over a new `VideoRoute` enum |
| `run_video_generate_job` (candle) | 5-arm `else if settings.backend_candle_enabled && …` chain | `match resolve_candle_video_route(&request, settings)` over `CandleVideoRoute` |
| `run_image_generate_job` (candle) | 14-arm `else if settings.backend_candle_enabled && <predicate>(…)` ladder + reject arm + txt2img arm | `match resolve_candle_image_route(&request, settings)` over `CandleImageRoute` (candle sibling of `ImageRoute`) |
| `generate_stream` (base.rs) | inline 5-way `match` producing `(identity_init, flux_ip_dir, flux_true_cfg)` + a mutable `ideogram_edit_mask` | `resolve_generic_lane_conditioning(..) -> LaneConditioning` (one resolver call) |

The macOS `run_image_generate_job` lane was **already** table-ized via `ImageRoute`/`resolve_image_route`; this PR brings the other three dispatch surfaces up to that same pattern rather than inventing a new style.

### Routing parity (byte-identical)

Every family routes to the same handler + conditioning per lane. The route resolvers are **pure mechanical extractions**: same predicate order (verified by extracting the original ladder's predicate sequence and diffing against the resolver), same per-family engine/handler, same `cfg` gating (macOS vs `not(macos)+backend-candle`), same `backend_candle_enabled` gate (front-loaded in the candle resolvers — equivalent to the per-arm `&&`). No engine/handler that any `(model, family, backend, lane)` routed to was changed. `resolve_generic_lane_conditioning` reproduces the 5 arms' exact tuple values, including the ideogram mask side-channel.

### Misindented block finding (video_jobs.rs — the latent bug called out)

**Cosmetic, not a logic bug.** The block sits inside a `tokio::select!` recv arm (`maybe_progress = rx.recv() => { … }`) and was indented 8 spaces short of the arm body. I traced the braces: the arm's `{` and `}` correctly enclose the block, so the scoping/logic was already right — only the whitespace was wrong. It survived because **rustfmt does not reflow code inside macro invocations**, so `cargo fmt` never touched it (and `fmt --check` passes with it misindented). Reindented by hand to align into the arm body; `git diff -w` shows zero content change.

### Tests

- Added route-decision tests: `video_route_replace_person_dispatches_by_model` (macOS), `candle_video_route_gates_on_backend_flag_then_mode` + `candle_image_route_gates_on_flag_then_pose_reject_then_txt2img` (candle lane), `generic_lane_conditioning_defaults_when_no_reference` (macOS).
- Oracle: the existing `image_route_count_follows_dispatch_order` and all worker tests pass unchanged (529 passed, 0 failed on the macOS lane).

### Verification

- macOS lane: `npm run rust:check` green (fmt --all --check, clippy --all-targets -D warnings, cargo test, cargo build).
- candle lane (macOS host): `cargo check -p sceneworks-worker --no-default-features --features backend-candle --all-targets` + clippy -D warnings green for the *shared* candle code. The `not(target_os = "macos")`+candle-gated arms and their tests compile only on the Linux parity lane (cudarc/nvcc is unavailable on this macOS host — the documented "cannot fully build on macOS" trap), so those arms were hand-audited against the captured original. The Linux `parity` CI lane compiles + runs them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)