### PR TITLE
fix(worker): fingerprint adapter/weight content in the generator-cache key (sc-8841)

### DIFF
--- a/crates/sceneworks-worker/src/generator_cache.rs
+++ b/crates/sceneworks-worker/src/generator_cache.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::{mpsc, OnceLock};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 use gen_core::{
     AdapterKind, AdapterSpec, Generator, LoadSpec, MoeExpert, Precision, Quant, WeightsSource,
@@ -45,13 +45,61 @@ pub(crate) struct GeneratorCacheKey {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum CacheWeightsSource {
-    Dir(PathBuf),
-    File(PathBuf),
+    Dir(PathBuf, Fingerprint),
+    File(PathBuf, Fingerprint),
+}
+
+/// Content-change proxy for a weights/adapter file (or HF snapshot dir) referenced in the cache key
+/// (sc-8841, F-039). The pre-fingerprint key identified weights/adapters by path + scale only, so a
+/// file replaced at the SAME path — a re-imported LoRA, a re-converted checkpoint — was served from
+/// the resident generator with the OLD tensors until the 300 s idle timeout ("my new LoRA does
+/// nothing"). Folding `(size, mtime)` into the key self-heals for ANY overwrite path (in-process
+/// re-import/re-convert, out-of-band replacement, manual swap) without an explicit evict hook that
+/// only fires for the code paths that remember to call it.
+///
+/// We deliberately stat metadata rather than hashing contents: mtime+size is a cheap, good
+/// content-change proxy, and hashing multi-GB weight files on every generation would be a severe
+/// perf regression.
+///
+/// For a `Dir` (an HF snapshot) we fingerprint the DIRECTORY's own metadata. A re-convert lands via
+/// the finalize/rename path (`finalize_converted_dir`), which replaces directory entries and bumps
+/// the dir's mtime, so a re-converted snapshot at the same path is a distinct key. `size` for a dir
+/// is its own metadata length (not the recursive content size) — it only needs to move on change,
+/// not be meaningful; mtime carries the signal.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Fingerprint {
+    /// `metadata()` succeeded: `(len, modified)`. `modified` is `None` on the rare platform/FS that
+    /// does not report an mtime, in which case `len` alone carries the (weaker) signal.
+    Present {
+        size: u64,
+        mtime: Option<SystemTime>,
+    },
+    /// `metadata()` errored (path missing, transient stat failure, permissions). Kept DISTINCT from
+    /// any `Present` value so a stat error forces a cache MISS (rebuild) rather than serving a stale
+    /// entry — the load that follows surfaces the real error. Two `Unavailable`s compare equal
+    /// (`Eq` must stay reflexive), but that only arises when the file is genuinely gone on both the
+    /// cached and the incoming key, in which case the reload fails loudly anyway.
+    Unavailable,
+}
+
+impl Fingerprint {
+    /// Snapshot `(size, mtime)` for `path` once, at key-construction time, so the fingerprint is
+    /// stable across the lookup within a single generation (no mtime drift mid-request).
+    fn of(path: &Path) -> Self {
+        match std::fs::metadata(path) {
+            Ok(meta) => Self::Present {
+                size: meta.len(),
+                mtime: meta.modified().ok(),
+            },
+            Err(_) => Self::Unavailable,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct CacheAdapterSpec {
     path: PathBuf,
+    fingerprint: Fingerprint,
     scale_bits: u32,
     kind: AdapterKind,
     pass_scale_bits: Option<Vec<u32>>,
@@ -86,8 +134,8 @@ impl GeneratorCacheKey {
 impl From<&WeightsSource> for CacheWeightsSource {
     fn from(source: &WeightsSource) -> Self {
         match source {
-            WeightsSource::Dir(path) => Self::Dir(path.clone()),
-            WeightsSource::File(path) => Self::File(path.clone()),
+            WeightsSource::Dir(path) => Self::Dir(path.clone(), Fingerprint::of(path)),
+            WeightsSource::File(path) => Self::File(path.clone(), Fingerprint::of(path)),
         }
     }
 }
@@ -96,6 +144,7 @@ impl From<&AdapterSpec> for CacheAdapterSpec {
     fn from(spec: &AdapterSpec) -> Self {
         Self {
             path: spec.path.clone(),
+            fingerprint: Fingerprint::of(&spec.path),
             scale_bits: spec.scale.to_bits(),
             kind: spec.kind,
             pass_scale_bits: spec
@@ -432,6 +481,116 @@ mod tests {
         assert_ne!(
             GeneratorCacheKey::from_load_spec("z_image_turbo", &with_adapter),
             GeneratorCacheKey::from_load_spec("z_image_turbo", &different_scale)
+        );
+    }
+
+    // sc-8841 (F-039): the fingerprint helper is the core of the fix — it must report a DIFFERENT
+    // value when a file at the same path changes (size or mtime), and `Unavailable` (a distinct,
+    // cache-missing value) when the path can't be stat'd.
+    #[test]
+    fn fingerprint_tracks_content_change_and_missing_files() {
+        use std::io::Write;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("weights.safetensors");
+        std::fs::write(&path, b"original").expect("write original");
+        let original = Fingerprint::of(&path);
+        assert!(
+            matches!(original, Fingerprint::Present { .. }),
+            "an existing file must fingerprint as Present, got {original:?}"
+        );
+        // Re-stat with no change: same fingerprint → the common case still hits the cache.
+        assert_eq!(
+            original,
+            Fingerprint::of(&path),
+            "an unchanged file must produce a stable fingerprint (no spurious cache miss)"
+        );
+
+        // Grow the file (size changes) — must differ even if the clock granularity hides the mtime.
+        {
+            let mut f = std::fs::OpenOptions::new()
+                .append(true)
+                .open(&path)
+                .expect("open for append");
+            f.write_all(b"-more-bytes").expect("append");
+        }
+        assert_ne!(
+            original,
+            Fingerprint::of(&path),
+            "a size change at the same path must change the fingerprint"
+        );
+
+        // mtime sensitivity, proven as a pure value comparison so it does not depend on filesystem
+        // timestamp granularity or a coarse system clock: two same-size fingerprints whose mtime
+        // differs must NOT compare equal (a same-size overwrite — e.g. a re-convert that lands an
+        // identically-sized file — still busts the cache via the mtime).
+        let now = SystemTime::now();
+        let earlier = Fingerprint::Present {
+            size: 4096,
+            mtime: Some(now),
+        };
+        let later = Fingerprint::Present {
+            size: 4096,
+            mtime: Some(now + Duration::from_secs(120)),
+        };
+        assert_ne!(
+            earlier, later,
+            "a bumped mtime at the same size must change the fingerprint"
+        );
+
+        // Missing path → Unavailable, distinct from any Present value so a stat error rebuilds
+        // rather than serving a stale entry.
+        let missing = Fingerprint::of(&dir.path().join("does-not-exist"));
+        assert_eq!(missing, Fingerprint::Unavailable);
+        assert_ne!(missing, original);
+        assert_ne!(missing, earlier);
+    }
+
+    // sc-8841 (F-039): the whole-key oracle. A LoRA re-imported at the SAME path (new bytes, same
+    // name) must yield a DIFFERENT cache key so the resident generator reloads instead of silently
+    // reusing the stale adapter within the 300 s idle window. An unchanged file must yield the SAME
+    // key so the common case keeps hitting the cache (no perf regression from spurious misses).
+    #[test]
+    fn cache_key_changes_when_adapter_file_is_replaced_at_same_path() {
+        use std::io::Write;
+
+        let base_dir = tempfile::tempdir().expect("base tempdir");
+        let lora_dir = tempfile::tempdir().expect("lora tempdir");
+        let lora_path = lora_dir.path().join("style.safetensors");
+        std::fs::write(&lora_path, b"v1-tensors").expect("write lora v1");
+
+        let make_spec = || {
+            let mut spec = LoadSpec::new(WeightsSource::Dir(base_dir.path().to_path_buf()));
+            spec.adapters = vec![AdapterSpec::new(lora_path.clone(), 0.8, AdapterKind::Lora)];
+            spec
+        };
+
+        let key_v1 = GeneratorCacheKey::from_load_spec("z_image_turbo", &make_spec());
+        // Same file, no change → identical key → cache still hits.
+        assert_eq!(
+            key_v1,
+            GeneratorCacheKey::from_load_spec("z_image_turbo", &make_spec()),
+            "an unchanged adapter file must produce an identical cache key (cache hit preserved)"
+        );
+
+        // Re-import the LoRA at the same path with new, DIFFERENTLY-SIZED bytes (a re-import writes
+        // a fresh file). The size delta alone busts the key regardless of clock granularity; the
+        // mtime path is covered as a pure value comparison in `fingerprint_tracks_content_change_*`.
+        {
+            let mut f = std::fs::OpenOptions::new()
+                .write(true)
+                .truncate(true)
+                .open(&lora_path)
+                .expect("reopen lora");
+            f.write_all(b"v2-completely-different-tensors-and-longer")
+                .expect("write lora v2");
+        }
+
+        let key_v2 = GeneratorCacheKey::from_load_spec("z_image_turbo", &make_spec());
+        assert_ne!(
+            key_v1, key_v2,
+            "re-importing a LoRA at the same path must change the cache key so the stale adapter \
+             is not served from cache"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes **sc-8841 / F-039** — [story](https://app.shortcut.com/trefry/story/8841).

`GeneratorCacheKey` identified weights/adapters by **path + scale only**. A file replaced at the same path — a re-imported LoRA, a re-converted checkpoint — was served from the resident generator with the **old tensors** until the 300 s idle timeout. Symptom: re-import a LoRA under the same name and regenerate within 5 minutes → the stale adapter is silently used ("my new LoRA does nothing").

## Fix

Fold a `(size, mtime)` **fingerprint** into the cache key for **every** file/dir path it references:

- `CacheWeightsSource::Dir` / `File` — base weights, `control`, each `extra_controls`, `ip_adapter`, and both PiD aux-weights (`checkpoint`, `gemma`).
- `CacheAdapterSpec.path` — every LoRA/adapter file.

This is the **self-healing** option (a) from the story: it busts the cache on ANY overwrite path (in-process re-import/re-convert, out-of-band replacement, manual swap), unlike an evict hook that only fires for the code paths that remember to call it.

### Fingerprint fields
`Fingerprint::Present { size: u64, mtime: Option<SystemTime> }`, captured via `std::fs::metadata` (`len()` + `modified()`). We deliberately do **not** hash contents — mtime+size is a cheap content-change proxy; hashing multi-GB weights per generation would be a severe perf regression.

### Dir (HF snapshot) handling
A `Dir` source fingerprints the **directory's own metadata**. A re-convert lands via the finalize/rename path (`finalize_converted_dir`), which replaces directory entries and bumps the dir's mtime, so a re-converted snapshot at the same path is a distinct key.

### metadata-error behavior
On any `metadata()` error (missing path, transient stat failure) the fingerprint is `Fingerprint::Unavailable`, kept **distinct from any `Present`** value so a stat error forces a cache **miss / rebuild** rather than serving a stale entry — the following load surfaces the real error. Two `Unavailable`s compare equal only when the file is genuinely gone on both keys, in which case the reload fails loudly anyway. `Eq` stays reflexive.

### Determinism
The fingerprint is snapshotted **once at key construction** (`Fingerprint::of`), so it is stable across the lookup within a single generation — no mtime drift mid-request.

## Cache-hit preserved
An **unchanged** file produces an **identical** key → the common case still hits the resident generator. Covered by an explicit assertion, so there's no spurious-miss perf regression.

## Tests
- `fingerprint_tracks_content_change_and_missing_files` — Present on an existing file; **stable** when unchanged; **differs** on a size change (real FS); **differs** on an mtime bump (pure value comparison, no clock-granularity flake); `Unavailable` + distinct for a missing path.
- `cache_key_changes_when_adapter_file_is_replaced_at_same_path` — the whole-key oracle: identical key when the adapter file is unchanged (cache hit), **different** key when the LoRA is re-imported at the same path.

Existing generator-cache tests unchanged and green (10/10).

## Verification
- `cargo test -p sceneworks-worker --lib generator_cache` — 10 passed.
- `cargo fmt --all -- --check` — clean.
- `cargo clippy -p sceneworks-worker --all-targets -- -D warnings` — clean.
- Candle lane: `cargo check -p sceneworks-worker --no-default-features --features backend-candle --all-targets` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)