### PR TITLE
fix(worker): pose/upscale path + download hardening (epic 8800 batch 1)

### DIFF
--- a/crates/sceneworks-worker/src/canny.rs
+++ b/crates/sceneworks-worker/src/canny.rs
@@ -31,7 +31,11 @@ pub const DEFAULT_HIGH_THRESHOLD: f32 = 100.0;
 /// `cv2.cvtColor(..., COLOR_RGB2GRAY)` produces upstream so edge magnitudes land
 /// where the canny head was trained.
 fn to_gray(img: &RgbImage) -> GrayImage {
-    image::DynamicImage::ImageRgb8(img.clone()).to_luma8()
+    // `imageops::grayscale` reads the borrowed RGB buffer directly; the old
+    // `DynamicImage::ImageRgb8(img.clone())` path cloned the whole image (~tens of MB at
+    // typical control-image sizes) just to reach `to_luma8` (sc-8927). Both use the same
+    // Rec. 601 luma weighting, so the output is identical.
+    image::imageops::grayscale(img)
 }
 
 /// Broadcast a single-channel edge map (white edges on black) to an RGB control

--- a/crates/sceneworks-worker/src/downloads.rs
+++ b/crates/sceneworks-worker/src/downloads.rs
@@ -20,6 +20,25 @@ pub(crate) async fn ensure_cached_file(
     label: &str,
     expected_size: Option<u64>,
 ) -> WorkerResult<PathBuf> {
+    ensure_cached_file_verified(context, url, target, label, expected_size, None).await
+}
+
+/// [`ensure_cached_file`] that additionally verifies the completed file against an
+/// `expected_sha256` (a content digest — e.g. an HF `lfs.oid`) before returning
+/// (sc-8879). A malformed/absent digest is skipped by `verify_file_sha256`, so callers
+/// can pass whatever the source advertises; a mismatch removes the file and errors.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+pub(crate) async fn ensure_cached_file_verified(
+    context: &DownloadContext<'_>,
+    url: &str,
+    target: &Path,
+    label: &str,
+    expected_size: Option<u64>,
+    expected_sha256: Option<&str>,
+) -> WorkerResult<PathBuf> {
     let expected_size = match expected_size {
         Some(size) => Some(size),
         None => remote_content_length(context.client, url).await?,
@@ -29,10 +48,18 @@ pub(crate) async fn ensure_cached_file(
             .map(|expected| metadata.len() == expected)
             .unwrap_or(true)
         {
+            // A cached file that already matches the expected length still gets its
+            // digest checked so a size-colliding tampered artifact can't be reused.
+            if let Some(expected) = expected_sha256 {
+                verify_file_sha256(target, expected, label).await?;
+            }
             return Ok(target.to_path_buf());
         }
     }
     if expected_size.is_none() && target.exists() {
+        if let Some(expected) = expected_sha256 {
+            verify_file_sha256(target, expected, label).await?;
+        }
         return Ok(target.to_path_buf());
     }
     if let Some(parent) = target.parent() {
@@ -50,7 +77,7 @@ pub(crate) async fn ensure_cached_file(
         url,
         target,
         expected_size,
-        None,
+        expected_sha256,
         label,
         &mut progress,
     )
@@ -108,12 +135,16 @@ pub(crate) async fn ensure_hf_cached_file(
             "Hugging Face file {file} not found in {repo}."
         )));
     };
-    ensure_cached_file(
+    ensure_cached_file_verified(
         context,
         &snapshot_file.download_url,
         target,
         &snapshot_file.path,
         snapshot_file.size,
+        // Verify the content against HF's `lfs.oid` (present for the LFS-tracked
+        // weights) so a pinned-revision download is integrity-checked, not just
+        // length-checked (sc-8879).
+        snapshot_file.sha256.as_deref(),
     )
     .await
 }

--- a/crates/sceneworks-worker/src/media_jobs.rs
+++ b/crates/sceneworks-worker/src/media_jobs.rs
@@ -786,6 +786,68 @@ where
     let work_dir = std::env::temp_dir().join(format!("sw-person-track-{}", job.id));
     tokio::fs::create_dir_all(&work_dir).await?;
 
+    // Run the fallible sampling/assembly/segmentation body, then remove `work_dir` on EVERY
+    // outcome — success, the not-found error, a cancel, or a render/detect failure (sc-8912).
+    // Previously the cleanup lived only on the not-found and success paths, so an intervening
+    // `?` leaked the staged frame PNGs in the system temp dir. The body borrows the outer locals
+    // and consumes the `run_segmenter` FnOnce, so it's an inline `async` block whose result is
+    // captured before cleanup.
+    let outcome = assemble_real_person_track_body(
+        api,
+        settings,
+        job,
+        source_media_path,
+        project_path,
+        track_id,
+        &weights,
+        conf,
+        &timestamps,
+        selected_box,
+        selected_timestamp,
+        duration,
+        segment_enabled,
+        &backend,
+        run_segmenter,
+        &work_dir,
+    )
+    .await;
+    let _ = tokio::fs::remove_dir_all(&work_dir).await;
+    outcome
+}
+
+/// The fallible body of [`assemble_real_person_track_shared`], factored out so the caller can
+/// remove the staged-frame `work_dir` on every exit path (success or error, sc-8912). Returns the
+/// assembled track; the not-found case is still a typed `InvalidPayload` error (cleanup now happens
+/// in the caller, so this no longer removes the dir itself).
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+#[allow(clippy::too_many_arguments)]
+async fn assemble_real_person_track_body<F, Fut>(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    source_media_path: &std::path::Path,
+    project_path: &std::path::Path,
+    track_id: &str,
+    weights: &std::path::Path,
+    conf: f32,
+    timestamps: &[f64],
+    selected_box: crate::person_track::NormalizedBox,
+    selected_timestamp: f64,
+    duration: f64,
+    segment_enabled: bool,
+    backend: &PersonTrackBackend,
+    run_segmenter: F,
+    work_dir: &std::path::Path,
+) -> WorkerResult<RealPersonTrack>
+where
+    F: FnOnce(SegmentClip) -> Fut,
+    Fut: std::future::Future<Output = SegmentOutcome>,
+{
+    use crate::person_track as pt;
+
     // The detector reports its real execution device per frame; `device_default` is the fallback for
     // the zero-frame case. Keep each rendered frame (don't delete in-loop): the segmentation pass
     // re-reads the detected target frames by the same sample index. They share the cadence, so
@@ -813,7 +875,7 @@ where
             Some(ffmpeg_context),
         )
         .await?;
-        let weights_for_frame = weights.clone();
+        let weights_for_frame = weights.to_path_buf();
         let frame_for_task = frame_path.clone();
         let result = tokio::task::spawn_blocking(move || {
             crate::person_jobs::detect_people_blocking(weights_for_frame, frame_for_task, conf)
@@ -843,9 +905,9 @@ where
     }
 
     let observations = pt::observe(per_frame);
-    let assembly = pt::assemble_track(&observations, selected_box, selected_timestamp, &timestamps);
+    let assembly = pt::assemble_track(&observations, selected_box, selected_timestamp, timestamps);
     if assembly.target_track_id.is_none() || assembly.detected_frames == 0 {
-        let _ = tokio::fs::remove_dir_all(&work_dir).await;
+        // `work_dir` is removed by the caller on this (and every) exit path (sc-8912).
         return Err(WorkerError::InvalidPayload(
             "Selected person was not found in the source video. Re-run detection or adjust the selection."
                 .to_owned(),
@@ -869,7 +931,6 @@ where
         run_segmenter,
     )
     .await?;
-    let _ = tokio::fs::remove_dir_all(&work_dir).await;
 
     Ok(RealPersonTrack {
         frames: frames_json,

--- a/crates/sceneworks-worker/src/pose_jobs.rs
+++ b/crates/sceneworks-worker/src/pose_jobs.rs
@@ -29,7 +29,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
-use crate::downloads::{ensure_cached_file, DownloadContext};
+use crate::downloads::{ensure_cached_file, verify_file_sha256, DownloadContext};
 use image::RgbImage;
 #[cfg(not(target_os = "macos"))]
 use ort::execution_providers::CUDAExecutionProvider;
@@ -63,6 +63,14 @@ const DET_FILE: &str = "yolox_m_8xb8-300e_humanart-c2c7a14a.onnx";
 const POSE_FILE: &str = "rtmw-dw-x-l_simcc-cocktail14_270e-384x288_20231122.onnx";
 const DET_URL: &str = "https://download.openmmlab.com/mmpose/v1/projects/rtmposev1/onnx_sdk/yolox_m_8xb8-300e_humanart-c2c7a14a.zip";
 const POSE_URL: &str = "https://download.openmmlab.com/mmpose/v1/projects/rtmw/onnx_sdk/rtmw-dw-x-l_simcc-cocktail14_270e-384x288_20231122.zip";
+/// Pinned SHA-256 of the openmmlab .zip bundles (sc-8879). These runtime weights are
+/// fetched over the network from `download.openmmlab.com` with no digest advertised by
+/// the host, so the download is verified against these constants before extraction. A
+/// mismatch (host-side swap, corrupted transfer, MITM) fails the job with the
+/// integrity-check error instead of silently loading tampered weights. Digests were
+/// computed from the published bundles (94,223,081 B / 213,433,855 B respectively).
+const DET_ZIP_SHA256: &str = "a000224fd8ba283202bc62d4a5fcdfe353adb9f468777dbac1ea2ada2093adde";
+const POSE_ZIP_SHA256: &str = "a87e1af41a0a067776dba7d46e1c21c8f6e9f18e247e0e606718dd1f31e96ffd";
 const DETECTOR_ID: &str = "rtmw-dw-x-l/ort";
 
 /// The hardware execution provider this build registers before the CPU fallback:
@@ -618,6 +626,7 @@ async fn ensure_weights(
         "SCENEWORKS_DWPOSE_DET",
         DET_FILE,
         DET_URL,
+        DET_ZIP_SHA256,
         &cache,
         &download_context,
     )
@@ -626,6 +635,7 @@ async fn ensure_weights(
         "SCENEWORKS_DWPOSE_POSE",
         POSE_FILE,
         POSE_URL,
+        POSE_ZIP_SHA256,
         &cache,
         &download_context,
     )
@@ -637,6 +647,7 @@ async fn ensure_one(
     env_key: &str,
     file: &str,
     url: &str,
+    zip_sha256: &str,
     cache: &Path,
     context: &DownloadContext<'_>,
 ) -> WorkerResult<PathBuf> {
@@ -669,6 +680,11 @@ async fn ensure_one(
         None,
     )
     .await?;
+    // The openmmlab host advertises no digest and `ensure_cached_file` only checks the
+    // transfer length, so verify the fetched bundle against the pinned SHA-256 before
+    // extracting the weights it contains (sc-8879). A mismatch removes the file and
+    // fails the job with the integrity-check error.
+    verify_file_sha256(&zip_path, zip_sha256, &format!("DWPose {file} bundle")).await?;
     // The openmmlab bundle is a .zip containing a single .onnx; extract it.
     let target_clone = target.clone();
     let file_owned = file.to_owned();

--- a/crates/sceneworks-worker/src/pose_jobs.rs
+++ b/crates/sceneworks-worker/src/pose_jobs.rs
@@ -643,6 +643,29 @@ async fn ensure_weights(
     Ok((det, pose))
 }
 
+/// Resolve an explicit env-pinned weight path (sc-8911). Unset → `Ok(None)` (fall through
+/// to cache/download). Set and existing → `Ok(Some(path))`. Set but missing → an
+/// `InvalidPayload` error, so an operator's typo fails loudly rather than silently
+/// loading whatever the download path resolves. Takes the raw value explicitly so it's
+/// unit-testable without mutating the process environment.
+fn resolve_pinned_weight(
+    env_key: &str,
+    value: Option<std::ffi::OsString>,
+    file: &str,
+) -> WorkerResult<Option<PathBuf>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let path = PathBuf::from(&value);
+    if path.exists() {
+        return Ok(Some(path));
+    }
+    Err(WorkerError::InvalidPayload(format!(
+        "{env_key} is set to {} but that path does not exist. Point it at the local {file}, or unset it to download on first use.",
+        path.display()
+    )))
+}
+
 async fn ensure_one(
     env_key: &str,
     file: &str,
@@ -651,11 +674,12 @@ async fn ensure_one(
     cache: &Path,
     context: &DownloadContext<'_>,
 ) -> WorkerResult<PathBuf> {
-    if let Ok(pinned) = std::env::var(env_key) {
-        let path = PathBuf::from(pinned);
-        if path.exists() {
-            return Ok(path);
-        }
+    // An explicitly-set env pin must resolve to an existing file. If it's set but the
+    // path is missing, that's an operator error — surface it instead of silently falling
+    // through to the cache/network (sc-8911), which would mask a typo and load different
+    // weights than the operator intended.
+    if let Some(path) = resolve_pinned_weight(env_key, std::env::var_os(env_key), file)? {
+        return Ok(path);
     }
     let target = cache.join(file);
     if target.exists() {

--- a/crates/sceneworks-worker/src/pose_jobs.rs
+++ b/crates/sceneworks-worker/src/pose_jobs.rs
@@ -777,24 +777,43 @@ fn resolve_source(
             });
         }
     }
-    // project-relative path
+    // project-relative path, confined to the project tree: reject any `..`/root/prefix
+    // component so a crafted `../../<anything>` can't escape `proj` (sc-8875). The raw
+    // cwd-relative fallback is dropped for the same reason — an unresolved relative path
+    // would otherwise reach `decode_image_any` resolved against the worker's cwd.
     if let (Some(raw), Some(proj)) = (raw, project_path) {
-        let candidate = proj.join(raw);
-        if candidate.exists() {
-            return Ok(PoseSource {
-                asset_id,
-                display_name,
-                temp,
-                path: Some(candidate),
-            });
+        if let Some(candidate) = join_project_relative(proj, raw) {
+            if candidate.exists() {
+                return Ok(PoseSource {
+                    asset_id,
+                    display_name,
+                    temp,
+                    path: Some(candidate),
+                });
+            }
         }
     }
     Ok(PoseSource {
         asset_id,
         display_name,
         temp,
-        path: raw.map(PathBuf::from),
+        path: None,
     })
+}
+
+/// Join a project-relative source path under `project_path`, accepting only
+/// `Component::Normal` segments so a payload can never traverse out of the project
+/// tree with `..`, an absolute root, or a drive/UNC prefix (sc-8875). Returns `None`
+/// if any component is non-`Normal` (the caller then treats the source as unresolved).
+fn join_project_relative(project_path: &Path, raw: &str) -> Option<PathBuf> {
+    let mut path = project_path.to_path_buf();
+    for component in Path::new(raw).components() {
+        match component {
+            std::path::Component::Normal(value) => path.push(value),
+            _ => return None,
+        }
+    }
+    Some(path)
 }
 
 fn resolve_asset_path(

--- a/crates/sceneworks-worker/src/pose_jobs.rs
+++ b/crates/sceneworks-worker/src/pose_jobs.rs
@@ -928,6 +928,34 @@ pub(crate) async fn run_pose_detect_job(
         .map(|s| resolve_source(s, &store, settings, project_id, project_path.as_deref()))
         .collect::<WorkerResult<_>>()?;
 
+    // Snapshot the staged File-Upload temp paths up front so cleanup runs on EVERY exit
+    // path — success, cancel, or an intervening error (sc-8912). The old code only cleaned
+    // up after the render finished, so a cancel/detect/render failure leaked the staged
+    // uploads. `resolved` is later moved into the render task, so this list (cheap: just
+    // the temp paths) is what the deferred cleanup keys off, independent of `resolved`.
+    let temp_upload_paths: Vec<PathBuf> = resolved
+        .iter()
+        .filter(|s| s.temp)
+        .filter_map(|s| s.path.clone())
+        .collect();
+
+    // Run the fallible body, then clean up the temp uploads regardless of outcome before
+    // propagating (defer-style). Cleanup is confined to the pose-uploads cache inside
+    // `cleanup_temp_uploads`, so a project asset resolved by id is never touched.
+    let result = run_pose_detect_inner(api, settings, http_client, job, resolved, min_conf).await;
+    cleanup_temp_uploads(settings, &temp_upload_paths).await;
+    result
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_pose_detect_inner(
+    api: &ApiClient,
+    settings: &Settings,
+    http_client: &reqwest::Client,
+    job: &JobSnapshot,
+    resolved: Vec<PoseSource>,
+    min_conf: f64,
+) -> WorkerResult<()> {
     update_job(
         api,
         &job.id,
@@ -994,13 +1022,14 @@ pub(crate) async fn run_pose_detect_job(
     // thread and grows the silent window toward the 90s stale-sweep on large multi-person high-res
     // batches — the same failure class sc-8390 fixed for the inference half. Fold it into a
     // `spawn_blocking` under `run_blocking_with_heartbeat` so it's both off-thread AND heartbeat-
-    // covered (sc-8848). `resolved` is moved in for the render and handed back out so the subsequent
-    // `cleanup_temp_sources` still sees it. The render loop is worker code too, so it shares the
-    // detect stage's `CancelFlag` (sc-9123) and bails between sources AND between per-person
-    // rasters (each is a `max(w,h)²` canvas + PNG encode — the expensive unit) with the typed
-    // `Canceled`; any skeleton PNGs already written sit in the job-scoped cache dir and are inert.
+    // covered (sc-8848). `resolved` is moved into the render task (it owns the source paths + asset
+    // ids for the output records); temp-upload cleanup keys off the snapshot the caller took before
+    // this move (sc-8912), so it doesn't need handing back. The render loop is worker code too, so it
+    // shares the detect stage's `CancelFlag` (sc-9123) and bails between sources AND between
+    // per-person rasters (each is a `max(w,h)²` canvas + PNG encode — the expensive unit) with the
+    // typed `Canceled`; any skeleton PNGs already written sit in the job-scoped cache dir and are inert.
     let render_cancel = cancel.clone();
-    let (out_sources, resolved) = run_blocking_with_heartbeat(
+    let out_sources = run_blocking_with_heartbeat(
         api,
         settings,
         &job.id,
@@ -1090,14 +1119,10 @@ pub(crate) async fn run_pose_detect_job(
                     "poses": poses,
                 }));
             }
-            Ok((out_sources, resolved))
+            Ok(out_sources)
         }),
     )
     .await?;
-
-    // Delete File-Upload temp sources now detection is done (guarded to the
-    // pose-uploads cache so a project asset resolved by id is never removed).
-    cleanup_temp_sources(settings, &resolved).await;
 
     let mut result = JsonObject::new();
     result.insert("sources".to_owned(), Value::Array(out_sources));
@@ -1124,16 +1149,20 @@ pub(crate) async fn run_pose_detect_job(
     Ok(())
 }
 
-async fn cleanup_temp_sources(settings: &Settings, sources: &[PoseSource]) {
+/// Delete the staged File-Upload temp sources, confined to the pose-uploads cache so a
+/// project asset resolved by id is never removed. Takes the pre-computed temp paths (the
+/// caller snapshots them before `resolved` is moved into the render task) so this runs on
+/// every exit path — success OR error (sc-8912). Best-effort; a missing/already-removed
+/// file is a no-op.
+async fn cleanup_temp_uploads(settings: &Settings, temp_paths: &[PathBuf]) {
+    if temp_paths.is_empty() {
+        return;
+    }
     let uploads_root = settings.data_dir.join("cache").join("pose-uploads");
     let Ok(uploads_root) = uploads_root.canonicalize() else {
         return;
     };
-    for src in sources {
-        if !src.temp {
-            continue;
-        }
-        let Some(path) = &src.path else { continue };
+    for path in temp_paths {
         if let Ok(resolved) = path.canonicalize() {
             if resolved.starts_with(&uploads_root) {
                 let _ = tokio::fs::remove_file(&resolved).await;

--- a/crates/sceneworks-worker/src/pose_jobs.rs
+++ b/crates/sceneworks-worker/src/pose_jobs.rs
@@ -711,10 +711,14 @@ async fn ensure_one(
     verify_file_sha256(&zip_path, zip_sha256, &format!("DWPose {file} bundle")).await?;
     // The openmmlab bundle is a .zip containing a single .onnx; extract it.
     let target_clone = target.clone();
+    let zip_for_extract = zip_path.clone();
     let file_owned = file.to_owned();
-    tokio::task::spawn_blocking(move || extract_onnx(&zip_path, &file_owned, &target_clone))
+    tokio::task::spawn_blocking(move || extract_onnx(&zip_for_extract, &file_owned, &target_clone))
         .await
         .map_err(|error| task_join_error("weight extract task", error))??;
+    // Drop the (large — ~90-210 MB) archive now the .onnx is extracted; keeping it just
+    // wastes cache disk (sc-8927). Best-effort: a failure here doesn't fail the job.
+    let _ = tokio::fs::remove_file(&zip_path).await;
     Ok(target)
 }
 

--- a/crates/sceneworks-worker/src/pose_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/pose_jobs/tests.rs
@@ -214,6 +214,63 @@ fn pose_detect_candle_real_weights_finds_person() {
     }
 }
 
+fn pose_test_settings(data_dir: &Path) -> Settings {
+    Settings {
+        api_url: "http://127.0.0.1".to_owned(),
+        access_token: None,
+        data_dir: data_dir.to_path_buf(),
+        config_dir: data_dir.join("config"),
+        worker_id: "test-worker".to_owned(),
+        gpu_id: "gpu-0".to_owned(),
+        is_child_worker: false,
+        poll_seconds: 1,
+        heartbeat_seconds: 1,
+        shutdown_timeout_seconds: 1,
+        huggingface_base_url: crate::DEFAULT_HUGGINGFACE_BASE_URL.to_owned(),
+        huggingface_token: None,
+        credentials: Vec::new(),
+        max_lora_url_bytes: crate::DEFAULT_MAX_LORA_URL_BYTES,
+        max_model_url_bytes: crate::DEFAULT_MAX_MODEL_URL_BYTES,
+        allow_private_lora_urls: false,
+        utility_workers: 1,
+        backend_mlx_enabled: true,
+        backend_candle_enabled: false,
+        gpu_memory_limit_bytes: 0,
+    }
+}
+
+/// sc-8912: temp-upload cleanup deletes staged files under the pose-uploads cache and
+/// leaves everything else alone — so it can be run unconditionally on every exit path
+/// (success OR error) without risking a project asset. The snapshot-of-paths signature is
+/// exactly what the caller runs after the fallible body.
+#[tokio::test]
+async fn cleanup_temp_uploads_removes_only_pose_upload_files() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let settings = pose_test_settings(dir.path());
+
+    let uploads_root = dir.path().join("cache").join("pose-uploads");
+    std::fs::create_dir_all(&uploads_root).expect("mk uploads root");
+    let staged = uploads_root.join("upload-abc.png");
+    std::fs::write(&staged, b"staged").expect("write staged");
+
+    // A file OUTSIDE the uploads cache (e.g. a project asset) must never be removed.
+    let outside = dir.path().join("projects").join("p1");
+    std::fs::create_dir_all(&outside).expect("mk outside");
+    let asset = outside.join("asset.png");
+    std::fs::write(&asset, b"asset").expect("write asset");
+
+    cleanup_temp_uploads(&settings, &[staged.clone(), asset.clone()]).await;
+
+    assert!(!staged.exists(), "a staged pose-upload must be removed");
+    assert!(
+        asset.exists(),
+        "a file outside the pose-uploads cache must be left alone"
+    );
+
+    // Re-running on an already-removed file is a harmless no-op (error-path safety).
+    cleanup_temp_uploads(&settings, &[staged]).await;
+}
+
 /// sc-8879: the openmmlab DWPose bundle digests must be real, distinct 64-hex SHA-256
 /// values (not a placeholder) so the download integrity check actually enforces a pin.
 #[test]

--- a/crates/sceneworks-worker/src/pose_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/pose_jobs/tests.rs
@@ -214,6 +214,25 @@ fn pose_detect_candle_real_weights_finds_person() {
     }
 }
 
+/// sc-8879: the openmmlab DWPose bundle digests must be real, distinct 64-hex SHA-256
+/// values (not a placeholder) so the download integrity check actually enforces a pin.
+#[test]
+fn dwpose_zip_digests_are_pinned_sha256() {
+    for (label, digest) in [("det", DET_ZIP_SHA256), ("pose", POSE_ZIP_SHA256)] {
+        assert_eq!(digest.len(), 64, "{label} digest must be 64-hex sha256");
+        assert!(
+            digest
+                .chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+            "{label} digest must be lowercase hex, got {digest}"
+        );
+    }
+    assert_ne!(
+        DET_ZIP_SHA256, POSE_ZIP_SHA256,
+        "det and pose bundles are different files with different digests"
+    );
+}
+
 /// sc-8875: a project-relative source path is confined to the project tree — any `..`
 /// (or absolute/prefix) component must reject the join so a crafted `../../secret.png`
 /// can't escape `project_path`. Plain `Normal` segments still resolve under the project.

--- a/crates/sceneworks-worker/src/pose_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/pose_jobs/tests.rs
@@ -233,6 +233,48 @@ fn dwpose_zip_digests_are_pinned_sha256() {
     );
 }
 
+/// sc-8911: an env-pinned weight path that is set-but-missing must error, not silently
+/// fall through to the cache/download. Unset → `None`; set + existing → `Some(path)`.
+#[test]
+fn resolve_pinned_weight_errors_on_missing_env_path() {
+    use std::ffi::OsString;
+
+    // Unset: fall through.
+    assert_eq!(
+        resolve_pinned_weight("SCENEWORKS_DWPOSE_DET", None, DET_FILE).expect("unset ok"),
+        None,
+        "an unset pin must fall through"
+    );
+
+    // Set but nonexistent: error (not a silent fall-through).
+    let missing = resolve_pinned_weight(
+        "SCENEWORKS_DWPOSE_DET",
+        Some(OsString::from("/nonexistent/dwpose/yolox.onnx")),
+        DET_FILE,
+    );
+    assert!(
+        matches!(missing, Err(WorkerError::InvalidPayload(ref m)) if m.contains("SCENEWORKS_DWPOSE_DET") && m.contains("does not exist")),
+        "a set-but-missing pin must error, got {missing:?}"
+    );
+
+    // Set and existing: resolve to that path. Write a real temp file to point at.
+    let existing_path =
+        std::env::temp_dir().join(format!("sw-dwpose-pin-test-{}.onnx", std::process::id()));
+    std::fs::write(&existing_path, b"onnx").expect("write temp weight");
+    let resolved = resolve_pinned_weight(
+        "SCENEWORKS_DWPOSE_DET",
+        Some(existing_path.as_os_str().to_owned()),
+        DET_FILE,
+    )
+    .expect("existing pin ok");
+    assert_eq!(
+        resolved.as_deref(),
+        Some(existing_path.as_path()),
+        "existing pin resolves"
+    );
+    let _ = std::fs::remove_file(&existing_path);
+}
+
 /// sc-8875: a project-relative source path is confined to the project tree — any `..`
 /// (or absolute/prefix) component must reject the join so a crafted `../../secret.png`
 /// can't escape `project_path`. Plain `Normal` segments still resolve under the project.

--- a/crates/sceneworks-worker/src/pose_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/pose_jobs/tests.rs
@@ -214,6 +214,40 @@ fn pose_detect_candle_real_weights_finds_person() {
     }
 }
 
+/// sc-8875: a project-relative source path is confined to the project tree — any `..`
+/// (or absolute/prefix) component must reject the join so a crafted `../../secret.png`
+/// can't escape `project_path`. Plain `Normal` segments still resolve under the project.
+#[test]
+fn join_project_relative_rejects_parent_escape() {
+    let proj = Path::new("/data/projects/p1");
+
+    // A benign relative path resolves under the project root.
+    assert_eq!(
+        join_project_relative(proj, "assets/img.png"),
+        Some(PathBuf::from("/data/projects/p1/assets/img.png")),
+        "a plain relative path must resolve under the project"
+    );
+
+    // `..` traversal is rejected outright (no escape, no lexical resolution).
+    assert_eq!(
+        join_project_relative(proj, "../../../../etc/passwd"),
+        None,
+        "a `..` escape must be rejected"
+    );
+    assert_eq!(
+        join_project_relative(proj, "assets/../../secret.png"),
+        None,
+        "an interior `..` must be rejected"
+    );
+
+    // An absolute path (RootDir component) is rejected — it must not override the base.
+    assert_eq!(
+        join_project_relative(proj, "/etc/passwd"),
+        None,
+        "an absolute path must be rejected"
+    );
+}
+
 /// sc-9123: the between-iteration cancel check used by both worker-side pose loops (batch detect +
 /// skeleton render) must surface the TYPED `Canceled` carrying the shared terminal message — that
 /// is what `run_blocking_with_heartbeat` maps to the terminal `Canceled` post instead of a failure

--- a/crates/sceneworks-worker/src/upscale_jobs.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs.rs
@@ -443,6 +443,13 @@ fn manifest_onnx_resource(manifest_entry: &Value, factor: u8) -> Option<(String,
 /// registry loads it directly (converts to MLX layout in-memory, no Python). Public; downloaded on
 /// first use. Overridable via the manifest `seedvr2` resource or `SCENEWORKS_SEEDVR2_CHECKPOINT`.
 const SEEDVR2_REPO: &str = "numz/SeedVR2_comfyUI";
+/// Pinned SeedVR2 checkpoint revision (sc-8879). `numz/SeedVR2_comfyUI` is a third-party
+/// mirror; fetching the mutable `main` branch means an upstream re-push would silently
+/// change the weights we load. Pin the exact commit that carries the 3B fp16 DiT + VAE
+/// (`seedvr2_ema_3b_fp16.safetensors` / `ema_vae_fp16.safetensors`) so downloads are
+/// reproducible. HF's tree API still reports each file's `lfs.oid`, which
+/// `ensure_hf_cached_file` verifies the content against.
+const SEEDVR2_REVISION: &str = "09ced71023636e9bc8cdf9cdecfb2625d1e691e8";
 /// The exact filenames `Seedvr2Pipeline::load` expects in the checkpoint dir (3B fp16 DiT + VAE).
 const SEEDVR2_DIT_FILE: &str = "seedvr2_ema_3b_fp16.safetensors";
 const SEEDVR2_VAE_FILE: &str = "ema_vae_fp16.safetensors";
@@ -525,7 +532,15 @@ async fn ensure_seedvr2_checkpoint(
         if target.exists() {
             continue;
         }
-        ensure_hf_cached_file(&context, &repo, "main", src_file, &target)
+        // Pin the exact commit for the default third-party mirror so `main` moving under
+        // us can't swap the weights (sc-8879). A manifest-supplied override repo may carry
+        // its own revision layout, so only pin when we're using the default repo.
+        let revision = if repo == SEEDVR2_REPO {
+            SEEDVR2_REVISION
+        } else {
+            "main"
+        };
+        ensure_hf_cached_file(&context, &repo, revision, src_file, &target)
             .await
             .map_err(|error| {
                 let detail = match &error {

--- a/crates/sceneworks-worker/src/upscale_jobs.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs.rs
@@ -967,14 +967,15 @@ pub(crate) async fn run_image_upscale_job(
         )
         .await?;
         let cancel = CancelFlag::new();
-        let seed_source = source_image.clone();
+        // Move `source_image` into the future — the `else` branch already consumes it and it's
+        // unused after this `if`, so the clone (a full RGB buffer copy) was needless (sc-8927).
         run_upscale_with_heartbeat(
             api,
             settings,
             &job.id,
             cancel.clone(),
             tokio::spawn(async move {
-                run_seedvr2_upscale(dir, seed_source, factor, softness, seed, cancel).await
+                run_seedvr2_upscale(dir, source_image, factor, softness, seed, cancel).await
             }),
         )
         .await?

--- a/crates/sceneworks-worker/src/upscale_jobs.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs.rs
@@ -361,6 +361,46 @@ fn upscale_blocking(
 // ONNX weight provisioning (download-on-first-use, mirrors Python resolution order)
 // ---------------------------------------------------------------------------
 
+/// Resolve an explicit env-pinned weight *file* (sc-8911). Unset → `Ok(None)` (fall
+/// through to cache/download). Set + existing → `Ok(Some(path))`. Set but missing → an
+/// `InvalidPayload` error so a typo fails loudly instead of silently loading whatever the
+/// download resolves. `what` names the expected file in the error. Takes the raw value
+/// explicitly so it's unit-testable without mutating the process environment.
+fn resolve_env_file_pin(
+    key: &str,
+    value: Option<std::ffi::OsString>,
+    what: &str,
+) -> WorkerResult<Option<PathBuf>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let path = PathBuf::from(&value);
+    if path.exists() {
+        return Ok(Some(path));
+    }
+    Err(WorkerError::InvalidPayload(format!(
+        "{key} is set to {} but that path does not exist. Point it at {what}, or unset it to download on first use.",
+        path.display()
+    )))
+}
+
+/// Resolve the `SCENEWORKS_SEEDVR2_CHECKPOINT` dir pin (sc-8911). Unset → `Ok(None)`. Set
+/// and holding both checkpoint files → `Ok(Some(dir))`. Set but incomplete → an
+/// `InvalidPayload` error. Testable without env mutation via the explicit raw value.
+fn resolve_seedvr2_dir_pin(value: Option<std::ffi::OsString>) -> WorkerResult<Option<PathBuf>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let dir = PathBuf::from(&value);
+    if dir.join(SEEDVR2_DIT_FILE).exists() && dir.join(SEEDVR2_VAE_FILE).exists() {
+        return Ok(Some(dir));
+    }
+    Err(WorkerError::InvalidPayload(format!(
+        "SCENEWORKS_SEEDVR2_CHECKPOINT is set to {} but that directory is missing {SEEDVR2_DIT_FILE} and/or {SEEDVR2_VAE_FILE}. Point it at a complete checkpoint dir, or unset it to download on first use.",
+        dir.display()
+    )))
+}
+
 /// Resolve the ONNX for `factor`. Order: explicit env pin
 /// (`SCENEWORKS_REALESRGAN_X{factor}_ONNX`, then `SCENEWORKS_REALESRGAN_ONNX`), then the
 /// app cache `<data_dir>/cache/upscale/`, then a manifest `onnx` resource if the job
@@ -377,11 +417,15 @@ async fn ensure_onnx(
         format!("SCENEWORKS_REALESRGAN_X{factor}_ONNX"),
         "SCENEWORKS_REALESRGAN_ONNX".to_owned(),
     ] {
-        if let Ok(pinned) = std::env::var(&key) {
-            let path = PathBuf::from(pinned);
-            if path.exists() {
-                return Ok(path);
-            }
+        // A set-but-missing env pin is an operator error: fail loudly instead of silently
+        // falling through to the cache/HF download and loading different weights than the
+        // operator asked for (sc-8911).
+        if let Some(path) = resolve_env_file_pin(
+            &key,
+            std::env::var_os(&key),
+            &format!("the local Real-ESRGAN x{factor} ONNX export"),
+        )? {
+            return Ok(path);
         }
     }
 
@@ -494,11 +538,11 @@ async fn ensure_seedvr2_checkpoint(
     job: &JobSnapshot,
     manifest_entry: &Value,
 ) -> WorkerResult<PathBuf> {
-    if let Ok(pinned) = std::env::var("SCENEWORKS_SEEDVR2_CHECKPOINT") {
-        let dir = PathBuf::from(pinned);
-        if dir.join(SEEDVR2_DIT_FILE).exists() && dir.join(SEEDVR2_VAE_FILE).exists() {
-            return Ok(dir);
-        }
+    // A set env pin must resolve to a dir holding both checkpoint files; if it's set but
+    // incomplete, that's an operator error — fail loudly instead of silently downloading
+    // (sc-8911).
+    if let Some(dir) = resolve_seedvr2_dir_pin(std::env::var_os("SCENEWORKS_SEEDVR2_CHECKPOINT"))? {
+        return Ok(dir);
     }
 
     let dir = settings

--- a/crates/sceneworks-worker/src/upscale_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs/tests.rs
@@ -560,6 +560,25 @@ fn dataset_upscale_output_path_rejects_traversal_ids() {
     );
 }
 
+/// sc-8879: the default third-party SeedVR2 mirror is fetched at a pinned commit, never
+/// the mutable `main` branch, so an upstream re-push can't silently swap the weights we
+/// load. Lock the constant to a real 40-hex commit id.
+#[test]
+fn seedvr2_revision_is_pinned_commit_not_main() {
+    assert_ne!(SEEDVR2_REVISION, "main", "SeedVR2 must pin a fixed revision");
+    assert_eq!(
+        SEEDVR2_REVISION.len(),
+        40,
+        "a pinned HF revision is a 40-char commit sha"
+    );
+    assert!(
+        SEEDVR2_REVISION
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+        "the pinned revision must be lowercase hex"
+    );
+}
+
 #[test]
 fn dataset_repoint_body_maps_records_with_a_null_asset_id() {
     let body = dataset_repoint_body(&[

--- a/crates/sceneworks-worker/src/upscale_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs/tests.rs
@@ -560,12 +560,82 @@ fn dataset_upscale_output_path_rejects_traversal_ids() {
     );
 }
 
+/// sc-8911: a set-but-missing Real-ESRGAN ONNX env pin must error, not silently fall
+/// through to the cache/HF download. Unset → `None`; set + existing → `Some(path)`.
+#[test]
+fn resolve_env_file_pin_errors_on_missing_path() {
+    use std::ffi::OsString;
+
+    assert_eq!(
+        resolve_env_file_pin("SCENEWORKS_REALESRGAN_ONNX", None, "the export").expect("unset ok"),
+        None,
+        "an unset pin must fall through"
+    );
+
+    let missing = resolve_env_file_pin(
+        "SCENEWORKS_REALESRGAN_X4_ONNX",
+        Some(OsString::from("/nonexistent/realesrgan_x4.onnx")),
+        "the local Real-ESRGAN x4 ONNX export",
+    );
+    assert!(
+        matches!(missing, Err(WorkerError::InvalidPayload(ref m)) if m.contains("SCENEWORKS_REALESRGAN_X4_ONNX") && m.contains("does not exist")),
+        "a set-but-missing pin must error, got {missing:?}"
+    );
+
+    let existing = std::env::temp_dir().join(format!(
+        "sw-realesrgan-pin-test-{}.onnx",
+        std::process::id()
+    ));
+    std::fs::write(&existing, b"onnx").expect("write temp onnx");
+    let resolved = resolve_env_file_pin(
+        "SCENEWORKS_REALESRGAN_ONNX",
+        Some(existing.as_os_str().to_owned()),
+        "the export",
+    )
+    .expect("existing pin ok");
+    assert_eq!(resolved.as_deref(), Some(existing.as_path()));
+    let _ = std::fs::remove_file(&existing);
+}
+
+/// sc-8911: a set `SCENEWORKS_SEEDVR2_CHECKPOINT` that is missing either checkpoint file
+/// must error; a complete dir resolves; unset falls through.
+#[test]
+fn resolve_seedvr2_dir_pin_errors_on_incomplete_dir() {
+    use std::ffi::OsString;
+
+    assert_eq!(
+        resolve_seedvr2_dir_pin(None).expect("unset ok"),
+        None,
+        "an unset pin must fall through"
+    );
+
+    // A temp dir missing both files → error.
+    let empty = std::env::temp_dir().join(format!("sw-seedvr2-pin-test-{}", std::process::id()));
+    std::fs::create_dir_all(&empty).expect("mkdir temp");
+    let incomplete = resolve_seedvr2_dir_pin(Some(OsString::from(empty.as_os_str())));
+    assert!(
+        matches!(incomplete, Err(WorkerError::InvalidPayload(ref m)) if m.contains("SCENEWORKS_SEEDVR2_CHECKPOINT") && m.contains("missing")),
+        "an incomplete checkpoint dir must error, got {incomplete:?}"
+    );
+
+    // Populate both canonical files → resolves.
+    std::fs::write(empty.join(SEEDVR2_DIT_FILE), b"dit").expect("write dit");
+    std::fs::write(empty.join(SEEDVR2_VAE_FILE), b"vae").expect("write vae");
+    let resolved =
+        resolve_seedvr2_dir_pin(Some(OsString::from(empty.as_os_str()))).expect("complete dir ok");
+    assert_eq!(resolved.as_deref(), Some(empty.as_path()));
+    let _ = std::fs::remove_dir_all(&empty);
+}
+
 /// sc-8879: the default third-party SeedVR2 mirror is fetched at a pinned commit, never
 /// the mutable `main` branch, so an upstream re-push can't silently swap the weights we
 /// load. Lock the constant to a real 40-hex commit id.
 #[test]
 fn seedvr2_revision_is_pinned_commit_not_main() {
-    assert_ne!(SEEDVR2_REVISION, "main", "SeedVR2 must pin a fixed revision");
+    assert_ne!(
+        SEEDVR2_REVISION, "main",
+        "SeedVR2 must pin a fixed revision"
+    );
     assert_eq!(
         SEEDVR2_REVISION.len(),
         40,


### PR DESCRIPTION
Code-review remediation batch (epic 8800, batch 1). Five worker findings across the DWPose pose-detect, Real-ESRGAN/SeedVR2 upscale, and person-track paths. One commit per story.

## Stories

- **sc-8875 [F-073] Confine relative pose source paths like absolute ones** — the project-relative source branch did a bare `proj.join(raw)` (so `../../<x>.png` escaped the project tree) and the final fallback handed a raw cwd-relative path to `decode_image_any`. Added `join_project_relative`, which accepts only `Component::Normal` segments (rejecting `..`, absolute roots, drive/UNC prefixes), and dropped the raw fallback.

- **sc-8879 [F-077] Verify/pin third-party runtime-weight downloads (DWPose, SeedVR2)** — DWPose ONNX zips were fetched from download.openmmlab.com with no digest + length-only check; SeedVR2 was pulled from the third-party `numz/SeedVR2_comfyUI` mirror at mutable `main`. Pinned the SHA-256 of each openmmlab .zip (computed from the published bundles) and verify via `verify_file_sha256` before extraction; pinned SeedVR2 to the exact commit `09ced71023636e9bc8cdf9cdecfb2625d1e691e8`; threaded the HF `lfs.oid` digest through `ensure_hf_cached_file` (new `ensure_cached_file_verified`) so pinned downloads are content-checked, not just length-checked.

- **sc-8911 [F-109] Error on a set-but-missing env-pinned weight path** — `SCENEWORKS_DWPOSE_DET/_POSE`, `SCENEWORKS_REALESRGAN_*_ONNX`, and `SCENEWORKS_SEEDVR2_CHECKPOINT` silently fell through to cache/download when set but missing, masking operator typos. Extracted testable pure resolvers that return `Ok(None)` unset / `Ok(Some)` present / an actionable `InvalidPayload` error when set-but-missing.

- **sc-8912 [F-110] Run temp/work-dir cleanup on error paths too** — pose `cleanup_temp_sources` ran only after render success, and the person-track `work_dir` was removed only on not-found/success; intervening `?` (cancel, render/detect failure, segmentation error) leaked staged uploads / frame PNGs. Pose now snapshots temp-upload paths up front and runs cleanup on every outcome via `run_pose_detect_inner` + `cleanup_temp_uploads`; person-track factors the fallible body into `assemble_real_person_track_body` and removes `work_dir` in the caller on every exit path.

- **sc-8927 [F-125] Delete DWPose zip after extraction; avoid needless full-image clones** — `ensure_one` never removed the ~90-210 MB openmmlab .zip after extracting the .onnx (now deleted best-effort); canny `to_gray` cloned the whole image via `DynamicImage::ImageRgb8(img.clone()).to_luma8()` (now `image::imageops::grayscale(img)`, identical Rec. 601 output); the standalone SeedVR2 upscale branch cloned the full `source_image` before a spawn although it's unused after (now moved into the future).

## Tests added
- `join_project_relative_rejects_parent_escape` — `..`/absolute/interior-`..` rejected, plain relative resolves.
- `dwpose_zip_digests_are_pinned_sha256` / `seedvr2_revision_is_pinned_commit_not_main` — pins are real 64-hex digests / a 40-hex commit, not `main`/placeholders.
- `resolve_pinned_weight_errors_on_missing_env_path`, `resolve_env_file_pin_errors_on_missing_path`, `resolve_seedvr2_dir_pin_errors_on_incomplete_dir` — unset / set-missing / set-present for each env pin.
- `cleanup_temp_uploads_removes_only_pose_upload_files` — deletes only pose-upload files, leaves outside assets, safe no-op on already-removed.
- Existing canny tests confirm the grayscale swap leaves edge output unchanged.

## Verification
- `cargo test -p sceneworks-worker --lib`: 578 passed, 0 failed.
- `npm run rust:check` (fmt --all --check + clippy -D warnings): clean.
- `cargo check -p sceneworks-worker --no-default-features -F backend-candle --all-targets` (macOS host): clean. The signature of the shared `assemble_real_person_track_shared` and `ensure_cached_file` is unchanged, and the new `assemble_real_person_track_body` carries the same cfg guard as its caller, so the off-Mac candle entry points are unaffected. Note: the Linux/CUDA candle lane can't be linked on this macOS host (no CUDA toolchain), so the true parity build should be confirmed by CI.
- DWPose digests + SeedVR2 revision were sourced by actually downloading the published bundles / querying the HF revision API in this session (not guessed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)