### PR TITLE
refactor(web): decompose god components + prop lists (epic 8800 batch W2)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -2113,9 +2113,18 @@ export function App() {
     [token],
   );
   // Keep the ref current for the App-level scratch-op survivor (sc-8850), which purges
-  // from the SSE/sweep path without re-subscribing. Assigned here (after purgeAsset is
-  // defined) rather than in the hoisted ref block above, which runs before this const.
-  purgeAssetRef.current = purgeAsset;
+  // from the SSE/sweep path without re-subscribing. Published from a post-commit effect
+  // rather than the render body (sc-9641, following sc-8940): render-body ref mutation is
+  // unsafe because a discarded concurrent/StrictMode render could leave the ref pointing
+  // at an uncommitted closure. useLayoutEffect (no dep array) mirrors the sc-8940 refresh
+  // block above so the ref always holds the newest *committed* purgeAsset, and flushes
+  // before any passive effect on the same commit. `purgeAsset` is a useCallback([token]),
+  // so this only rewrites when the token changes. It lives here (not in the sc-8940 block)
+  // because purgeAsset is defined after it; the sole read site (the scratch registry's
+  // purge callback) fires from the SSE/sweep path — post-commit — never during render.
+  useLayoutEffect(() => {
+    purgeAssetRef.current = purgeAsset;
+  });
 
   const importAsset = useCallback(
     async (file, options = {}) => {

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -23,7 +23,7 @@ import { LogsScreen } from "./screens/LogsScreen.jsx";
 import { LicensesScreen } from "./screens/LicensesScreen.jsx";
 import { SetupWizard } from "./screens/SetupWizard.jsx";
 import { editModelForAsset } from "./presetUtils.js";
-import { capTerminalJobs, sortNewest, sortOldest, sortWorkers, upsertJobNewest } from "./sorters.js";
+import { sortNewest, sortWorkers, upsertJobNewest } from "./sorters.js";
 import { useCharacters } from "./hooks/useCharacters.js";
 import { usePresets } from "./hooks/usePresets.js";
 import { useTraining } from "./hooks/useTraining.js";
@@ -32,7 +32,7 @@ import { usePersonTracks } from "./hooks/usePersonTracks.js";
 import { useTimelines } from "./hooks/useTimelines.js";
 import { AppStaticContext, AppLiveContext } from "./context/AppContext.js";
 import { DEFAULT_MAC_CAPABILITIES } from "./macGating.js";
-import { ACCENTS, DEFAULT_ACCENT, isAccentId } from "./accents.js";
+import { ACCENTS, isAccentId } from "./accents.js";
 import {
   dropUpscaledVariants,
   findFoldedAssetById,
@@ -43,130 +43,29 @@ import { buildWorkersById } from "./workers.js";
 import { createEditorScratchRegistry } from "./editorScratch.js";
 import { isDesktop as isDesktopShell, tauriInvoke } from "./runtime.js";
 import { readAccessToken, storeAccessToken, clearAccessToken } from "./accessToken.js";
+import {
+  buildLocalJobStack,
+  failedJobNotice,
+  generatedResultAssetCount,
+  isActiveWorker,
+  isImageGenerationJob,
+  isInterleaveJob,
+  isPlaceholderOnlyGpuWorker,
+  isSelectableGpuWorker,
+  isVideoGenerationJob,
+  localJobStackLimit,
+  mergeFreshJobs,
+  noticeKindForJob,
+  parseSseJson,
+  readStoredAccent,
+  readStoredTheme,
+} from "./appHelpers.js";
 
 // Desktop (Tauri) shell detection (unified helper, epic 4484 story 6). The first-run
 // setup wizard is desktop-only; web/Docker (and a remote LAN browser) keep the
 // existing first-run project gate. Tauri commands persist the wizard state (the API
 // binds a random port each launch, so localStorage — keyed to the origin — can't be
 // relied on across launches).
-
-function isActiveWorker(worker) {
-  return worker.status !== "offline";
-}
-
-function hasCapability(worker, capability) {
-  return Array.isArray(worker.capabilities) && worker.capabilities.includes(capability);
-}
-
-function isPlaceholderOnlyGpuWorker(worker) {
-  if (!hasCapability(worker, "gpu")) {
-    return false;
-  }
-  const capabilities = Array.isArray(worker.capabilities) ? worker.capabilities : [];
-  return capabilities.every((capability) => ["placeholder", "gpu", "nvidia"].includes(capability));
-}
-
-function isSelectableGpuWorker(worker) {
-  return worker.gpuId && worker.gpuId !== "cpu" && hasCapability(worker, "gpu") && !isPlaceholderOnlyGpuWorker(worker);
-}
-
-function failedJobNotice(job) {
-  const label = String(job.type ?? "job").replaceAll("_", " ");
-  const detail = job.error || job.message || "Failed without additional worker detail.";
-  return `${label}: ${detail}`;
-}
-
-function isImageGenerationJob(job) {
-  return ["image_generate", "image_edit"].includes(job.type);
-}
-
-function isVideoGenerationJob(job) {
-  return ["video_generate", "video_extend", "video_bridge"].includes(job.type);
-}
-
-function isInterleaveJob(job) {
-  return job.type === "image_interleave";
-}
-
-function parseSseJson(event, label) {
-  try {
-    return JSON.parse(event.data);
-  } catch (err) {
-    console.warn(`Ignoring malformed ${label} SSE event`, err);
-    return null;
-  }
-}
-
-// sc-4198: notice kind for a job-failure banner. LoRA import/train failures get
-// their own kind so the matching job's later completion dismisses exactly that
-// banner (replacing the old "lora import:"/"lora training:" startsWith protocol);
-// everything else is a general error.
-function noticeKindForJob(job) {
-  if (job?.type === "lora_import") return "lora-import";
-  if (job?.type === "lora_train") return "lora-train";
-  return "general";
-}
-
-function jobFreshnessMs(job) {
-  const timestamp = job?.updatedAt ?? job?.completedAt ?? job?.canceledAt ?? job?.startedAt ?? job?.createdAt;
-  const parsed = Date.parse(timestamp ?? "");
-  return Number.isFinite(parsed) ? parsed : 0;
-}
-
-function mergeFreshJobs(currentJobs, serverJobs) {
-  const merged = new Map();
-  for (const job of serverJobs) {
-    merged.set(job.id, job);
-  }
-  for (const current of currentJobs) {
-    const server = merged.get(current.id);
-    if (!server || jobFreshnessMs(current) > jobFreshnessMs(server)) {
-      merged.set(current.id, current);
-    }
-  }
-  // sc-8860 (F-058): this deliberately keeps client-side entries the server no
-  // longer returns, so without a cap a long session grows unbounded. Cap the
-  // retained terminal-job tail (active jobs are never dropped) so a refresh can't
-  // monotonically grow `jobs`.
-  return capTerminalJobs([...merged.values()].sort(sortNewest));
-}
-
-function generatedResultAssetCount(job) {
-  if (Array.isArray(job.result?.assetIds)) {
-    return job.result.assetIds.length;
-  }
-  if (Array.isArray(job.result?.assets)) {
-    return job.result.assets.length;
-  }
-  return 0;
-}
-
-// Studios stack every running and queued run (plus the most recent finished run
-// until its successor starts), so a new submission no longer evicts the prior
-// progress card. Capped so a long session can't grow the visible stack unbounded.
-const localJobStackLimit = 25;
-
-// Build a studio's local-job stack: the runs it explicitly remembered plus any
-// still-active generation jobs for the open project, de-duped and ordered
-// oldest-first (running run on top, queued runs following in execution order),
-// keeping only the most recent `localJobStackLimit` entries.
-function buildLocalJobStack(rememberedIds, jobs, activeProjectId, isGenerationJob) {
-  const remembered = rememberedIds.map((id) => jobs.find((job) => job.id === id)).filter(Boolean);
-  const projectJobs = jobs.filter(
-    (job) =>
-      activeProjectId &&
-      job.projectId === activeProjectId &&
-      isGenerationJob(job) &&
-      !terminalStatuses.has(job.status),
-  );
-  const byId = new Map();
-  [...remembered, ...projectJobs].forEach((job) => {
-    if (job?.id && !byId.has(job.id)) {
-      byId.set(job.id, job);
-    }
-  });
-  return Array.from(byId.values()).sort(sortOldest).slice(-localJobStackLimit);
-}
 
 // Lazy-load the canvas editor so Konva (canvas-based, heavy) stays out of the
 // initial bundle and the jsdom test path — it only loads when the view is opened.
@@ -236,30 +135,6 @@ const viewTitles = {
     blurb: "Third-party components bundled with SceneWorks and their license notices.",
   },
 };
-
-function readStoredTheme() {
-  if (typeof window === "undefined") {
-    return "light";
-  }
-  try {
-    const saved = window.localStorage.getItem("sceneworks-theme");
-    return saved === "dark" || saved === "light" ? saved : "light";
-  } catch {
-    return "light";
-  }
-}
-
-function readStoredAccent() {
-  if (typeof window === "undefined") {
-    return DEFAULT_ACCENT;
-  }
-  try {
-    const saved = window.localStorage.getItem("sceneworks-accent");
-    return isAccentId(saved) ? saved : DEFAULT_ACCENT;
-  } catch {
-    return DEFAULT_ACCENT;
-  }
-}
 
 function ProjectSwitcher({ activeProject, projects, onSelect, onCreate, disabled }) {
   const [open, setOpen] = useState(false);

--- a/apps/web/src/appHelpers.js
+++ b/apps/web/src/appHelpers.js
@@ -1,0 +1,152 @@
+// sc-8854 (F-052): pure module-level helpers extracted from App.jsx. These were already
+// file-local functions with no closure over component state — worker/job classification,
+// SSE parsing, notice mapping, job-list merge/cap, the local-job stack builder, and the
+// persisted theme/accent readers. Moving them out of the ~2,650-line App god component
+// shrinks its top-of-file surface and makes each independently unit-testable
+// (appHelpers.test.js) without mounting App. Behavior is unchanged — this is a move, not a
+// rewrite.
+import { terminalStatuses } from "./constants.js";
+import { capTerminalJobs, sortNewest, sortOldest } from "./sorters.js";
+import { DEFAULT_ACCENT, isAccentId } from "./accents.js";
+
+export function isActiveWorker(worker) {
+  return worker.status !== "offline";
+}
+
+export function hasCapability(worker, capability) {
+  return Array.isArray(worker.capabilities) && worker.capabilities.includes(capability);
+}
+
+export function isPlaceholderOnlyGpuWorker(worker) {
+  if (!hasCapability(worker, "gpu")) {
+    return false;
+  }
+  const capabilities = Array.isArray(worker.capabilities) ? worker.capabilities : [];
+  return capabilities.every((capability) => ["placeholder", "gpu", "nvidia"].includes(capability));
+}
+
+export function isSelectableGpuWorker(worker) {
+  return worker.gpuId && worker.gpuId !== "cpu" && hasCapability(worker, "gpu") && !isPlaceholderOnlyGpuWorker(worker);
+}
+
+export function failedJobNotice(job) {
+  const label = String(job.type ?? "job").replaceAll("_", " ");
+  const detail = job.error || job.message || "Failed without additional worker detail.";
+  return `${label}: ${detail}`;
+}
+
+export function isImageGenerationJob(job) {
+  return ["image_generate", "image_edit"].includes(job.type);
+}
+
+export function isVideoGenerationJob(job) {
+  return ["video_generate", "video_extend", "video_bridge"].includes(job.type);
+}
+
+export function isInterleaveJob(job) {
+  return job.type === "image_interleave";
+}
+
+export function parseSseJson(event, label) {
+  try {
+    return JSON.parse(event.data);
+  } catch (err) {
+    console.warn(`Ignoring malformed ${label} SSE event`, err);
+    return null;
+  }
+}
+
+// sc-4198: notice kind for a job-failure banner. LoRA import/train failures get
+// their own kind so the matching job's later completion dismisses exactly that
+// banner (replacing the old "lora import:"/"lora training:" startsWith protocol);
+// everything else is a general error.
+export function noticeKindForJob(job) {
+  if (job?.type === "lora_import") return "lora-import";
+  if (job?.type === "lora_train") return "lora-train";
+  return "general";
+}
+
+export function jobFreshnessMs(job) {
+  const timestamp = job?.updatedAt ?? job?.completedAt ?? job?.canceledAt ?? job?.startedAt ?? job?.createdAt;
+  const parsed = Date.parse(timestamp ?? "");
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function mergeFreshJobs(currentJobs, serverJobs) {
+  const merged = new Map();
+  for (const job of serverJobs) {
+    merged.set(job.id, job);
+  }
+  for (const current of currentJobs) {
+    const server = merged.get(current.id);
+    if (!server || jobFreshnessMs(current) > jobFreshnessMs(server)) {
+      merged.set(current.id, current);
+    }
+  }
+  // sc-8860 (F-058): this deliberately keeps client-side entries the server no
+  // longer returns, so without a cap a long session grows unbounded. Cap the
+  // retained terminal-job tail (active jobs are never dropped) so a refresh can't
+  // monotonically grow `jobs`.
+  return capTerminalJobs([...merged.values()].sort(sortNewest));
+}
+
+export function generatedResultAssetCount(job) {
+  if (Array.isArray(job.result?.assetIds)) {
+    return job.result.assetIds.length;
+  }
+  if (Array.isArray(job.result?.assets)) {
+    return job.result.assets.length;
+  }
+  return 0;
+}
+
+// Studios stack every running and queued run (plus the most recent finished run
+// until its successor starts), so a new submission no longer evicts the prior
+// progress card. Capped so a long session can't grow the visible stack unbounded.
+export const localJobStackLimit = 25;
+
+// Build a studio's local-job stack: the runs it explicitly remembered plus any
+// still-active generation jobs for the open project, de-duped and ordered
+// oldest-first (running run on top, queued runs following in execution order),
+// keeping only the most recent `localJobStackLimit` entries.
+export function buildLocalJobStack(rememberedIds, jobs, activeProjectId, isGenerationJob) {
+  const remembered = rememberedIds.map((id) => jobs.find((job) => job.id === id)).filter(Boolean);
+  const projectJobs = jobs.filter(
+    (job) =>
+      activeProjectId &&
+      job.projectId === activeProjectId &&
+      isGenerationJob(job) &&
+      !terminalStatuses.has(job.status),
+  );
+  const byId = new Map();
+  [...remembered, ...projectJobs].forEach((job) => {
+    if (job?.id && !byId.has(job.id)) {
+      byId.set(job.id, job);
+    }
+  });
+  return Array.from(byId.values()).sort(sortOldest).slice(-localJobStackLimit);
+}
+
+export function readStoredTheme() {
+  if (typeof window === "undefined") {
+    return "light";
+  }
+  try {
+    const saved = window.localStorage.getItem("sceneworks-theme");
+    return saved === "dark" || saved === "light" ? saved : "light";
+  } catch {
+    return "light";
+  }
+}
+
+export function readStoredAccent() {
+  if (typeof window === "undefined") {
+    return DEFAULT_ACCENT;
+  }
+  try {
+    const saved = window.localStorage.getItem("sceneworks-accent");
+    return isAccentId(saved) ? saved : DEFAULT_ACCENT;
+  } catch {
+    return DEFAULT_ACCENT;
+  }
+}

--- a/apps/web/src/appHelpers.test.js
+++ b/apps/web/src/appHelpers.test.js
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  buildLocalJobStack,
+  failedJobNotice,
+  generatedResultAssetCount,
+  hasCapability,
+  isActiveWorker,
+  isImageGenerationJob,
+  isInterleaveJob,
+  isPlaceholderOnlyGpuWorker,
+  isSelectableGpuWorker,
+  isVideoGenerationJob,
+  jobFreshnessMs,
+  mergeFreshJobs,
+  noticeKindForJob,
+  parseSseJson,
+  readStoredAccent,
+  readStoredTheme,
+} from "./appHelpers.js";
+import { DEFAULT_ACCENT } from "./accents.js";
+
+// sc-8854 (F-052): behavior lock for the pure helpers extracted out of App.jsx.
+
+describe("worker classification", () => {
+  it("treats any non-offline worker as active", () => {
+    expect(isActiveWorker({ status: "idle" })).toBe(true);
+    expect(isActiveWorker({ status: "offline" })).toBe(false);
+  });
+
+  it("checks capabilities defensively", () => {
+    expect(hasCapability({ capabilities: ["gpu"] }, "gpu")).toBe(true);
+    expect(hasCapability({ capabilities: ["gpu"] }, "cpu")).toBe(false);
+    expect(hasCapability({}, "gpu")).toBe(false);
+  });
+
+  it("flags placeholder-only GPU workers", () => {
+    expect(isPlaceholderOnlyGpuWorker({ capabilities: ["gpu", "placeholder"] })).toBe(true);
+    expect(isPlaceholderOnlyGpuWorker({ capabilities: ["gpu", "cuda"] })).toBe(false);
+    expect(isPlaceholderOnlyGpuWorker({ capabilities: ["cpu"] })).toBe(false);
+  });
+
+  it("selects only real, non-placeholder GPU workers", () => {
+    expect(isSelectableGpuWorker({ gpuId: "0", capabilities: ["gpu", "cuda"] })).toBe(true);
+    expect(isSelectableGpuWorker({ gpuId: "cpu", capabilities: ["gpu"] })).toBe(false);
+    expect(isSelectableGpuWorker({ gpuId: "0", capabilities: ["gpu", "placeholder"] })).toBe(false);
+  });
+});
+
+describe("job classification + notices", () => {
+  it("classifies image / video / interleave jobs", () => {
+    expect(isImageGenerationJob({ type: "image_generate" })).toBe(true);
+    expect(isImageGenerationJob({ type: "video_generate" })).toBe(false);
+    expect(isVideoGenerationJob({ type: "video_bridge" })).toBe(true);
+    expect(isInterleaveJob({ type: "image_interleave" })).toBe(true);
+    expect(isInterleaveJob({ type: "image_generate" })).toBe(false);
+  });
+
+  it("builds a readable failure notice with a fallback detail", () => {
+    expect(failedJobNotice({ type: "lora_train", error: "boom" })).toBe("lora train: boom");
+    expect(failedJobNotice({ type: "image_generate" })).toBe(
+      "image generate: Failed without additional worker detail.",
+    );
+  });
+
+  it("maps lora import/train jobs to their own notice kind", () => {
+    expect(noticeKindForJob({ type: "lora_import" })).toBe("lora-import");
+    expect(noticeKindForJob({ type: "lora_train" })).toBe("lora-train");
+    expect(noticeKindForJob({ type: "image_generate" })).toBe("general");
+    expect(noticeKindForJob(null)).toBe("general");
+  });
+
+  it("counts generated result assets from either shape", () => {
+    expect(generatedResultAssetCount({ result: { assetIds: ["a", "b"] } })).toBe(2);
+    expect(generatedResultAssetCount({ result: { assets: [{}, {}, {}] } })).toBe(3);
+    expect(generatedResultAssetCount({ result: {} })).toBe(0);
+  });
+});
+
+describe("parseSseJson", () => {
+  it("parses valid JSON payloads", () => {
+    expect(parseSseJson({ data: '{"x":1}' }, "test")).toEqual({ x: 1 });
+  });
+
+  it("returns null and warns on malformed data", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(parseSseJson({ data: "not json" }, "test")).toBeNull();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+
+describe("job freshness + merge", () => {
+  it("reads the freshest available timestamp, falling back to 0", () => {
+    expect(jobFreshnessMs({ updatedAt: "2026-01-01T00:00:00Z" })).toBeGreaterThan(0);
+    expect(jobFreshnessMs({})).toBe(0);
+  });
+
+  it("keeps the fresher of duplicate jobs and retains client-only entries", () => {
+    const current = [
+      { id: "a", status: "succeeded", createdAt: "2026-01-02T00:00:00Z", updatedAt: "2026-01-02T00:00:00Z" },
+      { id: "client-only", status: "succeeded", createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-01-01T00:00:00Z" },
+    ];
+    const server = [{ id: "a", status: "succeeded", createdAt: "2026-01-02T00:00:00Z", updatedAt: "2026-01-01T00:00:00Z" }];
+    const merged = mergeFreshJobs(current, server);
+    const byId = Object.fromEntries(merged.map((job) => [job.id, job]));
+    // The client's fresher "a" wins over the staler server copy.
+    expect(byId.a.updatedAt).toBe("2026-01-02T00:00:00Z");
+    // The client-only entry is retained.
+    expect(byId["client-only"]).toBeTruthy();
+  });
+});
+
+describe("buildLocalJobStack", () => {
+  const isGen = (job) => job.type === "image_generate";
+
+  it("includes remembered runs plus active project generation jobs, de-duped and oldest-first", () => {
+    const jobs = [
+      { id: "old", type: "image_generate", projectId: "p1", status: "succeeded", createdAt: "2026-01-01T00:00:00Z" },
+      { id: "running", type: "image_generate", projectId: "p1", status: "running", createdAt: "2026-01-03T00:00:00Z" },
+      { id: "queued", type: "image_generate", projectId: "p1", status: "queued", createdAt: "2026-01-04T00:00:00Z" },
+      { id: "other", type: "image_generate", projectId: "p2", status: "running", createdAt: "2026-01-05T00:00:00Z" },
+    ];
+    const stack = buildLocalJobStack(["old"], jobs, "p1", isGen);
+    const ids = stack.map((job) => job.id);
+    // Remembered terminal "old" is kept; active p1 jobs added; p2 excluded; no dupes.
+    expect(ids).toContain("old");
+    expect(ids).toContain("running");
+    expect(ids).toContain("queued");
+    expect(ids).not.toContain("other");
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("returns an empty stack when there is no active project", () => {
+    const jobs = [{ id: "a", type: "image_generate", projectId: "p1", status: "running", createdAt: "2026-01-01T00:00:00Z" }];
+    expect(buildLocalJobStack([], jobs, null, isGen)).toEqual([]);
+  });
+});
+
+describe("stored theme + accent readers", () => {
+  const store = new Map();
+
+  beforeEach(() => {
+    store.clear();
+    vi.stubGlobal("window", {
+      localStorage: {
+        getItem: (key) => (store.has(key) ? store.get(key) : null),
+        setItem: (key, value) => store.set(key, value),
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("reads a valid stored theme and defaults to light otherwise", () => {
+    store.set("sceneworks-theme", "dark");
+    expect(readStoredTheme()).toBe("dark");
+    store.set("sceneworks-theme", "banana");
+    expect(readStoredTheme()).toBe("light");
+    store.delete("sceneworks-theme");
+    expect(readStoredTheme()).toBe("light");
+  });
+
+  it("reads a valid stored accent and defaults otherwise", () => {
+    store.set("sceneworks-accent", "not-an-accent");
+    expect(readStoredAccent()).toBe(DEFAULT_ACCENT);
+  });
+});

--- a/apps/web/src/hooks/useTraining.js
+++ b/apps/web/src/hooks/useTraining.js
@@ -82,16 +82,20 @@ export function useTraining({ token, activeProject, setError, setJobs }) {
   // metadata write — it does not bump the dataset version — so callers refetch readiness, not the
   // dataset, afterward.
   const setTrainingDatasetItemQualityAck = useCallback(
-    async (datasetId, itemId, checks, optionsOrProjectId = {}, explicitProjectId = activeProject?.id) => {
-      const options = typeof optionsOrProjectId === "string" ? {} : (optionsOrProjectId ?? {});
-      const projectId = typeof optionsOrProjectId === "string" ? optionsOrProjectId : explicitProjectId;
+    async (datasetId, itemId, checks, options = {}) => {
+      // sc-8942 (F-140): single options object. The optional target project is a named
+      // `projectId` field (defaulting to the active project) rather than the old
+      // type-switching 4th param (string=projectId | object=options), which was unique in
+      // the codebase and easy to call wrong — a mistyped arg silently fell through to the
+      // active project. No caller ever used the string form, so this is behavior-preserving.
+      const { projectId = activeProject?.id, expectedContentHash, expectedCaptionHash } = options ?? {};
       if (!projectId || !datasetId || !itemId) {
         throw new Error("Select a training dataset item first.");
       }
       const body = {
         checks,
-        ...(options.expectedContentHash ? { expectedContentHash: options.expectedContentHash } : {}),
-        ...(options.expectedCaptionHash ? { expectedCaptionHash: options.expectedCaptionHash } : {}),
+        ...(expectedContentHash ? { expectedContentHash } : {}),
+        ...(expectedCaptionHash ? { expectedCaptionHash } : {}),
       };
       return apiFetch(
         `/api/v1/projects/${projectId}/training/datasets/${encodeURIComponent(datasetId)}/items/${encodeURIComponent(itemId)}/quality-ack`,

--- a/apps/web/src/imageJobAdvanced.js
+++ b/apps/web/src/imageJobAdvanced.js
@@ -1,0 +1,178 @@
+import { buildStructuredPromptRecipe } from "./ideogramCaption.js";
+import { tierQuantize } from "./quantTier.js";
+
+// sc-8854 (F-052): pure builder for the Image Studio job's `advanced` payload. Extracted
+// verbatim from ImageStudio.submit() — the ~110-line object literal that assembled the
+// payload from ~15 conditional spreads was the app's highest-drift surface (each new
+// advanced knob threaded a new conditional through the middle of a 240-line async
+// function). Pulling it into a pure state → payload function makes it independently
+// unit-testable and keeps submit() focused on orchestration (prompt resolution, the API
+// call, submitting-state). Behavior is preserved exactly: every conditional, guard, and
+// omit-when-default rule (which keeps existing recipes byte-identical) is unchanged.
+//
+// The worker clones `advanced` verbatim into the asset's rawAdapterSettings, so omitting a
+// key when it equals the engine default is load-bearing — it keeps saved recipes stable
+// across releases. Do not "simplify" a spread into an always-present key.
+export function buildImageJobAdvanced(state) {
+  const {
+    resolution,
+    // Structured-prompt recipe round-trip (sc-6147).
+    sendStructured,
+    submitIntent,
+    submitCaption,
+    submitBackend,
+    // Sampler / scheduler (epic 1753 / 7114).
+    sampler,
+    scheduler,
+    schedulerShift,
+    // Step / guidance overrides.
+    stepsOverride,
+    guidanceOverride,
+    guidanceMethod,
+    // Flash attention (sc-3674).
+    flashAttn,
+    // Caption upsampling (sc-6135).
+    promptEnhance,
+    enhancePrompt,
+    // Boogu precision (sc-6568) + quant-tier A/B (sc-8515).
+    precisionToggle,
+    bf16Precision,
+    showTierPicker,
+    quantTier,
+    // PiD decoder (epic 7840).
+    showPidToggle,
+    usePid,
+    // Character-reference knobs.
+    mode,
+    referenceAssetId,
+    hideReferenceStrength,
+    ipAdapterScale,
+    identityStructure,
+    controlnetScale,
+    variationStrength,
+    trueCfgScale,
+    viewAngles,
+    viewAngle,
+    // Pose library.
+    posePayload,
+    faceRestore,
+    // Strict-control conditioning (epic 8236).
+    controlActive,
+    activeControlMode,
+    controlPassthroughId,
+    effectiveControlScale,
+  } = state;
+
+  return {
+    resolution,
+    // Structured-prompt recipe round-trip (sc-6147): persist the full caption +
+    // original intent + magic-prompt backend alongside the job so "Use this recipe"
+    // can rehydrate the builder rather than replay the serialized JSON as a plain
+    // prompt. Rides in `advanced`, which the worker clones verbatim into the asset's
+    // rawAdapterSettings — no backend change needed. Only for structured models.
+    ...(sendStructured
+      ? {
+          structuredPrompt: buildStructuredPromptRecipe({
+            intent: submitIntent,
+            caption: submitCaption,
+            magicPromptBackend: submitBackend,
+            edited: !submitBackend,
+          }),
+        }
+      : {}),
+    // Configurable sampler / scheduler (epic 1753). Worker registry
+    // falls back to model-native when given "default", so emitting the
+    // values unconditionally is safe — invalid values are ignored.
+    ...(sampler && sampler !== "default" ? { sampler } : {}),
+    ...(scheduler && scheduler !== "default" ? { scheduler } : {}),
+    // Guidance method (epic 7434). "cfg" is the engine-standard no-op, so it is
+    // omitted — keeping existing recipes byte-identical; only a non-default
+    // method (CFG++) rides the payload. The worker N3-falls an unadvertised
+    // method back to the default, so an invalid value is harmless.
+    ...(guidanceMethod && guidanceMethod !== "cfg" ? { guidanceMethod } : {}),
+    // The schedule shift (time-shift mu) is only honored when a curated
+    // (non-default) scheduler is active — it shapes that curated schedule;
+    // the default scheduler keeps the engine's resolution-native shift, so
+    // emitting it there would override the no-op default (epic 7114).
+    ...(scheduler &&
+    scheduler !== "default" &&
+    Number.isFinite(Number(schedulerShift))
+      ? { schedulerShift: Number(schedulerShift) }
+      : {}),
+    // Step / guidance overrides — empty string means "use the model
+    // default", which the worker reads off MODEL_TARGETS.
+    ...(stepsOverride !== "" && Number.isFinite(Number(stepsOverride))
+      ? { steps: Number(stepsOverride) }
+      : {}),
+    ...(guidanceOverride !== "" && Number.isFinite(Number(guidanceOverride))
+      ? { guidanceScale: Number(guidanceOverride) }
+      : {}),
+    // Flash attention (sc-3674): only emitted when toggled OFF — the worker defaults to ON
+    // when `advanced.flashAttn` is absent, so the default-on case adds nothing to the payload.
+    // Only the candle (Windows/CUDA) SDXL backend reads it; every other backend ignores it.
+    ...(flashAttn ? {} : { flashAttn: false }),
+    // FLUX.2-dev caption upsampling (sc-6135): emitted only when the model declares the
+    // toggle AND it's on (off-by-default; the worker/engine ignore it for other models).
+    ...(promptEnhance && enhancePrompt ? { enhancePrompt: true } : {}),
+    // Boogu precision (sc-6568): emit mlxQuantize:0 (full-precision bf16) only when the model
+    // exposes the precision toggle AND bf16 is selected; the default Q8 emits nothing (the
+    // worker reads manifest mlx.quantize and fetches the `<variant>-bf16/` subfolder on demand).
+    // `!showTierPicker` is a defensive guard: Boogu downloads via `base/`-style subfolder globs
+    // (no `downloads[].variant` keys), so `hasVariantMatrix` — and therefore `showTierPicker` —
+    // is always false for the precisionToggle set; the two controls are disjoint. The guard
+    // makes that invariant load-bearing so a future manifest change can never emit both
+    // mlxQuantize spreads for one model (the tier picker below would win the object-spread
+    // race, but we never render/emit both).
+    ...(precisionToggle && bf16Precision && !showTierPicker ? { mlxQuantize: 0 } : {}),
+    // Quant-tier A/B (sc-8515): when the model has >1 tier installed and a tier is picked,
+    // send that tier's mlxQuantize (bf16→0, q8→8, q4→4). The worker's resolve_quant +
+    // generator cache route to it (reload-always). Emitted only when the picker is shown
+    // AND the picked tier maps to a known quant value, so single-tier models and the
+    // "default" pseudo-variant never leak an mlxQuantize into the payload. Disjoint from the
+    // Boogu precisionToggle above (non-matrix models), enforced by its `!showTierPicker` guard.
+    ...(showTierPicker && tierQuantize(quantTier) !== null
+      ? { mlxQuantize: tierQuantize(quantTier) }
+      : {}),
+    // PiD decoder (epic 7840, sc-7851): emit usePid:true only when the toggle is shown
+    // (model PiD-eligible AND checkpoint installed) AND on. The worker swaps the native
+    // VAE for the PiD decode + 2K/4K super-resolve pass; it rides `advanced` (opaque
+    // pass-through, zero contract-snapshot drift) and is cloned into the asset's
+    // rawAdapterSettings — that recorded `usePid:true` is the output's non-commercial
+    // marker. The worker independently no-ops to the native VAE if the checkpoint is gone.
+    ...(showPidToggle && usePid ? { usePid: true } : {}),
+    // IP-Adapter / InstantID reference strength only applies when a character
+    // reference is attached AND the model uses the IP-Adapter knob; Qwen's
+    // edit pipeline ignores this scalar (hideReferenceStrength gates it out).
+    ...(mode === "character_image" && referenceAssetId && !hideReferenceStrength
+      ? { ipAdapterScale }
+      : {}),
+    // Identity structure (controlnetConditioningScale) is InstantID-only — sent
+    // only when the model exposes the control and a reference is attached.
+    ...(mode === "character_image" && referenceAssetId && identityStructure
+      ? { controlnetConditioningScale: controlnetScale }
+      : {}),
+    // Variation knob (trueCfgScale) — FLUX uses it alongside ipAdapterScale,
+    // Qwen uses it as the only variation lever. Sent only when the model
+    // declares a variationStrength slider AND a reference is attached.
+    ...(mode === "character_image" && referenceAssetId && variationStrength
+      ? { trueCfgScale }
+      : {}),
+    // View angle (InstantID) — only when a specific angle is chosen and no pose is
+    // selected (a library pose drives the whole body, superseding the head angle).
+    ...(mode === "character_image" && referenceAssetId && viewAngles && viewAngle && !posePayload.length
+      ? { viewAngle }
+      : {}),
+    // Pose library (InstantID) — one image per selected pose; faceRestore toggles
+    // the full-body face-restoration pass.
+    ...(posePayload.length ? { poses: posePayload, faceRestore } : {}),
+    // Strict-control conditioning (epic 8236, sc-8245). The control type the worker's shared
+    // strict-control driver reads (strict_control.rs `requested_control_kind`). Pose is the
+    // engine default (omitted → byte-preserved), so only non-pose modes ride the payload. The
+    // control-lock strength (`advanced.controlScale`) is sent whenever the panel is active.
+    ...(controlActive && activeControlMode !== "pose" ? { controlMode: activeControlMode } : {}),
+    // Use-as-is passthrough: a pre-made canny/depth map fed verbatim
+    // (strict_control.rs `resolve_user_control_map`). Derive mode uses request.sourceAssetId.
+    ...(controlPassthroughId ? { controlImage: controlPassthroughId } : {}),
+    ...(controlActive ? { controlScale: effectiveControlScale } : {}),
+  };
+}

--- a/apps/web/src/imageJobAdvanced.test.js
+++ b/apps/web/src/imageJobAdvanced.test.js
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest";
+
+import { buildImageJobAdvanced } from "./imageJobAdvanced.js";
+
+// sc-8854 (F-052): the `advanced` payload is the app's highest-drift surface — every
+// conditional spread encodes an omit-when-default rule that keeps saved recipes
+// byte-identical across releases. These tests pin those rules so the extraction from
+// ImageStudio.submit() is provably behavior-preserving and future edits stay honest.
+
+// A state shaped so every optional spread is OFF: the payload should carry only the
+// always-present keys (resolution + flashAttn:false when flashAttn is off).
+function offState(overrides = {}) {
+  return {
+    resolution: "1024x1024",
+    sendStructured: false,
+    submitIntent: "",
+    submitCaption: null,
+    submitBackend: null,
+    sampler: "default",
+    scheduler: "default",
+    schedulerShift: "",
+    stepsOverride: "",
+    guidanceOverride: "",
+    guidanceMethod: "cfg",
+    flashAttn: true,
+    promptEnhance: false,
+    enhancePrompt: false,
+    precisionToggle: false,
+    bf16Precision: false,
+    showTierPicker: false,
+    quantTier: "default",
+    showPidToggle: false,
+    usePid: false,
+    mode: "text_to_image",
+    referenceAssetId: null,
+    hideReferenceStrength: false,
+    ipAdapterScale: 0.8,
+    identityStructure: false,
+    controlnetScale: 0.5,
+    variationStrength: false,
+    trueCfgScale: 4,
+    viewAngles: false,
+    viewAngle: "",
+    posePayload: [],
+    faceRestore: false,
+    controlActive: false,
+    activeControlMode: null,
+    controlPassthroughId: null,
+    effectiveControlScale: 0.7,
+    ...overrides,
+  };
+}
+
+describe("buildImageJobAdvanced", () => {
+  it("emits only the always-present keys when every optional knob is at its default", () => {
+    const advanced = buildImageJobAdvanced(offState());
+    // flashAttn:true (default-on) is omitted; nothing else leaks.
+    expect(advanced).toEqual({ resolution: "1024x1024" });
+  });
+
+  it("emits flashAttn:false only when flash attention is toggled off", () => {
+    expect(buildImageJobAdvanced(offState({ flashAttn: true }))).not.toHaveProperty("flashAttn");
+    expect(buildImageJobAdvanced(offState({ flashAttn: false })).flashAttn).toBe(false);
+  });
+
+  it("omits sampler/scheduler when default and includes them otherwise", () => {
+    expect(buildImageJobAdvanced(offState())).not.toHaveProperty("sampler");
+    const custom = buildImageJobAdvanced(offState({ sampler: "euler", scheduler: "karras" }));
+    expect(custom.sampler).toBe("euler");
+    expect(custom.scheduler).toBe("karras");
+  });
+
+  it("omits guidanceMethod for the engine no-op 'cfg' and rides a non-default method", () => {
+    expect(buildImageJobAdvanced(offState({ guidanceMethod: "cfg" }))).not.toHaveProperty("guidanceMethod");
+    expect(buildImageJobAdvanced(offState({ guidanceMethod: "cfg_pp" })).guidanceMethod).toBe("cfg_pp");
+  });
+
+  it("only rides schedulerShift when a curated (non-default) scheduler is active and the value is finite", () => {
+    // Default scheduler → shift omitted even if provided.
+    expect(
+      buildImageJobAdvanced(offState({ scheduler: "default", schedulerShift: "3" })),
+    ).not.toHaveProperty("schedulerShift");
+    // Curated scheduler + finite shift → coerced to Number and sent.
+    expect(
+      buildImageJobAdvanced(offState({ scheduler: "karras", schedulerShift: "3" })).schedulerShift,
+    ).toBe(3);
+    // Curated scheduler but a non-finite shift (Number("abc") -> NaN) → omitted. Note the
+    // empty-string case coerces to 0 (Number("") === 0), which IS finite, matching the
+    // original submit() behavior, so it would be sent — we don't assert it away here.
+    expect(
+      buildImageJobAdvanced(offState({ scheduler: "karras", schedulerShift: "abc" })),
+    ).not.toHaveProperty("schedulerShift");
+  });
+
+  it("coerces step/guidance overrides and omits empty strings", () => {
+    expect(buildImageJobAdvanced(offState({ stepsOverride: "", guidanceOverride: "" }))).toEqual({
+      resolution: "1024x1024",
+    });
+    const set = buildImageJobAdvanced(offState({ stepsOverride: "28", guidanceOverride: "3.5" }));
+    expect(set.steps).toBe(28);
+    expect(set.guidanceScale).toBe(3.5);
+  });
+
+  it("emits enhancePrompt only when the model declares the toggle and it is on", () => {
+    expect(buildImageJobAdvanced(offState({ promptEnhance: true, enhancePrompt: false }))).not.toHaveProperty(
+      "enhancePrompt",
+    );
+    expect(buildImageJobAdvanced(offState({ promptEnhance: false, enhancePrompt: true }))).not.toHaveProperty(
+      "enhancePrompt",
+    );
+    expect(
+      buildImageJobAdvanced(offState({ promptEnhance: true, enhancePrompt: true })).enhancePrompt,
+    ).toBe(true);
+  });
+
+  it("keeps the Boogu precision and quant-tier mlxQuantize spreads disjoint", () => {
+    // Boogu precision toggle: bf16 selected, no tier picker → mlxQuantize:0.
+    expect(
+      buildImageJobAdvanced(offState({ precisionToggle: true, bf16Precision: true, showTierPicker: false }))
+        .mlxQuantize,
+    ).toBe(0);
+    // Its !showTierPicker guard suppresses the Boogu path when a tier picker is present;
+    // the tier path then decides. With a "default" pseudo-tier the tier path also omits,
+    // so neither spread leaks mlxQuantize.
+    expect(
+      buildImageJobAdvanced(
+        offState({ precisionToggle: true, bf16Precision: true, showTierPicker: true, quantTier: "default" }),
+      ),
+    ).not.toHaveProperty("mlxQuantize");
+    // With a real picked tier, that tier's quant value wins (q8 -> 8), never the Boogu 0.
+    expect(
+      buildImageJobAdvanced(
+        offState({ precisionToggle: true, bf16Precision: true, showTierPicker: true, quantTier: "q8" }),
+      ).mlxQuantize,
+    ).toBe(8);
+  });
+
+  it("maps the picked quant tier to mlxQuantize (bf16->0, q8->8, q4->4) and omits the 'default' pseudo-tier", () => {
+    expect(buildImageJobAdvanced(offState({ showTierPicker: true, quantTier: "q4" })).mlxQuantize).toBe(4);
+    expect(buildImageJobAdvanced(offState({ showTierPicker: true, quantTier: "bf16" })).mlxQuantize).toBe(0);
+    // "default" → tierQuantize null → omitted.
+    expect(buildImageJobAdvanced(offState({ showTierPicker: true, quantTier: "default" }))).not.toHaveProperty(
+      "mlxQuantize",
+    );
+  });
+
+  it("emits usePid only when the PiD toggle is shown and on", () => {
+    expect(buildImageJobAdvanced(offState({ showPidToggle: false, usePid: true }))).not.toHaveProperty("usePid");
+    expect(buildImageJobAdvanced(offState({ showPidToggle: true, usePid: true })).usePid).toBe(true);
+  });
+
+  it("embeds a structured-prompt recipe only for structured submissions", () => {
+    expect(buildImageJobAdvanced(offState({ sendStructured: false }))).not.toHaveProperty("structuredPrompt");
+    const structured = buildImageJobAdvanced(
+      offState({ sendStructured: true, submitIntent: "a cat", submitCaption: { subject: "cat" }, submitBackend: "llm" }),
+    );
+    expect(structured.structuredPrompt).toMatchObject({ intent: "a cat", magicPromptBackend: "llm", edited: false });
+  });
+
+  describe("character-reference gating", () => {
+    const charRef = { mode: "character_image", referenceAssetId: "ref-1" };
+
+    it("gates ipAdapterScale on a character reference that is not hidden", () => {
+      expect(buildImageJobAdvanced(offState(charRef)).ipAdapterScale).toBe(0.8);
+      expect(
+        buildImageJobAdvanced(offState({ ...charRef, hideReferenceStrength: true })),
+      ).not.toHaveProperty("ipAdapterScale");
+      // No reference → omitted regardless.
+      expect(buildImageJobAdvanced(offState({ mode: "character_image", referenceAssetId: null }))).not.toHaveProperty(
+        "ipAdapterScale",
+      );
+    });
+
+    it("gates controlnetConditioningScale on identityStructure + reference", () => {
+      expect(
+        buildImageJobAdvanced(offState({ ...charRef, identityStructure: true, controlnetScale: 0.6 }))
+          .controlnetConditioningScale,
+      ).toBe(0.6);
+      expect(buildImageJobAdvanced(offState({ ...charRef, identityStructure: false }))).not.toHaveProperty(
+        "controlnetConditioningScale",
+      );
+    });
+
+    it("suppresses viewAngle when a pose is selected (pose supersedes head angle)", () => {
+      const base = { ...charRef, viewAngles: true, viewAngle: "three_quarter" };
+      expect(buildImageJobAdvanced(offState(base)).viewAngle).toBe("three_quarter");
+      expect(
+        buildImageJobAdvanced(offState({ ...base, posePayload: [{ id: "p1", keypoints: [] }] })),
+      ).not.toHaveProperty("viewAngle");
+    });
+  });
+
+  describe("pose + strict control", () => {
+    it("emits poses + faceRestore when a pose payload is present", () => {
+      const poses = [{ id: "p1", keypoints: [1, 2] }];
+      const advanced = buildImageJobAdvanced(offState({ posePayload: poses, faceRestore: true }));
+      expect(advanced.poses).toBe(poses);
+      expect(advanced.faceRestore).toBe(true);
+    });
+
+    it("rides controlMode only for a non-pose active control mode, plus controlScale whenever active", () => {
+      const pose = buildImageJobAdvanced(offState({ controlActive: true, activeControlMode: "pose" }));
+      expect(pose).not.toHaveProperty("controlMode");
+      expect(pose.controlScale).toBe(0.7);
+
+      const canny = buildImageJobAdvanced(
+        offState({ controlActive: true, activeControlMode: "canny", effectiveControlScale: 0.9 }),
+      );
+      expect(canny.controlMode).toBe("canny");
+      expect(canny.controlScale).toBe(0.9);
+    });
+
+    it("rides controlImage only for a passthrough control map", () => {
+      expect(buildImageJobAdvanced(offState({ controlPassthroughId: null }))).not.toHaveProperty("controlImage");
+      expect(
+        buildImageJobAdvanced(offState({ controlActive: true, controlPassthroughId: "map-1" })).controlImage,
+      ).toBe("map-1");
+    });
+  });
+});

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -10,7 +10,6 @@ import { RefinePromptControl } from "../components/RefinePromptControl.jsx";
 import StructuredPromptBuilder from "../components/StructuredPromptBuilder.jsx";
 import ReferenceCaptionPicker from "../components/ReferenceCaptionPicker.jsx";
 import {
-  buildStructuredPromptRecipe,
   emptyCaption,
   orderCaption,
   parseMagicPromptCaption,
@@ -18,6 +17,7 @@ import {
   serializeCaption,
   validateCaption,
 } from "../ideogramCaption.js";
+import { buildImageJobAdvanced } from "../imageJobAdvanced.js";
 import { usePoseLibrary, useUserPoseLoader } from "../poseLibrary.js";
 
 const PROMPT_SUGGESTION_POOL = [
@@ -104,7 +104,6 @@ import {
   installedTiers,
   shouldShowTierPicker,
   tierLabel,
-  tierQuantize,
 } from "../quantTier.js";
 import { PROMPT_REFINE_MODEL_ID, VISION_CAPTION_MODEL_ID, VISION_CAPTION_MODEL_REPO } from "../constants.js";
 import { pickClosestResolution } from "../resolutionMatch.js";
@@ -1372,118 +1371,48 @@ export function ImageStudio() {
               },
             }
           : {}),
-        advanced: {
+        // advanced payload (sc-8854, F-052): assembled by the pure buildImageJobAdvanced
+        // builder so this async submit() stays focused on prompt resolution + the API
+        // call. Every omit-when-default rule (which keeps saved recipes byte-identical)
+        // lives in imageJobAdvanced.js and is covered by imageJobAdvanced.test.js.
+        advanced: buildImageJobAdvanced({
           resolution,
-          // Structured-prompt recipe round-trip (sc-6147): persist the full caption +
-          // original intent + magic-prompt backend alongside the job so "Use this recipe"
-          // can rehydrate the builder rather than replay the serialized JSON as a plain
-          // prompt. Rides in `advanced`, which the worker clones verbatim into the asset's
-          // rawAdapterSettings — no backend change needed. Only for structured models.
-          ...(sendStructured
-            ? {
-                structuredPrompt: buildStructuredPromptRecipe({
-                  intent: submitIntent,
-                  caption: submitCaption,
-                  magicPromptBackend: submitBackend,
-                  edited: !submitBackend,
-                }),
-              }
-            : {}),
-          // Configurable sampler / scheduler (epic 1753). Worker registry
-          // falls back to model-native when given "default", so emitting the
-          // values unconditionally is safe — invalid values are ignored.
-          ...(sampler && sampler !== "default" ? { sampler } : {}),
-          ...(scheduler && scheduler !== "default" ? { scheduler } : {}),
-          // Guidance method (epic 7434). "cfg" is the engine-standard no-op, so it is
-          // omitted — keeping existing recipes byte-identical; only a non-default
-          // method (CFG++) rides the payload. The worker N3-falls an unadvertised
-          // method back to the default, so an invalid value is harmless.
-          ...(guidanceMethod && guidanceMethod !== "cfg" ? { guidanceMethod } : {}),
-          // The schedule shift (time-shift mu) is only honored when a curated
-          // (non-default) scheduler is active — it shapes that curated schedule;
-          // the default scheduler keeps the engine's resolution-native shift, so
-          // emitting it there would override the no-op default (epic 7114).
-          ...(scheduler &&
-          scheduler !== "default" &&
-          Number.isFinite(Number(schedulerShift))
-            ? { schedulerShift: Number(schedulerShift) }
-            : {}),
-          // Step / guidance overrides — empty string means "use the model
-          // default", which the worker reads off MODEL_TARGETS.
-          ...(stepsOverride !== "" && Number.isFinite(Number(stepsOverride))
-            ? { steps: Number(stepsOverride) }
-            : {}),
-          ...(guidanceOverride !== "" && Number.isFinite(Number(guidanceOverride))
-            ? { guidanceScale: Number(guidanceOverride) }
-            : {}),
-          // Flash attention (sc-3674): only emitted when toggled OFF — the worker defaults to ON
-          // when `advanced.flashAttn` is absent, so the default-on case adds nothing to the payload.
-          // Only the candle (Windows/CUDA) SDXL backend reads it; every other backend ignores it.
-          ...(flashAttn ? {} : { flashAttn: false }),
-          // FLUX.2-dev caption upsampling (sc-6135): emitted only when the model declares the
-          // toggle AND it's on (off-by-default; the worker/engine ignore it for other models).
-          ...(promptEnhance && enhancePrompt ? { enhancePrompt: true } : {}),
-          // Boogu precision (sc-6568): emit mlxQuantize:0 (full-precision bf16) only when the model
-          // exposes the precision toggle AND bf16 is selected; the default Q8 emits nothing (the
-          // worker reads manifest mlx.quantize and fetches the `<variant>-bf16/` subfolder on demand).
-          // `!showTierPicker` is a defensive guard: Boogu downloads via `base/`-style subfolder globs
-          // (no `downloads[].variant` keys), so `hasVariantMatrix` — and therefore `showTierPicker` —
-          // is always false for the precisionToggle set; the two controls are disjoint. The guard
-          // makes that invariant load-bearing so a future manifest change can never emit both
-          // mlxQuantize spreads for one model (the tier picker below would win the object-spread
-          // race, but we never render/emit both).
-          ...(precisionToggle && bf16Precision && !showTierPicker ? { mlxQuantize: 0 } : {}),
-          // Quant-tier A/B (sc-8515): when the model has >1 tier installed and a tier is picked,
-          // send that tier's mlxQuantize (bf16→0, q8→8, q4→4). The worker's resolve_quant +
-          // generator cache route to it (reload-always). Emitted only when the picker is shown
-          // AND the picked tier maps to a known quant value, so single-tier models and the
-          // "default" pseudo-variant never leak an mlxQuantize into the payload. Disjoint from the
-          // Boogu precisionToggle above (non-matrix models), enforced by its `!showTierPicker` guard.
-          ...(showTierPicker && tierQuantize(quantTier) !== null
-            ? { mlxQuantize: tierQuantize(quantTier) }
-            : {}),
-          // PiD decoder (epic 7840, sc-7851): emit usePid:true only when the toggle is shown
-          // (model PiD-eligible AND checkpoint installed) AND on. The worker swaps the native
-          // VAE for the PiD decode + 2K/4K super-resolve pass; it rides `advanced` (opaque
-          // pass-through, zero contract-snapshot drift) and is cloned into the asset's
-          // rawAdapterSettings — that recorded `usePid:true` is the output's non-commercial
-          // marker. The worker independently no-ops to the native VAE if the checkpoint is gone.
-          ...(showPidToggle && usePid ? { usePid: true } : {}),
-          // IP-Adapter / InstantID reference strength only applies when a character
-          // reference is attached AND the model uses the IP-Adapter knob; Qwen's
-          // edit pipeline ignores this scalar (hideReferenceStrength gates it out).
-          ...(mode === "character_image" && referenceAssetId && !hideReferenceStrength
-            ? { ipAdapterScale }
-            : {}),
-          // Identity structure (controlnetConditioningScale) is InstantID-only — sent
-          // only when the model exposes the control and a reference is attached.
-          ...(mode === "character_image" && referenceAssetId && identityStructure
-            ? { controlnetConditioningScale: controlnetScale }
-            : {}),
-          // Variation knob (trueCfgScale) — FLUX uses it alongside ipAdapterScale,
-          // Qwen uses it as the only variation lever. Sent only when the model
-          // declares a variationStrength slider AND a reference is attached.
-          ...(mode === "character_image" && referenceAssetId && variationStrength
-            ? { trueCfgScale }
-            : {}),
-          // View angle (InstantID) — only when a specific angle is chosen and no pose is
-          // selected (a library pose drives the whole body, superseding the head angle).
-          ...(mode === "character_image" && referenceAssetId && viewAngles && viewAngle && !posePayload.length
-            ? { viewAngle }
-            : {}),
-          // Pose library (InstantID) — one image per selected pose; faceRestore toggles
-          // the full-body face-restoration pass.
-          ...(posePayload.length ? { poses: posePayload, faceRestore } : {}),
-          // Strict-control conditioning (epic 8236, sc-8245). The control type the worker's shared
-          // strict-control driver reads (strict_control.rs `requested_control_kind`). Pose is the
-          // engine default (omitted → byte-preserved), so only non-pose modes ride the payload. The
-          // control-lock strength (`advanced.controlScale`) is sent whenever the panel is active.
-          ...(controlActive && activeControlMode !== "pose" ? { controlMode: activeControlMode } : {}),
-          // Use-as-is passthrough: a pre-made canny/depth map fed verbatim
-          // (strict_control.rs `resolve_user_control_map`). Derive mode uses request.sourceAssetId.
-          ...(controlPassthroughId ? { controlImage: controlPassthroughId } : {}),
-          ...(controlActive ? { controlScale: effectiveControlScale } : {}),
-        },
+          sendStructured,
+          submitIntent,
+          submitCaption,
+          submitBackend,
+          sampler,
+          scheduler,
+          schedulerShift,
+          stepsOverride,
+          guidanceOverride,
+          guidanceMethod,
+          flashAttn,
+          promptEnhance,
+          enhancePrompt,
+          precisionToggle,
+          bf16Precision,
+          showTierPicker,
+          quantTier,
+          showPidToggle,
+          usePid,
+          mode,
+          referenceAssetId,
+          hideReferenceStrength,
+          ipAdapterScale,
+          identityStructure,
+          controlnetScale,
+          variationStrength,
+          trueCfgScale,
+          viewAngles,
+          viewAngle,
+          posePayload,
+          faceRestore,
+          controlActive,
+          activeControlMode,
+          controlPassthroughId,
+          effectiveControlScale,
+        }),
       });
       onLocalJobCreated?.(job);
     } finally {

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -1407,6 +1407,26 @@ export function TrainingStudio({ mode = "training" } = {}) {
     }
   }
 
+  // sc-8942 (F-140): one cohesive bundle of the Dataset Doctor readout props, shaped like
+  // the DatasetDoctorReadout signature. Both the Dataset editor and Configure-job panels
+  // take this single prop instead of the eight individually-threaded props they each used
+  // to mirror. The six fix-action handlers are hoisted function declarations (stable), so
+  // this memo only re-creates when the report or its loading flag changes.
+  const datasetDoctor = useMemo(
+    () => ({
+      report: readiness,
+      loading: readinessLoading,
+      onRemoveDuplicates: removeDuplicates,
+      onUpscaleLowRes: upscaleLowRes,
+      onSmartCrop: smartCropItems,
+      onStripExif: stripExifItems,
+      onAnalyzeDataset: analyzeDataset,
+      onAnalyzeFaces: analyzeFaces,
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- action handlers are stable hoisted fn decls
+    [readiness, readinessLoading],
+  );
+
   return (
     <ModelAvailabilityGate
       ready={trainingReady}
@@ -1529,16 +1549,9 @@ export function TrainingStudio({ mode = "training" } = {}) {
                   applyOrderedNames={applyOrderedNames}
                   setCaptionDialog={setCaptionDialog}
                   health={health}
-                  readiness={readiness}
-                  readinessLoading={readinessLoading}
+                  datasetDoctor={datasetDoctor}
                   readinessByKey={readinessByKey}
                   onToggleItemAck={toggleItemQualityAck}
-                  onRemoveDuplicates={removeDuplicates}
-                  onUpscaleLowRes={upscaleLowRes}
-                  onSmartCrop={smartCropItems}
-                  onStripExif={stripExifItems}
-                  onAnalyzeDataset={analyzeDataset}
-                  onAnalyzeFaces={analyzeFaces}
                   canSave={canSave}
                   saveDataset={saveDataset}
                   savingDataset={savingDataset}
@@ -1612,15 +1625,8 @@ export function TrainingStudio({ mode = "training" } = {}) {
                   resetConfigDefaults={resetConfigDefaults}
                   submitTrainingJob={submitTrainingJob}
                   configSnapshot={configSnapshot}
-                  readiness={readiness}
-                  readinessLoading={readinessLoading}
+                  datasetDoctor={datasetDoctor}
                   readinessBlocksTraining={readinessBlocksTraining}
-                  onRemoveDuplicates={removeDuplicates}
-                  onUpscaleLowRes={upscaleLowRes}
-                  onSmartCrop={smartCropItems}
-                  onStripExif={stripExifItems}
-                  onAnalyzeDataset={analyzeDataset}
-                  onAnalyzeFaces={analyzeFaces}
                 />
               ) : null}
             </section>

--- a/apps/web/src/screens/training/ConfigureJobPanel.jsx
+++ b/apps/web/src/screens/training/ConfigureJobPanel.jsx
@@ -58,15 +58,12 @@ export function ConfigureJobPanel({
   resetConfigDefaults,
   submitTrainingJob,
   configSnapshot,
-  readiness = null,
-  readinessLoading = false,
+  // sc-8942 (F-140): grouped Dataset Doctor readout props (report/loading + the six
+  // fix-action callbacks), shared verbatim with DatasetEditorPanel. Spread straight onto
+  // DatasetDoctorReadout below. `readinessBlocksTraining` stays a separate prop — it gates
+  // the Train button, not the readout.
+  datasetDoctor,
   readinessBlocksTraining = false,
-  onRemoveDuplicates,
-  onUpscaleLowRes,
-  onSmartCrop,
-  onStripExif,
-  onAnalyzeDataset,
-  onAnalyzeFaces,
 }) {
   return (
     <>
@@ -430,17 +427,7 @@ export function ConfigureJobPanel({
           {/* Dataset Doctor readout before the Train button (sc-6534). Advisory: it
               only hard-blocks training when the gate is Blocked (too few images / a
               fatal flag); warnings stay informational. */}
-          <DatasetDoctorReadout
-            report={readiness}
-            loading={readinessLoading}
-            compact
-            onRemoveDuplicates={onRemoveDuplicates}
-            onUpscaleLowRes={onUpscaleLowRes}
-            onSmartCrop={onSmartCrop}
-            onStripExif={onStripExif}
-            onAnalyzeDataset={onAnalyzeDataset}
-            onAnalyzeFaces={onAnalyzeFaces}
-          />
+          <DatasetDoctorReadout {...datasetDoctor} compact />
           {readinessBlocksTraining ? (
             <p className="inline-warning">
               This dataset isn’t ready to train yet — open Data Sets to add or fix images.

--- a/apps/web/src/screens/training/ConfigureJobPanel.test.jsx
+++ b/apps/web/src/screens/training/ConfigureJobPanel.test.jsx
@@ -73,8 +73,9 @@ function baseProps(overrides = {}) {
     resetConfigDefaults: noop,
     submitTrainingJob: noop,
     configSnapshot: null,
-    readiness: null,
-    readinessLoading: false,
+    // sc-8942 (F-140): the Dataset Doctor readout props are now one grouped `datasetDoctor`
+    // bundle (report/loading + the six fix-action handlers) shared with DatasetEditorPanel.
+    datasetDoctor: { report: null, loading: false },
     readinessBlocksTraining: false,
     ...overrides,
   };
@@ -96,7 +97,10 @@ describe("ConfigureJobPanel readiness gate", () => {
     mount(
       <ConfigureJobPanel
         {...baseProps({
-          readiness: { gate: "blocked", subScores: { technical: 0 }, counts: { fatal: 1 }, itemCount: 2, items: [], datasetFlags: [] },
+          datasetDoctor: {
+            report: { gate: "blocked", subScores: { technical: 0 }, counts: { fatal: 1 }, itemCount: 2, items: [], datasetFlags: [] },
+            loading: false,
+          },
           readinessBlocksTraining: true,
         })}
       />,

--- a/apps/web/src/screens/training/DatasetEditorPanel.jsx
+++ b/apps/web/src/screens/training/DatasetEditorPanel.jsx
@@ -74,16 +74,14 @@ export function DatasetEditorPanel({
   applyOrderedNames,
   setCaptionDialog,
   health,
-  readiness = null,
-  readinessLoading = false,
+  // sc-8942 (F-140): the Dataset Doctor's readout props (report/loading + the six
+  // fix-action callbacks) are grouped into one `datasetDoctor` bundle instead of being
+  // threaded individually. ConfigureJobPanel takes the same bundle, so the identical
+  // set of props is no longer hand-mirrored across two panels. Shaped exactly like the
+  // DatasetDoctorReadout signature so it can be spread straight onto it.
+  datasetDoctor,
   readinessByKey,
   onToggleItemAck,
-  onRemoveDuplicates,
-  onUpscaleLowRes,
-  onSmartCrop,
-  onStripExif,
-  onAnalyzeDataset,
-  onAnalyzeFaces,
   canSave,
   saveDataset,
   savingDataset,
@@ -112,6 +110,9 @@ export function DatasetEditorPanel({
   captionModelSizeLabel = "",
   captionModelName = "JoyCaption",
 }) {
+  // Local aliases for the doctor readout's report/loading, still referenced directly by
+  // the distributions block and the per-card readiness badges below.
+  const { report: readiness = null, loading: readinessLoading = false } = datasetDoctor ?? {};
   return (
     <>
       <div className="training-panel-head">
@@ -207,15 +208,8 @@ export function DatasetEditorPanel({
             <span>{health.valid ? "Dataset is ready for downstream steps" : "Add image assets to build this dataset"}</span>
           </div>
           <DatasetDoctorReadout
-            report={readiness}
-            loading={readinessLoading}
+            {...datasetDoctor}
             onRecaptionFlagged={(itemIds) => setCaptionDialog({ type: "flagged", itemIds })}
-            onRemoveDuplicates={onRemoveDuplicates}
-            onUpscaleLowRes={onUpscaleLowRes}
-            onSmartCrop={onSmartCrop}
-            onStripExif={onStripExif}
-            onAnalyzeDataset={onAnalyzeDataset}
-            onAnalyzeFaces={onAnalyzeFaces}
           />
           {readiness?.distributions ? (
             <details className="dataset-doctor-advanced">


### PR DESCRIPTION
Epic 8800 code-review remediation, web batch W2. Three stories, three commits, all behavior-preserving.

## Stories

### sc-9641 [F-138 follow-up] — Move render-body `purgeAssetRef` write into a post-commit effect (bug)
`App.jsx`: `purgeAssetRef.current = purgeAsset` was still assigned in the render body — the same render-body ref-mutation anti-pattern sc-8940 fixed for the 9 `refresh*Ref` writes, but left out of that story's scope. Moved into an adjacent no-dep `useLayoutEffect` mirroring the sc-8940 block, so the ref is published post-commit. Verified the sole reader (the editor scratch-op survivor's purge callback) fires from the SSE/sweep path, post-commit — never during render.

### sc-8942 [F-140] — Decompose widest prop lists + overloaded signature (chore)
`TrainingStudio.jsx` / `training/DatasetEditorPanel.jsx` / `training/ConfigureJobPanel.jsx` / `hooks/useTraining.js`:
- Grouped the eight Dataset Doctor readout props (`report`/`loading` + the six fix-action callbacks) that both panels hand-mirrored into a single `datasetDoctor` bundle, shaped like the `DatasetDoctorReadout` signature and spread straight onto it. The identical prop set is no longer threaded twice.
- `setTrainingDatasetItemQualityAck` now takes a single options object (`projectId` a named field defaulting to the active project) instead of the type-switching 4th param (`string`=projectId | `object`=options) — a signature unique in the codebase where a mistyped arg silently used the active project. No caller used the string form, so behavior is preserved.

### sc-8854 [F-052] — App / ImageEditor / ImageStudio god components (chore) — PARTIAL, behavior-preserving
Broke out the highest-value, clearly-separable pure logic; each extraction is a move covered by new unit tests:
- **ImageStudio** — the ~110-line `advanced` object literal in `submit()` (15 conditional spreads; the app's highest-drift surface) is now a pure `buildImageJobAdvanced(state)` in **`imageJobAdvanced.js`**. `submit()` keeps prompt resolution + the API call. Every omit-when-default rule (which keeps saved recipes byte-identical) is pinned by `imageJobAdvanced.test.js` (17 tests).
- **App** — the 16 file-local pure helpers (worker/job classification, SSE parse, notice mapping, job merge/cap, local-job-stack builder, theme/accent readers) move to **`appHelpers.js`**, shrinking App's top-of-file surface and making them testable without mounting App (`appHelpers.test.js`, 16 tests).

**Deferred from sc-8854** (too entangled to extract safely without behavior risk this pass; documented on the story):
- App `useJobEvents` / `useAccessGate` hooks — `token` feeds ~40 dependency arrays across data-load/SSE/media-ticket/child hooks; extracting risks changing effect ordering/identities.
- `AppContext` high-churn vs low-churn split — touches every consumer.
- Per-tool ImageEditor mask/boxes/color-grade modules — bound to the `editsRef`/`boxesRef` ref-mirror state.

## Tests & verification
- `npm run lint` (apps/web): **0 errors** (47 pre-existing exhaustive-deps warnings, none added).
- `npm test` (apps/web): **1158 / 1160 pass** (+33 new tests vs the 1127 baseline).
- The 2 failures are a **pre-existing** LogsScreen fake-timers isolation flake (`sc-8849` tests) — reproduces deterministically on a clean `origin/main` branch with none of these changes applied, and both tests pass when `LogsScreen.test.jsx` runs in isolation. Filed as **sc-9744** (bug, epic 8800). Not touched by this batch per the raise-don't-silently-fix rule.

Stories: sc-8854, sc-8942, sc-9641 · related follow-up filed: sc-9744

🤖 Generated with [Claude Code](https://claude.com/claude-code)