### PR TITLE
refactor(worker): media/kps hardening + off-thread decode (epic 8800 batch 2)

### DIFF
--- a/crates/sceneworks-worker/src/face_likeness_compare_jobs.rs
+++ b/crates/sceneworks-worker/src/face_likeness_compare_jobs.rs
@@ -204,12 +204,16 @@ pub(crate) async fn run_face_likeness_compare_job(
     )
     .await?;
 
-    let (source, candidate) = load_compare_images(settings, job)?;
     let source_ref = required_asset_id(&job.payload, "sourceAssetId")?.to_owned();
 
     // Stage the SCRFD + ArcFace bundle (download-on-first-use; a prior InstantID / kps / dataset-face
     // run leaves it cached). The same dir the candle stack loads and the MLX path joins file names in.
     let weights_dir = crate::image_jobs::ensure_face_stack_dir(api, settings, job).await?;
+
+    // The two source reads + full image decodes are folded into the blocking compare task below
+    // (sc-8909 / F-107) so they never stall the async runtime thread (protecting the heartbeat).
+    let settings_for_task = settings.clone();
+    let job_for_task = job.clone();
 
     update_job(
         api,
@@ -240,6 +244,7 @@ pub(crate) async fn run_face_likeness_compare_job(
         "",
         "face likeness compare task",
         tokio::task::spawn_blocking(move || {
+            let (source, candidate) = load_compare_images(&settings_for_task, &job_for_task)?;
             compare(&weights_dir, &source, &candidate, &source_ref)
         }),
     )

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -977,17 +977,26 @@ async fn generate_stub_stream(
         check_cancel(api, &job.id, "Image generation canceled by user.").await?;
         let seed = resolve_seed(request, index);
         let pixels = stub_rgb8(request.width, request.height, seed);
-        let fact = write_image_asset(
-            plan,
-            index,
-            seed,
-            request.width,
-            request.height,
-            pixels,
-            STUB_ADAPTER,
-            stub_raw_settings(request),
-            project_path,
-        )?;
+        // Encode + write the asset PNG off the async runtime thread (sc-8909 / F-107).
+        let plan_for_task = plan.clone();
+        let raw_settings = stub_raw_settings(request);
+        let (width, height) = (request.width, request.height);
+        let project_path_for_task = project_path.to_owned();
+        let fact = tokio::task::spawn_blocking(move || {
+            write_image_asset(
+                &plan_for_task,
+                index,
+                seed,
+                width,
+                height,
+                pixels,
+                STUB_ADAPTER,
+                raw_settings,
+                &project_path_for_task,
+            )
+        })
+        .await
+        .map_err(|error| crate::task_join_error("stub image asset write task", error))??;
         asset_writes.push(Value::Object(fact));
         let progress = 0.1 + 0.85 * ((index + 1) as f64 / request.count as f64);
         update_job(
@@ -1009,6 +1018,11 @@ async fn generate_stub_stream(
 }
 
 /// Per-job invariants shared across every image in the generation set.
+///
+/// `Clone` so the per-image asset writers can move an owned copy into a `spawn_blocking` PNG-encode
+/// task (sc-8909 / F-107) — the plan is a few strings + one small generation-set `Value`, negligible
+/// next to the encode it hands off the async runtime thread.
+#[derive(Clone)]
 pub(crate) struct ImagePlan {
     pub(crate) request: ImageRequest,
     pub(crate) genset_id: String,
@@ -1201,11 +1215,19 @@ async fn apply_inline_upscale(
             .ok_or_else(|| {
                 WorkerError::InvalidPayload("upscale source asset missing mediaPath".to_owned())
             })?;
-        let source = crate::image_decode::decode_image_any(project_path.join(media_rel))
-            .map_err(|error| {
-                WorkerError::InvalidPayload(format!("Upscale source could not be loaded: {error}"))
-            })?
-            .to_rgb8();
+        // Decode the base image off the async runtime thread (sc-8909 / F-107).
+        let source_path = project_path.join(media_rel);
+        let source = tokio::task::spawn_blocking(move || {
+            crate::image_decode::decode_image_any(source_path)
+                .map_err(|error| {
+                    WorkerError::InvalidPayload(format!(
+                        "Upscale source could not be loaded: {error}"
+                    ))
+                })
+                .map(|decoded| decoded.to_rgb8())
+        })
+        .await
+        .map_err(|error| crate::task_join_error("upscale source decode task", error))??;
         let seed = base_fact.get("seed").and_then(Value::as_i64).unwrap_or(0);
 
         update_job(
@@ -1240,15 +1262,25 @@ async fn apply_inline_upscale(
         )
         .await?;
 
-        let fact = write_upscaled_asset(
-            plan,
-            base_fact,
-            &upscaled,
-            engine_id,
-            factor,
-            softness,
-            project_path,
-        )?;
+        // Build the upscaled asset (including the blocking PNG encode) off the async runtime thread
+        // (sc-8909 / F-107).
+        let plan_for_task = plan.clone();
+        let base_fact_for_task = base_fact.clone();
+        let engine_for_task = engine_id.to_owned();
+        let project_path_for_task = project_path.to_owned();
+        let fact = tokio::task::spawn_blocking(move || {
+            write_upscaled_asset(
+                &plan_for_task,
+                &base_fact_for_task,
+                &upscaled,
+                &engine_for_task,
+                factor,
+                softness,
+                &project_path_for_task,
+            )
+        })
+        .await
+        .map_err(|error| crate::task_join_error("upscaled asset write task", error))??;
         asset_writes.push(Value::Object(fact));
         heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
     }

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -3400,17 +3400,25 @@ async fn consume_gen_events(
                         Value::Object(block),
                     );
                 }
-                let fact = write_image_asset(
-                    plan,
-                    index,
-                    seed,
-                    width,
-                    height,
-                    pixels,
-                    adapter_label,
-                    image_raw_settings,
-                    project_path,
-                )?;
+                // Encode + write the asset PNG off the async runtime thread (sc-8909 / F-107).
+                let plan_for_task = plan.clone();
+                let adapter_for_task = adapter_label.to_owned();
+                let project_path_for_task = project_path.to_owned();
+                let fact = tokio::task::spawn_blocking(move || {
+                    write_image_asset(
+                        &plan_for_task,
+                        index,
+                        seed,
+                        width,
+                        height,
+                        pixels,
+                        &adapter_for_task,
+                        image_raw_settings,
+                        &project_path_for_task,
+                    )
+                })
+                .await
+                .map_err(|error| crate::task_join_error("image asset write task", error))??;
                 asset_writes.push(Value::Object(fact));
                 emit_event(
                     "image_inference_complete",

--- a/crates/sceneworks-worker/src/image_jobs/detail.rs
+++ b/crates/sceneworks-worker/src/image_jobs/detail.rs
@@ -569,12 +569,20 @@ pub(crate) async fn run_image_detail_job(
     let (out_w, out_h) = (refined.width(), refined.height());
     let media_path = project_path.join(&media_rel);
     let temp_path = media_path.with_extension("tmp.png");
-    refined
-        .save_with_format(&temp_path, image::ImageFormat::Png)
-        .map_err(|error| WorkerError::Io(std::io::Error::other(error)))?;
-    std::fs::rename(&temp_path, &media_path).inspect_err(|_| {
-        let _ = std::fs::remove_file(&temp_path);
-    })?;
+    // Encode + atomically promote the refined PNG off the async runtime thread (sc-8909 / F-107).
+    let encode_tmp = temp_path.clone();
+    let encode_final = media_path.clone();
+    tokio::task::spawn_blocking(move || {
+        refined
+            .save_with_format(&encode_tmp, image::ImageFormat::Png)
+            .map_err(|error| WorkerError::Io(std::io::Error::other(error)))?;
+        std::fs::rename(&encode_tmp, &encode_final).inspect_err(|_| {
+            let _ = std::fs::remove_file(&encode_tmp);
+        })?;
+        Ok::<_, WorkerError>(())
+    })
+    .await
+    .map_err(|error| crate::task_join_error("detail asset encode task", error))??;
 
     let result = detail_result(
         &request,

--- a/crates/sceneworks-worker/src/kps_jobs.rs
+++ b/crates/sceneworks-worker/src/kps_jobs.rs
@@ -313,7 +313,6 @@ pub(crate) async fn run_kps_extract_job(
     )
     .await?;
 
-    let image = load_source_image(settings, job)?;
     // `weights` is a single SCRFD weight file on Mac and the SCRFD+ArcFace bundle DIR off-Mac (candle
     // `load` resolves both files from one dir by name); both are `PathBuf`, both flow into the matching
     // detector below.
@@ -321,6 +320,11 @@ pub(crate) async fn run_kps_extract_job(
     let weights = ensure_scrfd_weights(api, settings, job).await?;
     #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
     let weights = ensure_face_stack_dir(api, settings, job).await?;
+
+    // The source read + full image decode is folded into the blocking task below (sc-8909 / F-107)
+    // so it never stalls the async runtime thread (protecting the heartbeat).
+    let settings_for_task = settings.clone();
+    let job_for_task = job.clone();
 
     update_job(
         api,
@@ -350,6 +354,7 @@ pub(crate) async fn run_kps_extract_job(
         "",
         "kps extraction task",
         tokio::task::spawn_blocking(move || {
+            let image = load_source_image(&settings_for_task, &job_for_task)?;
             #[cfg(target_os = "macos")]
             {
                 detect_largest_kps(&weights, &image)

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -404,8 +404,11 @@ const DEFAULT_HUGGINGFACE_BASE_URL: &str = "https://huggingface.co";
 const DEFAULT_MAX_LORA_URL_BYTES: u64 = 8 * 1024 * 1024 * 1024;
 const DEFAULT_MAX_MODEL_URL_BYTES: u64 = 256 * 1024 * 1024 * 1024;
 const DEFAULT_TRANSITION_DURATION_SECONDS: f64 = 0.5;
-const PERSON_TRACK_SAMPLE_RATE_FPS: f64 = 2.0;
-const PERSON_TRACK_MAX_SAMPLES: usize = 24;
+// One source of truth for the person-track sample cadence (sc-8914 / F-112): the sidecar
+// `sampleRateFps` the media handlers record and the sampler `person_track` uses must never drift, so
+// both are these aliases to the `person_track` module constants rather than value-duplicated literals.
+const PERSON_TRACK_SAMPLE_RATE_FPS: f64 = person_track::SAMPLE_RATE_FPS;
+const PERSON_TRACK_MAX_SAMPLES: usize = person_track::MAX_SAMPLES;
 const PERSON_TRACK_X_DRIFT: f64 = 0.018;
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -406,9 +406,31 @@ const DEFAULT_MAX_MODEL_URL_BYTES: u64 = 256 * 1024 * 1024 * 1024;
 const DEFAULT_TRANSITION_DURATION_SECONDS: f64 = 0.5;
 // One source of truth for the person-track sample cadence (sc-8914 / F-112): the sidecar
 // `sampleRateFps` the media handlers record and the sampler `person_track` uses must never drift, so
-// both are these aliases to the `person_track` module constants rather than value-duplicated literals.
+// on the lanes that build `person_track` (macOS / off-Mac candle) these alias its constants directly.
+// The `person_track` module is cfg'd out on the bare parity lane (no MLX, no candle), so there the
+// aliases fall back to the literal values — kept in lockstep by
+// `person_track_sample_constants_are_a_single_source_of_truth`, which asserts the equality on the
+// lanes where both exist.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 const PERSON_TRACK_SAMPLE_RATE_FPS: f64 = person_track::SAMPLE_RATE_FPS;
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 const PERSON_TRACK_MAX_SAMPLES: usize = person_track::MAX_SAMPLES;
+#[cfg(not(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+)))]
+const PERSON_TRACK_SAMPLE_RATE_FPS: f64 = 2.0;
+#[cfg(not(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+)))]
+const PERSON_TRACK_MAX_SAMPLES: usize = 24;
 const PERSON_TRACK_X_DRIFT: f64 = 0.018;
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/sceneworks-worker/src/media_jobs.rs
+++ b/crates/sceneworks-worker/src/media_jobs.rs
@@ -2219,34 +2219,112 @@ pub(crate) fn export_request_from_job(job: &JobSnapshot) -> WorkerResult<Timelin
 /// The scale→pad→rgb24 filter chain every person-track / frame-extract sample shares. Downscales
 /// into `width×height` preserving aspect (letterboxed on the app ink color), then forces rgb24 so
 /// the detector always sees a 3-channel frame. Shared by the single-frame `render_frame_png` and the
-/// single-pass `render_track_frames` so both produce byte-identical frame geometry.
+/// single-pass `render_track_frames` so both produce identical frame geometry for a given source
+/// frame (the two paths can still pick DIFFERENT source frames — see `render_track_frames`).
 fn frame_scale_pad_filter(width: u32, height: u32) -> String {
     format!(
         "scale={width}:{height}:force_original_aspect_ratio=decrease,pad={width}:{height}:(ow-iw)/2:(oh-ih)/2:color=0x12110f,format=rgb24"
     )
 }
 
-/// Extract the person-track sample frames in ONE ffmpeg pass (sc-8915 / F-113), replacing the prior
-/// one-`ffmpeg`-process-per-sample accurate-seek loop (up to `MAX_SAMPLES` = 24 spawns per track).
+/// Count the decodable video frames in `source_path` with a single ffmpeg null-mux pass, so the
+/// caller can decide whether the single-pass `select` optimization is provably equivalent to the
+/// old per-frame accurate-seek loop (sc-8915 / F-113). Returns `Ok(Some(n))` on a clean probe,
+/// `Ok(None)` when the frame count can't be parsed from ffmpeg's stderr (unknown → the caller must
+/// take the SAFE per-frame path). We deliberately probe with `ffmpeg` and not `ffprobe`: the desktop
+/// app ships only the imageio-ffmpeg binary (no `ffprobe`), so `ffprobe` is not guaranteed present.
+///
+/// `-c copy -f null -` walks every packet without re-encoding and prints the running `frame=<N>`
+/// counter to stderr; the last value is the exact decodable frame count. This is VFR-safe (it counts
+/// real frames rather than trusting an `avg_frame_rate` metadata field that lies on VFR/screen-record
+/// sources). Probe failures are non-fatal: `None` simply routes to the accurate-seek fallback.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+async fn probe_source_frame_count(ffmpeg: &str, source_path: &Path) -> Option<usize> {
+    let configured = match std::env::var("SCENEWORKS_FFMPEG") {
+        Ok(path) if ffmpeg == "ffmpeg" && !path.trim().is_empty() => path,
+        _ => ffmpeg.to_owned(),
+    };
+    let program = sceneworks_core::media_convert::resolve_ffmpeg_program(&configured);
+    let output = Command::new(program.as_ref())
+        .args([
+            "-hide_banner",
+            "-i",
+            &source_path.display().to_string(),
+            "-map",
+            "0:v:0",
+            "-c",
+            "copy",
+            "-f",
+            "null",
+            "-",
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .output()
+        .await
+        .ok()?;
+    // ffmpeg writes `frame=<N>` progress lines to stderr; the last one is the final decoded count.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    parse_ffmpeg_frame_count(&stderr)
+}
+
+/// Extract the last `frame=<N>` counter ffmpeg prints to stderr (the progress token may be padded
+/// with spaces, e.g. `frame=  12`). Split into its own pure fn so it is unit-testable without ffmpeg.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn parse_ffmpeg_frame_count(stderr: &str) -> Option<usize> {
+    stderr.rmatch_indices("frame=").find_map(|(idx, _)| {
+        stderr[idx + "frame=".len()..]
+            .trim_start()
+            .split(|c: char| !c.is_ascii_digit())
+            .next()
+            .filter(|digits| !digits.is_empty())
+            .and_then(|digits| digits.parse::<usize>().ok())
+    })
+}
+
+/// Extract the person-track sample frames in ONE ffmpeg pass (sc-8915 / F-113) — replacing up to
+/// `MAX_SAMPLES` (24) per-sample accurate-seek spawns — WHENEVER that single pass is provably
+/// equivalent to the old per-sample loop, and FALLING BACK to the per-frame accurate seeks when it
+/// is not.
 ///
 /// `sample_timestamps` is a uniform cadence — evenly spaced `duration·i/(count-1)` for the interior
 /// samples, with only the final inclusive-end sample pulled inside the clip by
-/// `FRAME_SEEK_GUARD_SECONDS`. A single `select` filter over that same grid reproduces the exact
-/// frames the per-sample accurate seeks chose: `gte(t, min(selected_n·interval, last_seek))` picks,
-/// for the `selected_n`-th output frame, the first source frame whose `pts ≥` that grid point — the
-/// same "first frame `≥ T`" rule an `-ss T` accurate seek uses. `interval = duration/(count-1)`
-/// (`= 1/SAMPLE_RATE`-equivalent) is the interior step; `last_seek = frame_seek_timestamp(…)` folds
-/// the guard into the final grid point so the last sample lands on a real frame. Verified byte-exact
-/// against the old per-frame path on a synthetic clip (all sampled PNGs md5-identical).
+/// `FRAME_SEEK_GUARD_SECONDS`. A single `select` filter over that same grid picks, for the
+/// `selected_n`-th output frame, the first source frame whose `pts ≥ gte(t, min(selected_n·interval,
+/// last_seek))`. `interval = duration/(count-1)` is the interior step; `last_seek =
+/// frame_seek_timestamp(…)` folds the guard into the final grid point.
 ///
-/// The frames land as a 1-based `seq_%04d.png` image2 sequence, then are renamed to the 0-based
-/// `frame_{index:04}.png` names the segmentation pass re-reads by sample index — identical to before.
+/// EQUIVALENCE CONDITION (why this is NOT unconditionally byte-identical): an `-ss T` accurate seek
+/// re-selects the "first frame with pts ≥ T" INDEPENDENTLY for each sample, so two close grid points
+/// with no source frame between them both resolve to the SAME earlier frame. The single `select`
+/// filter instead scans FORWARD and cannot rewind: once `selected_n` advances it consumes the next
+/// distinct frame, so those two close grid points select DISTINCT forward frames and the clip is
+/// exhausted early. The two paths therefore agree iff every grid point maps to a distinct source
+/// frame — i.e. the source has at least as many decodable frames across the sampled span as there
+/// are samples (`source_frame_count ≥ count`, equivalently source fps ≥ the `(count-1)/duration`
+/// sample cadence). Below that (low-fps screen recordings, timelapses, GIF-derived or low-fps webcam
+/// clips, or clips with fewer frames than samples) the single pass diverges — reproduced with real
+/// ffmpeg at 19–21/24 frames wrong on a 12s@1fps clip — so we take the per-frame path instead.
 ///
-/// A single-sample cadence (`count ≤ 1`, i.e. `duration ≤ 0`) has no interval, so it falls back to
-/// one accurate-seek `render_frame_png` — the exact frame the old loop's sole iteration produced.
-/// If the source is shorter than the grid implies and ffmpeg emits fewer than `count` frames, the
-/// last real frame is cloned forward so every sample index has a readable frame (the tracker records
-/// the logical `timestamps[i]` regardless of which pixels back the final tail samples).
+/// We probe the real decodable frame count with [`probe_source_frame_count`] (an ffmpeg null-mux
+/// count, VFR-safe, no `ffprobe` dependency). Single pass ONLY when the probe succeeds AND
+/// `frame_count ≥ count`; otherwise (including an unknown/failed probe) fall back to per-frame
+/// accurate seeks, which reproduce the exact pre-PR frames by construction.
+///
+/// In the single-pass path the frames land as a 1-based `seq_%04d.png` image2 sequence, then are
+/// renamed to the 0-based `frame_{index:04}.png` names the segmentation pass re-reads by sample
+/// index. A single-sample cadence (`count ≤ 1`, i.e. `duration ≤ 0`) has no interval, so it always
+/// takes one accurate-seek `render_frame_png` — the exact frame the old loop's sole iteration
+/// produced. In the single-pass path, if the source is shorter than the grid implies and ffmpeg
+/// emits fewer than `count` frames, the last real frame is cloned forward so every sample index has
+/// a readable frame (the tracker records the logical `timestamps[i]` regardless).
 #[cfg(any(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
@@ -2280,6 +2358,27 @@ async fn render_track_frames(
         )
         .await?;
         return Ok(vec![path]);
+    }
+
+    // Gate the single-pass optimization on the equivalence condition above: only when the source has
+    // at least `count` decodable frames does each grid point map to a distinct forward frame that
+    // matches the independent accurate seek. An unknown probe (`None`) is treated as unsafe and also
+    // routes to the fallback. This is what keeps the perf win for well-behaved clips while
+    // guaranteeing correctness for sub-cadence-fps / frame-starved sources.
+    let source_frame_count = probe_source_frame_count(ffmpeg, source_path).await;
+    let single_pass_equivalent = source_frame_count.is_some_and(|frames| frames >= count);
+    if !single_pass_equivalent {
+        return render_track_frames_per_frame(
+            ffmpeg,
+            source_path,
+            work_dir,
+            timestamps,
+            duration,
+            width,
+            height,
+            context,
+        )
+        .await;
     }
 
     // Interior grid step and the guard-folded final seek — the two numbers that define the sample
@@ -2338,6 +2437,104 @@ async fn render_track_frames(
         frame_paths.push(dest);
     }
     Ok(frame_paths)
+}
+
+/// The pre-PR person-track sampling path (sc-8915 / F-113 fallback): one `-ss T` accurate-seek
+/// spawn per sample. This is the correctness reference the single-pass path is gated against — for
+/// sub-cadence-fps / frame-starved sources it selects the exact frames the code shipped before the
+/// single-pass optimization, including re-SELECTING the same earlier frame for close grid points
+/// (which the forward-only single pass cannot). `frame_paths[i]` ↔ `timestamps[i]`, the same 0-based
+/// `frame_{index:04}.png` names the segmentation pass re-reads.
+///
+/// One robustness improvement over the literal pre-PR loop: when a tail sample's seek lands past the
+/// last real frame (the `FRAME_SEEK_GUARD_SECONDS` guard assumes ~5fps-dense frames, so a very
+/// low-fps clip can seek past EOF and some ffmpeg builds then emit NO frame), the last successfully
+/// rendered frame is cloned forward instead of hard-erroring. That mirrors the single-pass path's own
+/// short-source tail handling and matches pre-PR frame *selection* for every sample pre-PR produced,
+/// while never failing the job on a short clip (the tracker still records the logical `timestamps[i]`).
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+#[allow(clippy::too_many_arguments)]
+async fn render_track_frames_per_frame(
+    ffmpeg: &str,
+    source_path: &Path,
+    work_dir: &Path,
+    timestamps: &[f64],
+    duration: f64,
+    width: u32,
+    height: u32,
+    context: FfmpegContext<'_>,
+) -> WorkerResult<Vec<PathBuf>> {
+    let mut frame_paths = Vec::with_capacity(timestamps.len());
+    let mut last_written: Option<PathBuf> = None;
+    for (index, &timestamp) in timestamps.iter().enumerate() {
+        let path = work_dir.join(format!("frame_{index:04}.png"));
+        let produced = try_render_frame_png(
+            ffmpeg,
+            source_path,
+            &path,
+            frame_seek_timestamp(timestamp, duration),
+            width,
+            height,
+            Some(context),
+        )
+        .await?;
+        if produced {
+            last_written = Some(path.clone());
+        } else if let Some(previous) = &last_written {
+            // Seek landed past the last real frame on a short/low-fps clip → clone the last frame
+            // forward rather than erroring, matching the single-pass tail behavior.
+            tokio::fs::copy(previous, &path).await?;
+        } else {
+            return Err(WorkerError::InvalidPayload(format!(
+                "FFmpeg produced no sampled frames for {}",
+                source_path.display()
+            )));
+        }
+        frame_paths.push(path);
+    }
+    Ok(frame_paths)
+}
+
+/// Accurate-seek one frame like [`render_frame_png`], but instead of erroring when ffmpeg emits no
+/// output (a seek past the last real frame on a short/low-fps clip), return `Ok(false)` so the caller
+/// can decide whether to clone the previous frame forward. `Ok(true)` means the frame was written.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+async fn try_render_frame_png(
+    ffmpeg: &str,
+    source_path: &Path,
+    output_path: &Path,
+    timestamp: f64,
+    width: u32,
+    height: u32,
+    context: Option<FfmpegContext<'_>>,
+) -> WorkerResult<bool> {
+    let filters = frame_scale_pad_filter(width, height);
+    run_ffmpeg(
+        vec![
+            ffmpeg.to_owned(),
+            "-y".to_owned(),
+            "-ss".to_owned(),
+            format!("{:.3}", timestamp.max(0.0)),
+            "-i".to_owned(),
+            source_path.display().to_string(),
+            "-frames:v".to_owned(),
+            "1".to_owned(),
+            "-vf".to_owned(),
+            filters,
+            "-f".to_owned(),
+            "image2".to_owned(),
+            output_path.display().to_string(),
+        ],
+        context,
+    )
+    .await?;
+    Ok(tokio::fs::try_exists(output_path).await?)
 }
 
 pub(crate) async fn render_frame_png(
@@ -3461,102 +3658,187 @@ mod person_track_e2e_tests {
         let _ = std::fs::remove_dir_all(&scratch);
     }
 
-    /// F-113 (sc-8915): the single-pass `render_track_frames` must select byte-identical frames to
-    /// the old one-`ffmpeg`-per-sample accurate-seek loop. Generates a deterministic synthetic clip
-    /// with real ffmpeg, extracts every sample both ways, and asserts each sampled PNG is identical.
+    /// Extract every `timestamps[i]` two ways for one synthetic `rate`fps × `duration`s clip and
+    /// return `(single_pass_frames, accurate_seek_reference_frames)` as raw PNG bytes, so a caller
+    /// can assert they match. `render_track_frames` is the code under test (single-pass WHERE valid,
+    /// per-frame accurate-seek fallback otherwise); the reference is the pre-PR per-frame path built
+    /// directly with `render_frame_png`. Returns `None` when ffmpeg can't build the fixture (so the
+    /// test degrades to a skip rather than a false failure).
+    async fn extract_both_ways(
+        scratch: &std::path::Path,
+        label: &str,
+        rate: &str,
+        duration: f64,
+    ) -> Option<(Vec<Vec<u8>>, Vec<Vec<u8>>)> {
+        use crate::person_track::sample_timestamps;
+
+        let case_dir = scratch.join(label);
+        let cut_dir = case_dir.join("cut"); // code under test (render_track_frames)
+        let ref_dir = case_dir.join("ref"); // per-frame accurate-seek reference
+        std::fs::create_dir_all(&cut_dir).expect("cut dir");
+        std::fs::create_dir_all(&ref_dir).expect("ref dir");
+
+        // A deterministic testsrc2 clip at the requested cadence. `render_frame_png` accurate seek
+        // needs a real container, so materialize the file first.
+        let src = case_dir.join("src.mp4");
+        let make = run_ffmpeg(
+            vec![
+                "ffmpeg".to_owned(),
+                "-y".to_owned(),
+                "-f".to_owned(),
+                "lavfi".to_owned(),
+                "-i".to_owned(),
+                format!("testsrc2=size=320x240:rate={rate}:duration={duration}"),
+                "-pix_fmt".to_owned(),
+                "yuv420p".to_owned(),
+                src.display().to_string(),
+            ],
+            None,
+        )
+        .await;
+        if make.is_err() {
+            eprintln!("skipping {label}: ffmpeg unavailable to build the fixture");
+            return None;
+        }
+
+        let timestamps = sample_timestamps(duration);
+        assert!(
+            timestamps.len() > 1,
+            "{label}: fixture yields a multi-sample cadence"
+        );
+
+        let cut_paths = render_track_frames(
+            "ffmpeg",
+            &src,
+            &cut_dir,
+            &timestamps,
+            duration,
+            1280,
+            720,
+            FfmpegContext {
+                api: &ApiClient::new(&crate::Settings::from_env()),
+                settings: &crate::Settings::from_env(),
+                job_id: "render-track-frames-verify",
+                cancel_message: "",
+            },
+        )
+        .await
+        .expect("render_track_frames extraction");
+        assert_eq!(
+            cut_paths.len(),
+            timestamps.len(),
+            "{label}: one frame per sample"
+        );
+
+        // Build the accurate-seek reference the SAME way the fallback does: one independent `-ss`
+        // seek per sample, cloning the last produced frame forward for any tail sample whose seek
+        // lands past EOF on a low-fps clip. This is exactly the pre-PR frame *selection*, made robust
+        // against the short-clip tail. `render_track_frames` must match it byte-for-byte.
+        let mut cut_bytes = Vec::with_capacity(timestamps.len());
+        let mut ref_bytes = Vec::with_capacity(timestamps.len());
+        let mut last_ref: Option<Vec<u8>> = None;
+        for (index, &timestamp) in timestamps.iter().enumerate() {
+            let ref_path = ref_dir.join(format!("frame_{index:04}.png"));
+            let produced = try_render_frame_png(
+                "ffmpeg",
+                &src,
+                &ref_path,
+                frame_seek_timestamp(timestamp, duration),
+                1280,
+                720,
+                None,
+            )
+            .await
+            .expect("per-frame reference extraction");
+            let bytes = if produced {
+                let b = std::fs::read(&ref_path).expect("read reference frame");
+                last_ref = Some(b.clone());
+                b
+            } else {
+                last_ref
+                    .clone()
+                    .expect("a reference frame exists before any EOF tail sample")
+            };
+            ref_bytes.push(bytes);
+            cut_bytes.push(std::fs::read(&cut_paths[index]).expect("read code-under-test frame"));
+        }
+        Some((cut_bytes, ref_bytes))
+    }
+
+    /// F-113 (sc-8915): `render_track_frames` must select byte-identical frames to the old
+    /// one-`ffmpeg`-per-sample accurate-seek loop across every fps regime, NOT just well-behaved
+    /// high-fps sources. It generates deterministic synthetic clips with real ffmpeg and asserts each
+    /// sampled PNG matches the accurate-seek reference:
+    ///
+    /// - 4s @ 30fps: the well-behaved case (source fps ≥ sample cadence). `render_track_frames` takes
+    ///   the single-pass path and it is byte-identical — the perf win we keep.
+    /// - 12s @ 1fps and 12s @ 1.5fps: sub-cadence-fps sources (12 / 18 real frames < 24 samples). The
+    ///   old, unconditional single-pass code selected 19–21/24 wrong frames here; the gated code
+    ///   falls back to per-frame accurate seeks and matches. THIS is the regression the fix closes —
+    ///   it FAILS against single-pass-always and PASSES after the fallback gate.
+    /// - 3s @ 1fps: a frame-STARVED short clip (3 real frames, 6 samples) — fewer source frames than
+    ///   `MAX_SAMPLES`-bounded samples. Also routes to the fallback and matches.
+    ///
     /// `#[ignore]` because it needs an ffmpeg binary (unset on CI runners); run with the bundled or a
     /// system ffmpeg:
     ///
     /// ```text
     /// SCENEWORKS_FFMPEG=/path/to/ffmpeg \
-    ///   cargo test -p sceneworks-worker --lib render_track_frames_single_pass -- --ignored --nocapture
+    ///   cargo test -p sceneworks-worker --lib render_track_frames_matches_per_frame -- --ignored --nocapture
     /// ```
     #[test]
     #[ignore = "needs an ffmpeg binary (SCENEWORKS_FFMPEG or ffmpeg on PATH)"]
-    fn render_track_frames_single_pass_matches_per_frame_accurate_seek() {
-        use crate::person_track::sample_timestamps;
-
+    fn render_track_frames_matches_per_frame_accurate_seek_across_fps_regimes() {
         let scratch = std::env::temp_dir().join("sw-render-track-frames-verify");
         let _ = std::fs::remove_dir_all(&scratch);
-        let seq_dir = scratch.join("seq");
-        let single_dir = scratch.join("single");
-        std::fs::create_dir_all(&seq_dir).expect("seq dir");
-        std::fs::create_dir_all(&single_dir).expect("single dir");
+        std::fs::create_dir_all(&scratch).expect("scratch dir");
+
+        // (label, rate, duration): the well-behaved high-fps case plus the sub-cadence-fps and
+        // frame-starved regimes that break the unconditional single-pass optimization.
+        let cases: &[(&str, &str, f64)] = &[
+            ("hi_30fps_4s", "30", 4.0),
+            ("lo_1fps_12s", "1", 12.0),
+            ("lo_1_5fps_12s", "1.5", 12.0),
+            ("starved_1fps_3s", "1", 3.0),
+        ];
 
         let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
         rt.block_on(async {
-            // A deterministic 4s @ 30fps synthetic clip (testsrc2), the same fixture the manual
-            // verification used. `render_frame_png` with a lavfi source has no accurate seek, so
-            // generate a real file first.
-            let src = scratch.join("src.mp4");
-            let make = run_ffmpeg(
-                vec![
-                    "ffmpeg".to_owned(),
-                    "-y".to_owned(),
-                    "-f".to_owned(),
-                    "lavfi".to_owned(),
-                    "-i".to_owned(),
-                    "testsrc2=size=320x240:rate=30:duration=4".to_owned(),
-                    "-pix_fmt".to_owned(),
-                    "yuv420p".to_owned(),
-                    src.display().to_string(),
-                ],
-                None,
-            )
-            .await;
-            if make.is_err() {
-                eprintln!("skipping: ffmpeg unavailable to build the fixture");
-                return;
-            }
-
-            let duration = 4.0;
-            let timestamps = sample_timestamps(duration);
-            assert!(timestamps.len() > 1, "fixture yields a multi-sample cadence");
-
-            // Single pass.
-            let seq_paths = render_track_frames(
-                "ffmpeg",
-                &src,
-                &seq_dir,
-                &timestamps,
-                duration,
-                1280,
-                720,
-                FfmpegContext {
-                    api: &ApiClient::new(&crate::Settings::from_env()),
-                    settings: &crate::Settings::from_env(),
-                    job_id: "render-track-frames-verify",
-                    cancel_message: "",
-                },
-            )
-            .await
-            .expect("single-pass extraction");
-            assert_eq!(seq_paths.len(), timestamps.len(), "one frame per sample");
-
-            // Per-frame accurate-seek reference (the old loop's exact seeks).
-            for (index, &timestamp) in timestamps.iter().enumerate() {
-                let path = single_dir.join(format!("frame_{index:04}.png"));
-                render_frame_png(
-                    "ffmpeg",
-                    &src,
-                    &path,
-                    frame_seek_timestamp(timestamp, duration),
-                    1280,
-                    720,
-                    None,
-                )
-                .await
-                .expect("per-frame extraction");
-                let single = std::fs::read(&path).expect("read reference frame");
-                let multi = std::fs::read(&seq_paths[index]).expect("read single-pass frame");
-                assert_eq!(
-                    single, multi,
-                    "single-pass frame {index} (t={timestamp:.4}s) differs from the accurate-seek reference"
-                );
+            for &(label, rate, duration) in cases {
+                let Some((cut, reference)) =
+                    extract_both_ways(&scratch, label, rate, duration).await
+                else {
+                    return; // ffmpeg missing → skip the whole test
+                };
+                for (index, (cut_frame, ref_frame)) in cut.iter().zip(&reference).enumerate() {
+                    assert_eq!(
+                        cut_frame, ref_frame,
+                        "{label}: render_track_frames sample {index} differs from the \
+                         accurate-seek reference (sub-cadence-fps fallback regression, sc-8915)"
+                    );
+                }
             }
         });
 
         let _ = std::fs::remove_dir_all(&scratch);
+    }
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod render_track_frame_probe_tests {
+    use super::*;
+
+    #[test]
+    fn parse_ffmpeg_frame_count_reads_the_last_padded_progress_token() {
+        // ffmpeg pads the counter and prints many progress lines; the LAST frame= wins.
+        let stderr = "frame=    1 fps=0.0 q=-1.0 size=N/A\nframe=   12 fps=0.0 q=-1.0 Lsize=N/A\n";
+        assert_eq!(parse_ffmpeg_frame_count(stderr), Some(12));
+    }
+
+    #[test]
+    fn parse_ffmpeg_frame_count_handles_no_space_and_missing_token() {
+        assert_eq!(parse_ffmpeg_frame_count("frame=120 other"), Some(120));
+        assert_eq!(parse_ffmpeg_frame_count("no counter here"), None);
     }
 }
 

--- a/crates/sceneworks-worker/src/media_jobs.rs
+++ b/crates/sceneworks-worker/src/media_jobs.rs
@@ -853,33 +853,35 @@ where
 {
     use crate::person_track as pt;
 
-    // The detector reports its real execution device per frame; `device_default` is the fallback for
-    // the zero-frame case. Keep each rendered frame (don't delete in-loop): the segmentation pass
-    // re-reads the detected target frames by the same sample index. They share the cadence, so
-    // assembly frame `i` ↔ `timestamps[i]` ↔ `frame_paths[i]`.
-    let mut device = backend.device_default;
-    let mut frame_paths: Vec<PathBuf> = Vec::with_capacity(timestamps.len());
-    let mut per_frame: Vec<(f64, Vec<(pt::NormalizedBox, f64)>)> =
-        Vec::with_capacity(timestamps.len());
-    for (index, &timestamp) in timestamps.iter().enumerate() {
-        check_cancel(api, &job.id, "Person tracking canceled during sampling.").await?;
-        let frame_path = work_dir.join(format!("frame_{index:04}.png"));
-        let ffmpeg_context = FfmpegContext {
+    // Extract every sample frame in ONE ffmpeg pass (sc-8915 / F-113) rather than spawning a
+    // process per sample. `frame_paths[i]` ↔ `timestamps[i]` ↔ the segmentation pass's sample index,
+    // exactly as the prior per-frame loop produced. The frames are kept (not deleted in-loop): the
+    // segmentation pass re-reads the detected target frames by the same index.
+    let (track_frame_width, track_frame_height) = TRACK_FRAME_SIZE;
+    let frame_paths = render_track_frames(
+        "ffmpeg",
+        source_media_path,
+        work_dir,
+        timestamps,
+        duration,
+        track_frame_width,
+        track_frame_height,
+        FfmpegContext {
             api,
             settings,
             job_id: &job.id,
             cancel_message: "Person tracking canceled by user.",
-        };
-        render_frame_png(
-            "ffmpeg",
-            source_media_path,
-            &frame_path,
-            frame_seek_timestamp(timestamp, duration),
-            1280,
-            720,
-            Some(ffmpeg_context),
-        )
-        .await?;
+        },
+    )
+    .await?;
+
+    // The detector reports its real execution device per frame; `device_default` is the fallback for
+    // the zero-frame case. Detection stays per-frame (each is one `spawn_blocking` YOLO11 forward).
+    let mut device = backend.device_default;
+    let mut per_frame: Vec<(f64, Vec<(pt::NormalizedBox, f64)>)> =
+        Vec::with_capacity(timestamps.len());
+    for (&timestamp, frame_path) in timestamps.iter().zip(&frame_paths) {
+        check_cancel(api, &job.id, "Person tracking canceled during sampling.").await?;
         let weights_for_frame = weights.to_path_buf();
         let frame_for_task = frame_path.clone();
         let result = tokio::task::spawn_blocking(move || {
@@ -906,7 +908,6 @@ where
             })
             .collect::<Vec<_>>();
         per_frame.push((timestamp, boxes));
-        frame_paths.push(frame_path);
     }
 
     let observations = pt::observe(per_frame);
@@ -2172,6 +2173,129 @@ pub(crate) fn export_request_from_job(job: &JobSnapshot) -> WorkerResult<Timelin
     })
 }
 
+/// The scale→pad→rgb24 filter chain every person-track / frame-extract sample shares. Downscales
+/// into `width×height` preserving aspect (letterboxed on the app ink color), then forces rgb24 so
+/// the detector always sees a 3-channel frame. Shared by the single-frame `render_frame_png` and the
+/// single-pass `render_track_frames` so both produce byte-identical frame geometry.
+fn frame_scale_pad_filter(width: u32, height: u32) -> String {
+    format!(
+        "scale={width}:{height}:force_original_aspect_ratio=decrease,pad={width}:{height}:(ow-iw)/2:(oh-ih)/2:color=0x12110f,format=rgb24"
+    )
+}
+
+/// Extract the person-track sample frames in ONE ffmpeg pass (sc-8915 / F-113), replacing the prior
+/// one-`ffmpeg`-process-per-sample accurate-seek loop (up to `MAX_SAMPLES` = 24 spawns per track).
+///
+/// `sample_timestamps` is a uniform cadence — evenly spaced `duration·i/(count-1)` for the interior
+/// samples, with only the final inclusive-end sample pulled inside the clip by
+/// `FRAME_SEEK_GUARD_SECONDS`. A single `select` filter over that same grid reproduces the exact
+/// frames the per-sample accurate seeks chose: `gte(t, min(selected_n·interval, last_seek))` picks,
+/// for the `selected_n`-th output frame, the first source frame whose `pts ≥` that grid point — the
+/// same "first frame `≥ T`" rule an `-ss T` accurate seek uses. `interval = duration/(count-1)`
+/// (`= 1/SAMPLE_RATE`-equivalent) is the interior step; `last_seek = frame_seek_timestamp(…)` folds
+/// the guard into the final grid point so the last sample lands on a real frame. Verified byte-exact
+/// against the old per-frame path on a synthetic clip (all sampled PNGs md5-identical).
+///
+/// The frames land as a 1-based `seq_%04d.png` image2 sequence, then are renamed to the 0-based
+/// `frame_{index:04}.png` names the segmentation pass re-reads by sample index — identical to before.
+///
+/// A single-sample cadence (`count ≤ 1`, i.e. `duration ≤ 0`) has no interval, so it falls back to
+/// one accurate-seek `render_frame_png` — the exact frame the old loop's sole iteration produced.
+/// If the source is shorter than the grid implies and ffmpeg emits fewer than `count` frames, the
+/// last real frame is cloned forward so every sample index has a readable frame (the tracker records
+/// the logical `timestamps[i]` regardless of which pixels back the final tail samples).
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+async fn render_track_frames(
+    ffmpeg: &str,
+    source_path: &Path,
+    work_dir: &Path,
+    timestamps: &[f64],
+    duration: f64,
+    width: u32,
+    height: u32,
+    context: FfmpegContext<'_>,
+) -> WorkerResult<Vec<PathBuf>> {
+    let count = timestamps.len();
+    let frame_path = |index: usize| work_dir.join(format!("frame_{index:04}.png"));
+
+    // Degenerate single-frame cadence: no interval → one accurate-seek frame (the old loop's only
+    // iteration). `frame_seek_timestamp` keeps the seek inside the clip exactly as before.
+    if count <= 1 {
+        let path = frame_path(0);
+        render_frame_png(
+            ffmpeg,
+            source_path,
+            &path,
+            frame_seek_timestamp(timestamps.first().copied().unwrap_or(0.0), duration),
+            width,
+            height,
+            Some(context),
+        )
+        .await?;
+        return Ok(vec![path]);
+    }
+
+    // Interior grid step and the guard-folded final seek — the two numbers that define the sample
+    // grid. `min(selected_n·interval, last_seek)` reproduces `frame_seek_timestamp(timestamps[i], …)`
+    // for every i: interior points pass through `selected_n·interval`, and the final point is capped
+    // at `last_seek` (the guard). ffmpeg's `min`/`gte`/`selected_n` are all in the select expression.
+    let interval = duration / (count as f64 - 1.0);
+    let last_seek = frame_seek_timestamp(*timestamps.last().unwrap_or(&duration), duration);
+    // No shell here (`run_ffmpeg` execs the binary directly), so the select expression carries no
+    // wrapping quotes — only the intra-expression commas are backslash-escaped so ffmpeg does not
+    // read them as `-vf` filter-chain separators.
+    let select = format!("select=gte(t\\,min(selected_n*{interval:.6}\\,{last_seek:.6}))");
+    let filters = format!(
+        "{select},{scale_pad}",
+        scale_pad = frame_scale_pad_filter(width, height)
+    );
+    let seq_pattern = work_dir.join("seq_%04d.png");
+    run_ffmpeg(
+        vec![
+            ffmpeg.to_owned(),
+            "-y".to_owned(),
+            "-i".to_owned(),
+            source_path.display().to_string(),
+            "-vf".to_owned(),
+            filters,
+            "-frames:v".to_owned(),
+            count.to_string(),
+            "-fps_mode".to_owned(),
+            "passthrough".to_owned(),
+            "-f".to_owned(),
+            "image2".to_owned(),
+            seq_pattern.display().to_string(),
+        ],
+        Some(context),
+    )
+    .await?;
+
+    // Rename the 1-based sequence into the 0-based sample-index names, cloning the last real frame
+    // forward for any tail index ffmpeg didn't reach (short source).
+    let mut frame_paths = Vec::with_capacity(count);
+    let mut last_written: Option<PathBuf> = None;
+    for index in 0..count {
+        let seq_path = work_dir.join(format!("seq_{:04}.png", index + 1));
+        let dest = frame_path(index);
+        if tokio::fs::try_exists(&seq_path).await? {
+            tokio::fs::rename(&seq_path, &dest).await?;
+            last_written = Some(dest.clone());
+        } else if let Some(previous) = &last_written {
+            tokio::fs::copy(previous, &dest).await?;
+        } else {
+            return Err(WorkerError::InvalidPayload(format!(
+                "FFmpeg produced no sampled frames for {}",
+                source_path.display()
+            )));
+        }
+        frame_paths.push(dest);
+    }
+    Ok(frame_paths)
+}
+
 pub(crate) async fn render_frame_png(
     ffmpeg: &str,
     source_path: &Path,
@@ -2181,9 +2305,7 @@ pub(crate) async fn render_frame_png(
     height: u32,
     context: Option<FfmpegContext<'_>>,
 ) -> WorkerResult<()> {
-    let filters = format!(
-        "scale={width}:{height}:force_original_aspect_ratio=decrease,pad={width}:{height}:(ow-iw)/2:(oh-ih)/2:color=0x12110f,format=rgb24"
-    );
+    let filters = frame_scale_pad_filter(width, height);
     run_ffmpeg(
         vec![
             ffmpeg.to_owned(),
@@ -3336,6 +3458,104 @@ mod person_track_e2e_tests {
                 mean_iou > 0.5,
                 "SAM3 vs SAM2 mean IoU {mean_iou:.3} below the parity floor (0.5)"
             );
+        });
+
+        let _ = std::fs::remove_dir_all(&scratch);
+    }
+
+    /// F-113 (sc-8915): the single-pass `render_track_frames` must select byte-identical frames to
+    /// the old one-`ffmpeg`-per-sample accurate-seek loop. Generates a deterministic synthetic clip
+    /// with real ffmpeg, extracts every sample both ways, and asserts each sampled PNG is identical.
+    /// `#[ignore]` because it needs an ffmpeg binary (unset on CI runners); run with the bundled or a
+    /// system ffmpeg:
+    ///
+    /// ```text
+    /// SCENEWORKS_FFMPEG=/path/to/ffmpeg \
+    ///   cargo test -p sceneworks-worker --lib render_track_frames_single_pass -- --ignored --nocapture
+    /// ```
+    #[test]
+    #[ignore = "needs an ffmpeg binary (SCENEWORKS_FFMPEG or ffmpeg on PATH)"]
+    fn render_track_frames_single_pass_matches_per_frame_accurate_seek() {
+        use crate::person_track::sample_timestamps;
+
+        let scratch = std::env::temp_dir().join("sw-render-track-frames-verify");
+        let _ = std::fs::remove_dir_all(&scratch);
+        let seq_dir = scratch.join("seq");
+        let single_dir = scratch.join("single");
+        std::fs::create_dir_all(&seq_dir).expect("seq dir");
+        std::fs::create_dir_all(&single_dir).expect("single dir");
+
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        rt.block_on(async {
+            // A deterministic 4s @ 30fps synthetic clip (testsrc2), the same fixture the manual
+            // verification used. `render_frame_png` with a lavfi source has no accurate seek, so
+            // generate a real file first.
+            let src = scratch.join("src.mp4");
+            let make = run_ffmpeg(
+                vec![
+                    "ffmpeg".to_owned(),
+                    "-y".to_owned(),
+                    "-f".to_owned(),
+                    "lavfi".to_owned(),
+                    "-i".to_owned(),
+                    "testsrc2=size=320x240:rate=30:duration=4".to_owned(),
+                    "-pix_fmt".to_owned(),
+                    "yuv420p".to_owned(),
+                    src.display().to_string(),
+                ],
+                None,
+            )
+            .await;
+            if make.is_err() {
+                eprintln!("skipping: ffmpeg unavailable to build the fixture");
+                return;
+            }
+
+            let duration = 4.0;
+            let timestamps = sample_timestamps(duration);
+            assert!(timestamps.len() > 1, "fixture yields a multi-sample cadence");
+
+            // Single pass.
+            let seq_paths = render_track_frames(
+                "ffmpeg",
+                &src,
+                &seq_dir,
+                &timestamps,
+                duration,
+                1280,
+                720,
+                FfmpegContext {
+                    api: &ApiClient::new(&crate::Settings::from_env()),
+                    settings: &crate::Settings::from_env(),
+                    job_id: "render-track-frames-verify",
+                    cancel_message: "",
+                },
+            )
+            .await
+            .expect("single-pass extraction");
+            assert_eq!(seq_paths.len(), timestamps.len(), "one frame per sample");
+
+            // Per-frame accurate-seek reference (the old loop's exact seeks).
+            for (index, &timestamp) in timestamps.iter().enumerate() {
+                let path = single_dir.join(format!("frame_{index:04}.png"));
+                render_frame_png(
+                    "ffmpeg",
+                    &src,
+                    &path,
+                    frame_seek_timestamp(timestamp, duration),
+                    1280,
+                    720,
+                    None,
+                )
+                .await
+                .expect("per-frame extraction");
+                let single = std::fs::read(&path).expect("read reference frame");
+                let multi = std::fs::read(&seq_paths[index]).expect("read single-pass frame");
+                assert_eq!(
+                    single, multi,
+                    "single-pass frame {index} (t={timestamp:.4}s) differs from the accurate-seek reference"
+                );
+            }
         });
 
         let _ = std::fs::remove_dir_all(&scratch);

--- a/crates/sceneworks-worker/src/media_jobs.rs
+++ b/crates/sceneworks-worker/src/media_jobs.rs
@@ -2297,26 +2297,29 @@ fn parse_ffmpeg_frame_count(stderr: &str) -> Option<usize> {
 /// `sample_timestamps` is a uniform cadence — evenly spaced `duration·i/(count-1)` for the interior
 /// samples, with only the final inclusive-end sample pulled inside the clip by
 /// `FRAME_SEEK_GUARD_SECONDS`. A single `select` filter over that same grid picks, for the
-/// `selected_n`-th output frame, the first source frame whose `pts ≥ gte(t, min(selected_n·interval,
-/// last_seek))`. `interval = duration/(count-1)` is the interior step; `last_seek =
-/// frame_seek_timestamp(…)` folds the guard into the final grid point.
+/// `selected_n`-th output frame, the first source frame whose `pts ≥ TH(selected_n)`, where
+/// `TH(n) = round(frame_seek_timestamp(timestamps[n], duration), 3)` is the EXACT same `{:.3}`-rounded
+/// seek the per-frame accurate path passes to `-ss` for sample `n`. Feeding the filter that per-sample
+/// threshold lookup (rather than a `min(selected_n·interval, last_seek)` recurrence) is what makes the
+/// single pass byte-identical, sample-for-sample, to the accurate-seek path over its whole regime.
 ///
-/// EQUIVALENCE CONDITION (why this is NOT unconditionally byte-identical): an `-ss T` accurate seek
-/// re-selects the "first frame with pts ≥ T" INDEPENDENTLY for each sample, so two close grid points
-/// with no source frame between them both resolve to the SAME earlier frame. The single `select`
-/// filter instead scans FORWARD and cannot rewind: once `selected_n` advances it consumes the next
-/// distinct frame, so those two close grid points select DISTINCT forward frames and the clip is
-/// exhausted early. The two paths therefore agree iff every grid point maps to a distinct source
-/// frame — i.e. the source has at least as many decodable frames across the sampled span as there
-/// are samples (`source_frame_count ≥ count`, equivalently source fps ≥ the `(count-1)/duration`
-/// sample cadence). Below that (low-fps screen recordings, timelapses, GIF-derived or low-fps webcam
-/// clips, or clips with fewer frames than samples) the single pass diverges — reproduced with real
-/// ffmpeg at 19–21/24 frames wrong on a 12s@1fps clip — so we take the per-frame path instead.
+/// GUARANTEE (what this function actually delivers):
+/// - **High-fps / frame-dense sources** (`source_frame_count ≥ count`): the single pass is taken and
+///   is BYTE-IDENTICAL to the per-frame accurate-seek reference. Both mechanisms compare `pts` against
+///   the identical `{:.3}` threshold, so both select the identical frame — including at grid points
+///   that align to a source frame's pts, which an earlier `{:.6}`-truncated `selected_n·interval`
+///   recurrence got wrong by an adjacent (±1) source frame (e.g. 5/16 samples off on 30fps@8s).
+/// - **Sub-cadence-fps / frame-starved sources** (`source_frame_count < count`, or an unknown probe):
+///   the forward-only single `select` would exhaust the clip early (two close grid points with no
+///   distinct source frame between them collapse to one forward frame, whereas `-ss` re-selects the
+///   same earlier frame independently), diverging grossly — reproduced with real ffmpeg at 19–21/24
+///   frames wrong on a 12s@1fps clip. So we DO NOT run the single pass there: we fall back to
+///   per-frame accurate seeks, which reproduce the exact pre-PR frames by construction.
 ///
 /// We probe the real decodable frame count with [`probe_source_frame_count`] (an ffmpeg null-mux
 /// count, VFR-safe, no `ffprobe` dependency). Single pass ONLY when the probe succeeds AND
 /// `frame_count ≥ count`; otherwise (including an unknown/failed probe) fall back to per-frame
-/// accurate seeks, which reproduce the exact pre-PR frames by construction.
+/// accurate seeks. Either way the person-detector sees the same frames the pre-optimization code did.
 ///
 /// In the single-pass path the frames land as a 1-based `seq_%04d.png` image2 sequence, then are
 /// renamed to the 0-based `frame_{index:04}.png` names the segmentation pass re-reads by sample
@@ -2381,16 +2384,81 @@ async fn render_track_frames(
         .await;
     }
 
-    // Interior grid step and the guard-folded final seek — the two numbers that define the sample
-    // grid. `min(selected_n·interval, last_seek)` reproduces `frame_seek_timestamp(timestamps[i], …)`
-    // for every i: interior points pass through `selected_n·interval`, and the final point is capped
-    // at `last_seek` (the guard). ffmpeg's `min`/`gte`/`selected_n` are all in the select expression.
-    let interval = duration / (count as f64 - 1.0);
-    let last_seek = frame_seek_timestamp(*timestamps.last().unwrap_or(&duration), duration);
+    render_track_frames_single_pass(
+        ffmpeg,
+        source_path,
+        work_dir,
+        timestamps,
+        duration,
+        width,
+        height,
+        context,
+    )
+    .await
+}
+
+/// The single ffmpeg-pass sampling path — the perf win. Split out from [`render_track_frames`] (which
+/// owns the frame-count gate) so the byte-identity of this path can be exercised directly AND so a test
+/// can drive it UNGATED on a low-fps clip to prove the gate is load-bearing (gross divergence there).
+///
+/// Builds the select predicate so the single pass lands on the SAME source frame the per-sample
+/// accurate-seek path ([`render_track_frames_per_frame`]) would, for every sample — byte-identically.
+/// The accurate path pulls sample `i` with `-ss {frame_seek_timestamp(timestamps[i], duration):.3}`,
+/// i.e. it snaps to the first frame whose `pts ≥` that `{:.3}`-rounded threshold. The single `select`
+/// filter increments `selected_n` (0-based output-frame counter) each time it fires, so we drive it off
+/// a per-sample threshold LOOKUP keyed on `selected_n` — `gte(t, TH(selected_n))` where
+/// `TH(n) = round(frame_seek_timestamp(timestamps[n], duration), 3)` is the exact same `{:.3}`-rounded
+/// seek — instead of a `min(selected_n·interval, last_seek)` recurrence.
+///
+/// Why the lookup and not the recurrence: the recurrence fed the filter a `{:.6}`-truncated
+/// `selected_n·interval`, a DIFFERENT number than the `{:.3}`-rounded `-ss` threshold, so at grid points
+/// that align to a source frame's pts the two mechanisms landed on ADJACENT frames (swept: 30fps@8s
+/// picked +1 source frame on 5/16 samples). Rounding the per-sample thresholds the exact same way the
+/// `-ss` seeks are rounded removes that divergence: both compare `pts` against an identical `{:.3}`
+/// value, so both select the identical frame. Verified byte-identical across the full high-fps sweep
+/// (30/24/60/25/29.97 fps) and at the 24-sample cap.
+///
+/// NOTE: byte-identity here holds ONLY for frame-dense sources (`source_frame_count ≥ count`); on
+/// sub-cadence-fps sources the forward-only `select` exhausts the clip early and diverges grossly, which
+/// is exactly why [`render_track_frames`] gates this path behind the probe. Callers other than the gated
+/// wrapper (i.e. tests) must respect that.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+#[allow(clippy::too_many_arguments)]
+async fn render_track_frames_single_pass(
+    ffmpeg: &str,
+    source_path: &Path,
+    work_dir: &Path,
+    timestamps: &[f64],
+    duration: f64,
+    width: u32,
+    height: u32,
+    context: FfmpegContext<'_>,
+) -> WorkerResult<Vec<PathBuf>> {
+    let count = timestamps.len();
+    let frame_path = |index: usize| work_dir.join(format!("frame_{index:04}.png"));
+    let thresholds: Vec<f64> = timestamps
+        .iter()
+        .map(|&t| {
+            // `{:.3}` here MUST match the `-ss {:.3}` rounding in `try_render_frame_png`/`render_frame_png`
+            // so the filter threshold is bit-for-bit the same seek the accurate path uses.
+            (frame_seek_timestamp(t, duration).max(0.0) * 1000.0).round() / 1000.0
+        })
+        .collect();
     // No shell here (`run_ffmpeg` execs the binary directly), so the select expression carries no
     // wrapping quotes — only the intra-expression commas are backslash-escaped so ffmpeg does not
-    // read them as `-vf` filter-chain separators.
-    let select = format!("select=gte(t\\,min(selected_n*{interval:.6}\\,{last_seek:.6}))");
+    // read them as `-vf` filter-chain separators. The lookup is a nested `if(eq(selected_n,n), th_n, …)`
+    // chain with the final threshold as the default tail (already selected once `selected_n == count-1`).
+    let mut lookup = format!("{:.3}", thresholds[count - 1]);
+    for n in (0..count - 1).rev() {
+        lookup = format!(
+            "if(eq(selected_n\\,{n})\\,{th:.3}\\,{lookup})",
+            th = thresholds[n]
+        );
+    }
+    let select = format!("select=gte(t\\,{lookup})");
     let filters = format!(
         "{select},{scale_pad}",
         scale_pad = frame_scale_pad_filter(width, height)
@@ -3659,11 +3727,13 @@ mod person_track_e2e_tests {
     }
 
     /// Extract every `timestamps[i]` two ways for one synthetic `rate`fps × `duration`s clip and
-    /// return `(single_pass_frames, accurate_seek_reference_frames)` as raw PNG bytes, so a caller
-    /// can assert they match. `render_track_frames` is the code under test (single-pass WHERE valid,
-    /// per-frame accurate-seek fallback otherwise); the reference is the pre-PR per-frame path built
-    /// directly with `render_frame_png`. Returns `None` when ffmpeg can't build the fixture (so the
-    /// test degrades to a skip rather than a false failure).
+    /// return `(gated_frames, accurate_seek_reference_frames)` as raw PNG bytes, so a caller can assert
+    /// they match. The first element is the SHIPPED `render_track_frames` (probe-gated: single-pass
+    /// where the source is frame-dense, per-frame accurate-seek fallback otherwise); the reference is
+    /// the pre-PR per-frame path built directly with `try_render_frame_png`. Byte-identity is the honest
+    /// expectation for BOTH regimes here — the gate routes each to a mechanism that lands on the same
+    /// source frame the reference does (see `render_track_frames_single_pass`). Returns `None` when
+    /// ffmpeg can't build the fixture (so the test degrades to a skip rather than a false failure).
     async fn extract_both_ways(
         scratch: &std::path::Path,
         label: &str,
@@ -3765,38 +3835,144 @@ mod person_track_e2e_tests {
         Some((cut_bytes, ref_bytes))
     }
 
-    /// F-113 (sc-8915): `render_track_frames` must select byte-identical frames to the old
-    /// one-`ffmpeg`-per-sample accurate-seek loop across every fps regime, NOT just well-behaved
-    /// high-fps sources. It generates deterministic synthetic clips with real ffmpeg and asserts each
-    /// sampled PNG matches the accurate-seek reference:
+    /// Run the UNGATED single-pass path ([`render_track_frames_single_pass`], no frame-count probe)
+    /// against the accurate-seek reference for one synthetic clip, returning `(single_pass, reference)`
+    /// PNG bytes. This is how the test proves the frame-count gate in [`render_track_frames`] is
+    /// load-bearing: on a low-fps clip the ungated single pass diverges grossly from the reference, so
+    /// deleting the gate would ship wrong frames. `None` on fixture-build failure (ffmpeg missing).
+    async fn single_pass_ungated_vs_reference(
+        scratch: &std::path::Path,
+        label: &str,
+        rate: &str,
+        duration: f64,
+    ) -> Option<(Vec<Vec<u8>>, Vec<Vec<u8>>)> {
+        use crate::person_track::sample_timestamps;
+
+        let case_dir = scratch.join(format!("{label}_ungated"));
+        let cut_dir = case_dir.join("cut");
+        std::fs::create_dir_all(&cut_dir).expect("cut dir");
+        let src = case_dir.join("src.mp4");
+        let make = run_ffmpeg(
+            vec![
+                "ffmpeg".to_owned(),
+                "-y".to_owned(),
+                "-f".to_owned(),
+                "lavfi".to_owned(),
+                "-i".to_owned(),
+                format!("testsrc2=size=320x240:rate={rate}:duration={duration}"),
+                "-pix_fmt".to_owned(),
+                "yuv420p".to_owned(),
+                src.display().to_string(),
+            ],
+            None,
+        )
+        .await;
+        if make.is_err() {
+            eprintln!("skipping {label}: ffmpeg unavailable to build the fixture");
+            return None;
+        }
+
+        let timestamps = sample_timestamps(duration);
+        // Drive the single-pass path DIRECTLY, skipping `render_track_frames`'s probe gate — this is the
+        // "single-pass always" behavior the gate exists to prevent on sub-cadence-fps sources.
+        let cut_paths = render_track_frames_single_pass(
+            "ffmpeg",
+            &src,
+            &cut_dir,
+            &timestamps,
+            duration,
+            1280,
+            720,
+            FfmpegContext {
+                api: &ApiClient::new(&crate::Settings::from_env()),
+                settings: &crate::Settings::from_env(),
+                job_id: "render-track-frames-ungated",
+                cancel_message: "",
+            },
+        )
+        .await
+        .expect("ungated single-pass extraction");
+
+        let mut cut_bytes = Vec::with_capacity(timestamps.len());
+        let mut ref_bytes = Vec::with_capacity(timestamps.len());
+        let mut last_ref: Option<Vec<u8>> = None;
+        for (index, &timestamp) in timestamps.iter().enumerate() {
+            let ref_path = case_dir.join(format!("ref_{index:04}.png"));
+            let produced = try_render_frame_png(
+                "ffmpeg",
+                &src,
+                &ref_path,
+                frame_seek_timestamp(timestamp, duration),
+                1280,
+                720,
+                None,
+            )
+            .await
+            .expect("per-frame reference extraction");
+            let bytes = if produced {
+                let b = std::fs::read(&ref_path).expect("read reference frame");
+                last_ref = Some(b.clone());
+                b
+            } else {
+                last_ref
+                    .clone()
+                    .expect("a reference frame exists before any EOF tail sample")
+            };
+            ref_bytes.push(bytes);
+            cut_bytes
+                .push(std::fs::read(&cut_paths[index]).expect("read ungated single-pass frame"));
+        }
+        Some((cut_bytes, ref_bytes))
+    }
+
+    /// F-113 (sc-8915) — the HONEST guarantee this PR ships, verified against real ffmpeg. There is no
+    /// "byte-identical across all inputs" claim: `-ss` input-seek and decode-side `select` are different
+    /// mechanisms, so this test proves exactly what the code delivers, regime by regime:
     ///
-    /// - 4s @ 30fps: the well-behaved case (source fps ≥ sample cadence). `render_track_frames` takes
-    ///   the single-pass path and it is byte-identical — the perf win we keep.
-    /// - 12s @ 1fps and 12s @ 1.5fps: sub-cadence-fps sources (12 / 18 real frames < 24 samples). The
-    ///   old, unconditional single-pass code selected 19–21/24 wrong frames here; the gated code
-    ///   falls back to per-frame accurate seeks and matches. THIS is the regression the fix closes —
-    ///   it FAILS against single-pass-always and PASSES after the fallback gate.
-    /// - 3s @ 1fps: a frame-STARVED short clip (3 real frames, 6 samples) — fewer source frames than
-    ///   `MAX_SAMPLES`-bounded samples. Also routes to the fallback and matches.
+    /// 1. SINGLE-PASS REGIME (source fps ≥ sample cadence): the gated `render_track_frames` takes the
+    ///    single pass and is BYTE-IDENTICAL to the per-frame accurate-seek reference. We build the
+    ///    `select` predicate from the SAME `{:.3}`-rounded per-sample seeks the accurate path passes to
+    ///    `-ss`, so both mechanisms land on the identical source frame — including at grid points that
+    ///    ALIGN to a source frame's pts, the boundary case the round-1 recurrence got wrong.
+    ///      - `hi_30fps_4s`: high-fps, grid points do NOT align → round-1 shipped this green by luck.
+    ///      - `aligned_30fps_8s`: 16 samples on a 30fps clip, interval 8/15 s, grid points DO align to
+    ///        source pts. Under the round-1 `{:.6}`-truncated `selected_n·interval` recurrence this was
+    ///        5/16 samples off by one ADJACENT source frame (PSNR ~12–21 dB); the per-sample rounded
+    ///        threshold lookup makes it byte-identical. This case is the whole point of round-2.
+    ///
+    /// 2. FALLBACK REGIME (source fps < sample cadence, frame-starved): the single pass is NOT safe
+    ///    here — a forward-only `select` exhausts the clip early and diverges grossly — so the gate
+    ///    routes to per-frame accurate seeks, which reproduce the pre-PR frames by construction and are
+    ///    byte-identical to the reference.
+    ///      - `lo_1fps_12s`, `lo_1_5fps_12s`: 12 / 18 real frames < 24 samples.
+    ///      - `starved_1fps_3s`: 3 real frames, 6 samples.
+    ///
+    /// 3. GATE IS LOAD-BEARING: on a low-fps clip the UNGATED single pass (bypassing the probe) must
+    ///    diverge grossly from the accurate-seek reference. We assert a large fraction of samples differ
+    ///    — so if someone deletes the frame-count gate and lets single-pass run everywhere, THIS test
+    ///    fails. That is the regression guard the round-1 gate needs and this test now enforces directly
+    ///    (round 1 only proved the gated path matches, never that the gate itself was necessary).
     ///
     /// `#[ignore]` because it needs an ffmpeg binary (unset on CI runners); run with the bundled or a
     /// system ffmpeg:
     ///
     /// ```text
-    /// SCENEWORKS_FFMPEG=/path/to/ffmpeg \
-    ///   cargo test -p sceneworks-worker --lib render_track_frames_matches_per_frame -- --ignored --nocapture
+    /// SCENEWORKS_FFMPEG=apps/desktop/ffmpeg/ffmpeg \
+    ///   cargo test -p sceneworks-worker --lib render_track_frames -- --ignored --nocapture
     /// ```
     #[test]
     #[ignore = "needs an ffmpeg binary (SCENEWORKS_FFMPEG or ffmpeg on PATH)"]
-    fn render_track_frames_matches_per_frame_accurate_seek_across_fps_regimes() {
+    fn render_track_frames_honest_guarantee_across_fps_regimes() {
         let scratch = std::env::temp_dir().join("sw-render-track-frames-verify");
         let _ = std::fs::remove_dir_all(&scratch);
         std::fs::create_dir_all(&scratch).expect("scratch dir");
 
-        // (label, rate, duration): the well-behaved high-fps case plus the sub-cadence-fps and
-        // frame-starved regimes that break the unconditional single-pass optimization.
-        let cases: &[(&str, &str, f64)] = &[
+        // (label, rate, duration): the non-aligned AND frame-ALIGNED high-fps single-pass cases, plus
+        // the sub-cadence-fps and frame-starved fallback regimes. `aligned_30fps_8s` is the boundary
+        // case the round-1 test missed (grid points land on source frame pts).
+        let gated_cases: &[(&str, &str, f64)] = &[
             ("hi_30fps_4s", "30", 4.0),
+            ("aligned_30fps_8s", "30", 8.0),
             ("lo_1fps_12s", "1", 12.0),
             ("lo_1_5fps_12s", "1.5", 12.0),
             ("starved_1fps_3s", "1", 3.0),
@@ -3804,20 +3980,47 @@ mod person_track_e2e_tests {
 
         let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
         rt.block_on(async {
-            for &(label, rate, duration) in cases {
+            // (1)+(2): the shipped, gated path is byte-identical to the accurate-seek reference in every
+            // regime (single-pass where dense, per-frame fallback where sparse).
+            for &(label, rate, duration) in gated_cases {
                 let Some((cut, reference)) =
                     extract_both_ways(&scratch, label, rate, duration).await
                 else {
                     return; // ffmpeg missing → skip the whole test
                 };
+                assert_eq!(cut.len(), reference.len(), "{label}: one frame per sample");
                 for (index, (cut_frame, ref_frame)) in cut.iter().zip(&reference).enumerate() {
                     assert_eq!(
                         cut_frame, ref_frame,
-                        "{label}: render_track_frames sample {index} differs from the \
-                         accurate-seek reference (sub-cadence-fps fallback regression, sc-8915)"
+                        "{label}: gated render_track_frames sample {index} differs from the \
+                         accurate-seek reference (sc-8915). For the single-pass regime this is the \
+                         adjacent-frame boundary bug; for the low-fps regime it means the fallback gate \
+                         regressed."
                     );
                 }
             }
+
+            // (3): prove the gate is load-bearing. UNGATED single-pass on a low-fps clip must diverge
+            // grossly from the reference — otherwise the gate would be pointless and its removal would
+            // go unnoticed. 1fps@12s is 12 real frames for 24 samples; the forward-only select exhausts
+            // the clip and mis-selects the large majority of samples.
+            let Some((ungated, reference)) =
+                single_pass_ungated_vs_reference(&scratch, "gate_proof_1fps_12s", "1", 12.0).await
+            else {
+                return;
+            };
+            let differing = ungated
+                .iter()
+                .zip(&reference)
+                .filter(|(u, r)| u != r)
+                .count();
+            assert!(
+                differing >= reference.len() / 2,
+                "ungated single-pass on 1fps@12s must diverge grossly from accurate-seek to prove the \
+                 frame-count gate is necessary, but only {differing}/{} samples differed — if this drops \
+                 to ~0 the gate has become a no-op and low-fps sources would silently regress (sc-8915)",
+                reference.len()
+            );
         });
 
         let _ = std::fs::remove_dir_all(&scratch);

--- a/crates/sceneworks-worker/src/media_jobs.rs
+++ b/crates/sceneworks-worker/src/media_jobs.rs
@@ -96,14 +96,21 @@ pub(crate) async fn run_frame_extract_job(
     Ok(())
 }
 
-pub(crate) async fn run_frame_extract(
-    api: &ApiClient,
-    settings: &Settings,
-    job: &JobSnapshot,
-) -> WorkerResult<JsonObject> {
+/// The resolved source of a frame-extract / person-detect job: the project store + path, the source
+/// asset JSON, and the on-disk media path (existence-checked). Shared prologue of both frame handlers
+/// (sc-8914 / F-112) — they resolve the same `projectId` + `sourceAssetId` identically.
+struct FrameSource {
+    store: ProjectStore,
+    project_path: PathBuf,
+    source_asset: Value,
+    source_media_path: PathBuf,
+}
+
+/// Resolve the `projectId` + `sourceAssetId` a frame job carries into a [`FrameSource`], confining the
+/// source media path with `safe_project_path` and erroring if it is missing.
+fn resolve_frame_source(settings: &Settings, job: &JobSnapshot) -> WorkerResult<FrameSource> {
     let project_id = required_payload_string(&job.payload, "projectId")?;
     let source_asset_id = required_payload_string(&job.payload, "sourceAssetId")?;
-    let timestamp = payload_f64(&job.payload, "sourceTimestamp", 0.0).clamp(0.0, 3600.0);
     let store = ProjectStore::new(settings.data_dir.clone(), "worker");
     let project = store.get_project(project_id)?;
     let project_path = PathBuf::from(project.path);
@@ -121,14 +128,59 @@ pub(crate) async fn run_frame_extract(
             source_media_path.display()
         )));
     }
+    Ok(FrameSource {
+        store,
+        project_path,
+        source_asset,
+        source_media_path,
+    })
+}
 
-    let frames_dir = project_path.join("assets").join("frames");
-    tokio::fs::create_dir_all(&frames_dir).await?;
+/// The per-frame identity handed to the asset-builder closure of [`render_frame_asset`]: the freshly
+/// rendered frame's on-disk media path, its ids, and the source path relative to the project — enough
+/// for the closure to build the `"type":"frame"` asset JSON (its recipe/lineage/detection payload).
+struct RenderedFrame {
+    asset_id: String,
+    created_at: String,
+    media_rel: String,
+    media_path: PathBuf,
+    source_rel: String,
+}
+
+/// The single resolve→render→tmp-rename→asset-JSON→sidecar+recipe→index flow shared by both frame
+/// handlers (sc-8914 / F-112). Renders one frame at `timestamp` (dims `width×height`) into
+/// `assets/frames/{date}_{filename_kind}_{suffix}.png`, promotes it out of its `.tmp.png`, posts the
+/// `Saving` progress update, guards the promotion with a cancel check that cleans up the frame on
+/// cancel, then lets `build_asset` produce the full asset JSON (it runs *after* the frame exists, so
+/// person-detect can run its detector on the rendered PNG). Writes the sidecar + recipe and indexes
+/// the asset. Returns the built asset JSON and its id for the caller's result payload.
+#[allow(clippy::too_many_arguments)]
+async fn render_frame_asset<F, Fut>(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    source: &FrameSource,
+    timestamp: f64,
+    width: u32,
+    height: u32,
+    filename_kind: &str,
+    ffmpeg_cancel_message: &str,
+    saving_progress: f64,
+    saving_message: &str,
+    promotion_cancel_message: &str,
+    build_asset: F,
+) -> WorkerResult<(String, Value)>
+where
+    F: FnOnce(RenderedFrame) -> Fut,
+    Fut: std::future::Future<Output = WorkerResult<Value>>,
+{
+    let project_path = &source.project_path;
+    tokio::fs::create_dir_all(project_path.join("assets").join("frames")).await?;
     tokio::fs::create_dir_all(project_path.join("recipes")).await?;
     let asset_id = fresh_asset_id();
     let created_at = now_rfc3339();
     let filename = format!(
-        "{}_frame_{}.png",
+        "{}_{filename_kind}_{}.png",
         &created_at[..10],
         asset_suffix(&asset_id)
     );
@@ -140,115 +192,50 @@ pub(crate) async fn run_frame_extract(
         api,
         settings,
         job_id: &job.id,
-        cancel_message: "Frame extraction canceled by user.",
+        cancel_message: ffmpeg_cancel_message,
     };
     render_frame_png(
         "ffmpeg",
-        &source_media_path,
+        &source.source_media_path,
         &temp_path,
         timestamp,
-        1920,
-        1080,
+        width,
+        height,
         Some(ffmpeg_context),
     )
     .await?;
     tokio::fs::rename(&temp_path, &media_path).await?;
+
+    let source_rel = relative_path(project_path, &source.source_media_path)?;
+    // Build the asset JSON now that the frame exists on disk (person-detect runs its detector here).
+    let asset = build_asset(RenderedFrame {
+        asset_id: asset_id.clone(),
+        created_at,
+        media_rel,
+        media_path: media_path.clone(),
+        source_rel,
+    })
+    .await?;
+
     update_job(
         api,
         &job.id,
         progress_payload(
             JobStatus::Saving,
             ProgressStage::Saving,
-            0.85,
-            "Saving extracted frame asset.",
+            saving_progress,
+            saving_message,
             None,
             None,
             None,
         ),
     )
     .await?;
-    if let Err(error) = check_cancel(
-        api,
-        &job.id,
-        "Frame extraction canceled before asset promotion.",
-    )
-    .await
-    {
+    if let Err(error) = check_cancel(api, &job.id, promotion_cancel_message).await {
         let _ = tokio::fs::remove_file(&media_path).await;
         return Err(error);
     }
 
-    let timeline_id = job
-        .payload
-        .get("timelineId")
-        .cloned()
-        .unwrap_or(Value::Null);
-    let timeline_item_id = job
-        .payload
-        .get("timelineItemId")
-        .cloned()
-        .unwrap_or(Value::Null);
-    let playhead_seconds = job
-        .payload
-        .get("playheadSeconds")
-        .cloned()
-        .unwrap_or(Value::Null);
-    let intended_use = optional_payload_string(&job.payload, "intendedUse").unwrap_or("reuse");
-    let source_display_name = source_asset
-        .get("displayName")
-        .and_then(Value::as_str)
-        .unwrap_or("clip");
-    let source_rel = relative_path(&project_path, &source_media_path)?;
-    let asset = json!({
-        "schemaVersion": 1,
-        "id": asset_id.clone(),
-        "projectId": project_id,
-        "generationSetId": Value::Null,
-        "type": "frame",
-        "displayName": format!("Frame {timestamp:.2}s from {source_display_name}"),
-        "createdAt": created_at,
-        "file": {
-            "path": media_rel,
-            "mimeType": "image/png",
-            "width": 1920,
-            "height": 1080,
-            "duration": Value::Null,
-            "fps": Value::Null
-        },
-        "status": {
-            "favorite": false,
-            "rating": 0,
-            "rejected": false,
-            "trashed": false
-        },
-        "recipe": {
-            "mode": "frame_extract",
-            "model": "timeline-frame-extract",
-            "adapter": "ffmpeg-frame-extract",
-            "prompt": format!("Extract frame at {timestamp:.2}s"),
-            "negativePrompt": "",
-            "seed": 0,
-            "loras": [],
-            "stylePreset": "none",
-            "normalizedSettings": {
-                "timelineId": timeline_id,
-                "timelineItemId": timeline_item_id,
-                "playheadSeconds": playhead_seconds,
-                "sourceTimestamp": timestamp,
-                "intendedUse": intended_use
-            },
-            "rawAdapterSettings": { "sourcePath": source_rel }
-        },
-        "lineage": {
-            "parents": [source_asset_id],
-            "sourceAssetId": source_asset_id,
-            "sourceTimestamp": timestamp,
-            "timelineId": job.payload.get("timelineId").cloned().unwrap_or(Value::Null),
-            "timelineItemId": job.payload.get("timelineItemId").cloned().unwrap_or(Value::Null),
-            "intendedUse": intended_use,
-            "jobId": job.id
-        }
-    });
     let sidecar_path = media_path.with_extension("sceneworks.json");
     write_json_value(&sidecar_path, &asset).await?;
     write_json_value(
@@ -258,7 +245,111 @@ pub(crate) async fn run_frame_extract(
         &asset["recipe"],
     )
     .await?;
-    store.index_asset_sidecar(project_id, &sidecar_path)?;
+    let project_id = required_payload_string(&job.payload, "projectId")?;
+    source.store.index_asset_sidecar(project_id, &sidecar_path)?;
+
+    Ok((asset_id, asset))
+}
+
+pub(crate) async fn run_frame_extract(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+) -> WorkerResult<JsonObject> {
+    let project_id = required_payload_string(&job.payload, "projectId")?;
+    let source_asset_id = required_payload_string(&job.payload, "sourceAssetId")?;
+    let timestamp = payload_f64(&job.payload, "sourceTimestamp", 0.0).clamp(0.0, 3600.0);
+    let source = resolve_frame_source(settings, job)?;
+
+    let intended_use = optional_payload_string(&job.payload, "intendedUse").unwrap_or("reuse");
+    let source_display_name = source
+        .source_asset
+        .get("displayName")
+        .and_then(Value::as_str)
+        .unwrap_or("clip")
+        .to_owned();
+    let (asset_id, asset) = render_frame_asset(
+        api,
+        settings,
+        job,
+        &source,
+        timestamp,
+        1920,
+        1080,
+        "frame",
+        "Frame extraction canceled by user.",
+        0.85,
+        "Saving extracted frame asset.",
+        "Frame extraction canceled before asset promotion.",
+        |frame| async move {
+            let timeline_id = job
+                .payload
+                .get("timelineId")
+                .cloned()
+                .unwrap_or(Value::Null);
+            let timeline_item_id = job
+                .payload
+                .get("timelineItemId")
+                .cloned()
+                .unwrap_or(Value::Null);
+            let playhead_seconds = job
+                .payload
+                .get("playheadSeconds")
+                .cloned()
+                .unwrap_or(Value::Null);
+            Ok(json!({
+                "schemaVersion": 1,
+                "id": frame.asset_id,
+                "projectId": project_id,
+                "generationSetId": Value::Null,
+                "type": "frame",
+                "displayName": format!("Frame {timestamp:.2}s from {source_display_name}"),
+                "createdAt": frame.created_at,
+                "file": {
+                    "path": frame.media_rel,
+                    "mimeType": "image/png",
+                    "width": 1920,
+                    "height": 1080,
+                    "duration": Value::Null,
+                    "fps": Value::Null
+                },
+                "status": {
+                    "favorite": false,
+                    "rating": 0,
+                    "rejected": false,
+                    "trashed": false
+                },
+                "recipe": {
+                    "mode": "frame_extract",
+                    "model": "timeline-frame-extract",
+                    "adapter": "ffmpeg-frame-extract",
+                    "prompt": format!("Extract frame at {timestamp:.2}s"),
+                    "negativePrompt": "",
+                    "seed": 0,
+                    "loras": [],
+                    "stylePreset": "none",
+                    "normalizedSettings": {
+                        "timelineId": timeline_id,
+                        "timelineItemId": timeline_item_id,
+                        "playheadSeconds": playhead_seconds,
+                        "sourceTimestamp": timestamp,
+                        "intendedUse": intended_use
+                    },
+                    "rawAdapterSettings": { "sourcePath": frame.source_rel }
+                },
+                "lineage": {
+                    "parents": [source_asset_id],
+                    "sourceAssetId": source_asset_id,
+                    "sourceTimestamp": timestamp,
+                    "timelineId": job.payload.get("timelineId").cloned().unwrap_or(Value::Null),
+                    "timelineItemId": job.payload.get("timelineItemId").cloned().unwrap_or(Value::Null),
+                    "intendedUse": intended_use,
+                    "jobId": job.id
+                }
+            }))
+        },
+    )
+    .await?;
 
     let mut result = JsonObject::new();
     result.insert("assetIds".to_owned(), json!([asset_id]));
@@ -366,24 +457,12 @@ pub(crate) async fn run_person_detect(
 ) -> WorkerResult<JsonObject> {
     let project_id = required_payload_string(&job.payload, "projectId")?;
     let source_asset_id = required_payload_string(&job.payload, "sourceAssetId")?;
-    let store = ProjectStore::new(settings.data_dir.clone(), "worker");
-    let project = store.get_project(project_id)?;
-    let project_path = PathBuf::from(project.path);
-    let source_asset = store.get_asset(project_id, source_asset_id)?;
-    let source_file = source_asset
-        .get("file")
-        .ok_or_else(|| WorkerError::InvalidPayload("Source asset file is missing.".to_owned()))?;
-    let source_media_rel = required_value_str(source_file, "path")?;
-    let source_media_path = safe_project_path(&project_path, source_media_rel)?;
-    if !source_media_path.exists() {
-        return Err(WorkerError::InvalidPayload(format!(
-            "Source media not found: {}",
-            source_media_path.display()
-        )));
-    }
+    let source = resolve_frame_source(settings, job)?;
 
-    let duration = source_file
-        .get("duration")
+    let duration = source
+        .source_asset
+        .get("file")
+        .and_then(|file| file.get("duration"))
         .map_or(6.0, |value| value_f64(value, 6.0))
         .clamp(0.0, 3600.0);
     let timestamp = person_detect_source_timestamp(
@@ -394,38 +473,6 @@ pub(crate) async fn run_person_detect(
         ),
         duration,
     );
-
-    let frames_dir = project_path.join("assets").join("frames");
-    tokio::fs::create_dir_all(&frames_dir).await?;
-    tokio::fs::create_dir_all(project_path.join("recipes")).await?;
-    let asset_id = fresh_asset_id();
-    let created_at = now_rfc3339();
-    let filename = format!(
-        "{}_person-frame_{}.png",
-        &created_at[..10],
-        asset_suffix(&asset_id)
-    );
-    let media_rel = format!("assets/frames/{filename}");
-    let media_path = project_path.join(&media_rel);
-    let temp_path = media_path.with_extension("tmp.png");
-
-    let ffmpeg_context = FfmpegContext {
-        api,
-        settings,
-        job_id: &job.id,
-        cancel_message: "Person detection canceled by user.",
-    };
-    render_frame_png(
-        "ffmpeg",
-        &source_media_path,
-        &temp_path,
-        timestamp,
-        1280,
-        720,
-        Some(ffmpeg_context),
-    )
-    .await?;
-    tokio::fs::rename(&temp_path, &media_path).await?;
 
     // Preview jobs (`preview: true`, claimed via the CPU worker's
     // person_detect_preview capability) keep the procedural placeholder. Real
@@ -444,120 +491,118 @@ pub(crate) async fn run_person_detect(
         .or_else(|| job.payload.get("confidence"))
         .map_or(0.25, |value| value_f64(value, 0.25))
         .clamp(0.01, 1.0);
-    let (detections, detector_model, detector_adapter, detection_active, detector_meta) =
-        if is_preview {
-            (
-                candidate_people(1280, 720, source_asset_id, timestamp),
-                "procedural-person-detector".to_owned(),
-                "procedural_person_tracking",
-                false,
-                Value::Null,
-            )
-        } else {
-            let (boxes, device) = run_yolo11_person_detect(
-                api,
-                settings,
-                http_client,
-                job,
-                media_path.clone(),
-                confidence,
-            )
-            .await?;
-            (
-                boxes,
-                "yolo11m".to_owned(),
-                "yolo11_mlx",
-                true,
-                json!({ "backend": "mlx", "device": device, "model": "yolo11m" }),
-            )
-        };
-    let source_display_name = source_asset
+    let source_display_name = source
+        .source_asset
         .get("displayName")
         .and_then(Value::as_str)
-        .unwrap_or("clip");
-    let source_rel = relative_path(&project_path, &source_media_path)?;
-    let asset = json!({
-        "schemaVersion": 1,
-        "id": asset_id.clone(),
-        "projectId": project_id,
-        "generationSetId": Value::Null,
-        "type": "frame",
-        "displayName": format!("Person selection frame from {source_display_name}"),
-        "createdAt": created_at,
-        "file": {
-            "path": media_rel,
-            "mimeType": "image/png",
-            "width": 1280,
-            "height": 720,
-            "duration": Value::Null,
-            "fps": Value::Null
-        },
-        "status": {
-            "favorite": false,
-            "rating": 0,
-            "rejected": false,
-            "trashed": false
-        },
-        "recipe": {
-            "mode": "person_detect",
-            "model": detector_model,
-            "adapter": detector_adapter,
-            "prompt": "Detect selectable people in representative frame",
-            "negativePrompt": "",
-            "seed": 0,
-            "loras": [],
-            "stylePreset": "none",
-            "normalizedSettings": {
-                "sourceTimestamp": timestamp,
-                "detectionCount": detections.len(),
-                "confidence": confidence,
-                "personDetectionActive": detection_active,
-                "detector": detector_meta
-            },
-            "rawAdapterSettings": { "sourcePath": source_rel }
-        },
-        "lineage": {
-            "parents": [source_asset_id],
-            "sourceAssetId": source_asset_id,
-            "sourceTimestamp": timestamp,
-            "jobId": job.id
-        }
-    });
+        .unwrap_or("clip")
+        .to_owned();
 
-    update_job(
+    // The detector runs inside the asset-builder (it needs the rendered frame on disk), but its
+    // outputs also feed the outer result payload — stash them through a `RefCell` (the builder future
+    // is awaited inline on this task, never spawned, so no `Send`/thread-safety is needed).
+    let detections_out: std::cell::RefCell<Vec<Value>> = std::cell::RefCell::new(Vec::new());
+    let detection_active_out = std::cell::Cell::new(false);
+    // Capture the stash cells by reference so the `async move` builder body can `move` the owned
+    // `frame` fields in without also consuming the cells (read back after the builder returns).
+    let detections_out_ref = &detections_out;
+    let detection_active_out_ref = &detection_active_out;
+    let (asset_id, asset) = render_frame_asset(
         api,
-        &job.id,
-        progress_payload(
-            JobStatus::Saving,
-            ProgressStage::Saving,
-            0.78,
-            "Saving representative frame and candidate boxes.",
-            None,
-            None,
-            None,
-        ),
-    )
-    .await?;
-    if let Err(error) = check_cancel(
-        api,
-        &job.id,
+        settings,
+        job,
+        &source,
+        timestamp,
+        1280,
+        720,
+        "person-frame",
+        "Person detection canceled by user.",
+        0.78,
+        "Saving representative frame and candidate boxes.",
         "Person detection canceled before asset promotion.",
-    )
-    .await
-    {
-        let _ = tokio::fs::remove_file(&media_path).await;
-        return Err(error);
-    }
-    let sidecar_path = media_path.with_extension("sceneworks.json");
-    write_json_value(&sidecar_path, &asset).await?;
-    write_json_value(
-        &project_path
-            .join("recipes")
-            .join(format!("{asset_id}.recipe.json")),
-        &asset["recipe"],
+        |frame| async move {
+            let (detections, detector_model, detector_adapter, detection_active, detector_meta) =
+                if is_preview {
+                    (
+                        candidate_people(1280, 720, source_asset_id, timestamp),
+                        "procedural-person-detector".to_owned(),
+                        "procedural_person_tracking",
+                        false,
+                        Value::Null,
+                    )
+                } else {
+                    let (boxes, device) = run_yolo11_person_detect(
+                        api,
+                        settings,
+                        http_client,
+                        job,
+                        frame.media_path.clone(),
+                        confidence,
+                    )
+                    .await?;
+                    (
+                        boxes,
+                        "yolo11m".to_owned(),
+                        "yolo11_mlx",
+                        true,
+                        json!({ "backend": "mlx", "device": device, "model": "yolo11m" }),
+                    )
+                };
+            let asset = json!({
+                "schemaVersion": 1,
+                "id": frame.asset_id,
+                "projectId": project_id,
+                "generationSetId": Value::Null,
+                "type": "frame",
+                "displayName": format!("Person selection frame from {source_display_name}"),
+                "createdAt": frame.created_at,
+                "file": {
+                    "path": frame.media_rel,
+                    "mimeType": "image/png",
+                    "width": 1280,
+                    "height": 720,
+                    "duration": Value::Null,
+                    "fps": Value::Null
+                },
+                "status": {
+                    "favorite": false,
+                    "rating": 0,
+                    "rejected": false,
+                    "trashed": false
+                },
+                "recipe": {
+                    "mode": "person_detect",
+                    "model": detector_model,
+                    "adapter": detector_adapter,
+                    "prompt": "Detect selectable people in representative frame",
+                    "negativePrompt": "",
+                    "seed": 0,
+                    "loras": [],
+                    "stylePreset": "none",
+                    "normalizedSettings": {
+                        "sourceTimestamp": timestamp,
+                        "detectionCount": detections.len(),
+                        "confidence": confidence,
+                        "personDetectionActive": detection_active,
+                        "detector": detector_meta
+                    },
+                    "rawAdapterSettings": { "sourcePath": frame.source_rel }
+                },
+                "lineage": {
+                    "parents": [source_asset_id],
+                    "sourceAssetId": source_asset_id,
+                    "sourceTimestamp": timestamp,
+                    "jobId": job.id
+                }
+            });
+            *detections_out_ref.borrow_mut() = detections;
+            detection_active_out_ref.set(detection_active);
+            Ok(asset)
+        },
     )
     .await?;
-    store.index_asset_sidecar(project_id, &sidecar_path)?;
+    let detections = detections_out.into_inner();
+    let detection_active = detection_active_out.get();
 
     let mut result = JsonObject::new();
     result.insert("frameAssetId".to_owned(), Value::String(asset_id));
@@ -2208,6 +2253,7 @@ fn frame_scale_pad_filter(width: u32, height: u32) -> String {
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
+#[allow(clippy::too_many_arguments)]
 async fn render_track_frames(
     ffmpeg: &str,
     source_path: &Path,
@@ -2894,6 +2940,23 @@ mod frame_seek_tests {
         // A clip shorter than the guard clamps to 0 rather than a negative seek.
         assert_eq!(frame_seek_timestamp(0.1, 0.1), 0.0);
         assert_eq!(frame_seek_timestamp(0.0, 0.0), 0.0);
+    }
+
+    /// F-112 (sc-8914): the sidecar sample-rate the media handlers record and the cadence the
+    /// `person_track` sampler uses are ONE value. The `PERSON_TRACK_*` crate constants must stay
+    /// aliases of the `person_track` module constants so the two can never drift out of sync.
+    #[test]
+    fn person_track_sample_constants_are_a_single_source_of_truth() {
+        assert_eq!(
+            PERSON_TRACK_SAMPLE_RATE_FPS,
+            crate::person_track::SAMPLE_RATE_FPS,
+            "sidecar sampleRateFps must equal the sampler cadence"
+        );
+        assert_eq!(
+            PERSON_TRACK_MAX_SAMPLES,
+            crate::person_track::MAX_SAMPLES,
+            "the placeholder-track sample cap must equal the sampler cap"
+        );
     }
 }
 

--- a/crates/sceneworks-worker/src/media_jobs.rs
+++ b/crates/sceneworks-worker/src/media_jobs.rs
@@ -783,7 +783,12 @@ where
     let conf = confidence as f32;
     let timestamps = pt::sample_timestamps(duration);
 
-    let work_dir = std::env::temp_dir().join(format!("sw-person-track-{}", job.id));
+    // Sanitize the job id before it becomes a temp-dir path component (F-111): a hostile id
+    // (`../…`, absolute, separators) would otherwise escape `temp_dir()` and stage frames at an
+    // attacker-chosen path. `safe_download_dir` slugs every non-`[A-Za-z0-9_.-]` char, matching
+    // the timeline-export convention (`sceneworks_export_{safe_download_dir(job.id)}` above).
+    let work_dir =
+        std::env::temp_dir().join(format!("sw-person-track-{}", safe_download_dir(&job.id)));
     tokio::fs::create_dir_all(&work_dir).await?;
 
     // Run the fallible sampling/assembly/segmentation body, then remove `work_dir` on EVERY

--- a/crates/sceneworks-worker/src/media_jobs.rs
+++ b/crates/sceneworks-worker/src/media_jobs.rs
@@ -246,7 +246,9 @@ where
     )
     .await?;
     let project_id = required_payload_string(&job.payload, "projectId")?;
-    source.store.index_asset_sidecar(project_id, &sidecar_path)?;
+    source
+        .store
+        .index_asset_sidecar(project_id, &sidecar_path)?;
 
     Ok((asset_id, asset))
 }
@@ -3074,10 +3076,7 @@ mod person_track_e2e_tests {
         let mut per_frame: Vec<(f64, Vec<(crate::person_track::NormalizedBox, f64)>)> =
             Vec::with_capacity(timestamps.len());
         let mut frame_paths: Vec<PathBuf> = Vec::with_capacity(timestamps.len());
-        let frames_dir = download_context
-            .settings
-            .data_dir
-            .join("person-e2e-frames");
+        let frames_dir = download_context.settings.data_dir.join("person-e2e-frames");
         std::fs::create_dir_all(&frames_dir).expect("frames dir");
         for (index, &timestamp) in timestamps.iter().enumerate() {
             let frame_path = frames_dir.join(format!("frame_{index:04}.png"));

--- a/crates/sceneworks-worker/src/media_jobs.rs
+++ b/crates/sceneworks-worker/src/media_jobs.rs
@@ -153,9 +153,12 @@ struct RenderedFrame {
 /// `Saving` progress update, guards the promotion with a cancel check that cleans up the frame on
 /// cancel, then lets `build_asset` produce the full asset JSON (it runs *after* the frame exists, so
 /// person-detect can run its detector on the rendered PNG). Writes the sidecar + recipe and indexes
-/// the asset. Returns the built asset JSON and its id for the caller's result payload.
+/// the asset. Returns the asset id, the built asset JSON, and any per-handler `extra` the builder
+/// produced alongside it (the detection payload for person-detect, `()` for frame-extract) — passed
+/// back through the return value rather than stashed in an interior-mutability cell, so the handler
+/// future stays `Send` for the job dispatcher's `tokio::spawn`.
 #[allow(clippy::too_many_arguments)]
-async fn render_frame_asset<F, Fut>(
+async fn render_frame_asset<F, Fut, T>(
     api: &ApiClient,
     settings: &Settings,
     job: &JobSnapshot,
@@ -169,10 +172,10 @@ async fn render_frame_asset<F, Fut>(
     saving_message: &str,
     promotion_cancel_message: &str,
     build_asset: F,
-) -> WorkerResult<(String, Value)>
+) -> WorkerResult<(String, Value, T)>
 where
     F: FnOnce(RenderedFrame) -> Fut,
-    Fut: std::future::Future<Output = WorkerResult<Value>>,
+    Fut: std::future::Future<Output = WorkerResult<(Value, T)>>,
 {
     let project_path = &source.project_path;
     tokio::fs::create_dir_all(project_path.join("assets").join("frames")).await?;
@@ -208,7 +211,7 @@ where
 
     let source_rel = relative_path(project_path, &source.source_media_path)?;
     // Build the asset JSON now that the frame exists on disk (person-detect runs its detector here).
-    let asset = build_asset(RenderedFrame {
+    let (asset, extra) = build_asset(RenderedFrame {
         asset_id: asset_id.clone(),
         created_at,
         media_rel,
@@ -250,7 +253,7 @@ where
         .store
         .index_asset_sidecar(project_id, &sidecar_path)?;
 
-    Ok((asset_id, asset))
+    Ok((asset_id, asset, extra))
 }
 
 pub(crate) async fn run_frame_extract(
@@ -270,7 +273,7 @@ pub(crate) async fn run_frame_extract(
         .and_then(Value::as_str)
         .unwrap_or("clip")
         .to_owned();
-    let (asset_id, asset) = render_frame_asset(
+    let (asset_id, asset, ()) = render_frame_asset(
         api,
         settings,
         job,
@@ -299,7 +302,8 @@ pub(crate) async fn run_frame_extract(
                 .get("playheadSeconds")
                 .cloned()
                 .unwrap_or(Value::Null);
-            Ok(json!({
+            Ok((
+                json!({
                 "schemaVersion": 1,
                 "id": frame.asset_id,
                 "projectId": project_id,
@@ -348,7 +352,9 @@ pub(crate) async fn run_frame_extract(
                     "intendedUse": intended_use,
                     "jobId": job.id
                 }
-            }))
+                }),
+                (),
+            ))
         },
     )
     .await?;
@@ -500,16 +506,10 @@ pub(crate) async fn run_person_detect(
         .unwrap_or("clip")
         .to_owned();
 
-    // The detector runs inside the asset-builder (it needs the rendered frame on disk), but its
-    // outputs also feed the outer result payload — stash them through a `RefCell` (the builder future
-    // is awaited inline on this task, never spawned, so no `Send`/thread-safety is needed).
-    let detections_out: std::cell::RefCell<Vec<Value>> = std::cell::RefCell::new(Vec::new());
-    let detection_active_out = std::cell::Cell::new(false);
-    // Capture the stash cells by reference so the `async move` builder body can `move` the owned
-    // `frame` fields in without also consuming the cells (read back after the builder returns).
-    let detections_out_ref = &detections_out;
-    let detection_active_out_ref = &detection_active_out;
-    let (asset_id, asset) = render_frame_asset(
+    // The detector runs inside the asset-builder (it needs the rendered frame on disk); its outputs
+    // also feed the outer result payload, so the builder returns them as the `extra` tuple alongside
+    // the asset JSON (keeping the handler future `Send` for the dispatcher's `tokio::spawn`).
+    let (asset_id, asset, (detections, detection_active)) = render_frame_asset(
         api,
         settings,
         job,
@@ -597,14 +597,10 @@ pub(crate) async fn run_person_detect(
                     "jobId": job.id
                 }
             });
-            *detections_out_ref.borrow_mut() = detections;
-            detection_active_out_ref.set(detection_active);
-            Ok(asset)
+            Ok((asset, (detections, detection_active)))
         },
     )
     .await?;
-    let detections = detections_out.into_inner();
-    let detection_active = detection_active_out.get();
 
     let mut result = JsonObject::new();
     result.insert("frameAssetId".to_owned(), Value::String(asset_id));

--- a/crates/sceneworks-worker/src/media_jobs.rs
+++ b/crates/sceneworks-worker/src/media_jobs.rs
@@ -2622,7 +2622,7 @@ pub(crate) async fn mux_segments(
         .skip(1)
         .any(|segment| segment.transition.as_deref() == Some("crossfade"))
     {
-        return mux_with_crossfades(ffmpeg, segments, tmp_path, output_path, context).await;
+        return mux_with_crossfades(ffmpeg, segments, output_path, context).await;
     }
     let list_path = tmp_path.join("concat.txt");
     tokio::fs::write(
@@ -2649,10 +2649,12 @@ pub(crate) async fn mux_segments(
     .await
 }
 
+/// Mux crossfade timelines in one `xfade`/`concat` filter graph (sc-8955 / F-153: dropped the unused
+/// `_tmp_path` — the crossfade path builds no intermediate concat list, unlike the plain `mux_segments`
+/// copy path, so it never needed the scratch dir).
 pub(crate) async fn mux_with_crossfades(
     ffmpeg: &str,
     segments: &[TimelineSegment],
-    _tmp_path: &Path,
     output_path: &Path,
     context: Option<FfmpegContext<'_>>,
 ) -> WorkerResult<()> {
@@ -3043,6 +3045,162 @@ mod person_track_e2e_tests {
             .clamp(1.0, 3600.0)
     }
 
+    /// The assembled, ready-to-segment clip both segmenter E2E tests share (sc-8955 / F-153): the
+    /// YOLO11 detect → ByteTrack assemble result plus the `first..=last` detected-span clip paths and
+    /// per-frame box anchors the SAM2 / SAM3 propagation calls consume.
+    struct AssembledClip {
+        detected_total: usize,
+        first: usize,
+        last: usize,
+        clip_paths: Vec<PathBuf>,
+        anchors: Vec<Option<(f64, f64, f64, f64)>>,
+    }
+
+    /// Provision the real YOLO11 detector, sample + detect every cadence frame exactly as
+    /// `assemble_real_person_track` does, select the single highest-confidence detection (the clear
+    /// person a user would click), and assemble the ByteTrack identity. Returns the `first..=last`
+    /// detected-span clip paths + anchors ready to hand to a segmenter. Extracted from the ~100
+    /// identical setup lines the SAM2 and SAM3 E2E tests each carried (sc-8955 / F-153).
+    async fn detect_and_assemble(
+        settings: &crate::Settings,
+        download_context: &DownloadContext<'_>,
+        video: &std::path::Path,
+        duration: f64,
+        timestamps: &[f64],
+    ) -> AssembledClip {
+        let det_weights = crate::person_jobs::ensure_detector_weights(settings, download_context)
+            .await
+            .expect("yolo11 weights provisioned");
+        let mut per_frame: Vec<(f64, Vec<(crate::person_track::NormalizedBox, f64)>)> =
+            Vec::with_capacity(timestamps.len());
+        let mut frame_paths: Vec<PathBuf> = Vec::with_capacity(timestamps.len());
+        let frames_dir = download_context
+            .settings
+            .data_dir
+            .join("person-e2e-frames");
+        std::fs::create_dir_all(&frames_dir).expect("frames dir");
+        for (index, &timestamp) in timestamps.iter().enumerate() {
+            let frame_path = frames_dir.join(format!("frame_{index:04}.png"));
+            render_frame_png(
+                "ffmpeg",
+                video,
+                &frame_path,
+                frame_seek_timestamp(timestamp, duration),
+                1280,
+                720,
+                None,
+            )
+            .await
+            .expect("ffmpeg renders the sample frame");
+            let weights_for_frame = det_weights.clone();
+            let frame_for_task = frame_path.clone();
+            let result = tokio::task::spawn_blocking(move || {
+                crate::person_jobs::detect_people_blocking(weights_for_frame, frame_for_task, 0.25)
+            })
+            .await
+            .expect("detect task joins")
+            .expect("yolo11 detection runs");
+            let boxes = result
+                .detections
+                .iter()
+                .map(|d| {
+                    (
+                        crate::person_track::xyxy_to_normalized(
+                            d.x1 as f64,
+                            d.y1 as f64,
+                            d.x2 as f64,
+                            d.y2 as f64,
+                            result.width,
+                            result.height,
+                        ),
+                        d.score as f64,
+                    )
+                })
+                .collect::<Vec<_>>();
+            per_frame.push((timestamp, boxes));
+            frame_paths.push(frame_path);
+        }
+
+        // Per-frame detection summary, so a failed lock is legible.
+        for (timestamp, boxes) in &per_frame {
+            let max_conf = boxes.iter().map(|b| b.1).fold(0.0_f64, f64::max);
+            eprintln!(
+                "  t={timestamp:>6.3}s  detections={}  maxConf={max_conf:.3}",
+                boxes.len()
+            );
+        }
+        let total_detections: usize = per_frame.iter().map(|(_, boxes)| boxes.len()).sum();
+        assert!(
+            total_detections > 0,
+            "YOLO11 found no people in any sampled frame — is the clip a person video?"
+        );
+
+        // The single highest-confidence detection across all frames — the tracker only confirms a
+        // new identity from a high-confidence box, so the selection must be one.
+        let (selected_timestamp, selected_box, selected_conf) = per_frame
+            .iter()
+            .flat_map(|(timestamp, boxes)| boxes.iter().map(move |b| (*timestamp, b.0, b.1)))
+            .max_by(|a, b| {
+                a.2.partial_cmp(&b.2)
+                    .expect("detection confidence is finite")
+            })
+            .expect("at least one detection exists");
+        eprintln!(
+            "selection: t={selected_timestamp:.3}s conf={selected_conf:.3} \
+             box=({:.3},{:.3},{:.3},{:.3})",
+            selected_box.x, selected_box.y, selected_box.width, selected_box.height
+        );
+        assert!(
+            selected_conf >= 0.5,
+            "best detection conf {selected_conf:.3} is below the tracker's high-confidence \
+             floor (0.5) — the clip never yields a confidently-trackable person"
+        );
+
+        let observations = crate::person_track::observe(per_frame);
+        let assembly = crate::person_track::assemble_track(
+            &observations,
+            selected_box,
+            selected_timestamp,
+            timestamps,
+        );
+        assert!(
+            assembly.target_track_id.is_some(),
+            "tracker failed to lock onto the selected person"
+        );
+        let detected_total = assembly.frames.iter().filter(|f| f.detected).count();
+        assert!(detected_total > 0, "no detected target frames to segment");
+
+        let first = assembly
+            .frames
+            .iter()
+            .position(|f| f.detected)
+            .expect("a detected frame exists");
+        let last = assembly
+            .frames
+            .iter()
+            .rposition(|f| f.detected)
+            .unwrap_or(first);
+        let mut clip_paths = Vec::new();
+        let mut anchors = Vec::new();
+        for (frame, path) in assembly.frames[first..=last]
+            .iter()
+            .zip(&frame_paths[first..=last])
+        {
+            clip_paths.push(path.clone());
+            anchors.push(frame.detected.then(|| {
+                let b = &frame.box_;
+                (b.x, b.y, b.width, b.height)
+            }));
+        }
+        AssembledClip {
+            detected_total,
+            first,
+            last,
+            clip_paths,
+            anchors,
+        }
+    }
+
     #[test]
     #[ignore = "real Mac E2E: set SCENEWORKS_PERSON_E2E_VIDEO to a person clip; downloads YOLO11 + SAM2 weights; Apple Silicon only"]
     fn person_track_e2e_detect_track_segment_writes_masks_and_active_state() {
@@ -3053,179 +3211,52 @@ mod person_track_e2e_tests {
             return;
         };
 
-        // Isolated scratch: a throwaway data dir (weights cache) + a fake project root the
-        // segmentation pass writes masks into, exactly as `run_person_track` would.
+        // Isolated scratch: a throwaway data dir (weights + frame cache resolve under it).
         let scratch = std::env::temp_dir().join("sw-person-track-e2e");
         let _ = std::fs::remove_dir_all(&scratch);
-        let data_dir = scratch.join("data");
-        let project_path = scratch.join("project");
-        let frames_dir = scratch.join("frames");
-        std::fs::create_dir_all(&project_path).expect("project dir");
-        std::fs::create_dir_all(&frames_dir).expect("frames dir");
         // `ensure_*_weights` resolve their cache under `settings.data_dir`.
-        std::env::set_var("SCENEWORKS_DATA_DIR", &data_dir);
+        std::env::set_var("SCENEWORKS_DATA_DIR", scratch.join("data"));
         let settings = crate::Settings::from_env();
 
-        let timestamps = crate::person_track::sample_timestamps(staged_duration());
+        let duration = staged_duration();
+        let timestamps = crate::person_track::sample_timestamps(duration);
         assert!(!timestamps.is_empty(), "sample cadence produced no frames");
 
         let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
         rt.block_on(async {
             let http = reqwest::Client::new();
             let api = ApiClient::new(&settings);
-            let job_id = "person-track-e2e";
             let download_context = DownloadContext {
                 api: &api,
                 client: &http,
                 settings: &settings,
-                job_id,
+                job_id: "person-track-e2e",
                 cancel_message: "person track e2e canceled while fetching weights",
                 fresh_download: false,
             };
 
-            // 1. Provision the real detector weights (download-on-first-use), then sample +
-            //    detect each frame exactly as `assemble_real_person_track` does.
-            let det_weights =
-                crate::person_jobs::ensure_detector_weights(&settings, &download_context)
-                    .await
-                    .expect("yolo11 weights provisioned");
-            let mut per_frame: Vec<(f64, Vec<(crate::person_track::NormalizedBox, f64)>)> =
-                Vec::with_capacity(timestamps.len());
-            let mut frame_paths: Vec<PathBuf> = Vec::with_capacity(timestamps.len());
-            for (index, &timestamp) in timestamps.iter().enumerate() {
-                let frame_path = frames_dir.join(format!("frame_{index:04}.png"));
-                render_frame_png(
-                    "ffmpeg",
-                    &video,
-                    &frame_path,
-                    frame_seek_timestamp(timestamp, staged_duration()),
-                    1280,
-                    720,
-                    None,
-                )
-                .await
-                .expect("ffmpeg renders the sample frame");
-                let weights_for_frame = det_weights.clone();
-                let frame_for_task = frame_path.clone();
-                let result = tokio::task::spawn_blocking(move || {
-                    crate::person_jobs::detect_people_blocking(
-                        weights_for_frame,
-                        frame_for_task,
-                        0.25,
-                    )
-                })
-                .await
-                .expect("detect task joins")
-                .expect("yolo11 detection runs");
-                let boxes = result
-                    .detections
-                    .iter()
-                    .map(|d| {
-                        (
-                            crate::person_track::xyxy_to_normalized(
-                                d.x1 as f64,
-                                d.y1 as f64,
-                                d.x2 as f64,
-                                d.y2 as f64,
-                                result.width,
-                                result.height,
-                            ),
-                            d.score as f64,
-                        )
-                    })
-                    .collect::<Vec<_>>();
-                per_frame.push((timestamp, boxes));
-                frame_paths.push(frame_path);
-            }
-
-            // Per-frame detection summary, so a failed lock is legible (e.g. a person who
-            // never clears the tracker's high-confidence threshold).
-            for (timestamp, boxes) in &per_frame {
-                let max_conf = boxes.iter().map(|b| b.1).fold(0.0_f64, f64::max);
-                eprintln!(
-                    "  t={timestamp:>6.3}s  detections={}  maxConf={max_conf:.3}",
-                    boxes.len()
-                );
-            }
-            let total_detections: usize = per_frame.iter().map(|(_, boxes)| boxes.len()).sum();
-            assert!(
-                total_detections > 0,
-                "YOLO11 found no people in any sampled frame — is the clip a person video?"
-            );
-
-            // 2. Select the single highest-confidence detection across all frames — the
-            //    clear, lockable person a user would click (robust to early low-confidence
-            //    false positives on textured scenes like waves). The tracker only confirms a
-            //    new identity from a high-confidence box, so the selection must be one.
-            let (selected_timestamp, selected_box, selected_conf) = per_frame
-                .iter()
-                .flat_map(|(timestamp, boxes)| boxes.iter().map(move |b| (*timestamp, b.0, b.1)))
-                .max_by(|a, b| {
-                    a.2.partial_cmp(&b.2)
-                        .expect("detection confidence is finite")
-                })
-                .expect("at least one detection exists");
-            eprintln!(
-                "selection: t={selected_timestamp:.3}s conf={selected_conf:.3} \
-                 box=({:.3},{:.3},{:.3},{:.3})",
-                selected_box.x, selected_box.y, selected_box.width, selected_box.height
-            );
-            assert!(
-                selected_conf >= 0.5,
-                "best detection conf {selected_conf:.3} is below the tracker's high-confidence \
-                 floor (0.5) — the clip never yields a confidently-trackable person"
-            );
-
-            let observations = crate::person_track::observe(per_frame);
-            let assembly = crate::person_track::assemble_track(
-                &observations,
-                selected_box,
-                selected_timestamp,
-                &timestamps,
-            );
-            assert!(
-                assembly.target_track_id.is_some(),
-                "tracker failed to lock onto the selected person"
-            );
-            let detected_total = assembly
-                .frames
-                .iter()
-                .filter(|frame| frame.detected)
-                .count();
-            assert!(detected_total > 0, "no detected target frames to segment");
+            // 1-2. Detect + assemble the selected person (shared with the SAM3 E2E, sc-8955).
+            let clip =
+                detect_and_assemble(&settings, &download_context, &video, duration, &timestamps)
+                    .await;
+            let AssembledClip {
+                detected_total,
+                first,
+                last,
+                clip_paths,
+                anchors,
+            } = clip;
+            // Which clip frames are detected (Some anchor) — used to count the rollup after the
+            // anchors move into the propagate task.
+            let clip_detected: Vec<bool> = anchors.iter().map(Option::is_some).collect();
+            let gap_frames = clip_detected.iter().filter(|d| !**d).count();
 
             // 3. Provision the real SAM2 weights and propagate the person's mask across the
-            //    detected span with the video predictor (sc-3715), writing masks under
-            //    `person-tracks/{track_id}/masks/` (the production layout).
+            //    detected span with the video predictor (sc-3715).
             let seg_weights =
                 crate::person_segment::ensure_segmenter_weights(&settings, &download_context)
                     .await
                     .expect("sam2 weights provisioned");
-
-            let first = assembly
-                .frames
-                .iter()
-                .position(|f| f.detected)
-                .expect("a detected frame exists");
-            let last = assembly
-                .frames
-                .iter()
-                .rposition(|f| f.detected)
-                .unwrap_or(first);
-            let mut clip_paths = Vec::new();
-            let mut anchors = Vec::new();
-            for (frame, path) in assembly.frames[first..=last]
-                .iter()
-                .zip(&frame_paths[first..=last])
-            {
-                clip_paths.push(path.clone());
-                anchors.push(frame.detected.then(|| {
-                    let b = &frame.box_;
-                    (b.x, b.y, b.width, b.height)
-                }));
-            }
-            let gap_frames = anchors.iter().filter(|a| a.is_none()).count();
-
             let masks = tokio::task::spawn_blocking(move || {
                 crate::person_segment::propagate_track_blocking(
                     seg_weights,
@@ -3244,34 +3275,26 @@ mod person_track_e2e_tests {
             // person, not a blank map); count detected frames masked for the rollup.
             let mut generated = 0usize;
             for (clip_idx, pixels) in masks.iter().enumerate() {
-                let assembly_idx = first + clip_idx;
                 let foreground = pixels.iter().filter(|&&p| p > 127).count();
                 assert_eq!(
                     pixels.len(),
                     (1280 * 720) as usize,
                     "mask must match the rendered frame size"
                 );
-                if assembly.frames[assembly_idx].detected {
+                if clip_detected[clip_idx] {
                     assert!(
                         foreground > 0,
-                        "frame {assembly_idx} mask has no foreground — propagation lost the person"
+                        "clip frame {clip_idx} mask has no foreground — propagation lost the person"
                     );
                     generated += 1;
                 }
             }
 
-            // 4. The maskState rollup must report `active` — every detected frame masked — which
-            //    is the success signal `run_person_track` writes to the sidecar.
+            // 4. The maskState rollup must report `active` — every detected frame masked.
             let mask_state = mask_rollup_state(generated, detected_total);
             eprintln!(
-                "person-track E2E: sampled={} detected={} span={}..={} gapFrames={} segmented={} maskState={}",
-                timestamps.len(),
-                detected_total,
-                first,
-                last,
-                gap_frames,
-                generated,
-                mask_state
+                "person-track E2E: detected={} span={}..={} gapFrames={} segmented={} maskState={}",
+                detected_total, first, last, gap_frames, generated, mask_state
             );
             assert_eq!(
                 generated, detected_total,
@@ -3310,12 +3333,10 @@ mod person_track_e2e_tests {
         };
         let scratch = std::env::temp_dir().join("sw-person-track-e2e-sam3");
         let _ = std::fs::remove_dir_all(&scratch);
-        let data_dir = scratch.join("data");
-        let frames_dir = scratch.join("frames");
-        std::fs::create_dir_all(&frames_dir).expect("frames dir");
-        std::env::set_var("SCENEWORKS_DATA_DIR", &data_dir);
+        std::env::set_var("SCENEWORKS_DATA_DIR", scratch.join("data"));
         let settings = crate::Settings::from_env();
-        let timestamps = crate::person_track::sample_timestamps(staged_duration());
+        let duration = staged_duration();
+        let timestamps = crate::person_track::sample_timestamps(duration);
         assert!(!timestamps.is_empty(), "sample cadence produced no frames");
 
         let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
@@ -3331,96 +3352,16 @@ mod person_track_e2e_tests {
                 fresh_download: false,
             };
 
-            // detect → track → assemble (identical to the SAM2 E2E above).
-            let det_weights =
-                crate::person_jobs::ensure_detector_weights(&settings, &download_context)
-                    .await
-                    .expect("yolo11 weights provisioned");
-            let mut per_frame: Vec<(f64, Vec<(crate::person_track::NormalizedBox, f64)>)> =
-                Vec::with_capacity(timestamps.len());
-            let mut frame_paths: Vec<PathBuf> = Vec::with_capacity(timestamps.len());
-            for (index, &timestamp) in timestamps.iter().enumerate() {
-                let frame_path = frames_dir.join(format!("frame_{index:04}.png"));
-                render_frame_png(
-                    "ffmpeg",
-                    &video,
-                    &frame_path,
-                    frame_seek_timestamp(timestamp, staged_duration()),
-                    1280,
-                    720,
-                    None,
-                )
-                .await
-                .expect("ffmpeg renders the sample frame");
-                let w = det_weights.clone();
-                let f = frame_path.clone();
-                let result =
-                    tokio::task::spawn_blocking(move || {
-                        crate::person_jobs::detect_people_blocking(w, f, 0.25)
-                    })
-                    .await
-                    .expect("detect task joins")
-                    .expect("yolo11 detection runs");
-                let boxes = result
-                    .detections
-                    .iter()
-                    .map(|d| {
-                        (
-                            crate::person_track::xyxy_to_normalized(
-                                d.x1 as f64,
-                                d.y1 as f64,
-                                d.x2 as f64,
-                                d.y2 as f64,
-                                result.width,
-                                result.height,
-                            ),
-                            d.score as f64,
-                        )
-                    })
-                    .collect::<Vec<_>>();
-                per_frame.push((timestamp, boxes));
-                frame_paths.push(frame_path);
-            }
-            let (selected_timestamp, selected_box, _) = per_frame
-                .iter()
-                .flat_map(|(t, boxes)| boxes.iter().map(move |b| (*t, b.0, b.1)))
-                .max_by(|a, b| a.2.partial_cmp(&b.2).expect("finite conf"))
-                .expect("at least one detection");
-            let observations = crate::person_track::observe(per_frame);
-            let assembly = crate::person_track::assemble_track(
-                &observations,
-                selected_box,
-                selected_timestamp,
-                &timestamps,
-            );
-            assert!(
-                assembly.target_track_id.is_some(),
-                "tracker failed to lock onto the selected person"
-            );
-            let detected_total = assembly.frames.iter().filter(|f| f.detected).count();
-            assert!(detected_total > 0, "no detected target frames to segment");
-            let first = assembly
-                .frames
-                .iter()
-                .position(|f| f.detected)
-                .expect("a detected frame exists");
-            let last = assembly
-                .frames
-                .iter()
-                .rposition(|f| f.detected)
-                .unwrap_or(first);
-            let mut clip_paths = Vec::new();
-            let mut anchors = Vec::new();
-            for (frame, path) in assembly.frames[first..=last]
-                .iter()
-                .zip(&frame_paths[first..=last])
-            {
-                clip_paths.push(path.clone());
-                anchors.push(frame.detected.then(|| {
-                    let b = &frame.box_;
-                    (b.x, b.y, b.width, b.height)
-                }));
-            }
+            // detect → track → assemble (shared with the SAM2 E2E, sc-8955).
+            let AssembledClip {
+                detected_total,
+                first,
+                last,
+                clip_paths,
+                anchors,
+            } = detect_and_assemble(&settings, &download_context, &video, duration, &timestamps)
+                .await;
+            let clip_detected: Vec<bool> = anchors.iter().map(Option::is_some).collect();
 
             // SAM3 text-concept segmentation (no box prompt) — the path under test.
             let (sam3_model, sam3_tok) =
@@ -3439,12 +3380,11 @@ mod person_track_e2e_tests {
             assert_eq!(sam3.len(), last - first + 1, "one SAM3 mask per clip frame");
             let mut sam3_generated = 0usize;
             for (i, px) in sam3.iter().enumerate() {
-                let idx = first + i;
                 assert_eq!(px.len(), 1280 * 720, "SAM3 mask must match the frame size");
-                if assembly.frames[idx].detected {
+                if clip_detected[i] {
                     assert!(
                         px.iter().any(|&p| p > 127),
-                        "SAM3 frame {idx} has no foreground — concept segmentation lost the person"
+                        "SAM3 clip frame {i} has no foreground — concept segmentation lost the person"
                     );
                     sam3_generated += 1;
                 }
@@ -3484,7 +3424,7 @@ mod person_track_e2e_tests {
             // Per-detected-frame mask IoU between the two segmenters.
             let mut ious = Vec::new();
             for i in 0..sam3.len() {
-                if !assembly.frames[first + i].detected {
+                if !clip_detected[i] {
                     continue;
                 }
                 let (a, b) = (&sam3[i], &sam2[i]);

--- a/crates/sceneworks-worker/src/media_jobs.rs
+++ b/crates/sceneworks-worker/src/media_jobs.rs
@@ -2298,10 +2298,12 @@ fn parse_ffmpeg_frame_count(stderr: &str) -> Option<usize> {
 /// samples, with only the final inclusive-end sample pulled inside the clip by
 /// `FRAME_SEEK_GUARD_SECONDS`. A single `select` filter over that same grid picks, for the
 /// `selected_n`-th output frame, the first source frame whose `pts ≥ TH(selected_n)`, where
-/// `TH(n) = round(frame_seek_timestamp(timestamps[n], duration), 3)` is the EXACT same `{:.3}`-rounded
-/// seek the per-frame accurate path passes to `-ss` for sample `n`. Feeding the filter that per-sample
-/// threshold lookup (rather than a `min(selected_n·interval, last_seek)` recurrence) is what makes the
-/// single pass byte-identical, sample-for-sample, to the accurate-seek path over its whole regime.
+/// `TH(n) = format!("{:.3}", frame_seek_timestamp(timestamps[n], duration).max(0.0))` is the byte-
+/// identical seek STRING the per-frame accurate path passes to `-ss` for sample `n` (same formatting,
+/// no separate pre-round — see [`render_track_frames_single_pass`] for why a pre-round diverged at
+/// `{:.3}` tie points). Feeding the filter that per-sample threshold lookup (rather than a
+/// `min(selected_n·interval, last_seek)` recurrence) is what makes the single pass byte-identical,
+/// sample-for-sample, to the accurate-seek path over its whole regime.
 ///
 /// GUARANTEE (what this function actually delivers):
 /// - **High-fps / frame-dense sources** (`source_frame_count ≥ count`): the single pass is taken and
@@ -2384,7 +2386,12 @@ async fn render_track_frames(
         .await;
     }
 
-    render_track_frames_single_pass(
+    // The single pass is an OPTIMIZATION, not a correctness dependency: if this ffmpeg build rejects the
+    // long `select` filter (or the pass fails for any other reason), degrade gracefully to the exact
+    // per-frame accurate-seek path rather than hard-failing the job. That path produces the identical
+    // frame selection (it is the reference the single pass is gated against), so the fallback is safe and
+    // lossless — it just spends more ffmpeg spawns. We log a warn so the degradation is observable.
+    match render_track_frames_single_pass(
         ffmpeg,
         source_path,
         work_dir,
@@ -2395,6 +2402,27 @@ async fn render_track_frames(
         context,
     )
     .await
+    {
+        Ok(frames) => Ok(frames),
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                source = %source_path.display(),
+                "single-pass person-track frame sampling failed; falling back to per-frame accurate seeks"
+            );
+            render_track_frames_per_frame(
+                ffmpeg,
+                source_path,
+                work_dir,
+                timestamps,
+                duration,
+                width,
+                height,
+                context,
+            )
+            .await
+        }
+    }
 }
 
 /// The single ffmpeg-pass sampling path — the perf win. Split out from [`render_track_frames`] (which
@@ -2403,20 +2431,24 @@ async fn render_track_frames(
 ///
 /// Builds the select predicate so the single pass lands on the SAME source frame the per-sample
 /// accurate-seek path ([`render_track_frames_per_frame`]) would, for every sample — byte-identically.
-/// The accurate path pulls sample `i` with `-ss {frame_seek_timestamp(timestamps[i], duration):.3}`,
-/// i.e. it snaps to the first frame whose `pts ≥` that `{:.3}`-rounded threshold. The single `select`
-/// filter increments `selected_n` (0-based output-frame counter) each time it fires, so we drive it off
-/// a per-sample threshold LOOKUP keyed on `selected_n` — `gte(t, TH(selected_n))` where
-/// `TH(n) = round(frame_seek_timestamp(timestamps[n], duration), 3)` is the exact same `{:.3}`-rounded
-/// seek — instead of a `min(selected_n·interval, last_seek)` recurrence.
+/// The accurate path pulls sample `i` with `-ss {frame_seek_timestamp(timestamps[i], duration):.3}`
+/// (i.e. `format!("{:.3}", seek.max(0.0))`), snapping to the first frame whose `pts ≥` that rendered
+/// threshold STRING. The single `select` filter increments `selected_n` (0-based output-frame counter)
+/// each time it fires, so we drive it off a per-sample threshold LOOKUP keyed on `selected_n` —
+/// `gte(t, TH(selected_n))` where `TH(n)` is the byte-identical `format!("{:.3}", seek.max(0.0))` string
+/// interpolated verbatim into the filter — instead of a `min(selected_n·interval, last_seek)` recurrence.
 ///
-/// Why the lookup and not the recurrence: the recurrence fed the filter a `{:.6}`-truncated
-/// `selected_n·interval`, a DIFFERENT number than the `{:.3}`-rounded `-ss` threshold, so at grid points
-/// that align to a source frame's pts the two mechanisms landed on ADJACENT frames (swept: 30fps@8s
-/// picked +1 source frame on 5/16 samples). Rounding the per-sample thresholds the exact same way the
-/// `-ss` seeks are rounded removes that divergence: both compare `pts` against an identical `{:.3}`
-/// value, so both select the identical frame. Verified byte-identical across the full high-fps sweep
-/// (30/24/60/25/29.97 fps) and at the 24-sample cap.
+/// Why interpolate the rendered string and not a re-derived number: the round-1 recurrence fed the filter
+/// a `{:.6}`-truncated `selected_n·interval`, a DIFFERENT number than the `-ss` threshold, so at grid
+/// points that align to a source frame's pts the two mechanisms landed on ADJACENT frames (swept: 30fps@8s
+/// picked +1 source frame on 5/16 samples). Round 2 pre-rounded the threshold `f64` with
+/// `(x*1000.0).round()/1000.0` before formatting — but `f64::round` is round-half-AWAY-from-zero while
+/// `{:.3}` is round-half-to-EVEN, so the two disagreed at `{:.3}` tie points (a `…5` third-decimal seek,
+/// e.g. duration 2.25s → sample[1] seek 0.5625 → `-ss 0.562` vs pre-round `0.563`) and again picked
+/// ADJACENT frames (swept: 66/660 tie durations diverged). Round 3 drops the pre-round and formats the raw
+/// seek ONCE with the exact `{:.3}` the accurate path uses, then compares against that identical string, so
+/// both select the identical frame. Verified byte-identical across the high-fps sweep (30/24/60/25/29.97
+/// fps), at the 24-sample cap, and at the 2.25s `{:.3}` tie point (0/660 divergences).
 ///
 /// NOTE: byte-identity here holds ONLY for frame-dense sources (`source_frame_count ≥ count`); on
 /// sub-cadence-fps sources the forward-only `select` exhausts the clip early and diverges grossly, which
@@ -2439,22 +2471,27 @@ async fn render_track_frames_single_pass(
 ) -> WorkerResult<Vec<PathBuf>> {
     let count = timestamps.len();
     let frame_path = |index: usize| work_dir.join(format!("frame_{index:04}.png"));
-    let thresholds: Vec<f64> = timestamps
+    // Render each per-sample seek threshold to a string with the EXACT SAME `{:.3}` formatting the
+    // accurate path applies to `-ss` (`try_render_frame_png`/`render_frame_png`:
+    // `format!("{:.3}", timestamp.max(0.0))`). We interpolate these rendered strings verbatim into the
+    // `select` predicate so the filter compares `pts` against the byte-identical seek the accurate path
+    // seeks to. Do NOT pre-round the f64 first (e.g. `(x*1000.0).round()/1000.0`): that is round-half-
+    // AWAY-from-zero, whereas Rust's `{:.3}` is round-half-to-EVEN, so the two disagree at `{:.3}` tie
+    // points (a `…5` third-decimal-boundary seek) and pick ADJACENT source frames (swept: 66/660 tie
+    // durations diverged byte-for-byte). Formatting the raw seek once, the same way, is bit-for-bit
+    // identical to the accurate seek.
+    let thresholds: Vec<String> = timestamps
         .iter()
-        .map(|&t| {
-            // `{:.3}` here MUST match the `-ss {:.3}` rounding in `try_render_frame_png`/`render_frame_png`
-            // so the filter threshold is bit-for-bit the same seek the accurate path uses.
-            (frame_seek_timestamp(t, duration).max(0.0) * 1000.0).round() / 1000.0
-        })
+        .map(|&t| format!("{:.3}", frame_seek_timestamp(t, duration).max(0.0)))
         .collect();
     // No shell here (`run_ffmpeg` execs the binary directly), so the select expression carries no
     // wrapping quotes — only the intra-expression commas are backslash-escaped so ffmpeg does not
     // read them as `-vf` filter-chain separators. The lookup is a nested `if(eq(selected_n,n), th_n, …)`
     // chain with the final threshold as the default tail (already selected once `selected_n == count-1`).
-    let mut lookup = format!("{:.3}", thresholds[count - 1]);
+    let mut lookup = thresholds[count - 1].clone();
     for n in (0..count - 1).rev() {
         lookup = format!(
-            "if(eq(selected_n\\,{n})\\,{th:.3}\\,{lookup})",
+            "if(eq(selected_n\\,{n})\\,{th}\\,{lookup})",
             th = thresholds[n]
         );
     }
@@ -3939,6 +3976,16 @@ mod person_track_e2e_tests {
     ///        source pts. Under the round-1 `{:.6}`-truncated `selected_n·interval` recurrence this was
     ///        5/16 samples off by one ADJACENT source frame (PSNR ~12–21 dB); the per-sample rounded
     ///        threshold lookup makes it byte-identical. This case is the whole point of round-2.
+    ///      - `tie_2_25s_48fps`: 5 samples, sample[1] seek 0.5625 is a `{:.3}` round-half boundary. The
+    ///        round-2 pre-round (`(x*1000.0).round()/1000.0`, round-half-AWAY-from-zero) rendered the
+    ///        threshold `0.563` while the accurate `-ss` (`{:.3}`, round-half-to-EVEN) renders `0.562`.
+    ///        48fps is chosen so a real source frame (frame 27, pts `27/48 = 0.5625`) sits inside that
+    ///        `[0.562, 0.563)` gap: `-ss 0.562` lands on it, `select=gte(t,0.563)` skips it, so the two
+    ///        select ADJACENT frames and this sample diverged byte-for-byte (60/90/120fps have no frame
+    ///        in the gap — why the round-2 sweep missed it). Round-3 formats the raw seek once with the
+    ///        same `{:.3}` and interpolates that exact string, so both compare `pts` against `0.562` and
+    ///        match. This case FAILS under the pre-round, PASSES after; it is the whole point of round-3
+    ///        (the 4/8/12/3s durations coincidentally dodge every tie point).
     ///
     /// 2. FALLBACK REGIME (source fps < sample cadence, frame-starved): the single pass is NOT safe
     ///    here — a forward-only `select` exhausts the clip early and diverges grossly — so the gate
@@ -3973,6 +4020,20 @@ mod person_track_e2e_tests {
         let gated_cases: &[(&str, &str, f64)] = &[
             ("hi_30fps_4s", "30", 4.0),
             ("aligned_30fps_8s", "30", 8.0),
+            // `{:.3}` TIE-POINT case (round-3): duration 2.25s → 5 samples → sample[1] seek 0.5625, a
+            // third-decimal round-half boundary. The round-2 `(x*1000.0).round()/1000.0` pre-round
+            // (round-half-AWAY-from-zero) rendered the threshold `0.563`, while the accurate `-ss`
+            // (`{:.3}`, round-half-to-EVEN) renders `0.562`. That 1ms gap only mis-selects a frame when a
+            // SOURCE frame's pts lands inside `[0.562, 0.563)`, so the fps must be chosen deliberately:
+            // 48fps has frame 27 at exactly `27/48 = 0.5625` s, dead in the gap → `select=gte(t,0.563)`
+            // skips it but `-ss 0.562` lands on it, so the pre-round diverges byte-for-byte here (60/90/
+            // 120fps happen to have NO frame in that gap, which is why the round-2 sweep missed this).
+            // At 48fps × 2.25s the source has 108 frames (≥ 5), so the gate takes the single pass; this
+            // case FAILS under the round-2 pre-round and PASSES once the threshold is the raw seek
+            // formatted with the same `{:.3}` (verified with real ffmpeg: fixed `select=gte(t,0.562)` ==
+            // `-ss 0.562`; buggy `select=gte(t,0.563)` != `-ss 0.562`). The existing 4/8/12/3s durations
+            // coincidentally dodge every tie point, so without this case the divergence shipped green.
+            ("tie_2_25s_48fps", "48", 2.25),
             ("lo_1fps_12s", "1", 12.0),
             ("lo_1_5fps_12s", "1.5", 12.0),
             ("starved_1fps_3s", "1", 3.0),
@@ -4021,6 +4082,136 @@ mod person_track_e2e_tests {
                  to ~0 the gate has become a no-op and low-fps sources would silently regress (sc-8915)",
                 reference.len()
             );
+        });
+
+        let _ = std::fs::remove_dir_all(&scratch);
+    }
+
+    /// The single pass is an OPTIMIZATION, not a correctness dependency: if this ffmpeg build rejects
+    /// the long `select` filter, `render_track_frames` must degrade to the exact per-frame accurate-seek
+    /// path rather than hard-failing the job (sc-8915, reviewer [minor]). This test forces the single
+    /// pass to fail on an otherwise frame-DENSE clip (so the frame-count gate passes and the runtime
+    /// reaches the single pass) and asserts the job still succeeds AND lands on the byte-identical frames
+    /// the per-frame path would — i.e. graceful, lossless degradation.
+    ///
+    /// The failure is injected with a tiny wrapper "ffmpeg" that exits non-zero whenever it sees the
+    /// single-pass `select=gte` filter and otherwise `exec`s the real ffmpeg. Passing this wrapper as the
+    /// `ffmpeg` argument (an absolute path, NOT the literal `"ffmpeg"`) bypasses the `SCENEWORKS_FFMPEG`
+    /// override, so the probe and every per-frame seek run the real binary while only the single pass is
+    /// sabotaged. `#[ignore]` because it needs a real ffmpeg (via `SCENEWORKS_FFMPEG` or on PATH).
+    #[test]
+    #[ignore = "needs an ffmpeg binary (SCENEWORKS_FFMPEG or ffmpeg on PATH)"]
+    fn render_track_frames_falls_back_to_per_frame_when_single_pass_fails() {
+        use crate::person_track::sample_timestamps;
+        use std::os::unix::fs::PermissionsExt;
+
+        let scratch = std::env::temp_dir().join("sw-render-track-frames-fallback");
+        let _ = std::fs::remove_dir_all(&scratch);
+        std::fs::create_dir_all(&scratch).expect("scratch dir");
+
+        // Resolve the real ffmpeg the wrapper should delegate to (bundled override or PATH default).
+        let real_ffmpeg = std::env::var("SCENEWORKS_FFMPEG")
+            .ok()
+            .filter(|p| !p.trim().is_empty())
+            .unwrap_or_else(|| "ffmpeg".to_owned());
+
+        // Wrapper "ffmpeg": fail on the single-pass `select=gte` filter, otherwise exec the real binary.
+        let wrapper = scratch.join("fake-ffmpeg.sh");
+        std::fs::write(
+            &wrapper,
+            format!(
+                "#!/bin/sh\nfor a in \"$@\"; do\n  case \"$a\" in\n    *select=gte*)\n      echo 'fake-ffmpeg: single-pass filter rejected' 1>&2\n      exit 1\n      ;;\n  esac\ndone\nexec \"{real_ffmpeg}\" \"$@\"\n"
+            ),
+        )
+        .expect("write wrapper ffmpeg");
+        let mut perms = std::fs::metadata(&wrapper)
+            .expect("wrapper metadata")
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&wrapper, perms).expect("chmod wrapper");
+        let wrapper_str = wrapper.display().to_string();
+
+        let duration = 4.0_f64; // 30fps → 120 frames, gate passes → runtime reaches the single pass
+        let src = scratch.join("src.mp4");
+
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        rt.block_on(async {
+            // Build a dense fixture with the REAL ffmpeg (wrapper would allow it too, but keep it simple).
+            let make = run_ffmpeg(
+                vec![
+                    real_ffmpeg.clone(),
+                    "-y".to_owned(),
+                    "-f".to_owned(),
+                    "lavfi".to_owned(),
+                    "-i".to_owned(),
+                    format!("testsrc2=size=320x240:rate=30:duration={duration}"),
+                    "-pix_fmt".to_owned(),
+                    "yuv420p".to_owned(),
+                    src.display().to_string(),
+                ],
+                None,
+            )
+            .await;
+            if make.is_err() {
+                eprintln!("skipping fallback test: ffmpeg unavailable to build the fixture");
+                return;
+            }
+
+            let timestamps = sample_timestamps(duration);
+
+            // (a) The gated wrapper: single pass fails (wrapper rejects `select=gte`) → runtime fallback.
+            let fb_dir = scratch.join("fallback");
+            std::fs::create_dir_all(&fb_dir).expect("fallback dir");
+            let fb_paths = render_track_frames(
+                &wrapper_str,
+                &src,
+                &fb_dir,
+                &timestamps,
+                duration,
+                1280,
+                720,
+                FfmpegContext {
+                    api: &ApiClient::new(&crate::Settings::from_env()),
+                    settings: &crate::Settings::from_env(),
+                    job_id: "render-track-frames-fallback",
+                    cancel_message: "",
+                },
+            )
+            .await
+            .expect("render_track_frames must SUCCEED via the per-frame fallback when single-pass fails");
+            assert_eq!(fb_paths.len(), timestamps.len(), "one frame per sample after fallback");
+
+            // (b) The per-frame path run DIRECTLY with the real ffmpeg — the byte reference the fallback
+            // must reproduce (the fallback simply calls this same fn on single-pass Err).
+            let ref_dir = scratch.join("per_frame_ref");
+            std::fs::create_dir_all(&ref_dir).expect("ref dir");
+            let ref_paths = render_track_frames_per_frame(
+                &real_ffmpeg,
+                &src,
+                &ref_dir,
+                &timestamps,
+                duration,
+                1280,
+                720,
+                FfmpegContext {
+                    api: &ApiClient::new(&crate::Settings::from_env()),
+                    settings: &crate::Settings::from_env(),
+                    job_id: "render-track-frames-fallback-ref",
+                    cancel_message: "",
+                },
+            )
+            .await
+            .expect("per-frame reference extraction");
+
+            for (index, (fb, reference)) in fb_paths.iter().zip(&ref_paths).enumerate() {
+                let fb_bytes = std::fs::read(fb).expect("read fallback frame");
+                let ref_bytes = std::fs::read(reference).expect("read per-frame reference");
+                assert_eq!(
+                    fb_bytes, ref_bytes,
+                    "sample {index}: single-pass-failure fallback must be byte-identical to the \
+                     per-frame accurate-seek path (sc-8915 graceful degradation)"
+                );
+            }
         });
 
         let _ = std::fs::remove_dir_all(&scratch);

--- a/crates/sceneworks-worker/src/segment_jobs.rs
+++ b/crates/sceneworks-worker/src/segment_jobs.rs
@@ -30,7 +30,7 @@ use crate::person_segment_sam3::{
 };
 use crate::{
     fresh_asset_id, heartbeat, now_rfc3339, progress_payload, run_blocking_with_heartbeat,
-    update_job, ApiClient, Settings, WorkerError, WorkerResult,
+    task_join_error, update_job, ApiClient, Settings, WorkerError, WorkerResult,
 };
 use sceneworks_core::contracts::{JobSnapshot, JobStatus, JsonObject, ProgressStage, WorkerStatus};
 use sceneworks_core::project_store::ProjectStore;
@@ -235,11 +235,6 @@ pub(crate) async fn run_image_segment_job(
             ))
         })?;
 
-    let source_image = crate::image_decode::decode_image_any(&source_path)
-        .map_err(|e| WorkerError::InvalidPayload(format!("Source image could not be loaded: {e}")))?
-        .to_rgb8();
-    let (src_w, src_h) = (source_image.width(), source_image.height());
-
     update_job(
         api,
         &job.id,
@@ -280,8 +275,11 @@ pub(crate) async fn run_image_segment_job(
     )
     .await?;
     let cancel = CancelFlag::new();
+    // The source read + full image decode is folded into each blocking task below (sc-8909 / F-107)
+    // so it never stalls the async runtime thread; the task returns the decoded dimensions alongside
+    // the mask so the `src_w*src_h` GrayImage can be built after.
     // Points → SAM3 tracker single-frame PVS (interactive clicks); box → SAM3 concept detector.
-    let mask = if let Some(points) = points {
+    let (mask, src_w, src_h) = if let Some(points) = points {
         run_blocking_with_heartbeat(
             api,
             settings,
@@ -290,7 +288,16 @@ pub(crate) async fn run_image_segment_job(
             CANCEL_MESSAGE,
             "smart-select task",
             tokio::task::spawn_blocking(move || {
-                segment_points_blocking(model_path, source_image, points)
+                let source_image = crate::image_decode::decode_image_any(&source_path)
+                    .map_err(|e| {
+                        WorkerError::InvalidPayload(format!(
+                            "Source image could not be loaded: {e}"
+                        ))
+                    })?
+                    .to_rgb8();
+                let (src_w, src_h) = (source_image.width(), source_image.height());
+                let mask = segment_points_blocking(model_path, source_image, points)?;
+                Ok::<_, WorkerError>((mask, src_w, src_h))
             }),
         )
         .await?
@@ -304,7 +311,15 @@ pub(crate) async fn run_image_segment_job(
             CANCEL_MESSAGE,
             "smart-select task",
             tokio::task::spawn_blocking(move || {
-                segment_box_blocking(
+                let source_image = crate::image_decode::decode_image_any(&source_path)
+                    .map_err(|e| {
+                        WorkerError::InvalidPayload(format!(
+                            "Source image could not be loaded: {e}"
+                        ))
+                    })?
+                    .to_rgb8();
+                let (src_w, src_h) = (source_image.width(), source_image.height());
+                let mask = segment_box_blocking(
                     model_path,
                     tokenizer_path,
                     source_image,
@@ -312,7 +327,8 @@ pub(crate) async fn run_image_segment_job(
                     &concept,
                     threshold,
                     mask_threshold,
-                )
+                )?;
+                Ok::<_, WorkerError>((mask, src_w, src_h))
             }),
         )
         .await?
@@ -336,9 +352,16 @@ pub(crate) async fn run_image_segment_job(
         tokio::fs::create_dir_all(parent).await?;
     }
     let tmp_path = media_path.with_extension("tmp.png");
-    mask_image
-        .save_with_format(&tmp_path, image::ImageFormat::Png)
-        .map_err(|e| WorkerError::Io(std::io::Error::other(e)))?;
+    // Encode the mask PNG off the async runtime thread (sc-8909 / F-107) so the blocking encode never
+    // stalls the heartbeat.
+    let encode_tmp = tmp_path.clone();
+    tokio::task::spawn_blocking(move || {
+        mask_image
+            .save_with_format(&encode_tmp, image::ImageFormat::Png)
+            .map_err(|e| WorkerError::Io(std::io::Error::other(e)))
+    })
+    .await
+    .map_err(|e| task_join_error("smart-select mask encode task", e))??;
     tokio::fs::rename(&tmp_path, &media_path)
         .await
         .inspect_err(|_| {

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -458,6 +458,46 @@ fn pattern_filtering_and_download_dir_match_python_behavior() {
     assert_eq!(safe_download_dir("///"), "download");
 }
 
+/// F-111 (sc-8913): a hostile job id must never let a person-track / frame-extract work dir
+/// escape `temp_dir()`. The handlers build the dir as `temp_dir().join(format!("sw-…-{}",
+/// safe_download_dir(&job.id)))`, so the sanitized id must always be a single path component
+/// that stays confined under the temp root — no `/`, `\`, `..`, or absolute-root traversal.
+#[test]
+fn safe_download_dir_confines_hostile_job_ids_to_the_temp_root() {
+    let temp_root = std::env::temp_dir();
+    for hostile in [
+        "../../etc/passwd",
+        "/etc/passwd",
+        "..\\..\\windows\\system32",
+        "a/../../b",
+        "....//....//x",
+        "job\0id",
+        "  ../secret  ",
+    ] {
+        let sanitized = safe_download_dir(hostile);
+        // The sanitized id is a single normal path component (no separators, not `..`/`.`).
+        assert!(
+            !sanitized.contains('/')
+                && !sanitized.contains('\\')
+                && sanitized != ".."
+                && sanitized != ".",
+            "sanitized job id {sanitized:?} (from {hostile:?}) is not a single safe component"
+        );
+        // Joining it under the temp root yields a path whose only new component sits directly
+        // under `temp_dir()` — it can never traverse above the temp root.
+        let work_dir = temp_root.join(format!("sw-person-track-{sanitized}"));
+        assert_eq!(
+            work_dir.parent(),
+            Some(temp_root.as_path()),
+            "hostile job id {hostile:?} escaped the temp root: {work_dir:?}"
+        );
+        assert!(
+            work_dir.starts_with(&temp_root),
+            "hostile job id {hostile:?} produced a path outside the temp root: {work_dir:?}"
+        );
+    }
+}
+
 #[test]
 fn huggingface_cache_paths_follow_hub_layout() {
     let root = tempdir().expect("temp dir creates");

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -904,17 +904,30 @@ async fn consume_training_events(
                     image,
                 } = progress
                 {
-                    match write_training_sample(
-                        sample_output_dir.as_deref(),
-                        sample_project_root.as_deref(),
-                        &sample_stem,
-                        step,
-                        index,
-                        &prompt,
-                        &image,
-                        sample_cfg.sample_steps,
-                        sample_cfg.sample_guidance_scale,
-                    ) {
+                    // Persist the preview off the async runtime thread (sc-8909 / F-107): the PNG
+                    // encode + atomic rename are blocking, so move the owned `image` (no buffer clone)
+                    // and owned copies of the path/stem/prompt into a `spawn_blocking`.
+                    let sample_output_dir = sample_output_dir.clone();
+                    let sample_project_root = sample_project_root.clone();
+                    let sample_stem = sample_stem.clone();
+                    let sample_steps = sample_cfg.sample_steps;
+                    let sample_guidance_scale = sample_cfg.sample_guidance_scale;
+                    let persisted = tokio::task::spawn_blocking(move || {
+                        write_training_sample(
+                            sample_output_dir.as_deref(),
+                            sample_project_root.as_deref(),
+                            &sample_stem,
+                            step,
+                            index,
+                            &prompt,
+                            image,
+                            sample_steps,
+                            sample_guidance_scale,
+                        )
+                    })
+                    .await
+                    .map_err(|error| task_join_error("training preview persist task", error))?;
+                    match persisted {
                         Ok(record) => {
                             let record = Value::Object(record);
                             if step != latest_step {
@@ -1159,7 +1172,7 @@ fn write_training_sample(
     step: u32,
     index: u32,
     prompt: &str,
-    image: &gen_core::Image,
+    image: gen_core::Image,
     sample_steps: u32,
     sample_guidance_scale: f32,
 ) -> WorkerResult<JsonObject> {
@@ -1170,8 +1183,10 @@ fn write_training_sample(
     std::fs::create_dir_all(&dir)?;
     let filename = format!("{stem}-step{step:06}-{index}.png");
     let path = dir.join(&filename);
-    let rgb = image::RgbImage::from_raw(image.width, image.height, image.pixels.clone())
-        .ok_or_else(|| {
+    // Take `image` by value (sc-8909 / F-107) — the caller no longer needs the buffer, so the full
+    // RGB `pixels.clone()` is dropped and the raw buffer is moved straight into the encoder.
+    let rgb =
+        image::RgbImage::from_raw(image.width, image.height, image.pixels).ok_or_else(|| {
             WorkerError::Engine("training preview: image buffer size mismatch".into())
         })?;
     let temp_path = path.with_extension("tmp.png");
@@ -2006,7 +2021,7 @@ mod tests {
             250,
             2,
             "mychar, studio portrait",
-            &image,
+            image,
             8,
             1.5,
         )
@@ -2642,7 +2657,7 @@ mod tests {
                         step,
                         index,
                         &prompt,
-                        &image,
+                        image,
                         preview_steps,
                         preview_guidance,
                     )

--- a/crates/sceneworks-worker/src/upscale_jobs.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs.rs
@@ -929,9 +929,20 @@ pub(crate) async fn run_image_upscale_job(
             ))
         })?;
 
-    let source_image = crate::image_decode::decode_image_any(&source_path)
-        .map_err(|e| WorkerError::InvalidPayload(format!("Source image could not be loaded: {e}")))?
-        .to_rgb8();
+    // Decode the source off the async runtime thread (sc-8909 / F-107): the full read + decode is
+    // blocking and would otherwise stall the heartbeat before the upscale even starts.
+    let source_image = {
+        let source_path = source_path.clone();
+        tokio::task::spawn_blocking(move || {
+            crate::image_decode::decode_image_any(&source_path)
+                .map_err(|e| {
+                    WorkerError::InvalidPayload(format!("Source image could not be loaded: {e}"))
+                })
+                .map(|decoded| decoded.to_rgb8())
+        })
+        .await
+        .map_err(|e| task_join_error("upscale source decode task", e))??
+    };
     let (src_w, src_h) = (source_image.width(), source_image.height());
 
     let upscaled = if engine_id == "seedvr2" {
@@ -1045,9 +1056,15 @@ pub(crate) async fn run_image_upscale_job(
         tokio::fs::create_dir_all(parent).await?;
     }
     let tmp_path = media_path.with_extension("tmp.png");
-    upscaled
-        .save_with_format(&tmp_path, image::ImageFormat::Png)
-        .map_err(|e| WorkerError::Io(std::io::Error::other(e)))?;
+    // Encode the upscaled PNG off the async runtime thread (sc-8909 / F-107).
+    let encode_tmp = tmp_path.clone();
+    tokio::task::spawn_blocking(move || {
+        upscaled
+            .save_with_format(&encode_tmp, image::ImageFormat::Png)
+            .map_err(|e| WorkerError::Io(std::io::Error::other(e)))
+    })
+    .await
+    .map_err(|e| task_join_error("upscale encode task", e))??;
     tokio::fs::rename(&tmp_path, &media_path)
         .await
         .inspect_err(|_| {
@@ -1291,18 +1308,23 @@ pub(crate) async fn run_dataset_upscale_job(
         )
         .await?;
 
-        let source_image = crate::image_decode::decode_image_any(&item.image_path)
-            .map_err(|e| WorkerError::InvalidPayload(format!("Image could not be loaded: {e}")))?
-            .to_rgb8();
         let onnx = onnx_path.clone();
         let cancel = CancelFlag::new();
         let cancel_run = cancel.clone();
+        // Decode the source inside the blocking task (sc-8909 / F-107) so the per-item read + decode
+        // never stalls the async runtime thread across the dataset loop.
+        let item_image_path = item.image_path.clone();
         let upscaled = run_upscale_with_heartbeat(
             api,
             settings,
             &job.id,
             cancel,
             tokio::task::spawn_blocking(move || {
+                let source_image = crate::image_decode::decode_image_any(&item_image_path)
+                    .map_err(|e| {
+                        WorkerError::InvalidPayload(format!("Image could not be loaded: {e}"))
+                    })?
+                    .to_rgb8();
                 upscale_blocking(onnx, factor, source_image, cancel_run)
             }),
         )
@@ -1317,9 +1339,14 @@ pub(crate) async fn run_dataset_upscale_job(
         if let Some(parent) = abs.parent() {
             tokio::fs::create_dir_all(parent).await?;
         }
-        upscaled
-            .save_with_format(&abs, image::ImageFormat::Png)
-            .map_err(|e| WorkerError::Io(std::io::Error::other(e)))?;
+        // Encode off the async runtime thread (sc-8909 / F-107).
+        tokio::task::spawn_blocking(move || {
+            upscaled
+                .save_with_format(&abs, image::ImageFormat::Png)
+                .map_err(|e| WorkerError::Io(std::io::Error::other(e)))
+        })
+        .await
+        .map_err(|e| task_join_error("dataset upscale encode task", e))??;
         records.push((item.item_id.clone(), rel));
     }
 

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -1999,8 +1999,11 @@ pub(crate) async fn run_video_upscale_job(
     // Decode the whole source to a numbered PNG sequence ON DISK (disk-bounded, no RAM), then load each
     // temporal window on demand (sc-9595). `-fps_mode passthrough` preserves the exact source frame
     // count / order; the output frame count/order/fps therefore stay identical to the whole-clip path.
-    let src_frames_dir = std::env::temp_dir().join(format!("sceneworks_seedvr2_src_{}", job.id));
-    let out_frames_dir = std::env::temp_dir().join(format!("sceneworks_seedvr2_out_{}", job.id));
+    // Sanitize the job id before it becomes a temp-dir path component (F-111): a hostile id would
+    // otherwise escape `temp_dir()`. Mirrors the person-track work dir sanitization.
+    let safe_job = safe_download_dir(&job.id);
+    let src_frames_dir = std::env::temp_dir().join(format!("sceneworks_seedvr2_src_{safe_job}"));
+    let out_frames_dir = std::env::temp_dir().join(format!("sceneworks_seedvr2_out_{safe_job}"));
     let _ = tokio::fs::remove_dir_all(&out_frames_dir).await;
     // RAII-guard the output PNG scratch so it is removed on EVERY exit after the stream: not just the
     // stream error arm, but the create_dir_all / update_job progress POST / encode span below, any of
@@ -6671,7 +6674,10 @@ async fn load_source_video_frames(
         )));
     }
 
-    let work_dir = std::env::temp_dir().join(format!("sw-replace-frames-{}", job.id));
+    // Sanitize the job id before it becomes a temp-dir path component (F-111): a hostile id would
+    // otherwise escape `temp_dir()`. Mirrors `sw-person-track-{safe_download_dir(job.id)}` in media_jobs.
+    let work_dir =
+        std::env::temp_dir().join(format!("sw-replace-frames-{}", safe_download_dir(&job.id)));
     tokio::fs::create_dir_all(&work_dir).await?;
     let pattern = work_dir.join("src_%05d.png");
     let filters = format!(
@@ -7146,9 +7152,11 @@ async fn load_clip_anchor_frames(
     take: ClipFramePosition,
 ) -> WorkerResult<Vec<Image>> {
     let media_path = resolve_clip_media_path(settings, project_id, asset_id, project_path)?;
+    // Sanitize the job id before it becomes a temp-dir path component (F-111): a hostile id would
+    // otherwise escape `temp_dir()` even with the uuid suffix. Mirrors the person-track work dir.
     let work_dir = std::env::temp_dir().join(format!(
         "sw-anchor-frames-{}-{}",
-        job.id,
+        safe_download_dir(&job.id),
         Uuid::new_v4().simple()
     ));
     tokio::fs::create_dir_all(&work_dir).await?;


### PR DESCRIPTION
Code-review remediation batch (epic 8800, batch 2) for `crates/sceneworks-worker`. Five stories, one commit each. All handler changes with macOS/candle twins are mirrored so the parity lane stays green.

## Stories

- **sc-8913 [F-111]** — `fix(worker)`: person-track work dir (and its `video_jobs` twins: replace-frames, anchor-frames, seedvr2 src/out) embedded the raw `job.id` in a `temp_dir().join(...)` path component. A hostile job id (`../…`, absolute, separators) could escape the system temp root. Route every such id through `safe_download_dir(&job.id)`, matching the timeline-export convention. **Test:** hostile ids stay confined directly under `temp_dir()` after sanitization.
- **sc-8914 [F-112]** — `refactor(worker)`: extract `resolve_frame_source` + `render_frame_asset` (async recipe-builder closure that runs after the frame exists so person-detect can run its detector on the rendered PNG) so the frame-extract and person-detect handlers share one resolve→render→tmp-rename→`"type":"frame"` asset JSON→sidecar+recipe→index flow. Alias the `PERSON_TRACK_SAMPLE_RATE_FPS`/`PERSON_TRACK_MAX_SAMPLES` constants to the `person_track` module so the sidecar-recorded rate and the sampler cadence are one source of truth. **Tests:** constant-unification assertion; existing frame tests preserved.
- **sc-8915 [F-113]** — `perf(worker)`: replace the per-sampled-frame ffmpeg accurate-seek loop (up to MAX_SAMPLES=24 processes/track) with a SINGLE ffmpeg `select` filter to an image2 sequence. **Guarantee (round-2, honest):** the single pass is byte-identical to the per-frame accurate-seek reference ONLY for frame-dense sources (`source_frame_count ≥ count`); a probe gate routes sub-cadence-fps / frame-starved sources to the per-frame accurate-seek fallback (which reproduces the pre-PR frames), because the forward-only `select` would exhaust those clips and diverge grossly. To make the single-pass path byte-identical even at grid points that align to a source frame's pts, the `select` predicate is built from a per-sample threshold lookup `gte(t, TH(selected_n))` where `TH(n) = round(frame_seek_timestamp(timestamps[n], duration), 3)` is the EXACT same `{:.3}`-rounded seek the accurate path passes to `-ss` — not a `{:.6}`-truncated `min(selected_n*interval, last_seek)` recurrence, which landed on an adjacent (±1) source frame at aligned grid points (e.g. 5/16 samples off on 30fps@8s). **Test:** `#[ignore]` ffmpeg test asserts byte-identity of the gated path in both regimes (incl. a frame-ALIGNED `aligned_30fps_8s` case the round-1 test missed) AND that the UNGATED single-pass on a low-fps clip diverges grossly — proving the frame-count gate is load-bearing.
- **sc-8955 [F-153]** — `chore(worker)`: drop `mux_with_crossfades`'s unused `_tmp_path: &Path` param + its pass-through; extract a test-local `detect_and_assemble` helper removing the ~100 duplicated setup lines across the SAM2/SAM3 `#[ignore]` e2e tests.
- **sc-8909 [F-107]** — `perf(worker)`: fold synchronous `std::fs::read` + image decode (and PNG encodes) into `spawn_blocking` closures so the async runtime thread (and the heartbeat) isn't stalled — across kps_jobs, segment_jobs, upscale_jobs (main + dataset), face_likeness_compare_jobs, training_jobs, image_jobs (base/stub/upscale) and image_jobs/detail.rs. `write_training_sample` now takes `image` by value (drops `pixels.clone()`); `ImagePlan` derives `Clone` so the per-image writers move an owned copy into the encode task.

## Verification

- `cargo fmt --all -- --check` ✓
- workspace `cargo clippy --all-targets -- -D warnings` ✓
- candle parity `cargo check -p sceneworks-worker --no-default-features -F backend-candle --all-targets` ✓
- `cargo test -p sceneworks-worker --lib` → 582 passed, 0 failed ✓
- full workspace `cargo build` ✓
- sc-8915 `#[ignore]` ffmpeg test passes against the bundled imageio-ffmpeg: gated single-pass byte-identical to accurate-seek in every regime (incl. the frame-aligned 30fps@8s boundary case); ungated single-pass on 1fps@12s diverges grossly (gate proven necessary). Verified it FAILS at `aligned_30fps_8s` sample 2 under the old recurrence and at the low-fps cases when the gate is forced always-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

