### PR TITLE
fix(worker): bound host RAM in the SeedVR2 video-upscale path (sc-8829)

### DIFF
--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -1293,6 +1293,164 @@ fn snap_seedvr2_dim(value: u32) -> u32 {
     rounded.clamp(16, 4096)
 }
 
+// ---------------------------------------------------------------------------
+// Host-RAM bound for the SeedVR2 upscale (sc-8829, F-027)
+// ---------------------------------------------------------------------------
+// The engine (`mlx-gen-seedvr2`) already bounds its GPU/activation memory (a temporal chunk sizer +
+// spatial tiler). What is NOT bounded is *host* RGB8 RAM: `decode_seedvr2_source_frames` materializes
+// EVERY source frame into a `Vec<Image>` up front, and the up-to-4× output is likewise held whole in a
+// `Vec<RgbFrame>` before encode (the engine's `assemble_overlap` needs every decoded chunk at once, so
+// its API is fundamentally whole-clip). A few-minute 1080p clip => tens of GB of RGB8 (~17 GB source +
+// ~68 GB at 4×) => OOM-killed after minutes of GPU work.
+//
+// Fix (this story): a GENEROUS, machine-derived frame cap that FAILS LOUD *before* decode (using the
+// source asset's sidecar width/height/fps/duration) so no GPU work is wasted, with a post-decode
+// backstop for when the sidecar metadata is absent or wrong. True worker-level streaming chunking
+// (decode -> upscale -> append-encode a window at a time, reusing the engine's public
+// `plan_chunks`/`assemble_overlap` for a lossless seam) removes the cap entirely and is tracked as a
+// follow-up (SeedVR2 is temporal-context — window=(4,3,3) + a 3D causal VAE that re-anchors chunk
+// boundaries — so naive butt-joined chunking would seam; the follow-up must carry overlap cross-fade).
+
+/// Fraction of total physical RAM the source + output RGB8 buffers are allowed to occupy at once.
+/// Deliberately generous: the engine streams its own GPU allocation, so this bounds only the host-side
+/// pixel Vecs, which coexist with the OS, the loaded weights, ffmpeg, and the app. 0.5 leaves half of
+/// RAM for everything else while still admitting minutes-long clips on a large machine.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+const SEEDVR2_HOST_RAM_FRACTION: f64 = 0.5;
+
+/// Floor for the derived host-RAM budget when the physical-RAM probe fails (unknown platform / probe
+/// error): assume a modest 16 GB machine and take the fraction of it, so the cap is always active.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+const SEEDVR2_FALLBACK_RAM_BYTES: u64 = 16 * 1024 * 1024 * 1024;
+
+/// Total physical RAM in bytes, best-effort and portable (macOS `sysctl hw.memsize`, Linux
+/// `/proc/meminfo` `MemTotal`). Returns `None` if the probe fails; callers fall back to
+/// [`SEEDVR2_FALLBACK_RAM_BYTES`]. No new crate dependency — the two supported worker platforms
+/// (macOS + Windows/Linux-candle) are covered directly.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn total_physical_ram_bytes() -> Option<u64> {
+    #[cfg(target_os = "macos")]
+    {
+        let out = std::process::Command::new("sysctl")
+            .args(["-n", "hw.memsize"])
+            .output()
+            .ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        String::from_utf8_lossy(&out.stdout)
+            .trim()
+            .parse::<u64>()
+            .ok()
+    }
+    #[cfg(all(not(target_os = "macos"), target_os = "linux"))]
+    {
+        let meminfo = std::fs::read_to_string("/proc/meminfo").ok()?;
+        for line in meminfo.lines() {
+            if let Some(rest) = line.strip_prefix("MemTotal:") {
+                // "MemTotal:   16384000 kB"
+                let kb = rest
+                    .trim()
+                    .trim_end_matches(" kB")
+                    .trim()
+                    .parse::<u64>()
+                    .ok()?;
+                return Some(kb.saturating_mul(1024));
+            }
+        }
+        None
+    }
+    #[cfg(all(not(target_os = "macos"), not(target_os = "linux")))]
+    {
+        // Windows (candle lane): `wmic ComputerSystem get TotalPhysicalMemory` is the dependency-free
+        // probe. If it is unavailable the caller falls back to the conservative floor.
+        let out = std::process::Command::new("wmic")
+            .args(["ComputerSystem", "get", "TotalPhysicalMemory", "/value"])
+            .output()
+            .ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        let text = String::from_utf8_lossy(&out.stdout);
+        for line in text.lines() {
+            if let Some(rest) = line.trim().strip_prefix("TotalPhysicalMemory=") {
+                return rest.trim().parse::<u64>().ok();
+            }
+        }
+        None
+    }
+}
+
+/// The host-RAM byte budget for the combined source + output RGB8 buffers of one upscale job.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn seedvr2_host_ram_budget_bytes() -> u64 {
+    let total = total_physical_ram_bytes().unwrap_or(SEEDVR2_FALLBACK_RAM_BYTES);
+    ((total as f64) * SEEDVR2_HOST_RAM_FRACTION) as u64
+}
+
+/// Estimated peak host RGB8 bytes held at once for `frame_count` source frames at `src_w × src_h`
+/// upscaled by `factor`: the source Vec (`w·h·3` per frame) plus the output Vec (`(factor·w)·(factor·h)·3`
+/// per frame). Both are alive simultaneously across the decode → generate → encode span, so they add.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn seedvr2_estimated_host_bytes(frame_count: u64, src_w: u64, src_h: u64, factor: u64) -> u64 {
+    let src_per_frame = src_w.saturating_mul(src_h).saturating_mul(3);
+    let out_per_frame = src_per_frame.saturating_mul(factor).saturating_mul(factor);
+    frame_count.saturating_mul(src_per_frame.saturating_add(out_per_frame))
+}
+
+/// Fail loud (before decode / before GPU work) when the estimated combined source + output RGB8
+/// footprint exceeds the machine's host-RAM budget. `Ok(())` when it fits or when the frame count /
+/// dimensions are unknown (0) — the post-decode backstop re-checks with the real count in that case.
+/// The error names the limit AND the offending clip so the user knows exactly what to trim.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn check_seedvr2_host_ram(
+    frame_count: u64,
+    src_w: u64,
+    src_h: u64,
+    factor: u64,
+) -> WorkerResult<()> {
+    if frame_count == 0 || src_w == 0 || src_h == 0 {
+        return Ok(());
+    }
+    let needed = seedvr2_estimated_host_bytes(frame_count, src_w, src_h, factor);
+    let budget = seedvr2_host_ram_budget_bytes();
+    if needed > budget {
+        const GIB: f64 = 1024.0 * 1024.0 * 1024.0;
+        // Largest frame count that fits, so the message is actionable ("trim to ~N frames").
+        let per_frame = seedvr2_estimated_host_bytes(1, src_w, src_h, factor).max(1);
+        let max_frames = budget / per_frame;
+        return Err(WorkerError::InvalidPayload(format!(
+            "Video too large to upscale {factor}× on this machine: {frame_count} frames at \
+             {src_w}×{src_h} would need ~{needed:.1} GB of RGB frame memory (source + {factor}× \
+             output), over the ~{budget:.1} GB host-memory budget. Trim the clip to about \
+             {max_frames} frames (or fewer), lower the source resolution, or use {min_factor}× \
+             instead.",
+            needed = needed as f64 / GIB,
+            budget = budget as f64 / GIB,
+            min_factor = if factor > 2 { 2 } else { factor },
+        )));
+    }
+    Ok(())
+}
+
 /// Resolve a project-relative asset path safely under `project_path` (reject `..` / absolute
 /// components — same guard as `upscale_jobs::resolve_source`).
 #[cfg(any(
@@ -1494,6 +1652,19 @@ pub(crate) async fn run_video_upscale_job(
         .and_then(Value::as_str)
         .map(str::to_owned);
 
+    // Host-RAM bound (sc-8829, F-027): reject an over-budget clip BEFORE decode / GPU work, using the
+    // asset sidecar's width/height/duration/fps. When any field is missing the estimate is 0 and this
+    // is a no-op — the post-decode backstop (below) re-checks with the real decoded frame count so the
+    // giant 4× allocation is still refused, just a bit later. `check_seedvr2_host_ram` fails loud with
+    // the limit + the clip's size so no minutes-long GPU run is wasted on an eventual OOM-kill.
+    {
+        let meta_w = file.get("width").and_then(Value::as_u64).unwrap_or(0);
+        let meta_h = file.get("height").and_then(Value::as_u64).unwrap_or(0);
+        let meta_duration = file.get("duration").and_then(Value::as_f64).unwrap_or(0.0);
+        let meta_frames = (meta_duration * source_fps as f64).round().max(0.0) as u64;
+        check_seedvr2_host_ram(meta_frames, meta_w, meta_h, factor as u64)?;
+    }
+
     check_cancel(api, &job.id, SEEDVR2_CANCEL_MESSAGE).await?;
     update_job(
         api,
@@ -1527,6 +1698,16 @@ pub(crate) async fn run_video_upscale_job(
     let src_w = source_frames[0].width;
     let src_h = source_frames[0].height;
     let frame_count = source_frames.len() as u32;
+    // Post-decode backstop (sc-8829, F-027): re-check the host-RAM bound with the REAL decoded frame
+    // count + dimensions, catching the case where the sidecar metadata was absent or wrong. The source
+    // Vec is already resident here, but this refuses the far-larger up-to-4× output allocation before
+    // `generate_video` runs the GPU pipeline, so we still fail loud instead of OOM-killing mid-upscale.
+    check_seedvr2_host_ram(
+        frame_count as u64,
+        src_w as u64,
+        src_h as u64,
+        factor as u64,
+    )?;
     let (target_w, target_h) = match (req.target_width, req.target_height) {
         (Some(w), Some(h)) if w > 0 && h > 0 => (w, h),
         _ => (src_w.saturating_mul(factor), src_h.saturating_mul(factor)),
@@ -9258,6 +9439,85 @@ mod tests {
         assert!(
             decoded.audio.is_none(),
             "the engine emits no audio (worker muxes the source)"
+        );
+    }
+
+    // sc-8829 (F-027): host-RAM bound for the SeedVR2 upscale. These lock the estimator math and the
+    // fail-loud cap; the real per-machine budget (`seedvr2_host_ram_budget_bytes`) is exercised
+    // indirectly via the explicit-budget check below (the pure estimator is the oracle).
+
+    /// The estimate is source RGB8 (`w·h·3` per frame) + `factor²`× that for the output, times frames.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    #[test]
+    fn seedvr2_host_bytes_estimate_sums_source_and_upscaled_output() {
+        // 1 frame, 1920×1080, 4×: src = 1920·1080·3 = 6_220_800; out = 16× that.
+        let src = 1920u64 * 1080 * 3;
+        assert_eq!(
+            seedvr2_estimated_host_bytes(1, 1920, 1080, 4),
+            src + src * 16
+        );
+        // 2× scales the output term by 4; 100 frames scale linearly.
+        assert_eq!(
+            seedvr2_estimated_host_bytes(100, 1920, 1080, 2),
+            100 * (src + src * 4)
+        );
+        // A 1× (identity) upscale still counts both buffers (src + src).
+        assert_eq!(
+            seedvr2_estimated_host_bytes(10, 640, 480, 1),
+            10 * (640 * 480 * 3) * 2
+        );
+    }
+
+    /// Unknown dimensions/frame count (a 0 in any field) => the pre-decode check is a no-op (the
+    /// post-decode backstop re-checks with the real values), so a missing sidecar never wrongly rejects.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    #[test]
+    fn seedvr2_host_ram_check_skips_when_metadata_unknown() {
+        // Even a would-be-enormous clip passes when frame_count is unknown (0).
+        assert!(check_seedvr2_host_ram(0, 1920, 1080, 4).is_ok());
+        assert!(check_seedvr2_host_ram(100_000, 0, 0, 4).is_ok());
+    }
+
+    /// The estimator + budget compose into a fail-loud rejection: the finding's few-minute 1080p clip
+    /// (~4300 frames at 4× ≈ 320 GB of RGB8) exceeds any realistic host budget, so it must error — and
+    /// the message names both the limit and the clip size. A short clip under the budget passes.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    #[test]
+    fn seedvr2_host_ram_budget_rejects_oversized_clip() {
+        // The pathological clip: its per-frame footprint alone (src + 16× output) times ~4300 frames is
+        // hundreds of GB — larger than the derived budget on any machine this worker runs on.
+        let big = seedvr2_estimated_host_bytes(4300, 1920, 1080, 4);
+        assert!(
+            big as f64 / (1024.0 * 1024.0 * 1024.0) > 300.0,
+            "sanity: the pathological clip is >300 GB of RGB8"
+        );
+        // The real budget is a fraction of physical RAM, always < 300 GB on supported hardware, so this
+        // clip is rejected loudly with an actionable message.
+        let err = check_seedvr2_host_ram(4300, 1920, 1080, 4).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("Video too large"), "fails loud: {msg}");
+        assert!(
+            msg.contains("4300 frames"),
+            "names the clip's frame count: {msg}"
+        );
+        assert!(
+            msg.contains("1920×1080"),
+            "names the source resolution: {msg}"
+        );
+
+        // A tiny clip (8 frames, 64×48, 2×) is nowhere near any budget — it must pass.
+        assert!(
+            check_seedvr2_host_ram(8, 64, 48, 2).is_ok(),
+            "a small clip is not rejected"
         );
     }
 

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -1400,16 +1400,32 @@ fn seedvr2_host_ram_budget_bytes() -> u64 {
     ((total as f64) * SEEDVR2_HOST_RAM_FRACTION) as u64
 }
 
-/// Estimated peak host RGB8 bytes held at once for `frame_count` source frames at `src_w × src_h`
-/// upscaled by `factor`: the source Vec (`w·h·3` per frame) plus the output Vec (`(factor·w)·(factor·h)·3`
-/// per frame). Both are alive simultaneously across the decode → generate → encode span, so they add.
+/// Estimated peak host RGB8 bytes held at once for `frame_count` source frames at `src_w × src_h`:
+/// the source Vec (`w·h·3` per frame) plus the output Vec (`out_w·out_h·3` per frame). Both are alive
+/// simultaneously across the decode → generate → encode span, so they add.
+///
+/// The output size is either the explicit snapped target (`out_dims = Some((out_w, out_h))`, the
+/// accurate post-decode path where the real allocated resolution is known) or, when the target is not
+/// yet resolved (the coarse pre-decode gate), `factor × src` via `out_dims = None`. Using the real
+/// snapped target matters because `VideoUpscaleRequest.target_width/height` can override `factor`
+/// independently (clamped to ≤4096), so a `factor²·src` estimate can under-count a larger explicit
+/// target by up to ~16× and let an OOM-prone job through.
 #[cfg(any(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
-fn seedvr2_estimated_host_bytes(frame_count: u64, src_w: u64, src_h: u64, factor: u64) -> u64 {
+fn seedvr2_estimated_host_bytes(
+    frame_count: u64,
+    src_w: u64,
+    src_h: u64,
+    factor: u64,
+    out_dims: Option<(u64, u64)>,
+) -> u64 {
     let src_per_frame = src_w.saturating_mul(src_h).saturating_mul(3);
-    let out_per_frame = src_per_frame.saturating_mul(factor).saturating_mul(factor);
+    let out_per_frame = match out_dims {
+        Some((out_w, out_h)) => out_w.saturating_mul(out_h).saturating_mul(3),
+        None => src_per_frame.saturating_mul(factor).saturating_mul(factor),
+    };
     frame_count.saturating_mul(src_per_frame.saturating_add(out_per_frame))
 }
 
@@ -1426,26 +1442,37 @@ fn check_seedvr2_host_ram(
     src_w: u64,
     src_h: u64,
     factor: u64,
+    out_dims: Option<(u64, u64)>,
 ) -> WorkerResult<()> {
     if frame_count == 0 || src_w == 0 || src_h == 0 {
         return Ok(());
     }
-    let needed = seedvr2_estimated_host_bytes(frame_count, src_w, src_h, factor);
+    let needed = seedvr2_estimated_host_bytes(frame_count, src_w, src_h, factor, out_dims);
     let budget = seedvr2_host_ram_budget_bytes();
     if needed > budget {
         const GIB: f64 = 1024.0 * 1024.0 * 1024.0;
         // Largest frame count that fits, so the message is actionable ("trim to ~N frames").
-        let per_frame = seedvr2_estimated_host_bytes(1, src_w, src_h, factor).max(1);
+        let per_frame = seedvr2_estimated_host_bytes(1, src_w, src_h, factor, out_dims).max(1);
         let max_frames = budget / per_frame;
+        // Describe the output the estimate actually sized: the explicit snapped target when set,
+        // otherwise the implicit `factor×` output. Only suggest a smaller factor when there IS a
+        // smaller one to drop to (never "use 2×" while already at 2×, and never for explicit targets
+        // where factor isn't what drove the size).
+        let out_desc = match out_dims {
+            Some((out_w, out_h)) => format!("{out_w}×{out_h} output"),
+            None => format!("{factor}× output"),
+        };
+        let downgrade = match out_dims {
+            None if factor > 2 => " or use 2× instead",
+            _ => "",
+        };
         return Err(WorkerError::InvalidPayload(format!(
-            "Video too large to upscale {factor}× on this machine: {frame_count} frames at \
-             {src_w}×{src_h} would need ~{needed:.1} GB of RGB frame memory (source + {factor}× \
-             output), over the ~{budget:.1} GB host-memory budget. Trim the clip to about \
-             {max_frames} frames (or fewer), lower the source resolution, or use {min_factor}× \
-             instead.",
+            "Video too large to upscale on this machine: {frame_count} frames at {src_w}×{src_h} \
+             would need ~{needed:.1} GB of RGB frame memory (source + {out_desc}), over the \
+             ~{budget:.1} GB host-memory budget. Trim the clip to about {max_frames} frames (or \
+             fewer), lower the source/target resolution{downgrade}.",
             needed = needed as f64 / GIB,
             budget = budget as f64 / GIB,
-            min_factor = if factor > 2 { 2 } else { factor },
         )));
     }
     Ok(())
@@ -1662,7 +1689,9 @@ pub(crate) async fn run_video_upscale_job(
         let meta_h = file.get("height").and_then(Value::as_u64).unwrap_or(0);
         let meta_duration = file.get("duration").and_then(Value::as_f64).unwrap_or(0.0);
         let meta_frames = (meta_duration * source_fps as f64).round().max(0.0) as u64;
-        check_seedvr2_host_ram(meta_frames, meta_w, meta_h, factor as u64)?;
+        // Coarse pre-flight: target dims aren't snapped yet, so size the output from `factor` (None).
+        // The accurate post-decode check below re-runs with the real snapped target resolution.
+        check_seedvr2_host_ram(meta_frames, meta_w, meta_h, factor as u64, None)?;
     }
 
     check_cancel(api, &job.id, SEEDVR2_CANCEL_MESSAGE).await?;
@@ -1698,22 +1727,25 @@ pub(crate) async fn run_video_upscale_job(
     let src_w = source_frames[0].width;
     let src_h = source_frames[0].height;
     let frame_count = source_frames.len() as u32;
-    // Post-decode backstop (sc-8829, F-027): re-check the host-RAM bound with the REAL decoded frame
-    // count + dimensions, catching the case where the sidecar metadata was absent or wrong. The source
-    // Vec is already resident here, but this refuses the far-larger up-to-4× output allocation before
-    // `generate_video` runs the GPU pipeline, so we still fail loud instead of OOM-killing mid-upscale.
-    check_seedvr2_host_ram(
-        frame_count as u64,
-        src_w as u64,
-        src_h as u64,
-        factor as u64,
-    )?;
     let (target_w, target_h) = match (req.target_width, req.target_height) {
         (Some(w), Some(h)) if w > 0 && h > 0 => (w, h),
         _ => (src_w.saturating_mul(factor), src_h.saturating_mul(factor)),
     };
     let target_w = snap_seedvr2_dim(target_w);
     let target_h = snap_seedvr2_dim(target_h);
+    // Post-decode backstop (sc-8829, F-027): re-check the host-RAM bound with the REAL decoded frame
+    // count + dimensions AND the real snapped target resolution — an explicit `target_width/height`
+    // can be much larger than `factor × src` (clamped to ≤4096), so sizing the output from the snapped
+    // target (not `factor²·src`) is what actually catches an oversized target. Runs AFTER the target
+    // snap but BEFORE `generate_video` fires the up-to-4× GPU allocation, so we still fail loud instead
+    // of OOM-killing mid-upscale.
+    check_seedvr2_host_ram(
+        frame_count as u64,
+        src_w as u64,
+        src_h as u64,
+        factor as u64,
+        Some((target_w as u64, target_h as u64)),
+    )?;
     let seed = req.seed.unwrap_or(0);
 
     // Run the SeedVR2 upscale through the shared streaming driver (generator cache + stall
@@ -9446,28 +9478,38 @@ mod tests {
     // fail-loud cap; the real per-machine budget (`seedvr2_host_ram_budget_bytes`) is exercised
     // indirectly via the explicit-budget check below (the pure estimator is the oracle).
 
-    /// The estimate is source RGB8 (`w·h·3` per frame) + `factor²`× that for the output, times frames.
+    /// The estimate is source RGB8 (`w·h·3` per frame) + the output buffer, times frames. With
+    /// `out_dims = None` the output is sized from `factor²·src` (the coarse pre-decode gate); with
+    /// explicit `out_dims` it's sized from the real snapped target (the accurate post-decode path).
     #[cfg(any(
         target_os = "macos",
         all(not(target_os = "macos"), feature = "backend-candle")
     ))]
     #[test]
     fn seedvr2_host_bytes_estimate_sums_source_and_upscaled_output() {
-        // 1 frame, 1920×1080, 4×: src = 1920·1080·3 = 6_220_800; out = 16× that.
+        // 1 frame, 1920×1080, 4× (factor-sized): src = 1920·1080·3 = 6_220_800; out = 16× that.
         let src = 1920u64 * 1080 * 3;
         assert_eq!(
-            seedvr2_estimated_host_bytes(1, 1920, 1080, 4),
+            seedvr2_estimated_host_bytes(1, 1920, 1080, 4, None),
             src + src * 16
         );
         // 2× scales the output term by 4; 100 frames scale linearly.
         assert_eq!(
-            seedvr2_estimated_host_bytes(100, 1920, 1080, 2),
+            seedvr2_estimated_host_bytes(100, 1920, 1080, 2, None),
             100 * (src + src * 4)
         );
         // A 1× (identity) upscale still counts both buffers (src + src).
         assert_eq!(
-            seedvr2_estimated_host_bytes(10, 640, 480, 1),
+            seedvr2_estimated_host_bytes(10, 640, 480, 1, None),
             10 * (640 * 480 * 3) * 2
+        );
+        // Explicit output dims size the output term directly, IGNORING factor: a 640×480 source with a
+        // 4096×4096 target (factor is irrelevant here) => src + 4096·4096·3 per frame.
+        let src_small = 640u64 * 480 * 3;
+        let out_big = 4096u64 * 4096 * 3;
+        assert_eq!(
+            seedvr2_estimated_host_bytes(1, 640, 480, 2, Some((4096, 4096))),
+            src_small + out_big
         );
     }
 
@@ -9480,8 +9522,8 @@ mod tests {
     #[test]
     fn seedvr2_host_ram_check_skips_when_metadata_unknown() {
         // Even a would-be-enormous clip passes when frame_count is unknown (0).
-        assert!(check_seedvr2_host_ram(0, 1920, 1080, 4).is_ok());
-        assert!(check_seedvr2_host_ram(100_000, 0, 0, 4).is_ok());
+        assert!(check_seedvr2_host_ram(0, 1920, 1080, 4, None).is_ok());
+        assert!(check_seedvr2_host_ram(100_000, 0, 0, 4, None).is_ok());
     }
 
     /// The estimator + budget compose into a fail-loud rejection: the finding's few-minute 1080p clip
@@ -9495,14 +9537,14 @@ mod tests {
     fn seedvr2_host_ram_budget_rejects_oversized_clip() {
         // The pathological clip: its per-frame footprint alone (src + 16× output) times ~4300 frames is
         // hundreds of GB — larger than the derived budget on any machine this worker runs on.
-        let big = seedvr2_estimated_host_bytes(4300, 1920, 1080, 4);
+        let big = seedvr2_estimated_host_bytes(4300, 1920, 1080, 4, None);
         assert!(
             big as f64 / (1024.0 * 1024.0 * 1024.0) > 300.0,
             "sanity: the pathological clip is >300 GB of RGB8"
         );
         // The real budget is a fraction of physical RAM, always < 300 GB on supported hardware, so this
         // clip is rejected loudly with an actionable message.
-        let err = check_seedvr2_host_ram(4300, 1920, 1080, 4).unwrap_err();
+        let err = check_seedvr2_host_ram(4300, 1920, 1080, 4, None).unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("Video too large"), "fails loud: {msg}");
         assert!(
@@ -9516,8 +9558,74 @@ mod tests {
 
         // A tiny clip (8 frames, 64×48, 2×) is nowhere near any budget — it must pass.
         assert!(
-            check_seedvr2_host_ram(8, 64, 48, 2).is_ok(),
+            check_seedvr2_host_ram(8, 64, 48, 2, None).is_ok(),
             "a small clip is not rejected"
+        );
+    }
+
+    /// The core of this fix (sc-8829 review): an explicit `target_width/height` far larger than
+    /// `factor × src` (clamped ≤4096) is now REJECTED by the post-decode check. A modest source with a
+    /// 2× factor would PASS the old `factor²·src`-only estimate, but a 4096×4096 snapped target holds a
+    /// ~200 MB/frame output buffer — over ~4300 frames that dwarfs any host budget and must fail loud.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    #[test]
+    fn seedvr2_host_ram_rejects_oversized_explicit_target() {
+        // 1280×720 source at 2× would be a 2560×1440 output (~11 MB/frame) — the OLD factor-only
+        // estimate. Under that estimate ~4300 frames is only ~60 GB and could pass on a big machine.
+        let factor_only = seedvr2_estimated_host_bytes(4300, 1280, 720, 2, None);
+        // But the request overrides the target to 4096×4096 (~50 MB/frame output): the accurate,
+        // target-sized estimate is far larger — proving the old estimate under-counted this job.
+        let target_sized = seedvr2_estimated_host_bytes(4300, 1280, 720, 2, Some((4096, 4096)));
+        assert!(
+            target_sized > factor_only * 3,
+            "the explicit 4096² target dwarfs the factor²·src estimate ({target_sized} > {factor_only})"
+        );
+        assert!(
+            target_sized as f64 / (1024.0 * 1024.0 * 1024.0) > 200.0,
+            "sanity: the target-sized footprint is >200 GB of RGB8"
+        );
+        // The factor-only pre-decode gate would let this through; the target-sized post-decode check
+        // rejects it loudly (the whole point of the fix).
+        let err = check_seedvr2_host_ram(4300, 1280, 720, 2, Some((4096, 4096))).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("Video too large"), "fails loud: {msg}");
+        assert!(
+            msg.contains("4096×4096 output"),
+            "names the oversized target output size: {msg}"
+        );
+        // factor==2 minor: never suggest downgrading to 2× while already at (or below) 2×.
+        assert!(
+            !msg.contains("use 2×"),
+            "does not suggest 2× when already at 2× / explicit target: {msg}"
+        );
+    }
+
+    /// The factor==2 minor in isolation: a factor-only rejection at 2× must not tell the user to "use
+    /// 2× instead" (they already are). At 4× the downgrade suggestion IS present.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    #[test]
+    fn seedvr2_host_ram_message_suppresses_self_factor_downgrade() {
+        let at_two = format!(
+            "{}",
+            check_seedvr2_host_ram(4300, 1920, 1080, 2, None).unwrap_err()
+        );
+        assert!(
+            !at_two.contains("use 2×"),
+            "at 2× the message must not suggest 2×: {at_two}"
+        );
+        let at_four = format!(
+            "{}",
+            check_seedvr2_host_ram(4300, 1920, 1080, 4, None).unwrap_err()
+        );
+        assert!(
+            at_four.contains("use 2× instead"),
+            "at 4× the message suggests dropping to 2×: {at_four}"
         );
     }
 


### PR DESCRIPTION
Closes **[sc-8829](https://app.shortcut.com/trefry/story/8829)** — [F-027] Bound memory in the SeedVR2 video-upscale path.

## Finding: temporal behavior
**SeedVR2 is temporal-context, NOT per-frame-independent.** Evidence in `mlx-gen-seedvr2`:
- `src/lib.rs:9-13` — DiT uses spatiotemporal window attention `window=(T,H,W)=(4,3,3)`; the VAE is 3D causal with 4:1 temporal compression.
- `src/video.rs:6-17` — the causal VAE re-anchors each chunk's first frame, so butt-joined chunks produce a hard seam; the engine fixes it INTERNALLY with an overlap cross-fade (`pipeline.rs::generate_video` builds `chunk_frames: Vec<Vec<Image>>` then `video::assemble_overlap`).

So the engine already bounds **GPU/activation** memory (chunk sizer + spatial tiler). The unbounded resource is purely **host RGB8 RAM**: `decode_seedvr2_source_frames` materializes every source frame into a `Vec<Image>` up front, and the up-to-4× output is held whole in a `Vec<RgbFrame>` before encode. The engine's API is fundamentally whole-clip (`assemble_overlap` needs every decoded chunk resident at once), so worker-side streaming can't reuse it trivially.

## Chosen approach: generous machine-derived cap now + streaming follow-up
Because SeedVR2 is temporal-context and the engine API is whole-clip, true worker-level streaming (decode→upscale→append-encode with cross-fade across worker windows) is a large restructure of the **shared** `generate_video` funnel (used by every video engine) plus a new streaming encoder — high regression surface for cancel/heartbeat/progress. That exceeds "minimum code that solves the problem."

This PR instead adds a **generous, machine-derived host-RAM cap** and files **[sc-9595](https://app.shortcut.com/trefry/story/9595)** (relates-to sc-8829) for the streaming-chunking work that removes the cap.

## How both memory sides are bounded
`check_seedvr2_host_ram(frames, w, h, factor)` estimates the combined peak: source (`w·h·3`/frame) **plus** output (`factor²`× that/frame), which coexist across decode→generate→encode. It rejects when that exceeds `0.5 ×` total physical RAM (probed portably via `sysctl hw.memsize` / `/proc/meminfo` / `wmic`; conservative 16 GB floor if the probe fails). Enforced at **two** points:
1. **Pre-decode** — from the source asset sidecar (`width`/`height`/`duration`/`fps`), so an over-budget clip fails loud before any decode or GPU work; the error names the limit and the clip's size and suggests trimming / lower res / 2×.
2. **Post-decode backstop** — re-checks with the real decoded frame count/dims (for absent/wrong sidecars), refusing the far-larger 4× allocation before `generate_video` runs the GPU pipeline.

Peak host RGB8 before: unbounded (~85 GB for a few-min 1080p 4× clip → OOM-kill). After: bounded to ≤ 50% of physical RAM, or a loud pre-flight rejection.

## Capability
The cap narrows capability for very long / high-res clips (they now error instead of OOM-killing). sc-9595 restores any-length upscaling with bounded memory via streaming chunks. No behavior change for clips that succeed today.

## Cancel/heartbeat
Unchanged — this adds pre/post-decode guards around the existing `generate_video` funnel; the per-chunk cancel/heartbeat path (epic 8800) is untouched.

## Tests / build
- 3 new unit tests (estimator math; no-op on unknown metadata; fail-loud rejection of the finding's pathological clip with an actionable message). Existing SeedVR2 upscale test is the end-to-end oracle (unchanged).
- Both build lanes green: macOS default + `cargo check -p sceneworks-worker --no-default-features --features backend-candle --all-targets`. `cargo fmt --check` + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)