### PR TITLE
feat(worker): candle-lane standard-tier routing; retire 4 ad-hoc candle repo resolvers (sc-9092)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef844683e9e40e5135bac36f183b56e856930036#ef844683e9e40e5135bac36f183b56e856930036"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c16d381f5eb5f251b6ef8a6d695eb11d07b013d8#c16d381f5eb5f251b6ef8a6d695eb11d07b013d8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef844683e9e40e5135bac36f183b56e856930036#ef844683e9e40e5135bac36f183b56e856930036"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c16d381f5eb5f251b6ef8a6d695eb11d07b013d8#c16d381f5eb5f251b6ef8a6d695eb11d07b013d8"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -494,7 +494,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef844683e9e40e5135bac36f183b56e856930036#ef844683e9e40e5135bac36f183b56e856930036"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c16d381f5eb5f251b6ef8a6d695eb11d07b013d8#c16d381f5eb5f251b6ef8a6d695eb11d07b013d8"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -508,7 +508,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef844683e9e40e5135bac36f183b56e856930036#ef844683e9e40e5135bac36f183b56e856930036"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c16d381f5eb5f251b6ef8a6d695eb11d07b013d8#c16d381f5eb5f251b6ef8a6d695eb11d07b013d8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef844683e9e40e5135bac36f183b56e856930036#ef844683e9e40e5135bac36f183b56e856930036"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c16d381f5eb5f251b6ef8a6d695eb11d07b013d8#c16d381f5eb5f251b6ef8a6d695eb11d07b013d8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef844683e9e40e5135bac36f183b56e856930036#ef844683e9e40e5135bac36f183b56e856930036"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c16d381f5eb5f251b6ef8a6d695eb11d07b013d8#c16d381f5eb5f251b6ef8a6d695eb11d07b013d8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -542,7 +542,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef844683e9e40e5135bac36f183b56e856930036#ef844683e9e40e5135bac36f183b56e856930036"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c16d381f5eb5f251b6ef8a6d695eb11d07b013d8#c16d381f5eb5f251b6ef8a6d695eb11d07b013d8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -559,7 +559,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef844683e9e40e5135bac36f183b56e856930036#ef844683e9e40e5135bac36f183b56e856930036"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c16d381f5eb5f251b6ef8a6d695eb11d07b013d8#c16d381f5eb5f251b6ef8a6d695eb11d07b013d8"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef844683e9e40e5135bac36f183b56e856930036#ef844683e9e40e5135bac36f183b56e856930036"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c16d381f5eb5f251b6ef8a6d695eb11d07b013d8#c16d381f5eb5f251b6ef8a6d695eb11d07b013d8"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -587,7 +587,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef844683e9e40e5135bac36f183b56e856930036#ef844683e9e40e5135bac36f183b56e856930036"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c16d381f5eb5f251b6ef8a6d695eb11d07b013d8#c16d381f5eb5f251b6ef8a6d695eb11d07b013d8"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -599,7 +599,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef844683e9e40e5135bac36f183b56e856930036#ef844683e9e40e5135bac36f183b56e856930036"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c16d381f5eb5f251b6ef8a6d695eb11d07b013d8#c16d381f5eb5f251b6ef8a6d695eb11d07b013d8"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -609,7 +609,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef844683e9e40e5135bac36f183b56e856930036#ef844683e9e40e5135bac36f183b56e856930036"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c16d381f5eb5f251b6ef8a6d695eb11d07b013d8#c16d381f5eb5f251b6ef8a6d695eb11d07b013d8"
 dependencies = [
  "candle-gen",
  "candle-gen-sdxl",
@@ -623,7 +623,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef844683e9e40e5135bac36f183b56e856930036#ef844683e9e40e5135bac36f183b56e856930036"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c16d381f5eb5f251b6ef8a6d695eb11d07b013d8#c16d381f5eb5f251b6ef8a6d695eb11d07b013d8"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -637,7 +637,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef844683e9e40e5135bac36f183b56e856930036#ef844683e9e40e5135bac36f183b56e856930036"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c16d381f5eb5f251b6ef8a6d695eb11d07b013d8#c16d381f5eb5f251b6ef8a6d695eb11d07b013d8"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -650,7 +650,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef844683e9e40e5135bac36f183b56e856930036#ef844683e9e40e5135bac36f183b56e856930036"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c16d381f5eb5f251b6ef8a6d695eb11d07b013d8#c16d381f5eb5f251b6ef8a6d695eb11d07b013d8"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -663,7 +663,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef844683e9e40e5135bac36f183b56e856930036#ef844683e9e40e5135bac36f183b56e856930036"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c16d381f5eb5f251b6ef8a6d695eb11d07b013d8#c16d381f5eb5f251b6ef8a6d695eb11d07b013d8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -679,7 +679,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef844683e9e40e5135bac36f183b56e856930036#ef844683e9e40e5135bac36f183b56e856930036"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c16d381f5eb5f251b6ef8a6d695eb11d07b013d8#c16d381f5eb5f251b6ef8a6d695eb11d07b013d8"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -692,7 +692,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef844683e9e40e5135bac36f183b56e856930036#ef844683e9e40e5135bac36f183b56e856930036"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c16d381f5eb5f251b6ef8a6d695eb11d07b013d8#c16d381f5eb5f251b6ef8a6d695eb11d07b013d8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -703,7 +703,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef844683e9e40e5135bac36f183b56e856930036#ef844683e9e40e5135bac36f183b56e856930036"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c16d381f5eb5f251b6ef8a6d695eb11d07b013d8#c16d381f5eb5f251b6ef8a6d695eb11d07b013d8"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -718,7 +718,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef844683e9e40e5135bac36f183b56e856930036#ef844683e9e40e5135bac36f183b56e856930036"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c16d381f5eb5f251b6ef8a6d695eb11d07b013d8#c16d381f5eb5f251b6ef8a6d695eb11d07b013d8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -735,7 +735,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef844683e9e40e5135bac36f183b56e856930036#ef844683e9e40e5135bac36f183b56e856930036"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c16d381f5eb5f251b6ef8a6d695eb11d07b013d8#c16d381f5eb5f251b6ef8a6d695eb11d07b013d8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -754,7 +754,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef844683e9e40e5135bac36f183b56e856930036#ef844683e9e40e5135bac36f183b56e856930036"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c16d381f5eb5f251b6ef8a6d695eb11d07b013d8#c16d381f5eb5f251b6ef8a6d695eb11d07b013d8"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -765,7 +765,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef844683e9e40e5135bac36f183b56e856930036#ef844683e9e40e5135bac36f183b56e856930036"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c16d381f5eb5f251b6ef8a6d695eb11d07b013d8#c16d381f5eb5f251b6ef8a6d695eb11d07b013d8"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -778,7 +778,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef844683e9e40e5135bac36f183b56e856930036#ef844683e9e40e5135bac36f183b56e856930036"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c16d381f5eb5f251b6ef8a6d695eb11d07b013d8#c16d381f5eb5f251b6ef8a6d695eb11d07b013d8"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -789,7 +789,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef844683e9e40e5135bac36f183b56e856930036#ef844683e9e40e5135bac36f183b56e856930036"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c16d381f5eb5f251b6ef8a6d695eb11d07b013d8#c16d381f5eb5f251b6ef8a6d695eb11d07b013d8"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -802,7 +802,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef844683e9e40e5135bac36f183b56e856930036#ef844683e9e40e5135bac36f183b56e856930036"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c16d381f5eb5f251b6ef8a6d695eb11d07b013d8#c16d381f5eb5f251b6ef8a6d695eb11d07b013d8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -4622,7 +4622,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -8138,7 +8138,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1390,9 +1390,8 @@
       "family": "ideogram",
       "type": "image",
       // Ideogram 4: 9.3B single-stream flow-matching DiT (asymmetric CFG — two DiTs) +
-      // Qwen3-VL-8B text encoder, native MLX only (no torch backend), so hidden off-Mac via
-      // macOnly. Dispatched through the engines::MODEL_TABLE / gen_core registry id `ideogram_4`
-      // (adapter label below is the asset stamp, mirrors mlx_<family>). Epic 4725.
+      // Qwen3-VL-8B text encoder. Dispatched through the engines::MODEL_TABLE / gen_core registry id
+      // `ideogram_4` (adapter label below is the asset stamp, mirrors mlx_<family>). Epic 4725.
       "adapter": "mlx_ideogram",
       // text_to_image + img2img/Remix edit + mask inpaint/outpaint (sc-6303): the native engine's
       // edit path VAE-encodes the source and denoises from a strength-derived step; `image_inpaint`
@@ -1400,7 +1399,13 @@
       // worker's `resolve_ideogram_edit` (base MLX path) builds the source `Reference` + optional
       // `Conditioning::Mask`; the Edit tab gates on `edit_image` + `macSupport.features.edit`.
       "capabilities": ["text_to_image", "edit_image", "image_inpaint"],
-      "macOnly": true,
+      // sc-9092 (epic 9083 gap #3): macOnly is now a no-op label (mirroring krea/lens/klein/flux2_dev) —
+      // candle availability is driven by the routing tables (`CANDLE_ROUTED_MODELS` / `is_candle_engine`),
+      // not this flag. The candle (Windows/Linux) lane packed-loads the SAME `SceneWorks/ideogram-4-mlx`
+      // q4/q8 turnkey the macOS path loads (candle-gen sc-9412), so the per-tier turnkey download above is
+      // installable off-Mac and the separate `SceneWorks/ideogram-4` bf16 diffusers off-Mac entry (the
+      // retired `candle_ideogram_repo` target) is removed.
+      "macOnly": false,
       // Ideogram 4 was trained on STRUCTURED JSON CAPTIONS, not free text — plain text is
       // out-of-distribution (coherent but prompt-agnostic). SceneWorks builds the JSON caption
       // (high-level description + style + compositional deconstruction with 0-1000 bounding boxes
@@ -1413,30 +1418,39 @@
           // packed `q4/` (default, ~15.4 GB) + `q8/` (~28.7 GB, opt-in via advanced mlxQuantize: 8)
           // subdirs, each a self-contained snapshot (2 DiTs + Qwen3-VL TE + VAE + tokenizer). The
           // worker (resolve_ideogram_model_dir, image_jobs) picks the quant subdir and fetches q8/
-          // on demand. Gated non-commercial license; macOS-only download.
+          // on demand. Gated non-commercial license.
+          // sc-9092 (epic 9083 gap #3): installable on Windows/Linux too — the candle Ideogram loader
+          // packed-detects the SAME `SceneWorks/ideogram-4-mlx` q4/q8 tier the macOS path loads
+          // (candle-gen sc-9412, both DiTs), so the off-Mac candle lane picks its tier at download
+          // exactly like macOS via the shared `resolve_weights_dir`/`ideogram_model_subdir`, and the
+          // separate off-Mac `SceneWorks/ideogram-4` bf16 diffusers entry (the retired
+          // `candle_ideogram_repo` target) is removed. q4 is the default off-Mac tier (q8 is a macOS-only
+          // on-demand fetch; off-Mac gracefully falls back to q4).
           "provider": "huggingface",
           "repo": "SceneWorks/ideogram-4-mlx",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
-          "platforms": ["macos"],
+          "platforms": ["macos", "windows", "linux"],
           "estimatedSizeBytes": 15400562623,
           "footprint": { "diskSizeBytes": 15400562623, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
-          // bf16 snapshot — shared across backends from the separate `SceneWorks/ideogram-4` repo's
-          // `bf16/` subdir (the MLX-quantized `ideogram-4-mlx` turnkey above is not bf16). Off-Mac the
-          // candle provider loads it (epic 6561 / sc-6859, `candle_ideogram_subdir`); on macOS it is the
-          // selectable full-precision MLX tier (sc-8513, epic 8506) — the worker resolves this repo's
-          // `bf16/` subdir when advanced mlxQuantize<=0 (rather than a duplicate copy in the MLX repo).
-          // A later quant variant can slot in alongside `bf16/` without a rename. Gated non-commercial.
+          // bf16 snapshot — shared from the separate `SceneWorks/ideogram-4` repo's `bf16/` subdir (the
+          // MLX-quantized `ideogram-4-mlx` turnkey above is not bf16). On macOS it is the selectable
+          // full-precision MLX tier (sc-8513, epic 8506) — the worker resolves this repo's `bf16/` subdir
+          // when advanced mlxQuantize<=0 (rather than a duplicate copy in the MLX repo). A later quant
+          // variant can slot in alongside `bf16/` without a rename. Gated non-commercial.
           // sc-8508: this is a genuine per-tier quant variant (q4 vs bf16 of the same model), so it is
           // labeled `variant: bf16` — even though the two tiers happen to live in separate HF repos.
+          // sc-9092: macOS-only now. The off-Mac candle lane packed-loads the `SceneWorks/ideogram-4-mlx`
+          // q4 turnkey above (via the shared resolver), so the retired `candle_ideogram_repo` bf16 target
+          // resolves nothing off-Mac — the windows/linux platforms are dropped.
           "provider": "huggingface",
           "repo": "SceneWorks/ideogram-4",
           "variant": "bf16",
           "files": ["bf16/*"],
-          "platforms": ["macos", "windows", "linux"],
+          "platforms": ["macos"],
           "estimatedSizeBytes": 54760833024,
           "footprint": { "diskSizeBytes": 54760833024, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
@@ -1519,7 +1533,9 @@
       // Same edit surface as the base (sc-6303): the shared denoise serves img2img/Remix + mask
       // inpaint/outpaint in the CFG-free turbo path too (only the initial latent + start step differ).
       "capabilities": ["text_to_image", "edit_image", "image_inpaint"],
-      "macOnly": true,
+      // sc-9092: macOnly is a no-op label (see `ideogram_4`) — the candle (Windows/Linux) lane packed-loads
+      // the SAME `SceneWorks/ideogram-4-mlx` q4 turnkey (with the bundled turbo LoRA) the macOS path loads.
+      "macOnly": false,
       // Same structured JSON-caption prompt surface as the base model (turbo distills the base, so
       // the caption contract is identical).
       "structuredPrompt": true,
@@ -1532,27 +1548,34 @@
           // BEFORE the LoRA was published shares this repo's snapshot, and a coarse `q4/*` glob is
           // already satisfied by the base files — so the missing LoRA would never flag "incomplete"
           // / show the Fix button. The specific path makes the check exact (apps/rust-api models.rs).
+          // sc-9092: installable on Windows/Linux too — the candle Ideogram-Turbo loader packed-detects
+          // the SAME `SceneWorks/ideogram-4-mlx` q4 turnkey (carrying the bundled `turbo_lora.safetensors`)
+          // the macOS path loads (candle-gen sc-9412), so the off-Mac candle lane picks its tier at
+          // download exactly like macOS, and the separate off-Mac `SceneWorks/ideogram-4` bf16 diffusers
+          // entry (the retired `candle_ideogram_repo` target) is removed.
           "provider": "huggingface",
           "repo": "SceneWorks/ideogram-4-mlx",
           "variant": "q4",
           "default": true,
           "files": ["q4/*", "q4/turbo_lora.safetensors"],
-          "platforms": ["macos"],
+          "platforms": ["macos", "windows", "linux"],
           "estimatedSizeBytes": 16247340792,
           "footprint": { "diskSizeBytes": 16247340792, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           // bf16 snapshot — shared from the separate `SceneWorks/ideogram-4` repo's `bf16/` subdir,
-          // which carries `turbo_lora.safetensors` (the turbo loader merges it at load). Off-Mac the
-          // candle provider loads it (epic 6561 / sc-6859); on macOS it is the selectable full-precision
-          // MLX tier (sc-8513) — the worker resolves this repo's `bf16/` when advanced mlxQuantize<=0,
-          // rather than duplicating it into the MLX turnkey repo. Same gated non-commercial license.
+          // which carries `turbo_lora.safetensors` (the turbo loader merges it at load). On macOS it is the
+          // selectable full-precision MLX tier (sc-8513) — the worker resolves this repo's `bf16/` when
+          // advanced mlxQuantize<=0, rather than duplicating it into the MLX turnkey repo. Same gated
+          // non-commercial license.
           // sc-8508: genuine per-tier quant variant (q4 vs bf16 of the same model) → labeled `bf16`.
+          // sc-9092: macOS-only now — the off-Mac candle lane packed-loads the `SceneWorks/ideogram-4-mlx`
+          // q4 turnkey above, so the retired `candle_ideogram_repo` bf16 target resolves nothing off-Mac.
           "provider": "huggingface",
           "repo": "SceneWorks/ideogram-4",
           "variant": "bf16",
           "files": ["bf16/*"],
-          "platforms": ["macos", "windows", "linux"],
+          "platforms": ["macos"],
           "estimatedSizeBytes": 54760833024,
           "footprint": { "diskSizeBytes": 54760833024, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
@@ -1624,33 +1647,30 @@
       // `adapter` is the asset stamp (mirrors mlx_<family>).
       "adapter": "mlx_boogu",
       "capabilities": ["text_to_image"],
-      "macOnly": true,
+      // sc-9092 (epic 9083 gap #3): macOnly is now a no-op label (mirroring krea/lens/ideogram) — candle
+      // availability is driven by the routing tables (`CANDLE_ROUTED_MODELS` / `is_candle_engine`), not
+      // this flag. The candle (Windows/Linux) lane packed-loads the SAME `SceneWorks/boogu-image-mlx`
+      // Q8 `base/` subfolder the macOS path loads (candle-gen sc-9410 packed-detect, via the shared
+      // `resolve_weights_dir`/`boogu_model_subdir`), so the per-variant turnkey download below is
+      // installable off-Mac and the separate `Boogu/Boogu-Image-0.1-Base` diffusers entry (the retired
+      // `candle_boogu_repo` target) is removed.
+      "macOnly": false,
       "downloads": [
         {
           // Pre-converted MLX turnkey on the SceneWorks HF org (epic 6387 / sc-6397): ONE repo with
-          // Q8 `base/ turbo/ edit/` subfolders (the ship default) + `*-bf16/` full-precision
-          // subfolders. Each subfolder is a complete `transformer/` + `mllm/` (Qwen3-VL + tokenizer)
-          // + `vae/` snapshot loadable via BooguPipeline::from_snapshot. This entry pulls only the Q8
-          // `base/` subfolder (leaf-dir globs — the subfolder nests, so a single-level `base/*` would
-          // miss the files). Apache-2.0, ungated.
+          // Q8 `base/ turbo/ edit/` subfolders (the ship default) + `*-bf16/` `*-q4/` full-precision /
+          // packed subfolders. Each subfolder is a complete `transformer/` + `mllm/` (Qwen3-VL +
+          // tokenizer) + `vae/` snapshot loadable via BooguPipeline::from_snapshot. This entry pulls only
+          // the Q8 `base/` subfolder (leaf-dir globs — the subfolder nests, so a single-level `base/*`
+          // would miss the files). Apache-2.0, ungated.
+          // sc-9092: installable on Windows/Linux too — the candle lane packed-loads this SAME Q8 `base/`
+          // subfolder (candle-gen sc-9410). The non-default `-bf16/` `-q4/` tiers are a macOS-only
+          // on-demand fetch (`ensure_boogu_tier_present`); off-Mac resolves the shipped Q8 default.
           "provider": "huggingface",
           "repo": "SceneWorks/boogu-image-mlx",
           "files": ["base/transformer/*", "base/mllm/*", "base/vae/*"],
-          "platforms": ["macos"],
+          "platforms": ["macos", "windows", "linux"],
           "estimatedSizeBytes": 23380234752
-        },
-        {
-          // Candle (Windows/Linux CUDA) bf16 snapshot (sc-7524, epic 6831): the candle provider can't
-          // read the MLX-quantized turnkey above, so off-Mac loads bf16 from the ORIGINAL public repo
-          // `Boogu/Boogu-Image-0.1-Base` (Apache-2.0, ungated) — already a complete `mllm/ transformer/
-          // vae/` snapshot at the root (the worker's `candle_boogu_repo` loads from the snapshot root, no
-          // subfolder). Whole repo (empty files list). bf16 only (the candle provider rejects on-the-fly
-          // quant). Windows/Linux download.
-          "provider": "huggingface",
-          "repo": "Boogu/Boogu-Image-0.1-Base",
-          "files": [],
-          "platforms": ["windows", "linux"],
-          "estimatedSizeBytes": 38500000000
         }
       ],
       "paths": {
@@ -1726,26 +1746,20 @@
       // code (BooguPipeline::generate_turbo), the `turbo/` checkpoint.
       "adapter": "mlx_boogu",
       "capabilities": ["text_to_image"],
-      "macOnly": true,
+      // sc-9092: macOnly is a no-op label (see `boogu_image`) — the candle (Windows/Linux) lane packed-loads
+      // the SAME `SceneWorks/boogu-image-mlx` Q8 `turbo/` subfolder the macOS path loads (candle-gen sc-9410).
+      "macOnly": false,
       "downloads": [
         {
           // Q8 `turbo/` subfolder of the shared SceneWorks/boogu-image-mlx turnkey (sc-6397).
+          // sc-9092: installable on Windows/Linux too — the candle lane packed-loads this SAME Q8 `turbo/`
+          // subfolder; the `Boogu/Boogu-Image-0.1-Turbo` off-Mac diffusers entry (retired
+          // `candle_boogu_repo` target) is removed.
           "provider": "huggingface",
           "repo": "SceneWorks/boogu-image-mlx",
           "files": ["turbo/transformer/*", "turbo/mllm/*", "turbo/vae/*"],
-          "platforms": ["macos"],
+          "platforms": ["macos", "windows", "linux"],
           "estimatedSizeBytes": 23380234586
-        },
-        {
-          // Candle (Windows/Linux CUDA) bf16 snapshot (sc-7524): off-Mac loads bf16 from the ORIGINAL
-          // public repo `Boogu/Boogu-Image-0.1-Turbo` (the DMD few-step distill — its own weights; same
-          // `mllm/ transformer/ vae/` root layout). Whole repo (empty files list). bf16 only (the candle
-          // provider rejects on-the-fly quant). Apache-2.0, ungated.
-          "provider": "huggingface",
-          "repo": "Boogu/Boogu-Image-0.1-Turbo",
-          "files": [],
-          "platforms": ["windows", "linux"],
-          "estimatedSizeBytes": 38500000000
         }
       ],
       "paths": {
@@ -1816,26 +1830,21 @@
       // only. Native MLX only; the `edit/` checkpoint (carries the lazily-loaded f32 vision tower).
       "adapter": "mlx_boogu",
       "capabilities": ["edit_image"],
-      "macOnly": true,
+      // sc-9092: macOnly is a no-op label (see `boogu_image`) — the candle (Windows/Linux) lane packed-loads
+      // the SAME `SceneWorks/boogu-image-mlx` Q8 `edit/` subfolder the macOS path loads (candle-gen sc-9410,
+      // which loads the Qwen3-VL vision tower off-Mac).
+      "macOnly": false,
       "downloads": [
         {
           // Q8 `edit/` subfolder of SceneWorks/boogu-image-mlx (sc-6397).
+          // sc-9092: installable on Windows/Linux too — the candle lane packed-loads this SAME Q8 `edit/`
+          // subfolder; the `Boogu/Boogu-Image-0.1-Edit` off-Mac diffusers entry (retired `candle_boogu_repo`
+          // target) is removed.
           "provider": "huggingface",
           "repo": "SceneWorks/boogu-image-mlx",
           "files": ["edit/transformer/*", "edit/mllm/*", "edit/vae/*"],
-          "platforms": ["macos"],
+          "platforms": ["macos", "windows", "linux"],
           "estimatedSizeBytes": 23380234314
-        },
-        {
-          // Candle (Windows/Linux CUDA) bf16 snapshot (sc-7524): off-Mac loads bf16 from the ORIGINAL
-          // public repo `Boogu/Boogu-Image-0.1-Edit` (the instruction-edit checkpoint — its `mllm/` carries
-          // the Qwen3-VL vision tower; same `mllm/ transformer/ vae/` root layout). Whole repo (empty files
-          // list). bf16 only (the candle provider rejects on-the-fly quant). Apache-2.0, ungated.
-          "provider": "huggingface",
-          "repo": "Boogu/Boogu-Image-0.1-Edit",
-          "files": [],
-          "platforms": ["windows", "linux"],
-          "estimatedSizeBytes": 38500000000
         }
       ],
       "paths": {

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -710,13 +710,18 @@
         // artifact tagged with a `variant` key + a `footprint` (required on-disk diskSizeBytes;
         // resident/peak backfilled by sc-8770). diskSizeBytes are the EXACT summed on-disk bytes of
         // each SceneWorks/lens-mlx tier subdir. Replaces the dead whole-repo microsoft/Lens download.
+        // sc-9092 (epic 9083 gap #3): these per-tier MLX turnkey subdirs are now installable on
+        // Windows/Linux too — the candle Lens loader packed-detects the SAME `SceneWorks/lens-mlx`
+        // q4/q8/bf16 tier the macOS path loads (candle-gen sc-8799), so the off-Mac lane picks its tier
+        // at download exactly like macOS, and the separate `SceneWorks/Lens` bf16 diffusers INFERENCE
+        // entry (the retired `candle_lens_repo` target) is removed.
         {
           "provider": "huggingface",
           "repo": "SceneWorks/lens-mlx",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
-          "platforms": ["macos"],
+          "platforms": ["macos", "windows", "linux"],
           "estimatedSizeBytes": 18998339228,
           "footprint": { "diskSizeBytes": 18998339228, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
@@ -725,7 +730,7 @@
           "repo": "SceneWorks/lens-mlx",
           "variant": "q8",
           "files": ["q8/*"],
-          "platforms": ["macos"],
+          "platforms": ["macos", "windows", "linux"],
           "estimatedSizeBytes": 29921486998,
           "footprint": { "diskSizeBytes": 29921486998, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
@@ -734,43 +739,27 @@
           "repo": "SceneWorks/lens-mlx",
           "variant": "bf16",
           "files": ["bf16/*"],
-          "platforms": ["macos"],
+          "platforms": ["macos", "windows", "linux"],
           "estimatedSizeBytes": 22347329085,
           "footprint": { "diskSizeBytes": 22347329085, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
-          // Off-Mac candle (Windows/Linux) diffusers rehost (sc-8799): the MLX turnkeys above are packed
-          // q4/q8/bf16 tiers the candle diffusers loader can't read, so the candle lane loads THIS
-          // self-contained diffusers snapshot (tokenizer/ text_encoder/ transformer/ vae/ at the repo
-          // root — what candle_gen_lens::Pipeline::load_components reads), rebuilt from Comfy-Org/Lens +
-          // openai/gpt-oss-20b (MXFP4) + FLUX.2-dev after the original microsoft/Lens went dead. Whole
-          // repo (files: []); the candle provider quantizes on-the-fly (Q4/Q8, descriptor-gated) at
-          // load, so the single bf16 source serves every candle quant tier. Mirrors ideogram_4's
-          // off-Mac bf16 entry + the Wan2.2 macOS-MLX/off-Mac-diffusers split. Resolved by
-          // `candle_lens_repo` (image_jobs/base.rs). Candle sibling of the MLX host sc-8767.
-          "provider": "huggingface",
-          "repo": "SceneWorks/Lens",
-          "variant": "bf16",
-          "files": [],
-          "platforms": ["windows", "linux"],
-          "estimatedSizeBytes": 22334041829,
-          "footprint": { "diskSizeBytes": 22334041829, "residentMemoryBytes": null, "peakMemoryBytes": null }
-        },
-        {
-          // macOS LoRA-training base (sc-8797): the same SceneWorks/Lens diffusers rehost the off-Mac
-          // entry above fetches, exposed as an installable variant on macOS. The MLX q4/q8/bf16 tiers
+          // LoRA-training base (sc-8797): the SceneWorks/Lens FLAT diffusers rehost, exposed as an
+          // installable variant. The MLX q4/q8/bf16 tiers
           // above are packed turnkey SUBDIRS the trainer's flat-diffusers loader doesn't read and the
           // training installed-gate (`training_base_model_installed`, keyed on the target's
           // `baseModelRepo` HF-cache presence) doesn't see — before the tier split (sc-8767) the lens
           // install WAS the flat microsoft/Lens repo, so one download served inference + training.
-          // Installing this variant restores that for macOS training; off-Mac needs nothing extra (the
-          // bf16 candle entry already fetches the whole repo). Per-variant install state probes this
-          // entry's own repo, so it tracks independently of the MLX tiers (sc-8508).
+          // sc-9092: candle inference now packed-loads the `SceneWorks/lens-mlx` turnkey tiers directly
+          // (the separate off-Mac bf16 diffusers INFERENCE entry is retired), so the flat-diffusers
+          // TRAINING base is exposed on Windows/Linux too (the candle LoRA trainer's flat loader still
+          // needs it) — not just macOS. Per-variant install state probes this entry's own repo, so it
+          // tracks independently of the MLX inference tiers (sc-8508).
           "provider": "huggingface",
           "repo": "SceneWorks/Lens",
           "variant": "training",
           "files": [],
-          "platforms": ["macos"],
+          "platforms": ["macos", "windows", "linux"],
           "estimatedSizeBytes": 22334041829,
           "footprint": { "diskSizeBytes": 22334041829, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
@@ -848,13 +837,18 @@
         // on-disk from the SceneWorks/lens-turbo-mlx repo. Note the q8 text-encoder int8 up-cast of the
         // MXFP4 MoE is LARGER than bf16, so q8 > bf16 on disk here. Replaces the whole-repo dense
         // microsoft/Lens-Turbo download.
+        // sc-9092 (epic 9083 gap #3): installable on Windows/Linux too — the candle Lens-Turbo loader
+        // packed-detects the SAME `SceneWorks/lens-turbo-mlx` q4/q8/bf16 tier the macOS path loads
+        // (candle-gen sc-8799), so the off-Mac lane picks its tier at download exactly like macOS, and
+        // the separate `SceneWorks/Lens-Turbo` bf16 diffusers entry (the retired `candle_lens_repo`
+        // target) is removed.
         {
           "provider": "huggingface",
           "repo": "SceneWorks/lens-turbo-mlx",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
-          "platforms": ["macos"],
+          "platforms": ["macos", "windows", "linux"],
           "estimatedSizeBytes": 21830326407,
           // Measured on-device (sc-8516, harness crates/sceneworks-worker/src/footprint_measure.rs):
           // Apple Silicon, 1024², fresh process, via mlx_rs::memory::{get_active_memory,get_peak_memory}.
@@ -870,7 +864,7 @@
           "repo": "SceneWorks/lens-turbo-mlx",
           "variant": "q8",
           "files": ["q8/*"],
-          "platforms": ["macos"],
+          "platforms": ["macos", "windows", "linux"],
           "estimatedSizeBytes": 32753474289,
           "footprint": { "diskSizeBytes": 32753474289, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
@@ -879,25 +873,9 @@
           "repo": "SceneWorks/lens-turbo-mlx",
           "variant": "bf16",
           "files": ["bf16/*"],
-          "platforms": ["macos"],
+          "platforms": ["macos", "windows", "linux"],
           "estimatedSizeBytes": 30651441376,
           "footprint": { "diskSizeBytes": 30651441376, "residentMemoryBytes": null, "peakMemoryBytes": null }
-        },
-        {
-          // Off-Mac candle (Windows/Linux) diffusers rehost (sc-8799): the distilled sibling of the
-          // base-Lens off-Mac entry above. The MLX turnkeys are packed q4/q8/bf16 tiers the candle
-          // diffusers loader can't read, so the candle lane loads THIS self-contained diffusers snapshot
-          // (tokenizer/ text_encoder/ transformer/ vae/ at the repo root), rebuilt from Comfy-Org/Lens'
-          // lens_turbo_bf16 DiT + openai/gpt-oss-20b (MXFP4) + FLUX.2-dev after microsoft/Lens-Turbo went
-          // dead. Whole repo (files: []); candle quantizes on-the-fly at load. Resolved by
-          // `candle_lens_repo`. Candle sibling of the MLX host sc-8763.
-          "provider": "huggingface",
-          "repo": "SceneWorks/Lens-Turbo",
-          "variant": "bf16",
-          "files": [],
-          "platforms": ["windows", "linux"],
-          "estimatedSizeBytes": 22334041788,
-          "footprint": { "diskSizeBytes": 22334041788, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "paths": {
@@ -1925,8 +1903,11 @@
       "adapter": "mlx_krea",
       "capabilities": ["text_to_image"],
       // macOnly is now a no-op label (mirroring klein/flux2_dev): candle availability is driven by the
-      // routing tables (`CANDLE_ROUTED_MODELS` / `is_candle_engine`), not this flag. The candle
-      // (Windows/Linux) lane lights up off the bf16 download below (sc-7581).
+      // routing tables (`CANDLE_ROUTED_MODELS` / `is_candle_engine`), not this flag. sc-9092: the candle
+      // (Windows/Linux) lane now packed-loads the SAME `SceneWorks/krea-2-turbo-mlx` q4/q8/bf16 turnkey
+      // tiers the macOS path loads (candle-gen sc-9411 packed-detect via `krea_model_subdir`), so the
+      // per-tier turnkey downloads below are installable off-Mac and the separate `krea/Krea-2-Turbo`
+      // diffusers entry (the retired `candle_krea_repo` target) is removed.
       "macOnly": false,
       "downloads": [
         {
@@ -1944,7 +1925,7 @@
             "q8/scheduler/*",
             "q8/model_index.json"
           ],
-          "platforms": ["macos"],
+          "platforms": ["macos", "windows", "linux"],
           "estimatedSizeBytes": 20600000000
         },
         {
@@ -1960,7 +1941,7 @@
             "q4/scheduler/*",
             "q4/model_index.json"
           ],
-          "platforms": ["macos"],
+          "platforms": ["macos", "windows", "linux"],
           "estimatedSizeBytes": 12488709648
         },
         {
@@ -1977,20 +1958,8 @@
             "bf16/scheduler/*",
             "bf16/model_index.json"
           ],
-          "platforms": ["macos"],
+          "platforms": ["macos", "windows", "linux"],
           "estimatedSizeBytes": 35678119918
-        },
-        {
-          // Candle (Windows/Linux CUDA) dense bf16 — the ungated public `krea/Krea-2-Turbo` diffusers tree
-          // (Krea 2 Community License). The native candle loader (`Weights::from_dir`) reads the diffusers
-          // subdirs from the snapshot ROOT (no quant subdir — the boogu pattern), so it does NOT use the
-          // MLX `q8/` turnkey above; `candle_krea_repo` reads this entry's `repo`. The repo also ships a
-          // redundant ~24 GB single-file `turbo.safetensors`; skip it (the loader reads only the subdirs).
-          "provider": "huggingface",
-          "repo": "krea/Krea-2-Turbo",
-          "files": ["model_index.json", "transformer/*", "text_encoder/*", "vae/*", "tokenizer/*"],
-          "platforms": ["windows", "linux"],
-          "estimatedSizeBytes": 33800000000
         }
       ],
       "paths": {

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1405,24 +1405,26 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520
 # backend-candle` still resolves the SINGLE gen-core rev 330d339 (the skew gate). ALL candle-gen-*
 # rev lines move together. This is the post-squash main rev — the old branch-head pin 7b7e86a was
 # orphaned by the squash-merge and is no longer reachable.
-# Bumped `7c43ec8` -> `ef84468` (sc-9592): candle-gen main head, picking up the sc-9116 i32-overflow
-# attention sweep (candle-gen #320: shared `candle_gen::attention` query-row chunking now guards the
-# Krea 2 DiT `sdpa`, whose unchunked `[b,48,s,s]` scores tensor overflowed i32 at renders ≥ ~1344² →
-# CUDA_ERROR_ILLEGAL_ADDRESS + poisoned CUDA context until worker restart) plus the #324 (sc-9570)
-# consolidation of the per-crate attention_budgeted copies onto that shared helper. candle-gen's OWN
-# gen-core pin is UNCHANGED at b520a0e (= this worker's mlx-gen pin above), so `--features
-# backend-candle` still resolves the SINGLE gen-core rev (the skew gate). ALL candle-gen-* rev lines
-# move together. ef84468 also carries the sc-9592 1536² krea GPU regression smoke (#329) and the
-# sc-9545 LTX packed-tier ingestion (#328, engine-internal).
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef844683e9e40e5135bac36f183b56e856930036", features = ["cuda"], optional = true }
+# Bumped `ef84468` -> `c16d381f` (sc-9092, epic 9083 gap #3; rebased onto main's ef84468 sc-9592 pin):
+# candle-gen main HEAD, which carries the packed-tier load rollout for the candle image families —
+# ideogram (sc-9412), boogu (sc-9410), krea (sc-9411), lens (sc-8799) all packed-DETECT the hosted MLX
+# `q4/q8/bf16` turnkey subdirs. `c16d381` is main's `ef84468` (the i32-overflow attention sweep +
+# 1536² krea regression smoke) plus ONE further commit — candle-gen #330 (sc-9300, INT8-ConvRot consume
+# path, engine-internal). The worker's candle lane now resolves those weights through the SHARED
+# `resolve_weights_dir` / `standard_tier_subdir` (retiring the four ad-hoc
+# `candle_{ideogram,boogu,krea,lens}_repo` resolvers), reading the SAME turnkey the macOS path loads.
+# candle-gen main's OWN gen-core pin is UNCHANGED at b520a0e7 (= this worker's mlx-gen pin above, and ==
+# ef84468's gen-core), so `--features backend-candle --target all` still resolves the SINGLE gen-core rev
+# b520a0e7 (the skew gate) — no testkit dev-dep reconcile needed. ALL candle-gen-* rev lines move together.
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c16d381f5eb5f251b6ef8a6d695eb11d07b013d8", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef844683e9e40e5135bac36f183b56e856930036", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef844683e9e40e5135bac36f183b56e856930036", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef844683e9e40e5135bac36f183b56e856930036", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef844683e9e40e5135bac36f183b56e856930036", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c16d381f5eb5f251b6ef8a6d695eb11d07b013d8", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c16d381f5eb5f251b6ef8a6d695eb11d07b013d8", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c16d381f5eb5f251b6ef8a6d695eb11d07b013d8", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c16d381f5eb5f251b6ef8a6d695eb11d07b013d8", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1430,17 +1432,17 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef844683e9e40e5135bac36f183b56e856930036", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c16d381f5eb5f251b6ef8a6d695eb11d07b013d8", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef844683e9e40e5135bac36f183b56e856930036", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c16d381f5eb5f251b6ef8a6d695eb11d07b013d8", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef844683e9e40e5135bac36f183b56e856930036", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c16d381f5eb5f251b6ef8a6d695eb11d07b013d8", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1450,7 +1452,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef844683e9e40e5135bac36f183b56e856930036", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c16d381f5eb5f251b6ef8a6d695eb11d07b013d8", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1458,21 +1460,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef844683e9e40e5135bac36f183b56e856930036", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c16d381f5eb5f251b6ef8a6d695eb11d07b013d8", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef844683e9e40e5135bac36f183b56e856930036", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef844683e9e40e5135bac36f183b56e856930036", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c16d381f5eb5f251b6ef8a6d695eb11d07b013d8", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c16d381f5eb5f251b6ef8a6d695eb11d07b013d8", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef844683e9e40e5135bac36f183b56e856930036", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c16d381f5eb5f251b6ef8a6d695eb11d07b013d8", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1481,17 +1483,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef844683e9e40e5135bac36f183b56e856930036", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c16d381f5eb5f251b6ef8a6d695eb11d07b013d8", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef844683e9e40e5135bac36f183b56e856930036", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c16d381f5eb5f251b6ef8a6d695eb11d07b013d8", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef844683e9e40e5135bac36f183b56e856930036", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c16d381f5eb5f251b6ef8a6d695eb11d07b013d8", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1500,7 +1502,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef844683e9e40e5135bac36f183b56e856930036", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c16d381f5eb5f251b6ef8a6d695eb11d07b013d8", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1533,7 +1535,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef844683e9e40e5135bac36f183b56e856930036", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c16d381f5eb5f251b6ef8a6d695eb11d07b013d8", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1542,12 +1544,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef844683e9e40e5135bac36f183b56e856930036", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c16d381f5eb5f251b6ef8a6d695eb11d07b013d8", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef844683e9e40e5135bac36f183b56e856930036", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c16d381f5eb5f251b6ef8a6d695eb11d07b013d8", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1555,7 +1557,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef844
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef844683e9e40e5135bac36f183b56e856930036", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c16d381f5eb5f251b6ef8a6d695eb11d07b013d8", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1564,7 +1566,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef844683e9e40e5135bac36f183b56e856930036", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c16d381f5eb5f251b6ef8a6d695eb11d07b013d8", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1572,7 +1574,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef844683e9e40e5135bac36f183b56e856930036", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c16d381f5eb5f251b6ef8a6d695eb11d07b013d8", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1586,7 +1588,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef844683e9e40e5135bac36f183b56e856930036", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c16d381f5eb5f251b6ef8a6d695eb11d07b013d8", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1613,7 +1615,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef844683e9e40e5135bac36f183b56e856930036", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c16d381f5eb5f251b6ef8a6d695eb11d07b013d8", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1624,7 +1626,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef844683e9e40e5135bac36f183b56e856930036", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c16d381f5eb5f251b6ef8a6d695eb11d07b013d8", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/generator_cache.rs
+++ b/crates/sceneworks-worker/src/generator_cache.rs
@@ -594,6 +594,46 @@ mod tests {
         );
     }
 
+    /// sc-9092 (epic 9083): the candle-lane A/B quant toggle must MISS the generator cache so the new
+    /// tier is loaded rather than the resident one reused. On the candle lane (now routed through the
+    /// shared `standard_tier_subdir`, sc-9092) toggling `advanced.mlxQuantize` changes BOTH the resolved
+    /// tier subdir (`q4/` ↔ `q8/` ↔ `bf16/`) AND the load `quantize` — either alone flips the key, so a
+    /// toggle can never collide with the cached generator (reload-always on toggle, epic 8506). This is
+    /// the candle sibling of the MLX A/B behaviour: `GeneratorCacheKey` already keys on both fields.
+    #[test]
+    fn cache_key_includes_quant_tier_toggle() {
+        // q4 tier: `<root>/q4` weights + Q4 load quant.
+        let mut q4 = LoadSpec::new(WeightsSource::Dir(PathBuf::from("/models/lens/q4")));
+        q4.quantize = Some(Quant::Q4);
+        // q8 tier: `<root>/q8` weights + Q8 load quant (the A/B toggle target).
+        let mut q8 = LoadSpec::new(WeightsSource::Dir(PathBuf::from("/models/lens/q8")));
+        q8.quantize = Some(Quant::Q8);
+        // bf16 tier: `<root>/bf16` weights, dense (no quant).
+        let bf16 = LoadSpec::new(WeightsSource::Dir(PathBuf::from("/models/lens/bf16")));
+
+        // Every pairwise toggle is a distinct cache entry → a miss → a reload, never a wrong-tier reuse.
+        assert_ne!(
+            GeneratorCacheKey::from_load_spec("lens", &q4),
+            GeneratorCacheKey::from_load_spec("lens", &q8)
+        );
+        assert_ne!(
+            GeneratorCacheKey::from_load_spec("lens", &q8),
+            GeneratorCacheKey::from_load_spec("lens", &bf16)
+        );
+        assert_ne!(
+            GeneratorCacheKey::from_load_spec("lens", &q4),
+            GeneratorCacheKey::from_load_spec("lens", &bf16)
+        );
+        // The `quantize` field alone flips the key even if the tier dir were identical — the candle lane
+        // has always keyed on it (generator_cache.rs), so the A/B toggle is safe regardless of layout.
+        let mut same_dir_q8 = q4.clone();
+        same_dir_q8.quantize = Some(Quant::Q8);
+        assert_ne!(
+            GeneratorCacheKey::from_load_spec("lens", &q4),
+            GeneratorCacheKey::from_load_spec("lens", &same_dir_q8)
+        );
+    }
+
     #[test]
     fn cache_key_includes_control_and_ip_components() {
         let mut control = LoadSpec::new(WeightsSource::Dir(PathBuf::from("/models/base")));

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -306,10 +306,11 @@ fn model_repo(request: &ImageRequest, model: &ResolvedModel) -> String {
         .to_owned()
 }
 
-/// The separate `SceneWorks/ideogram-4` repo that hosts Ideogram 4's bf16 tree under `bf16/` — shared
-/// by the candle off-Mac lane (sc-6859) and, on macOS, the selectable full-precision MLX tier
-/// (sc-8513). The MLX `q4/`/`q8/` turnkey lives in `SceneWorks/ideogram-4-mlx`; bf16 is resolved from
-/// THIS repo rather than duplicated. (The candle lane has its own cfg-gated [`CANDLE_IDEOGRAM_REPO`].)
+/// The separate `SceneWorks/ideogram-4` repo that hosts Ideogram 4's bf16 tree under `bf16/`, the
+/// macOS selectable full-precision MLX tier (sc-8513). The MLX `q4/`/`q8/` turnkey lives in
+/// `SceneWorks/ideogram-4-mlx`; bf16 is resolved from THIS repo rather than duplicated. (Off-Mac the
+/// candle Ideogram lane packed-loads the `SceneWorks/ideogram-4-mlx` turnkey subdir directly via the
+/// shared `resolve_weights_dir`/`ideogram_model_subdir` since sc-9092 — no separate candle repo.)
 #[cfg(target_os = "macos")]
 const IDEOGRAM_BF16_REPO: &str = "SceneWorks/ideogram-4";
 
@@ -343,12 +344,12 @@ pub(crate) fn resolve_weights_dir(
     // turbo variant (mlx-gen #488) shares the same turnkey — each subdir also carries the bundled
     // `turbo_lora.safetensors` the `ideogram_4_turbo` engine installs at load.
     if request.model == "ideogram_4" || request.model == "ideogram_4_turbo" {
-        // bf16 (sc-8513, epic 8506) is the SHARED `SceneWorks/ideogram-4` repo's `bf16/` subdir — the
-        // same full-precision tree the candle off-Mac lane loads (sc-6859) — NOT duplicated into the
-        // MLX turnkey. When the macOS request opts into bf16 (advanced mlxQuantize<=0) AND it is
-        // downloaded, resolve there (the dense weights load with no quantize); else the q4 (default)/q8
-        // turnkey subdir. A partial bf16 download falls back rather than half-loading. (macOS/MLX only —
-        // the candle lane resolves bf16 through its own `candle_ideogram_subdir` path, unchanged.)
+        // bf16 (sc-8513, epic 8506) is the SHARED `SceneWorks/ideogram-4` repo's `bf16/` subdir — NOT
+        // duplicated into the MLX turnkey. When the macOS request opts into bf16 (advanced mlxQuantize<=0)
+        // AND it is downloaded, resolve there (the dense weights load with no quantize); else the q4
+        // (default)/q8 turnkey subdir. A partial bf16 download falls back rather than half-loading.
+        // (macOS/MLX only — this `#[cfg(target_os = "macos")]` block is skipped on the candle lane, which
+        // shares the `ideogram_model_subdir` q4/q8 turnkey resolution below since sc-9092.)
         #[cfg(target_os = "macos")]
         {
             let wants_bf16 = request
@@ -437,6 +438,18 @@ const STANDARD_TIER_MODELS: &[&str] = &[
     // weights, bf16 resolves to Quant::None). Replaces the gated BFL download + install-time quantize.
     "flux_schnell",
     "flux_dev",
+    // Lens / Lens-Turbo (sc-9092, epic 9083 gap #3): the SceneWorks re-hosted `SceneWorks/lens-mlx` /
+    // `SceneWorks/lens-turbo-mlx` turnkeys are standard q4/q8/bf16 tiers (their manifests already flag
+    // `mlx.standardTierLayout: true`, so `uses_standard_tier_layout` was already true via the manifest —
+    // registering them here is the zero-manifest-change form + documents the candle-lane opt-in). As of
+    // the candle-gen packed-load rollout (sc-8799) the candle Lens loader packed-detects the SAME
+    // turnkey subdir the macOS path loads, so the ad-hoc `candle_lens_repo` (a separate bf16 diffusers
+    // rehost) is retired and both lanes resolve Lens through `standard_tier_subdir`. Lens is the lone
+    // candle family that ALSO advertises `supported_quants` (Q4/Q8) today, so `resolve_quant` engages on
+    // its candle lane; ideogram/boogu/krea keep their legacy per-family subdir resolvers (non-standard
+    // q4-default / per-variant / q8-default layouts) and are NOT registered here.
+    "lens",
+    "lens_turbo",
 ];
 
 /// Standard-tier models whose text encoder ships DENSE bf16 in EVERY tier (epic 8506, sc-8711:
@@ -2793,12 +2806,14 @@ fn is_candle_engine(model: &str) -> bool {
             | "boogu_image_turbo"
             | "boogu_image_edit"
             // Krea 2 Turbo (sc-7581, epic 7565 P4): txt2img + inference LoRA/LoKr on the generic candle
-            // lane (CFG-free 8-step). Like Boogu, its MLX turnkey (`SceneWorks/krea-2-turbo-mlx`, q8/q4
-            // packed) isn't candle-readable, so the candle lane loads bf16 from the ungated public
-            // `krea/Krea-2-Turbo` snapshot root (no subdir). The `candle-gen-krea` descriptor advertises
-            // supports_lora/supports_lokr (sc-7836), so `generate_candle_stream` resolves a
+            // lane (CFG-free 8-step). sc-9092: the candle lane now packed-loads the SAME
+            // `SceneWorks/krea-2-turbo-mlx` q8/q4 turnkey subdir the macOS path loads (candle-gen sc-9411
+            // packed-detect, via the shared `resolve_weights_dir`/`krea_model_subdir`) — the ad-hoc
+            // `candle_krea_repo` bf16 diffusers rehost is retired. The `candle-gen-krea` descriptor
+            // advertises supports_lora/supports_lokr (sc-7836), so `generate_candle_stream` resolves a
             // `krea_2_raw`-trained adapter via `model.supports_adapters()`. No edit/reference/control
-            // shapes and no on-the-fly quant (dense bf16 only).
+            // shapes; on-the-fly quant stays descriptor-gated (`supported_quants` still `&[]` — the
+            // packed turnkey self-describes its tier at load).
             | "krea_2_turbo"
             // Stable Diffusion 3.5 (sc-7880, epic 7982): Large / Large Turbo / Medium all ride the generic
             // candle txt2img lane (the `candle-gen-sd3` provider). `generate_candle_stream` resolves Q4/Q8
@@ -2838,196 +2853,6 @@ fn candle_adapter_label(model: &str) -> &'static str {
         // sdxl / realvisxl share the candle "sdxl" engine.
         _ => CANDLE_ADAPTER,
     }
-}
-
-/// The candle Ideogram 4 weights repo (bf16). Ideogram is the lone candle image family whose upstream
-/// isn't candle-readable — the published `SceneWorks/ideogram-4-mlx` turnkey (the MODEL_TABLE default +
-/// the macOS MLX repo) is MLX-quantized — so the candle lane loads bf16 from a separate repo (sc-6859),
-/// the image sibling of the video `CANDLE_WAN_5B_REPO`. The bf16 weights live under the repo's `bf16/`
-/// subdir so quant variants (`q4/`/`q8/`) can slot in later without a rename (cf. the MLX turnkey).
-#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-const CANDLE_IDEOGRAM_REPO: &str = "SceneWorks/ideogram-4";
-
-/// Resolve the candle Ideogram weights repo: the off-Mac (`std::env::consts::OS`) download entry's
-/// `repo` from the manifest (the bf16 repo) — the single source of truth, also driving the downloader —
-/// else the [`CANDLE_IDEOGRAM_REPO`] default. Deliberately NOT the entry-level `repo`, which is the
-/// macOS MLX turnkey. Mirrors how `candle_video_repo` overrides the MLX repo with the diffusers one.
-#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-fn candle_ideogram_repo(request: &ImageRequest) -> String {
-    let os = std::env::consts::OS;
-    request
-        .model_manifest_entry
-        .get("downloads")
-        .and_then(Value::as_array)
-        .and_then(|downloads| {
-            downloads.iter().find_map(|entry| {
-                let matches_os = entry
-                    .get("platforms")
-                    .and_then(Value::as_array)
-                    .is_some_and(|platforms| platforms.iter().any(|p| p.as_str() == Some(os)));
-                if !matches_os {
-                    return None;
-                }
-                entry
-                    .get("repo")
-                    .and_then(Value::as_str)
-                    .map(str::trim)
-                    .filter(|repo| !repo.is_empty())
-                    .map(str::to_owned)
-            })
-        })
-        .unwrap_or_else(|| CANDLE_IDEOGRAM_REPO.to_owned())
-}
-
-/// The precision subdir within the candle Ideogram repo snapshot. Candle is bf16-only today (the
-/// provider rejects on-the-fly quant), so this resolves the `bf16/` subdir (mirroring the MLX turnkey's
-/// `q4/`/`q8/`); a future candle quant variant slots in alongside it. Falls back to the snapshot root so
-/// a flat (subdir-less) layout still loads.
-#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-fn candle_ideogram_subdir(root: &Path) -> PathBuf {
-    let bf16 = root.join("bf16");
-    if bf16.join("transformer").join("model.safetensors").is_file() {
-        bf16
-    } else {
-        root.to_path_buf()
-    }
-}
-
-/// The default candle Boogu-Image-0.1 weights repo for a variant. The MLX turnkey
-/// (`SceneWorks/boogu-image-mlx`, the `MODEL_TABLE` default + the macOS MLX repo) is MLX-quantized and
-/// NOT candle-readable, but — unlike Ideogram — Boogu needs no re-hosted bf16 turnkey: the ORIGINAL
-/// public repos `Boogu/Boogu-Image-0.1-{Base,Turbo,Edit}` (Apache-2.0, ungated) are already bf16 and
-/// already laid out as a complete `mllm/ transformer/ vae/` snapshot at the repo root — exactly what the
-/// provider's `pipeline::load_components` reads. So the candle lane points straight at them (one repo per
-/// variant, loaded from the snapshot root — no `base/ turbo/ edit/` subfolder, unlike the MLX turnkey).
-#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-fn candle_boogu_default_repo(model: &str) -> &'static str {
-    match model {
-        "boogu_image_turbo" => "Boogu/Boogu-Image-0.1-Turbo",
-        "boogu_image_edit" => "Boogu/Boogu-Image-0.1-Edit",
-        _ => "Boogu/Boogu-Image-0.1-Base",
-    }
-}
-
-/// Resolve the candle Boogu weights repo for `request.model`: the off-Mac (`std::env::consts::OS`)
-/// download entry's `repo` from the manifest (the single source of truth, also driving the downloader) —
-/// else the per-variant [`candle_boogu_default_repo`]. Deliberately NOT the entry-level `repo` /
-/// `model_repo`, which is the macOS MLX turnkey. Mirrors `candle_ideogram_repo`.
-#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-fn candle_boogu_repo(request: &ImageRequest) -> String {
-    let os = std::env::consts::OS;
-    request
-        .model_manifest_entry
-        .get("downloads")
-        .and_then(Value::as_array)
-        .and_then(|downloads| {
-            downloads.iter().find_map(|entry| {
-                let matches_os = entry
-                    .get("platforms")
-                    .and_then(Value::as_array)
-                    .is_some_and(|platforms| platforms.iter().any(|p| p.as_str() == Some(os)));
-                if !matches_os {
-                    return None;
-                }
-                entry
-                    .get("repo")
-                    .and_then(Value::as_str)
-                    .map(str::trim)
-                    .filter(|repo| !repo.is_empty())
-                    .map(str::to_owned)
-            })
-        })
-        .unwrap_or_else(|| candle_boogu_default_repo(&request.model).to_owned())
-}
-
-/// The candle Krea 2 Turbo weights repo (bf16). The MLX turnkey (`SceneWorks/krea-2-turbo-mlx`, the
-/// `MODEL_TABLE` default + the macOS MLX repo) ships packed `q8/`/`q4/` subdirs, which the candle
-/// provider (dense bf16, `supported_quants: &[]`) can't load — but, like Boogu, Krea needs no re-hosted
-/// bf16 turnkey: the ORIGINAL public `krea/Krea-2-Turbo` (Krea 2 Community License, ungated) is already a
-/// complete bf16 `transformer/ text_encoder/ vae/ tokenizer/` diffusers snapshot at the repo root —
-/// exactly what the provider's `pipeline::load_components` reads. So the candle lane points straight at it
-/// (loaded from the snapshot root — no subdir). Mirrors `candle_boogu_repo` / `candle_ideogram_repo`.
-#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-const CANDLE_KREA_REPO: &str = "krea/Krea-2-Turbo";
-
-/// Resolve the candle Krea weights repo: the off-Mac (`std::env::consts::OS`) download entry's `repo`
-/// from the manifest (the bf16 repo — the single source of truth, also driving the downloader) — else
-/// the [`CANDLE_KREA_REPO`] default. Deliberately NOT the entry-level `repo` / `model_repo`, which is the
-/// macOS MLX turnkey. Mirrors `candle_boogu_repo`.
-#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-fn candle_krea_repo(request: &ImageRequest) -> String {
-    let os = std::env::consts::OS;
-    request
-        .model_manifest_entry
-        .get("downloads")
-        .and_then(Value::as_array)
-        .and_then(|downloads| {
-            downloads.iter().find_map(|entry| {
-                let matches_os = entry
-                    .get("platforms")
-                    .and_then(Value::as_array)
-                    .is_some_and(|platforms| platforms.iter().any(|p| p.as_str() == Some(os)));
-                if !matches_os {
-                    return None;
-                }
-                entry
-                    .get("repo")
-                    .and_then(Value::as_str)
-                    .map(str::trim)
-                    .filter(|repo| !repo.is_empty())
-                    .map(str::to_owned)
-            })
-        })
-        .unwrap_or_else(|| CANDLE_KREA_REPO.to_owned())
-}
-
-/// The default candle Lens / Lens-Turbo weights repo for a variant. Microsoft pulled the original
-/// `microsoft/Lens` + `microsoft/Lens-Turbo` from HF; the macOS/MLX path recovered them as the
-/// packed `SceneWorks/lens-mlx` / `SceneWorks/lens-turbo-mlx` tiers (sc-8767 — the `MODEL_TABLE`
-/// default + the macOS MLX repo), which are MLX-quantized (`bf16/`/`q8/`/`q4/` subdirs) and NOT
-/// candle-readable. The candle lane instead loads a re-assembled **self-contained diffusers** snapshot
-/// (`tokenizer/ text_encoder/ transformer/ vae/` at the repo root — exactly what `Pipeline::load_components`
-/// reads): `SceneWorks/Lens` (base) / `SceneWorks/Lens-Turbo` (distilled), rebuilt from the Comfy-Org/Lens
-/// DiT + stock `openai/gpt-oss-20b` (MXFP4) encoder/tokenizer + the FLUX.2-dev VAE (sc-8799 — the candle
-/// sibling of sc-8767). Loaded from the snapshot root, no subdir. Per-variant like `candle_boogu_default_repo`.
-#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-fn candle_lens_default_repo(model: &str) -> &'static str {
-    match model {
-        "lens_turbo" => "SceneWorks/Lens-Turbo",
-        _ => "SceneWorks/Lens",
-    }
-}
-
-/// Resolve the candle Lens weights repo for `request.model`: the off-Mac (`std::env::consts::OS`)
-/// download entry's `repo` from the manifest (the single source of truth, also driving the downloader) —
-/// else the per-variant [`candle_lens_default_repo`]. Deliberately NOT the entry-level `repo` /
-/// `model_repo`, which is the macOS MLX turnkey (`SceneWorks/lens-mlx`, unreadable by the candle
-/// diffusers loader). Mirrors `candle_boogu_repo` / `candle_krea_repo`.
-#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-fn candle_lens_repo(request: &ImageRequest) -> String {
-    let os = std::env::consts::OS;
-    request
-        .model_manifest_entry
-        .get("downloads")
-        .and_then(Value::as_array)
-        .and_then(|downloads| {
-            downloads.iter().find_map(|entry| {
-                let matches_os = entry
-                    .get("platforms")
-                    .and_then(Value::as_array)
-                    .is_some_and(|platforms| platforms.iter().any(|p| p.as_str() == Some(os)));
-                if !matches_os {
-                    return None;
-                }
-                entry
-                    .get("repo")
-                    .and_then(Value::as_str)
-                    .map(str::trim)
-                    .filter(|repo| !repo.is_empty())
-                    .map(str::to_owned)
-            })
-        })
-        .unwrap_or_else(|| candle_lens_default_repo(&request.model).to_owned())
 }
 
 /// Windows/CUDA candle execution path (sc-3675 SDXL, generalized in sc-5096). The macOS dispatch is
@@ -3076,70 +2901,23 @@ async fn generate_candle_stream(
         model.backend()
     };
     let is_ideogram = crate::ideogram_caption::is_ideogram_model(&request.model);
-    // Boogu (sc-7524) is the second candle image family whose upstream turnkey isn't candle-readable: its
-    // `SceneWorks/boogu-image-mlx` turnkey is MLX-quantized, so the candle lane loads bf16 from the
-    // ORIGINAL public `Boogu/Boogu-Image-0.1-{Base,Turbo,Edit}` repos (per-variant; each a complete
-    // `mllm/ transformer/ vae/` snapshot at its root — loaded directly, no subfolder).
-    let is_boogu = matches!(
-        request.model.as_str(),
-        "boogu_image" | "boogu_image_turbo" | "boogu_image_edit"
-    );
-    // Krea 2 Turbo (sc-7581) is the third such family: its `SceneWorks/krea-2-turbo-mlx` turnkey is packed
-    // q8/q4, so the candle lane loads bf16 from the ungated public `krea/Krea-2-Turbo` (the boogu pattern —
-    // the diffusers snapshot root, no subdir).
-    let is_krea = request.model == "krea_2_turbo";
-    // Lens / Lens-Turbo (sc-8799) is the fourth such family: Microsoft pulled the original
-    // `microsoft/Lens*`, and the recovered `SceneWorks/lens-mlx` / `SceneWorks/lens-turbo-mlx` turnkeys
-    // (sc-8767) are MLX-packed q4/q8/bf16 tiers the candle diffusers loader can't read, so the candle lane
-    // loads the re-assembled self-contained diffusers snapshot `SceneWorks/Lens` / `SceneWorks/Lens-Turbo`
-    // (snapshot root, no subdir).
-    let is_lens = matches!(request.model.as_str(), "lens" | "lens_turbo");
-    // Ideogram + Boogu + Krea + Lens are the candle image families whose `MODEL_TABLE` turnkey isn't
-    // candle-readable: the published `SceneWorks/ideogram-4-mlx` / `SceneWorks/boogu-image-mlx` /
-    // `SceneWorks/krea-2-turbo-mlx` / `SceneWorks/lens{,-turbo}-mlx` (the macOS MLX repos) are
-    // MLX-quantized, so the candle lane loads from a different repo. Ideogram re-hosts a bf16 copy
-    // (`SceneWorks/ideogram-4`'s `bf16/` subdir, because the upstream is gated); Boogu + Krea point straight
-    // at their ungated public originals (`Boogu/Boogu-Image-0.1-*` / `krea/Krea-2-Turbo`); Lens loads a
-    // re-assembled diffusers rehost (`SceneWorks/Lens{,-Turbo}`, the original source being dead) — all from
-    // the snapshot root. macOS keeps the MLX turnkeys. Every other candle family shares its upstream
-    // diffusers repo via `model_repo`.
-    let repo = if is_ideogram {
-        candle_ideogram_repo(request)
-    } else if is_boogu {
-        candle_boogu_repo(request)
-    } else if is_krea {
-        candle_krea_repo(request)
-    } else if is_lens {
-        candle_lens_repo(request)
-    } else {
-        model_repo(request, &model)
-    };
-    // A convert-at-install model (FLUX.2-klein `_true_v2`, sc-7459) is a single-file fine-tune with no
-    // diffusers tree in its HF cache, so it loads from the locally-assembled converted dir via the
-    // `modelPath` seam (injected by the API's `inject_converted_model_path`), exactly like the MLX
-    // path's `resolve_weights_dir`. An explicit `modelPath` (advanced override or manifest) wins over
-    // the HF-cache snapshot; `resolve_app_managed_model_dir` constrains it to app-managed data.
-    let model_path = request
-        .advanced
-        .get("modelPath")
-        .or_else(|| request.model_manifest_entry.get("modelPath"))
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|path| !path.is_empty());
-    let weights_dir = if let Some(model_path) = model_path {
-        resolve_app_managed_model_dir(settings, model_path, "Image modelPath")?
-    } else {
-        let snapshot = huggingface_snapshot_dir(&settings.data_dir, &repo).ok_or_else(|| {
-            WorkerError::InvalidPayload(format!("candle weights snapshot not found for {repo}"))
-        })?;
-        // Ideogram nests its weights under a `bf16/` subdir; Boogu's originals (and every other family)
-        // are a complete snapshot at the root, so `weights_dir` is the snapshot itself.
-        if is_ideogram {
-            candle_ideogram_subdir(&snapshot)
-        } else {
-            snapshot
-        }
-    };
+    // Standard-tier weight resolution, SHARED with the MLX lane (sc-9092, epic 9083 gap #3). Every
+    // candle image family — Ideogram / Boogu / Krea / Lens included — now packed-loads the SAME
+    // SceneWorks MLX-packed per-tier turnkey the macOS path uses: as of the candle-gen rollout all 11
+    // packed-load-capable crates read a packed `q4/q8/bf16` (or the Ideogram/Boogu/Krea legacy-layout)
+    // turnkey subdir directly, so the four ad-hoc `candle_{ideogram,boogu,krea,lens}_repo` resolvers
+    // (which pointed candle at a SEPARATE bf16 diffusers rehost because it couldn't read the packed
+    // turnkeys) are retired. `resolve_weights_dir` applies the identical dispatch the MLX path uses —
+    // an explicit `modelPath` override (FLUX.2-klein `_true_v2` convert-at-install), then the Ideogram
+    // (`ideogram_model_subdir`) / Boogu (`boogu_model_subdir`) / Krea (`krea_model_subdir`) per-family
+    // subdir, then `standard_tier_subdir` (Lens + the STANDARD_TIER_MODELS registry) resolving the
+    // requested `advanced.mlxQuantize` → q4/q8/bf16 tier — so the candle lane needs no bespoke repo
+    // logic. `model` is already resolved via `mlx_model` above, so a `None` here means only the
+    // snapshot is absent (unfetched turnkey), which stays a loud load error.
+    let weights_dir = resolve_weights_dir(request, settings)?.ok_or_else(|| {
+        let repo = model_repo(request, &model);
+        WorkerError::InvalidPayload(format!("candle weights snapshot not found for {repo}"))
+    })?;
 
     // Descriptor-derived denoise/guidance surface (distilled families → no guidance/negative; guided
     // families → the scale + negative prompt). Identical to the MLX path; quant + LoRA are omitted.
@@ -3271,7 +3049,10 @@ async fn generate_candle_stream(
     // other candle family ignores the fields too.
     let enhance = PromptEnhance::from_advanced(&request.advanced);
     // Record the effective CFG knob (guidance for guided families, else true_cfg) + quant bits in the
-    // recipe, so a Lens asset's sidecar reflects the Q4/Q8 it ran at (parity with the MLX path).
+    // recipe, so a Lens asset's sidecar reflects the Q4/Q8 it ran at (parity with the MLX path). The
+    // recorded repo is the resolved model repo (the MLX turnkey the candle lane now packed-loads from,
+    // sc-9092) — the same `model_repo` the MLX path records.
+    let repo = model_repo(request, &model);
     let raw_settings = mlx_raw_settings(request, &repo, steps, quant_bits, guidance.or(true_cfg));
     let spec = load_spec(weights_dir, quant, adapters, None);
 
@@ -3685,23 +3466,6 @@ mod candle_label_tests {
         assert_eq!(candle_adapter_label("sd3_5_medium"), "candle_sd3");
     }
 
-    // sc-8799: the candle Lens lane resolves the re-assembled diffusers rehost per variant (NOT the
-    // MLX-packed `SceneWorks/lens{,-turbo}-mlx` turnkey `model_repo` falls back to), since Microsoft
-    // pulled the original `microsoft/Lens*`. Base → `SceneWorks/Lens`, distilled → `SceneWorks/Lens-Turbo`.
-    // `candle_lens_repo` layers only a manifest-`downloads` override on top of this default (the exact
-    // shape unit-tested for the sibling `candle_ideogram_repo` lane), so the per-variant map is the crux.
-    #[test]
-    fn candle_lens_default_repo_is_per_variant_diffusers_rehost() {
-        assert_eq!(candle_lens_default_repo("lens"), "SceneWorks/Lens");
-        assert_eq!(
-            candle_lens_default_repo("lens_turbo"),
-            "SceneWorks/Lens-Turbo"
-        );
-        // Neither default is the MLX turnkey the entry-level `repo` / `model_repo` would supply.
-        assert!(!candle_lens_default_repo("lens").ends_with("-mlx"));
-        assert!(!candle_lens_default_repo("lens_turbo").ends_with("-mlx"));
-    }
-
     #[test]
     fn is_candle_engine_covers_only_the_wired_txt2img_families() {
         for model in [
@@ -4018,6 +3782,45 @@ mod standard_tier_tests {
             json!({ "denseTextEncoderTier": true })
         )));
         assert!(!is_dense_te_tier(&manifest_request("flux2_dev", json!({}))));
+    }
+
+    /// sc-9092 (epic 9083 gap #3): the candle Lens lane no longer resolves a SEPARATE bf16 diffusers
+    /// rehost (`SceneWorks/Lens{,-Turbo}`, the retired `candle_lens_repo`) — it packed-loads the SAME
+    /// `SceneWorks/lens{,-turbo}-mlx` MLX turnkey the macOS path uses, routed through the shared
+    /// `standard_tier_subdir` (`lens`/`lens_turbo` opt in via `mlx.standardTierLayout`, exactly like the
+    /// MLX lane). This proves the shared tier resolver picks the requested q4/q8/bf16 subdir of a Lens
+    /// turnkey snapshot off-Mac — the candle-lane sibling of the SD3.5 `standard_tier_subdir` tests
+    /// above — so the retired resolver is fully replaced by the standard machinery.
+    #[test]
+    fn candle_lens_resolves_packed_turnkey_tier_subdir() {
+        let lens_request = |bits: serde_json::Value| {
+            ImageRequest::from_payload(
+                json!({ "model": "lens", "advanced": { "mlxQuantize": bits } })
+                    .as_object()
+                    .unwrap(),
+            )
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        // A Lens turnkey ships packed per-tier subdirs (transformer + gpt-oss-20b MoE TE + FLUX.2 VAE).
+        seed_tier(root, "q4", "diffusion_pytorch_model.safetensors");
+        seed_tier(root, "q8", "diffusion_pytorch_model.safetensors");
+        seed_tier(root, "bf16", "diffusion_pytorch_model.safetensors.index.json");
+
+        // A/B tier toggle: default (q4) / mlxQuantize:8 (q8) / mlxQuantize:0 (bf16) each resolve to
+        // their tier subdir — the same q4-default recipe the `lens` manifest declares (`mlx.quantize:4`).
+        assert_eq!(
+            standard_tier_subdir(root, &lens_request(json!(null))),
+            root.join("q4")
+        );
+        assert_eq!(
+            standard_tier_subdir(root, &lens_request(json!(8))),
+            root.join("q8")
+        );
+        assert_eq!(
+            standard_tier_subdir(root, &lens_request(json!(0))),
+            root.join("bf16")
+        );
     }
 }
 

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -3822,6 +3822,67 @@ mod standard_tier_tests {
             root.join("bf16")
         );
     }
+
+    /// sc-9092 (epic 9083 gap #3, review fix): Ideogram + Boogu were left `macOnly:true` with only
+    /// off-Mac diffusers download entries, which the PR deleted — so off-Mac they resolved to the MLX
+    /// turnkey (`SceneWorks/{ideogram-4,boogu-image}-mlx`) whose download entries were macOS-only and
+    /// thus never fetched (a "candle weights snapshot not found" load error). The fix flips them
+    /// `macOnly:false` and extends the turnkey download `platforms` to windows/linux, so both lanes
+    /// packed-load the SAME turnkey the macOS path uses (candle-gen sc-9412 / sc-9410). This asserts the
+    /// per-family subdir resolvers pick the shipped tier of a turnkey snapshot regardless of platform —
+    /// the ideogram/boogu sibling of `candle_lens_resolves_packed_turnkey_tier_subdir` above.
+    #[test]
+    fn candle_ideogram_boogu_resolve_packed_turnkey_tier_subdir() {
+        let model_request = |model: &str, bits: serde_json::Value| {
+            ImageRequest::from_payload(
+                json!({ "model": model, "advanced": { "mlxQuantize": bits } })
+                    .as_object()
+                    .unwrap(),
+            )
+        };
+
+        // Ideogram turnkey (`SceneWorks/ideogram-4-mlx`): q4 default (candle off-Mac tier) + on-demand
+        // q8. `ideogram_model_subdir` probes `<tier>/transformer/model.safetensors`.
+        {
+            let tmp = tempfile::tempdir().unwrap();
+            let root = tmp.path();
+            seed_tier(root, "q4", "model.safetensors");
+            seed_tier(root, "q8", "model.safetensors");
+            for model in ["ideogram_4", "ideogram_4_turbo"] {
+                // Default → q4 (the shipped off-Mac tier).
+                assert_eq!(
+                    ideogram_model_subdir(root, &model_request(model, json!(null))),
+                    root.join("q4")
+                );
+                // mlxQuantize:8 → q8 when present.
+                assert_eq!(
+                    ideogram_model_subdir(root, &model_request(model, json!(8))),
+                    root.join("q8")
+                );
+            }
+        }
+
+        // Boogu turnkey (`SceneWorks/boogu-image-mlx`): Q8 `base/`/`turbo/`/`edit/` is the shipped
+        // (off-Mac) default. `boogu_model_subdir` probes `<variant>/transformer/diffusion_pytorch_model.safetensors`.
+        {
+            let tmp = tempfile::tempdir().unwrap();
+            let root = tmp.path();
+            for variant in ["base", "turbo", "edit"] {
+                seed_tier(root, variant, "diffusion_pytorch_model.safetensors");
+            }
+            for (model, variant) in [
+                ("boogu_image", "base"),
+                ("boogu_image_turbo", "turbo"),
+                ("boogu_image_edit", "edit"),
+            ] {
+                // Default (no mlxQuantize) → the shipped Q8 `<variant>/` subfolder.
+                assert_eq!(
+                    boogu_model_subdir(root, &model_request(model, json!(null))),
+                    root.join(variant)
+                );
+            }
+        }
+    }
 }
 
 /// sc-8820: the recorded quant must reflect the tier subdir ACTUALLY resolved, not the one requested,


### PR DESCRIPTION
## sc-9092 — Worker: candle-lane standard-tier routing

Epic 9083 gap #3. The candle image lane now resolves weights through the **same shared machinery as the MLX lane**, packed-loading the **same** hosted SceneWorks MLX turnkey tiers instead of a separate bf16 diffusers rehost — retiring the four ad-hoc candle repo resolvers that existed only because candle couldn't read the packed turnkeys.

### ⚠️ Review fix (commit `f64eed48`) — ideogram/boogu off-Mac regression
The first cut retired the `candle_ideogram_repo`/`candle_boogu_repo` resolvers and rerouted ideogram/boogu through `resolve_weights_dir` → `model_repo` (their MLX turnkeys `SceneWorks/{ideogram-4,boogu-image}-mlx`), **but left those turnkey download entries `platforms:["macos"]` and the catalog entries `macOnly:true`** — so off-Mac (Windows/Linux) all five ids resolved to a snapshot that is never downloaded → `huggingface_snapshot_dir` None → *"candle weights snapshot not found"* load error (a regression vs `main`). lens/krea were rewired correctly; ideogram/boogu were only half-retired. Fixed by mirroring the krea/lens treatment:
- Extended `SceneWorks/ideogram-4-mlx` (q4) + `SceneWorks/boogu-image-mlx` (Q8 base/turbo/edit) turnkey download `platforms` → `["macos","windows","linux"]` — the SAME tier the candle loaders packed-detect off-Mac (candle-gen **sc-9412** both DiTs, **sc-9410** incl. edit-q4 vision tower, GPU-validated on sm_120).
- Flipped **`macOnly:false`** on `ideogram_4` / `ideogram_4_turbo` / `boogu_image` / `boogu_image_turbo` / `boogu_image_edit`.
- Removed the now-orphaned off-Mac diffusers entries no code resolves anymore: `SceneWorks/ideogram-4` bf16 windows/linux (kept **macOS** — the selectable full-precision MLX tier `IDEOGRAM_BF16_REPO`) and the three `Boogu/Boogu-Image-0.1-{Base,Turbo,Edit}` windows/linux entries.
- Routing unchanged: `resolve_weights_dir` already branches ideogram/boogu to `ideogram_model_subdir` (q4/q8) / `boogu_model_subdir` (base/turbo/edit Q8) before `uses_standard_tier_layout`, so no `STANDARD_TIER_MODELS` entry is needed (they keep their legacy non-standard layouts). Added `candle_ideogram_boogu_resolve_packed_turnkey_tier_subdir`.

**All four candle image families are now off-Mac-downloadable and resolver-free.**

### What routed
- `generate_candle_stream` replaces its bespoke repo/weights_dir block with the shared **`resolve_weights_dir`** (the identical dispatch the MLX `generate_stream` uses): `modelPath` override → ideogram/boogu/krea per-family subdir → **`standard_tier_subdir`** (q4/q8/bf16 from `advanced.mlxQuantize`). The recipe repo is recorded via `model_repo` (the MLX turnkey candle now loads).
- `lens`/`lens_turbo` registered in `STANDARD_TIER_MODELS` (they already flag `mlx.standardTierLayout` in the manifest — this is the zero-manifest-change form + documents the candle opt-in).

### Resolvers deleted (zero candle-special-case resolvers remain)
`candle_ideogram_repo` (+`CANDLE_IDEOGRAM_REPO`, `candle_ideogram_subdir`), `candle_boogu_repo` (+`candle_boogu_default_repo`), `candle_krea_repo` (+`CANDLE_KREA_REPO`), `candle_lens_repo` (+`candle_lens_default_repo`).

### Manifest (off-Mac tier picks)
The `SceneWorks/lens-mlx`, `SceneWorks/lens-turbo-mlx`, `SceneWorks/krea-2-turbo-mlx` per-tier **q4/q8/bf16** turnkey downloads are now installable on windows/linux too (candle picks its tier at download exactly like macOS); the separate off-Mac diffusers **inference** entries (`SceneWorks/Lens{,-Turbo}`, `krea/Krea-2-Turbo`) are removed. The `SceneWorks/Lens` flat-diffusers **training** base is exposed off-Mac (the candle LoRA trainer still needs the flat tree). **ideogram/boogu turnkeys (`SceneWorks/{ideogram-4,boogu-image}-mlx`) are now installable + `macOnly:false` off-Mac too** (see the Review fix above); their off-Mac diffusers rehost entries (`SceneWorks/ideogram-4` bf16 win/linux + `Boogu/Boogu-Image-0.1-*` win/linux) are removed.

### Cache test (candle A/B toggle)
- `cache_key_includes_quant_tier_toggle` — the candle A/B quant toggle changes **both** the resolved tier subdir and the load quant, so a toggle always misses the generator cache (reload-always, epic 8506).
- `candle_lens_resolves_packed_turnkey_tier_subdir` — Lens tier A/B via the shared `standard_tier_subdir`.

### Pin lockstep
- candle-gen pin **`7c43ec8f` → `c16d381f`** (candle-gen main HEAD — all 11 packed-load conversions).
- candle-gen main's gen-core pin is already **`b520a0e7`** (= this worker's mlx-gen pin), so `--features backend-candle --target all` resolves **one** gen-core rev — **no testkit dev-dep reconcile needed**.

### Verification
- **Skew gates green** (all three): `sceneworks-worker --features backend-candle`, `sceneworks-rust-api --features embed-web,backend-candle`, default lane — each resolves exactly one `sceneworks-gen-core b520a0e7`.
- **`--features backend-candle` clippy** (`--tests -D warnings`, VS2022 v143 + CUDA 12.9, cap=120): **clean (exit 0)**.
- **candle-feature tests pass** — all `standard_tier_tests` (incl. the new `candle_ideogram_boogu_resolve_packed_turnkey_tier_subdir`) + the full `image_jobs::` suite (43) green; re-verified after the review fix (VS2022 v143 + CUDA 12.9, cap=120).
- Default (non-candle) clippy + `sceneworks-core` manifest/routing tests green; manifest scaffold check passes.

### Follow-up
- **sc-9607** (candle-gen): flip `supported_quants` (Q4/Q8) on the ideogram/boogu/krea descriptors so the worker A/B toggle engages `resolve_quant` for them (only `lens` advertises it on candle-gen main today). AC #3 completes there for the three non-lens families; the packed loaders already auto-detect the tier, so load works today.

Relates: epic 9083, sc-8508 (manifest/variant machinery), sc-8515 (toggle), sc-9089 (packed-load rollout umbrella).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
