### PR TITLE
refactor(rust-api): upload/multipart + validation cleanups (epic 8800 batch 13)

### DIFF
--- a/apps/rust-api/src/assets.rs
+++ b/apps/rust-api/src/assets.rs
@@ -86,6 +86,14 @@ pub(crate) async fn import_asset(
         {
             match field.name() {
                 Some("file") => {
+                    // sc-8883 (F-081): reject a second `file` field instead of
+                    // overwriting `file` — the old code dropped the first staged temp
+                    // path on the floor, leaking a multi-GB tmp until the 24h sweep (a
+                    // disk-exhaustion lever for an authenticated caller). Matches the
+                    // LoRA/model imports, which also reject a duplicate file field.
+                    if file.is_some() {
+                        return Err(ApiError::bad_request("Only one file field is allowed"));
+                    }
                     let filename = field.file_name().unwrap_or("upload").to_owned();
                     let content_type = field.content_type().map(str::to_owned);
                     let temp_path = write_upload_field_to_temp_file(&state, field).await?;

--- a/apps/rust-api/src/assets.rs
+++ b/apps/rust-api/src/assets.rs
@@ -201,7 +201,7 @@ pub(crate) fn sweep_stale_asset_uploads_before(
 /// pose-source uploads use `pose-uploads` so they can be swept independently).
 pub(crate) async fn write_upload_field_to_dir(
     state: &AppState,
-    mut field: axum::extract::multipart::Field<'_>,
+    field: axum::extract::multipart::Field<'_>,
     subdir: &str,
 ) -> Result<PathBuf, ApiError> {
     let upload_dir = state.settings.data_dir.join("cache").join(subdir);
@@ -209,37 +209,18 @@ pub(crate) async fn write_upload_field_to_dir(
         .await
         .map_err(|error| ApiError::internal(error.to_string()))?;
     let temp_path = upload_dir.join(format!("upload-{}.tmp", Uuid::new_v4().simple()));
-    let mut file = tokio::fs::File::create(&temp_path)
-        .await
-        .map_err(|error| ApiError::internal(error.to_string()))?;
-    // sc-4204 (F-API-6): clean up the temp file on EVERY error path (chunk read,
-    // write, flush, or size cap), not just the size cap — an aborted or malformed
-    // multi-gigabyte upload otherwise leaks as an orphaned upload-*.tmp. Mirrors
-    // write_lora_upload_field_to_staged_file.
-    let mut uploaded_bytes = 0usize;
-    let write_result = async {
-        while let Some(chunk) = field
-            .chunk()
-            .await
-            .map_err(|error| ApiError::bad_request(error.to_string()))?
-        {
-            uploaded_bytes = uploaded_bytes.saturating_add(chunk.len());
-            if uploaded_bytes > MAX_UPLOAD_BYTES {
-                return Err(ApiError::payload_too_large("Uploaded file is too large"));
-            }
-            file.write_all(&chunk)
-                .await
-                .map_err(|error| ApiError::internal(error.to_string()))?;
-        }
-        file.flush()
-            .await
-            .map_err(|error| ApiError::internal(error.to_string()))
-    }
-    .await;
-    if let Err(error) = write_result {
-        let _ = tokio::fs::remove_file(&temp_path).await;
-        return Err(error);
-    }
+    // sc-8886 (F-084): shared streaming writer. Cleanup removes only the temp file —
+    // the `cache/<subdir>` staging dir is shared, not per-upload, so it is left in place.
+    stream_multipart_field_to_file(
+        field,
+        &temp_path,
+        MAX_UPLOAD_BYTES,
+        || "Uploaded file is too large".to_owned(),
+        || async {
+            let _ = tokio::fs::remove_file(&temp_path).await;
+        },
+    )
+    .await?;
     Ok(temp_path)
 }
 

--- a/apps/rust-api/src/assets.rs
+++ b/apps/rust-api/src/assets.rs
@@ -156,11 +156,11 @@ pub(crate) async fn write_upload_field_to_temp_file(
 
 /// Remove stale asset-import temp uploads (`<data_dir>/cache/uploads/upload-*`) at
 /// startup — the backstop for aborted or errored imports whose error path didn't
-/// clean up (sc-4204). Mirrors `sweep_stale_pose_uploads` / `sweep_stale_lora_uploads`.
+/// clean up (sc-4204). Thin wrapper over the shared `sweep_stale_uploads` (sc-8885).
 pub(crate) fn sweep_stale_asset_uploads(data_dir: &FsPath) -> std::io::Result<usize> {
     sweep_stale_asset_uploads_before(
         data_dir,
-        SystemTime::now() - Duration::from_secs(STALE_LORA_UPLOAD_SECONDS),
+        SystemTime::now() - Duration::from_secs(STALE_UPLOAD_SECONDS),
     )
 }
 
@@ -168,31 +168,7 @@ pub(crate) fn sweep_stale_asset_uploads_before(
     data_dir: &FsPath,
     cutoff: SystemTime,
 ) -> std::io::Result<usize> {
-    let upload_root = data_dir.join("cache").join("uploads");
-    let entries = match std::fs::read_dir(upload_root) {
-        Ok(entries) => entries,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(0),
-        Err(error) => return Err(error),
-    };
-    let mut removed = 0usize;
-    for entry in entries {
-        let entry = entry?;
-        let filename = entry.file_name();
-        if !filename.to_string_lossy().starts_with("upload-") {
-            continue;
-        }
-        let modified = entry.metadata()?.modified().unwrap_or(UNIX_EPOCH);
-        if modified <= cutoff {
-            let path = entry.path();
-            let _ = if entry.file_type()?.is_dir() {
-                std::fs::remove_dir_all(&path)
-            } else {
-                std::fs::remove_file(&path)
-            };
-            removed += 1;
-        }
-    }
-    Ok(removed)
+    sweep_stale_uploads(data_dir, "uploads", cutoff)
 }
 
 /// Stream a multipart field to a unique temp file under `<data_dir>/cache/<subdir>`,

--- a/apps/rust-api/src/keypoints.rs
+++ b/apps/rust-api/src/keypoints.rs
@@ -104,30 +104,6 @@ pub(crate) async fn delete_keypoint_collection(
 /// Remove stale keypoint-source temp uploads at startup (the backstop for captures that were
 /// never saved). Mirrors `sweep_stale_pose_uploads`.
 pub(crate) fn sweep_stale_keypoint_uploads(data_dir: &FsPath) -> std::io::Result<usize> {
-    let cutoff = SystemTime::now() - Duration::from_secs(STALE_LORA_UPLOAD_SECONDS);
-    let upload_root = data_dir.join("cache").join("keypoint-uploads");
-    let entries = match std::fs::read_dir(upload_root) {
-        Ok(entries) => entries,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(0),
-        Err(error) => return Err(error),
-    };
-    let mut removed = 0usize;
-    for entry in entries {
-        let entry = entry?;
-        let filename = entry.file_name();
-        if !filename.to_string_lossy().starts_with("upload-") {
-            continue;
-        }
-        let modified = entry.metadata()?.modified().unwrap_or(UNIX_EPOCH);
-        if modified <= cutoff {
-            let path = entry.path();
-            let _ = if entry.file_type()?.is_dir() {
-                std::fs::remove_dir_all(&path)
-            } else {
-                std::fs::remove_file(&path)
-            };
-            removed += 1;
-        }
-    }
-    Ok(removed)
+    let cutoff = SystemTime::now() - Duration::from_secs(STALE_UPLOAD_SECONDS);
+    sweep_stale_uploads(data_dir, "keypoint-uploads", cutoff)
 }

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -801,6 +801,11 @@ where
 /// that had already drifted (some skipped non-directories, some didn't). Handles both
 /// files and directories so a staging area holding either is fully reclaimed. A missing
 /// root is not an error (nothing was ever staged). Returns the number of entries removed.
+///
+/// Per-entry reclamation is best-effort: a single unremovable stale entry (locked,
+/// permission-denied) is logged and skipped so the rest of the sweep still runs — the
+/// original per-area sweepers used `let _ =` and continued the loop. Only the outer
+/// `read_dir` failure remains fatal (nothing else could have been reclaimed anyway).
 pub(crate) fn sweep_stale_uploads(
     data_dir: &FsPath,
     subdir: &str,
@@ -814,18 +819,68 @@ pub(crate) fn sweep_stale_uploads(
     };
     let mut removed = 0usize;
     for entry in entries {
-        let entry = entry?;
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => {
+                tracing::warn!(
+                    event = "stale_upload_entry_read_failed",
+                    sweep = subdir,
+                    error = %error,
+                    "could not read a stale-upload dir entry; skipping it"
+                );
+                continue;
+            }
+        };
         if !entry.file_name().to_string_lossy().starts_with("upload-") {
             continue;
         }
-        let modified = entry.metadata()?.modified().unwrap_or(UNIX_EPOCH);
-        if modified <= cutoff {
-            if entry.file_type()?.is_dir() {
-                std::fs::remove_dir_all(entry.path())?;
-            } else {
-                std::fs::remove_file(entry.path())?;
+        let is_dir = match entry.file_type() {
+            Ok(file_type) => file_type.is_dir(),
+            Err(error) => {
+                tracing::warn!(
+                    event = "stale_upload_stat_failed",
+                    sweep = subdir,
+                    path = %entry.path().display(),
+                    error = %error,
+                    "could not stat a stale-upload entry; skipping it"
+                );
+                continue;
             }
-            removed += 1;
+        };
+        let modified = match entry.metadata() {
+            Ok(metadata) => metadata.modified().unwrap_or(UNIX_EPOCH),
+            Err(error) => {
+                tracing::warn!(
+                    event = "stale_upload_stat_failed",
+                    sweep = subdir,
+                    path = %entry.path().display(),
+                    error = %error,
+                    "could not read a stale-upload entry's mtime; skipping it"
+                );
+                continue;
+            }
+        };
+        if modified <= cutoff {
+            let path = entry.path();
+            let removal = if is_dir {
+                std::fs::remove_dir_all(&path)
+            } else {
+                std::fs::remove_file(&path)
+            };
+            match removal {
+                Ok(()) => removed += 1,
+                Err(error) => {
+                    // Best-effort: one locked/permission-denied temp must not block
+                    // reclaiming the rest of the stale entries in this sweep.
+                    tracing::warn!(
+                        event = "stale_upload_remove_failed",
+                        sweep = subdir,
+                        path = %path.display(),
+                        error = %error,
+                        "could not remove a stale upload entry; leaving it and continuing"
+                    );
+                }
+            }
         }
     }
     Ok(removed)

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -730,6 +730,60 @@ async fn shutdown_signal() {
     }
 }
 
+/// Stream a multipart field to `temp_path`, enforcing `max_bytes` (returning
+/// `413` with `limit_msg` when exceeded), then flush. sc-8886 (F-084): the single
+/// implementation behind every multipart upload writer (asset / lora / model), which
+/// were three copy-pasted chunk loops differing only in cap source, destination, and
+/// message. On ANY error path (chunk read, write, flush, or size cap) the file handle
+/// is dropped and `cleanup` runs before the error is returned, so an aborted or
+/// malformed multi-gigabyte upload never leaks a temp file (sc-4204). `cleanup` lets a
+/// caller remove more than the file itself (e.g. the per-upload parent directory).
+/// The parent directory of `temp_path` must already exist.
+pub(crate) async fn stream_multipart_field_to_file<Fut>(
+    mut field: axum::extract::multipart::Field<'_>,
+    temp_path: &FsPath,
+    max_bytes: usize,
+    limit_msg: impl FnOnce() -> String,
+    cleanup: impl FnOnce() -> Fut,
+) -> Result<(), ApiError>
+where
+    Fut: std::future::Future<Output = ()>,
+{
+    let mut file = match tokio::fs::File::create(temp_path).await {
+        Ok(file) => file,
+        Err(error) => {
+            cleanup().await;
+            return Err(ApiError::internal(error.to_string()));
+        }
+    };
+    let mut uploaded_bytes = 0usize;
+    let write_result = async {
+        while let Some(chunk) = field
+            .chunk()
+            .await
+            .map_err(|error| ApiError::bad_request(error.to_string()))?
+        {
+            uploaded_bytes = uploaded_bytes.saturating_add(chunk.len());
+            if uploaded_bytes > max_bytes {
+                return Err(ApiError::payload_too_large(limit_msg()));
+            }
+            file.write_all(&chunk)
+                .await
+                .map_err(|error| ApiError::internal(error.to_string()))?;
+        }
+        file.flush()
+            .await
+            .map_err(|error| ApiError::internal(error.to_string()))
+    }
+    .await;
+    if let Err(error) = write_result {
+        drop(file);
+        cleanup().await;
+        return Err(error);
+    }
+    Ok(())
+}
+
 pub fn create_app(settings: Settings) -> Result<Router, JobsStoreError> {
     Ok(create_app_with_state(settings)?.0)
 }

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -823,6 +823,35 @@ pub(crate) fn sweep_stale_uploads(
     Ok(removed)
 }
 
+/// Log (but never fail on) a startup directory-creation error. sc-8882 (F-080): the
+/// old `let _ =` swallowed permissions/disk problems, so they only ever surfaced as
+/// downstream 500s. Startup stays best-effort — a missing dir errors where it is used.
+fn warn_on_startup_err(label: &str, path: &FsPath, result: std::io::Result<()>) {
+    if let Err(error) = result {
+        tracing::warn!(
+            event = "startup_create_dir_failed",
+            dir = label,
+            path = %path.display(),
+            error = %error,
+            "could not create startup directory"
+        );
+    }
+}
+
+/// Log (but never fail on) a stale-upload sweep error. sc-8882 (F-080): a failed sweep
+/// silently leaves leaked multi-GB upload temps unreclaimed; a warning makes that
+/// diagnosable without aborting startup.
+fn warn_on_sweep_err(kind: &str, result: std::io::Result<usize>) {
+    if let Err(error) = result {
+        tracing::warn!(
+            event = "stale_upload_sweep_failed",
+            sweep = kind,
+            error = %error,
+            "stale upload sweep failed; leaked temp uploads may remain"
+        );
+    }
+}
+
 pub fn create_app(settings: Settings) -> Result<Router, JobsStoreError> {
     Ok(create_app_with_state(settings)?.0)
 }
@@ -833,16 +862,33 @@ pub fn create_app(settings: Settings) -> Result<Router, JobsStoreError> {
 pub(crate) fn create_app_with_state(
     settings: Settings,
 ) -> Result<(Router, AppState), JobsStoreError> {
-    let _ = std::fs::create_dir_all(&settings.data_dir);
-    let _ = std::fs::create_dir_all(&settings.config_dir);
+    // sc-8882 (F-080): a permissions/disk failure here is otherwise invisible until a
+    // downstream 500 — surface it as a warning so it is diagnosable. Non-fatal: startup
+    // continues (a missing dir surfaces later where it is actually used).
+    warn_on_startup_err(
+        "data_dir",
+        &settings.data_dir,
+        std::fs::create_dir_all(&settings.data_dir),
+    );
+    warn_on_startup_err(
+        "config_dir",
+        &settings.config_dir,
+        std::fs::create_dir_all(&settings.config_dir),
+    );
     if let Some(jobs_db_parent) = settings.jobs_db_path.parent() {
-        let _ = std::fs::create_dir_all(jobs_db_parent);
+        warn_on_startup_err(
+            "jobs_db_parent",
+            jobs_db_parent,
+            std::fs::create_dir_all(jobs_db_parent),
+        );
     }
-    let _ = sweep_stale_lora_uploads(&settings.data_dir);
-    let _ = sweep_stale_pose_uploads(&settings.data_dir);
-    let _ = sweep_stale_keypoint_uploads(&settings.data_dir);
+    // sc-8882 (F-080): a failed sweep leaves leaked multi-GB upload temps unreclaimed
+    // and was previously silent. WARN (never fatal) so the operator can investigate.
+    warn_on_sweep_err("lora", sweep_stale_lora_uploads(&settings.data_dir));
+    warn_on_sweep_err("pose", sweep_stale_pose_uploads(&settings.data_dir));
+    warn_on_sweep_err("keypoint", sweep_stale_keypoint_uploads(&settings.data_dir));
     // sc-4204 (F-API-6): asset-import temp files (cache/uploads) had no startup sweep.
-    let _ = sweep_stale_asset_uploads(&settings.data_dir);
+    warn_on_sweep_err("asset", sweep_stale_asset_uploads(&settings.data_dir));
     let jobs_store = Arc::new(JobsStore::new(&settings.jobs_db_path));
     jobs_store.initialize()?;
     let interrupted_jobs_on_startup = jobs_store.mark_interrupted_on_startup()?.len();

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -166,7 +166,10 @@ const MAX_UPLOAD_BYTES: usize = 2 * 1024 * 1024 * 1024;
 const MAX_MODEL_UPLOAD_BYTES: usize = 256 * 1024 * 1024 * 1024;
 const MAX_LORA_MULTIPART_BODY_BYTES: usize = MAX_UPLOAD_BYTES + 16 * 1024 * 1024;
 const MAX_MODEL_MULTIPART_BODY_BYTES: usize = MAX_MODEL_UPLOAD_BYTES + 16 * 1024 * 1024;
-const STALE_LORA_UPLOAD_SECONDS: u64 = 24 * 60 * 60;
+// sc-8885 (F-083): the shared max age for every `cache/*-uploads` staging area (asset,
+// lora, model, pose, keypoint) before the startup sweep reclaims it. Named for uploads
+// in general — the old `STALE_LORA_UPLOAD_SECONDS` misleadingly implied LoRA-only.
+const STALE_UPLOAD_SECONDS: u64 = 24 * 60 * 60;
 // Thread-local (not a process-global atomic) so a test overriding the cap to
 // exercise the size limit can't leak that value into other LoRA-upload tests
 // running concurrently on sibling threads. `#[tokio::test]` uses a current-thread
@@ -782,6 +785,42 @@ where
         return Err(error);
     }
     Ok(())
+}
+
+/// Remove stale `upload-*` entries under `<data_dir>/cache/<subdir>` older than
+/// `cutoff`. sc-8885 (F-083): the single implementation behind every per-area startup
+/// sweep (asset, lora, model, pose, keypoint) — previously four/five copy-pasted loops
+/// that had already drifted (some skipped non-directories, some didn't). Handles both
+/// files and directories so a staging area holding either is fully reclaimed. A missing
+/// root is not an error (nothing was ever staged). Returns the number of entries removed.
+pub(crate) fn sweep_stale_uploads(
+    data_dir: &FsPath,
+    subdir: &str,
+    cutoff: SystemTime,
+) -> std::io::Result<usize> {
+    let upload_root = data_dir.join("cache").join(subdir);
+    let entries = match std::fs::read_dir(upload_root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(error) => return Err(error),
+    };
+    let mut removed = 0usize;
+    for entry in entries {
+        let entry = entry?;
+        if !entry.file_name().to_string_lossy().starts_with("upload-") {
+            continue;
+        }
+        let modified = entry.metadata()?.modified().unwrap_or(UNIX_EPOCH);
+        if modified <= cutoff {
+            if entry.file_type()?.is_dir() {
+                std::fs::remove_dir_all(entry.path())?;
+            } else {
+                std::fs::remove_file(entry.path())?;
+            }
+            removed += 1;
+        }
+    }
+    Ok(removed)
 }
 
 pub fn create_app(settings: Settings) -> Result<Router, JobsStoreError> {

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -170,6 +170,14 @@ const MAX_MODEL_MULTIPART_BODY_BYTES: usize = MAX_MODEL_UPLOAD_BYTES + 16 * 1024
 // lora, model, pose, keypoint) before the startup sweep reclaims it. Named for uploads
 // in general — the old `STALE_LORA_UPLOAD_SECONDS` misleadingly implied LoRA-only.
 const STALE_UPLOAD_SECONDS: u64 = 24 * 60 * 60;
+// sc-8884 (F-082): the char cap applied to every free-text prompt field (`prompt` and
+// `negativePrompt`). Both are persisted into jobs.db and re-broadcast over SSE on every
+// `job.updated`, so an uncapped field bloats the row and every subscriber's payload.
+const MAX_PROMPT_CHARS: usize = 4000;
+// sc-8884 (F-082): serialized-size ceiling for the free-form `advanced` object. It is a
+// pass-through bag threaded to the worker, so it has no per-key schema — bound its total
+// serialized size instead. 64 KiB is generous for legitimate advanced settings.
+const MAX_ADVANCED_JSON_BYTES: usize = 64 * 1024;
 // Thread-local (not a process-global atomic) so a test overriding the cap to
 // exercise the size limit can't leak that value into other LoRA-upload tests
 // running concurrently on sibling threads. `#[tokio::test]` uses a current-thread
@@ -2344,15 +2352,39 @@ fn validate_person_track_job(payload: &PersonTrackJobRequest) -> Result<(), ApiE
     Ok(())
 }
 
+/// sc-8884 (F-082): `negativePrompt` and the free-form `advanced` bag previously escaped
+/// all length validation (only `prompt` was capped), so an oversized field was persisted
+/// to jobs.db and re-serialized to every SSE subscriber on each status change. Cap the
+/// negative prompt at the same char limit as `prompt` and bound `advanced`'s serialized
+/// size. Shared by `validate_image_job` / `validate_video_job`.
+fn validate_prompt_extras(negative_prompt: &str, advanced: &JsonObject) -> Result<(), ApiError> {
+    if negative_prompt.chars().count() > MAX_PROMPT_CHARS {
+        return Err(ApiError::bad_request(format!(
+            "negativePrompt must be at most {MAX_PROMPT_CHARS} characters"
+        )));
+    }
+    // Serialize once to measure the on-the-wire size of the pass-through bag.
+    let advanced_bytes = serde_json::to_vec(advanced)
+        .map(|bytes| bytes.len())
+        .unwrap_or(0);
+    if advanced_bytes > MAX_ADVANCED_JSON_BYTES {
+        return Err(ApiError::bad_request(format!(
+            "advanced settings must serialize to at most {MAX_ADVANCED_JSON_BYTES} bytes"
+        )));
+    }
+    Ok(())
+}
+
 fn validate_image_job(payload: &ImageJobRequest) -> Result<(), ApiError> {
     if payload.project_id.is_empty() {
         return Err(ApiError::bad_request("projectId is required"));
     }
-    if payload.prompt.is_empty() || payload.prompt.chars().count() > 4000 {
+    if payload.prompt.is_empty() || payload.prompt.chars().count() > MAX_PROMPT_CHARS {
         return Err(ApiError::bad_request(
             "prompt must be between 1 and 4000 characters",
         ));
     }
+    validate_prompt_extras(&payload.negative_prompt, &payload.advanced)?;
     if ![
         "text_to_image",
         "edit_image",
@@ -2397,11 +2429,12 @@ fn validate_video_job(payload: &VideoJobRequest) -> Result<(), ApiError> {
     if payload.project_id.is_empty() {
         return Err(ApiError::bad_request("projectId is required"));
     }
-    if payload.prompt.is_empty() || payload.prompt.chars().count() > 4000 {
+    if payload.prompt.is_empty() || payload.prompt.chars().count() > MAX_PROMPT_CHARS {
         return Err(ApiError::bad_request(
             "prompt must be between 1 and 4000 characters",
         ));
     }
+    validate_prompt_extras(&payload.negative_prompt, &payload.advanced)?;
     if ![
         "image_to_video",
         "text_to_video",

--- a/apps/rust-api/src/loras.rs
+++ b/apps/rust-api/src/loras.rs
@@ -714,7 +714,7 @@ pub(crate) async fn lora_import_request_from_multipart(
 
 pub(crate) async fn write_lora_upload_field_to_staged_file(
     state: &AppState,
-    mut field: axum::extract::multipart::Field<'_>,
+    field: axum::extract::multipart::Field<'_>,
     filename: &str,
 ) -> Result<PathBuf, ApiError> {
     let upload_dir = state
@@ -727,35 +727,16 @@ pub(crate) async fn write_lora_upload_field_to_staged_file(
         .await
         .map_err(|error| ApiError::internal(error.to_string()))?;
     let temp_path = upload_dir.join(filename);
-    let mut file = tokio::fs::File::create(&temp_path)
-        .await
-        .map_err(|error| ApiError::internal(error.to_string()))?;
-    let mut uploaded_bytes = 0usize;
-    let write_result = async {
-        while let Some(chunk) = field
-            .chunk()
-            .await
-            .map_err(|error| ApiError::bad_request(error.to_string()))?
-        {
-            uploaded_bytes = uploaded_bytes.saturating_add(chunk.len());
-            if uploaded_bytes > max_lora_upload_bytes() {
-                return Err(ApiError::payload_too_large(
-                    "Uploaded LoRA file exceeds the 2GB limit",
-                ));
-            }
-            file.write_all(&chunk)
-                .await
-                .map_err(|error| ApiError::internal(error.to_string()))?;
-        }
-        file.flush()
-            .await
-            .map_err(|error| ApiError::internal(error.to_string()))
-    }
-    .await;
-    if let Err(error) = write_result {
-        cleanup_staged_lora_upload(&temp_path).await;
-        return Err(error);
-    }
+    // sc-8886 (F-084): shared streaming writer. Cleanup removes the staged file AND its
+    // per-upload parent directory, so an aborted upload leaves no `upload-<uuid>/` dir.
+    stream_multipart_field_to_file(
+        field,
+        &temp_path,
+        max_lora_upload_bytes(),
+        || "Uploaded LoRA file exceeds the 2GB limit".to_owned(),
+        || cleanup_staged_lora_upload(&temp_path),
+    )
+    .await?;
     Ok(temp_path)
 }
 

--- a/apps/rust-api/src/loras.rs
+++ b/apps/rust-api/src/loras.rs
@@ -998,7 +998,7 @@ pub(crate) fn read_safetensors_header_for_api(
 pub(crate) fn sweep_stale_lora_uploads(data_dir: &FsPath) -> std::io::Result<usize> {
     sweep_stale_lora_uploads_before(
         data_dir,
-        SystemTime::now() - Duration::from_secs(STALE_LORA_UPLOAD_SECONDS),
+        SystemTime::now() - Duration::from_secs(STALE_UPLOAD_SECONDS),
     )
 }
 
@@ -1006,31 +1006,9 @@ pub(crate) fn sweep_stale_lora_uploads_before(
     data_dir: &FsPath,
     cutoff: SystemTime,
 ) -> std::io::Result<usize> {
-    let upload_root = data_dir.join("cache").join("lora-uploads");
-    let entries = match std::fs::read_dir(upload_root) {
-        Ok(entries) => entries,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(0),
-        Err(error) => return Err(error),
-    };
-    let mut removed = 0usize;
-    for entry in entries {
-        let entry = entry?;
-        let file_type = entry.file_type()?;
-        if !file_type.is_dir() {
-            continue;
-        }
-        let filename = entry.file_name();
-        let filename = filename.to_string_lossy();
-        if !filename.starts_with("upload-") {
-            continue;
-        }
-        let modified = entry.metadata()?.modified().unwrap_or(UNIX_EPOCH);
-        if modified <= cutoff {
-            std::fs::remove_dir_all(entry.path())?;
-            removed += 1;
-        }
-    }
-    Ok(removed)
+    // sc-8885 (F-083): LoRA uploads only ever stage per-upload directories, so the
+    // shared sweeper's file+dir handling is a strict superset of the old dir-only loop.
+    sweep_stale_uploads(data_dir, "lora-uploads", cutoff)
 }
 
 pub(crate) fn lora_source_provider(payload: &LoraImportRequest) -> &'static str {

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -742,7 +742,7 @@ pub(crate) async fn model_import_request_from_multipart(
 
 pub(crate) async fn write_model_upload_field_to_staged_file(
     state: &AppState,
-    mut field: axum::extract::multipart::Field<'_>,
+    field: axum::extract::multipart::Field<'_>,
     filename: &str,
 ) -> Result<PathBuf, ApiError> {
     let upload_dir = state
@@ -755,38 +755,21 @@ pub(crate) async fn write_model_upload_field_to_staged_file(
         .await
         .map_err(|error| ApiError::internal(error.to_string()))?;
     let temp_path = upload_dir.join(filename);
-    let mut file = tokio::fs::File::create(&temp_path)
-        .await
-        .map_err(|error| ApiError::internal(error.to_string()))?;
-    let mut uploaded_bytes = 0usize;
-    let write_result = async {
-        while let Some(chunk) = field
-            .chunk()
-            .await
-            .map_err(|error| ApiError::bad_request(error.to_string()))?
-        {
-            uploaded_bytes = uploaded_bytes.saturating_add(chunk.len());
-            if uploaded_bytes > max_model_upload_bytes() {
-                return Err(ApiError::payload_too_large(format!(
-                    "Uploaded model file exceeds the {} limit",
-                    format_bytes(max_model_upload_bytes() as u64)
-                )));
-            }
-            file.write_all(&chunk)
-                .await
-                .map_err(|error| ApiError::internal(error.to_string()))?;
-        }
-        file.flush()
-            .await
-            .map_err(|error| ApiError::internal(error.to_string()))?;
-        Ok(())
-    }
-    .await;
-    if let Err(error) = write_result {
-        drop(file);
-        cleanup_staged_model_upload(&temp_path).await;
-        return Err(error);
-    }
+    // sc-8886 (F-084): shared streaming writer. Cleanup removes the staged file AND its
+    // per-upload parent directory.
+    stream_multipart_field_to_file(
+        field,
+        &temp_path,
+        max_model_upload_bytes(),
+        || {
+            format!(
+                "Uploaded model file exceeds the {} limit",
+                format_bytes(max_model_upload_bytes() as u64)
+            )
+        },
+        || cleanup_staged_model_upload(&temp_path),
+    )
+    .await?;
     Ok(temp_path)
 }
 

--- a/apps/rust-api/src/poses.rs
+++ b/apps/rust-api/src/poses.rs
@@ -72,32 +72,8 @@ pub(crate) async fn create_pose_sources(
 /// at startup — the backstop for detect jobs that never ran (the worker deletes its
 /// own sources after a successful detect). Mirrors `sweep_stale_lora_uploads`.
 pub(crate) fn sweep_stale_pose_uploads(data_dir: &FsPath) -> std::io::Result<usize> {
-    let cutoff = SystemTime::now() - Duration::from_secs(STALE_LORA_UPLOAD_SECONDS);
-    let upload_root = data_dir.join("cache").join("pose-uploads");
-    let entries = match std::fs::read_dir(upload_root) {
-        Ok(entries) => entries,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(0),
-        Err(error) => return Err(error),
-    };
-    let mut removed = 0usize;
-    for entry in entries {
-        let entry = entry?;
-        let filename = entry.file_name();
-        if !filename.to_string_lossy().starts_with("upload-") {
-            continue;
-        }
-        let modified = entry.metadata()?.modified().unwrap_or(UNIX_EPOCH);
-        if modified <= cutoff {
-            let path = entry.path();
-            let _ = if entry.file_type()?.is_dir() {
-                std::fs::remove_dir_all(&path)
-            } else {
-                std::fs::remove_file(&path)
-            };
-            removed += 1;
-        }
-    }
-    Ok(removed)
+    let cutoff = SystemTime::now() - Duration::from_secs(STALE_UPLOAD_SECONDS);
+    sweep_stale_uploads(data_dir, "pose-uploads", cutoff)
 }
 
 /// Stream a worker pose-detect skeleton preview from the cache so the Create tab

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -801,6 +801,62 @@ async fn import_asset_removes_staged_temp_file_when_a_later_field_errors() {
     );
 }
 
+#[tokio::test]
+async fn import_asset_rejects_duplicate_file_field_and_cleans_first_temp() {
+    // sc-8883 (F-081): a second `file` field must be rejected (400), and the first
+    // already-staged temp must be cleaned up rather than orphaned until the 24h sweep.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    let data_dir = settings.data_dir.clone();
+    let app = create_app(settings).expect("app creates");
+
+    let boundary = "SCENEWORKS_DUP_FILE_BOUNDARY";
+    let mut body = Vec::new();
+    for name in ["file", "file"] {
+        body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+        body.extend_from_slice(
+            format!("Content-Disposition: form-data; name=\"{name}\"; filename=\"x.png\"\r\n")
+                .as_bytes(),
+        );
+        body.extend_from_slice(b"Content-Type: image/png\r\n\r\n");
+        body.extend_from_slice(b"\x89PNG\r\n\x1a\n payload bytes");
+        body.extend_from_slice(b"\r\n");
+    }
+    body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+
+    let (status, _, response) = request_raw(
+        app,
+        "POST",
+        "/api/v1/projects/project-1/assets",
+        body,
+        &[(
+            "content-type",
+            &format!("multipart/form-data; boundary={boundary}"),
+        )],
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let value: Value = serde_json::from_slice(&response).expect("json body parses");
+    assert!(value["detail"]
+        .as_str()
+        .is_some_and(|detail| detail.contains("Only one file field is allowed")));
+
+    // The first staged temp must not leak under cache/uploads.
+    let upload_root = data_dir.join("cache").join("uploads");
+    let leaked: Vec<_> = std::fs::read_dir(&upload_root)
+        .map(|entries| {
+            entries
+                .filter_map(Result::ok)
+                .filter(|entry| entry.file_name().to_string_lossy().starts_with("upload-"))
+                .collect()
+        })
+        .unwrap_or_default();
+    assert!(
+        leaked.is_empty(),
+        "first staged temp file leaked on duplicate file field: {leaked:?}"
+    );
+}
+
 #[test]
 fn shared_sweep_removes_stale_files_and_dirs_leaves_fresh_and_unrelated() {
     // sc-8885 (F-083): the unified sweeper handles both loose files and per-upload

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -896,6 +896,63 @@ fn shared_sweep_removes_stale_files_and_dirs_leaves_fresh_and_unrelated() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn shared_sweep_is_best_effort_when_one_entry_cannot_be_removed() {
+    // sc-8885 (F-083): per-entry reclamation is best-effort — a single unremovable
+    // stale entry (here a directory whose contents can't be deleted) is logged and
+    // skipped so every other stale entry in the sweep is still reclaimed. The original
+    // per-area sweepers used `let _ =` and continued; the unified helper must too.
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let root = temp_dir.path().join("data/cache/pose-uploads");
+    std::fs::create_dir_all(&root).expect("root creates");
+
+    // Two removable stale entries flanking one that cannot be removed.
+    let ok_file_a = root.join("upload-a.tmp");
+    let ok_file_b = root.join("upload-b.tmp");
+    std::fs::write(&ok_file_a, b"a").expect("a writes");
+    std::fs::write(&ok_file_b, b"b").expect("b writes");
+
+    // An unremovable stale directory: it holds an inner file, then we strip write
+    // permission on the directory itself so `remove_dir_all` fails (deleting the inner
+    // entry requires write on its parent) without touching the siblings' removability.
+    let locked_dir = root.join("upload-locked-dir");
+    std::fs::create_dir_all(&locked_dir).expect("locked dir creates");
+    std::fs::write(locked_dir.join("inner"), b"x").expect("inner writes");
+    std::fs::set_permissions(&locked_dir, std::fs::Permissions::from_mode(0o500))
+        .expect("chmod locked dir");
+
+    // Cutoff in the future -> every upload-* entry qualifies as stale.
+    let removed = sweep_stale_uploads(
+        &temp_dir.path().join("data"),
+        "pose-uploads",
+        SystemTime::now() + Duration::from_secs(1),
+    )
+    .expect("sweep does not abort on a single unremovable entry");
+
+    // Restore permissions so the tempdir can be torn down cleanly.
+    let _ = std::fs::set_permissions(&locked_dir, std::fs::Permissions::from_mode(0o700));
+
+    assert_eq!(
+        removed, 2,
+        "both removable stale entries are reclaimed despite the locked directory"
+    );
+    assert!(
+        !ok_file_a.exists(),
+        "sibling before the locked entry removed"
+    );
+    assert!(
+        !ok_file_b.exists(),
+        "sibling after the locked entry removed"
+    );
+    assert!(
+        locked_dir.exists(),
+        "the unremovable entry is left in place, not aborting the sweep"
+    );
+}
+
 #[tokio::test]
 async fn create_image_job_rejects_over_length_negative_prompt() {
     // sc-8884 (F-082): negativePrompt now shares the prompt char cap.

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -897,6 +897,77 @@ fn shared_sweep_removes_stale_files_and_dirs_leaves_fresh_and_unrelated() {
 }
 
 #[tokio::test]
+async fn create_image_job_rejects_over_length_negative_prompt() {
+    // sc-8884 (F-082): negativePrompt now shares the prompt char cap.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (status, error) = request(
+        app,
+        "POST",
+        "/api/v1/image/jobs",
+        json!({
+            "projectId": "project-1",
+            "mode": "text_to_image",
+            "prompt": "mist over hills",
+            "count": 1,
+            "negativePrompt": "n".repeat(4001),
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(error["detail"]
+        .as_str()
+        .is_some_and(|detail| detail.contains("negativePrompt")));
+}
+
+#[tokio::test]
+async fn create_image_job_rejects_oversized_advanced_object() {
+    // sc-8884 (F-082): the free-form `advanced` bag is bounded by serialized size.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (status, error) = request(
+        app,
+        "POST",
+        "/api/v1/image/jobs",
+        json!({
+            "projectId": "project-1",
+            "mode": "text_to_image",
+            "prompt": "mist over hills",
+            "count": 1,
+            "advanced": { "blob": "a".repeat(64 * 1024 + 1) },
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(error["detail"]
+        .as_str()
+        .is_some_and(|detail| detail.contains("advanced")));
+}
+
+#[tokio::test]
+async fn create_video_job_rejects_over_length_negative_prompt() {
+    // sc-8884 (F-082): the negative-prompt cap is shared by the video validator too.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (status, error) = request(
+        app,
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": "project-1",
+            "mode": "text_to_video",
+            "prompt": "a drone shot",
+            "negativePrompt": "n".repeat(4001),
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(error["detail"]
+        .as_str()
+        .is_some_and(|detail| detail.contains("negativePrompt")));
+}
+
+#[tokio::test]
 async fn worker_can_register_claim_and_complete_job_through_http() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let app = create_app(test_settings(&temp_dir)).expect("app creates");

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -7,9 +7,9 @@ use super::{
     inprocess_worker_gpu_id, lora_artifact_paths, merge_model_manifest_entry, mlx_catalog_status,
     open_bind_override_enabled, safe_download_dir, serialize_job_lora, should_warn_open_bind,
     strip_jsonc_comments, sweep_stale_asset_uploads_before, sweep_stale_lora_uploads_before,
-    Settings, WorkerCapability, WorkerSnapshot, WorkerStatus, API_MANAGED_MANIFEST_HEADER,
-    DEFAULT_API_HOST, EVENT_BUFFER_SIZE, HEARTBEAT_SSE_DATA, HEARTBEAT_SSE_WIRE,
-    TEST_MAX_LORA_UPLOAD_BYTES,
+    sweep_stale_uploads, Settings, WorkerCapability, WorkerSnapshot, WorkerStatus,
+    API_MANAGED_MANIFEST_HEADER, DEFAULT_API_HOST, EVENT_BUFFER_SIZE, HEARTBEAT_SSE_DATA,
+    HEARTBEAT_SSE_WIRE, TEST_MAX_LORA_UPLOAD_BYTES,
 };
 use axum::body::{to_bytes, Body};
 use axum::http::{Request, StatusCode};
@@ -798,6 +798,45 @@ async fn import_asset_removes_staged_temp_file_when_a_later_field_errors() {
     assert!(
         leaked.is_empty(),
         "staged upload temp file leaked on error: {leaked:?}"
+    );
+}
+
+#[test]
+fn shared_sweep_removes_stale_files_and_dirs_leaves_fresh_and_unrelated() {
+    // sc-8885 (F-083): the unified sweeper handles both loose files and per-upload
+    // directories, and only touches `upload-*` entries at/older than the cutoff.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let root = temp_dir.path().join("data/cache/pose-uploads");
+    std::fs::create_dir_all(&root).expect("root creates");
+    let stale_file = root.join("upload-old.tmp");
+    let stale_dir = root.join("upload-old-dir");
+    let unrelated = root.join("keep-me.txt");
+    std::fs::write(&stale_file, b"x").expect("stale file writes");
+    std::fs::create_dir_all(&stale_dir).expect("stale dir creates");
+    std::fs::write(stale_dir.join("inner"), b"y").expect("inner writes");
+    std::fs::write(&unrelated, b"z").expect("unrelated writes");
+
+    // Cutoff in the future -> everything upload-* qualifies as stale.
+    let removed = sweep_stale_uploads(
+        &temp_dir.path().join("data"),
+        "pose-uploads",
+        SystemTime::now() + Duration::from_secs(1),
+    )
+    .expect("shared sweep");
+    assert_eq!(removed, 2, "both the file and the directory are removed");
+    assert!(!stale_file.exists());
+    assert!(!stale_dir.exists());
+    assert!(unrelated.exists(), "non upload-* entries are left alone");
+
+    // A missing root is not an error.
+    assert_eq!(
+        sweep_stale_uploads(
+            &temp_dir.path().join("data"),
+            "does-not-exist",
+            SystemTime::now(),
+        )
+        .expect("missing root is ok"),
+        0
     );
 }
 


### PR DESCRIPTION
Code-review remediation batch (epic 8800, batch 13) — five low-severity findings in `apps/rust-api`, from `CODE_REVIEW_2026-07-01.md` (F-080..F-084). All in one PR; one commit per story.

## Stories

- **sc-8882 [F-080]** — Startup dir creation and stale-upload sweeps no longer swallow errors. `create_app_with_state` routed every `create_dir_all` and sweep through `warn_on_startup_err` / `warn_on_sweep_err` (WARN, never fatal) instead of `let _ =`.
- **sc-8883 [F-081]** — A duplicate multipart `file` field in `import_asset` is now rejected with 400 (matching LoRA/model imports); the already-staged first temp is cleaned up by the existing collect-error path instead of leaking until the 24h sweep.
- **sc-8884 [F-082]** — `negativePrompt` and the free-form `advanced` object now get length validation: a shared `validate_prompt_extras` caps `negativePrompt` at 4000 chars and bounds `advanced` to a 64 KiB serialized ceiling, applied by both `validate_image_job` and `validate_video_job`.
- **sc-8885 [F-083]** — The four copy-pasted `sweep_stale_*_uploads` (asset, lora, pose, keypoint) collapse into one `sweep_stale_uploads(data_dir, subdir, cutoff)` that handles both files and directories (a strict superset of the drifted originals); constant renamed `STALE_LORA_UPLOAD_SECONDS` → `STALE_UPLOAD_SECONDS`.
- **sc-8886 [F-084]** — The three copy-pasted multipart streaming writers (asset, lora, model) collapse into one `stream_multipart_field_to_file` helper with a caller-supplied cleanup closure. Behavior-preserving; the drop-before-cleanup that only the model variant had is now uniform.

Note: sc-8883/8885/8886 all touch `assets.rs` upload handling and were implemented coherently — the unified writer includes the temp-file cleanup on every error path, and the duplicate-field rejection lands before the first staged temp is overwritten.

## Tests
Added 5 tests (all passing):
- `import_asset_rejects_duplicate_file_field_and_cleans_first_temp` (F-081)
- `shared_sweep_removes_stale_files_and_dirs_leaves_fresh_and_unrelated` (F-083)
- `create_image_job_rejects_over_length_negative_prompt` (F-082)
- `create_image_job_rejects_oversized_advanced_object` (F-082)
- `create_video_job_rejects_over_length_negative_prompt` (F-082)

## Verification
- `npm run rust:fmt` (cargo fmt --check): clean
- `npm run rust:lint` (clippy --all-targets -D warnings): clean
- `cargo test -p sceneworks-rust-api`: 177 passed / 0 failed
- Full workspace `rust:test` (default-members) + build: green
- No response-shape/DTO changes → no contract/bindings regen needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)