### PR TITLE
fix(core): validate the timeline id charset before deriving its file path (sc-8871)

### DIFF
--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -777,6 +777,16 @@ impl ProjectStore {
     ) -> ProjectStoreResult<Value> {
         let (project_path, _project_guard) = self.lock_project(project_id)?;
         let timeline_id = required_str(&timeline, "id")?.to_owned();
+        // The client supplies `id`, and `timeline_file_path` embeds its last 8
+        // chars into the write path while `relative_string`'s lexical strip lets
+        // an unnormalized `..`-bearing id through — charset-check it (matching the
+        // asset/character/track/dataset guards) BEFORE any path is derived so the
+        // write can never escape the project dir (sc-8871 / F-069).
+        if !is_safe_id(&timeline_id) {
+            return Err(ProjectStoreError::BadRequest(
+                "Invalid timeline id".to_owned(),
+            ));
+        }
         let timeline_project_id = required_str(&timeline, "projectId")?;
         if timeline_project_id != project_id {
             return Err(ProjectStoreError::BadRequest(
@@ -4375,6 +4385,83 @@ mod tests {
             .persist_generated_asset(&project.id, "job-1", "genset_x", &safe_fact)
             .expect("safe media path persists");
         assert_eq!(safe["id"], json!("asset_safe1"));
+    }
+
+    /// sc-8871 (F-069): `save_timeline` derives the write path from the
+    /// client-supplied `id` (last 8 chars slugged into the filename) and
+    /// `relative_string`'s lexical strip lets an unnormalized `..`-bearing id
+    /// through, so — matching the asset/character/track/dataset guards — the id
+    /// must be charset-checked before any path is derived. A traversal or
+    /// separator-bearing id is rejected with `BadRequest` and writes nothing;
+    /// a normal id still saves under the project's `timelines/` dir.
+    #[test]
+    fn save_timeline_rejects_unsafe_id_before_deriving_path() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Boundary").expect("project creates");
+        let timelines_dir = std::path::Path::new(&project.path).join("timelines");
+
+        let timeline_with = |id: &str| {
+            json!({
+                "id": id,
+                "projectId": project.id,
+                "name": "My Timeline",
+            })
+        };
+
+        for unsafe_id in [
+            "../../../../tmp/escape",
+            "timeline/../../escape",
+            "a/b/c",
+            "id.with.dots",
+            "  ",
+            "",
+        ] {
+            let result = store.save_timeline(&project.id, timeline_with(unsafe_id));
+            assert!(
+                matches!(result, Err(ProjectStoreError::BadRequest(_))),
+                "expected id {unsafe_id:?} to be rejected, got {result:?}"
+            );
+        }
+
+        // Nothing should have been written for any rejected id — no file can land
+        // inside (or escape) the timelines dir.
+        let timeline_files: Vec<_> = std::fs::read_dir(&timelines_dir)
+            .map(|entries| entries.filter_map(Result::ok).collect())
+            .unwrap_or_default();
+        assert!(
+            timeline_files.is_empty(),
+            "rejected ids must not write any timeline file, found {timeline_files:?}"
+        );
+        // And the traversal target above the project root must not exist either.
+        assert!(
+            !temp_dir
+                .path()
+                .join("escape.sceneworks.timeline.json")
+                .exists(),
+            "traversal id must not write outside the project dir"
+        );
+
+        // A normal safe id still saves correctly under timelines/.
+        let saved = store
+            .save_timeline(&project.id, timeline_with("timeline_abc123"))
+            .expect("safe timeline id persists");
+        assert_eq!(saved["id"], json!("timeline_abc123"));
+        let written: Vec<_> = std::fs::read_dir(&timelines_dir)
+            .expect("timelines dir exists after save")
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_str()
+                    .is_some_and(|name| name.ends_with(".sceneworks.timeline.json"))
+            })
+            .collect();
+        assert_eq!(
+            written.len(),
+            1,
+            "exactly one timeline file should be written for the safe id, found {written:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`ProjectStore::save_timeline` never ran `is_safe_id` on the client-supplied `id` (F-069 / sc-8871). `timeline_file_path` embeds the id's last 8 chars into the write path, and `relative_string`'s lexical `strip_prefix` lets an unnormalized `..`-bearing id pass through — so a crafted id (e.g. one ending in path separators or `..`) could produce a constrained write anywhere inside the project dir (filename always ends `.sceneworks.timeline.json`), escape the project dir entirely, and leave an index row whose `file_path` contains `..`. Asset, character, track, and dataset ids are all charset-checked; timelines were the only gap.

## Fix

- **`is_safe_id` guard in `save_timeline`** — immediately after reading `id` and **before** `timeline_file_path` / `relative_string` derive any path, reject an id failing `is_safe_id` with `ProjectStoreError::BadRequest("Invalid timeline id")`, matching the exact convention the sibling id-validated entities use (`crates/sceneworks-core/src/project_store.rs`).

## Other timeline entry points checked

- `save_existing_timeline` routes through `save_timeline`, so it inherits the guard.
- The create-timeline helper also funnels through `save_timeline`.
- `timeline_file_path` has exactly one caller (`save_timeline`, line 815) — no other write site derives a path from a raw id.
- The **read** path (`find_timeline_file`) already canonicalizes the resolved path and asserts it `starts_with` the project root, and scans the timelines dir matching by id rather than deriving a filename, so it was never the gap.

## Tests

Added `save_timeline_rejects_unsafe_id_before_deriving_path`, mirroring the existing `persist_generated_asset_rejects_unsafe_media_path` convention:
- Traversal (`../../../../tmp/escape`, `timeline/../../escape`), separator (`a/b/c`), dotted (`id.with.dots`), and blank ids are each rejected with `BadRequest`.
- Asserts **no** timeline file is written for any rejected id and that the traversal target above the project root does not exist.
- A normal safe id (`timeline_abc123`) still saves correctly, producing exactly one `.sceneworks.timeline.json` under `timelines/`.

`cargo fmt --check`, `cargo clippy -p sceneworks-core --all-targets`, and `cargo test -p sceneworks-core` (plus repo `npm run rust:check`) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)