### PR TITLE
test(worker): reimplement 3 character_image engine-wiring guards vs Rust engine table (sc-9513)

### DIFF
--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -838,10 +838,11 @@ mod tests {
     // checks `mlx` on macOS (where the MLX provider crates are linked) and `candle` on the
     // `backend-candle` build — whichever registry is active — so each backend's truthfulness is enforced
     // on its own lane. `"default"` is the engine-default sentinel, always allowed.
-    #[cfg(any(
-        target_os = "macos",
-        all(not(target_os = "macos"), feature = "backend-candle")
-    ))]
+    // All-targets (no cfg gate): the embedded manifest + jsonc strip live in `sceneworks_core`, which
+    // compiles on every platform, so this parses on the plain Linux/Windows check lane too. The
+    // sampler/scheduler drift guards below still gate themselves on macos/candle (they need a linked
+    // provider registry), but the character_image engine-wiring guards (sc-9513) read only the manifest
+    // + the declarative wiring table, so they run everywhere `cargo test` does — including CI's ubuntu lane.
     fn parse_builtin_models() -> serde_json::Value {
         let text = sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS
             .iter()
@@ -850,6 +851,188 @@ mod tests {
             .1;
         let stripped = sceneworks_core::jsonc::strip_jsonc_comments(text);
         serde_json::from_str(&stripped).expect("parse builtin.models.jsonc")
+    }
+
+    // ── sc-9513 (F-059 follow-up of sc-8861): character_image ⇄ engine-wiring honesty guards ─────────
+    //
+    // These three guards were extracted to `tests/test_builtin_manifest_audit.py` by sc-8861 but still
+    // cross-referenced the retired Python worker's `scene_worker.image_adapters.MODEL_TARGETS` engine
+    // table via a lazy `importorskip` — so once epic-8283 deletes `apps/worker` they degrade to a clean
+    // SKIP and their coverage is lost. They are reimplemented here against the Rust worker's own engine
+    // wiring, reading the SAME embedded `config/manifests/builtin.models.jsonc` the Python audit parsed,
+    // so the character_image ⇄ engine-declaration invariants keep running Python-free (and on CI's ubuntu
+    // lane, since they need neither a linked provider registry nor a macos/candle build).
+    //
+    // Source of truth for the engine facts: the worker's character-image identity/pose engine wiring —
+    // the bespoke identity/pose providers `resolve_image_route` / `resolve_candle_image_route`
+    // (`image_jobs/base.rs`) dispatch to. That dispatch ladder is `#[cfg]`-gated to the macOS (MLX) and
+    // `backend-candle` builds, so it is not even compiled on the plain check lane; this small declarative
+    // table restates its identity/pose facts as all-targets data (the Rust analog of the Python
+    // `ipAdapter`/`instantId`/`pulidFlux`/`controlNetPose` blocks). Keep it in sync when a model gains or
+    // loses an identity/pose backbone:
+    //   * `flux_dev`            → XLabs FLUX IP-Adapter          (image_jobs/flux_ipadapter.rs)
+    //   * `sdxl` / `realvisxl`  → h94 IP-Adapter-plus-face        (image_jobs/sdxl_ipadapter.rs)
+    //   * `kolors`              → Kolors IP-Adapter-Plus + pose CN (image_jobs/kolors_ipadapter.rs + kolors_control.rs)
+    //   * `instantid_realvisxl` → InstantID IdentityNet           (image_jobs/instantid.rs)
+    //   * `pulid_flux_dev`      → PuLID-FLUX face identity          (image_jobs/pulid.rs + pulid_candle.rs)
+    // (Base `qwen_image` also carries a strict-pose ControlNet, but it is NOT a reference-identity engine
+    // and its pose picker is gated by manifest `ui.poseLibrary` alone — not `character_image` — so it is
+    // outside these identity-honesty guards and intentionally not a row here.)
+    struct CharacterEngineWiring {
+        sceneworks_id: &'static str,
+        /// A dedicated reference-identity backbone (IP-Adapter / InstantID / PuLID-FLUX) — the Rust
+        /// equivalent of Python `bool(MODEL_TARGETS[id].ipAdapter or .instantId or .pulidFlux)`.
+        identity_engine: bool,
+        /// The strict-pose ControlNet repo the model carries, if any (Python `controlNetPose.repo`).
+        control_net_pose_repo: Option<&'static str>,
+    }
+
+    const CHARACTER_IMAGE_ENGINE_WIRING: &[CharacterEngineWiring] = &[
+        CharacterEngineWiring {
+            sceneworks_id: "flux_dev",
+            identity_engine: true,
+            control_net_pose_repo: None,
+        },
+        CharacterEngineWiring {
+            sceneworks_id: "sdxl",
+            identity_engine: true,
+            control_net_pose_repo: None,
+        },
+        CharacterEngineWiring {
+            sceneworks_id: "realvisxl",
+            identity_engine: true,
+            control_net_pose_repo: None,
+        },
+        CharacterEngineWiring {
+            sceneworks_id: "kolors",
+            identity_engine: true,
+            control_net_pose_repo: Some("Kwai-Kolors/Kolors-ControlNet-Pose"),
+        },
+        CharacterEngineWiring {
+            sceneworks_id: "instantid_realvisxl",
+            identity_engine: true,
+            control_net_pose_repo: None,
+        },
+        CharacterEngineWiring {
+            sceneworks_id: "pulid_flux_dev",
+            identity_engine: true,
+            control_net_pose_repo: None,
+        },
+    ];
+
+    fn character_engine_wiring(id: &str) -> Option<&'static CharacterEngineWiring> {
+        CHARACTER_IMAGE_ENGINE_WIRING
+            .iter()
+            .find(|row| row.sceneworks_id == id)
+    }
+
+    /// True iff the manifest `model` lists `capability` in its `capabilities` array.
+    fn advertises_capability(model: &serde_json::Value, capability: &str) -> bool {
+        model["capabilities"]
+            .as_array()
+            .is_some_and(|caps| caps.iter().any(|c| c.as_str() == Some(capability)))
+    }
+
+    // Guard 1 (was `test_character_image_capability_implies_engine_or_tuning_declaration`, sc-2018): every
+    // builtin that advertises `character_image` must have EITHER a worker identity engine (IP-Adapter /
+    // InstantID / PuLID-FLUX) OR a `ui.variationStrength` declaration. Otherwise the capability flag is
+    // dishonest — the picker shows the model in "With character" mode but the worker silently ignores the
+    // reference (the shape of z_image_turbo's pre-sc-2005 bug). The cross-backbone guard: a future
+    // character_image backbone added without engine wiring fails here before it ever reaches a user.
+    #[test]
+    fn character_image_capability_implies_engine_or_tuning_declaration() {
+        let manifest = parse_builtin_models();
+        let models = manifest["models"].as_array().expect("models array");
+        let mut misleading: Vec<String> = Vec::new();
+        for model in models {
+            let Some(id) = model["id"].as_str() else {
+                continue;
+            };
+            if !advertises_capability(model, "character_image") {
+                continue;
+            }
+            let has_engine = character_engine_wiring(id).is_some_and(|w| w.identity_engine);
+            let has_variation_ui = model
+                .get("ui")
+                .and_then(|ui| ui.get("variationStrength"))
+                .is_some_and(|v| !v.is_null());
+            if !(has_engine || has_variation_ui) {
+                misleading.push(id.to_owned());
+            }
+        }
+        assert!(
+            misleading.is_empty(),
+            "Models advertise `character_image` without an identity engine (IP-Adapter / InstantID / \
+             PuLID-FLUX in CHARACTER_IMAGE_ENGINE_WIRING) or a `ui.variationStrength` declaration: {misleading:?}. \
+             Wire an identity engine for a reference/face-ID backbone, or declare `ui.variationStrength` \
+             for an edit-style backbone (sc-2017), or drop the capability flag (the z_image_turbo bug, sc-2005)."
+        );
+    }
+
+    // Guard 2 (was `test_kolors_declares_strict_pose_controlnet`, sc-2264): Kolors is the strict pose
+    // tier — the manifest must advertise `ui.poseLibrary` AND the worker wiring must carry the
+    // Kolors-ControlNet-Pose repo so the pose picker offers it and the adapter can load the pose
+    // ControlNet. Identity still rides the IP-Adapter; the pose path composes both.
+    #[test]
+    fn kolors_declares_strict_pose_controlnet() {
+        let manifest = parse_builtin_models();
+        let models = manifest["models"].as_array().expect("models array");
+        let kolors = models
+            .iter()
+            .find(|m| m["id"].as_str() == Some("kolors"))
+            .expect("kolors manifest entry");
+        assert_eq!(
+            kolors
+                .get("ui")
+                .and_then(|ui| ui.get("poseLibrary"))
+                .and_then(serde_json::Value::as_bool),
+            Some(true),
+            "kolors must declare ui.poseLibrary so the pose picker offers the strict tier (sc-2264)."
+        );
+        let wiring = character_engine_wiring("kolors").expect("kolors character-engine wiring");
+        assert_eq!(
+            wiring.control_net_pose_repo,
+            Some("Kwai-Kolors/Kolors-ControlNet-Pose"),
+            "kolors wiring must carry the Kolors-ControlNet-Pose repo for the strict pose path."
+        );
+        assert!(
+            wiring.identity_engine,
+            "kolors pose path needs the IP-Adapter for identity."
+        );
+    }
+
+    // Guard 3 (was `test_models_with_engine_block_advertise_character_image`): the reverse-drift guard.
+    // Any model that ships an identity engine exists to serve Character Studio's reference flow — the
+    // manifest MUST advertise `character_image` so the picker surfaces it. Catches the case where someone
+    // wires the worker engine but forgets to flip the manifest flag, leaving the engine unreachable.
+    #[test]
+    fn models_with_engine_block_advertise_character_image() {
+        let manifest = parse_builtin_models();
+        let models = manifest["models"].as_array().expect("models array");
+        let mut unreachable_ids: Vec<String> = Vec::new();
+        for wiring in CHARACTER_IMAGE_ENGINE_WIRING {
+            if !wiring.identity_engine {
+                continue;
+            }
+            let Some(model) = models
+                .iter()
+                .find(|m| m["id"].as_str() == Some(wiring.sceneworks_id))
+            else {
+                // Identity engine wired but not exposed as a built-in (unwired path) — mirrors the
+                // Python guard's `if builtin is None: continue`.
+                continue;
+            };
+            if !advertises_capability(model, "character_image") {
+                unreachable_ids.push(wiring.sceneworks_id.to_owned());
+            }
+        }
+        assert!(
+            unreachable_ids.is_empty(),
+            "Models have an identity engine in CHARACTER_IMAGE_ENGINE_WIRING but the builtin manifest \
+             does not advertise `character_image`: {unreachable_ids:?}. Add the capability to \
+             `capabilities` and `ui.recommendedFor` so the Image Studio \"With character\" picker surfaces \
+             the model."
+        );
     }
 
     // The effective `limits[key]` list for `backend`: the per-backend `<backend>.limits[key]` override

--- a/documents/MULTI_MODEL_REFERENCE_CONDITIONING.md
+++ b/documents/MULTI_MODEL_REFERENCE_CONDITIONING.md
@@ -153,7 +153,7 @@ Every reference-capable model declares `character_image` in **both** `capabiliti
 }
 ```
 
-The audit in `tests/test_worker_runtime.py::test_character_image_capability_implies_engine_or_tuning_declaration` enforces that any model claiming this capability has the engine wiring or tuning declaration to back it up (sc-2018).
+The audit `character_image_capability_implies_engine_or_tuning_declaration` (in `crates/sceneworks-worker/src/engines.rs`, reimplemented against the Rust engine wiring by sc-9513) enforces that any model claiming this capability has the engine wiring or tuning declaration to back it up (sc-2018).
 
 ### 3.2 Declarative tuning hints (`ui.*`)
 
@@ -204,7 +204,7 @@ State is persisted per-workspace via `useStudioSettingsWriter` ([useStudioSettin
 
 The Rust API is the queue and manifest server; it doesn't run inference. Two surfaces matter for the contract:
 
-- **`lora_family.rs::model_capabilities_for_type_and_family(type, family)`** — fallback capability list when a custom model omits `capabilities`. Updated by sc-2005 to drop the dishonest `character_image` claim from z-image's default. The audit `test_models_with_engine_block_advertise_character_image` (sc-2018) guards against the reverse drift.
+- **`lora_family.rs::model_capabilities_for_type_and_family(type, family)`** — fallback capability list when a custom model omits `capabilities`. Updated by sc-2005 to drop the dishonest `character_image` claim from z-image's default. The audit `models_with_engine_block_advertise_character_image` (`crates/sceneworks-worker/src/engines.rs`, sc-2018 / reimplemented in Rust by sc-9513) guards against the reverse drift.
 - **`ui.*` freeform passthrough** — Rust deserializes `ui` as `serde_json::Value` and ships it to the web client untouched. Adding a new `ui.someNewSlider` field requires no Rust changes; the picker reads it directly from the model entry.
 
 The `referenceAssetId` field on the job DTO is the only non-freeform reference-conditioning hook: it's surfaced as a typed field on `CreateImageJobRequest` so the picker can pass it through (with permission validation) without packing it into `advanced`.
@@ -213,11 +213,11 @@ The `referenceAssetId` field on the job DTO is the only non-freeform reference-c
 
 ## 6. CI enforcement (sc-2018)
 
-Three audits ride in `tests/test_worker_runtime.py`:
+Three audits enforce the contract. The two ENGINE-WIRING guards were originally Python (sc-2018), moved to `tests/test_builtin_manifest_audit.py` by sc-8861, then reimplemented in Rust against the worker's own engine wiring by sc-9513 (F-059 / epic 8283 Python eradication) — they now live in `crates/sceneworks-worker/src/engines.rs` and read the embedded manifest, so they run Python-free after `apps/worker` is deleted. The third is a pure-manifest guard that stays in Python:
 
-1. **`test_character_image_capability_implies_engine_or_tuning_declaration`** — for every builtin model declaring `character_image`, assert the worker has an engine block (`ipAdapter` / `instantId` in `MODEL_TARGETS`) or the manifest declares `ui.variationStrength`. Catches the "advertised but unwired" bug shape from sc-2005.
-2. **`test_models_with_engine_block_advertise_character_image`** — for every `MODEL_TARGETS` entry with an engine block, assert the builtin manifest advertises `character_image`. Catches the "wired but hidden" bug shape.
-3. **`test_hide_reference_strength_models_declare_a_variation_knob`** — `hideReferenceStrength: true` must be accompanied by `variationStrength`.
+1. **`character_image_capability_implies_engine_or_tuning_declaration`** (Rust, `engines.rs`) — for every builtin model declaring `character_image`, assert the worker has an identity engine (IP-Adapter / InstantID / PuLID-FLUX in the `CHARACTER_IMAGE_ENGINE_WIRING` table) or the manifest declares `ui.variationStrength`. Catches the "advertised but unwired" bug shape from sc-2005.
+2. **`models_with_engine_block_advertise_character_image`** (Rust, `engines.rs`) — for every identity engine in `CHARACTER_IMAGE_ENGINE_WIRING`, assert the builtin manifest advertises `character_image`. Catches the "wired but hidden" bug shape.
+3. **`test_hide_reference_strength_models_declare_a_variation_knob`** (`tests/test_builtin_manifest_audit.py`) — `hideReferenceStrength: true` must be accompanied by `variationStrength`.
 
 Plus `scripts/check-scaffold.mjs::assertCharacterImageTuningSurface()` runs audit #3 at build time so it fails before pytest does.
 

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -19,12 +19,16 @@ self-contained readers are inlined below rather than imported from
     inside an entry doesn't trip a naive comment strip; used by the per-model
     ``mlx`` block audits.
 
-The three character_image ENGINE-WIRING guards additionally cross-reference the
-worker's ``MODEL_TARGETS`` table (which is worker-owned config, not manifest
-data). They lazily ``importorskip`` it so they exercise the full manifest ↔
-worker cross-check while the worker still exists, and degrade to a clean SKIP
-(not a collection error) once ``apps/worker`` is deleted. Reimplementing those
-against the Rust engine table post-8283 is tracked as a follow-up.
+The three character_image ENGINE-WIRING guards that used to live here additionally
+cross-referenced the retired Python worker's ``MODEL_TARGETS`` table via a lazy
+``importorskip``, so they degraded to a clean SKIP once ``apps/worker`` was deleted
+(epic 8283) — losing their coverage. sc-9513 (F-059 follow-up) reimplemented them
+against the Rust worker's own character-image engine wiring, reading this SAME
+embedded manifest, in ``crates/sceneworks-worker/src/engines.rs`` (the tests
+``character_image_capability_implies_engine_or_tuning_declaration`` /
+``kolors_declares_strict_pose_controlnet`` /
+``models_with_engine_block_advertise_character_image``). This module now imports no
+``scene_worker`` symbol at all.
 """
 
 from __future__ import annotations
@@ -32,8 +36,6 @@ from __future__ import annotations
 import json
 import re
 from pathlib import Path
-
-import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 MANIFEST_PATH = ROOT / "config" / "manifests" / "builtin.models.jsonc"
@@ -124,21 +126,6 @@ def _manifest_brace_walker():
         return find_balanced_block(mlx_open)
 
     return raw, find_entry_block, find_mlx_block
-
-
-def _model_targets() -> dict:
-    """Worker-owned engine table (`ipAdapter`/`instantId`/`pulidFlux`/
-    `controlNetPose`). This is the sole scene_worker dependency in this module
-    and is imported lazily so its removal (epic 8283) turns the three
-    engine-wiring cross-checks below into a SKIP rather than a collection error.
-    sc-8861 FOLLOW_UP: reimplement those three against the Rust engine table
-    (crates/sceneworks-worker) once apps/worker is deleted.
-    """
-    image_adapters = pytest.importorskip(
-        "scene_worker.image_adapters",
-        reason="scene_worker.image_adapters (MODEL_TARGETS) retired with apps/worker (epic 8283)",
-    )
-    return image_adapters.MODEL_TARGETS
 
 
 # ---------------------------------------------------------------------------
@@ -281,90 +268,16 @@ def test_sdxl_manifest_has_mlx_block():
 # ---------------------------------------------------------------------------
 # character_image capability / UI-wiring audits (manifest-parsed dict).
 # Extracted from tests/test_worker_image_adapters.py (sc-8861 / F-059).
-# The three engine-wiring guards also cross-reference the worker MODEL_TARGETS
-# table via the lazy `_model_targets()` importorskip above.
+#
+# The three character_image ENGINE-WIRING guards that used to live here
+# (test_character_image_capability_implies_engine_or_tuning_declaration /
+# test_kolors_declares_strict_pose_controlnet /
+# test_models_with_engine_block_advertise_character_image) cross-referenced the
+# retired Python worker's MODEL_TARGETS table, so they were reimplemented against
+# the Rust worker's own character-image engine wiring in
+# crates/sceneworks-worker/src/engines.rs (sc-9513). The manifest-only symmetry
+# guard below has no worker dependency and stays here.
 # ---------------------------------------------------------------------------
-
-
-def test_character_image_capability_implies_engine_or_tuning_declaration():
-    """Every builtin model that advertises `character_image` must have either
-    a worker engine block (`ipAdapter` / `instantId` in MODEL_TARGETS) OR a
-    `ui.variationStrength` declaration in the manifest. Otherwise the capability
-    flag is dishonest — the picker shows the model in "With character" mode but
-    the worker silently ignores the reference, the same shape as z_image_turbo's
-    pre-sc-2005 bug. This is the cross-backbone guard for epic 2003 (sc-2018):
-    adding a future character_image backbone without engine wiring will fail
-    here before it ever reaches a user.
-    """
-    model_targets = _model_targets()
-    manifest = _load_builtin_models_manifest()
-    misleading: list[str] = []
-    for model in manifest.get("models", []):
-        capabilities = model.get("capabilities") or []
-        if "character_image" not in capabilities:
-            continue
-        target = model_targets.get(model["id"], {})
-        ui = model.get("ui") or {}
-        has_engine = bool(target.get("ipAdapter") or target.get("instantId") or target.get("pulidFlux"))
-        has_variation_ui = bool(ui.get("variationStrength"))
-        if not (has_engine or has_variation_ui):
-            misleading.append(model["id"])
-    assert not misleading, (
-        f"Models advertise `character_image` without engine wiring or a "
-        f"`ui.variationStrength` declaration: {misleading}. Add an `ipAdapter`, "
-        f"`instantId`, or `pulidFlux` block in MODEL_TARGETS for an IP-Adapter / "
-        f"face-ID backbone, or declare `ui.variationStrength` for an edit-style "
-        f"backbone (sc-2017), or drop the capability flag (the z_image_turbo bug, "
-        f"sc-2005)."
-    )
-
-
-def test_kolors_declares_strict_pose_controlnet():
-    """sc-2264: Kolors is the strict pose tier — the manifest must advertise
-    ui.poseLibrary AND the worker target must carry the controlNetPose config so
-    the pose picker offers it and the adapter can load the pose ControlNet."""
-    model_targets = _model_targets()
-    manifest = _load_builtin_models_manifest()
-    manifest_by_id = {model["id"]: model for model in manifest.get("models", [])}
-    kolors = manifest_by_id.get("kolors", {})
-    assert kolors.get("ui", {}).get("poseLibrary") is True, (
-        "kolors must declare ui.poseLibrary so the pose picker offers the strict tier (sc-2264)."
-    )
-    target = model_targets.get("kolors", {})
-    assert target.get("controlNetPose", {}).get("repo") == "Kwai-Kolors/Kolors-ControlNet-Pose", (
-        "kolors MODEL_TARGETS must carry the Kolors-ControlNet-Pose repo for the strict pose path."
-    )
-    # Identity still rides the IP-Adapter; the pose path composes both.
-    assert target.get("ipAdapter"), "kolors pose path needs the IP-Adapter for identity."
-
-
-def test_models_with_engine_block_advertise_character_image():
-    """The reverse-drift guard. Any model that ships an `ipAdapter` or
-    `instantId` block in MODEL_TARGETS exists to serve Character Studio's
-    reference flow — the manifest must advertise the capability so the picker
-    surfaces it. Catches the case where someone wires the worker engine but
-    forgets to flip the manifest flag, leaving the engine unreachable.
-    """
-    model_targets = _model_targets()
-    manifest = _load_builtin_models_manifest()
-    manifest_by_id = {model["id"]: model for model in manifest.get("models", [])}
-    unreachable: list[str] = []
-    for model_id, target in model_targets.items():
-        if not (target.get("ipAdapter") or target.get("instantId") or target.get("pulidFlux")):
-            continue
-        builtin = manifest_by_id.get(model_id)
-        if builtin is None:
-            # Worker-only target not exposed as a built-in (unwired path).
-            continue
-        capabilities = builtin.get("capabilities") or []
-        if "character_image" not in capabilities:
-            unreachable.append(model_id)
-    assert not unreachable, (
-        f"Models have engine blocks in MODEL_TARGETS but the builtin manifest "
-        f"does not advertise `character_image`: {unreachable}. Add the capability "
-        f"to `capabilities` and `ui.recommendedFor` so the Image Studio "
-        f"\"With character\" picker surfaces the model."
-    )
 
 
 def test_hide_reference_strength_models_declare_a_variation_knob():


### PR DESCRIPTION
## What

Follow-up to sc-8861 (F-059, epic 8283 Python eradication). sc-8861 extracted the live `builtin.models.jsonc` audits into standalone `tests/test_builtin_manifest_audit.py`, but 3 `character_image` engine-wiring guards still lazily `importorskip`ed the retired Python worker's `MODEL_TARGETS`. Once epic-8283 deletes `apps/worker` they degrade to a clean SKIP and their coverage is silently lost.

This reimplements them against the Rust worker's own character-image engine wiring, reading the **same** embedded `config/manifests/builtin.models.jsonc` the Python audit parsed.

## How

In `crates/sceneworks-worker/src/engines.rs`:
- Add a declarative `CHARACTER_IMAGE_ENGINE_WIRING` table — the all-targets Rust analog of the Python `ipAdapter`/`instantId`/`pulidFlux`/`controlNetPose` blocks. The real identity/pose dispatch predicates (`resolve_image_route` / `resolve_candle_image_route` in `image_jobs/base.rs`) are `#[cfg]`-gated to macOS(MLX)/`backend-candle`, so they aren't compiled on the plain check lane; the table restates their facts as data (kept in sync with the bespoke `*_ipadapter.rs` / `instantid.rs` / `pulid.rs` / `kolors_control.rs` providers, documented in-file).
- Add `character_image_capability_implies_engine_or_tuning_declaration`, `kolors_declares_strict_pose_controlnet`, and `models_with_engine_block_advertise_character_image` as **non-gated** `#[test]`s (they need only the embedded manifest + the table, no provider registry), so they run on CI's ubuntu `cargo test` lane — actually *broader* coverage than the old macos/candle-gated manifest guards.
- Un-gate the `parse_builtin_models` test helper (manifest + jsonc live in `sceneworks-core`, all-targets).

In `tests/test_builtin_manifest_audit.py`:
- Remove the 3 guards + the `_model_targets()` `importorskip` helper + the now-unused `pytest` import. The module now imports **no** `scene_worker` symbol. The pure-manifest `test_hide_reference_strength_models_declare_a_variation_knob` stays.

Also refreshed `documents/MULTI_MODEL_REFERENCE_CONDITIONING.md` (its guard references were already stale) to point at the Rust reimplementation.

## Verification
- `cargo test -p sceneworks-worker --lib engines::tests` → 11 passed (incl. the 3 new guards) on the Windows/non-candle build (mirrors ubuntu CI).
- `cargo clippy -p sceneworks-worker --all-targets` → clean.
- `python -m pytest -q tests/test_builtin_manifest_audit.py` → 7 passed.
- `node scripts/check-scaffold.mjs` → passed.

Relates to sc-8861; part of epic 8283. Blocks sc-8863.

🤖 Generated with [Claude Code](https://claude.com/claude-code)