### PR TITLE
fix(worker): person detect/segment robustness + preprocessor dedup (epic 8800 batch 3)

### DIFF
--- a/crates/sceneworks-worker/src/person_jobs.rs
+++ b/crates/sceneworks-worker/src/person_jobs.rs
@@ -228,6 +228,12 @@ fn preprocess(img: &RgbImage) -> (Vec<f32>, Letterbox) {
 
 /// Decode the (1,84,8400) channel-major output into person boxes (original px),
 /// pre-NMS. `data` is laid out as `data[channel * anchors + anchor]`.
+///
+/// The output shape/length are validated against the `(1, channels, anchors)` contract
+/// before any indexing (F-102): a user can pin an arbitrary ONNX export via
+/// `SCENEWORKS_PERSON_DETECTOR_WEIGHTS` whose output rank/length differs, and reading
+/// `shape[1]`/`shape[2]` or `data[channel*anchors + a]` on a shorter buffer would panic
+/// (OOB) and unwind the async task. Return an `Engine` error instead (sc-8904).
 fn decode(
     data: &[f32],
     shape: &[i64],
@@ -235,11 +241,25 @@ fn decode(
     conf: f32,
     frame_w: u32,
     frame_h: u32,
-) -> Vec<Detection> {
-    let channels = shape[1] as usize; // 84 = 4 box + 80 classes
-    let anchors = shape[2] as usize; // 8400
+) -> WorkerResult<Vec<Detection>> {
+    if shape.len() < 3 {
+        return Err(WorkerError::Engine(format!(
+            "yolo11m output rank {} < 3 (expected (1, channels, anchors))",
+            shape.len()
+        )));
+    }
+    let channels = shape[1].max(0) as usize; // 84 = 4 box + 80 classes
+    let anchors = shape[2].max(0) as usize; // 8400
     if channels < 5 {
-        return Vec::new();
+        return Ok(Vec::new());
+    }
+    if data.len() < channels.saturating_mul(anchors) {
+        return Err(WorkerError::Engine(format!(
+            "yolo11m output has {} values but the (channels={channels} × anchors={anchors}) \
+             contract needs {}",
+            data.len(),
+            channels.saturating_mul(anchors)
+        )));
     }
     let score_ch = 4 + PERSON_CLASS;
     let (fw, fh) = (frame_w as f32, frame_h as f32);
@@ -265,7 +285,7 @@ fn decode(
             score,
         });
     }
-    out
+    Ok(out)
 }
 
 fn iou(a: &Detection, b: &Detection) -> f32 {
@@ -719,7 +739,7 @@ impl Yolo {
             .map_err(|e| WorkerError::InvalidPayload(format!("yolo11m output reshape: {e}")))?;
         let data = out.as_slice::<f32>();
         let shape = [1_i64, 84, ANCHORS as i64];
-        let raw = decode(data, &shape, &lb, conf, img.width(), img.height());
+        let raw = decode(data, &shape, &lb, conf, img.width(), img.height())?;
         Ok(nms(raw, NMS_IOU))
     }
 }
@@ -891,7 +911,7 @@ impl OrtYolo {
         // so `decode` indexes it correctly regardless of the exact class count.
         let (shape, data) = outputs[0].try_extract_tensor::<f32>().map_err(ort_err)?;
         let shape: Vec<i64> = shape.to_vec();
-        let raw = decode(data, &shape, &lb, conf, img.width(), img.height());
+        let raw = decode(data, &shape, &lb, conf, img.width(), img.height())?;
         Ok(nms(raw, NMS_IOU))
     }
 }

--- a/crates/sceneworks-worker/src/person_jobs.rs
+++ b/crates/sceneworks-worker/src/person_jobs.rs
@@ -188,10 +188,38 @@ fn sample_rgb(img: &RgbImage, x: f32, y: f32, c: usize, border: f32) -> f32 {
     top * (1.0 - fy) + bot * fy
 }
 
-/// Build the (1,640,640,3) RGB `/255` letterboxed input in **NHWC** order (the layout
-/// `mlx_gen::nn::conv2d` expects) and return the geometry.
-#[cfg(target_os = "macos")]
-fn preprocess(img: &RgbImage) -> (Vec<f32>, Letterbox) {
+/// Destination layout for the shared letterbox preprocessor: NHWC (the layout
+/// `mlx_gen::nn::conv2d` expects, macOS) or NCHW (the `yolo11m.onnx` export expects,
+/// off-Mac). The two backends' letterbox + cv2 half-pixel sampling are byte-identical;
+/// only the destination index differs (sc-8906, F-104).
+#[derive(Clone, Copy)]
+enum InputLayout {
+    /// `hwc[(y * DET + x) * 3 + c]`.
+    #[cfg(target_os = "macos")]
+    Nhwc,
+    /// `chw[c * DET * DET + y * DET + x]`.
+    #[cfg(not(target_os = "macos"))]
+    Nchw,
+}
+
+impl InputLayout {
+    /// Flat destination index for pixel `(x, y)` channel `c` in the `3 * DET * DET` buffer.
+    #[inline]
+    fn index(self, x: usize, y: usize, c: usize) -> usize {
+        match self {
+            #[cfg(target_os = "macos")]
+            InputLayout::Nhwc => (y * DET + x) * 3 + c,
+            #[cfg(not(target_os = "macos"))]
+            InputLayout::Nchw => c * DET * DET + y * DET + x,
+        }
+    }
+}
+
+/// Build the (1,640,640,3) RGB `/255` letterboxed 640² input in `layout` order and return
+/// the geometry. The letterbox math + cv2 INTER_LINEAR half-pixel sampling are shared by
+/// both backends (macOS NHWC / off-Mac NCHW) — previously two byte-identical cfg-gated
+/// copies that could silently drift (sc-8906, F-104); only [`InputLayout::index`] differs.
+fn preprocess_letterbox(img: &RgbImage, layout: InputLayout) -> (Vec<f32>, Letterbox) {
     let lb = Letterbox::compute(img.width(), img.height());
     let (w, h) = (img.width() as f32, img.height() as f32);
     let new_w = (w * lb.ratio).round();
@@ -203,14 +231,13 @@ fn preprocess(img: &RgbImage) -> (Vec<f32>, Letterbox) {
     let pad_x = lb.pad_x as usize;
     let pad_y = lb.pad_y as usize;
 
-    // NHWC: hwc[(y * DET + x) * 3 + c].
-    let mut hwc = vec![PAD_VALUE / 255.0; DET * DET * 3];
+    let mut buf = vec![PAD_VALUE / 255.0; DET * DET * 3];
     for dy in 0..new_h {
         let src_y = (dy as f32 + 0.5) * sy - 0.5; // cv2 INTER_LINEAR half-pixel
-        let row = ((dy + pad_y) * DET + pad_x) * 3;
+        let y = dy + pad_y;
         for dx in 0..new_w {
             let src_x = (dx as f32 + 0.5) * sx - 0.5;
-            let base = row + dx * 3;
+            let x = dx + pad_x;
             for c in 0..3 {
                 let v = sample_rgb(
                     img,
@@ -219,11 +246,11 @@ fn preprocess(img: &RgbImage) -> (Vec<f32>, Letterbox) {
                     c,
                     0.0,
                 );
-                hwc[base + c] = v / 255.0;
+                buf[layout.index(x, y, c)] = v / 255.0;
             }
         }
     }
-    (hwc, lb)
+    (buf, lb)
 }
 
 /// Decode the (1,84,8400) channel-major output into person boxes (original px),
@@ -725,18 +752,21 @@ impl Yolo {
     }
 
     fn detect_people(&self, img: &RgbImage, conf: f32) -> WorkerResult<Vec<Detection>> {
-        let (input, lb) = preprocess(img);
+        let (input, lb) = preprocess_letterbox(img, InputLayout::Nhwc);
         let x = Array::from_slice(&input, &[1, DET as i32, DET as i32, 3]);
+        // A forward/reshape failure is an engine-execution fault, not a bad user payload —
+        // classify it as `Engine` like the `ort` sibling + the SAM2/SAM3 propagate paths
+        // (sc-8906, F-104); the old `InvalidPayload` mislabeled an MLX crash as user error.
         let out = self
             .run(&x)
-            .map_err(|e| WorkerError::InvalidPayload(format!("yolo11m forward: {e}")))?
+            .map_err(|e| WorkerError::Engine(format!("yolo11m forward: {e}")))?
             .output;
         // The head ends in a transpose, so `out` is a non-contiguous view; `as_slice`
         // would hand back the *physical* (pre-transpose) buffer. Flatten first to force a
         // logical-order copy → the `(1,84,8400)` channel-major layout `decode` indexes.
         let out = out
             .reshape(&[-1])
-            .map_err(|e| WorkerError::InvalidPayload(format!("yolo11m output reshape: {e}")))?;
+            .map_err(|e| WorkerError::Engine(format!("yolo11m output reshape: {e}")))?;
         let data = out.as_slice::<f32>();
         let shape = [1_i64, 84, ANCHORS as i64];
         let raw = decode(data, &shape, &lb, conf, img.width(), img.height())?;
@@ -799,45 +829,6 @@ pub(crate) fn detect_people_blocking(
 // with the CUDA EP (+ CPU fallback) and feeds its `(1,84,8400)` output into the shared
 // `decode`/`nms` math, exactly as the MLX path does.
 // ---------------------------------------------------------------------------
-
-/// Build the (1,3,640,640) RGB `/255` letterboxed input in **NCHW** order (the layout the
-/// `yolo11m.onnx` export expects) and return the geometry. Same letterbox + cv2 half-pixel
-/// sampling as the MLX `preprocess`, only the output channel order differs.
-#[cfg(not(target_os = "macos"))]
-fn preprocess_nchw(img: &RgbImage) -> (Vec<f32>, Letterbox) {
-    let lb = Letterbox::compute(img.width(), img.height());
-    let (w, h) = (img.width() as f32, img.height() as f32);
-    let new_w = (w * lb.ratio).round();
-    let new_h = (h * lb.ratio).round();
-    let sx = w / new_w.max(1.0);
-    let sy = h / new_h.max(1.0);
-    let new_w = new_w as usize;
-    let new_h = new_h as usize;
-    let pad_x = lb.pad_x as usize;
-    let pad_y = lb.pad_y as usize;
-
-    // NCHW: chw[c * DET * DET + y * DET + x].
-    let mut chw = vec![PAD_VALUE / 255.0; 3 * DET * DET];
-    for dy in 0..new_h {
-        let src_y = (dy as f32 + 0.5) * sy - 0.5; // cv2 INTER_LINEAR half-pixel
-        let y = dy + pad_y;
-        for dx in 0..new_w {
-            let src_x = (dx as f32 + 0.5) * sx - 0.5;
-            let x = dx + pad_x;
-            for c in 0..3 {
-                let v = sample_rgb(
-                    img,
-                    src_x.clamp(0.0, w - 1.0),
-                    src_y.clamp(0.0, h - 1.0),
-                    c,
-                    0.0,
-                );
-                chw[c * DET * DET + y * DET + x] = v / 255.0;
-            }
-        }
-    }
-    (chw, lb)
-}
 
 #[cfg(not(target_os = "macos"))]
 fn ort_err<R>(e: ort::Error<R>) -> WorkerError {
@@ -902,7 +893,7 @@ impl OrtYolo {
 
     /// Detect every person in one frame → NMS'd boxes in original px.
     fn detect_people(&mut self, img: &RgbImage, conf: f32) -> WorkerResult<Vec<Detection>> {
-        let (input, lb) = preprocess_nchw(img);
+        let (input, lb) = preprocess_letterbox(img, InputLayout::Nchw);
         let tensor = Tensor::from_array(([1_i64, 3, DET as i64, DET as i64].to_vec(), input))
             .map_err(ort_err)?;
         let outputs = self.session.run(ort::inputs![tensor]).map_err(ort_err)?;

--- a/crates/sceneworks-worker/src/person_jobs.rs
+++ b/crates/sceneworks-worker/src/person_jobs.rs
@@ -864,10 +864,19 @@ impl OrtYolo {
                 session,
                 device: "cuda",
             }),
-            Err(_) => Ok(Self {
-                session: build_session(path, false)?,
-                device: "cpu",
-            }),
+            // Log WHY the CUDA session build failed before silently rebuilding on CPU
+            // (F-099): otherwise a cuDNN/CUDA mismatch or a genuinely GPU-less box both
+            // present as an unexplained "device = cpu" with no breadcrumb (sc-8901).
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    "yolo11m CUDA session build failed; falling back to CPU"
+                );
+                Ok(Self {
+                    session: build_session(path, false)?,
+                    device: "cpu",
+                })
+            }
         }
     }
 

--- a/crates/sceneworks-worker/src/person_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/person_jobs/tests.rs
@@ -51,7 +51,7 @@ fn decode_keeps_person_anchors_above_conf_and_builds_xyxy() {
         pad_x: 0.0,
         pad_y: 0.0,
     };
-    let dets = decode(&data, &shape, &lb, 0.25, 640, 640);
+    let dets = decode(&data, &shape, &lb, 0.25, 640, 640).expect("valid shape decodes");
     assert_eq!(dets.len(), 1, "only the above-conf person anchor survives");
     let d = dets[0];
     assert!((d.x1 - 80.0).abs() < 1e-3);
@@ -71,10 +71,38 @@ fn decode_clamps_boxes_to_the_frame() {
         pad_x: 0.0,
         pad_y: 0.0,
     };
-    let dets = decode(&data, &shape, &lb, 0.25, 640, 640);
+    let dets = decode(&data, &shape, &lb, 0.25, 640, 640).expect("valid shape decodes");
     assert_eq!(dets.len(), 1);
     assert_eq!(dets[0].x1, 0.0);
     assert_eq!(dets[0].y1, 0.0);
+}
+
+#[test]
+fn decode_rejects_malformed_output_shape_and_length() {
+    let lb = Letterbox {
+        ratio: 1.0,
+        pad_x: 0.0,
+        pad_y: 0.0,
+    };
+    // Rank < 3 (a 2-D output from a mis-pinned ONNX export) → Engine error, not an OOB panic.
+    let rank2 = decode(&[0.0; 12], &[1, 6], &lb, 0.25, 640, 640);
+    assert!(
+        matches!(rank2, Err(WorkerError::Engine(_))),
+        "rank-2 output must be rejected, got {rank2:?}"
+    );
+    // Well-formed rank but the data buffer is shorter than channels×anchors → Engine error.
+    // (1,6,2) needs 12 values; hand it 5 so `data[score_ch*anchors + a]` would read OOB.
+    let short = decode(&[0.0; 5], &[1, 6, 2], &lb, 0.25, 640, 640);
+    assert!(
+        matches!(short, Err(WorkerError::Engine(_))),
+        "truncated data buffer must be rejected, got {short:?}"
+    );
+    // channels < 5 (no person class channel) is a benign "nothing to decode", not an error.
+    let no_person = decode(&[0.0; 8], &[1, 4, 2], &lb, 0.25, 640, 640);
+    assert!(
+        matches!(no_person, Ok(ref v) if v.is_empty()),
+        "channels<5 → empty, got {no_person:?}"
+    );
 }
 
 #[test]

--- a/crates/sceneworks-worker/src/person_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/person_jobs/tests.rs
@@ -105,6 +105,50 @@ fn decode_rejects_malformed_output_shape_and_length() {
     );
 }
 
+/// sc-8906 / F-104: the shared letterbox preprocessor places pixels + pads identically
+/// whichever layout the platform selects. Runs against the layout compiled on this lane
+/// (NHWC on macOS, NCHW off-Mac) via `InputLayout::index`, so the SAME buffer contents are
+/// asserted through the SAME indexing the production path uses — pinning that the dedup
+/// preserved both the geometry and the (previously divergent) per-layout index math.
+#[test]
+fn preprocess_letterbox_places_pixels_and_pads_per_layout() {
+    // A square image fills the 640² input edge-to-edge (ratio 1.0, no pad), so every
+    // in-bounds pixel is written and the buffer carries the source color, not PAD_VALUE.
+    let mut img = RgbImage::new(DET as u32, DET as u32);
+    for px in img.pixels_mut() {
+        *px = image::Rgb([10, 20, 30]);
+    }
+    #[cfg(target_os = "macos")]
+    let layout = InputLayout::Nhwc;
+    #[cfg(not(target_os = "macos"))]
+    let layout = InputLayout::Nchw;
+
+    let (buf, lb) = preprocess_letterbox(&img, layout);
+    assert_eq!(buf.len(), DET * DET * 3);
+    assert!((lb.ratio - 1.0).abs() < 1e-6, "square image → ratio 1.0");
+    assert_eq!((lb.pad_x, lb.pad_y), (0.0, 0.0), "no letterbox pad");
+    // A center pixel carries the source color at every channel via the layout's own index.
+    let (cx, cy) = (DET / 2, DET / 2);
+    for (c, &raw) in [10u8, 20, 30].iter().enumerate() {
+        let v = buf[layout.index(cx, cy, c)];
+        assert!(
+            (v - raw as f32 / 255.0).abs() < 1e-3,
+            "channel {c} at center should be {raw}/255, got {v}"
+        );
+    }
+
+    // A portrait image (narrower than tall) fits by height → horizontal pad columns stay
+    // at PAD_VALUE/255. Column 0 is entirely inside the pad band.
+    let portrait = RgbImage::from_pixel(200, 400, image::Rgb([255, 255, 255]));
+    let (pbuf, plb) = preprocess_letterbox(&portrait, layout);
+    assert!(plb.pad_x > 0.0, "portrait letterboxes with horizontal pad");
+    let pad = PAD_VALUE / 255.0;
+    assert!(
+        (pbuf[layout.index(0, DET / 2, 0)] - pad).abs() < 1e-6,
+        "left pad column stays at PAD_VALUE"
+    );
+}
+
 #[test]
 fn nms_drops_high_overlap_keeps_disjoint() {
     let strong = Detection {

--- a/crates/sceneworks-worker/src/person_segment.rs
+++ b/crates/sceneworks-worker/src/person_segment.rs
@@ -269,7 +269,18 @@ pub(crate) fn propagate_track_blocking(
             let mask = predictor
                 .mask_to_video_res(&state, low)
                 .map_err(|e| WorkerError::Engine(format!("sam2 mask resize: {e}")))?;
-            out[*frame_idx as usize] = mask.as_slice::<u8>().to_vec();
+            // Bounds-check the predictor's returned frame index rather than trusting it:
+            // a negative i32 would wrap via `as usize` and an out-of-range index would
+            // panic on `out[..]`, unwinding the blocking task (media_jobs would absorb it
+            // as a silent "degraded"). Surface an `Engine` error instead (sc-8905, F-103).
+            let idx = usize::try_from(*frame_idx).ok().filter(|&i| i < out.len());
+            let Some(idx) = idx else {
+                return Err(WorkerError::Engine(format!(
+                    "sam2 propagate returned frame index {frame_idx} out of range 0..{}",
+                    out.len()
+                )));
+            };
+            out[idx] = mask.as_slice::<u8>().to_vec();
         }
         Ok(out)
     };

--- a/crates/sceneworks-worker/src/person_segment.rs
+++ b/crates/sceneworks-worker/src/person_segment.rs
@@ -177,11 +177,17 @@ pub(crate) fn propagate_track_blocking(
     cancel: Option<CancelFlag>,
     mut progress: Option<SegmentProgress>,
 ) -> WorkerResult<Vec<Vec<u8>>> {
-    assert_eq!(
-        clip_frame_paths.len(),
-        anchors.len(),
-        "frames/anchors mismatch"
-    );
+    // A frames/anchors length mismatch is a caller contract violation. The old `assert_eq!`
+    // panicked inside `spawn_blocking`, which `media_jobs` absorbed as a silent "degraded"
+    // (box-fallback) result rather than a surfaced error — return `InvalidPayload` so the
+    // mismatch fails the job loudly (sc-8903, F-101).
+    if clip_frame_paths.len() != anchors.len() {
+        return Err(WorkerError::InvalidPayload(format!(
+            "propagate clip frames ({}) and anchors ({}) length mismatch",
+            clip_frame_paths.len(),
+            anchors.len()
+        )));
+    }
     check_segment_canceled(cancel.as_ref())?;
     let prompt =
         anchors.first().copied().flatten().ok_or_else(|| {
@@ -345,6 +351,29 @@ mod tests {
         assert!(
             matches!(result, Err(WorkerError::Canceled(ref m)) if m == CANCEL_MESSAGE),
             "expected Canceled, got {result:?}"
+        );
+    }
+
+    /// sc-8903 / F-101: a frames/anchors length mismatch returns `InvalidPayload` (a surfaced
+    /// error) instead of the old `assert_eq!` panic that `media_jobs` absorbed as a silent
+    /// "degraded" box-fallback. The length check runs before any frame decode / weight load, so
+    /// the nonexistent paths are never touched — the returned error is the mismatch, not a
+    /// frame-open error.
+    #[test]
+    fn frames_anchors_length_mismatch_returns_invalid_payload() {
+        let result = propagate_track_blocking(
+            PathBuf::from("/nonexistent/sam2.safetensors"),
+            vec![
+                PathBuf::from("/nonexistent/a.png"),
+                PathBuf::from("/nonexistent/b.png"),
+            ],
+            vec![Some((0.1, 0.1, 0.5, 0.5))], // one anchor for two frames
+            None,
+            None,
+        );
+        assert!(
+            matches!(result, Err(WorkerError::InvalidPayload(ref m)) if m.contains("length mismatch")),
+            "expected InvalidPayload length mismatch, got {result:?}"
         );
     }
 

--- a/crates/sceneworks-worker/src/person_segment_sam3.rs
+++ b/crates/sceneworks-worker/src/person_segment_sam3.rs
@@ -206,11 +206,17 @@ pub(crate) fn segment_track_blocking(
     cancel: Option<CancelFlag>,
     mut progress: Option<SegmentProgress>,
 ) -> WorkerResult<Vec<Vec<u8>>> {
-    assert_eq!(
-        clip_frame_paths.len(),
-        anchors.len(),
-        "frames/anchors mismatch"
-    );
+    // A frames/anchors length mismatch is a caller contract violation. The old `assert_eq!`
+    // panicked inside `spawn_blocking`, which `media_jobs` absorbed as a silent "degraded"
+    // (box-fallback) result rather than a surfaced error — return `InvalidPayload` so the
+    // mismatch fails the job loudly (sc-8903, F-101). Kept in sync with the candle twin.
+    if clip_frame_paths.len() != anchors.len() {
+        return Err(WorkerError::InvalidPayload(format!(
+            "segment clip frames ({}) and anchors ({}) length mismatch",
+            clip_frame_paths.len(),
+            anchors.len()
+        )));
+    }
     check_segment_canceled(cancel.as_ref())?;
     if !anchors.iter().any(Option::is_some) {
         return Err(WorkerError::InvalidPayload(
@@ -699,6 +705,29 @@ mod tests {
         assert!(
             matches!(all, Err(WorkerError::Canceled(_))),
             "segment_all_persons_in_memory: expected Canceled"
+        );
+    }
+
+    /// sc-8903 / F-101: a frames/anchors length mismatch returns `InvalidPayload` (a surfaced
+    /// error) instead of the old `assert_eq!` panic that `media_jobs` absorbed as a silent
+    /// "degraded" box-fallback. The length check runs before any frame decode / weight load, so
+    /// the nonexistent paths are never touched.
+    #[test]
+    fn frames_anchors_length_mismatch_returns_invalid_payload() {
+        let result = segment_track_blocking(
+            PathBuf::from("/nonexistent/model.safetensors"),
+            PathBuf::from("/nonexistent/tokenizer.json"),
+            vec![
+                PathBuf::from("/nonexistent/a.png"),
+                PathBuf::from("/nonexistent/b.png"),
+            ],
+            vec![Some((0.1, 0.1, 0.5, 0.5))], // one anchor for two frames
+            None,
+            None,
+        );
+        assert!(
+            matches!(result, Err(WorkerError::InvalidPayload(ref m)) if m.contains("length mismatch")),
+            "expected InvalidPayload length mismatch, got {result:?}"
         );
     }
 

--- a/crates/sceneworks-worker/src/person_segment_sam3.rs
+++ b/crates/sceneworks-worker/src/person_segment_sam3.rs
@@ -304,16 +304,32 @@ pub(crate) fn segment_track_blocking(
     };
     let masks = outputs
         .iter()
-        .map(|frame| {
-            frame
-                .obj_ids
-                .iter()
-                .position(|&o| o == selected)
-                .map(|i| mask_to_frame(&frame.masks[i], MASK_GRID, width, height))
-                .unwrap_or_default()
-        })
-        .collect();
+        .map(|frame| frame_mask_for_object(frame, selected, width, height))
+        .collect::<WorkerResult<Vec<_>>>()?;
     Ok(masks)
+}
+
+/// Emit the selected object's binary mask on one SAM3 frame, or an empty vec when the object
+/// isn't present (legitimate per-frame absence → orchestrator box-fallback). Guards the
+/// `obj_ids`/`masks` parallel-vec assumption: an id present in `obj_ids` but with no matching
+/// entry in `masks` is a malformed engine output, surfaced as an `Engine` error rather than
+/// indexing OOB (sc-8905, F-103).
+fn frame_mask_for_object(
+    frame: &VideoFrameOutput,
+    selected: i32,
+    width: u32,
+    height: u32,
+) -> WorkerResult<Vec<u8>> {
+    let Some(i) = frame.obj_ids.iter().position(|&o| o == selected) else {
+        return Ok(Vec::new());
+    };
+    let logits = frame.masks.get(i).ok_or_else(|| {
+        WorkerError::Engine(format!(
+            "sam3 frame has obj id {selected} at index {i} but only {} masks",
+            frame.masks.len()
+        ))
+    })?;
+    mask_to_frame(logits, MASK_GRID, width, height)
 }
 
 /// Normalize an `[x1, y1, x2, y2]` pixel box (clamped to the image) to SAM3's `[cx, cy, w, h]`
@@ -441,7 +457,7 @@ pub(crate) fn segment_box_blocking(
         )
     })?;
     // Reuse the >0 binarize + resize-to-source path (inverts the 1008² squash back to the frame).
-    Ok(mask_to_frame(&grid_mask, grid, width, height))
+    mask_to_frame(&grid_mask, grid, width, height)
 }
 
 /// Smart-select POINT path (epic 6087, sc-6346): segment whatever lies under fg/bg click points on
@@ -514,7 +530,7 @@ pub(crate) fn segment_points_blocking(
         .map_err(|e| WorkerError::Engine(format!("sam3 mask read: {e}")))?
         .as_slice::<f32>()
         .to_vec();
-    Ok(mask_to_frame(&logits, grid, width, height))
+    mask_to_frame(&logits, grid, width, height)
 }
 
 /// Segment + track every "person" across already-decoded RGB `frames` with the SAM3 text-concept
@@ -623,6 +639,10 @@ pub(crate) fn segment_all_persons_in_memory(
             .then(a.cmp(b))
     });
 
+    // `zip` already bounds to the shorter of obj_ids/masks, so the parallel-vec assumption is
+    // safe here; `mask_to_frame` now returns an `Engine` error on a malformed (grid-mismatched)
+    // mask instead of the empty-vec sentinel, so propagate rather than silently dropping it
+    // (sc-8905, F-103).
     let per_frame = outputs
         .iter()
         .map(|frame| {
@@ -630,11 +650,10 @@ pub(crate) fn segment_all_persons_in_memory(
                 .obj_ids
                 .iter()
                 .zip(&frame.masks)
-                .map(|(oid, logits)| (*oid, mask_to_frame(logits, MASK_GRID, width, height)))
-                .filter(|(_, mask)| !mask.is_empty())
-                .collect()
+                .map(|(oid, logits)| Ok((*oid, mask_to_frame(logits, MASK_GRID, width, height)?)))
+                .collect::<WorkerResult<Vec<_>>>()
         })
-        .collect();
+        .collect::<WorkerResult<Vec<_>>>()?;
 
     Ok(AllPersonMasks {
         order,
@@ -729,6 +748,44 @@ mod tests {
             matches!(result, Err(WorkerError::InvalidPayload(ref m)) if m.contains("length mismatch")),
             "expected InvalidPayload length mismatch, got {result:?}"
         );
+    }
+
+    /// sc-8905 / F-103: `frame_mask_for_object` guards the obj_ids/masks parallel-vec
+    /// assumption. An id present in `obj_ids` but with no matching `masks` entry (a malformed
+    /// engine output) surfaces an `Engine` error instead of indexing OOB; an absent id returns
+    /// an empty vec (legitimate per-frame absence); a well-formed pair produces a mask.
+    #[test]
+    fn frame_mask_for_object_guards_parallel_vecs() {
+        // obj id 5 is present but `masks` is empty → parallel-vec violation → Engine error.
+        let malformed = VideoFrameOutput {
+            obj_ids: vec![5],
+            masks: vec![],
+        };
+        let err = frame_mask_for_object(&malformed, 5, 8, 8);
+        assert!(
+            matches!(err, Err(WorkerError::Engine(ref m)) if m.contains("masks")),
+            "obj id without a mask must error, got {err:?}"
+        );
+
+        // Selected object absent from this frame → empty vec (box-fallback), not an error.
+        let absent = VideoFrameOutput {
+            obj_ids: vec![9],
+            masks: vec![vec![-1.0f32; MASK_GRID * MASK_GRID]],
+        };
+        let empty = frame_mask_for_object(&absent, 5, 8, 8).expect("absent object is not an error");
+        assert!(
+            empty.is_empty(),
+            "absent object → empty mask (box fallback)"
+        );
+
+        // Well-formed pair → a real binary mask at the requested dims.
+        let present = VideoFrameOutput {
+            obj_ids: vec![5],
+            masks: vec![vec![1.0f32; MASK_GRID * MASK_GRID]],
+        };
+        let mask = frame_mask_for_object(&present, 5, 8, 8).expect("well-formed mask");
+        assert_eq!(mask.len(), 64, "mask sized to width*height");
+        assert!(mask.iter().all(|&v| v == 0 || v == 255), "mask is binary");
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/person_segment_sam3_candle.rs
+++ b/crates/sceneworks-worker/src/person_segment_sam3_candle.rs
@@ -137,11 +137,17 @@ pub(crate) fn segment_track_blocking(
     cancel: Option<CancelFlag>,
     mut progress: Option<SegmentProgress>,
 ) -> WorkerResult<Vec<Vec<u8>>> {
-    assert_eq!(
-        clip_frame_paths.len(),
-        anchors.len(),
-        "frames/anchors mismatch"
-    );
+    // A frames/anchors length mismatch is a caller contract violation. The old `assert_eq!`
+    // panicked inside `spawn_blocking`, which `media_jobs` absorbed as a silent "degraded"
+    // (box-fallback) result rather than a surfaced error — return `InvalidPayload` so the
+    // mismatch fails the job loudly (sc-8903, F-101). Kept in sync with the MLX twin.
+    if clip_frame_paths.len() != anchors.len() {
+        return Err(WorkerError::InvalidPayload(format!(
+            "segment clip frames ({}) and anchors ({}) length mismatch",
+            clip_frame_paths.len(),
+            anchors.len()
+        )));
+    }
     check_segment_canceled(cancel.as_ref())?;
     if !anchors.iter().any(Option::is_some) {
         return Err(WorkerError::InvalidPayload(
@@ -431,6 +437,29 @@ mod tests {
         assert!(
             matches!(all, Err(WorkerError::Canceled(_))),
             "segment_all_persons_in_memory: expected Canceled"
+        );
+    }
+
+    /// sc-8903 / F-101: a frames/anchors length mismatch returns `InvalidPayload` (a surfaced
+    /// error) instead of the old `assert_eq!` panic that `media_jobs` absorbed as a silent
+    /// "degraded" box-fallback. Kept in sync with the MLX twin's test. The length check runs
+    /// before any frame decode / weight load, so the nonexistent paths are never touched.
+    #[test]
+    fn frames_anchors_length_mismatch_returns_invalid_payload() {
+        let result = segment_track_blocking(
+            PathBuf::from("/nonexistent/model.safetensors"),
+            PathBuf::from("/nonexistent/tokenizer.json"),
+            vec![
+                PathBuf::from("/nonexistent/a.png"),
+                PathBuf::from("/nonexistent/b.png"),
+            ],
+            vec![Some((0.1, 0.1, 0.5, 0.5))], // one anchor for two frames
+            None,
+            None,
+        );
+        assert!(
+            matches!(result, Err(WorkerError::InvalidPayload(ref m)) if m.contains("length mismatch")),
+            "expected InvalidPayload length mismatch, got {result:?}"
         );
     }
 

--- a/crates/sceneworks-worker/src/person_segment_sam3_candle.rs
+++ b/crates/sceneworks-worker/src/person_segment_sam3_candle.rs
@@ -234,16 +234,32 @@ pub(crate) fn segment_track_blocking(
     };
     let masks = outputs
         .iter()
-        .map(|frame| {
-            frame
-                .obj_ids
-                .iter()
-                .position(|&o| o == selected)
-                .map(|i| mask_to_frame(&frame.masks[i], MASK_GRID, width, height))
-                .unwrap_or_default()
-        })
-        .collect();
+        .map(|frame| frame_mask_for_object(frame, selected, width, height))
+        .collect::<WorkerResult<Vec<_>>>()?;
     Ok(masks)
+}
+
+/// Emit the selected object's binary mask on one SAM3 frame, or an empty vec when the object
+/// isn't present (legitimate per-frame absence → orchestrator box-fallback). Guards the
+/// `obj_ids`/`masks` parallel-vec assumption: an id present in `obj_ids` but with no matching
+/// entry in `masks` is a malformed engine output, surfaced as an `Engine` error rather than
+/// indexing OOB (sc-8905, F-103). Kept in sync with the MLX twin.
+fn frame_mask_for_object(
+    frame: &VideoFrameOutput,
+    selected: i32,
+    width: u32,
+    height: u32,
+) -> WorkerResult<Vec<u8>> {
+    let Some(i) = frame.obj_ids.iter().position(|&o| o == selected) else {
+        return Ok(Vec::new());
+    };
+    let logits = frame.masks.get(i).ok_or_else(|| {
+        WorkerError::Engine(format!(
+            "sam3 frame has obj id {selected} at index {i} but only {} masks",
+            frame.masks.len()
+        ))
+    })?;
+    mask_to_frame(logits, MASK_GRID, width, height)
 }
 
 /// Segment + track every "person" across already-decoded RGB `frames` with the off-Mac candle SAM3
@@ -361,6 +377,10 @@ pub(crate) fn segment_all_persons_in_memory(
             .then(a.cmp(b))
     });
 
+    // `zip` already bounds to the shorter of obj_ids/masks; `mask_to_frame` now returns an
+    // `Engine` error on a malformed (grid-mismatched) mask instead of the empty-vec sentinel,
+    // so propagate rather than silently dropping it (sc-8905, F-103). Kept in sync with the MLX
+    // twin.
     let per_frame = outputs
         .iter()
         .map(|frame| {
@@ -368,11 +388,10 @@ pub(crate) fn segment_all_persons_in_memory(
                 .obj_ids
                 .iter()
                 .zip(&frame.masks)
-                .map(|(oid, logits)| (*oid, mask_to_frame(logits, MASK_GRID, width, height)))
-                .filter(|(_, mask)| !mask.is_empty())
-                .collect()
+                .map(|(oid, logits)| Ok((*oid, mask_to_frame(logits, MASK_GRID, width, height)?)))
+                .collect::<WorkerResult<Vec<_>>>()
         })
-        .collect();
+        .collect::<WorkerResult<Vec<_>>>()?;
 
     Ok(AllPersonMasks {
         order,

--- a/crates/sceneworks-worker/src/person_segment_sam3_common.rs
+++ b/crates/sceneworks-worker/src/person_segment_sam3_common.rs
@@ -187,21 +187,43 @@ pub(crate) fn select_object<F: Sam3FrameOutput>(
 /// Binarize a `grid×grid` SAM3 mask (logit `> 0`) to a 0/255 buffer, then resize it to
 /// `width×height` (bilinear) and re-threshold to a clean binary `L` mask — the per-clip-frame
 /// output the orchestrator writes. Inverts SAM3's uniform 1008² squash back to the frame aspect.
-pub(crate) fn mask_to_frame(mask_logits: &[f32], grid: usize, width: u32, height: u32) -> Vec<u8> {
+///
+/// Returns an `Engine` error when the logit buffer's length doesn't match `grid×grid` (so
+/// `GrayImage::from_raw` would fail): the old code returned an empty vec there, which is the
+/// exact sentinel the orchestrator reads as "object absent → box fallback" — so a malformed
+/// mask silently degraded to no-mask instead of surfacing (sc-8905, F-103). Legitimate
+/// per-frame absence is signalled by the *caller* (no matching object id), never by this
+/// helper swallowing a shape error.
+pub(crate) fn mask_to_frame(
+    mask_logits: &[f32],
+    grid: usize,
+    width: u32,
+    height: u32,
+) -> WorkerResult<Vec<u8>> {
+    if mask_logits.len() != grid * grid {
+        return Err(crate::WorkerError::Engine(format!(
+            "sam3 mask has {} logits, expected grid×grid = {}",
+            mask_logits.len(),
+            grid * grid
+        )));
+    }
     let bin: Vec<u8> = mask_logits
         .iter()
         .map(|&v| if v > 0.0 { 255 } else { 0 })
         .collect();
-    let Some(small) = image::GrayImage::from_raw(grid as u32, grid as u32, bin) else {
-        return Vec::new();
-    };
+    let small = image::GrayImage::from_raw(grid as u32, grid as u32, bin).ok_or_else(|| {
+        crate::WorkerError::Engine(format!(
+            "sam3 mask buffer ({}) does not fit a {grid}×{grid} GrayImage",
+            grid * grid
+        ))
+    })?;
     let resized =
         image::imageops::resize(&small, width, height, image::imageops::FilterType::Triangle);
-    resized
+    Ok(resized
         .into_raw()
         .into_iter()
         .map(|v| if v > 127 { 255 } else { 0 })
-        .collect()
+        .collect())
 }
 
 /// Normalized centroid-x (0..1) of a SAM3 low-res mask's foreground (logit `> 0`); `None` if the
@@ -344,10 +366,23 @@ mod tests {
                 logits[y * grid + x] = 1.0;
             }
         }
-        let out = mask_to_frame(&logits, grid, 8, 8);
+        let out = mask_to_frame(&logits, grid, 8, 8).expect("well-formed grid resizes");
         assert_eq!(out.len(), 64);
         assert!(out.iter().all(|&v| v == 0 || v == 255), "output is binary");
         assert_eq!(out[0], 255, "top-left corner is foreground");
         assert_eq!(out[63], 0, "bottom-right corner is background");
+    }
+
+    /// sc-8905 / F-103: a logit buffer whose length doesn't match grid×grid returns an `Engine`
+    /// error, not the empty-vec sentinel the orchestrator reads as "object absent → box
+    /// fallback". Previously a malformed mask silently degraded to no-mask.
+    #[test]
+    fn mask_to_frame_rejects_mismatched_grid_length() {
+        // grid says 4×4 (16 logits) but only 10 are supplied.
+        let result = mask_to_frame(&[1.0f32; 10], 4, 8, 8);
+        assert!(
+            matches!(result, Err(crate::WorkerError::Engine(ref m)) if m.contains("logits")),
+            "mismatched grid length must be rejected, got {result:?}"
+        );
     }
 }

--- a/crates/sceneworks-worker/src/pose_jobs.rs
+++ b/crates/sceneworks-worker/src/pose_jobs.rs
@@ -196,12 +196,30 @@ fn yolox_preprocess(img: &RgbImage) -> (Vec<f32>, f32) {
 
 /// This YOLOX export bakes in NMS: `dets`(1,N,5)=[xyxy,score]. rtmlib's
 /// `shape[-1]==5` branch: boxes /= ratio, keep score > 0.3.
-fn yolox_decode(dets: &[f32], shape: &[i64], ratio: f32) -> Vec<Box4> {
+///
+/// The shape/length are validated against the `(…, N, 5)` contract before indexing
+/// (F-102): a mis-pinned ONNX export with a rank < 2 shape or a `dets` buffer shorter
+/// than `N*5` would panic on `shape[1]` / `dets[base + 4]` and unwind the async task;
+/// return an `Engine` error instead (sc-8904).
+fn yolox_decode(dets: &[f32], shape: &[i64], ratio: f32) -> WorkerResult<Vec<Box4>> {
     let mut out = Vec::new();
     if shape.last().copied() != Some(5) {
-        return out;
+        return Ok(out);
     }
-    let n = shape[1] as usize;
+    if shape.len() < 2 {
+        return Err(WorkerError::Engine(format!(
+            "yolox output rank {} < 2 (expected (…, N, 5))",
+            shape.len()
+        )));
+    }
+    let n = shape[1].max(0) as usize;
+    if dets.len() < n.saturating_mul(5) {
+        return Err(WorkerError::Engine(format!(
+            "yolox output has {} values but (N={n} × 5) needs {}",
+            dets.len(),
+            n.saturating_mul(5)
+        )));
+    }
     for i in 0..n {
         let base = i * 5;
         if dets[base + 4] > 0.3 {
@@ -213,7 +231,7 @@ fn yolox_decode(dets: &[f32], shape: &[i64], ratio: f32) -> Vec<Box4> {
             });
         }
     }
-    out
+    Ok(out)
 }
 
 /// Build the (1,3,PH,PW) BGR-normalized pose input for one bbox + return the
@@ -260,6 +278,12 @@ fn argmax(slice: &[f32]) -> (usize, f32) {
 }
 
 /// Decode SimCC outputs → 133 `[x, y, score]` in original px.
+///
+/// The SimCC-x shape/length are validated against the `(1, K, Wx)` contract before
+/// indexing (F-102): a mis-pinned RTMW export with a rank < 3 shape, `K == 0`, or a
+/// `simcc_x`/`simcc_y` buffer shorter than `K*Wx` / `K*Wy` would panic on `sx_shape[2]`
+/// or the per-keypoint slices and unwind the async task; return an `Engine` error
+/// instead (sc-8904).
 fn pose_decode(
     simcc_x: &[f32],
     sx_shape: &[i64],
@@ -268,13 +292,33 @@ fn pose_decode(
     cy: f32,
     sw: f32,
     sh: f32,
-) -> Vec<[f32; 3]> {
-    let k = sx_shape[1] as usize;
-    let wx = sx_shape[2] as usize;
+) -> WorkerResult<Vec<[f32; 3]>> {
+    if sx_shape.len() < 3 {
+        return Err(WorkerError::Engine(format!(
+            "rtmw simcc_x rank {} < 3 (expected (1, K, Wx))",
+            sx_shape.len()
+        )));
+    }
+    let k = sx_shape[1].max(0) as usize;
+    let wx = sx_shape[2].max(0) as usize;
+    if k == 0 {
+        return Err(WorkerError::Engine(
+            "rtmw simcc_x has 0 keypoints".to_owned(),
+        ));
+    }
     let wy = simcc_y.len() / k;
+    if simcc_x.len() < k.saturating_mul(wx) || simcc_y.len() < k.saturating_mul(wy) {
+        return Err(WorkerError::Engine(format!(
+            "rtmw simcc buffers too short: x has {} (needs {}), y has {} (needs {})",
+            simcc_x.len(),
+            k.saturating_mul(wx),
+            simcc_y.len(),
+            k.saturating_mul(wy)
+        )));
+    }
     let x0 = cx - sw / 2.0;
     let y0 = cy - sh / 2.0;
-    (0..k)
+    Ok((0..k)
         .map(|j| {
             let (xloc, mvx) = argmax(&simcc_x[j * wx..(j + 1) * wx]);
             let (yloc, mvy) = argmax(&simcc_y[j * wy..(j + 1) * wy]);
@@ -288,7 +332,7 @@ fn pose_decode(
             let py = (ly / SPLIT) / PH as f32 * sh + y0;
             [px, py, val]
         })
-        .collect()
+        .collect())
 }
 
 // ---------------------------------------------------------------------------
@@ -305,7 +349,18 @@ struct PoseRecord {
 
 /// Convert one person's raw 133 `[x,y,score]` (original px) into the SceneWorks
 /// OpenPose record, normalized by (w,h). Mirrors `wholebody_to_openpose`.
-fn wholebody_to_openpose(kps: &[[f32; 3]], w: f32, h: f32) -> PoseRecord {
+///
+/// Requires the full COCO-WholeBody-133 keypoint set (F-102): the body/hand/face slices
+/// index `kps` up to 132, so a shorter buffer (a mis-pinned RTMW export with a different
+/// keypoint count) would panic on `kps[i]` and unwind the async task. Return an `Engine`
+/// error instead of indexing OOB (sc-8904).
+fn wholebody_to_openpose(kps: &[[f32; 3]], w: f32, h: f32) -> WorkerResult<PoseRecord> {
+    if kps.len() < 133 {
+        return Err(WorkerError::Engine(format!(
+            "rtmw decode produced {} keypoints, expected 133 (COCO-WholeBody)",
+            kps.len()
+        )));
+    }
     let pt = |i: usize| [kps[i][0] / w, kps[i][1] / h, kps[i][2]];
     let seq = |lo: usize, hi: usize| (lo..hi).map(pt).collect::<Vec<_>>();
     let mut body = vec![[0.0f32; 3]; 18];
@@ -318,11 +373,11 @@ fn wholebody_to_openpose(kps: &[[f32; 3]], w: f32, h: f32) -> PoseRecord {
         (ls[1] + rs[1]) / 2.0 / h,
         ls[2].min(rs[2]),
     ];
-    PoseRecord {
+    Ok(PoseRecord {
         keypoints: body,
         hands: [seq(91, 112), seq(112, 133)],
         face: seq(23, 91),
-    }
+    })
 }
 
 /// Re-normalize a source-aspect pose into a centered `max(w,h)` SQUARE (pad short
@@ -534,10 +589,10 @@ impl Detector {
     fn detect(&mut self, img: &RgbImage) -> WorkerResult<Vec<Vec<[f32; 3]>>> {
         let (din, ratio) = yolox_preprocess(img);
         let dout = run(&mut self.det, [1, 3, DET as i64, DET as i64], din)?;
-        let boxes = dout
-            .first()
-            .map(|(shape, data)| yolox_decode(data, shape, ratio))
-            .unwrap_or_default();
+        let boxes = match dout.first() {
+            Some((shape, data)) => yolox_decode(data, shape, ratio)?,
+            None => Vec::new(),
+        };
         let mut people = Vec::new();
         for b in &boxes {
             let (pin, cx, cy, sw, sh) = pose_preprocess(img, b);
@@ -559,7 +614,7 @@ impl Detector {
                 cy,
                 sw,
                 sh,
-            ));
+            )?);
         }
         Ok(people)
     }
@@ -1090,15 +1145,15 @@ async fn run_pose_detect_inner(
                     .people
                     .iter()
                     .map(|kps| {
-                        let rec = squareify(&wholebody_to_openpose(kps, w, h), w, h);
+                        let rec = squareify(&wholebody_to_openpose(kps, w, h)?, w, h);
                         let bb = bbox(
                             &[&rec.keypoints, &rec.hands[0], &rec.hands[1], &rec.face],
                             min_conf,
                         );
                         let area = bb.map_or(0.0, |b| (b[2] - b[0]) * (b[3] - b[1]));
-                        (area, rec, bb)
+                        Ok((area, rec, bb))
                     })
-                    .collect();
+                    .collect::<WorkerResult<Vec<_>>>()?;
                 ordered
                     .sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
 

--- a/crates/sceneworks-worker/src/pose_jobs.rs
+++ b/crates/sceneworks-worker/src/pose_jobs.rs
@@ -489,16 +489,39 @@ impl Detector {
     /// off-Mac) and falling back to CPU if the provider can't initialise (mirrors
     /// Python `load_pose_detector`).
     fn load(det_path: &Path, pose_path: &Path) -> WorkerResult<Self> {
-        match (
-            build_session(det_path, true),
-            build_session(pose_path, true),
-        ) {
-            (Ok(det), Ok(pose)) => Ok(Self {
+        // Build the det session on the hardware EP first; only try the pose session on the
+        // EP if that succeeded — a failing accel provider fails identically for both, so
+        // building the second is wasted work (F-099). Bind and `warn!` the error before the
+        // CPU fallback so an accel-init failure leaves a breadcrumb instead of an
+        // unexplained "device = cpu" (sc-8901).
+        let accel = match build_session(det_path, true) {
+            Ok(det) => match build_session(pose_path, true) {
+                Ok(pose) => Some((det, pose)),
+                Err(error) => {
+                    tracing::warn!(
+                        %error,
+                        provider = ACCEL_DEVICE,
+                        "DWPose pose-model {ACCEL_DEVICE} session build failed; falling back to CPU"
+                    );
+                    None
+                }
+            },
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    provider = ACCEL_DEVICE,
+                    "DWPose detector {ACCEL_DEVICE} session build failed; falling back to CPU"
+                );
+                None
+            }
+        };
+        match accel {
+            Some((det, pose)) => Ok(Self {
                 det,
                 pose,
                 device: ACCEL_DEVICE,
             }),
-            _ => Ok(Self {
+            None => Ok(Self {
                 det: build_session(det_path, false)?,
                 pose: build_session(pose_path, false)?,
                 device: "cpu",

--- a/crates/sceneworks-worker/src/pose_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/pose_jobs/tests.rs
@@ -15,7 +15,7 @@ fn wholebody_to_openpose_maps_indices_and_computes_neck() {
     kps[0] = [100.0, 10.0, 5.0]; // nose -> op 0
     kps[5] = [80.0, 40.0, 4.0]; // l_sho -> op 5
     kps[6] = [120.0, 50.0, 6.0]; // r_sho -> op 6
-    let rec = wholebody_to_openpose(&kps, 200.0, 100.0);
+    let rec = wholebody_to_openpose(&kps, 200.0, 100.0).expect("133 keypoints convert");
     // nose normalized
     assert!(approx(rec.keypoints[0][0], 0.5, 1e-6));
     assert!(approx(rec.keypoints[0][1], 0.1, 1e-6));
@@ -106,12 +106,26 @@ fn yolox_decode_embedded_nms_branch() {
         10.0, 20.0, 30.0, 40.0, 0.9, // keep
         1.0, 2.0, 3.0, 4.0, 0.1, // drop (score <= 0.3)
     ];
-    let boxes = yolox_decode(&dets, &[1, 2, 5], 0.5);
+    let boxes = yolox_decode(&dets, &[1, 2, 5], 0.5).expect("valid (N,5) decodes");
     assert_eq!(boxes.len(), 1);
     assert!(approx(boxes[0].x1, 20.0, 1e-6));
     assert!(approx(boxes[0].y2, 80.0, 1e-6));
     // non-NMS shape (last dim != 5) -> empty (we only ship the embedded-NMS export)
-    assert!(yolox_decode(&[0.0; 85], &[1, 1, 85], 1.0).is_empty());
+    assert!(yolox_decode(&[0.0; 85], &[1, 1, 85], 1.0)
+        .expect("non-5 last dim is a benign empty")
+        .is_empty());
+}
+
+#[test]
+fn yolox_decode_rejects_truncated_output() {
+    // Last dim is 5 (the embedded-NMS branch) but the data buffer is shorter than N*5:
+    // (1,2,5) needs 10 values, hand it 5 → Engine error instead of an OOB panic (F-102).
+    let short = yolox_decode(&[0.0; 5], &[1, 2, 5], 1.0);
+    // `Box4` isn't `Debug`, so match the error shape directly rather than formatting.
+    assert!(
+        matches!(short, Err(WorkerError::Engine(_))),
+        "truncated yolox buffer must be rejected"
+    );
 }
 
 #[test]
@@ -126,7 +140,8 @@ fn pose_decode_argmax_and_rescale() {
     sy[2] = 7.0;
     // crop geometry: center (50,60), scale (PW, PH) so px = (loc/2)/PW*PW + x0.
     let (cx, cy, sw, sh) = (50.0f32, 60.0f32, PW as f32, PH as f32);
-    let kp = pose_decode(&sx, &[1, k as i64, wx as i64], &sy, cx, cy, sw, sh);
+    let kp = pose_decode(&sx, &[1, k as i64, wx as i64], &sy, cx, cy, sw, sh)
+        .expect("valid simcc decodes");
     assert_eq!(kp.len(), 1);
     // x: loc 2 -> 2/2=1 ; (1)/PW*sw + (cx - sw/2) = 1 + (50 - PW/2)
     let x0 = cx - sw / 2.0;
@@ -141,9 +156,39 @@ fn pose_decode_argmax_and_rescale() {
 fn pose_decode_negative_value_marks_missing() {
     let sx = vec![-1.0f32; 4];
     let sy = vec![-1.0f32; 4];
-    let kp = pose_decode(&sx, &[1, 1, 4], &sy, 50.0, 60.0, PW as f32, PH as f32);
+    let kp = pose_decode(&sx, &[1, 1, 4], &sy, 50.0, 60.0, PW as f32, PH as f32)
+        .expect("valid simcc decodes");
     // val <= 0 -> loc (-1,-1) -> negative rescaled coords, score <= 0
     assert!(kp[0][2] <= 0.0);
+}
+
+#[test]
+fn pose_decode_rejects_malformed_simcc() {
+    // Rank < 3 simcc_x shape → Engine error, not an OOB panic on sx_shape[2] (F-102).
+    let rank2 = pose_decode(&[0.0; 4], &[1, 4], &[0.0; 4], 0.0, 0.0, 1.0, 1.0);
+    assert!(
+        matches!(rank2, Err(WorkerError::Engine(_))),
+        "rank-2 simcc_x must be rejected, got {rank2:?}"
+    );
+    // Well-formed rank but simcc_x is shorter than K*Wx → Engine error.
+    let short = pose_decode(&[0.0; 2], &[1, 2, 4], &[0.0; 8], 0.0, 0.0, 1.0, 1.0);
+    assert!(
+        matches!(short, Err(WorkerError::Engine(_))),
+        "truncated simcc_x must be rejected, got {short:?}"
+    );
+}
+
+#[test]
+fn wholebody_to_openpose_rejects_short_keypoint_set() {
+    // Fewer than 133 keypoints (a mis-pinned RTMW export) → Engine error, not an OOB panic
+    // on the body/hand/face slices (F-102).
+    let short = vec![[0.0f32; 3]; 100];
+    let result = wholebody_to_openpose(&short, 200.0, 100.0);
+    // `PoseRecord` isn't `Debug`, so match the error shape directly rather than formatting.
+    assert!(
+        matches!(result, Err(WorkerError::Engine(msg)) if msg.contains("133")),
+        "100-keypoint buffer must be rejected with a 133-keypoint Engine error"
+    );
 }
 
 /// sc-5496 off-Mac GPU smoke (ignored — needs the real RTMW onnx weights + CUDA). Validates the
@@ -184,7 +229,11 @@ fn pose_detect_candle_real_weights_finds_person() {
         "expected at least one detected person"
     );
     let (w, h) = (src.width as f32, src.height as f32);
-    let rec = squareify(&wholebody_to_openpose(&src.people[0], w, h), w, h);
+    let rec = squareify(
+        &wholebody_to_openpose(&src.people[0], w, h).expect("133 keypoints convert"),
+        w,
+        h,
+    );
     assert_eq!(rec.keypoints.len(), 18);
 
     // Confident body points are normalized (not raw pixels) and land near the [0,1]

--- a/crates/sceneworks-worker/src/upscale_jobs.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs.rs
@@ -261,10 +261,20 @@ impl Upscaler {
                 session,
                 device: ACCEL_DEVICE,
             }),
-            Err(_) => Ok(Self {
-                session: build_session(path, false)?,
-                device: "cpu",
-            }),
+            // Log WHY the hardware-EP session build failed before silently rebuilding on
+            // CPU (F-099) — otherwise a CoreML/CUDA init failure just presents as an
+            // unexplained "device = cpu" with no breadcrumb (sc-8901).
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    provider = ACCEL_DEVICE,
+                    "Real-ESRGAN {ACCEL_DEVICE} session build failed; falling back to CPU"
+                );
+                Ok(Self {
+                    session: build_session(path, false)?,
+                    device: "cpu",
+                })
+            }
         }
     }
 


### PR DESCRIPTION
Code-review remediation batch 3 (epic 8800) for `crates/sceneworks-worker`. Five defects in the person detect / pose / upscale / segment paths, one commit per story.

## Stories

- **sc-8901 [F-099]** — Log swallowed accel-init errors before CPU fallback. `OrtYolo::load` (person_jobs), `Detector::load` (pose_jobs), `Upscaler::load` (upscale_jobs) matched `Err(_)` on the CUDA/CoreML session build and silently rebuilt on CPU — a cuDNN/CUDA mismatch and a GPU-less box both presented as an unexplained `device = cpu`. Bind + `tracing::warn!` the error before the CPU fallback at all three sites; for DWPose, also short-circuit the second accel-session build (the pose model) when the first (the detector) already failed.

- **sc-8904 [F-102]** — Guard ONNX output rank/length before indexing in decode. `decode` (person_jobs) and `yolox_decode` / `pose_decode` / `wholebody_to_openpose` (pose_jobs) indexed `shape[1]`/`shape[2]` and `data[channel*anchors+a]` / `kps[i]` without checking the output rank or buffer length. A user can pin an arbitrary ONNX via `SCENEWORKS_PERSON_DETECTOR_WEIGHTS` / `SCENEWORKS_DWPOSE_*` with a different output shape → OOB panic that unwinds the async task (silent "degraded" for DWPose). Each now validates against its contract and returns `WorkerError::Engine` instead; signatures become `WorkerResult<…>` with `?` at call sites.

- **sc-8906 [F-104]** — Merge duplicated NHWC/NCHW letterbox preprocessors; classify YOLO forward failures as Engine. `preprocess` (macOS NHWC) and `preprocess_nchw` (off-Mac NCHW) were byte-identical except the destination index, both cfg-gated so drift was invisible. Merged into one `preprocess_letterbox(img, InputLayout)`; only `InputLayout::index` differs per backend. Separately, `detect_people` (MLX) mapped forward/reshape failures to `InvalidPayload` while every sibling uses `Engine` — changed both `map_err`s to `Engine`.

- **sc-8903 [F-101]** — Replace frames/anchors `assert_eq!` with `WorkerError` in the blocking entry points. `person_segment`, `person_segment_sam3`, and `person_segment_sam3_candle` each asserted `assert_eq!(clip_frame_paths.len(), anchors.len())`; a mismatch panicked inside `spawn_blocking` and `media_jobs` absorbed it as a silent "degraded". All three (incl. the candle twin, kept in sync) now return `WorkerError::InvalidPayload` with both lengths.

- **sc-8905 [F-103]** — Bounds-check the predictor's returned frame index; surface malformed masks. Three fixes: (1) `person_segment` bounds-checks the predictor's frame index (a negative i32 wrapped via `as usize`) via `usize::try_from` + range filter → `Engine` error; (2) the SAM3 video path indexed `frame.masks[i]` assuming parallel-length vecs — extracted into a shared `frame_mask_for_object` that guards `masks.get(i)`; (3) `mask_to_frame` returned an empty vec on `GrayImage::from_raw` failure — the exact sentinel the orchestrator reads as "object absent → box fallback" — now returns `WorkerResult<Vec<u8>>` and errors on a grid-length mismatch.

## Tests added
- `decode_rejects_malformed_output_shape_and_length` (person_jobs)
- `yolox_decode_rejects_truncated_output`, `pose_decode_rejects_malformed_simcc`, `wholebody_to_openpose_rejects_short_keypoint_set` (pose_jobs)
- `preprocess_letterbox_places_pixels_and_pads_per_layout` (person_jobs)
- `frames_anchors_length_mismatch_returns_invalid_payload` (person_segment, person_segment_sam3, person_segment_sam3_candle)
- `mask_to_frame_rejects_mismatched_grid_length` (person_segment_sam3_common)
- `frame_mask_for_object_guards_parallel_vecs` (person_segment_sam3)

## Verification
- `npm run rust:check` (fmt --check + clippy -D warnings + full workspace test + build) — PASS
- worker lib tests: 594 passed, 0 failed, 137 ignored
- candle parity: `cargo check -p sceneworks-worker --no-default-features -F backend-candle --all-targets` — PASS + clippy clean (Stories 4 & 5 touch the candle twin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
