### PR TITLE
fix(rust-api): fetch multi-repo download co-requisites so PiD's gemma encoder installs (sc-9696)

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -175,7 +175,81 @@ pub(crate) async fn create_model_download_job(
             ApiError::bad_request("Model does not define a Hugging Face download")
         })?,
     };
-    let repo = required_string_field(&download, "repo")?.to_owned();
+    // The selected `download` is always the primary/tier entry — `model_download` and
+    // `model_download_for_variant` skip co-requisites (sc-9696), so a co-requisite can never be
+    // installed as if it were the model itself.
+    let requested_variant = payload
+        .variant
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let job_payload = build_model_download_job_payload(
+        &model,
+        &model_id,
+        &download,
+        requested_variant,
+        true,
+        &state.settings.data_dir,
+    )?;
+
+    // Co-requisites (sc-9696): dependencies that must install ALONGSIDE the primary — e.g. the PiD
+    // decoder's shared gemma-2-2b-it caption encoder, or 10Eros's cond_safe distill LoRA. Without
+    // them the feature silently no-ops (for PiD, `resolve_pid_weights` falls back to the native VAE
+    // with no error). The catalog already filtered `downloads` to this OS, so every co-requisite
+    // here applies. Each is queued as its own ModelDownload job (the worker is one-repo-per-job);
+    // the catalog reports the entry installed only once all of them are cached
+    // (`install_state_for`). `include_family: false` because a co-requisite (e.g. a text encoder)
+    // is a different artifact than the model's primary checkpoint and must not be reconciled
+    // against the model's family.
+    let requested_gpu = requested_gpu_or_auto(payload.requested_gpu);
+    for co_requisite in model_co_requisite_downloads(&model) {
+        let co_payload = build_model_download_job_payload(
+            &model,
+            &model_id,
+            &co_requisite,
+            None,
+            false,
+            &state.settings.data_dir,
+        )?;
+        create_generation_job(
+            state.clone(),
+            JobType::ModelDownload,
+            None,
+            None,
+            co_payload,
+            requested_gpu.clone(),
+        )
+        .await?;
+    }
+
+    // The primary job is the one returned to the caller (its id is what the download UI tracks).
+    let job = create_generation_job(
+        state,
+        JobType::ModelDownload,
+        None,
+        None,
+        job_payload,
+        requested_gpu,
+    )
+    .await?;
+    Ok((StatusCode::CREATED, Json(job)))
+}
+
+/// Build the worker `ModelDownload` job payload for one `download` entry of `model`. Factored out
+/// (sc-9696) so the primary download and each co-requisite share identical payload shaping.
+/// `explicit_variant` records a request-selected quant tier (falling back to the entry's own
+/// `variant`); `include_family` forwards the model's declared family for the worker's post-download
+/// family reconcile (sc-1663) — pass `false` for co-requisites, whose weights are a different artifact
+/// than the model's primary checkpoint.
+fn build_model_download_job_payload(
+    model: &Value,
+    model_id: &str,
+    download: &Value,
+    explicit_variant: Option<&str>,
+    include_family: bool,
+    data_dir: &FsPath,
+) -> Result<JsonObject, ApiError> {
+    let repo = required_string_field(download, "repo")?.to_owned();
     let files = download
         .get("files")
         .and_then(Value::as_array)
@@ -188,29 +262,27 @@ pub(crate) async fn create_model_download_job(
         })
         .unwrap_or_default();
     let mut job_payload = JsonObject::new();
-    job_payload.insert("modelId".to_owned(), Value::String(model_id.clone()));
+    job_payload.insert("modelId".to_owned(), Value::String(model_id.to_owned()));
     job_payload.insert(
         "modelName".to_owned(),
         Value::String(
             model
                 .get("name")
                 .and_then(Value::as_str)
-                .unwrap_or(&model_id)
+                .unwrap_or(model_id)
                 .to_owned(),
         ),
     );
     job_payload.insert(
         "provider".to_owned(),
-        Value::String(required_string_field(&download, "provider")?.to_owned()),
+        Value::String(required_string_field(download, "provider")?.to_owned()),
     );
     job_payload.insert("repo".to_owned(), Value::String(repo.clone()));
     job_payload.insert("files".to_owned(), json!(files));
     // Record which quant tier this job installs (sc-8508) so the download record + per-variant
     // install tracking agree on the tier. Falls back to the selected entry's own `variant` when the
     // request omitted one (the default tier may still be a labeled variant).
-    if let Some(variant) = payload
-        .variant
-        .as_deref()
+    if let Some(variant) = explicit_variant
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(str::to_owned)
@@ -227,34 +299,24 @@ pub(crate) async fn create_model_download_job(
     // weights match it (parity with model import). The catalog is project-curated, but
     // a mis-declared family would otherwise silently mismatch downstream adapter
     // selection; the worker reconciles and fails on a confident conflict (sc-1663).
-    if let Some(family) = model.get("family").and_then(Value::as_str) {
-        if !family.trim().is_empty() {
-            job_payload.insert("family".to_owned(), Value::String(family.to_owned()));
+    if include_family {
+        if let Some(family) = model.get("family").and_then(Value::as_str) {
+            if !family.trim().is_empty() {
+                job_payload.insert("family".to_owned(), Value::String(family.to_owned()));
+            }
         }
     }
     job_payload.insert(
         "targetDir".to_owned(),
         Value::String(
-            state
-                .settings
-                .data_dir
+            data_dir
                 .join("models")
                 .join(safe_download_dir(&repo))
                 .display()
                 .to_string(),
         ),
     );
-
-    let job = create_generation_job(
-        state,
-        JobType::ModelDownload,
-        None,
-        None,
-        job_payload,
-        requested_gpu_or_auto(payload.requested_gpu),
-    )
-    .await?;
-    Ok((StatusCode::CREATED, Json(job)))
+    Ok(job_payload)
 }
 
 /// Convert a model's native checkpoint into the local MLX format (macOS/Apple
@@ -900,21 +962,53 @@ fn install_state_for(
         let cache_incomplete = cache_health
             .as_ref()
             .is_some_and(|health| health.incomplete);
-        let missing_required_files = cache_health
+        let mut missing_required_files = cache_health
             .as_ref()
             .map(|health| health.missing_files.clone())
             .unwrap_or_default();
         let managed_installed = model_is_installed(&managed_path);
+        let primary_installed = managed_installed || cache_installed;
         let installed_path = if cache_installed || cache_incomplete {
             cache_path.clone()
         } else {
             Some(managed_path)
         };
+        // Co-requisites (sc-9696): the entry counts as installed only when the primary AND every
+        // co-requisite dependency (e.g. the PiD decoder's shared gemma-2-2b-it caption encoder) are
+        // cached. Gating on this keeps a feature that silently no-ops without its dependency (PiD →
+        // native VAE) from advertising as ready, and a present primary with a missing/partial
+        // co-requisite surfaces as a repairable partial install (cache_incomplete → repairAvailable),
+        // whose repair re-runs the download job that now fetches the co-requisite too.
+        let mut co_requisites_installed = true;
+        let mut co_requisite_incomplete = false;
+        for co_requisite in model_co_requisite_downloads(model) {
+            let Some(repo) = co_requisite.get("repo").and_then(Value::as_str) else {
+                continue;
+            };
+            let files = string_array_field(&co_requisite, "files");
+            let health = huggingface_repo_cache_path(data_dir, repo)
+                .map(|path| huggingface_cache_health(&path, &files));
+            if health.as_ref().is_some_and(|health| health.installed) {
+                continue;
+            }
+            co_requisites_installed = false;
+            co_requisite_incomplete |= health.as_ref().is_some_and(|health| health.incomplete);
+            match health
+                .as_ref()
+                .map(|health| health.missing_files.as_slice())
+            {
+                Some(missing) if !missing.is_empty() => missing_required_files
+                    .extend(missing.iter().map(|file| format!("{repo}/{file}"))),
+                _ => missing_required_files.push(repo.to_owned()),
+            }
+        }
         ModelCatalogEntryState {
             downloadable: true,
             installed_path: installed_path.map(|path| path.display().to_string()),
-            installed: managed_installed || cache_installed,
-            cache_incomplete,
+            installed: primary_installed && co_requisites_installed,
+            cache_incomplete: cache_incomplete
+                || (primary_installed && !co_requisites_installed)
+                || co_requisite_incomplete,
             missing_required_files,
         }
     } else if let Some(installed_path) = model_manifest_installed_path(model, data_dir) {
@@ -972,7 +1066,7 @@ fn model_has_variant_matrix(model: &Value) -> bool {
     };
     downloads
         .iter()
-        .filter(|entry| is_supported_model_download(entry))
+        .filter(|entry| is_supported_model_download(entry) && !is_co_requisite_download(entry))
         .any(|entry| {
             entry
                 .get("variant")
@@ -997,7 +1091,8 @@ fn model_variant_states(model: &Value, data_dir: &FsPath) -> Vec<ModelVariantSta
     let mut seen_variants = std::collections::HashSet::new();
     downloads
         .iter()
-        .filter(|entry| is_supported_model_download(entry))
+        // Co-requisites (sc-9696) are dependencies, not selectable tiers — never a variant state.
+        .filter(|entry| is_supported_model_download(entry) && !is_co_requisite_download(entry))
         .filter(|entry| {
             let key = entry
                 .get("variant")
@@ -1221,9 +1316,21 @@ async fn model_catalog_inner(
             let fallback_size_bytes = download_context
                 .as_ref()
                 .and_then(|context| context.fallback_size_bytes);
-            let effective_download_size_bytes = download_size_bytes.or(fallback_size_bytes);
+            let primary_size_bytes = download_size_bytes.or(fallback_size_bytes);
             let download_size_estimated =
                 download_size_bytes.is_none() && fallback_size_bytes.is_some();
+            // Co-requisites (sc-9696) install alongside the primary, so the displayed footprint must
+            // include them (e.g. PiD's ~2.7 GB checkpoint + ~5.2 GB gemma-2-2b-it). Their sizes come
+            // from the manifest (the live HF estimate above only sizes the primary repo).
+            let co_requisite_size_bytes: u64 = model_co_requisite_downloads(model)
+                .iter()
+                .filter_map(|download| manifest_download_size_bytes(model, download))
+                .sum();
+            let effective_download_size_bytes = match primary_size_bytes {
+                Some(primary) => Some(primary + co_requisite_size_bytes),
+                None if co_requisite_size_bytes > 0 => Some(co_requisite_size_bytes),
+                None => None,
+            };
             let state = install_state_for(download_context, model, &data_dir);
             let object = model
                 .as_object_mut()
@@ -1461,7 +1568,9 @@ pub(crate) fn model_download(model: &Value) -> Option<Value> {
     let downloads = model.get("downloads")?.as_array()?;
     let mut fallback = None;
     for download in downloads {
-        if !is_supported_model_download(download) {
+        // Co-requisites (sc-9696) install alongside the primary, never AS it — skip them when
+        // choosing the canonical entry for size/install-path/download.
+        if !is_supported_model_download(download) || is_co_requisite_download(download) {
             continue;
         }
         fallback.get_or_insert(download);
@@ -1470,6 +1579,33 @@ pub(crate) fn model_download(model: &Value) -> Option<Value> {
         }
     }
     fallback.cloned()
+}
+
+/// True when a download entry is a co-requisite dependency (sc-9696): fetched ALONGSIDE the primary
+/// download rather than as a pick-one alternate, and gating the entry's install state. See the
+/// manifest schema `downloads[].coRequisite`.
+pub(crate) fn is_co_requisite_download(download: &Value) -> bool {
+    download.get("coRequisite").and_then(Value::as_bool) == Some(true)
+}
+
+/// The co-requisite download entries for `model` (sc-9696) — the dependencies that must install
+/// alongside the primary (e.g. the PiD decoder's shared gemma-2-2b-it caption encoder). The catalog
+/// has already restricted `downloads` to the current OS (`retain_downloads_for_os`), so every entry
+/// returned applies to this platform. Only provider-supported entries are returned.
+pub(crate) fn model_co_requisite_downloads(model: &Value) -> Vec<Value> {
+    model
+        .get("downloads")
+        .and_then(Value::as_array)
+        .map(|downloads| {
+            downloads
+                .iter()
+                .filter(|download| {
+                    is_co_requisite_download(download) && is_supported_model_download(download)
+                })
+                .cloned()
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 /// Select a specific quant tier's download entry for a quant-matrix model (sc-8508). Returns the
@@ -1483,6 +1619,7 @@ pub(crate) fn model_download_for_variant(model: &Value, variant: &str) -> Option
         .iter()
         .find(|download| {
             is_supported_model_download(download)
+                && !is_co_requisite_download(download)
                 && download
                     .get("variant")
                     .and_then(Value::as_str)

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -7025,6 +7025,212 @@ async fn model_download_job_forwards_catalog_family_for_worker_reconciliation() 
     assert_eq!(job["payload"]["family"], "z-image");
 }
 
+/// Write the empty sibling manifests a `model_catalog` build requires, so a co-requisite test
+/// (sc-9696) only has to author its own `builtin.models.jsonc`.
+fn write_empty_sibling_manifests(config_dir: &std::path::Path) {
+    for (name, key) in [
+        ("user.models.jsonc", "models"),
+        ("builtin.loras.jsonc", "loras"),
+        ("user.loras.jsonc", "loras"),
+        ("builtin.recipe-presets.jsonc", "presets"),
+        ("user.recipe-presets.jsonc", "presets"),
+    ] {
+        std::fs::write(
+            config_dir.join(name),
+            format!("{{ \"schemaVersion\": 1, \"{key}\": [] }}"),
+        )
+        .expect("sibling manifest writes");
+    }
+}
+
+#[test]
+fn model_download_and_co_requisite_helpers_partition_downloads() {
+    // sc-9696: a co-requisite (fetch-all dependency) must never be chosen as the primary/tier
+    // download, and must be enumerable separately for the download job + install-state gating.
+    let model = json!({
+        "id": "pid_qwenimage",
+        "downloads": [
+            { "provider": "huggingface", "repo": "SceneWorks/pid-qwenimage" },
+            { "provider": "huggingface", "repo": "SceneWorks/gemma-2-2b-it", "coRequisite": true }
+        ]
+    });
+    assert_eq!(
+        super::model_download(&model).expect("primary resolves")["repo"],
+        "SceneWorks/pid-qwenimage"
+    );
+    let co_requisites = super::model_co_requisite_downloads(&model);
+    assert_eq!(co_requisites.len(), 1);
+    assert_eq!(co_requisites[0]["repo"], "SceneWorks/gemma-2-2b-it");
+
+    // Ordering-independent: a co-requisite listed FIRST still never wins the primary slot.
+    let reordered = json!({
+        "id": "pid_qwenimage",
+        "downloads": [
+            { "provider": "huggingface", "repo": "SceneWorks/gemma-2-2b-it", "coRequisite": true },
+            { "provider": "huggingface", "repo": "SceneWorks/pid-qwenimage" }
+        ]
+    });
+    assert_eq!(
+        super::model_download(&reordered).expect("primary resolves")["repo"],
+        "SceneWorks/pid-qwenimage"
+    );
+}
+
+#[tokio::test]
+async fn model_download_job_enqueues_co_requisite_dependencies() {
+    // sc-9696: installing a model with a co-requisite download (e.g. the PiD decoder's shared
+    // gemma-2-2b-it caption encoder) must queue a SECOND download job for the dependency — else it
+    // is never fetched and the feature silently no-ops (PiD → native VAE). The co-requisite job
+    // must NOT carry the model's family (it is a different artifact than the primary checkpoint).
+    std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        r#"
+            {
+              "schemaVersion": 1,
+              "models": [{
+                "id": "pid_qwenimage",
+                "name": "PiD Decoder",
+                "type": "utility",
+                "family": "pid",
+                "downloads": [
+                  { "provider": "huggingface", "repo": "SceneWorks/pid-qwenimage" },
+                  { "provider": "huggingface", "repo": "SceneWorks/gemma-2-2b-it", "coRequisite": true }
+                ]
+              }]
+            }
+            "#,
+    )
+    .expect("builtin models writes");
+    write_empty_sibling_manifests(&config_dir);
+
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (status, primary) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/models/pid_qwenimage/download",
+        json!({ "requestedGpu": "auto" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    // The returned job is the primary (its id is what the download UI tracks).
+    assert_eq!(primary["payload"]["repo"], "SceneWorks/pid-qwenimage");
+    assert_eq!(primary["payload"]["family"], "pid");
+
+    let (_, jobs) = request(app, "GET", "/api/v1/jobs", Value::Null).await;
+    let download_jobs = jobs
+        .as_array()
+        .expect("jobs is an array")
+        .iter()
+        .filter(|job| job["type"] == "model_download")
+        .collect::<Vec<_>>();
+    assert_eq!(
+        download_jobs.len(),
+        2,
+        "the primary and its one co-requisite must each get a download job"
+    );
+    let co_requisite = download_jobs
+        .iter()
+        .find(|job| job["payload"]["repo"] == "SceneWorks/gemma-2-2b-it")
+        .expect("a co-requisite download job is enqueued");
+    assert!(
+        co_requisite["payload"].get("family").map_or(true, Value::is_null),
+        "a co-requisite job must not carry the model family (different artifact than the checkpoint)"
+    );
+}
+
+#[tokio::test]
+async fn model_catalog_gates_install_state_on_co_requisite() {
+    // sc-9696: the entry is "installed" only when the primary AND every co-requisite are cached.
+    // Primary present but the gemma-2-2b-it caption encoder missing → not-installed + repairable, so
+    // the web PiD toggle stays hidden and the user still has a path to fetch the missing dependency.
+    std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        r#"
+            {
+              "schemaVersion": 1,
+              "models": [{
+                "id": "pid_qwenimage",
+                "name": "PiD Decoder",
+                "type": "utility",
+                "family": "pid",
+                "downloads": [
+                  { "provider": "huggingface", "repo": "SceneWorks/pid-qwenimage" },
+                  { "provider": "huggingface", "repo": "SceneWorks/gemma-2-2b-it", "coRequisite": true }
+                ]
+              }]
+            }
+            "#,
+    )
+    .expect("builtin models writes");
+    write_empty_sibling_manifests(&config_dir);
+
+    let hub = temp_dir.path().join("data/cache/huggingface/hub");
+    // Primary present: a payload file makes a non-diffusers snapshot resolve as installed.
+    let primary_snapshot = hub.join("models--SceneWorks--pid-qwenimage/snapshots/rev1");
+    std::fs::create_dir_all(&primary_snapshot).expect("primary snapshot dir creates");
+    std::fs::write(
+        primary_snapshot.join("pid_qwenimage_2kto4k.safetensors"),
+        "weights",
+    )
+    .expect("primary weights write");
+
+    // Case A: gemma co-requisite absent → not installed, repairable, and surfaced as missing.
+    let (status, models) = request(
+        create_app(test_settings(&temp_dir)).expect("app creates"),
+        "GET",
+        "/api/v1/models",
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(models[0]["id"], "pid_qwenimage");
+    assert_eq!(
+        models[0]["installState"], "missing",
+        "primary present but co-requisite gemma missing → not installed"
+    );
+    assert_eq!(models[0]["cacheState"], "incomplete");
+    assert_eq!(models[0]["repairAvailable"], true);
+    assert!(
+        models[0]["missingRequiredFiles"]
+            .as_array()
+            .expect("missingRequiredFiles is an array")
+            .iter()
+            .any(|entry| entry
+                .as_str()
+                .is_some_and(|value| value.contains("gemma-2-2b-it"))),
+        "the missing co-requisite must be surfaced in missingRequiredFiles"
+    );
+
+    // Case B: install the gemma co-requisite too → the entry now reports installed.
+    let gemma_snapshot = hub.join("models--SceneWorks--gemma-2-2b-it/snapshots/rev1");
+    std::fs::create_dir_all(&gemma_snapshot).expect("gemma snapshot dir creates");
+    std::fs::write(gemma_snapshot.join("config.json"), "{}").expect("gemma config write");
+    std::fs::write(gemma_snapshot.join("model.safetensors"), "weights")
+        .expect("gemma weights write");
+
+    let (status, models) = request(
+        create_app(test_settings(&temp_dir)).expect("app creates"),
+        "GET",
+        "/api/v1/models",
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        models[0]["installState"], "installed",
+        "primary + co-requisite both cached → installed"
+    );
+    assert_eq!(models[0]["cacheState"], "complete");
+}
+
 #[tokio::test]
 async fn lora_catalog_uses_huggingface_cache_install_state() {
     std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -4328,6 +4328,10 @@
           // produces usable text-to-video. Only the cond_safe variant is fetched.
           "provider": "huggingface",
           "repo": "TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
+          // Co-requisite (sc-9696): the cond_safe distill LoRA is a required runtime component
+          // (auto-injected per-pass; see mlx.autoDistillLora), so it must download alongside the
+          // 10Eros checkpoint rather than being a pick-one alternate.
+          "coRequisite": true,
           "files": ["ltx-2.3-22b-distilled-lora-1.1_fro90_ceil72_condsafe.safetensors"],
           "estimatedSizeBytes": 662072824
         }
@@ -5563,6 +5567,11 @@
           // mirror's LICENSE (Gemma Terms) + Prohibited Use Policy + NOTICE alongside the weights.
           "provider": "huggingface",
           "repo": "SceneWorks/gemma-2-2b-it",
+          // Co-requisite (sc-9696): fetched ALONGSIDE the PiD checkpoint, not an alternate to it.
+          // Model Manager downloads both, and the entry only reports installed once both are cached
+          // (else `resolve_pid_weights` silently no-ops to the native VAE). Shared across all four PiD
+          // decoders + SANA, so deleting one PiD decoder must NOT remove it.
+          "coRequisite": true,
           "files": [],
           "estimatedSizeBytes": 5228717488
         }
@@ -5633,6 +5642,11 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/gemma-2-2b-it",
+          // Co-requisite (sc-9696): fetched ALONGSIDE the PiD checkpoint, not an alternate to it.
+          // Model Manager downloads both, and the entry only reports installed once both are cached
+          // (else `resolve_pid_weights` silently no-ops to the native VAE). Shared across all four PiD
+          // decoders + SANA, so deleting one PiD decoder must NOT remove it.
+          "coRequisite": true,
           "files": [],
           "estimatedSizeBytes": 5228717488
         }
@@ -5702,6 +5716,11 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/gemma-2-2b-it",
+          // Co-requisite (sc-9696): fetched ALONGSIDE the PiD checkpoint, not an alternate to it.
+          // Model Manager downloads both, and the entry only reports installed once both are cached
+          // (else `resolve_pid_weights` silently no-ops to the native VAE). Shared across all four PiD
+          // decoders + SANA, so deleting one PiD decoder must NOT remove it.
+          "coRequisite": true,
           "files": [],
           "estimatedSizeBytes": 5228717488
         }
@@ -5771,6 +5790,11 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/gemma-2-2b-it",
+          // Co-requisite (sc-9696): fetched ALONGSIDE the PiD checkpoint, not an alternate to it.
+          // Model Manager downloads both, and the entry only reports installed once both are cached
+          // (else `resolve_pid_weights` silently no-ops to the native VAE). Shared across all four PiD
+          // decoders + SANA, so deleting one PiD decoder must NOT remove it.
+          "coRequisite": true,
           "files": [],
           "estimatedSizeBytes": 5228717488
         }

--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -237,7 +237,7 @@
           },
           "downloads": {
             "type": "array",
-            "description": "Download entries list alternate sources for the same model; at most one may be marked default: true. If none is marked, the first supported entry is used. When a model ships a quant matrix (epic 8506, sc-8508), each tier (bf16 / Q8 / Q4) is a SEPARATE download entry — same repo, distinct `files` filter and `variant` — so each tier is an independently installable artifact whose presence the catalog tracks per-variant.",
+            "description": "Download entries are usually PICK-ONE alternates for the same model: at most one may be marked default: true (else the first supported entry is used); a quant matrix (epic 8506, sc-8508) lists each tier (bf16 / Q8 / Q4) as a separate same-repo entry distinguished by `files`/`variant`; OS alternates are distinguished by `platforms`. Entries flagged `coRequisite: true` are the exception — FETCH-ALL dependencies (e.g. a decoder checkpoint plus its shared caption encoder) that install alongside the primary and gate its install state (sc-9696).",
             "contains": {
               "type": "object",
               "properties": {
@@ -265,7 +265,11 @@
                 },
                 "variant": {
                   "$ref": "#/$defs/quantVariantKey",
-                  "description": "The quantization tier this entry provisions (bf16 / q8 / q4). Present only on quant-matrix entries (sc-8508); a single-variant model omits it. The web/download-job selects a tier by this key, and per-variant install tracking reports which tiers are on disk."
+                  "description": "The quantization tier this entry provisions (bf16 / q8 / q4). Present only on quant-matrix entries (sc-8508); a single-variant model omits it. The web/download-job selects a tier by this key, and per-variant install tracking reports which tiers are on disk. Never combined with coRequisite (a co-requisite is not a selectable tier)."
+                },
+                "coRequisite": {
+                  "type": "boolean",
+                  "description": "Marks this entry as a FETCH-ALL dependency installed IN ADDITION TO the primary download, not a pick-one alternate (contrast `variant` tiers and `platforms` OS alternates). Installing the model queues the primary plus every co-requisite for the current OS, and the catalog reports the entry installed only once the primary AND all co-requisites are cached. Co-requisite entries are never chosen as the primary/default and are excluded from quant-tier enumeration. A co-requisite may be shared by several models (e.g. the PiD gemma-2-2b-it caption encoder), so deleting one model does NOT remove it. Example: a PiD decoder checkpoint (primary) + gemma-2-2b-it (co-requisite). See sc-9696, epic 7840."
                 },
                 "estimatedSizeBytes": {
                   "type": ["integer", "string"],


### PR DESCRIPTION
## Problem

Model Manager only fetched the **primary** download of a multi-repo catalog entry. The PiD decoder entries (`pid_qwenimage`/`pid_flux`/`pid_flux2`/`pid_sdxl`) each declare two co-requisite downloads — the checkpoint **and** `SceneWorks/gemma-2-2b-it` (the shared caption encoder) — but only the checkpoint was ever downloaded. `resolve_pid_weights` then silently fell back to the native VAE, so PiD output stayed at native resolution (e.g. Krea 2 at 1024×1024) **with no error**. Re-downloading in-app didn't help — the machinery never fetched the second repo.

A full manifest scan found the same pattern in `ltx_2_3_eros` (its cond_safe distill LoRA is a required runtime component). Everything else the code comment called "multi-entry" is a quant tier (`variant`) or OS alternate (`platforms`) — genuinely pick-one, already correct.

Coupled defect: `install_state_for` judged the entry installed from the primary repo alone, so the web PiD toggle appeared while its dependency was missing.

## Fix (explicit co-requisite marker)

`downloads[]` was overloaded — pick-one alternates (quant tiers / OS variants) mixed with fetch-all co-requisites, with no way to tell them apart. This adds an explicit marker and honors it:

- **Schema**: new `downloads[].coRequisite` boolean.
- **Manifest**: marked the 5 co-requisites (gemma in the 4 PiD entries + the ltx_2_3_eros distill LoRA).
- **`create_model_download_job`**: enqueues a download job per co-requisite (current OS). Extracted `build_model_download_job_payload`, shared by primary + co-requisites; co-requisites get `include_family: false` (a text encoder must not be reconciled against the model's family).
- **`model_download` / `model_download_for_variant`**: skip co-requisites when selecting the primary/tier.
- **`install_state_for`**: installed only when the primary **and** all co-requisites are cached; a present-primary + missing-co-requisite surfaces as repairable (`cacheState: incomplete` → `repairAvailable`) with the co-requisite listed in `missingRequiredFiles`. Co-requisites excluded from `model_variant_states`/`model_has_variant_matrix`; their size folded into `downloadSizeBytes`.
- **Delete left untouched** — `model_artifact_paths` uses the primary only, so a single delete never removes `gemma-2-2b-it`, which is shared across the four PiD entries and SANA.

This also closes the toggle-masking bug for free: the web `pidDecoderAvailable` keys on `installState === "installed"`, which now requires gemma — no web change needed.

## Testing

- 3 new rust-api unit tests: helper partition (primary vs co-requisite, order-independent); download job enqueues the co-requisite without the family; install-state gating (primary-only → `missing`/repairable → both cached → `installed`).
- Full rust-api lib suite: 167/167.
- `npm run rust:check` (fmt + clippy + test + build) green, before and after merging origin/main.
- `pidEligibility` web tests: 4/4.

Verified on disk that installing both `SceneWorks/pid-qwenimage` + `SceneWorks/gemma-2-2b-it` makes `resolve_pid_weights` resolve. Live 2K/4K generation still wants a build carrying this change + a GPU run.

Closes sc-9696 (epic 7840).

🤖 Generated with [Claude Code](https://claude.com/claude-code)