### PR TITLE
fix(rust-api): auth/events hardening (epic 8800 batch 11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,26 @@ Compose to the LAN; control access with `SCENEWORKS_ACCESS_TOKEN` and extend
 `SCENEWORKS_CORS_ORIGINS` with LAN hostnames or IP origins when the web app is opened
 from another machine.
 
+### Loopback trust and the multi-user-machine caveat
+
+When LAN remote access is on, the desktop launcher binds `0.0.0.0` and uses the
+pairing password as the API's access token, but the embedded desktop UI and the
+local GPU worker(s) reach the API over loopback (`127.0.0.1`/`::1`) with no password
+to send. To keep local use password-free while still gating LAN callers, the desktop
+sets `SCENEWORKS_TRUST_LOOPBACK`, which **trusts any loopback peer to bypass the
+access token** (epic 4484). Docker/server deployments never set it, so a
+reverse-proxied install — where every request appears to come from loopback — stays
+fail-closed.
+
+**Caveat (deliberate tradeoff):** loopback trust is per-connection, not per-OS-user.
+On a **shared/multi-user machine**, *any* local OS user or local process — not just
+the account running SceneWorks — can reach the API over `127.0.0.1` and inherit the
+same token-free access (project file reads, credential writes, job creation, model
+uploads). This is intentional for the single-user desktop it targets. If you run
+SceneWorks in remote-access mode on a machine other users can log into, either do not
+set `SCENEWORKS_TRUST_LOOPBACK` (so even loopback callers must present the token), or
+treat every local user on that host as fully trusted.
+
 For offline development or deterministic Rust API tests, set `SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE=1` to skip live Hugging Face model size lookups. The catalog still returns the same fields with unknown sizes.
 
 ## Service Credentials (API tokens)

--- a/apps/rust-api/src/auth.rs
+++ b/apps/rust-api/src/auth.rs
@@ -1,6 +1,96 @@
 use super::*;
 use axum::extract::ConnectInfo;
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
+
+// sc-8870 (F-068): failed-attempt throttle for the token oracle. `POST
+// /api/v1/auth/verify` is public and returns `{ok}` for any candidate token, and
+// every other gated route reveals validity via 401-vs-200; in LAN mode the token IS
+// the user's password, so with no lockout an attacker on the LAN can brute-force it
+// at wire speed. This is a small, self-contained per-peer-IP rolling-window counter:
+// once an IP exceeds `AUTH_THROTTLE_MAX_FAILURES` failures inside
+// `AUTH_THROTTLE_WINDOW`, further token attempts from that IP are refused with 429
+// until the window rolls off (each new failure re-arms the window, so sustained
+// guessing stays locked out). It is advisory/anti-automation, not a crypto control:
+// a success clears the peer's record immediately, and loopback-trusted peers never
+// reach it (the bypass returns first), so legitimate desktop/worker traffic is
+// untouched.
+const AUTH_THROTTLE_MAX_FAILURES: u32 = 10;
+const AUTH_THROTTLE_WINDOW: Duration = Duration::from_secs(60);
+
+#[derive(Debug, Default)]
+pub(crate) struct AuthThrottle {
+    state: Mutex<HashMap<IpAddr, AttemptRecord>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct AttemptRecord {
+    failures: u32,
+    // Start of the current rolling window; failures older than the window are reset.
+    window_start: Instant,
+}
+
+impl AuthThrottle {
+    /// Whether this peer is currently locked out (over the failure cap inside the
+    /// live window). Non-mutating: pure read of the current record. An unknown peer
+    /// (`None`) or a peer with a stale window is never blocked.
+    pub(crate) fn is_blocked(&self, peer: Option<IpAddr>) -> bool {
+        let Some(ip) = peer else {
+            return false;
+        };
+        let now = Instant::now();
+        let mut state = self.state.lock();
+        prune_attempts(&mut state, now);
+        state
+            .get(&ip)
+            .is_some_and(|record| record.failures >= AUTH_THROTTLE_MAX_FAILURES)
+    }
+
+    /// Record one failed token attempt for this peer, re-arming its window, and
+    /// return the running failure count so the caller can `warn!` on repeats. A
+    /// missing peer IP (unit-test oneshot path) is a no-op.
+    pub(crate) fn record_failure(&self, peer: Option<IpAddr>) -> u32 {
+        let Some(ip) = peer else {
+            return 0;
+        };
+        let now = Instant::now();
+        let mut state = self.state.lock();
+        prune_attempts(&mut state, now);
+        let record = state.entry(ip).or_insert(AttemptRecord {
+            failures: 0,
+            window_start: now,
+        });
+        record.failures = record.failures.saturating_add(1);
+        record.window_start = now;
+        record.failures
+    }
+
+    /// Clear a peer's failure record after a valid token, so a legitimate user who
+    /// mistyped a few times is not punished once they authenticate.
+    pub(crate) fn record_success(&self, peer: Option<IpAddr>) {
+        let Some(ip) = peer else {
+            return;
+        };
+        self.state.lock().remove(&ip);
+    }
+}
+
+/// Drop records whose window has fully rolled off so the map can't grow unbounded
+/// from one-off probes across many source IPs.
+fn prune_attempts(state: &mut HashMap<IpAddr, AttemptRecord>, now: Instant) {
+    state.retain(|_, record| now.duration_since(record.window_start) < AUTH_THROTTLE_WINDOW);
+}
+
+/// 429 response returned when a peer IP has exceeded the failed-token budget.
+fn throttled_response() -> Response {
+    (
+        StatusCode::TOO_MANY_REQUESTS,
+        Json(json!({
+            "detail": "Too many authentication attempts; try again later",
+            "authRequired": true
+        })),
+    )
+        .into_response()
+}
 
 pub(crate) async fn access_control(
     State(state): State<AppState>,
@@ -12,6 +102,26 @@ pub(crate) async fn access_control(
     next: Next,
 ) -> Response {
     let peer = connect_info.map(|ConnectInfo(addr)| addr);
+    let peer_ip = peer.map(|addr| addr.ip());
+
+    // sc-8870: a peer that already blew its token-guess budget is refused before any
+    // token comparison — this covers both the gated routes below and the public
+    // `/api/v1/auth/verify` oracle (the throttle check runs on every request, even the
+    // public ones, but only bites once an IP has racked up failures). Loopback-trusted
+    // peers can never accrue failures (the bypass returns first), so this only ever
+    // fires on a remote/LAN brute-forcer.
+    if !loopback_trusted(state.settings.trust_loopback, peer)
+        && state.auth_throttle.is_blocked(peer_ip)
+    {
+        tracing::warn!(
+            event = "auth_throttled",
+            path = %request.uri().path(),
+            status = StatusCode::TOO_MANY_REQUESTS.as_u16(),
+            "refused token attempt from throttled peer"
+        );
+        return throttled_response();
+    }
+
     if request.method() == Method::OPTIONS
         || !requires_token(request.method(), request.uri().path())
         || loopback_trusted(state.settings.trust_loopback, peer)
@@ -21,14 +131,21 @@ pub(crate) async fn access_control(
         return next.run(request).await;
     }
 
+    // A gated route hit with a missing/invalid token is a failed attempt — count it
+    // toward the per-IP throttle so an attacker probing e.g. `GET /api/v1/jobs` for a
+    // valid token is locked out just like one hammering `/auth/verify`.
+    let failures = state.auth_throttle.record_failure(peer_ip);
+
     // Make auth rejections visible to operators (they previously returned 401 with no
     // server-side trace). Log the path + reason + status only — never the token/secret
-    // (and `uri().path()` excludes any query string).
+    // (and `uri().path()` excludes any query string). Repeated failures escalate to a
+    // dedicated warn so a brute-force attempt stands out in the log.
     tracing::warn!(
         event = "auth_rejected",
         path = %request.uri().path(),
         reason = "missing_or_invalid_token",
         status = StatusCode::UNAUTHORIZED.as_u16(),
+        failures,
         "rejected unauthenticated API request"
     );
 

--- a/apps/rust-api/src/auth.rs
+++ b/apps/rust-api/src/auth.rs
@@ -5,15 +5,18 @@ use std::net::{IpAddr, SocketAddr};
 // sc-8870 (F-068): failed-attempt throttle for the token oracle. `POST
 // /api/v1/auth/verify` is public and returns `{ok}` for any candidate token, and
 // every other gated route reveals validity via 401-vs-200; in LAN mode the token IS
-// the user's password, so with no lockout an attacker on the LAN can brute-force it
+// the user's password, so with no throttle an attacker on the LAN can brute-force it
 // at wire speed. This is a small, self-contained per-peer-IP rolling-window counter:
 // once an IP exceeds `AUTH_THROTTLE_MAX_FAILURES` failures inside
-// `AUTH_THROTTLE_WINDOW`, further token attempts from that IP are refused with 429
-// until the window rolls off (each new failure re-arms the window, so sustained
-// guessing stays locked out). It is advisory/anti-automation, not a crypto control:
-// a success clears the peer's record immediately, and loopback-trusted peers never
-// reach it (the bypass returns first), so legitimate desktop/worker traffic is
-// untouched.
+// `AUTH_THROTTLE_WINDOW`, further token attempts from that IP are refused with 429.
+// It rate-limits guessing to a sustained ceiling of ~`AUTH_THROTTLE_MAX_FAILURES`
+// failed attempts per `AUTH_THROTTLE_WINDOW` per peer IP — it is NOT a permanent
+// lockout. A blocked peer short-circuits at `is_blocked` before `record_failure`, so
+// its window is never re-armed once it trips: ~`AUTH_THROTTLE_WINDOW` after the
+// capping failure the record rolls off (via `prune_attempts`) and the peer may try
+// again. It is advisory/anti-automation, not a crypto control: a success clears the
+// peer's record immediately, and loopback-trusted peers never reach it (the bypass
+// returns first), so legitimate desktop/worker traffic is untouched.
 const AUTH_THROTTLE_MAX_FAILURES: u32 = 10;
 const AUTH_THROTTLE_WINDOW: Duration = Duration::from_secs(60);
 
@@ -122,12 +125,30 @@ pub(crate) async fn access_control(
         return throttled_response();
     }
 
+    // Unconditional bypasses — nothing to meter here: a preflight, a public/non-gated
+    // path, a loopback-trusted peer, or a valid media ticket. Loopback peers are never
+    // throttled, and none of these paths present the header token.
     if request.method() == Method::OPTIONS
         || !requires_token(request.method(), request.uri().path())
         || loopback_trusted(state.settings.trust_loopback, peer)
-        || is_authorized(request.headers(), &state.settings)
         || media_ticket_authorized(&state, &request)
     {
+        return next.run(request).await;
+    }
+
+    // A valid header token on a gated route passes auth — and, like `/auth/verify`,
+    // clears this peer's failure budget (sc-8870, F-068). Without this, a non-web
+    // LAN/API client (epic 4484) hitting gated routes directly with an occasionally
+    // wrong token could creep toward the cap with no path to reset it; only the
+    // `/auth/verify` endpoint cleared the budget before. Take + release the throttle
+    // lock inside `record_success` (no lock held across the `next.run` await), matching
+    // the rest of `AuthThrottle`. Loopback-trusted peers already returned above, so this
+    // only runs for the token-authenticated remote path.
+    if is_authorized(request.headers(), &state.settings) {
+        // Only meter when a token is configured; with auth off there is no budget.
+        if !state.settings.access_token.is_empty() {
+            state.auth_throttle.record_success(peer_ip);
+        }
         return next.run(request).await;
     }
 

--- a/apps/rust-api/src/auth.rs
+++ b/apps/rust-api/src/auth.rs
@@ -219,6 +219,14 @@ pub(crate) fn requires_token(method: &Method, path: &str) -> bool {
 /// so a server deployment fronted by a reverse proxy — where every request would appear
 /// to come from loopback — stays fail-closed. Pure so the decision is unit-tested without
 /// a live listener; mirrors `should_warn_open_bind`.
+///
+/// Multi-user caveat (sc-8948, F-146 — accepted design tradeoff): this trust is
+/// per-connection, not per-OS-user. On a shared machine, ANY local user/process that
+/// can reach `127.0.0.1`/`::1` inherits the token bypass, not just the account running
+/// SceneWorks. Deliberate for the single-user desktop it targets; see the
+/// "Loopback trust and the multi-user-machine caveat" note in the root README's Local
+/// Access Control section. Do not set `SCENEWORKS_TRUST_LOOPBACK` on a host other local
+/// users can log into unless you trust them all.
 pub(crate) fn loopback_trusted(trust_loopback: bool, peer: Option<SocketAddr>) -> bool {
     trust_loopback && peer.is_some_and(|addr| addr.ip().is_loopback())
 }

--- a/apps/rust-api/src/events.rs
+++ b/apps/rust-api/src/events.rs
@@ -42,6 +42,29 @@ pub(crate) async fn create_event_ticket(State(state): State<AppState>) -> Json<T
     Json(state.event_tickets.issue())
 }
 
+// sc-8947 (F-146, Severity: Info — accepted control, recorded): the SSE stream is
+// gated by a `?ticket=` query param instead of the normal `X-SceneWorks-Token`
+// header because the browser `EventSource` API cannot set request headers. Putting
+// the *access token* in a URL would be a real leak (URLs land in history, logs,
+// Referer), so the token is NEVER used here — the client mints a throwaway ticket
+// and passes that instead. The ticket's exposure is bounded by two controls, and
+// this is the deliberate design; do NOT extend the query-string pattern to the
+// long-lived token:
+//   1. single-use — `consume()` removes the ticket on first redemption whether or
+//      not it was valid, so a leaked URL can be replayed at most zero times after
+//      the legitimate `EventSource` connects.
+//   2. short TTL — `EVENT_TICKET_TTL_SECONDS` (30s), so an unredeemed leak dies fast.
+//
+// The suggested optional hardening — pinning the ticket to the issuing peer IP — is
+// deliberately NOT implemented. Ticket issuance (`POST /jobs/events/ticket`, a
+// `fetch`) and redemption (`GET /jobs/events`, the `EventSource`) are two separate
+// connections, and the web client mints a fresh ticket on every (re)connect
+// (App.jsx `connect()`), including each auto-reconnect. On a dual-stack loopback
+// host `localhost` can resolve to `127.0.0.1` for one request and `::1` for the
+// other, so pinning the ticket to the issuer's IP would reject the redemption and
+// break legitimate SSE in exactly the loopback/LAN setup epic 4484 targets (and it
+// adds nothing behind a reverse proxy, where every peer already shares one IP). The
+// single-use + short-TTL pair is the accepted control.
 pub(crate) async fn job_events(
     State(state): State<AppState>,
     Query(query): Query<EventsQuery>,

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -1229,6 +1229,14 @@ async fn get_project_file(
                             format!("bytes {start}-{end}/{total}"),
                         ),
                         (header::CONTENT_LENGTH, len.to_string()),
+                        // sc-9674 (sc-8872 follow-up): forbid MIME sniffing so a
+                        // user-controlled project file can't be reinterpreted by the
+                        // browser as a different (e.g. active) content type than the
+                        // Content-Type we derived. Kept inline (no attachment
+                        // disposition) so <img>/<video> preview and byte-range
+                        // playback still work — the assets are served for inline
+                        // display, not forced download.
+                        (header::X_CONTENT_TYPE_OPTIONS, "nosniff".to_string()),
                     ],
                     Body::from_stream(stream),
                 )
@@ -1250,6 +1258,9 @@ async fn get_project_file(
             (header::CONTENT_TYPE, content_type),
             (header::ACCEPT_RANGES, "bytes".to_string()),
             (header::CONTENT_LENGTH, total.to_string()),
+            // sc-9674: forbid MIME sniffing (see the range branch above). Inline
+            // disposition is kept intentionally so image/video preview still works.
+            (header::X_CONTENT_TYPE_OPTIONS, "nosniff".to_string()),
         ],
         Body::from_stream(stream),
     )

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -67,7 +67,7 @@ use tower_http::cors::{AllowOrigin, CorsLayer};
 use uuid::Uuid;
 
 mod auth;
-use auth::{access_control, cors_layer, is_authorized};
+use auth::{access_control, cors_layer, is_authorized, AuthThrottle};
 mod characters;
 use characters::*;
 mod timelines;
@@ -337,6 +337,8 @@ pub struct AppState {
     events: Arc<EventHub>,
     event_tickets: Arc<TicketStore>,
     media_tickets: Arc<TicketStore>,
+    // sc-8870 (F-068): per-peer-IP failed-token throttle for the auth oracle.
+    auth_throttle: Arc<AuthThrottle>,
     manifest_cache: Arc<Mutex<ManifestCache>>,
     manifest_write_locks: Arc<Mutex<HashMap<PathBuf, Arc<AsyncMutex<()>>>>>,
     model_size_cache: Arc<Mutex<ModelSizeCache>>,
@@ -780,6 +782,7 @@ pub(crate) fn create_app_with_state(
         events: Arc::new(EventHub::default()),
         event_tickets: Arc::new(TicketStore::new(EVENT_TICKET_TTL_SECONDS)),
         media_tickets: Arc::new(TicketStore::new(MEDIA_TICKET_TTL_SECONDS)),
+        auth_throttle: Arc::new(AuthThrottle::default()),
         manifest_cache: Arc::new(Mutex::new(ManifestCache::default())),
         manifest_write_locks: Arc::new(Mutex::new(HashMap::new())),
         model_size_cache: Arc::new(Mutex::new(ModelSizeCache::default())),
@@ -1151,10 +1154,38 @@ async fn access(State(state): State<AppState>) -> Json<AccessResponse> {
     })
 }
 
-async fn verify_access(State(state): State<AppState>, headers: HeaderMap) -> Json<VerifyResponse> {
-    Json(VerifyResponse {
-        ok: is_authorized(&headers, &state.settings),
-    })
+async fn verify_access(
+    State(state): State<AppState>,
+    // `Option<…>` mirrors the auth middleware: unit-test oneshot requests have no
+    // connect info, so the peer is absent and the throttle is a no-op for them.
+    connect_info: Option<axum::extract::ConnectInfo<SocketAddr>>,
+    headers: HeaderMap,
+) -> Json<VerifyResponse> {
+    // sc-8870 (F-068): this endpoint is public and answers `{ok}` for any candidate
+    // token, so it is the cheapest brute-force oracle. The access-control middleware
+    // already refuses a peer that is over its failure budget (its entry check runs on
+    // every request, public ones included), so a throttled caller never reaches here;
+    // this handler only has to feed the counter — a wrong token is a failed attempt,
+    // a valid one clears the peer's record. Loopback-trusted peers still get counted
+    // here on a bad guess, but the desktop UI only ever sends the real token (or none,
+    // when auth is off), so in practice only a remote guesser accrues failures.
+    let peer_ip = connect_info.map(|axum::extract::ConnectInfo(addr)| addr.ip());
+    let ok = is_authorized(&headers, &state.settings);
+    // Only meter when a token is actually configured; with auth off every check is
+    // trivially `ok` and there is nothing to brute-force.
+    if !state.settings.access_token.is_empty() {
+        if ok {
+            state.auth_throttle.record_success(peer_ip);
+        } else {
+            let failures = state.auth_throttle.record_failure(peer_ip);
+            tracing::warn!(
+                event = "auth_verify_failed",
+                failures,
+                "rejected token via /auth/verify oracle"
+            );
+        }
+    }
+    Json(VerifyResponse { ok })
 }
 
 async fn get_project_file(

--- a/apps/rust-api/src/poses.rs
+++ b/apps/rust-api/src/poses.rs
@@ -116,7 +116,16 @@ pub(crate) async fn get_pose_preview(
         .await
         .map_err(|error| ApiError::internal(error.to_string()))?;
     Ok((
-        [(axum::http::header::CONTENT_TYPE, "image/png".to_owned())],
+        [
+            (axum::http::header::CONTENT_TYPE, "image/png".to_owned()),
+            // sc-9674 (sc-8872 follow-up): sibling media-serve endpoint on the API
+            // origin — forbid MIME sniffing, matching get_project_file. Served inline
+            // for <img> preview, so no attachment disposition.
+            (
+                axum::http::header::X_CONTENT_TYPE_OPTIONS,
+                "nosniff".to_owned(),
+            ),
+        ],
         bytes,
     )
         .into_response())

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -9629,6 +9629,66 @@ async fn event_tickets_are_protected_and_match_contract_shape() {
     assert_eq!(error["detail"], "Invalid or expired event stream ticket");
 }
 
+/// Drive a request but read only the status line, dropping the body. Needed for the
+/// SSE stream endpoint whose successful response body never ends (buffering it would
+/// hang the test).
+async fn request_status_only(app: axum::Router, method: &str, uri: &str) -> StatusCode {
+    let request = Request::builder()
+        .method(method)
+        .uri(uri)
+        .body(Body::empty())
+        .expect("request builds");
+    app.oneshot(request)
+        .await
+        .expect("response returns")
+        .status()
+}
+
+#[tokio::test]
+async fn sse_event_ticket_is_single_use_at_the_endpoint() {
+    // sc-8947 (F-146): the SSE ticket rides in the `?ticket=` query string because
+    // EventSource can't set headers. The accepted control that bounds a leaked URL is
+    // that the ticket is single-use (and short-TTL): the first `GET /jobs/events`
+    // redeems it, a replay of the same ticket is rejected. This pins that invariant at
+    // the HTTP layer (not just the ticket store) so nobody loosens the SSE gate.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let mut settings = test_settings(&temp_dir);
+    settings.access_token = "secret-token".to_owned();
+    let app = create_app(settings).expect("app creates");
+
+    let (status, ticket) = request_with_headers(
+        app.clone(),
+        "POST",
+        "/api/v1/jobs/events/ticket",
+        Value::Null,
+        &[("x-sceneworks-token", "secret-token")],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let ticket_value = ticket["ticket"].as_str().expect("ticket value").to_owned();
+
+    // First redemption connects the stream (200 OK, then the SSE body streams — we
+    // only read the status so the never-ending body doesn't hang the test).
+    let status = request_status_only(
+        app.clone(),
+        "GET",
+        &format!("/api/v1/jobs/events?ticket={ticket_value}"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    // Replaying the same ticket is rejected — a leaked URL can't be reused.
+    let (status, error) = request(
+        app,
+        "GET",
+        &format!("/api/v1/jobs/events?ticket={ticket_value}"),
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(error["detail"], "Invalid or expired event stream ticket");
+}
+
 #[tokio::test]
 async fn media_tickets_authenticate_project_file_urls() {
     // sc-8810: element-driven media requests (<img>/<video>/<a download>) cannot

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -9588,6 +9588,53 @@ async fn gated_route_brute_force_is_throttled_per_peer() {
 }
 
 #[tokio::test]
+async fn gated_route_success_clears_peer_throttle_budget() {
+    // sc-8870 (F-068): a valid token on a *gated route* must clear the peer's failure
+    // budget too, not only the `/auth/verify` endpoint. A non-web LAN/API client
+    // (epic 4484) hits gated routes directly with the token header; if it occasionally
+    // sends a wrong token it would creep toward the cap with no reset path unless a
+    // subsequent good request clears it. Accrue several misses, then one successful
+    // gated-route auth from the same peer, then confirm a full fresh window of misses
+    // is tolerated again (would have tripped at 10 total had success not reset it).
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let mut settings = test_settings(&temp_dir);
+    settings.access_token = "secret-token".to_owned();
+    let app = create_app(settings).expect("app creates");
+    let peer = "192.168.1.61:43000";
+    let bad = [("authorization", "Bearer wrong-token")];
+    let good = [("authorization", "Bearer secret-token")];
+
+    // Five misses (under the cap of 10) on a gated route.
+    for _ in 0..5 {
+        let (status, _) =
+            request_with_peer_headers(app.clone(), "GET", "/api/v1/jobs", Value::Null, peer, &bad)
+                .await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+    }
+
+    // A valid token on the same gated route passes auth and resets the budget.
+    let (status, _) =
+        request_with_peer_headers(app.clone(), "GET", "/api/v1/jobs", Value::Null, peer, &good)
+            .await;
+    assert_ne!(status, StatusCode::UNAUTHORIZED);
+    assert_ne!(status, StatusCode::TOO_MANY_REQUESTS);
+
+    // With the budget reset, nine more misses are tolerated without an early lockout —
+    // without the gated-route `record_success` the 5 + 5th earlier miss would already
+    // have pushed this past 10 and returned 429 instead of 401.
+    for _ in 0..9 {
+        let (status, _) =
+            request_with_peer_headers(app.clone(), "GET", "/api/v1/jobs", Value::Null, peer, &bad)
+                .await;
+        assert_eq!(
+            status,
+            StatusCode::UNAUTHORIZED,
+            "post-success budget must be reset on the gated-route path"
+        );
+    }
+}
+
+#[tokio::test]
 async fn event_tickets_are_protected_and_match_contract_shape() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let mut settings = test_settings(&temp_dir);

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -564,6 +564,44 @@ async fn request_with_peer(
     (status, value)
 }
 
+/// Like `request_with_peer` but also attaches request headers (e.g. an
+/// `authorization` token candidate), so the per-IP auth throttle (sc-8870) can be
+/// exercised against the token oracle with a simulated remote peer.
+async fn request_with_peer_headers(
+    app: axum::Router,
+    method: &str,
+    uri: &str,
+    body: Value,
+    peer: &str,
+    headers: &[(&str, &str)],
+) -> (StatusCode, Value) {
+    use axum::extract::ConnectInfo;
+    use std::net::SocketAddr;
+    let mut builder = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json");
+    for (name, value) in headers {
+        builder = builder.header(*name, *value);
+    }
+    let mut request = builder
+        .body(Body::from(body.to_string()))
+        .expect("request builds");
+    let addr: SocketAddr = peer.parse().expect("peer addr parses");
+    request.extensions_mut().insert(ConnectInfo(addr));
+    let response = app.oneshot(request).await.expect("response returns");
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body buffers");
+    let value = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).expect("json body parses")
+    };
+    (status, value)
+}
+
 async fn request_raw(
     app: axum::Router,
     method: &str,
@@ -9339,6 +9377,199 @@ async fn bearer_token_is_accepted_for_access_verification() {
 
     assert_eq!(status, StatusCode::OK);
     assert_eq!(verified["ok"], true);
+}
+
+#[tokio::test]
+async fn auth_verify_oracle_throttles_repeated_failures_per_peer() {
+    // sc-8870 (F-068): the public `/api/v1/auth/verify` oracle returns `{ok}` for any
+    // candidate token, so without a lockout a LAN attacker can brute-force the token
+    // (which IS the password in LAN mode) at wire speed. After a burst of wrong-token
+    // attempts from one peer IP, further attempts from that IP are refused with 429,
+    // while a fresh IP and the valid token are unaffected.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let mut settings = test_settings(&temp_dir);
+    settings.access_token = "secret-token".to_owned();
+    let app = create_app(settings).expect("app creates");
+    let attacker = "192.168.1.50:40000";
+    let bad = [("authorization", "Bearer wrong-token")];
+
+    // The first `AUTH_THROTTLE_MAX_FAILURES` (10) wrong guesses answer normally with
+    // `{ok:false}` — the oracle still works, it just counts each miss.
+    for _ in 0..10 {
+        let (status, verified) = request_with_peer_headers(
+            app.clone(),
+            "POST",
+            "/api/v1/auth/verify",
+            Value::Null,
+            attacker,
+            &bad,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(verified["ok"], false);
+    }
+
+    // The next attempt from the same peer is refused before the oracle answers.
+    let (status, body) = request_with_peer_headers(
+        app.clone(),
+        "POST",
+        "/api/v1/auth/verify",
+        Value::Null,
+        attacker,
+        &bad,
+    )
+    .await;
+    assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(
+        body["detail"], "Too many authentication attempts; try again later",
+        "throttled response must not leak validity",
+    );
+
+    // Even a *correct* token from the now-blocked peer is refused: the lockout is by
+    // IP, so an attacker can't slip a lucky guess past the throttle.
+    let (status, _) = request_with_peer_headers(
+        app.clone(),
+        "POST",
+        "/api/v1/auth/verify",
+        Value::Null,
+        attacker,
+        &[("authorization", "Bearer secret-token")],
+    )
+    .await;
+    assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
+
+    // A different peer IP is untouched and the valid token still verifies — a single
+    // brute-forcer can't lock out the whole deployment, and legitimate use is fine.
+    let (status, verified) = request_with_peer_headers(
+        app.clone(),
+        "POST",
+        "/api/v1/auth/verify",
+        Value::Null,
+        "10.0.0.9:55555",
+        &[("authorization", "Bearer secret-token")],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(verified["ok"], true);
+}
+
+#[tokio::test]
+async fn auth_verify_success_clears_peer_throttle_budget() {
+    // sc-8870: a legitimate user who mistypes a few times must not get locked out once
+    // they authenticate — a valid token clears the peer's failure record.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let mut settings = test_settings(&temp_dir);
+    settings.access_token = "secret-token".to_owned();
+    let app = create_app(settings).expect("app creates");
+    let peer = "192.168.1.77:41000";
+
+    // A handful of misses (under the cap of 10), then a success that resets the count.
+    for _ in 0..5 {
+        let (status, _) = request_with_peer_headers(
+            app.clone(),
+            "POST",
+            "/api/v1/auth/verify",
+            Value::Null,
+            peer,
+            &[("authorization", "Bearer wrong-token")],
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+    }
+    let (status, verified) = request_with_peer_headers(
+        app.clone(),
+        "POST",
+        "/api/v1/auth/verify",
+        Value::Null,
+        peer,
+        &[("authorization", "Bearer secret-token")],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(verified["ok"], true);
+
+    // With the budget reset, another full window of misses is tolerated again without
+    // an early lockout (would have tripped at 10 total had the success not cleared it).
+    for _ in 0..9 {
+        let (status, verified) = request_with_peer_headers(
+            app.clone(),
+            "POST",
+            "/api/v1/auth/verify",
+            Value::Null,
+            peer,
+            &[("authorization", "Bearer wrong-token")],
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "post-success budget must be reset");
+        assert_eq!(verified["ok"], false);
+    }
+}
+
+#[tokio::test]
+async fn loopback_trusted_peer_is_never_throttled() {
+    // sc-8870: the epic-4484 loopback-trust bypass must not accrue throttle failures —
+    // the desktop UI/worker reach the API over loopback with no token, and that must
+    // keep working no matter how many times it happens.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let mut settings = test_settings(&temp_dir);
+    settings.access_token = "secret-token".to_owned();
+    settings.trust_loopback = true;
+    let app = create_app(settings).expect("app creates");
+
+    // Far more than the cap of gated requests with no token, all over loopback → all
+    // served (the bypass returns before the throttle ever sees them).
+    for _ in 0..20 {
+        let (status, _) = request_with_peer(
+            app.clone(),
+            "GET",
+            "/api/v1/jobs",
+            Value::Null,
+            "127.0.0.1:51234",
+        )
+        .await;
+        assert_ne!(status, StatusCode::UNAUTHORIZED);
+        assert_ne!(status, StatusCode::TOO_MANY_REQUESTS);
+    }
+}
+
+#[tokio::test]
+async fn gated_route_brute_force_is_throttled_per_peer() {
+    // sc-8870: the throttle also covers the token oracle exposed by every gated route
+    // (401-vs-200 reveals a valid token), not just `/auth/verify`. A LAN peer hammering
+    // a gated route with a bad token gets locked out with 429 after the failure cap.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let mut settings = test_settings(&temp_dir);
+    settings.access_token = "secret-token".to_owned();
+    let app = create_app(settings).expect("app creates");
+    let attacker = "192.168.1.60:42000";
+    let bad = [("authorization", "Bearer wrong-token")];
+
+    for _ in 0..10 {
+        let (status, _) = request_with_peer_headers(
+            app.clone(),
+            "GET",
+            "/api/v1/jobs",
+            Value::Null,
+            attacker,
+            &bad,
+        )
+        .await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+    }
+    let (status, body) = request_with_peer_headers(
+        app.clone(),
+        "GET",
+        "/api/v1/jobs",
+        Value::Null,
+        attacker,
+        &bad,
+    )
+    .await;
+    assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(
+        body["detail"],
+        "Too many authentication attempts; try again later"
+    );
 }
 
 #[tokio::test]

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -8624,6 +8624,14 @@ async fn project_file_route_serves_files_and_rejects_traversal() {
             .and_then(|value| value.to_str().ok()),
         Some("image/png")
     );
+    // sc-9674 (sc-8872 follow-up): the serve response forbids MIME sniffing so a
+    // user-controlled project file can't be reinterpreted as active content.
+    assert_eq!(
+        headers
+            .get("x-content-type-options")
+            .and_then(|value| value.to_str().ok()),
+        Some("nosniff")
+    );
 
     let (status, _, bytes) = request_raw(
         app.clone(),
@@ -8694,6 +8702,13 @@ async fn project_file_route_serves_byte_ranges() {
     assert_eq!(
         headers.get("accept-ranges").and_then(|v| v.to_str().ok()),
         Some("bytes")
+    );
+    // sc-9674: the 206 partial-content branch also carries nosniff.
+    assert_eq!(
+        headers
+            .get("x-content-type-options")
+            .and_then(|v| v.to_str().ok()),
+        Some("nosniff")
     );
 
     // An open-ended range serves to EOF (this is how WebKit fetches the
@@ -9770,6 +9785,45 @@ async fn media_tickets_authenticate_project_file_urls() {
     )
     .await;
     assert_ne!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn pose_preview_route_sets_nosniff() {
+    // sc-9674 (sc-8872 follow-up): the pose-preview serve endpoint is a sibling
+    // media route on the API origin, so it must also forbid MIME sniffing. Served
+    // inline for <img> preview, so no attachment disposition.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    let data_dir = settings.data_dir.clone();
+    let app = create_app(settings).expect("app creates");
+
+    // The handler reads the rendered skeleton from the pose-detect cache; write one.
+    let preview_dir = data_dir.join("cache").join("pose_detect").join("job_ok");
+    std::fs::create_dir_all(&preview_dir).expect("preview dir creates");
+    std::fs::write(preview_dir.join("preview.png"), PNG_32X32).expect("preview writes");
+
+    let (status, headers, bytes) = request_raw(
+        app,
+        "GET",
+        "/api/v1/poses/preview/job_ok/preview.png",
+        Body::empty(),
+        &[],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(bytes, PNG_32X32);
+    assert_eq!(
+        headers
+            .get("content-type")
+            .and_then(|value| value.to_str().ok()),
+        Some("image/png")
+    );
+    assert_eq!(
+        headers
+            .get("x-content-type-options")
+            .and_then(|value| value.to_str().ok()),
+        Some("nosniff")
+    );
 }
 
 #[test]


### PR DESCRIPTION
Code-review remediation batch (epic 8800, batch 11) hardening the rust-api auth/events surface. Five stories; four code/docs commits (one story was already resolved in current source).

## Stories

- **sc-8870 [F-068] Rate-limit the public token-verification oracle** — `POST /api/v1/auth/verify` is public and answers `{ok}` for any candidate token, and every gated route leaks token validity via 401-vs-200, with no lockout. In LAN mode the token IS the password → wire-speed brute force. Added a lightweight per-peer-IP failed-attempt throttle (`AuthThrottle`: `Mutex<HashMap<IpAddr, {failures, window_start}>>`, 60s rolling window, 10-failure cap). Applied in the access-control middleware (entry block + failure counting on rejection) and inside `verify_access` (the oracle meters its own misses; a valid token clears the peer's record). Loopback-trusted peers (epic 4484) never accrue failures. Repeated failures log at `warn!`.

- **sc-8891 [F-089] Infallible `EventTicketStore::issue` returns `Result`** — **Already resolved in current source.** `TicketStore::issue` (tickets.rs) already returns `TicketResponse` directly, not `Result`; `create_event_ticket` calls it with no `?`. No `EventTicketStore::issue -> Result` exists. No commit (no empty commit filed).

- **sc-9674 [sc-8872 follow-up] `X-Content-Type-Options: nosniff` on media-serve endpoints** — Added `nosniff` to every body-bearing branch of `get_project_file` (206 + 200) and to `get_pose_preview`. **Judgment call:** did NOT add `Content-Disposition: attachment` — these assets are served inline for `<img>`/`<video>` preview and WebKit byte-range playback in the desktop webview; forcing attachment would break legitimate inline media. `nosniff` alone closes the sniffing vector without regressing playback.

- **sc-8947 [F-146, Info — accepted] SSE auth ticket in the query string** — **Judgment call:** did NOT implement the optional peer-IP pin. Issuance (`POST .../ticket`, a `fetch`) and redemption (`GET .../events`, the `EventSource`) are two separate connections, and the web client mints a fresh ticket on every (re)connect including each auto-reconnect (App.jsx `connect()`). On a dual-stack loopback host `localhost` resolves to `127.0.0.1` for one request and `::1` for the other, so IP-pinning would reject the redemption and break legitimate SSE in exactly the loopback/LAN setup epic 4484 targets (and adds nothing behind a reverse proxy). Documented the single-use + 30s-TTL design as the accepted control in a code comment so nobody extends the query-string pattern to the long-lived token.

- **sc-8948 [F-146, Info — accepted design tradeoff] Loopback trust grants token bypass to every local OS user** — No behavior change (deliberate, epic 4484). Delivered the recorded fix: a "Loopback trust and the multi-user-machine caveat" note in the root README's Local Access Control section, plus a concise caveat comment at the `loopback_trusted` check pointing to it.

## Tests added

- `auth_verify_oracle_throttles_repeated_failures_per_peer` — oracle throttles after the cap; refuses even a correct token from a blocked IP; a fresh IP + valid token unaffected.
- `auth_verify_success_clears_peer_throttle_budget` — a valid token clears the peer's failure budget.
- `loopback_trusted_peer_is_never_throttled` — the epic-4484 bypass never accrues failures.
- `gated_route_brute_force_is_throttled_per_peer` — the throttle also covers gated-route brute force, not just `/auth/verify`.
- nosniff assertions on the project-file 200 + 206 responses and a new `pose_preview_route_sets_nosniff`.
- `sse_event_ticket_is_single_use_at_the_endpoint` — pins the SSE accepted-control invariant at the HTTP layer (first GET connects, replay rejected 401).

## Verification

- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo test -p sceneworks-rust-api`: 170 passed. `cargo test --workspace --exclude sceneworks-desktop`: all green.
- Contract snapshots (`pytest -m parity`) unaffected: they run with auth off (throttle metering skipped) and the verify/ticket JSON body snapshots are unchanged; no regen needed.

## Pre-existing issue (not fixed — out of scope)

`cargo test --workspace` fails to **build** `sceneworks-desktop` in this worktree: its Tauri build script requires a staged sidecar `apps/desktop/binaries/sceneworks-api-aarch64-apple-darwin` that isn't committed (a worktree/packaging staging gap, unrelated to these changes). All non-desktop crates build and test clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
