### PR TITLE
chore(web): remove dead exports/scaffolds + unify terminal-status sets (sc-8938)

### DIFF
--- a/apps/web/src/formatting.js
+++ b/apps/web/src/formatting.js
@@ -1,3 +1,5 @@
+import { terminalStatuses } from "./jobTypes.js";
+
 export function formatSeconds(seconds) {
   if (seconds === null || seconds === undefined) {
     return "0s";
@@ -12,7 +14,7 @@ export function percent(value) {
 }
 
 export function liveElapsedSeconds(job, nowMs = Date.now()) {
-  if (["completed", "failed", "canceled", "interrupted"].includes(job.status) || !job.startedAt) {
+  if (terminalStatuses.has(job.status) || !job.startedAt) {
     return job.elapsedSeconds;
   }
   const startedMs = Date.parse(job.startedAt);

--- a/apps/web/src/pollJob.js
+++ b/apps/web/src/pollJob.js
@@ -1,4 +1,5 @@
 import { apiFetch } from "./api.js";
+import { errorStatuses } from "./jobTypes.js";
 
 // Resolve after `ms`, or reject with an AbortError if `signal` fires (or is already
 // aborted). Shared by the poll-to-completion runners so a caller's AbortController
@@ -65,7 +66,7 @@ export async function pollJobToCompletion({
     if (job.status === "completed") {
       return resolveResult(job);
     }
-    if (job.status === "failed" || job.status === "canceled" || job.status === "interrupted") {
+    if (errorStatuses.has(job.status)) {
       throw new Error(job.message || job.error || failureError);
     }
   }

--- a/apps/web/src/screens/ReplacePersonPanel.jsx
+++ b/apps/web/src/screens/ReplacePersonPanel.jsx
@@ -3,10 +3,6 @@ import { API_BASE_URL, withMediaTicket } from "../api.js";
 import { AssetPickerField } from "../components/AssetPicker.jsx";
 import { AssetMedia } from "../components/assetMedia.jsx";
 
-export function findReplacementModel(videoModels) {
-  return videoModels.find((item) => item.capabilities?.includes("replace_person")) ?? null;
-}
-
 const MASK_STATE_COPY = {
   active: "Per-frame segmentation masks generated for tracked frames.",
   generated: "Per-frame segmentation masks generated for most tracked frames.",

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -1713,19 +1713,6 @@ export function VideoStudio() {
                     <kbd>↵</kbd>
                   </span>
                 </div>
-                <div className="kbd-row">
-                  <span>Send to editor</span>
-                  <span className="kbd-keys">
-                    <kbd>⇧</kbd>
-                    <kbd>E</kbd>
-                  </span>
-                </div>
-                <div className="kbd-row">
-                  <span>Loop preview</span>
-                  <span className="kbd-keys">
-                    <kbd>L</kbd>
-                  </span>
-                </div>
               </dl>
             </aside>
           </div>


### PR DESCRIPTION
## sc-8938 [F-136] Remove dead web exports/scaffolds

Removes three pieces of dead web scaffolding and unifies duplicated terminal-status literals against the shared source of truth in `jobTypes.js`. All three parts of the finding resolved.

### Part 1 — VideoStudio Keyboard card (`VideoStudio.jsx`)
The card advertised three shortcuts. **Verified** by grepping the component and every global keydown listener (`App.jsx`, `ImageEditor.jsx`, `EditorScreen.jsx`, `CompactSelector.jsx`, `assetPanels.jsx`) that:
- **Render / Cmd-Enter** IS wired: the prompt textarea's `onKeyDown={onPromptKeyDown}` (from `generationStudio.jsx`) handles `(metaKey||ctrlKey) && Enter` → `form.requestSubmit()`. **Kept.**
- **Send to editor / Shift-E** — NO handler exists anywhere. **Deleted.**
- **Loop preview / L** — NO handler exists anywhere. **Deleted.**

The card keeps the one working row, so it is not empty. The real "Send to editor" **button** at `VideoStudio.jsx:1228` (an actual action) is unrelated to the dead keyboard-card row and is untouched.

### Part 2 — `findReplacementModel` (`ReplacePersonPanel.jsx`)
Confirmed **zero references** across `apps/web` (not imported by any component or test — only `ReplacePersonPanel` itself is imported by tests). Deleted the export and its definition. The panel computes the replace-capable model list inline via `replacementModels = videoModels.filter((item) => item.capabilities?.includes("replace_person"))`, which is unchanged and still works.

### Part 3 — `errorStatuses` unification
The finding's `formatting.js:368` line reference was **stale** (the file is 25 lines). Traced the actual duplication:
- **`errorStatuses`** (`jobTypes.js`) = `{failed, canceled, interrupted}` (terminal minus completed) — previously consumed **only** by its own test.
- **`pollJob.js`** hard-coded exactly that set inline (`failed || canceled || interrupted`). **Unified**: it now imports and uses `errorStatuses`, so the set is now consumed **in production**, not just its test — the single source of truth the story asked for.
- **`formatting.js`** hard-coded the **full** terminal set (`completed` + the three error states). That literal maps to `terminalStatuses`, **not** `errorStatuses`, so I did not force-merge it into `errorStatuses`; instead it now imports and uses the correct `terminalStatuses` set — same single-source-of-truth cleanup, correct set.

`jobTypes.js` is a leaf module (no imports), so there is no circular-import risk from `pollJob.js`/`formatting.js` importing it.

### Tests / lint
- `npx vitest run --environment jsdom`: **69 files / 1113 tests pass**. The existing `errorStatuses` test (asserts the set contents) remains meaningful and green.
- `eslint` of touched files: **0 errors** (pre-existing `react-hooks/exhaustive-deps` warnings on untouched lines remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)