### PR TITLE
feat(worker): enable Ideogram 4 (base) bf16 tier off-Mac on candle (sc-9650)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1487,14 +1487,18 @@
           // variant can slot in alongside `bf16/` without a rename. Gated non-commercial.
           // sc-8508: this is a genuine per-tier quant variant (q4 vs bf16 of the same model), so it is
           // labeled `variant: bf16` — even though the two tiers happen to live in separate HF repos.
-          // sc-9092: macOS-only now. The off-Mac candle lane packed-loads the `SceneWorks/ideogram-4-mlx`
-          // q4 turnkey above (via the shared resolver), so the retired `candle_ideogram_repo` bf16 target
-          // resolves nothing off-Mac — the windows/linux platforms are dropped.
+          // sc-9650: installable on Windows/Linux too — the candle Ideogram loader reads this repo's
+          // `bf16/` single-file `transformer/model.safetensors` and dense-loads it via `linear_detect`
+          // (no `.scales` sibling → the dense arm), exactly like macOS/MLX; the worker resolves it off-Mac
+          // through the un-gated `IDEOGRAM_BF16_REPO` bf16 branch (GPU-validated on sm_120: renders a
+          // coherent 1024² image). ~55 GB on disk / ~80 GB MEASURED VRAM for the two-DiT path — a 96 GB-card
+          // tier (see the candle VRAM block below). The packed q4/q8 tiers above still come from the `-mlx`
+          // turnkey; `candle_ideogram_repo` stays retired.
           "provider": "huggingface",
           "repo": "SceneWorks/ideogram-4",
           "variant": "bf16",
           "files": ["bf16/*"],
-          "platforms": ["macos"],
+          "platforms": ["macos", "windows", "linux"],
           "estimatedSizeBytes": 54760833024,
           "footprint": { "diskSizeBytes": 54760833024, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
@@ -1541,11 +1545,13 @@
       },
       // candle/CUDA VRAM gate (sc-9094, epic 9083) — MEASURED on an RTX PRO 6000 (Blackwell sm_120) at
       // 1024²/10-step via the candle-gen nvidia-smi peak monitor: q4 packed overall-peak 38.5 GB (the
-      // two-DiT Ideogram path). minMemoryGb 46 covers it with headroom; q8 ESTIMATED (~44 GB) pending
-      // measurement (bf16 not hosted for this id).
+      // two-DiT Ideogram path). minMemoryGb 46 gates the DEFAULT (q4) tier and covers it with headroom;
+      // q8 ESTIMATED (~44 GB). bf16 (sc-9650, off-Mac dense tier) MEASURED ~80 GB overall-peak (RTX PRO
+      // 6000, 1024²/48-step — the two dense-bf16 DiTs dominate); a 96 GB-card tier, small cards see it
+      // gated by its `vramGbByTier` ceiling.
       "candle": {
         "minMemoryGb": 46,
-        "vramGbByTier": { "q4": 38.5, "q8": 44.0 },
+        "vramGbByTier": { "q4": 38.5, "q8": 44.0, "bf16": 80.0 },
         "measured": false
       },
       // Ideogram Non-Commercial Model Agreement (gated): accept the license at the source repo and
@@ -1638,8 +1644,12 @@
           // advanced mlxQuantize<=0, rather than duplicating it into the MLX turnkey repo. Same gated
           // non-commercial license.
           // sc-8508: genuine per-tier quant variant (q4 vs bf16 of the same model) → labeled `bf16`.
-          // sc-9092: macOS-only now — the off-Mac candle lane packed-loads the `SceneWorks/ideogram-4-mlx`
-          // q4 turnkey above, so the retired `candle_ideogram_repo` bf16 target resolves nothing off-Mac.
+          // bf16 (sc-8513): the separate `SceneWorks/ideogram-4` `bf16/` dense tier, carrying
+          // `turbo_lora.safetensors`. macOS-only FOR NOW: sc-9650 enabled candle bf16 for the base id, but
+          // the candle Turbo LoRA merge on a dense bf16 base hits a BF16/F32 dtype mismatch
+          // (`candle-gen-ideogram` adapters.rs: the merge adds an F32 delta to the as-is BF16 base). Flip
+          // this to all-platforms once that candle-gen fix lands + the pin bumps. (Base q4/q8 come from the
+          // `-mlx` turnkey.)
           "provider": "huggingface",
           "repo": "SceneWorks/ideogram-4",
           "variant": "bf16",

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -307,11 +307,16 @@ fn model_repo(request: &ImageRequest, model: &ResolvedModel) -> String {
 }
 
 /// The separate `SceneWorks/ideogram-4` repo that hosts Ideogram 4's bf16 tree under `bf16/`, the
-/// macOS selectable full-precision MLX tier (sc-8513). The MLX `q4/`/`q8/` turnkey lives in
-/// `SceneWorks/ideogram-4-mlx`; bf16 is resolved from THIS repo rather than duplicated. (Off-Mac the
-/// candle Ideogram lane packed-loads the `SceneWorks/ideogram-4-mlx` turnkey subdir directly via the
-/// shared `resolve_weights_dir`/`ideogram_model_subdir` since sc-9092 — no separate candle repo.)
-#[cfg(target_os = "macos")]
+/// selectable full-precision tier (sc-8513). The `q4/`/`q8/` packed turnkey lives in
+/// `SceneWorks/ideogram-4-mlx`; bf16 is resolved from THIS repo rather than duplicated. sc-9650 wires it
+/// on the candle lane too: the `bf16/` subdir is in the SAME single-file `transformer/model.safetensors`
+/// layout the candle loader reads, and `linear_detect` takes its dense arm (no `.scales` sibling), so
+/// candle dense-loads bf16 exactly like macOS/MLX — while the packed q4/q8 tiers still come from the
+/// `-mlx` turnkey via `ideogram_model_subdir`.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 const IDEOGRAM_BF16_REPO: &str = "SceneWorks/ideogram-4";
 
 /// Resolve the weights snapshot directory: an explicit `modelPath` dir wins, else the
@@ -345,12 +350,16 @@ pub(crate) fn resolve_weights_dir(
     // `turbo_lora.safetensors` the `ideogram_4_turbo` engine installs at load.
     if request.model == "ideogram_4" || request.model == "ideogram_4_turbo" {
         // bf16 (sc-8513, epic 8506) is the SHARED `SceneWorks/ideogram-4` repo's `bf16/` subdir — NOT
-        // duplicated into the MLX turnkey. When the macOS request opts into bf16 (advanced mlxQuantize<=0)
-        // AND it is downloaded, resolve there (the dense weights load with no quantize); else the q4
-        // (default)/q8 turnkey subdir. A partial bf16 download falls back rather than half-loading.
-        // (macOS/MLX only — this `#[cfg(target_os = "macos")]` block is skipped on the candle lane, which
-        // shares the `ideogram_model_subdir` q4/q8 turnkey resolution below since sc-9092.)
-        #[cfg(target_os = "macos")]
+        // duplicated into the MLX turnkey. When a request opts into bf16 (advanced mlxQuantize<=0) AND it
+        // is downloaded, resolve there (the dense weights load with no quantize); else the q4 (default)/q8
+        // turnkey subdir. A partial bf16 download falls back rather than half-loading. sc-9650: wired on
+        // the candle lane too — the candle Ideogram loader reads the same `transformer/model.safetensors`
+        // layout and dense-loads bf16 via `linear_detect` (`resolve_quant` returns None for mlxQuantize<=0,
+        // so no on-the-fly quant runs). The packed q4/q8 tiers still resolve from the `-mlx` turnkey below.
+        #[cfg(any(
+            target_os = "macos",
+            all(not(target_os = "macos"), feature = "backend-candle")
+        ))]
         {
             let wants_bf16 = request
                 .advanced


### PR DESCRIPTION
## What
Enables the **Ideogram 4 (base) bf16 tier on the candle/CUDA lane** ([sc-9650](https://app.shortcut.com/trefry/story/9650), epic 9083). Previously macOS-only.

## Investigation → it's a SceneWorks-only change
The dense bf16 tier lives in the separate `SceneWorks/ideogram-4` repo (`bf16/`, ~55 GB). Its layout is **identical** to the packed q4/q8 turnkey (same components + single-file `transformer/model.safetensors`), and the candle Ideogram loader's `linear_detect` takes its **dense arm** on a no-`.scales` weight — which is the loader's *original baseline* (the `ideogram-render` example docstring literally "Loads a bf16 snapshot"). So **no candle-gen change / pin bump** is needed.

- Un-gate `IDEOGRAM_BF16_REPO` + the bf16 resolver branch (`resolve_weights_dir`) from `#[cfg(target_os="macos")]` → macOS-or-candle.
- Flip the `ideogram_4` bf16 download to `platforms: ["macos","windows","linux"]`.
- Add `bf16: 80` to the candle VRAM block.

## GPU validation (RTX PRO 6000, sm_120)
Rendered `ideogram_4` bf16 at 1024²/48-step via the `candle-gen-ideogram` render harness against the downloaded `bf16/` snapshot → **coherent photorealistic image** (verified visually; a first seed hit Ideogram's known safety-placeholder quirk sc-6501, a reseed rendered clean). **Measured overall-peak ~80 GB** (two dense-bf16 DiTs) → a 96 GB-card tier; smaller cards are gated by `vramGbByTier.bf16`.

## Scope: base only
`ideogram_4_turbo` bf16 stays **macOS-only** — its candle Turbo-LoRA merge on a dense bf16 base hits `dtype mismatch in add, lhs: BF16, rhs: F32` (`get_cpu_merge_base` returns the base as-is BF16 on a dense tier while the LoRA delta is F32). Filed as **[sc-9654](https://app.shortcut.com/trefry/story/9654)** — a one-line candle-gen fix (`base.to_dtype(F32)`), after which turbo bf16 flips to all-platforms (the manifest comment notes this). Base q4/q8 still resolve from the `-mlx` turnkey.

## Checks
- `cargo check -p sceneworks-worker --features backend-candle` clean (resolver un-gate compiles on candle).
- Manifest parses (57 models); `ideogram_4` now `q4[all] / q8[all] / bf16[all]`. `check-scaffold.mjs` + `cargo fmt` clean.

Relates: sc-9607, sc-9642, sc-9092, epic 9083.

🤖 Generated with [Claude Code](https://claude.com/claude-code)