### PR TITLE
fix(rust-api): require the access token for ui-preferences writes (sc-8869)

### DIFF
--- a/apps/rust-api/src/auth.rs
+++ b/apps/rust-api/src/auth.rs
@@ -13,7 +13,7 @@ pub(crate) async fn access_control(
 ) -> Response {
     let peer = connect_info.map(|ConnectInfo(addr)| addr);
     if request.method() == Method::OPTIONS
-        || !requires_token(request.uri().path())
+        || !requires_token(request.method(), request.uri().path())
         || loopback_trusted(state.settings.trust_loopback, peer)
         || is_authorized(request.headers(), &state.settings)
         || media_ticket_authorized(&state, &request)
@@ -66,12 +66,29 @@ pub(crate) fn cors_layer(settings: &Settings) -> CorsLayer {
         ])
 }
 
-/// Whether a path is gated by the access token. Only `/api/*` routes are
+/// Whether a request is gated by the access token. Only `/api/*` routes are
 /// protected (minus the explicitly public ones); everything else is the
 /// embedded web bundle / SPA fallback, which a browser must be able to load
 /// before it can attach the token header.
-pub(crate) fn requires_token(path: &str) -> bool {
-    path.starts_with("/api/") && !PUBLIC_PATHS.contains(&path)
+///
+/// The exemption is method-aware, not path-only (sc-8869, F-067): a public path
+/// is only exempt for the read-safe method(s) it was whitelisted for. The theme
+/// preferences path (`/api/v1/ui-preferences`) shares its route between a
+/// pre-auth GET (the theme read that loads before auth, to avoid a flash) and a
+/// PUT that writes `ui-preferences.json` to disk. Only the GET stays public; the
+/// disk-writing PUT must still present the token when one is configured, so an
+/// unauthenticated LAN caller can't overwrite the file (epic 4484: every write is
+/// authenticated). All other `PUBLIC_PATHS` entries expose a single route method,
+/// so a path-only exemption for them is already method-correct.
+pub(crate) fn requires_token(method: &Method, path: &str) -> bool {
+    if !path.starts_with("/api/") {
+        return false;
+    }
+    if path == UI_PREFERENCES_PATH {
+        // Only the pre-auth theme READ is public; the disk-writing PUT is gated.
+        return method != Method::GET;
+    }
+    !PUBLIC_PATHS.contains(&path)
 }
 
 /// Whether a request should bypass the access token because it originates from this

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -118,13 +118,18 @@ use keypoints::*;
 mod logs;
 use logs::*;
 
+// The theme-preferences route. Its GET (the pre-auth theme read) is public, but its
+// PUT writes `ui-preferences.json` to disk, so the exemption is method-aware — the
+// PUT is gated when a token is configured (sc-8869, F-067). See `auth::requires_token`.
+const UI_PREFERENCES_PATH: &str = "/api/v1/ui-preferences";
 const PUBLIC_PATHS: &[&str] = &[
     "/api/v1/health",
     "/api/v1/access",
     "/api/v1/auth/verify",
     "/api/v1/jobs/events",
-    // Non-sensitive UI state (theme); loaded before auth to avoid a flash.
-    "/api/v1/ui-preferences",
+    // Non-sensitive UI state (theme); the GET is loaded before auth to avoid a
+    // flash. The PUT is method-gated in `auth::requires_token`, not here.
+    UI_PREFERENCES_PATH,
 ];
 const DEFAULT_CORS_ORIGINS: &str = concat!(
     "http://localhost:5173,http://127.0.0.1:5173,",

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -1032,7 +1032,7 @@ pub(crate) fn create_app_with_state(
         )
         .route("/api/v1/credentials/:host", delete(delete_credential))
         .route(
-            "/api/v1/ui-preferences",
+            UI_PREFERENCES_PATH,
             get(get_ui_preferences).put(set_ui_preferences),
         )
         .route("/api/v1/models", get(list_models))

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -529,6 +529,41 @@ async fn request_with_headers(
     (status, value)
 }
 
+/// Drive a request through the router with a simulated peer `SocketAddr` in the
+/// request extensions, so the `Option<ConnectInfo<SocketAddr>>` extractor in the
+/// auth middleware resolves to that peer (the plain `oneshot` path has no connect
+/// info and so is never loopback-trusted). Used to exercise the epic-4484
+/// loopback-trust bypass end-to-end (sc-8869).
+async fn request_with_peer(
+    app: axum::Router,
+    method: &str,
+    uri: &str,
+    body: Value,
+    peer: &str,
+) -> (StatusCode, Value) {
+    use axum::extract::ConnectInfo;
+    use std::net::SocketAddr;
+    let mut request = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .expect("request builds");
+    let addr: SocketAddr = peer.parse().expect("peer addr parses");
+    request.extensions_mut().insert(ConnectInfo(addr));
+    let response = app.oneshot(request).await.expect("response returns");
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body buffers");
+    let value = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).expect("json body parses")
+    };
+    (status, value)
+}
+
 async fn request_raw(
     app: axum::Router,
     method: &str,
@@ -9097,17 +9132,139 @@ async fn worker_restart_requires_token() {
     assert_eq!(body["ok"], true);
 }
 
+#[tokio::test]
+async fn ui_preferences_get_is_public_but_put_requires_token() {
+    // sc-8869 (F-067): with a token configured, the pre-auth theme READ (GET) stays
+    // public so the UI can load the theme before auth, but the PUT writes
+    // `ui-preferences.json` to disk and must present the token — an unauthenticated
+    // LAN caller can no longer overwrite the file (epic 4484: every write authenticated).
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let mut settings = test_settings(&temp_dir);
+    settings.access_token = "secret-token".to_owned();
+    let app = create_app(settings).expect("app creates");
+
+    // GET without a token: still public (theme read loads before auth).
+    let (status, prefs) = request(app.clone(), "GET", "/api/v1/ui-preferences", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(prefs.get("theme").is_none());
+
+    // PUT without a token: rejected (disk write is now authenticated).
+    let (status, _) = request(
+        app.clone(),
+        "PUT",
+        "/api/v1/ui-preferences",
+        json!({ "theme": "dark", "accent": "coral" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+
+    // The rejected write must not have touched the stored preferences.
+    let (status, prefs) = request(app.clone(), "GET", "/api/v1/ui-preferences", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(prefs.get("theme").is_none());
+
+    // PUT with the correct token: accepted, and the write persists.
+    let (status, saved) = request_with_headers(
+        app.clone(),
+        "PUT",
+        "/api/v1/ui-preferences",
+        json!({ "theme": "dark", "accent": "coral" }),
+        &[("x-sceneworks-token", "secret-token")],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(saved["theme"], "dark");
+    assert_eq!(saved["accent"], "coral");
+
+    let (status, prefs) = request(app, "GET", "/api/v1/ui-preferences", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(prefs["theme"], "dark");
+    assert_eq!(prefs["accent"], "coral");
+}
+
+#[tokio::test]
+async fn ui_preferences_put_allowed_via_loopback_trust() {
+    // sc-8869 (F-067) / epic 4484: the method-aware gate must not break the
+    // loopback-trust bypass. A loopback peer (the embedded desktop UI/worker) with
+    // `trust_loopback` on writes preferences without a token, exactly as before, while
+    // a LAN peer with no token is still rejected.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let mut settings = test_settings(&temp_dir);
+    settings.access_token = "secret-token".to_owned();
+    settings.trust_loopback = true;
+    let app = create_app(settings).expect("app creates");
+
+    // Loopback peer, no token → allowed (desktop bypass preserved).
+    let (status, saved) = request_with_peer(
+        app.clone(),
+        "PUT",
+        "/api/v1/ui-preferences",
+        json!({ "theme": "light" }),
+        "127.0.0.1:51234",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(saved["theme"], "light");
+
+    // LAN peer, no token → still rejected even with trust_loopback on.
+    let (status, _) = request_with_peer(
+        app,
+        "PUT",
+        "/api/v1/ui-preferences",
+        json!({ "theme": "dark" }),
+        "192.168.1.5:51234",
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn ui_preferences_put_open_when_no_token_configured() {
+    // Behavior with NO token configured must be unchanged: everything is open, so an
+    // unauthenticated PUT still succeeds (the gate only bites when a token is set).
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    assert!(settings.access_token.is_empty());
+    let app = create_app(settings).expect("app creates");
+
+    let (status, saved) = request(
+        app,
+        "PUT",
+        "/api/v1/ui-preferences",
+        json!({ "theme": "dark" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(saved["theme"], "dark");
+}
+
 #[test]
 fn requires_token_only_gates_api_paths() {
+    use axum::http::Method;
     // Non-API paths (embedded UI / SPA fallback) must never require a token,
     // or the browser cannot load the bundle to prompt for one.
-    assert!(!requires_token("/"));
-    assert!(!requires_token("/assets/index-abc.js"));
-    assert!(!requires_token("/projects/some-id"));
+    assert!(!requires_token(&Method::GET, "/"));
+    assert!(!requires_token(&Method::GET, "/assets/index-abc.js"));
+    assert!(!requires_token(&Method::GET, "/projects/some-id"));
     // Public API paths stay open; other API paths stay gated.
-    assert!(!requires_token("/api/v1/health"));
-    assert!(requires_token("/api/v1/jobs"));
-    assert!(requires_token("/api/v1/projects"));
+    assert!(!requires_token(&Method::GET, "/api/v1/health"));
+    assert!(requires_token(&Method::GET, "/api/v1/jobs"));
+    assert!(requires_token(&Method::GET, "/api/v1/projects"));
+}
+
+#[test]
+fn requires_token_ui_preferences_is_method_aware() {
+    use axum::http::Method;
+    // sc-8869 (F-067): the theme-preferences route shares a GET (pre-auth theme
+    // read, public) and a PUT (disk write, must be authenticated). Only the GET is
+    // exempt; the PUT — and any other method — is gated when a token is configured.
+    assert!(!requires_token(&Method::GET, "/api/v1/ui-preferences"));
+    assert!(requires_token(&Method::PUT, "/api/v1/ui-preferences"));
+    assert!(requires_token(&Method::POST, "/api/v1/ui-preferences"));
+    // Other single-method public paths stay exempt regardless of method (they
+    // only wire one route method each), and non-public API paths stay gated.
+    assert!(!requires_token(&Method::POST, "/api/v1/auth/verify"));
+    assert!(requires_token(&Method::PUT, "/api/v1/credentials"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

**sc-8869 (Bug, F-067) — Unauthenticated PUT on `/api/v1/ui-preferences`.**

`requires_token` was **path-only**, and `/api/v1/ui-preferences` is in `PUBLIC_PATHS` so the pre-auth theme **READ** (GET) can load before auth (to avoid a theme flash). That exemption also covered the **PUT** handler, which writes `ui-preferences.json` to disk — so on a token-configured LAN bind any unauthenticated caller could overwrite theme/accent. Whitelist-validated so it's only a nuisance, but it's an **unauthenticated disk write** that violates epic 4484's "every write is authenticated" invariant.

## Fix — method-aware gate (not route-split)

Made `requires_token` **method-aware** (`path` + `&Method`) rather than splitting the route, because the gate lives in a single middleware that already sees the request method — this is the cleanest fit for the existing shape and keeps the whitelist in one place:

- `/api/v1/ui-preferences` stays public **only for GET**; the PUT (and any other method) is gated when a token is configured.
- The path literal is hoisted to a shared `UI_PREFERENCES_PATH` const so `lib.rs` (`PUBLIC_PATHS`) and `auth.rs` (`requires_token`) can't drift.
- Every other `PUBLIC_PATHS` entry wires a **single** route method (`/health` GET, `/access` GET, `/auth/verify` POST, `/jobs/events` GET), so a path-only exemption for them is already method-correct — behavior unchanged. The media-ticket bypass (project files / pose previews) is GET-only and untouched.

## Epic 4484 semantics preserved

Both bypasses sit **upstream** of the token check in the middleware, so they are unaffected by making the token check method-aware:

- **Loopback-trust / `TRUST_LOOPBACK` desktop bypass** — a loopback peer with `trust_loopback` on still writes preferences without a token (covered by a new end-to-end test), while a LAN peer with no token is still rejected.
- **No token configured** — everything stays open; an unauthenticated PUT still succeeds (covered by a test). The new rejection only bites a token-configured, non-loopback caller that omits the token.

## Tests (all passing; full rust-api suite green: 164 passed)

- `ui_preferences_get_is_public_but_put_requires_token` — with a token: GET succeeds **without** a token; PUT **without** a token → **401** and the stored file is left untouched; PUT **with** the token → **200** and persists.
- `ui_preferences_put_allowed_via_loopback_trust` — loopback peer + no token → PUT allowed (desktop bypass preserved); LAN peer + no token → still 401.
- `ui_preferences_put_open_when_no_token_configured` — no token configured → unauthenticated PUT still 200 (behavior unchanged).
- `requires_token_ui_preferences_is_method_aware` + updated `requires_token_only_gates_api_paths` — unit coverage for the new `(method, path)` signature.
- Added a `request_with_peer` test helper that injects `ConnectInfo<SocketAddr>` so the loopback-trust bypass is exercised end-to-end through the middleware.

`cargo test -p sceneworks-rust-api` (164 passed), `cargo clippy -p sceneworks-rust-api --all-targets` (clean), `cargo fmt --all -- --check` (clean). No route/DTO/schema change, so no contract regeneration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)