### PR TITLE
fix(worker): confine dataset-upscale imagePath reads + sanitize output write paths (sc-8842)

### DIFF
--- a/crates/sceneworks-worker/src/upscale_jobs.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs.rs
@@ -62,8 +62,8 @@ use serde_json::{json, Value};
 
 use crate::{
     cancel_requested_peek, fresh_asset_id, heartbeat, mark_job_canceled, now_rfc3339,
-    progress_payload, progress_report_interval, task_join_error, update_job, ApiClient,
-    CancelJoinGuard, Settings, WorkerError, WorkerResult,
+    progress_payload, progress_report_interval, resolve_dataset_item_path, safe_project_path,
+    task_join_error, update_job, ApiClient, CancelJoinGuard, Settings, WorkerError, WorkerResult,
 };
 use sceneworks_core::contracts::{JobSnapshot, JobStatus, JsonObject, ProgressStage, WorkerStatus};
 use sceneworks_core::project_store::ProjectStore;
@@ -1096,29 +1096,49 @@ struct DatasetUpscaleItem {
     image_path: PathBuf,
 }
 
-/// Parse the `items` array of a `dataset_upscale` job into typed entries (pure). Each entry needs a
-/// non-empty `itemId` + `imagePath`; malformed entries are skipped.
-fn parse_dataset_upscale_items(payload: &JsonObject) -> Vec<DatasetUpscaleItem> {
-    payload
-        .get("items")
-        .and_then(Value::as_array)
-        .map(|items| {
-            items
-                .iter()
-                .filter_map(|item| {
-                    let item_id = item.get("itemId").and_then(Value::as_str)?;
-                    let image_path = item.get("imagePath").and_then(Value::as_str)?;
-                    if item_id.is_empty() || image_path.is_empty() {
-                        return None;
-                    }
-                    Some(DatasetUpscaleItem {
-                        item_id: item_id.to_owned(),
-                        image_path: PathBuf::from(image_path),
-                    })
-                })
-                .collect()
+/// Parse the `items` array of a `dataset_upscale` job into typed entries. Each entry needs a
+/// non-empty `itemId` + `imagePath`; malformed entries are skipped. Every `imagePath` is confined
+/// to the payload's app-managed `datasetRoot` via [`resolve_dataset_item_path`] (sc-8842 / F-040):
+/// the `imagePath` is client-supplied and reaches an on-disk read, so an unconfined path would be an
+/// arbitrary-file-read/exfiltration primitive — a path escaping the dataset root fails the job.
+fn parse_dataset_upscale_items(
+    settings: &Settings,
+    payload: &JsonObject,
+) -> WorkerResult<Vec<DatasetUpscaleItem>> {
+    let dataset_root = payload
+        .get("datasetRoot")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload(
+                "Dataset upscale payload.datasetRoot must be an app-managed dataset path."
+                    .to_owned(),
+            )
+        })?;
+    let Some(items) = payload.get("items").and_then(Value::as_array) else {
+        return Ok(Vec::new());
+    };
+    items
+        .iter()
+        .filter_map(|item| {
+            let item_id = item.get("itemId").and_then(Value::as_str)?;
+            let image_path = item.get("imagePath").and_then(Value::as_str)?;
+            if item_id.is_empty() || image_path.is_empty() {
+                return None;
+            }
+            let resolved = resolve_dataset_item_path(
+                settings,
+                dataset_root,
+                image_path,
+                &format!("Dataset upscale item {item_id} imagePath"),
+            );
+            Some(resolved.map(|image_path| DatasetUpscaleItem {
+                item_id: item_id.to_owned(),
+                image_path,
+            }))
         })
-        .unwrap_or_default()
+        .collect()
 }
 
 /// Build the `/repoint` request body from `(item_id, project-relative source path)` results (pure).
@@ -1162,7 +1182,7 @@ pub(crate) async fn run_dataset_upscale_job(
             WorkerError::InvalidPayload("Dataset upscale jobs require a datasetId.".to_owned())
         })?
         .to_owned();
-    let items = parse_dataset_upscale_items(payload);
+    let items = parse_dataset_upscale_items(settings, payload)?;
     if items.is_empty() {
         return Err(WorkerError::InvalidPayload(
             "Dataset upscale job has no items to upscale.".to_owned(),
@@ -1228,8 +1248,12 @@ pub(crate) async fn run_dataset_upscale_job(
         )
         .await?;
 
+        // sc-8842 / F-040: `dataset_id` and `item_id` are client-supplied and here reach a
+        // filesystem write (`save_with_format` overwrites), so route the project-relative output
+        // through `safe_project_path` — a `/`, `..`, or absolute component is rejected before the
+        // write instead of traversing out of the project tree.
         let rel = format!("{derived_dir_rel}/{}.png", item.item_id);
-        let abs = project_path.join(&rel);
+        let abs = safe_project_path(&project_path, &rel)?;
         if let Some(parent) = abs.parent() {
             tokio::fs::create_dir_all(parent).await?;
         }

--- a/crates/sceneworks-worker/src/upscale_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs/tests.rs
@@ -427,26 +427,137 @@ fn real_esrgan_candle_real_weights_upscales() {
 
 // --- Dataset Doctor one-tap upscale plumbing (sc-6539), pure + weight-free ---
 
+#[cfg(test)]
+fn upscale_test_settings(data_dir: &std::path::Path) -> crate::Settings {
+    crate::Settings {
+        api_url: "http://127.0.0.1".to_owned(),
+        access_token: None,
+        data_dir: data_dir.to_path_buf(),
+        config_dir: data_dir.join("config"),
+        worker_id: "test-worker".to_owned(),
+        gpu_id: "gpu-0".to_owned(),
+        is_child_worker: false,
+        poll_seconds: 1,
+        heartbeat_seconds: 1,
+        shutdown_timeout_seconds: 1,
+        huggingface_base_url: crate::DEFAULT_HUGGINGFACE_BASE_URL.to_owned(),
+        huggingface_token: None,
+        credentials: Vec::new(),
+        max_lora_url_bytes: crate::DEFAULT_MAX_LORA_URL_BYTES,
+        max_model_url_bytes: crate::DEFAULT_MAX_MODEL_URL_BYTES,
+        allow_private_lora_urls: false,
+        utility_workers: 1,
+        backend_mlx_enabled: true,
+        backend_candle_enabled: false,
+        gpu_memory_limit_bytes: 0,
+    }
+}
+
 #[test]
 fn parse_dataset_upscale_items_reads_valid_entries_and_skips_malformed() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let settings = upscale_test_settings(dir.path());
+    let dataset_root = dir.path().join("datasets").join("ds-1");
+    let a = dataset_root.join("a.png");
+    let d = dataset_root.join("d.jpg");
     let payload = json!({
+        "datasetRoot": dataset_root.display().to_string(),
         "items": [
-            { "itemId": "a", "imagePath": "/data/a.png", "assetId": "asset_a" },
-            { "itemId": "", "imagePath": "/data/blank.png" }, // empty id → skipped
-            { "itemId": "c" },                                // no imagePath → skipped
-            { "itemId": "d", "imagePath": "/data/d.jpg" },
+            { "itemId": "a", "imagePath": a.display().to_string(), "assetId": "asset_a" },
+            { "itemId": "", "imagePath": dataset_root.join("blank.png").display().to_string() }, // empty id → skipped
+            { "itemId": "c" },                                                                    // no imagePath → skipped
+            { "itemId": "d", "imagePath": d.display().to_string() },
         ],
     });
-    let items = parse_dataset_upscale_items(payload.as_object().unwrap());
+    let items =
+        parse_dataset_upscale_items(&settings, payload.as_object().unwrap()).expect("items parse");
     assert_eq!(items.len(), 2);
     assert_eq!(items[0].item_id, "a");
-    assert_eq!(items[0].image_path, std::path::PathBuf::from("/data/a.png"));
+    assert_eq!(items[0].image_path, a);
     assert_eq!(items[1].item_id, "d");
 }
 
 #[test]
 fn parse_dataset_upscale_items_is_empty_without_an_items_array() {
-    assert!(parse_dataset_upscale_items(json!({}).as_object().unwrap()).is_empty());
+    let dir = tempfile::tempdir().expect("tempdir");
+    let settings = upscale_test_settings(dir.path());
+    let dataset_root = dir.path().join("datasets").join("ds-1");
+    let payload = json!({ "datasetRoot": dataset_root.display().to_string() });
+    assert!(
+        parse_dataset_upscale_items(&settings, payload.as_object().unwrap())
+            .expect("empty parse")
+            .is_empty()
+    );
+}
+
+// sc-8842 / F-040: a client-supplied `imagePath` escaping the app-managed dataset root is an
+// arbitrary-file-read/exfil primitive; `resolve_dataset_item_path` must reject it so the job fails
+// rather than reading (and later re-pointing at) an out-of-tree file.
+#[test]
+fn parse_dataset_upscale_items_reject_image_path_outside_dataset_root() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let settings = upscale_test_settings(dir.path());
+    let dataset_root = dir.path().join("datasets").join("ds-1");
+    let payload = json!({
+        "datasetRoot": dataset_root.display().to_string(),
+        "items": [
+            {
+                "itemId": "item_1",
+                "imagePath": dataset_root.join("../../etc/secret.png").display().to_string(),
+            },
+        ],
+    });
+    let error = parse_dataset_upscale_items(&settings, payload.as_object().unwrap())
+        .expect_err("traversal image path rejected");
+    assert!(
+        error
+            .to_string()
+            .contains("Dataset upscale item item_1 imagePath"),
+        "{error}"
+    );
+}
+
+#[test]
+fn parse_dataset_upscale_items_reject_missing_dataset_root() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let settings = upscale_test_settings(dir.path());
+    let payload = json!({ "items": [{ "itemId": "a", "imagePath": "a.png" }] });
+    let error = parse_dataset_upscale_items(&settings, payload.as_object().unwrap())
+        .expect_err("missing datasetRoot rejected");
+    assert!(error.to_string().contains("datasetRoot"), "{error}");
+}
+
+// sc-8842 / F-040: the output write path interpolates client-supplied `datasetId`/`itemId`; a
+// traversal component must be rejected by `safe_project_path` before `save_with_format` runs so a
+// crafted id cannot overwrite an arbitrary out-of-tree file with PNG bytes.
+#[test]
+fn dataset_upscale_output_path_rejects_traversal_ids() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let project_path = dir.path().join("project");
+    // itemId traversal
+    let rel = format!("training/datasets/ds-1/upscaled/{}.png", "../../escaped");
+    let error =
+        crate::safe_project_path(&project_path, &rel).expect_err("traversal itemId rejected");
+    assert!(
+        error.to_string().contains("Unsafe project-relative path"),
+        "{error}"
+    );
+    // datasetId traversal
+    let rel = format!("training/datasets/{}/upscaled/a.png", "../../../etc");
+    let error =
+        crate::safe_project_path(&project_path, &rel).expect_err("traversal datasetId rejected");
+    assert!(
+        error.to_string().contains("Unsafe project-relative path"),
+        "{error}"
+    );
+    // valid ids resolve inside the project tree
+    let rel = "training/datasets/ds-1/upscaled/item_1.png";
+    let abs = crate::safe_project_path(&project_path, rel).expect("valid path resolves");
+    assert!(abs.starts_with(&project_path), "{abs:?}");
+    assert!(
+        abs.ends_with("training/datasets/ds-1/upscaled/item_1.png"),
+        "{abs:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes [sc-8842](https://app.shortcut.com/trefry/story/8842) — [F-040] Confine dataset-upscale `imagePath` reads and sanitize `itemId`/`datasetId` write paths (Bug, security, Medium).

`run_dataset_upscale_job` decoded each client-supplied `items[].imagePath` **verbatim** into an on-disk read (despite `resolve_dataset_item_path` existing), and joined the output path `training/datasets/{datasetId}/upscaled/{itemId}.png` with both ids taken **verbatim** (only non-empty checked) before `save_with_format`. A crafted `dataset_upscale` payload was therefore an arbitrary-file **READ/exfil** (any `imagePath`) and an arbitrary-location PNG **WRITE** (an id with `/` or `..` traverses out; `save_with_format` overwrites) under worker privileges — sharper once epic 4484 exposes the jobs API over LAN.

This reuses the crate's **existing** confinement helpers (same pattern as the merged sc-8821 control-weight confinement) — no new confinement logic.

## Read fix
`parse_dataset_upscale_items` now routes every `imagePath` through **`resolve_dataset_item_path`**, confining it to the payload's app-managed `datasetRoot` (the same guard already used by caption / dataset-analysis / face-analysis jobs). A path escaping the dataset root fails the job with a clear `WorkerError` instead of being read. The function now takes `&Settings` and returns `WorkerResult<Vec<_>>`.

## Write fix
The project-relative output path now goes through **`safe_project_path`**, which rejects any non-`Normal` component (`/`, `..`, absolute) in `datasetId` or `itemId` **before** the `save_with_format` write. A traversal id errors rather than clobbering an out-of-tree file.

## Other sites swept
Within `run_dataset_upscale_job` and its sibling image-upscale job: the sibling's read (`resolve_source`) is store-resolved by asset id (not a verbatim payload path), and its write path (`assets/images/{generation_set_id}/{filename}`) is entirely worker-generated (UUID/timestamp/fresh asset id). No other verbatim payload-derived path joins found.

## Tests
- `parse_dataset_upscale_items_reject_image_path_outside_dataset_root` — traversal read rejected (no arbitrary read)
- `dataset_upscale_output_path_rejects_traversal_ids` — traversal `itemId`/`datasetId` rejected before write; valid ids still resolve inside the project tree
- `parse_dataset_upscale_items_reject_missing_dataset_root`
- Updated `parse_dataset_upscale_items_reads_valid_entries_and_skips_malformed` + `_is_empty_without_an_items_array` for the confined signature

All 5 pass. Verified `npm run rust:check` green + `cargo check -p sceneworks-worker --no-default-features --features backend-candle --all-targets` green (both lanes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)