### PR TITLE
refactor(web): dedupe save-preset, picker grid, and DOM test helpers (sc-8937)

### DIFF
--- a/apps/web/src/components/AssetPicker.jsx
+++ b/apps/web/src/components/AssetPicker.jsx
@@ -159,6 +159,50 @@ function filterPickerAssets(assets, query, searchIndex) {
   return assets.filter((asset) => !needle || searchIndex.get(asset.id)?.includes(needle));
 }
 
+// The `role="listbox"` asset-card grid shared by all three pickers (sc-8937): the
+// thumbnail + title/type/source/date/id/status card, its selected styling, and the
+// empty-state row. The pickers differ only in selection model and activation, passed
+// as callbacks so markup/classes/aria/keyboard behavior stay identical:
+//   - `isSelected(asset)` — single-select (id equality) vs multi-select (membership),
+//   - `onSelect(asset)` — click handler (set the id, or toggle by asset/id),
+//   - `onActivate(asset)` — optional double-click confirm; omit for grids without one,
+//   - `ariaMultiselectable` — `undefined` (single), `true`, or `multiple || undefined`,
+//   - `emptyLabel` — the empty-state message.
+function PickerCardGrid({ assets, isSelected, onSelect, onActivate, ariaMultiselectable, emptyLabel }) {
+  return (
+    <div aria-multiselectable={ariaMultiselectable} className="asset-picker-grid" role="listbox">
+      {assets.map((asset) => {
+        const selected = isSelected(asset);
+        const status = statusLabel(asset);
+        return (
+          <button
+            aria-selected={selected}
+            className={selected ? "asset-picker-card selected" : "asset-picker-card"}
+            key={asset.id}
+            onClick={() => onSelect(asset)}
+            onDoubleClick={onActivate ? () => onActivate(asset) : undefined}
+            role="option"
+            type="button"
+          >
+            <AssetThumbnail asset={asset} />
+            <span className="asset-picker-card-copy">
+              <strong>{titleFor(asset)}</strong>
+              <small>
+                {typeLabel(asset)} | {sourceLabel(asset)}
+              </small>
+              <small title={asset.id}>
+                {compactDate(asset.createdAt ?? asset.updatedAt)} | ID {assetIdentity(asset)}
+                {status ? ` | ${status}` : ""}
+              </small>
+            </span>
+          </button>
+        );
+      })}
+      {assets.length ? null : <div className="empty-panel compact-panel">{emptyLabel}</div>}
+    </div>
+  );
+}
+
 export function AssetPreviewChips({ assets, emptyLabel = "No asset selected" }) {
   if (!assets.length) {
     return <div className="asset-picker-empty">{emptyLabel}</div>;
@@ -299,36 +343,14 @@ function ImageEditSourcePickerModal({ assets, characters, importAsset, initialSe
 
   function renderAssetGrid(emptyLabel) {
     return (
-      <div aria-multiselectable={undefined} className="asset-picker-grid" role="listbox">
-        {visibleAssets.map((asset) => {
-          const selected = selectedId === asset.id;
-          const status = statusLabel(asset);
-          return (
-            <button
-              aria-selected={selected}
-              className={selected ? "asset-picker-card selected" : "asset-picker-card"}
-              key={asset.id}
-              onClick={() => setSelectedId(asset.id)}
-              onDoubleClick={() => onConfirm(asset.id)}
-              role="option"
-              type="button"
-            >
-              <AssetThumbnail asset={asset} />
-              <span className="asset-picker-card-copy">
-                <strong>{titleFor(asset)}</strong>
-                <small>
-                  {typeLabel(asset)} | {sourceLabel(asset)}
-                </small>
-                <small title={asset.id}>
-                  {compactDate(asset.createdAt ?? asset.updatedAt)} | ID {assetIdentity(asset)}
-                  {status ? ` | ${status}` : ""}
-                </small>
-              </span>
-            </button>
-          );
-        })}
-        {visibleAssets.length ? null : <div className="empty-panel compact-panel">{emptyLabel}</div>}
-      </div>
+      <PickerCardGrid
+        ariaMultiselectable={undefined}
+        assets={visibleAssets}
+        emptyLabel={emptyLabel}
+        isSelected={(asset) => selectedId === asset.id}
+        onActivate={(asset) => onConfirm(asset.id)}
+        onSelect={(asset) => setSelectedId(asset.id)}
+      />
     );
   }
 
@@ -551,36 +573,14 @@ export function AssetPickerModal({
           />
         </div>
 
-        <div aria-multiselectable={multiple || undefined} className="asset-picker-grid" role="listbox">
-          {visibleAssets.map((asset) => {
-            const selected = selectedIds.includes(asset.id);
-            const status = statusLabel(asset);
-            return (
-              <button
-                aria-selected={selected}
-                className={selected ? "asset-picker-card selected" : "asset-picker-card"}
-                key={asset.id}
-                onClick={() => toggleAsset(asset)}
-                onDoubleClick={() => !multiple && onConfirm([asset.id])}
-                role="option"
-                type="button"
-              >
-                <AssetThumbnail asset={asset} />
-                <span className="asset-picker-card-copy">
-                  <strong>{titleFor(asset)}</strong>
-                  <small>
-                    {typeLabel(asset)} | {sourceLabel(asset)}
-                  </small>
-                  <small title={asset.id}>
-                    {compactDate(asset.createdAt ?? asset.updatedAt)} | ID {assetIdentity(asset)}
-                    {status ? ` | ${status}` : ""}
-                  </small>
-                </span>
-              </button>
-            );
-          })}
-          {visibleAssets.length ? null : <div className="empty-panel compact-panel">No assets match this view</div>}
-        </div>
+        <PickerCardGrid
+          ariaMultiselectable={multiple || undefined}
+          assets={visibleAssets}
+          emptyLabel="No assets match this view"
+          isSelected={(asset) => selectedIds.includes(asset.id)}
+          onActivate={(asset) => !multiple && onConfirm([asset.id])}
+          onSelect={(asset) => toggleAsset(asset)}
+        />
 
         <footer className="asset-picker-footer">
           <span>{selectedIds.length ? `${selectedIds.length} selected` : "No selection"}</span>
@@ -708,35 +708,13 @@ export function CharacterImportDialog({
 
   function renderGrid(emptyLabel) {
     return (
-      <div aria-multiselectable className="asset-picker-grid" role="listbox">
-        {visibleAssets.map((asset) => {
-          const selected = selectedIds.includes(asset.id);
-          const status = statusLabel(asset);
-          return (
-            <button
-              aria-selected={selected}
-              className={selected ? "asset-picker-card selected" : "asset-picker-card"}
-              key={asset.id}
-              onClick={() => toggleAsset(asset.id)}
-              role="option"
-              type="button"
-            >
-              <AssetThumbnail asset={asset} />
-              <span className="asset-picker-card-copy">
-                <strong>{titleFor(asset)}</strong>
-                <small>
-                  {typeLabel(asset)} | {sourceLabel(asset)}
-                </small>
-                <small title={asset.id}>
-                  {compactDate(asset.createdAt ?? asset.updatedAt)} | ID {assetIdentity(asset)}
-                  {status ? ` | ${status}` : ""}
-                </small>
-              </span>
-            </button>
-          );
-        })}
-        {visibleAssets.length ? null : <div className="empty-panel compact-panel">{emptyLabel}</div>}
-      </div>
+      <PickerCardGrid
+        ariaMultiselectable
+        assets={visibleAssets}
+        emptyLabel={emptyLabel}
+        isSelected={(asset) => selectedIds.includes(asset.id)}
+        onSelect={(asset) => toggleAsset(asset.id)}
+      />
     );
   }
 

--- a/apps/web/src/components/ModelAvailabilityGate.test.jsx
+++ b/apps/web/src/components/ModelAvailabilityGate.test.jsx
@@ -1,7 +1,7 @@
 import React, { act } from "react";
-import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AppContext } from "../context/AppContext.js";
+import { click, mountRoot } from "../testUtils/dom.js";
 import { ModelAvailabilityGate } from "./ModelAvailabilityGate.jsx";
 
 describe("ModelAvailabilityGate", () => {
@@ -10,9 +10,7 @@ describe("ModelAvailabilityGate", () => {
 
   beforeEach(() => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
-    container = document.createElement("div");
-    document.body.appendChild(container);
-    root = createRoot(container);
+    ({ container, root } = mountRoot());
   });
 
   afterEach(async () => {
@@ -30,12 +28,6 @@ describe("ModelAvailabilityGate", () => {
           <ModelAvailabilityGate {...props} />
         </AppContext.Provider>,
       );
-    });
-  }
-
-  async function click(el) {
-    await act(async () => {
-      el.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
     });
   }
 

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -76,14 +76,9 @@ function defaultCharacterPrompt(character) {
   }
 }
 import {
-  applyPresetDefault,
-  buildStudioPresetPayload,
   finiteNumberOrUndefined,
-  presetNameTaken,
   serializeLora,
-  clearPresetDefault,
   noPresetId,
-  slugifyPresetId,
 } from "../presetUtils.js";
 import {
   LoraPickerSection,
@@ -92,6 +87,7 @@ import {
   PresetValidationWarnings,
   SavePresetPanel,
   useGenerationStudio,
+  useSavePreset,
 } from "./generationStudio.jsx";
 import { useAppContext } from "../context/AppContext.js";
 import { ModelAvailabilityGate } from "../components/ModelAvailabilityGate.jsx";
@@ -440,14 +436,6 @@ export function ImageStudio() {
   const [expanding, setExpanding] = useState(false);
   const [submitError, setSubmitError] = useState("");
   const [guideOpen, setGuideOpen] = useState(false);
-  // "Save as Preset" sidebar control — snapshots the current config into the
-  // workspace preset library. Defaults to project scope, falling back to global
-  // when no project is open (project-scoped presets require a project).
-  const [presetName, setPresetName] = useState("");
-  const [presetScope, setPresetScope] = useState(activeProject ? "project" : "global");
-  const [savingPreset, setSavingPreset] = useState(false);
-  const [presetSaveMessage, setPresetSaveMessage] = useState({ tone: "neutral", text: "" });
-  const presetDefaultSnapshots = useRef({});
   const editImageAssets = useMemo(
     () =>
       assets.filter(
@@ -1125,67 +1113,87 @@ export function ImageStudio() {
     [imageDescribe, activeProject?.id, describeCaptionStyle],
   );
 
-  // When restoring a snapshot, the saved count/resolution/negativePrompt already
-  // reflect the user's last state — skip the one preset-default pass that fires as the
-  // restored preset resolves so it doesn't overwrite them. "None" applies no defaults,
-  // so no guard is needed there.
-  const skipPresetDefaultsOnHydrate = useRef(
-    Object.keys(saved).length > 0 && saved.selectedPresetId !== noPresetId,
-  );
-  // [defaults key, setter] pairs restored through the remember/clear snapshot
-  // machinery, so switching to None (or another preset) puts the user's prior
-  // value back. Only keys the preset actually carries are applied, so older
-  // presets (which only stored count/resolution/negativePrompt) keep working and
-  // full-snapshot presets restore the prompt, cfg, sampler, reference + upscale
-  // knobs. The model is intentionally absent — presets never switch the model.
-  const presetDefaultFields = [
-    ["prompt", setPrompt],
-    ["negativePrompt", setNegativePrompt],
-    ["resolution", setResolution],
-    ["count", setCount],
-    ["guidanceScale", setGuidanceOverride],
-    ["steps", setStepsOverride],
-    ["sampler", setSampler],
-    ["scheduler", setScheduler],
-    ["schedulerShift", setSchedulerShift],
-    ["guidanceMethod", setGuidanceMethod],
-    ["ipAdapterScale", setIpAdapterScale],
-    ["controlnetScale", setControlnetScale],
-    ["trueCfgScale", setTrueCfgScale],
-    ["viewAngle", setViewAngle],
-    ["upscaleEnabled", setUpscaleEnabled],
-    ["upscaleFactor", setUpscaleFactor],
-    ["upscaleEngine", setUpscaleEngine],
-    ["upscaleSoftness", setUpscaleSoftness],
-  ];
-  useEffect(() => {
-    if (skipPresetDefaultsOnHydrate.current && selectedPreset) {
-      skipPresetDefaultsOnHydrate.current = false;
-      return;
-    }
-    if (!selectedPreset) {
-      for (const [key, setter] of presetDefaultFields) {
-        clearPresetDefault(setter, presetDefaultSnapshots, key);
+  // Save-as-Preset + the preset-default hydrate pass (sc-8937 — shared with the Video
+  // studio via useSavePreset). The [key, setter] pairs are restored through the
+  // remember/clear snapshot machinery, so switching to None (or another preset) puts
+  // the user's prior value back. Only keys the preset actually carries are applied, so
+  // older presets (which only stored count/resolution/negativePrompt) keep working and
+  // full-snapshot presets restore the prompt, cfg, sampler, reference + upscale knobs.
+  // The model is intentionally absent — presets never switch the model.
+  const {
+    presetName,
+    setPresetName,
+    presetScope,
+    setPresetScope,
+    savingPreset,
+    presetSaveMessage,
+    setPresetSaveMessage,
+    handleSaveAsPreset,
+  } = useSavePreset({
+    saved,
+    selectedPreset,
+    setSelectedPresetId,
+    presets,
+    mode,
+    model,
+    selectedLoras,
+    effectiveLoraWeight,
+    createPreset,
+    activeProject,
+    setMode,
+    presetDefaultFields: [
+      ["prompt", setPrompt],
+      ["negativePrompt", setNegativePrompt],
+      ["resolution", setResolution],
+      ["count", setCount],
+      ["guidanceScale", setGuidanceOverride],
+      ["steps", setStepsOverride],
+      ["sampler", setSampler],
+      ["scheduler", setScheduler],
+      ["schedulerShift", setSchedulerShift],
+      ["guidanceMethod", setGuidanceMethod],
+      ["ipAdapterScale", setIpAdapterScale],
+      ["controlnetScale", setControlnetScale],
+      ["trueCfgScale", setTrueCfgScale],
+      ["viewAngle", setViewAngle],
+      ["upscaleEnabled", setUpscaleEnabled],
+      ["upscaleFactor", setUpscaleFactor],
+      ["upscaleEngine", setUpscaleEngine],
+      ["upscaleSoftness", setUpscaleSoftness],
+    ],
+    // Restore the saved sub-mode ("type"). Edit presets only surface in edit mode, so
+    // this only ever flips between text/character within one workflow.
+    modeIsPresetable: (savedMode) => IMAGE_MODES.includes(savedMode),
+    onApplyDefaults: (defaults) => {
+      // Filling the prompt box counts as a user edit, so character mode's default
+      // prompt won't clobber the restored prompt.
+      if (Object.prototype.hasOwnProperty.call(defaults, "prompt")) {
+        promptEdited.current = true;
       }
-      return;
-    }
-    const defaults = selectedPreset.defaults ?? {};
-    for (const [key, setter] of presetDefaultFields) {
-      if (Object.prototype.hasOwnProperty.call(defaults, key)) {
-        applyPresetDefault(presetDefaultSnapshots, key, setter, defaults[key]);
-      }
-    }
-    // Filling the prompt box counts as a user edit, so character mode's default
-    // prompt won't clobber the restored prompt.
-    if (Object.prototype.hasOwnProperty.call(defaults, "prompt")) {
-      promptEdited.current = true;
-    }
-    // Restore the saved sub-mode ("type"). Edit presets only surface in edit
-    // mode, so this only ever flips between text/character within one workflow.
-    if (IMAGE_MODES.includes(defaults.mode)) {
-      setMode(defaults.mode);
-    }
-  }, [selectedPreset?.id]);
+    },
+    buildDefaults: () => ({
+      prompt,
+      negativePrompt,
+      resolution,
+      count,
+      mode,
+      guidanceScale: finiteNumberOrUndefined(guidanceOverride),
+      steps: finiteNumberOrUndefined(stepsOverride),
+      sampler,
+      scheduler,
+      schedulerShift,
+      guidanceMethod,
+      upscaleEnabled,
+      upscaleFactor,
+      upscaleEngine,
+      upscaleSoftness,
+      // Reference/identity knobs only matter for the character flow; keep them
+      // out of plain text/edit presets so they don't carry irrelevant state.
+      ...(mode === "character_image"
+        ? { ipAdapterScale, controlnetScale, trueCfgScale, viewAngle }
+        : {}),
+    }),
+  });
 
   useStudioSettingsWriter("image", activeProject?.id ?? null, {
     mode,
@@ -1225,75 +1233,6 @@ export function ImageStudio() {
     usePid,
     lastUsedTiers,
   });
-
-  // Snapshot the current working config into a named recipe preset in the
-  // workspace library. Captures the literal prompt + every visible knob + the
-  // selected LoRAs with their weights; the seed is intentionally left out so the
-  // preset stays reusable. The backend additionally enforces id uniqueness and
-  // model/workflow + LoRA compatibility, surfaced here via err.message.
-  async function handleSaveAsPreset() {
-    const trimmed = presetName.trim();
-    if (!trimmed) {
-      setPresetSaveMessage({ tone: "error", text: "Name the preset before saving." });
-      return;
-    }
-    if (!slugifyPresetId(trimmed)) {
-      setPresetSaveMessage({ tone: "error", text: "Use letters or numbers in the preset name." });
-      return;
-    }
-    if (presetScope === "project" && !activeProject) {
-      setPresetSaveMessage({ tone: "error", text: "Open a project first, or save to all projects." });
-      return;
-    }
-    if (presetNameTaken(trimmed, presets)) {
-      setPresetSaveMessage({ tone: "error", text: `"${trimmed}" already exists — pick a unique name.` });
-      return;
-    }
-    const payload = buildStudioPresetPayload({
-      name: trimmed,
-      scope: presetScope,
-      mode,
-      model,
-      loras: selectedLoras.map((lora) => ({ id: lora.id, weight: effectiveLoraWeight(lora) })),
-      defaults: {
-        prompt,
-        negativePrompt,
-        resolution,
-        count,
-        mode,
-        guidanceScale: finiteNumberOrUndefined(guidanceOverride),
-        steps: finiteNumberOrUndefined(stepsOverride),
-        sampler,
-        scheduler,
-        schedulerShift,
-        guidanceMethod,
-        upscaleEnabled,
-        upscaleFactor,
-        upscaleEngine,
-        upscaleSoftness,
-        // Reference/identity knobs only matter for the character flow; keep them
-        // out of plain text/edit presets so they don't carry irrelevant state.
-        ...(mode === "character_image"
-          ? { ipAdapterScale, controlnetScale, trueCfgScale, viewAngle }
-          : {}),
-      },
-    });
-    setSavingPreset(true);
-    setPresetSaveMessage({ tone: "neutral", text: "" });
-    try {
-      const created = await createPreset(payload);
-      setSelectedPresetId(created?.id ?? payload.id);
-      setPresetName("");
-      setPresetSaveMessage({
-        tone: "success",
-        text: `Saved "${trimmed}" to ${presetScope === "project" ? "this project" : "all projects"}.`,
-      });
-    } catch (err) {
-      setPresetSaveMessage({ tone: "error", text: err.message });
-    } finally {
-      setSavingPreset(false);
-    }
-  }
 
   // Each stacked run carries its already-resolved completed assets + the
   // expected count, which the WorkerProgressCard image-grid variant uses to

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -1,6 +1,6 @@
 import React, { act } from "react";
-import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { click, mountRoot, setFileInput, setInput, setSelect, unmountRoot } from "../testUtils/dom.js";
 
 // Pose loaders fetch best-effort on mount; stub the API so render never touches
 // the network. The studio's own mutations go through context fns, not apiFetch.
@@ -65,32 +65,6 @@ function baseContext(overrides = {}) {
   };
 }
 
-async function click(element) {
-  await act(async () => {
-    element.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
-  });
-}
-
-function setInput(element, value) {
-  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
-  setter.call(element, value);
-  element.dispatchEvent(new window.Event("input", { bubbles: true }));
-}
-
-function setSelect(element, value) {
-  const setter = Object.getOwnPropertyDescriptor(window.HTMLSelectElement.prototype, "value").set;
-  setter.call(element, value);
-  element.dispatchEvent(new window.Event("change", { bubbles: true }));
-}
-
-function setFileInput(element, files) {
-  Object.defineProperty(element, "files", {
-    configurable: true,
-    value: files,
-  });
-  element.dispatchEvent(new window.Event("change", { bubbles: true }));
-}
-
 const saveButton = (container) =>
   [...container.querySelectorAll("button")].find((b) => b.textContent.includes("Save as Preset"));
 const nameInput = (container) => container.querySelector('input[aria-label="Preset name"]');
@@ -108,14 +82,11 @@ describe("ImageStudio Save as Preset", () => {
   beforeEach(() => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
     window.localStorage.clear();
-    container = document.createElement("div");
-    document.body.appendChild(container);
-    root = createRoot(container);
+    ({ container, root } = mountRoot());
   });
 
   afterEach(async () => {
-    await act(async () => root.unmount());
-    container.remove();
+    await unmountRoot(root, container);
     vi.clearAllMocks();
   });
 
@@ -184,14 +155,11 @@ describe("ImageStudio advanced model defaults", () => {
   beforeEach(() => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
     window.localStorage.clear();
-    container = document.createElement("div");
-    document.body.appendChild(container);
-    root = createRoot(container);
+    ({ container, root } = mountRoot());
   });
 
   afterEach(async () => {
-    await act(async () => root.unmount());
-    container.remove();
+    await unmountRoot(root, container);
     vi.clearAllMocks();
   });
 
@@ -293,14 +261,11 @@ describe("ImageStudio guidance method picker (epic 7434, sc-7449)", () => {
   beforeEach(() => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
     window.localStorage.clear();
-    container = document.createElement("div");
-    document.body.appendChild(container);
-    root = createRoot(container);
+    ({ container, root } = mountRoot());
   });
 
   afterEach(async () => {
-    await act(async () => root.unmount());
-    container.remove();
+    await unmountRoot(root, container);
     vi.clearAllMocks();
   });
 
@@ -399,14 +364,11 @@ describe("ImageStudio edit source picker", () => {
   beforeEach(() => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
     window.localStorage.clear();
-    container = document.createElement("div");
-    document.body.appendChild(container);
-    root = createRoot(container);
+    ({ container, root } = mountRoot());
   });
 
   afterEach(async () => {
-    await act(async () => root.unmount());
-    container.remove();
+    await unmountRoot(root, container);
     vi.clearAllMocks();
   });
 
@@ -598,14 +560,11 @@ describe("ImageStudio model picker capability gating", () => {
   beforeEach(() => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
     window.localStorage.clear();
-    container = document.createElement("div");
-    document.body.appendChild(container);
-    root = createRoot(container);
+    ({ container, root } = mountRoot());
   });
 
   afterEach(async () => {
-    await act(async () => root.unmount());
-    container.remove();
+    await unmountRoot(root, container);
     vi.clearAllMocks();
   });
 
@@ -956,14 +915,11 @@ describe("ImageStudio structured-prompt recipe round-trip (sc-6147)", () => {
   beforeEach(() => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
     window.localStorage.clear();
-    container = document.createElement("div");
-    document.body.appendChild(container);
-    root = createRoot(container);
+    ({ container, root } = mountRoot());
   });
 
   afterEach(async () => {
-    await act(async () => root.unmount());
-    container.remove();
+    await unmountRoot(root, container);
     vi.clearAllMocks();
   });
 
@@ -1060,14 +1016,11 @@ describe("ImageStudio reference-image → JSON caption (epic 8102, sc-8108)", ()
   beforeEach(() => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
     window.localStorage.clear();
-    container = document.createElement("div");
-    document.body.appendChild(container);
-    root = createRoot(container);
+    ({ container, root } = mountRoot());
   });
 
   afterEach(async () => {
-    await act(async () => root.unmount());
-    container.remove();
+    await unmountRoot(root, container);
     vi.clearAllMocks();
   });
 
@@ -1193,14 +1146,11 @@ describe("ImageStudio Ideogram 4 auto-expand on plain-text Generate (sc-6501)", 
   beforeEach(() => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
     window.localStorage.clear();
-    container = document.createElement("div");
-    document.body.appendChild(container);
-    root = createRoot(container);
+    ({ container, root } = mountRoot());
   });
 
   afterEach(async () => {
-    await act(async () => root.unmount());
-    container.remove();
+    await unmountRoot(root, container);
     vi.clearAllMocks();
   });
 
@@ -1315,14 +1265,11 @@ describe("ImageStudio PiD decoder toggle (sc-7851)", () => {
   beforeEach(() => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
     window.localStorage.clear();
-    container = document.createElement("div");
-    document.body.appendChild(container);
-    root = createRoot(container);
+    ({ container, root } = mountRoot());
   });
 
   afterEach(async () => {
-    await act(async () => root.unmount());
-    container.remove();
+    await unmountRoot(root, container);
     vi.clearAllMocks();
   });
 
@@ -1408,14 +1355,11 @@ describe("ImageStudio strict-control panel (epic 8236, sc-8245)", () => {
   beforeEach(() => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
     window.localStorage.clear();
-    container = document.createElement("div");
-    document.body.appendChild(container);
-    root = createRoot(container);
+    ({ container, root } = mountRoot());
   });
 
   afterEach(async () => {
-    await act(async () => root.unmount());
-    container.remove();
+    await unmountRoot(root, container);
     vi.clearAllMocks();
   });
 

--- a/apps/web/src/screens/KeyPointLibraryScreen.test.jsx
+++ b/apps/web/src/screens/KeyPointLibraryScreen.test.jsx
@@ -1,6 +1,6 @@
 import React, { act } from "react";
-import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { click, mountRoot, unmountRoot } from "../testUtils/dom.js";
 
 // Control the mocked API: GETs return the fixture lists; mutations resolve and are recorded.
 const apiCalls = [];
@@ -51,11 +51,6 @@ function customPreset(overrides = {}) {
   };
 }
 
-async function click(element) {
-  await act(async () => {
-    element.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
-  });
-}
 async function setInputValue(input, value) {
   await act(async () => {
     const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
@@ -81,14 +76,11 @@ describe("KeyPointLibraryScreen", () => {
     collections = [];
     window.URL.createObjectURL = () => "blob:test";
     window.URL.revokeObjectURL = () => {};
-    container = document.createElement("div");
-    document.body.appendChild(container);
-    root = createRoot(container);
+    ({ container, root } = mountRoot());
   });
 
   afterEach(async () => {
-    await act(async () => root.unmount());
-    container.remove();
+    await unmountRoot(root, container);
     vi.clearAllMocks();
   });
 

--- a/apps/web/src/screens/ModelManagerScreen.test.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.test.jsx
@@ -1,17 +1,12 @@
 import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { click } from "../testUtils/dom.js";
 
 // ModelManagerScreen reads `window.__TAURI__` at module load (via ../credentials.js)
 // to pick the keychain transport, so we set the Tauri bridge and re-import the
 // module fresh in each test. Credentials are served by the mocked `list_credentials`
 // command. AppContext is imported from the same fresh graph so the provider matches.
-async function click(element) {
-  await act(async () => {
-    element.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
-  });
-}
-
 const GATED_MODEL = {
   id: "flux_dev",
   name: "FLUX.1 [dev]",

--- a/apps/web/src/screens/PoseLibraryScreen.test.jsx
+++ b/apps/web/src/screens/PoseLibraryScreen.test.jsx
@@ -1,6 +1,6 @@
 import React, { act } from "react";
-import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { click, mountRoot, unmountRoot } from "../testUtils/dom.js";
 
 // Control the mocked API: GET /assets returns `poseAssets`, mutations resolve and are
 // recorded in `apiCalls`.
@@ -48,12 +48,6 @@ function poseAsset(overrides = {}) {
   };
 }
 
-async function click(element) {
-  await act(async () => {
-    element.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
-  });
-}
-
 describe("PoseLibraryScreen", () => {
   let container;
   let root;
@@ -62,14 +56,11 @@ describe("PoseLibraryScreen", () => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
     apiCalls.length = 0;
     poseAssets = [];
-    container = document.createElement("div");
-    document.body.appendChild(container);
-    root = createRoot(container);
+    ({ container, root } = mountRoot());
   });
 
   afterEach(async () => {
-    await act(async () => root.unmount());
-    container.remove();
+    await unmountRoot(root, container);
     vi.clearAllMocks();
   });
 
@@ -192,14 +183,11 @@ describe("PoseLibraryScreen — Create tab", () => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
     apiCalls.length = 0;
     poseAssets = [];
-    container = document.createElement("div");
-    document.body.appendChild(container);
-    root = createRoot(container);
+    ({ container, root } = mountRoot());
   });
 
   afterEach(async () => {
-    await act(async () => root.unmount());
-    container.remove();
+    await unmountRoot(root, container);
     vi.clearAllMocks();
   });
 

--- a/apps/web/src/screens/SettingsScreen.test.jsx
+++ b/apps/web/src/screens/SettingsScreen.test.jsx
@@ -1,6 +1,7 @@
 import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { click } from "../testUtils/dom.js";
 
 // SettingsScreen computes `isDesktop` from window.__TAURI__ at module load, so we
 // set the Tauri bridge and re-import the module fresh in each test.
@@ -11,12 +12,6 @@ async function changeField(input, value) {
     input.dispatchEvent(
       new window.Event(input.tagName === "SELECT" ? "change" : "input", { bubbles: true }),
     );
-  });
-}
-
-async function click(element) {
-  await act(async () => {
-    element.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
   });
 }
 

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -51,15 +51,10 @@ function jobVideoResultAssets(job, assets) {
   return resolveJobResultAssets(job, assets, { type: "video" });
 }
 import {
-  applyPresetDefault,
-  buildStudioPresetPayload,
-  clearPresetDefault,
   finiteNumberOrUndefined,
   loraLooksLikeIcLora,
   noPresetId,
-  presetNameTaken,
   serializeLora,
-  slugifyPresetId,
 } from "../presetUtils.js";
 import {
   LoraPickerSection,
@@ -68,6 +63,7 @@ import {
   PresetValidationWarnings,
   SavePresetPanel,
   useGenerationStudio,
+  useSavePreset,
 } from "./generationStudio.jsx";
 import { ReplacePersonPanel } from "./ReplacePersonPanel.jsx";
 import { useAppContext } from "../context/AppContext.js";
@@ -281,14 +277,6 @@ export function VideoStudio() {
   const [previewPlaying, setPreviewPlaying] = useState(false);
   const [previewTime, setPreviewTime] = useState(0);
   const [previewDuration, setPreviewDuration] = useState(0);
-  // "Save as Preset" sidebar control — snapshots the current config into the
-  // workspace preset library. Defaults to project scope, falling back to global
-  // when no project is open (project-scoped presets require a project).
-  const [presetName, setPresetName] = useState("");
-  const [presetScope, setPresetScope] = useState(activeProject ? "project" : "global");
-  const [savingPreset, setSavingPreset] = useState(false);
-  const [presetSaveMessage, setPresetSaveMessage] = useState({ tone: "neutral", text: "" });
-  const presetDefaultSnapshots = useRef({});
   const capabilities = selectedModel?.capabilities ?? [];
   const supportsMode = capabilities.includes(mode);
   // GGUF quantization variants the torch adapter can load (sc-1982). Declared in
@@ -391,79 +379,6 @@ export function VideoStudio() {
   const requiresLtxIcLora = selectedModel?.id === ltxVideoModelId && ltxIcLoraRequiredModes.has(mode);
   const hasLtxIcLora = presetLoraDetails.some((lora) => !lora.missing && loraLooksLikeIcLora(lora));
 
-  // Snapshot the current working config into a named recipe preset in the
-  // workspace library. Captures the literal prompt + every visible knob + the
-  // selected LoRAs with their weights; the seed is intentionally left out so the
-  // preset stays reusable. The backend additionally enforces id uniqueness and
-  // model/workflow + LoRA compatibility, surfaced here via err.message.
-  async function handleSaveAsPreset() {
-    const trimmed = presetName.trim();
-    if (!trimmed) {
-      setPresetSaveMessage({ tone: "error", text: "Name the preset before saving." });
-      return;
-    }
-    if (!slugifyPresetId(trimmed)) {
-      setPresetSaveMessage({ tone: "error", text: "Use letters or numbers in the preset name." });
-      return;
-    }
-    if (!VIDEO_PRESET_MODES.includes(mode)) {
-      setPresetSaveMessage({ tone: "error", text: "Switch to Image, Text, or First/Last mode to save a preset." });
-      return;
-    }
-    if (presetScope === "project" && !activeProject) {
-      setPresetSaveMessage({ tone: "error", text: "Open a project first, or save to all projects." });
-      return;
-    }
-    if (presetNameTaken(trimmed, presets)) {
-      setPresetSaveMessage({ tone: "error", text: `"${trimmed}" already exists — pick a unique name.` });
-      return;
-    }
-    const payload = buildStudioPresetPayload({
-      name: trimmed,
-      scope: presetScope,
-      mode,
-      model,
-      loras: selectedLoras.map((lora) => ({ id: lora.id, weight: effectiveLoraWeight(lora) })),
-      defaults: {
-        prompt,
-        negativePrompt,
-        resolution,
-        duration,
-        fps,
-        quality,
-        mode,
-        guidanceScale: finiteNumberOrUndefined(guidanceOverride),
-        steps: finiteNumberOrUndefined(stepsOverride),
-        sampler,
-        scheduler,
-        schedulerShift,
-        precision,
-        quantization,
-        ltxPipeline,
-        distilledVariant,
-        motion,
-        videoCfgGuidanceScale: finiteNumberOrUndefined(ltxVideoCfg),
-        videoStgGuidanceScale: finiteNumberOrUndefined(ltxVideoStg),
-        videoRescaleScale: finiteNumberOrUndefined(ltxVideoRescale),
-      },
-    });
-    setSavingPreset(true);
-    setPresetSaveMessage({ tone: "neutral", text: "" });
-    try {
-      const created = await createPreset(payload);
-      setSelectedPresetId(created?.id ?? payload.id);
-      setPresetName("");
-      setPresetSaveMessage({
-        tone: "success",
-        text: `Saved "${trimmed}" to ${presetScope === "project" ? "this project" : "all projects"}.`,
-      });
-    } catch (err) {
-      setPresetSaveMessage({ tone: "error", text: err.message });
-    } finally {
-      setSavingPreset(false);
-    }
-  }
-
   useEffect(() => {
     if (selectedAsset?.type === "image" || selectedAsset?.type === "frame") {
       setSourceAssetId(selectedAsset.id);
@@ -553,62 +468,85 @@ export function VideoStudio() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode, model, selectedModel, videoModels, macCapabilities]);
 
-  // When restoring a snapshot, the saved length/fps/quality/resolution/negativePrompt
-  // already reflect the user's last state — skip the one preset-default pass that fires
-  // as the restored preset resolves so it doesn't overwrite them. "None" applies no
-  // defaults, so no guard is needed there.
-  const skipPresetDefaultsOnHydrate = useRef(
-    Object.keys(saved).length > 0 && saved.selectedPresetId !== noPresetId,
-  );
-  // [defaults key, setter] pairs restored through the remember/clear snapshot
-  // machinery, so switching to None (or another preset) puts the user's prior
-  // value back. Only keys the preset carries are applied, so older presets keep
-  // working and full-snapshot presets restore the prompt, cfg, sampler, and the
-  // native LTX guidance knobs. The model is intentionally absent — presets never
-  // switch the model.
-  const presetDefaultFields = [
-    ["prompt", setPrompt],
-    ["negativePrompt", setNegativePrompt],
-    ["resolution", setResolution],
-    ["duration", setDuration],
-    ["fps", setFps],
-    ["quality", setQuality],
-    ["guidanceScale", setGuidanceOverride],
-    ["steps", setStepsOverride],
-    ["sampler", setSampler],
-    ["scheduler", setScheduler],
-    ["schedulerShift", setSchedulerShift],
-    ["precision", setPrecision],
-    ["quantization", setQuantization],
-    ["ltxPipeline", setLtxPipeline],
-    ["distilledVariant", setDistilledVariant],
-    ["motion", setMotion],
-    ["videoCfgGuidanceScale", setLtxVideoCfg],
-    ["videoStgGuidanceScale", setLtxVideoStg],
-    ["videoRescaleScale", setLtxVideoRescale],
-  ];
-  useEffect(() => {
-    if (skipPresetDefaultsOnHydrate.current && selectedPreset) {
-      skipPresetDefaultsOnHydrate.current = false;
-      return;
-    }
-    if (!selectedPreset) {
-      for (const [key, setter] of presetDefaultFields) {
-        clearPresetDefault(setter, presetDefaultSnapshots, key);
-      }
-      return;
-    }
-    const defaults = selectedPreset.defaults ?? {};
-    for (const [key, setter] of presetDefaultFields) {
-      if (Object.prototype.hasOwnProperty.call(defaults, key)) {
-        applyPresetDefault(presetDefaultSnapshots, key, setter, defaults[key]);
-      }
-    }
+  // Save-as-Preset + the preset-default hydrate pass (sc-8937 — shared with the Image
+  // studio via useSavePreset). The [key, setter] pairs are restored through the
+  // remember/clear snapshot machinery, so switching to None (or another preset) puts
+  // the user's prior value back. Only keys the preset carries are applied, so older
+  // presets keep working and full-snapshot presets restore the prompt, cfg, sampler,
+  // and the native LTX guidance knobs. The model is intentionally absent — presets
+  // never switch the model.
+  const {
+    presetName,
+    setPresetName,
+    presetScope,
+    setPresetScope,
+    savingPreset,
+    presetSaveMessage,
+    setPresetSaveMessage,
+    handleSaveAsPreset,
+  } = useSavePreset({
+    saved,
+    selectedPreset,
+    setSelectedPresetId,
+    presets,
+    mode,
+    model,
+    selectedLoras,
+    effectiveLoraWeight,
+    createPreset,
+    activeProject,
+    setMode,
+    presetDefaultFields: [
+      ["prompt", setPrompt],
+      ["negativePrompt", setNegativePrompt],
+      ["resolution", setResolution],
+      ["duration", setDuration],
+      ["fps", setFps],
+      ["quality", setQuality],
+      ["guidanceScale", setGuidanceOverride],
+      ["steps", setStepsOverride],
+      ["sampler", setSampler],
+      ["scheduler", setScheduler],
+      ["schedulerShift", setSchedulerShift],
+      ["precision", setPrecision],
+      ["quantization", setQuantization],
+      ["ltxPipeline", setLtxPipeline],
+      ["distilledVariant", setDistilledVariant],
+      ["motion", setMotion],
+      ["videoCfgGuidanceScale", setLtxVideoCfg],
+      ["videoStgGuidanceScale", setLtxVideoStg],
+      ["videoRescaleScale", setLtxVideoRescale],
+    ],
     // Restore the saved sub-mode ("type") when it's a generatable video workflow.
-    if (VIDEO_PRESET_MODES.includes(defaults.mode)) {
-      setMode(defaults.mode);
-    }
-  }, [selectedPreset?.id]);
+    modeIsPresetable: (savedMode) => VIDEO_PRESET_MODES.includes(savedMode),
+    // Video gates saving to the presetable modes; blocks the rest with a message.
+    extraSaveGuard: () =>
+      VIDEO_PRESET_MODES.includes(mode)
+        ? null
+        : "Switch to Image, Text, or First/Last mode to save a preset.",
+    buildDefaults: () => ({
+      prompt,
+      negativePrompt,
+      resolution,
+      duration,
+      fps,
+      quality,
+      mode,
+      guidanceScale: finiteNumberOrUndefined(guidanceOverride),
+      steps: finiteNumberOrUndefined(stepsOverride),
+      sampler,
+      scheduler,
+      schedulerShift,
+      precision,
+      quantization,
+      ltxPipeline,
+      distilledVariant,
+      motion,
+      videoCfgGuidanceScale: finiteNumberOrUndefined(ltxVideoCfg),
+      videoStgGuidanceScale: finiteNumberOrUndefined(ltxVideoStg),
+      videoRescaleScale: finiteNumberOrUndefined(ltxVideoRescale),
+    }),
+  });
 
   useStudioSettingsWriter("video", activeProject?.id ?? null, {
     motion,

--- a/apps/web/src/screens/VideoStudio.test.jsx
+++ b/apps/web/src/screens/VideoStudio.test.jsx
@@ -1,6 +1,6 @@
 import React, { act } from "react";
-import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { click, mountRoot, setInput, unmountRoot } from "../testUtils/dom.js";
 
 vi.mock("../api.js", async (importOriginal) => {
   const actual = await importOriginal();
@@ -64,12 +64,6 @@ function baseContext(overrides = {}) {
   };
 }
 
-async function click(element) {
-  await act(async () => {
-    element.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
-  });
-}
-
 async function doubleClick(element) {
   await act(async () => {
     element.dispatchEvent(new window.MouseEvent("dblclick", { bubbles: true }));
@@ -78,12 +72,6 @@ async function doubleClick(element) {
 
 const buttonWithText = (root, text) =>
   [...root.querySelectorAll("button")].find((b) => b.textContent.trim() === text);
-
-function setInput(element, value) {
-  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
-  setter.call(element, value);
-  element.dispatchEvent(new window.Event("input", { bubbles: true }));
-}
 
 const saveButton = (container) =>
   [...container.querySelectorAll("button")].find((b) => b.textContent.includes("Save as Preset"));
@@ -96,14 +84,11 @@ describe("VideoStudio Save as Preset", () => {
   beforeEach(() => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
     window.localStorage.clear();
-    container = document.createElement("div");
-    document.body.appendChild(container);
-    root = createRoot(container);
+    ({ container, root } = mountRoot());
   });
 
   afterEach(async () => {
-    await act(async () => root.unmount());
-    container.remove();
+    await unmountRoot(root, container);
     vi.clearAllMocks();
   });
 
@@ -191,14 +176,11 @@ describe("VideoStudio video_bridge", () => {
   beforeEach(() => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
     window.localStorage.clear();
-    container = document.createElement("div");
-    document.body.appendChild(container);
-    root = createRoot(container);
+    ({ container, root } = mountRoot());
   });
 
   afterEach(async () => {
-    await act(async () => root.unmount());
-    container.remove();
+    await unmountRoot(root, container);
     vi.clearAllMocks();
   });
 
@@ -257,14 +239,11 @@ describe("VideoStudio fit mode (sc-6139)", () => {
   beforeEach(() => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
     window.localStorage.clear();
-    container = document.createElement("div");
-    document.body.appendChild(container);
-    root = createRoot(container);
+    ({ container, root } = mountRoot());
   });
 
   afterEach(async () => {
-    await act(async () => root.unmount());
-    container.remove();
+    await unmountRoot(root, container);
     vi.clearAllMocks();
   });
 
@@ -360,14 +339,11 @@ describe("VideoStudio Bernini task modes", () => {
   beforeEach(() => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
     window.localStorage.clear();
-    container = document.createElement("div");
-    document.body.appendChild(container);
-    root = createRoot(container);
+    ({ container, root } = mountRoot());
   });
 
   afterEach(async () => {
-    await act(async () => root.unmount());
-    container.remove();
+    await unmountRoot(root, container);
     vi.clearAllMocks();
   });
 
@@ -605,14 +581,11 @@ describe("VideoStudio SCAIL-2 character animation + replacement backend", () => 
   beforeEach(() => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
     window.localStorage.clear();
-    container = document.createElement("div");
-    document.body.appendChild(container);
-    root = createRoot(container);
+    ({ container, root } = mountRoot());
   });
 
   afterEach(async () => {
-    await act(async () => root.unmount());
-    container.remove();
+    await unmountRoot(root, container);
     vi.clearAllMocks();
   });
 
@@ -772,14 +745,11 @@ describe("VideoStudio Mac mode gating (sc-5716)", () => {
   beforeEach(() => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
     window.localStorage.clear();
-    container = document.createElement("div");
-    document.body.appendChild(container);
-    root = createRoot(container);
+    ({ container, root } = mountRoot());
   });
 
   afterEach(async () => {
-    await act(async () => root.unmount());
-    container.remove();
+    await unmountRoot(root, container);
     vi.clearAllMocks();
   });
 

--- a/apps/web/src/screens/VideoUpscalePanel.test.jsx
+++ b/apps/web/src/screens/VideoUpscalePanel.test.jsx
@@ -1,6 +1,7 @@
 import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { click } from "../testUtils/dom.js";
 
 import { VideoUpscalePanel } from "./VideoUpscalePanel.jsx";
 
@@ -25,12 +26,6 @@ afterEach(() => {
 async function renderPanel(ui) {
   await act(async () => {
     createRoot(container).render(ui);
-  });
-}
-
-async function click(element) {
-  await act(async () => {
-    element.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
   });
 }
 

--- a/apps/web/src/screens/generationStudio.jsx
+++ b/apps/web/src/screens/generationStudio.jsx
@@ -1,15 +1,20 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "../components/Icons.jsx";
 import { terminalStatuses } from "../jobTypes.js";
 import {
+  applyPresetDefault,
+  buildStudioPresetPayload,
+  clearPresetDefault,
   loraMatchesModel,
   loraWeight,
   noPresetId,
   presetLoraDetails as buildPresetLoraDetails,
   presetMatchesModel,
   presetMatchesWorkflow,
+  presetNameTaken,
   presetPromptParts as buildPresetPromptParts,
   presetValidation,
+  slugifyPresetId,
 } from "../presetUtils.js";
 
 const completedResultFallbackMs = 30000;
@@ -300,6 +305,140 @@ export function useGenerationStudio({
     toggleLora,
     effectiveLoraWeight,
     setLoraWeight,
+  };
+}
+
+// Save-as-Preset + preset-default hydrate machinery shared by the Image and Video
+// studios (sc-8937). Owns the save panel's state (name/scope/saving/message) and the
+// remember/restore snapshot ref, runs the one preset-default hydrate effect, and
+// exposes the save handler. The studios differ only in:
+//   - `presetDefaultFields`: the [key, setter] pairs the studio hydrates,
+//   - `buildDefaults()`: the raw defaults snapshot the save payload carries,
+//   - `modeIsPresetable(mode)`: which sub-modes a saved preset may restore ("type"),
+//   - `onApplyDefaults(defaults)`: optional per-studio side effect after hydrate
+//     (Image marks the prompt box edited so the character-mode default can't clobber
+//     the restored prompt),
+//   - `extraSaveGuard()`: optional pre-save gate (Video blocks non-video modes),
+// so those are passed in. Behavior (validation order, UX, saved/hydrated fields) is
+// identical to the per-studio copies this replaced.
+export function useSavePreset({
+  saved,
+  selectedPreset,
+  setSelectedPresetId,
+  presets,
+  mode,
+  model,
+  selectedLoras,
+  effectiveLoraWeight,
+  createPreset,
+  activeProject,
+  presetDefaultFields,
+  buildDefaults,
+  modeIsPresetable,
+  setMode,
+  onApplyDefaults = () => {},
+  extraSaveGuard = () => null,
+}) {
+  const [presetName, setPresetName] = useState("");
+  const [presetScope, setPresetScope] = useState(activeProject ? "project" : "global");
+  const [savingPreset, setSavingPreset] = useState(false);
+  const [presetSaveMessage, setPresetSaveMessage] = useState({ tone: "neutral", text: "" });
+  const presetDefaultSnapshots = useRef({});
+
+  // When restoring a snapshot, the saved knob values already reflect the user's last
+  // state — skip the one preset-default pass that fires as the restored preset resolves
+  // so it doesn't overwrite them. "None" applies no defaults, so no guard is needed there.
+  const skipPresetDefaultsOnHydrate = useRef(
+    Object.keys(saved).length > 0 && saved.selectedPresetId !== noPresetId,
+  );
+
+  useEffect(() => {
+    if (skipPresetDefaultsOnHydrate.current && selectedPreset) {
+      skipPresetDefaultsOnHydrate.current = false;
+      return;
+    }
+    if (!selectedPreset) {
+      for (const [key, setter] of presetDefaultFields) {
+        clearPresetDefault(setter, presetDefaultSnapshots, key);
+      }
+      return;
+    }
+    const defaults = selectedPreset.defaults ?? {};
+    for (const [key, setter] of presetDefaultFields) {
+      if (Object.prototype.hasOwnProperty.call(defaults, key)) {
+        applyPresetDefault(presetDefaultSnapshots, key, setter, defaults[key]);
+      }
+    }
+    onApplyDefaults(defaults);
+    // Restore the saved sub-mode ("type") when it's a presetable workflow.
+    if (modeIsPresetable(defaults.mode)) {
+      setMode(defaults.mode);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedPreset?.id]);
+
+  // Snapshot the current working config into a named recipe preset in the workspace
+  // library. Captures the literal prompt + every visible knob + the selected LoRAs
+  // with their weights; the seed is intentionally left out so the preset stays
+  // reusable. The backend additionally enforces id uniqueness and model/workflow +
+  // LoRA compatibility, surfaced here via err.message.
+  async function handleSaveAsPreset() {
+    const trimmed = presetName.trim();
+    if (!trimmed) {
+      setPresetSaveMessage({ tone: "error", text: "Name the preset before saving." });
+      return;
+    }
+    if (!slugifyPresetId(trimmed)) {
+      setPresetSaveMessage({ tone: "error", text: "Use letters or numbers in the preset name." });
+      return;
+    }
+    const guardMessage = extraSaveGuard();
+    if (guardMessage) {
+      setPresetSaveMessage({ tone: "error", text: guardMessage });
+      return;
+    }
+    if (presetScope === "project" && !activeProject) {
+      setPresetSaveMessage({ tone: "error", text: "Open a project first, or save to all projects." });
+      return;
+    }
+    if (presetNameTaken(trimmed, presets)) {
+      setPresetSaveMessage({ tone: "error", text: `"${trimmed}" already exists — pick a unique name.` });
+      return;
+    }
+    const payload = buildStudioPresetPayload({
+      name: trimmed,
+      scope: presetScope,
+      mode,
+      model,
+      loras: selectedLoras.map((lora) => ({ id: lora.id, weight: effectiveLoraWeight(lora) })),
+      defaults: buildDefaults(),
+    });
+    setSavingPreset(true);
+    setPresetSaveMessage({ tone: "neutral", text: "" });
+    try {
+      const created = await createPreset(payload);
+      setSelectedPresetId(created?.id ?? payload.id);
+      setPresetName("");
+      setPresetSaveMessage({
+        tone: "success",
+        text: `Saved "${trimmed}" to ${presetScope === "project" ? "this project" : "all projects"}.`,
+      });
+    } catch (err) {
+      setPresetSaveMessage({ tone: "error", text: err.message });
+    } finally {
+      setSavingPreset(false);
+    }
+  }
+
+  return {
+    presetName,
+    setPresetName,
+    presetScope,
+    setPresetScope,
+    savingPreset,
+    presetSaveMessage,
+    setPresetSaveMessage,
+    handleSaveAsPreset,
   };
 }
 

--- a/apps/web/src/testUtils/dom.js
+++ b/apps/web/src/testUtils/dom.js
@@ -1,0 +1,59 @@
+// Shared jsdom test helpers for the React studio/component suites (sc-8937).
+//
+// These were re-declared near-identically across a dozen *.test.jsx files. The
+// dispatch helpers below are the byte-for-byte canonical forms those files used;
+// centralizing them keeps a test-technique fix a one-file edit instead of a
+// dozen-file sweep. Files whose local helper diverges (e.g. a synchronous `click`
+// that runs inside the caller's own `act`) intentionally keep their own copy.
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+
+// Dispatch a bubbling click and flush the resulting React work inside `act`.
+// Matches the `async function click(element)` form the studio suites shared.
+export async function click(element) {
+  await act(async () => {
+    element.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+  });
+}
+
+// Set a controlled <input> value through the native setter (bypassing React's
+// value-tracking) and fire the `input` event React listens for. Synchronous —
+// callers wrap in `act` when they need the update flushed before asserting.
+export function setInput(element, value) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
+  setter.call(element, value);
+  element.dispatchEvent(new window.Event("input", { bubbles: true }));
+}
+
+// Set a controlled <select> value through the native setter and fire `change`.
+export function setSelect(element, value) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLSelectElement.prototype, "value").set;
+  setter.call(element, value);
+  element.dispatchEvent(new window.Event("change", { bubbles: true }));
+}
+
+// Attach a FileList to a file <input> and fire `change` so upload handlers run.
+export function setFileInput(element, files) {
+  Object.defineProperty(element, "files", {
+    configurable: true,
+    value: files,
+  });
+  element.dispatchEvent(new window.Event("change", { bubbles: true }));
+}
+
+// Create a detached container mounted on document.body plus a React root for it,
+// the create half of the shared beforeEach scaffolding. Returns both so the test
+// can render into `root` and query `container`.
+export function mountRoot() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  return { container, root };
+}
+
+// Tear a mountRoot() pair down, the cleanup half of the shared afterEach: unmount
+// inside `act` (so effect cleanups run) and detach the container from the DOM.
+export async function unmountRoot(root, container) {
+  await act(async () => root.unmount());
+  container.remove();
+}


### PR DESCRIPTION
## Summary

[F-135] Three near-identical blocks were duplicated across the web app. This extracts each into a single shared abstraction with **no behavior change**, so future validation/UX, card-layout, and test-technique fixes are one-file edits instead of multi-file sweeps.

Story: sc-8937 (Chore).

## Part A — `useSavePreset` (`apps/web/src/screens/generationStudio.jsx`)

`handleSaveAsPreset` + the preset-defaults hydrate effect were duplicated line-for-line in `ImageStudio.jsx` and `VideoStudio.jsx` (the shared `useGenerationStudio` had absorbed the rest but left these). Extracted `useSavePreset({ buildDefaults, presetDefaultFields, modeIsPresetable, onApplyDefaults, extraSaveGuard, ... })`, which owns:

- the save-panel state (`presetName` / `presetScope` / `savingPreset` / `presetSaveMessage`),
- the remember/restore snapshot ref,
- the single preset-default hydrate pass, and
- the `handleSaveAsPreset` handler.

**Behavior preserved exactly for both studios** (diffed the two originals field-by-field):
- Validation order is identical: `trim → slugify → [video mode-gate] → project-scope → name-taken`. The **video-only** mode gate (`"Switch to Image, Text, or First/Last mode to save a preset."`) rides `extraSaveGuard`, which defaults to a no-op so Image keeps having no gate.
- The **Image-only** `promptEdited.current = true` side-effect rides `onApplyDefaults` (no-op for Video).
- Each studio's `buildDefaults()` reproduces its exact save payload — including Image's conditional `character_image` knobs (`ipAdapterScale`/`controlnetScale`/`trueCfgScale`/`viewAngle`) and Video's LTX guidance fields.
- `modeIsPresetable` uses `IMAGE_MODES` for Image and `VIDEO_PRESET_MODES` for Video.

## Part B — `PickerCardGrid` (`apps/web/src/components/AssetPicker.jsx`)

Three byte-similar `role="listbox"` asset-card grids (`ImageEditSourcePickerModal`, `AssetPickerModal`, `CharacterImportDialog`) collapsed into one module-level `PickerCardGrid` parameterized by `isSelected` / `onSelect` / `onActivate` / `ariaMultiselectable` / `emptyLabel`. Markup, classes, aria, and single- vs. double-click activation are preserved exactly per grid:

- Grid 1 (single-select, `onDoubleClick` confirm),
- Grid 2 (multi-select, `!multiple && onConfirm([id])` double-click, `multiple || undefined` aria),
- Grid 3 (multi-select, `aria-multiselectable` always true, no double-click).

## Part C — `apps/web/src/testUtils/dom.js`

`click` / `setInput` / `setSelect` / `setFileInput` and the `createRoot` mount/unmount scaffolding were re-declared across a dozen `*.test.jsx` files. Added `src/testUtils/dom.js` exporting the **canonical** helpers (`click`, `setInput`, `setSelect`, `setFileInput`, `mountRoot`, `unmountRoot`) and migrated the files whose local copy was byte-identical:

Migrated (8): `ImageStudio.test.jsx`, `VideoStudio.test.jsx`, `SettingsScreen.test.jsx`, `VideoUpscalePanel.test.jsx`, `PoseLibraryScreen.test.jsx`, `KeyPointLibraryScreen.test.jsx`, `ModelManagerScreen.test.jsx`, `ModelAvailabilityGate.test.jsx`.

**Left alone on purpose** (divergent helpers, migrating would change behavior): the synchronous `click` run inside the caller's own `act` in `LikenessCompare` / `StructuredPromptBuilder` / `PaletteEditor` / `ReferenceCaptionPicker`; the async `setInputValue` variant; an inlined `setSelect`; and the `doubleClick` / `changeField` one-offs.

## Behavior preservation & tests

- No product behavior changed anywhere — this is a pure structure refactor.
- **Full web vitest suite green: 69 files, 1113 tests passed** (run with `--environment jsdom`), before and after merging `origin/main`.
- eslint: **0 errors**; net **−2 warnings** vs `main` (all remaining warnings pre-existing `react-hooks/exhaustive-deps`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)