### PR TITLE
refactor(web): app/editor cleanups (epic 8800 batch W1)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1316,6 +1316,13 @@ export function App() {
       if (job.status === "failed" && !hasVisibleLocalFailure(job)) {
         pushNotice(noticeKindForJob(job), failedJobNotice(job));
       }
+      // Evict the per-job refresh bookkeeping once the job is terminal (sc-8944): the
+      // dedupe counters are only consulted while a job is still emitting incremental
+      // asset updates. Without this the Map grows one entry per asset-producing job for
+      // the session's lifetime (unbounded, slow leak in multi-day sessions).
+      if (terminalStatuses.has(job.status)) {
+        generatedAssetRefreshesRef.current.delete(refreshKey);
+      }
     }
 
     function handleWorkerUpdated(event) {

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -42,6 +42,7 @@ import {
 import { buildWorkersById } from "./workers.js";
 import { createEditorScratchRegistry } from "./editorScratch.js";
 import { isDesktop as isDesktopShell, tauriInvoke } from "./runtime.js";
+import { readAccessToken, storeAccessToken, clearAccessToken } from "./accessToken.js";
 
 // Desktop (Tauri) shell detection (unified helper, epic 4484 story 6). The first-run
 // setup wizard is desktop-only; web/Docker (and a remote LAN browser) keep the
@@ -457,7 +458,10 @@ export function App() {
   // otherwise they fire optimistically, 401, and bury the password prompt under a band
   // of "access token required" errors (epic 4484).
   const [accessResolved, setAccessResolved] = useState(false);
-  const [token, setToken] = useState(() => window.localStorage.getItem("sceneworks-token") ?? "");
+  // The remote-access token (= host password). Storage key + threat-model note live in
+  // accessToken.js (sc-8880); it is persisted verbatim in localStorage so it survives
+  // reloads (a LAN remote-access requirement — see that module for the accepted XSS tradeoff).
+  const [token, setToken] = useState(() => readAccessToken());
   // What the user is typing into the login gate (sc-8808). Kept separate from the
   // live `token` so keystrokes never flip `authenticated` or churn the data/SSE
   // effects; `token` only changes once /api/v1/auth/verify accepts the draft.
@@ -1549,7 +1553,7 @@ export function App() {
       setAuthError("Couldn't reach the host to verify the password.");
       return;
     }
-    window.localStorage.setItem("sceneworks-token", candidate);
+    storeAccessToken(candidate);
     setToken(candidate);
     setPasswordDraft("");
     setAuthError("");
@@ -1560,7 +1564,7 @@ export function App() {
   // epic 4484 story 7). Setting the token state to "" re-renders the gate, which
   // keys off the token state (sc-8808).
   function lockRemote() {
-    window.localStorage.removeItem("sceneworks-token");
+    clearAccessToken();
     setToken("");
     setPasswordDraft("");
     setAuthError("");

--- a/apps/web/src/accessToken.js
+++ b/apps/web/src/accessToken.js
@@ -1,0 +1,48 @@
+// Single seam for the remote-access token (epic 4484 / sc-8880). The token IS the
+// host access password: a correct password verified against /api/v1/auth/verify is
+// promoted to the live token, sent as the Bearer credential on every authed request.
+//
+// STORAGE / THREAT MODEL (sc-8880, F-078): the token is persisted verbatim in
+// localStorage under a single key so it survives reloads — a hard requirement for a
+// LAN remote-access tool where re-typing the password every session would be a real
+// UX regression (sessionStorage would force exactly that). The plaintext-at-rest
+// exposure is an XSS-exfiltration risk on the app origin, but it is accepted under
+// this deployment's threat model:
+//   - The host binds loopback/LAN only; there is no public origin to phish.
+//   - The app has a strong XSS posture (no dangerouslySetInnerHTML on host data, CSP).
+//   - The token is scoped to a single self-hosted host the user already controls.
+// The real XSS mitigation is an httpOnly-cookie exchange, which is an architectural
+// change to the epic-4484 auth seam (server-set cookie + CSRF) rather than a client
+// tweak; it is deliberately out of scope here. Keeping the key + access in one module
+// means any future hardening (session vs local storage, cookie exchange) is a
+// one-file change instead of hunting scattered `localStorage.getItem("sceneworks-token")`
+// literals across App.jsx and credentials.js.
+
+// The localStorage key. Do not inline this string elsewhere — import it (or the
+// helpers below) so the storage contract stays centralized.
+export const ACCESS_TOKEN_KEY = "sceneworks-token";
+
+// Whether a Web Storage backend is reachable (guards non-browser / private-mode /
+// storage-disabled environments where the getter can throw).
+function storage() {
+  try {
+    return typeof window !== "undefined" ? window.localStorage : null;
+  } catch {
+    return null;
+  }
+}
+
+// The persisted access token, or "" when none is stored / storage is unavailable.
+export function readAccessToken() {
+  return storage()?.getItem(ACCESS_TOKEN_KEY) ?? "";
+}
+
+// Persist the verified access token so it survives reloads (see threat-model note).
+export function storeAccessToken(token) {
+  storage()?.setItem(ACCESS_TOKEN_KEY, token);
+}
+
+// Forget the stored token (the "lock"/forget affordance re-shows the login gate).
+export function clearAccessToken() {
+  storage()?.removeItem(ACCESS_TOKEN_KEY);
+}

--- a/apps/web/src/accessToken.test.js
+++ b/apps/web/src/accessToken.test.js
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  ACCESS_TOKEN_KEY,
+  clearAccessToken,
+  readAccessToken,
+  storeAccessToken,
+} from "./accessToken.js";
+
+describe("accessToken (sc-8880)", () => {
+  afterEach(() => {
+    // Restore any storage descriptor a test replaced, and clear the key.
+    if (originalStorageDescriptor) {
+      Object.defineProperty(globalThis, "localStorage", originalStorageDescriptor);
+      originalStorageDescriptor = null;
+    }
+    try {
+      globalThis.localStorage?.removeItem(ACCESS_TOKEN_KEY);
+    } catch {
+      // storage may be intentionally broken by a test — ignore.
+    }
+  });
+
+  let originalStorageDescriptor = null;
+
+  it("persists the token under the single canonical key so it survives a reload", () => {
+    expect(ACCESS_TOKEN_KEY).toBe("sceneworks-token");
+    storeAccessToken("hunter2");
+    // Read back through the helper AND the raw key: both must agree, proving the
+    // helper writes exactly the documented storage contract.
+    expect(readAccessToken()).toBe("hunter2");
+    expect(window.localStorage.getItem(ACCESS_TOKEN_KEY)).toBe("hunter2");
+  });
+
+  it("returns an empty string when no token is stored", () => {
+    expect(readAccessToken()).toBe("");
+  });
+
+  it("clears the stored token (the lock/forget affordance)", () => {
+    storeAccessToken("to-forget");
+    clearAccessToken();
+    expect(readAccessToken()).toBe("");
+    expect(window.localStorage.getItem(ACCESS_TOKEN_KEY)).toBeNull();
+  });
+
+  it("degrades gracefully when Web Storage is unavailable (private mode / disabled)", () => {
+    originalStorageDescriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      get() {
+        throw new Error("storage disabled");
+      },
+    });
+    // No throw from any helper; read yields the empty-token default.
+    expect(() => storeAccessToken("x")).not.toThrow();
+    expect(readAccessToken()).toBe("");
+    expect(() => clearAccessToken()).not.toThrow();
+  });
+});

--- a/apps/web/src/components/LoraPickerField.jsx
+++ b/apps/web/src/components/LoraPickerField.jsx
@@ -1,9 +1,8 @@
 import React from "react";
-import { loraMatchesModel, loraWeight, serializeLora } from "../presetUtils.js";
+import { MAX_JOB_LORAS_TOTAL, loraMatchesModel, loraWeight, serializeLora } from "../presetUtils.js";
 
-// Keep in sync with the worker guard (lora_adapters.MAX_JOB_LORAS) and the Rust
-// recipe-preset normalizer — generation rejects more than this many LoRAs per job.
-const MAX_JOB_LORAS = 5;
+// The per-job total cap (sc-8936): this Character Studio picker doesn't distinguish
+// builtin vs user LoRAs, so it gates on the hard total the worker enforces.
 
 // Family-filtered LoRA selection shared by the Character Studio Angle Set + Pose
 // Library panels (sc-2223). Mirrors the Image/Video Studio behaviour without
@@ -40,8 +39,8 @@ export function useLoraSelection(loras, model) {
       if (ids.includes(lora.id)) {
         return ids.filter((id) => id !== lora.id);
       }
-      if (ids.length >= MAX_JOB_LORAS) {
-        return ids; // the worker rejects more than MAX_JOB_LORAS per job
+      if (ids.length >= MAX_JOB_LORAS_TOTAL) {
+        return ids; // the worker rejects more than MAX_JOB_LORAS_TOTAL per job
       }
       return [...ids, lora.id];
     });

--- a/apps/web/src/credentials.js
+++ b/apps/web/src/credentials.js
@@ -1,4 +1,5 @@
 import { apiFetch } from "./api.js";
+import { readAccessToken } from "./accessToken.js";
 import { isDesktop, tauriInvoke } from "./runtime.js";
 
 // Service-credential transport shared by the Settings screen (where users manage
@@ -18,10 +19,9 @@ export const SCHEME_LABELS = {
 };
 
 // Server mode authenticates with the same access token the rest of the app uses.
+// The storage key + threat-model note live in accessToken.js (sc-8880).
 export function serverToken() {
-  return (
-    (typeof window !== "undefined" && window.localStorage.getItem("sceneworks-token")) || ""
-  );
+  return readAccessToken();
 }
 
 export async function loadCredentials() {

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -5244,6 +5244,91 @@ describe("SceneWorks app shell", () => {
     expect(document.body.querySelectorAll(".worker-progress-card__thumb-cell.skeleton").length).toBe(3);
   });
 
+  it("evicts the per-job asset-refresh bookkeeping once a job goes terminal (sc-8944)", async () => {
+    const createdJobs = [];
+    let assetRefreshFetches = 0;
+    global.fetch.mockImplementation((url, options = {}) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response([{ id: "project-1", name: "Noir" }]));
+      }
+      if (path.endsWith("/models")) {
+        return Promise.resolve(response([{ id: "z_image_turbo", name: "Z-Image", type: "image", family: "z-image" }]));
+      }
+      if (path.endsWith("/assets")) {
+        assetRefreshFetches += 1;
+        return Promise.resolve(response([]));
+      }
+      if (path.endsWith("/image/jobs") && options.method === "POST") {
+        const job = {
+          id: "image-job-1",
+          type: "image_generate",
+          status: "running",
+          stage: "running",
+          progress: 0.35,
+          projectId: "project-1",
+          projectName: "Noir",
+          requestedGpu: "auto",
+          payload: { prompt: "A cinematic frame of a neon street at midnight", count: 1 },
+        };
+        createdJobs.unshift(job);
+        return Promise.resolve(response(job));
+      }
+      if (path.endsWith("/jobs")) {
+        return Promise.resolve(response(createdJobs));
+      }
+      return Promise.resolve(response([]));
+    });
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+    await act(async () => {
+      [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Image").click();
+    });
+    await settle();
+    await act(async () => {
+      document.body.querySelector(".image-studio form").requestSubmit();
+    });
+    await settle();
+
+    // A completed generation-set fires the initial assets refresh and records the
+    // per-job dedupe entry (job.id -> generationSetId).
+    function emitCompleted(generationSetId) {
+      return act(async () => {
+        FakeEventSource.instances[0].listeners["job.updated"]({
+          data: JSON.stringify({
+            ...createdJobs[0],
+            status: "completed",
+            stage: "completed",
+            progress: 1,
+            result: { generationSetId, assetIds: [] },
+          }),
+        });
+      });
+    }
+
+    await emitCompleted("genset-1");
+    await settle();
+    const afterFirst = assetRefreshFetches;
+    expect(afterFirst).toBeGreaterThan(0);
+
+    // Re-emitting the SAME generation-set for the SAME (now terminal) job id must
+    // refresh again: the terminal eviction (sc-8944) cleared the dedupe entry, so the
+    // set is treated as new. Without eviction the entry would still dedupe this away.
+    await emitCompleted("genset-1");
+    await settle();
+    expect(assetRefreshFetches).toBeGreaterThan(afterFirst);
+  });
+
   it("shows local generation failures without duplicating the global banner", async () => {
     const createdJobs = [];
     global.fetch.mockImplementation((url, options = {}) => {

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -1336,6 +1336,46 @@ describe("SceneWorks app shell", () => {
     );
   });
 
+  it("does not mutate the API-returned asset record when flagging dataset-only (sc-8939)", async () => {
+    // Capture the exact object the upload transport returns so we can assert the import
+    // path treats it as immutable (the datasetOnly flag must land on a copy, not here).
+    const returnedAsset = {
+      id: "dataset-upload-mira",
+      displayName: "mira.png",
+      file: { path: "training/uploads/mira.png", mimeType: "image/png" },
+    };
+    const uploadDatasetItem = vi.fn(async () => returnedAsset);
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withTrainingDataSetsLibraryContext({
+          activeProject: { id: "project-a", name: "Project A" },
+          assets: [],
+          datasets: [],
+          createDataset: vi.fn(async (payload) => ({ id: "dataset-new", name: payload.name, version: 1, items: payload.items })),
+          uploadDatasetItem,
+        }),
+      );
+    });
+
+    const imageFile = new File([new Uint8Array([1, 2, 3])], "mira.png", { type: "image/png" });
+    await act(async () => {
+      [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Add images").click();
+    });
+    const fileInput = document.body.querySelector(".dataset-add-dropzone input[type=file]");
+    await act(async () => {
+      Object.defineProperty(fileInput, "files", { configurable: true, value: [imageFile] });
+      fileInput.dispatchEvent(new window.Event("change", { bubbles: true }));
+    });
+    await settle();
+
+    expect(uploadDatasetItem).toHaveBeenCalledTimes(1);
+    // The returned record is unchanged — no datasetOnly leaked onto the shared instance.
+    expect(returnedAsset).not.toHaveProperty("datasetOnly");
+    expect(Object.keys(returnedAsset)).toEqual(["id", "displayName", "file"]);
+  });
+
   it("opens and saves an existing training dataset membership", async () => {
     const loadDataset = vi.fn(async () => ({
       id: "dataset-a",

--- a/apps/web/src/presetUtils.js
+++ b/apps/web/src/presetUtils.js
@@ -1,5 +1,20 @@
 export const noPresetId = "__no_preset__";
 
+// LoRA-per-job / per-preset caps (sc-8936, F-134). Single source of truth for the web:
+// previously the same numbers were hand-copied as bare literals across the Image/Video
+// studios, the Character Studio picker, and the Preset Manager, so raising a cap (already
+// done once, 3 -> 4/5) meant hunting scattered magic numbers and left stale "/3" badges.
+//
+// These MUST stay in sync with the worker guards (single source of truth on that side):
+//   - MAX_JOB_LORAS_TOTAL == crates/sceneworks-worker/src/image_jobs.rs::MAX_JOB_LORAS (5):
+//     the hard per-job total the generation path rejects above (builtin + user combined).
+//   - MAX_USER_JOB_LORAS (4): the user-selectable cap the studio pickers enforce, leaving
+//     headroom for one auto-applied builtin LoRA within the total (pick 4 -> total 5).
+//   - MAX_PRESET_LORAS == the recipe-preset normalizer's cap (5): LoRAs a saved preset holds.
+export const MAX_JOB_LORAS_TOTAL = 5;
+export const MAX_USER_JOB_LORAS = 4;
+export const MAX_PRESET_LORAS = 5;
+
 export function rememberPresetDefault(snapshots, key, currentValue, appliedValue) {
   const previousSnapshot = snapshots.current[key];
   snapshots.current[key] = {

--- a/apps/web/src/presetUtils.test.js
+++ b/apps/web/src/presetUtils.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { MAX_JOB_LORAS_TOTAL, MAX_PRESET_LORAS, MAX_USER_JOB_LORAS } from "./presetUtils.js";
+
+// sc-8936 (F-134): the LoRA caps are now single constants instead of scattered magic
+// numbers. These assertions pin the values + the intended relationship so a future
+// change to one has to consciously reconcile the others (and keep them in sync with the
+// worker guards documented alongside the constants).
+describe("LoRA cap constants (sc-8936)", () => {
+  it("matches the current cap values", () => {
+    expect(MAX_JOB_LORAS_TOTAL).toBe(5);
+    expect(MAX_USER_JOB_LORAS).toBe(4);
+    expect(MAX_PRESET_LORAS).toBe(5);
+  });
+
+  it("leaves headroom for one auto-applied builtin within the per-job total", () => {
+    // The studio pickers cap user-selectable LoRAs below the hard total so a builtin
+    // can still ride along (pick 4 user -> total 5), matching the worker guard.
+    expect(MAX_USER_JOB_LORAS).toBeLessThan(MAX_JOB_LORAS_TOTAL);
+    expect(MAX_USER_JOB_LORAS + 1).toBe(MAX_JOB_LORAS_TOTAL);
+  });
+
+  it("caps saved-preset LoRAs at the per-job total", () => {
+    expect(MAX_PRESET_LORAS).toBe(MAX_JOB_LORAS_TOTAL);
+  });
+});

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Stage, Layer, Image as KonvaImage, Line, Rect, Transformer } from "react-konva";
 import { apiFetch } from "../api.js";
@@ -1031,7 +1031,11 @@ export function ImageEditor() {
   useEffect(() => { aiOpRef.current = aiOp; }, [aiOp]);
   useEffect(() => { workingRef.current = working; }, [working]);
 
-  const imageAssets = (assets ?? []).filter(assetCanRenderAsImage);
+  // Memoize the image-renderable subset (sc-8939): the Image Editor re-renders on every
+  // pointermove of a brush stroke / box drag, and re-filtering the full catalog each time
+  // is needless work (jank on big projects). Only recompute when the catalog changes; this
+  // also stabilizes the identity `imageAssets` feeds into the open-from-asset callback dep.
+  const imageAssets = useMemo(() => (assets ?? []).filter(assetCanRenderAsImage), [assets]);
 
   // Track the container size so the Konva stage fills the available canvas area.
   // Measure once up front (a ResizeObserver alone can miss the first layout) and

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -119,11 +119,6 @@ const EDITOR_SHORTCUTS = [
   },
 ];
 
-// Future-tool scaffold (epic 2427) — rendered as inert buttons so the frame + the
-// next slices' insertion points stay in place. All current epic-2427 tools are live
-// (Move + Crop + Upscale + Color + AI Edit + Detail), so this is empty for now.
-const UPCOMING_TOOLS = [];
-
 // Upper bound on images in a FLUX.2 multi-reference edit, matching the worker's MAX_EDIT_REFERENCES
 // (image_jobs/flux2.rs). The working image takes one slot, so the editor allows up to 3 user refs.
 export const MAX_EDIT_REFERENCES = 4;
@@ -3178,17 +3173,6 @@ export function ImageEditor() {
             >
               Boxes
             </button>
-            {UPCOMING_TOOLS.map((upcoming) => (
-              <button
-                className="image-editor-tool"
-                disabled
-                key={upcoming.id}
-                title={`${upcoming.label} — coming soon (${upcoming.story})`}
-                type="button"
-              >
-                {upcoming.label}
-              </button>
-            ))}
           </aside>
         ) : null}
 

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -108,12 +108,17 @@ const MODEL_TYPE_OPTIONS = [
   { value: "utility", label: "Utility" },
 ];
 
-// sc-7081 (epic 7080): model upload/import is hidden + disabled on every platform until a
+// sc-7081 (epic 7080, P0): model upload/import is hidden + disabled on every platform until a
 // real compatibility + conversion pipeline exists behind it. Today an imported checkpoint
 // has no runnable engine (macOS is MLX-only with a compile-time engine table; off-Mac only
 // loads full diffusers repos), so the form is kept in source but not rendered. The API
 // refuses the request too. Flip to true once the pipeline gates imports on a compatibility
 // verdict.
+//
+// KEEP, don't delete (sc-8941 / F-139): this is the deliberate P0-disabled scaffold that epic
+// 7080's P5 ("re-enable the UI behind the compat gate") restores — not accidental dead code.
+// The whole form + its state/handler below stay compile-time-gated by this flag so the
+// restoration point is preserved. Removing it would discard tracked, in-progress roadmap work.
 const MODEL_IMPORT_ENABLED = false;
 
 // Models render in type-grouped sections. Order is fixed; any model whose `type`

--- a/apps/web/src/screens/PresetManagerScreen.jsx
+++ b/apps/web/src/screens/PresetManagerScreen.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { Icon } from "../components/Icons.jsx";
 import {
+  MAX_PRESET_LORAS,
   compactModeList,
   loraMatchesModel,
   presetLoraId,
@@ -210,7 +211,7 @@ export function PresetManagerScreen() {
     }
     setForm((current) => {
       const hasLora = current.loras.some((lora) => lora.id === id);
-      if (hasLora || current.loras.length >= 5) {
+      if (hasLora || current.loras.length >= MAX_PRESET_LORAS) {
         return current;
       }
       const source = loras.find((lora) => lora.id === id);
@@ -844,7 +845,7 @@ export function PresetManagerScreen() {
                       ) : (
                         <button
                           className="lora-add"
-                          data-count={`${form.loras.length}/3`}
+                          data-count={`${form.loras.length}/${MAX_PRESET_LORAS}`}
                           disabled={!editable || !availableLoras.length}
                           onClick={() => setShowLoraPicker(true)}
                           type="button"

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -1054,9 +1054,12 @@ export function TrainingStudio({ mode = "training" } = {}) {
       for (const file of imageFiles) {
         const asset = await uploadDatasetItem(file);
         if (asset?.id) {
-          asset.datasetOnly = true;
-          imported.push(asset.id);
-          setUploadedDatasetAssets((current) => [asset, ...current.filter((item) => item.id !== asset.id)]);
+          // Flag the dataset-only origin on a COPY (sc-8939): mutating the API-returned
+          // record in place can leak the flag into any other holder of that instance
+          // (e.g. an asset cached in context). Build a fresh object instead.
+          const datasetAsset = { ...asset, datasetOnly: true };
+          imported.push(datasetAsset.id);
+          setUploadedDatasetAssets((current) => [datasetAsset, ...current.filter((item) => item.id !== datasetAsset.id)]);
           const caption = captionByStem.get(uploadFileStem(file.name));
           if (caption) {
             captionsByAssetId[asset.id] = { source: "imported", text: caption };

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -163,8 +163,15 @@ export function VideoStudio() {
   // by workspace in App.jsx, so this reads the right snapshot per workspace.
   const saved = useMemo(() => loadStudioSettings("video", activeProject?.id ?? null), [activeProject?.id]);
   const [motion, setMotion] = useState(saved.motion ?? "slow push-in");
-  const imageAssets = assets.filter((asset) => asset.type === "image" || asset.type === "frame");
-  const videoAssets = assets.filter((asset) => asset.type === "video");
+  // Memoize the per-type catalog splits (sc-8939): both feed a dozen pickers/trays and
+  // re-filtering the full catalog on every render (including unrelated state churn) is
+  // needless. Recompute only when the catalog changes; stable identities also keep the
+  // downstream memoized offers/consumers from thrashing.
+  const imageAssets = useMemo(
+    () => assets.filter((asset) => asset.type === "image" || asset.type === "frame"),
+    [assets],
+  );
+  const videoAssets = useMemo(() => assets.filter((asset) => asset.type === "video"), [assets]);
   // Open on Text→Video for parity with Image Studio's Text→Image default and the
   // launch-request fallback below (sc-5716); the prior image_to_video default was the odd one out.
   const [mode, setMode] = useState(saved.mode ?? "text_to_video");

--- a/apps/web/src/screens/generationStudio.jsx
+++ b/apps/web/src/screens/generationStudio.jsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Icon } from "../components/Icons.jsx";
 import { terminalStatuses } from "../jobTypes.js";
 import {
+  MAX_USER_JOB_LORAS,
   applyPresetDefault,
   buildStudioPresetPayload,
   clearPresetDefault,
@@ -261,7 +262,7 @@ export function useGenerationStudio({
       }
       const selected = ids.map((id) => compatibleLoras.find((item) => item.id === id)).filter(Boolean);
       const userCount = selected.filter((item) => item.scope !== "builtin").length;
-      if (lora.scope !== "builtin" && userCount >= 4) {
+      if (lora.scope !== "builtin" && userCount >= MAX_USER_JOB_LORAS) {
         return ids;
       }
       return [...ids, lora.id];
@@ -476,7 +477,7 @@ export function LoraPickerSection({
         <div className="lora-choice-list">
           {compatibleLoras.map((lora) => {
             const checked = selectedLoraIds.includes(lora.id);
-            const userLimitReached = lora.scope !== "builtin" && !checked && userSelectedLoraCount >= 4;
+            const userLimitReached = lora.scope !== "builtin" && !checked && userSelectedLoraCount >= MAX_USER_JOB_LORAS;
             const weight = effectiveLoraWeight(lora);
             return (
               <div className="lora-choice-item" key={lora.id}>

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -314,8 +314,10 @@ const STUB_ADAPTER: &str = "procedural_preview";
 /// so the sidecar + result agree on which backend produced the image.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 const CANDLE_ADAPTER: &str = "candle_sdxl";
-// Shared by the MLX path and the candle Lens lane (sc-5126) — both cap a job's user LoRAs at 3
-// (`resolve_adapters`), so the const is available on the Windows candle build too.
+// Shared by the MLX path and the candle Lens lane (sc-5126) — both cap a job's total LoRAs at
+// MAX_JOB_LORAS (`resolve_adapters`), so the const is available on the Windows candle build too.
+// The web pickers enforce a lower user-selectable cap (presetUtils.MAX_USER_JOB_LORAS) that leaves
+// headroom for an auto-applied builtin within this total (sc-8936).
 #[cfg(any(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")

--- a/crates/sceneworks-worker/src/image_jobs/flux2_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2_edit_candle.rs
@@ -34,8 +34,10 @@ const FLUX2_EDIT_CANDLE_DEFAULT_REPO: &str = "black-forest-labs/FLUX.2-klein-9B"
 /// diffusers snapshot and Q4-quantizes it at load (no install-time packed convert off-Mac).
 const FLUX2_EDIT_CANDLE_DEV_REPO: &str = "black-forest-labs/FLUX.2-dev";
 /// Cap on references fed to a single FLUX.2 edit (the multi-image picker, sc-6211): the dev edit is
-/// activation-bound, so cap at the engine's validated native fan-out (parity with the MLX
-/// `MAX_EDIT_REFERENCES`).
+/// activation-bound, so cap at the engine's validated native fan-out. This deliberately differs from
+/// the MLX `MAX_EDIT_REFERENCES` (4): that bound is set by the 96 GB Apple-Silicon unified-memory
+/// floor (5 refs at 1024² exceed it), which does not apply to this off-Mac CUDA lane — so it admits
+/// the engine's full 5-reference fan-out (sc-8936: was mislabeled "parity with the MLX const").
 const FLUX2_EDIT_CANDLE_MAX_REFERENCES: usize = 5;
 
 /// True when this is the FLUX.2 **dev** edit variant (`flux2_dev`): the 32B flagship that loads via the


### PR DESCRIPTION
Epic 8800 code-review remediation, web batch W1. Five F-series findings from `CODE_REVIEW_2026-07-01.md`, all web/JS (plus two comment-only worker edits for F-134's stale comments).

## Stories

- **sc-8880 [F-078]** — `fix(web)`: access token was read/written/cleared via bare `localStorage["sceneworks-token"]` literals scattered across App.jsx + credentials.js, with the plaintext-at-rest exposure undocumented. Extracted a single `accessToken.js` seam (key + read/store/clear, storage-unavailable-safe) and **documented the accepted LAN/loopback threat model** in one place (why localStorage over sessionStorage; httpOnly-cookie exchange is the real mitigation, deferred as an epic-4484 auth-seam change). Behavior unchanged. This is the finding's endorsed "accept + document" default.
- **sc-8936 [F-134]** — `refactor(web)`: centralized the scattered LoRA-cap magic numbers into single `presetUtils.js` constants (`MAX_JOB_LORAS_TOTAL` 5, `MAX_USER_JOB_LORAS` 4, `MAX_PRESET_LORAS` 5), wired all web sites, and **fixed the stale `/3` preset badge → `/5`**. Reworded the two wrong worker comments (comment-only): image_jobs.rs "cap at 3" → total-cap note; flux2_edit_candle "parity with MLX MAX_EDIT_REFERENCES" → explains the deliberate 4-vs-5 gap (MLX 4 = 96GB Apple-Silicon floor; off-Mac CUDA lane isn't bound by it).
- **sc-8939 [F-137]** — `refactor(web)`: `useMemo(..., [assets])` for the per-render asset-catalog filters in ImageEditor + VideoStudio (they re-filtered the full catalog on every pointermove of a stroke/drag), and stopped `TrainingStudio.handleImport` mutating the API-returned record (`{ ...asset, datasetOnly: true }` copy instead of in-place).
- **sc-8941 [F-139]** — `chore(web)`: removed the genuinely-dead `UPCOMING_TOOLS` scaffold (empty array + inert `.map`) from ImageEditor. Kept the `MODEL_IMPORT_ENABLED` model-import form (epic-7080 P0-disabled scaffold that P5 re-enables — deleting it would discard in-progress roadmap work; the finding permits "accept per the epic-7080 note"), strengthening its in-code note. `packages/shared` removal deferred to epic 8283 as **sc-9704** (still imported by the not-yet-deleted Python worker + CI pytest lane — removing it now would break CI).
- **sc-8944 [F-142]** — `fix(web)`: prune `generatedAssetRefreshesRef` when a job reaches a terminal status in `handleJobUpdated` (was an unbounded per-job leak for the session lifetime).

## Tests

- **New:** `accessToken.test.js` (round-trip, empty default, clear, storage-disabled fallback); `presetUtils.test.js` (cap values + user/total/preset relationship); sc-8944 eviction regression (a re-emitted generation-set on a now-terminal job refreshes again — verified to fail without the fix); sc-8939 mutation regression (asserts the API-returned record is left untouched — verified to fail without the fix).
- **Full suite green:** `npm --prefix apps/web run test` → 72 files / 1127 tests pass. `npm --prefix apps/web run lint` → 0 errors (47 pre-existing `exhaustive-deps` warnings, none from this change). `npm --prefix apps/web run build` → passes. `cargo fmt -p sceneworks-worker -- --check` → clean (worker edits are comment-only).

## Notes
- `packages/shared` (F-139) intentionally NOT removed here → tracked as **sc-9704** under epic 8283 (retire runtime Python), which is where the finding directs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)