### PR TITLE
fix(web): harden manifest-supplied license/homepage URLs before rendering as links (sc-8881)

### DIFF
--- a/apps/web/src/components/PromptGuideModal.jsx
+++ b/apps/web/src/components/PromptGuideModal.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Modal } from "./Modal.jsx";
 import { Markdown } from "./Markdown.jsx";
+import { safeExternalUrl } from "../urls.js";
 
 // Fetches a model's static Markdown prompt guide (served from /public/prompt-guides)
 // and renders it inside the shared Modal. `guide` is the resolved metadata
@@ -28,6 +29,13 @@ export function PromptGuideModal({ guide, modelName, onClose }) {
     };
   }, [guide.path]);
 
+  // `sources` come from the model manifest (`ui.promptGuide.sources`), so gate
+  // every URL through the shared scheme check (sc-8881) and drop any source
+  // whose link is not a safe http(s) external before rendering it as a link.
+  const safeSources = (guide.sources ?? [])
+    .map((source) => ({ label: source.label, href: safeExternalUrl(source.url) }))
+    .filter((source) => source.href);
+
   return (
     <Modal className="prompt-guide-modal" labelledBy="prompt-guide-title" onClose={onClose}>
       <header className="prompt-guide-head">
@@ -48,11 +56,11 @@ export function PromptGuideModal({ guide, modelName, onClose }) {
         {state.status === "ready" ? <Markdown content={state.content} /> : null}
       </div>
 
-      {guide.sources?.length ? (
+      {safeSources.length ? (
         <footer className="prompt-guide-sources">
           <span>Sources:</span>
-          {guide.sources.map((source) => (
-            <a key={source.url} href={source.url} target="_blank" rel="noopener noreferrer">
+          {safeSources.map((source) => (
+            <a key={source.href} href={source.href} target="_blank" rel="noopener noreferrer">
               {source.label}
             </a>
           ))}

--- a/apps/web/src/components/PromptGuideModal.test.jsx
+++ b/apps/web/src/components/PromptGuideModal.test.jsx
@@ -1,0 +1,70 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PromptGuideModal } from "./PromptGuideModal.jsx";
+
+// sc-8881 [F-079]: prompt-guide `sources` come from the model manifest
+// (`ui.promptGuide.sources`), rendered into `<a href>`. A `javascript:` source
+// URL must never produce a clickable javascript link. The Modal portals to
+// document.body, so anchors are queried there (see shared_modal_portals_to_body).
+describe("PromptGuideModal hardens manifest-supplied source URLs (sc-8881)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    // The guide body fetch is irrelevant to link hardening; resolve it empty.
+    global.fetch = vi.fn(() =>
+      Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve("") }),
+    );
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  async function renderModal(sources) {
+    await act(async () => {
+      root.render(
+        <PromptGuideModal
+          guide={{ title: "Guide", path: "/prompt-guides/x.md", sources }}
+          modelName="Test"
+          onClose={() => {}}
+        />,
+      );
+    });
+  }
+
+  it("drops a javascript: source instead of rendering a clickable javascript href", async () => {
+    await renderModal([{ label: "Evil", url: "javascript:alert(1)" }]);
+    const anchors = Array.from(document.body.querySelectorAll("a"));
+    // No anchor points at the javascript: payload.
+    expect(anchors.some((a) => a.getAttribute("href")?.startsWith("javascript:"))).toBe(false);
+    // The malicious source is omitted entirely (no dead link with its label).
+    expect(anchors.some((a) => a.textContent === "Evil")).toBe(false);
+  });
+
+  it("renders valid https sources unchanged", async () => {
+    await renderModal([{ label: "Docs", url: "https://example.com/docs" }]);
+    const anchor = Array.from(document.body.querySelectorAll("a")).find(
+      (a) => a.textContent === "Docs",
+    );
+    expect(anchor).toBeTruthy();
+    expect(anchor.getAttribute("href")).toBe("https://example.com/docs");
+  });
+
+  it("keeps safe sources while dropping unsafe ones in a mixed list", async () => {
+    await renderModal([
+      { label: "Good", url: "https://example.com/a" },
+      { label: "Bad", url: "javascript:alert(1)" },
+    ]);
+    const anchors = Array.from(document.body.querySelectorAll("a"));
+    expect(anchors.some((a) => a.textContent === "Good")).toBe(true);
+    expect(anchors.some((a) => a.textContent === "Bad")).toBe(false);
+  });
+});

--- a/apps/web/src/screens/LicensesScreen.jsx
+++ b/apps/web/src/screens/LicensesScreen.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from "react";
 
 import { bundledLicenses, licensesIntro } from "../data/bundledLicenses.js";
+import { safeExternalUrl } from "../urls.js";
 
 // About → Licenses (sc-3778). Aggregates the third-party components SceneWorks
 // redistributes in the desktop bundle (ffmpeg GPLv3, onnxruntime MIT, …) and
@@ -78,9 +79,13 @@ export function LicensesScreen() {
                 <>
                   <dt>Homepage</dt>
                   <dd>
-                    <a href={selected.homepage} target="_blank" rel="noreferrer">
-                      {selected.homepage}
-                    </a>
+                    {safeExternalUrl(selected.homepage) ? (
+                      <a href={safeExternalUrl(selected.homepage)} target="_blank" rel="noreferrer">
+                        {selected.homepage}
+                      </a>
+                    ) : (
+                      selected.homepage
+                    )}
                   </dd>
                 </>
               ) : null}

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -15,6 +15,7 @@ import { apiFetch } from "../api.js";
 import { isDesktop, tauriInvoke } from "../runtime.js";
 import { tierLabel } from "../quantTier.js";
 import { suggestTier } from "../tierSuggestion.js";
+import { safeExternalUrl } from "../urls.js";
 
 // Wan A14B is a two-expert mixture; its LoRAs come as a high/low-noise pair. These
 // base models accept the optional low-noise expert upload (sc-1991). The 5B model
@@ -233,7 +234,9 @@ function GatedModelNotice({
   onOpenSettings,
 }) {
   const hostLabel = host || "the required service";
-  const showSeparateLicense = licenseUrl && licenseUrl !== repoUrl;
+  const safeRepoUrl = safeExternalUrl(repoUrl);
+  const safeLicenseUrl = safeExternalUrl(licenseUrl);
+  const showSeparateLicense = safeLicenseUrl && safeLicenseUrl !== safeRepoUrl;
   return (
     <div className={present ? "model-gated-notice ready" : "model-gated-notice"}>
       <p className={present ? "inline-success" : "inline-warning"}>
@@ -247,13 +250,13 @@ function GatedModelNotice({
             Add token in Settings
           </button>
         )}
-        {repoUrl ? (
-          <a href={repoUrl} target="_blank" rel="noreferrer noopener">
+        {safeRepoUrl ? (
+          <a href={safeRepoUrl} target="_blank" rel="noreferrer noopener">
             Request access on Hugging Face
           </a>
         ) : null}
         {showSeparateLicense ? (
-          <a href={licenseUrl} target="_blank" rel="noreferrer noopener">
+          <a href={safeLicenseUrl} target="_blank" rel="noreferrer noopener">
             Review license
           </a>
         ) : null}

--- a/apps/web/src/urls.js
+++ b/apps/web/src/urls.js
@@ -1,0 +1,27 @@
+// Shared URL hardening for manifest-/data-supplied external links (sc-8881).
+//
+// Model manifests, the bundled-license manifest, and per-model prompt-guide
+// metadata all carry free-form URL fields (`licenseUrl`, `homepage`,
+// `ui.promptGuide.sources[].url`, …) that we render straight into `<a href>`.
+// Today those manifests are first-party and import is disabled (epic 7080), but
+// a future user-imported manifest turns a `javascript:` value into a click-time
+// script-execution vector. `safeExternalUrl` gates every such render site: it
+// returns the URL only when it parses as an absolute `http:`/`https:` URL, and
+// otherwise `undefined` so callers render the link inert or omit it entirely.
+export function safeExternalUrl(url) {
+  if (typeof url !== "string") return undefined;
+  const trimmed = url.trim();
+  if (!trimmed) return undefined;
+  let parsed;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    // Not an absolute URL (relative, malformed, or scheme-less) — reject rather
+    // than guess a base, since manifest links are meant to be absolute externals.
+    return undefined;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return undefined;
+  }
+  return trimmed;
+}

--- a/apps/web/src/urls.test.js
+++ b/apps/web/src/urls.test.js
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { safeExternalUrl } from "./urls.js";
+
+// sc-8881 [F-079]: manifest-supplied URL fields (licenseUrl, homepage,
+// prompt-guide sources) are rendered into `<a href>`; `safeExternalUrl` must
+// admit only absolute http(s) links and reject anything that could execute on
+// click (javascript:, data:, vbscript:) or is otherwise unusable.
+describe("safeExternalUrl", () => {
+  it("accepts absolute http and https URLs unchanged", () => {
+    expect(safeExternalUrl("https://huggingface.co/org/model")).toBe(
+      "https://huggingface.co/org/model",
+    );
+    expect(safeExternalUrl("http://example.com/path?q=1#frag")).toBe(
+      "http://example.com/path?q=1#frag",
+    );
+  });
+
+  it("trims surrounding whitespace on valid URLs", () => {
+    expect(safeExternalUrl("  https://example.com/x  ")).toBe("https://example.com/x");
+  });
+
+  it("is case-insensitive on the scheme", () => {
+    expect(safeExternalUrl("HTTPS://example.com")).toBe("HTTPS://example.com");
+  });
+
+  it("rejects javascript: URLs (click-time script execution vector)", () => {
+    expect(safeExternalUrl("javascript:alert(1)")).toBeUndefined();
+    expect(safeExternalUrl("JavaScript:alert(1)")).toBeUndefined();
+    // Leading whitespace must not smuggle the scheme past the check.
+    expect(safeExternalUrl("  javascript:alert(1)")).toBeUndefined();
+  });
+
+  it("rejects data: URLs", () => {
+    expect(safeExternalUrl("data:text/html,<script>alert(1)</script>")).toBeUndefined();
+  });
+
+  it("rejects vbscript: URLs", () => {
+    expect(safeExternalUrl("vbscript:msgbox(1)")).toBeUndefined();
+  });
+
+  it("rejects other non-http(s) schemes", () => {
+    expect(safeExternalUrl("mailto:someone@example.com")).toBeUndefined();
+    expect(safeExternalUrl("file:///etc/passwd")).toBeUndefined();
+    expect(safeExternalUrl("ftp://example.com/file")).toBeUndefined();
+  });
+
+  it("rejects relative and scheme-less URLs (manifest links must be absolute)", () => {
+    expect(safeExternalUrl("/relative/path")).toBeUndefined();
+    expect(safeExternalUrl("example.com/no-scheme")).toBeUndefined();
+    expect(safeExternalUrl("#anchor")).toBeUndefined();
+  });
+
+  it("rejects malformed, empty, and non-string inputs", () => {
+    expect(safeExternalUrl("")).toBeUndefined();
+    expect(safeExternalUrl("   ")).toBeUndefined();
+    expect(safeExternalUrl("http://")).toBeUndefined();
+    expect(safeExternalUrl("ht!tp://bad")).toBeUndefined();
+    expect(safeExternalUrl(null)).toBeUndefined();
+    expect(safeExternalUrl(undefined)).toBeUndefined();
+    expect(safeExternalUrl(42)).toBeUndefined();
+    expect(safeExternalUrl({})).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## [F-079] Harden manifest-supplied license/homepage URLs before rendering as links

Fixes **sc-8881** (Bug, security, Low).

### Problem
Manifest-/data-supplied URL fields were rendered directly into `<a href>`. A `javascript:` (or `data:`/`vbscript:`) value in a future user-imported manifest would execute on click. Today's impact is Low (manifests are first-party; import is disabled per epic 7080), but the render sites share the same unhardened shape.

### Fix
Added a shared helper `safeExternalUrl(url)` in **`apps/web/src/urls.js`** that:
- parses with WHATWG `new URL(...)` (guards parse errors in a `try/catch`),
- returns the URL only when its scheme is `http:` or `https:`,
- returns `undefined` for anything else (relative, scheme-less, `javascript:`, `data:`, `vbscript:`, `mailto:`, `file:`, malformed, empty, non-string).

Behavior for valid http/https URLs is identical.

### All render sites covered (full surface, not just the two cited lines)
Traced every manifest-/data-supplied external URL rendered into an `<a href>` across `apps/web`:

1. **`ModelManagerScreen.jsx`** `GatedModelNotice` — `repoUrl` (line ~251) and `licenseUrl` (line ~256). `repoUrl` is normally the self-built `https://` from `gatedRepoUrl()`, but it falls back to raw `model.licenseUrl` (`gatedRepoUrl(model) ?? model.licenseUrl`), so both are now gated. Unsafe → link omitted.
2. **`LicensesScreen.jsx`** — `component.homepage` (line ~81), sourced from `apps/desktop/licenses/manifest.json`. Unsafe → renders the text plainly (no anchor).
3. **`PromptGuideModal.jsx`** — `guide.sources[].url` from the model manifest (`ui.promptGuide.sources`). Unsafe sources are dropped from the list (no dead/inert links).

### Sites deliberately NOT changed (out of scope, not manifest external links)
- `KpsOverlay.jsx` `<image href>` — local blob image URL, not an `<a>` external link.
- `SettingsScreen.jsx` `remote.url` — device-local LAN URL rendered as `<code>` text / clipboard copy, not an anchor.
- `assetMedia.jsx` / `api.js` — `API_BASE_URL`-prefixed first-party media URLs.
- `Markdown.jsx` — already has its own scheme allowlist (`safeHref`) for prompt-guide content links; left as-is.

### Tests
- **`src/urls.test.js`** — unit tests: http/https accepted (with trailing-whitespace trim and case-insensitive scheme); `javascript:` / `data:` / `vbscript:` / `mailto:` / `file:` / `ftp:` / relative / scheme-less / malformed / empty / non-string all rejected.
- **`src/components/PromptGuideModal.test.jsx`** — component test: a `javascript:` source yields no clickable `javascript:` href and is omitted; valid https sources render unchanged; mixed lists keep safe and drop unsafe.

### How verified
- Touched-file vitest: 12 passed.
- Full web suite: **69 files, 1113 tests passed**.
- `npm run lint`: **0 errors** (49 pre-existing warnings, none in touched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)