### PR TITLE
fix(web): register CurveEditor drag listeners once; move App refresh-ref writes to a post-commit effect (sc-8940)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { apiFetch, eventUrl, isAbortError, setMediaTicket } from "./api.js";
 import { pollJobToCompletion } from "./pollJob.js";
 import { Icon } from "./components/Icons.jsx";
@@ -1494,15 +1494,27 @@ export function App() {
       .catch(() => {});
   }
 
-  refreshDataRef.current = refreshData;
-  refreshAssetsRef.current = refreshAssets;
-  refreshCharactersRef.current = refreshCharacters;
-  refreshLorasRef.current = refreshLoras;
-  refreshPresetsRef.current = refreshPresets;
-  refreshTrainingDatasetsRef.current = refreshTrainingDatasets;
-  refreshPersonTracksRef.current = refreshPersonTracks;
-  refreshTimelinesRef.current = refreshTimelines;
-  refreshDataWithLoraOverlayRef.current = refreshDataWithLoraOverlay;
+  // sc-8940: Publish the latest refresh closures into their refs from a post-commit
+  // effect rather than the render body — React documents render-body ref mutation as
+  // unsafe (a discarded concurrent/StrictMode render could leave a ref pointing at an
+  // uncommitted closure). No dep array means this runs on every commit, so the refs
+  // always hold the newest *committed* body (fresh token / activeProject). We use
+  // useLayoutEffect (not useEffect) so the assignment flushes before every passive
+  // effect on the same commit: the consumers of these refs (the [ready,token] load
+  // effect, the project-switch effect, the SSE handler) are all plain useEffects/event
+  // handlers, and React runs all layout effects before any passive effect — preserving
+  // the original ordering where consumers saw the fresh closure.
+  useLayoutEffect(() => {
+    refreshDataRef.current = refreshData;
+    refreshAssetsRef.current = refreshAssets;
+    refreshCharactersRef.current = refreshCharacters;
+    refreshLorasRef.current = refreshLoras;
+    refreshPresetsRef.current = refreshPresets;
+    refreshTrainingDatasetsRef.current = refreshTrainingDatasets;
+    refreshPersonTracksRef.current = refreshPersonTracks;
+    refreshTimelinesRef.current = refreshTimelines;
+    refreshDataWithLoraOverlayRef.current = refreshDataWithLoraOverlay;
+  });
 
 
   // Remote-browser login (epic 4484 story 7): the password IS the API access token.

--- a/apps/web/src/components/CurveEditor.jsx
+++ b/apps/web/src/components/CurveEditor.jsx
@@ -28,13 +28,22 @@ export function CurveEditor({ points, onChange, stroke = "var(--accent)" }) {
     return { x: clamp(x), y: clamp(y) };
   };
 
+  // sc-8940: The window drag listeners are registered ONCE (below, `[]` deps) so they
+  // aren't torn down and re-added on every render — including every drag-tick onChange.
+  // The move handler needs the latest points and onChange, so we stash them in a ref that
+  // is refreshed each render; the handler reads `latestRef.current` at fire time rather
+  // than closing over a snapshot that would go stale between re-subscriptions.
+  const latestRef = useRef({ pts, onChange });
+  latestRef.current = { pts, onChange };
+
   // Drag a point, keeping the list ordered: endpoints move in y only; interior
   // points clamp x strictly between their neighbors so the index stays stable.
   useEffect(() => {
     const onMove = (event) => {
       const i = dragRef.current;
       if (i == null) return;
-      const next = pts.map((p) => ({ ...p }));
+      const { pts: curPts, onChange: curOnChange } = latestRef.current;
+      const next = curPts.map((p) => ({ ...p }));
       const c = toCurve(event);
       if (i === 0) next[i] = { x: 0, y: c.y };
       else if (i === next.length - 1) next[i] = { x: 255, y: c.y };
@@ -43,7 +52,7 @@ export function CurveEditor({ points, onChange, stroke = "var(--accent)" }) {
         const hi = next[i + 1].x - 1;
         next[i] = { x: Math.min(hi, Math.max(lo, c.x)), y: c.y };
       }
-      onChange(next);
+      curOnChange(next);
     };
     const onUp = () => {
       dragRef.current = null;
@@ -54,7 +63,8 @@ export function CurveEditor({ points, onChange, stroke = "var(--accent)" }) {
       window.removeEventListener("pointermove", onMove);
       window.removeEventListener("pointerup", onUp);
     };
-  });
+    // Registered once — the handlers read live state via `latestRef`/`dragRef`.
+  }, []);
 
   // Click empty space → add a control point there (ignored if it lands on an x that
   // already has a point — normalizeCurvePoints would dedupe it anyway).

--- a/apps/web/src/components/CurveEditor.test.jsx
+++ b/apps/web/src/components/CurveEditor.test.jsx
@@ -56,4 +56,80 @@ describe("CurveEditor (sc-6109)", () => {
     await act(() => handles()[0].dispatchEvent(new MouseEvent("dblclick", { bubbles: true })));
     expect(onChange).not.toHaveBeenCalled(); // endpoint not removable
   });
+
+  it("dragging an interior handle moves it in curve space (sc-8940)", async () => {
+    const onChange = vi.fn();
+    const points = [
+      { x: 0, y: 0 },
+      { x: 128, y: 128 },
+      { x: 255, y: 255 },
+    ];
+    await act(() => root.render(<CurveEditor points={points} onChange={onChange} />));
+    // jsdom returns a zeroed rect, so pin a 255x255 rect at the origin: then a pointer at
+    // client (200, 55) maps to curve x=200, y=255-55=200.
+    const svg = container.querySelector("svg");
+    svg.getBoundingClientRect = () => ({ left: 0, top: 0, width: 255, height: 255 });
+
+    // Begin the drag on the interior handle, then move the window pointer.
+    await act(() =>
+      handles()[1].dispatchEvent(new PointerEvent("pointerdown", { bubbles: true })),
+    );
+    await act(() =>
+      window.dispatchEvent(new PointerEvent("pointermove", { clientX: 200, clientY: 55 })),
+    );
+    expect(onChange).toHaveBeenCalledWith([
+      { x: 0, y: 0 },
+      { x: 200, y: 200 },
+      { x: 255, y: 255 },
+    ]);
+
+    // pointerup ends the drag: further moves are ignored.
+    onChange.mockClear();
+    await act(() => window.dispatchEvent(new PointerEvent("pointerup", {})));
+    await act(() =>
+      window.dispatchEvent(new PointerEvent("pointermove", { clientX: 100, clientY: 100 })),
+    );
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("uses the latest points/onChange after a re-render without re-subscribing (sc-8940)", async () => {
+    // The window drag listeners are registered once; the move handler must read the
+    // *current* points and onChange via a ref, not a snapshot from the first render.
+    const addSpy = vi.spyOn(window, "addEventListener");
+    const firstOnChange = vi.fn();
+    const points = [
+      { x: 0, y: 0 },
+      { x: 128, y: 128 },
+      { x: 255, y: 255 },
+    ];
+    await act(() => root.render(<CurveEditor points={points} onChange={firstOnChange} />));
+    const svg = container.querySelector("svg");
+    svg.getBoundingClientRect = () => ({ left: 0, top: 0, width: 255, height: 255 });
+
+    const drCount = (type) =>
+      addSpy.mock.calls.filter(([evt]) => evt === type).length;
+    expect(drCount("pointermove")).toBe(1);
+    expect(drCount("pointerup")).toBe(1);
+
+    // Re-render with a NEW onChange; the single subscription must route to it.
+    const secondOnChange = vi.fn();
+    await act(() => root.render(<CurveEditor points={points} onChange={secondOnChange} />));
+    // No churn: still exactly one listener of each type across both renders.
+    expect(drCount("pointermove")).toBe(1);
+    expect(drCount("pointerup")).toBe(1);
+
+    await act(() =>
+      handles()[1].dispatchEvent(new PointerEvent("pointerdown", { bubbles: true })),
+    );
+    await act(() =>
+      window.dispatchEvent(new PointerEvent("pointermove", { clientX: 200, clientY: 55 })),
+    );
+    expect(firstOnChange).not.toHaveBeenCalled();
+    expect(secondOnChange).toHaveBeenCalledWith([
+      { x: 0, y: 0 },
+      { x: 200, y: 200 },
+      { x: 255, y: 255 },
+    ]);
+    addSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## sc-8940 (Bug) — [F-138]

Two behavior-preserving bad-pattern fixes flagged by the full code review.

### Part 1 — CurveEditor: register drag listeners once
`apps/web/src/components/CurveEditor.jsx`

The `pointermove`/`pointerup` window listeners were registered in a `useEffect` with **no dep array**, so both were removed and re-added on **every render** — including every drag-tick `onChange`. The `onMove` handler also closed over a snapshot of `pts`/`onChange` that went stale between re-subscriptions.

**Fix:** register both listeners **once** (`[]` deps). The move handler now reads the current points and `onChange` via a `latestRef` that is refreshed each render, so the single subscription always operates on live state.

**Behavior preserved (drag UX unchanged):**
- endpoints move in `y` only (x locked to 0 / 255)
- interior points clamp `x` strictly between their neighbors (index stays stable)
- `onChange(next)` fires per move tick with identical payload
- `pointerup` clears the drag ref (ends the drag)
- `toCurve` still reads the stable `svgRef`, so no stale-closure risk

### Part 2 — App: move ref writes out of the render body
`apps/web/src/App.jsx`

The nine `refresh*Ref.current = refresh*` assignments executed directly in the **render body**, which React documents as unsafe: a discarded concurrent/StrictMode render can leave a ref pointing at an uncommitted closure.

**Fix:** move the nine assignments into a **no-dep `useLayoutEffect`**. It runs on every commit (refs always hold the newest committed closure with fresh `token`/`activeProject`) but only for **committed** renders.

**Why `useLayoutEffect` and not `useEffect`:** React flushes all layout effects before any passive effect on the same commit. Every consumer of these refs — the `[ready, token]` initial-load effect, the project-switch effect, and the SSE job handler — is a plain passive `useEffect` or an event handler, so the assignment still lands before consumers read it, preserving the original ordering where consumers saw the fresh closure. Verified no consumer reads these refs during render.

Kept minimal: did **not** touch the separate `purgeAssetRef` block (outside this story's scope) and did **not** attempt the broader `useCallback`-stabilization of the nine functions (that is F-009's separate scope).

### Tests
- Added two `CurveEditor.test.jsx` cases:
  - dragging an interior handle moves it in curve space; `pointerup` ends the drag
  - listeners are registered **exactly once** across re-renders and route to the **latest** `onChange` (no stale-closure regression, no listener churn)
- Full web vitest suite: **69 files / 1115 tests pass**
- eslint: clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)