### PR TITLE
fix(worker): don't drive CFG-free SD3.5 Turbo with guidance in the LoRA smoke (sc-8868)

### DIFF
--- a/crates/sceneworks-worker/src/sd3_5_mlx_smoke.rs
+++ b/crates/sceneworks-worker/src/sd3_5_mlx_smoke.rs
@@ -390,26 +390,30 @@ fn sd3_5_lora_apply_mlx_gpu_smoke() {
     );
 
     let engine_id = env_or("SD3_LORA_ENGINE", "sd3_5_large");
-    let (hub_dir, env_snap, default_steps, default_guidance) = match engine_id.as_str() {
-        "sd3_5_medium" => (
-            "models--stabilityai--stable-diffusion-3.5-medium",
-            "SD3_MEDIUM_SNAPSHOT",
-            "40",
-            5.0,
-        ),
-        "sd3_5_large_turbo" => (
-            "models--stabilityai--stable-diffusion-3.5-large-turbo",
-            "SD3_TURBO_SNAPSHOT",
-            "4",
-            3.5,
-        ),
-        _ => (
-            "models--stabilityai--stable-diffusion-3.5-large",
-            "SD3_LARGE_SNAPSHOT",
-            "28",
-            3.5,
-        ),
-    };
+    // `default_guidance` mirrors `resolve_guidance`: `Some(scale)` for the true-CFG Large/Medium
+    // (supports_guidance=true), `None` for the CFG-free Turbo (supports_guidance=false) — so the smoke
+    // sends the SAME request shape the shipped worker sends (and the dedicated turbo smoke passes None).
+    let (hub_dir, env_snap, default_steps, default_guidance): (&str, &str, &str, Option<f32>) =
+        match engine_id.as_str() {
+            "sd3_5_medium" => (
+                "models--stabilityai--stable-diffusion-3.5-medium",
+                "SD3_MEDIUM_SNAPSHOT",
+                "40",
+                Some(5.0),
+            ),
+            "sd3_5_large_turbo" => (
+                "models--stabilityai--stable-diffusion-3.5-large-turbo",
+                "SD3_TURBO_SNAPSHOT",
+                "4",
+                None,
+            ),
+            _ => (
+                "models--stabilityai--stable-diffusion-3.5-large",
+                "SD3_LARGE_SNAPSHOT",
+                "28",
+                Some(3.5),
+            ),
+        };
 
     let scale: f32 = env_or("SD3_LORA_SCALE", "1.0")
         .parse()
@@ -435,7 +439,7 @@ fn sd3_5_lora_apply_mlx_gpu_smoke() {
         w,
         h,
         steps,
-        Some(default_guidance),
+        default_guidance,
         adapters,
         "sd3_5_lora.png",
     );


### PR DESCRIPTION
## What changed

The SD3.5 LoRA-apply worker-seam smoke (`sd3_5_lora_apply_mlx_gpu_smoke` in `crates/sceneworks-worker/src/sd3_5_mlx_smoke.rs`) built its per-engine recipe from a local table whose `default_guidance` column was a bare `f32`, and it passed `Some(default_guidance)` to `run_worker_smoke` **unconditionally**. That gave the `sd3_5_large_turbo` entry `Some(3.5)`.

That contradicts what the shipped worker actually sends:
- The `sd3_5_large_turbo` descriptor advertises `supports_guidance=false` (`MODEL_TABLE` `default_guidance: 0.0` in `engines.rs`), so the worker's `resolve_guidance` returns `None` and attaches no negative prompt (the ADD-distilled, CFG-free sibling).
- The dedicated `sd3_5_large_turbo_mlx_gpu_smoke` already passes `None`.

Because `run_worker_smoke` derives the negative prompt from `guidance.map(...)`, the old code also switched a `"blurry, low quality, distorted"` negative prompt on for Turbo — a request shape the shipped worker never emits. Running the LoRA smoke against Turbo would therefore either fail spuriously or validate a bogus request shape.

### Fix
- Changed the engine tuple's guidance column from `f32` to `Option<f32>`.
- `sd3_5_large_turbo` → `None`; `sd3_5_medium` → `Some(5.0)`; `sd3_5_large` (default) → `Some(3.5)`.
- Pass the `Option<f32>` straight through to `run_worker_smoke` (no more `Some(...)` wrapper), so the existing `guidance.map(...)` negative-prompt switch correctly omits the negative prompt for Turbo.

## Scope vs AC

- [x] Tuple carries `Option<f32>` for guidance instead of bare `f32` + unconditional `Some`.
- [x] `None` for `sd3_5_large_turbo` (CFG-free / `supports_guidance=false`); `Some(scale)` only for the true-CFG Large/Medium.
- [x] Negative-prompt handling consistent — Turbo attaches no negative prompt, matching the real worker and the dedicated turbo smoke.
- [x] Verified no other engine in the table is mis-declared vs its descriptor's `supports_guidance`: `sd3_5_large` and `sd3_5_medium` are both `supports_guidance=true` and keep `Some(...)`.

## How verified

- `cargo fmt --all -- --check` — clean.
- `cargo clippy -p sceneworks-worker --all-targets` — clean, no warnings.
- `cargo check -p sceneworks-worker --tests` — compiles (the smoke module is `#[cfg(all(test, target_os = "macos"))]`, so `--tests` on macOS builds it).
- `cargo test -p sceneworks-worker sd3_5_` — the 4 real-weight smokes stay `#[ignore]`d (need gated snapshots + Apple-Silicon GPU); the non-ignored `sd3_5_manifest_entries_gate_correctly` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)