### PR TITLE
fix(worker): segment/replace path + robustness + cancel/cache (epic 8800 batch 4)

### DIFF
--- a/crates/sceneworks-worker/src/kps_jobs.rs
+++ b/crates/sceneworks-worker/src/kps_jobs.rs
@@ -18,7 +18,14 @@
 //! the result is scale-free and round-trips through `generate_with_kps` (which draws
 //! `kps_norm · side` on a square canvas after letterboxing the reference the same way).
 
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+use std::cell::RefCell;
 use std::path::{Path, PathBuf};
+#[cfg(target_os = "macos")]
+use std::sync::{Mutex, OnceLock};
 
 // The neutral image type both backends operate on (`mlx_gen` and `candle_gen` both re-export
 // `gen_core::Image`; the single-rev skew gate keeps them the same type).
@@ -138,21 +145,77 @@ impl KpsExtraction {
     }
 }
 
+/// The SCRFD weight checkpoint parsed once and cached process-wide (sc-8910 / F-108). The safetensors
+/// parse (~100+ MB read) is the expensive, `Send` part; caching it here lets every `kps_extract` job —
+/// even one that lands on a fresh blocking thread — skip the disk re-read. Mirrors
+/// `pose_jobs::DETECTOR` / `person_segment_sam3::WEIGHTS` (poison-recovery: a poisoned lock drops the
+/// cached value and rebuilds). macOS only; `Weights` is the MLX weight container.
+#[cfg(target_os = "macos")]
+static WEIGHTS: OnceLock<Mutex<Option<Weights>>> = OnceLock::new();
+
+thread_local! {
+    /// The built [`Scrfd`] detector cached per blocking thread, keyed by weight path (sc-8910 /
+    /// F-108). The MLX model embeds an `Rc<…>` → `!Send`, so it can't live in a process-wide
+    /// `static Mutex` like the `Weights` above (this is exactly why `person_segment_sam3` caches
+    /// its built segmenter/tracker thread-local while caching `Weights` process-wide). `detect(&self,
+    /// …)` is a pure forward pass with no retained per-call state, so reuse across kps jobs is
+    /// byte-identical. Interactive kps extraction is serial, so one built detector stays resident per
+    /// blocking thread rather than being rebuilt from the cached weights on every job.
+    #[cfg(target_os = "macos")]
+    static SCRFD: RefCell<Option<(PathBuf, Scrfd)>> = const { RefCell::new(None) };
+
+    /// Off-Mac sibling (sc-8910 / F-108): the built candle SCRFD/ArcFace stack cached per blocking
+    /// thread, keyed by the staged `face_dir`. `candle_gen_face::load` re-reads both weight files and
+    /// rebuilds the models on every call, so caching skips that per-job cost the same way the MLX
+    /// `SCRFD`/`WEIGHTS` caches do. Thread-local (not a process-wide `Mutex`) keeps the two backends
+    /// symmetric and sidesteps any Send question on the candle analysis/device. `detect(&self, …)` is
+    /// a pure forward pass, so reuse across kps jobs is byte-identical.
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    static CANDLE_FACE: RefCell<Option<(PathBuf, candle_gen_face::CandleFaceAnalysis)>> =
+        const { RefCell::new(None) };
+}
+
 /// Load SCRFD + detect the largest face's landmarks in `image`, normalized to the square
 /// preset space. Runs the `!Send` MLX work; call inside `spawn_blocking`.
+///
+/// The weight checkpoint is parsed once into the process-wide [`WEIGHTS`] cache and the built
+/// detector is cached per blocking thread in [`SCRFD`], so a repeated interactive `kps_extract`
+/// skips both the ~100+ MB weight re-read and the model rebuild (sc-8910 / F-108).
 #[cfg(target_os = "macos")]
 fn detect_largest_kps(scrfd_path: &Path, image: &Image) -> WorkerResult<KpsExtraction> {
-    let weights = Weights::from_file(scrfd_path)
-        .map_err(|error| WorkerError::Engine(format!("SCRFD weights {scrfd_path:?}: {error}")))?;
-    let scrfd = Scrfd::from_weights(&weights)
-        .map_err(|error| WorkerError::Engine(format!("SCRFD load: {error}")))?;
     // gen-core d8038beb (sc-7176 pin sync): `detector_blob` is now fallible (returns a `Result`).
     let (blob, det_scale) =
         detector_blob(&image.pixels, image.height as usize, image.width as usize)
             .map_err(|error| WorkerError::Engine(format!("SCRFD blob: {error}")))?;
-    let dets = scrfd
-        .detect(&blob, det_scale, DET_THRESH, NMS_THRESH)
-        .map_err(|error| WorkerError::Engine(format!("SCRFD detect: {error}")))?;
+    let dets = SCRFD.with(|cell| -> WorkerResult<_> {
+        {
+            let cached = cell.borrow();
+            if cached.as_ref().map(|(path, _)| path.as_path()) != Some(scrfd_path) {
+                drop(cached);
+                // Parse the weights once, process-wide (poison-recovery), then build the detector for
+                // this thread.
+                let weights_cell = WEIGHTS.get_or_init(|| Mutex::new(None));
+                let mut guard = weights_cell.lock().unwrap_or_else(|poisoned| {
+                    let mut guard = poisoned.into_inner();
+                    *guard = None;
+                    guard
+                });
+                if guard.is_none() {
+                    *guard = Some(Weights::from_file(scrfd_path).map_err(|error| {
+                        WorkerError::Engine(format!("SCRFD weights {scrfd_path:?}: {error}"))
+                    })?);
+                }
+                let scrfd = Scrfd::from_weights(guard.as_ref().expect("weights loaded"))
+                    .map_err(|error| WorkerError::Engine(format!("SCRFD load: {error}")))?;
+                *cell.borrow_mut() = Some((scrfd_path.to_path_buf(), scrfd));
+            }
+        }
+        let cached = cell.borrow();
+        let (_, scrfd) = cached.as_ref().expect("detector cached");
+        scrfd
+            .detect(&blob, det_scale, DET_THRESH, NMS_THRESH)
+            .map_err(|error| WorkerError::Engine(format!("SCRFD detect: {error}")))
+    })?;
 
     let (w, h) = (image.width, image.height);
     let largest = dets.into_iter().max_by(|a, b| {
@@ -190,11 +253,23 @@ fn detect_largest_kps(scrfd_path: &Path, image: &Image) -> WorkerResult<KpsExtra
 /// backend-identical. The candle stack runs f32 on CUDA; call inside `spawn_blocking`.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 fn detect_largest_kps_candle(face_dir: &Path, image: &Image) -> WorkerResult<KpsExtraction> {
-    let analysis = candle_gen_face::load(face_dir)
-        .map_err(|error| WorkerError::Engine(format!("face stack {face_dir:?}: {error}")))?;
-    let dets = analysis
-        .detect(image)
-        .map_err(|error| WorkerError::Engine(format!("SCRFD detect: {error}")))?;
+    let dets = CANDLE_FACE.with(|cell| -> WorkerResult<_> {
+        {
+            let cached = cell.borrow();
+            if cached.as_ref().map(|(dir, _)| dir.as_path()) != Some(face_dir) {
+                drop(cached);
+                let analysis = candle_gen_face::load(face_dir).map_err(|error| {
+                    WorkerError::Engine(format!("face stack {face_dir:?}: {error}"))
+                })?;
+                *cell.borrow_mut() = Some((face_dir.to_path_buf(), analysis));
+            }
+        }
+        let cached = cell.borrow();
+        let (_, analysis) = cached.as_ref().expect("face analysis cached");
+        analysis
+            .detect(image)
+            .map_err(|error| WorkerError::Engine(format!("SCRFD detect: {error}")))
+    })?;
 
     let (w, h) = (image.width, image.height);
     let largest = dets.into_iter().max_by(|a, b| {
@@ -515,6 +590,17 @@ mod tests {
             "  extracted (score {:.3}, low_conf {}): le={le:?} re={re:?} nose={nose:?} ml={ml:?} mr={mr:?}",
             extraction.det_score, extraction.low_confidence
         );
+
+        // sc-8910 / F-108: a SECOND extraction on the same weights hits the cached `Weights` +
+        // per-thread `Scrfd` (no re-read, no rebuild) and must be byte-identical to the first —
+        // the cache reuse is transparent, not a source of drift.
+        let again = detect_largest_kps(&scrfd_path, &image).expect("cached detect");
+        assert_eq!(
+            again.kps.expect("kps on cached detect"),
+            kps,
+            "cached SCRFD detector must produce identical landmarks"
+        );
+        assert_eq!(again.det_score, extraction.det_score);
     }
 
     /// Real-weights smoke (sc-5497, candle): run the actual candle SCRFD/ArcFace path on a real face
@@ -577,5 +663,15 @@ mod tests {
             "  candle extracted (score {:.3}, low_conf {}): le={le:?} re={re:?} nose={nose:?} ml={ml:?} mr={mr:?}",
             extraction.det_score, extraction.low_confidence
         );
+
+        // sc-8910 / F-108: a SECOND extraction hits the cached candle face stack (no reload) and
+        // must be byte-identical — the cache reuse is transparent.
+        let again = detect_largest_kps_candle(&face_dir, &image).expect("cached detect");
+        assert_eq!(
+            again.kps.expect("kps on cached detect"),
+            kps,
+            "cached candle face stack must produce identical landmarks"
+        );
+        assert_eq!(again.det_score, extraction.det_score);
     }
 }

--- a/crates/sceneworks-worker/src/person_replace.rs
+++ b/crates/sceneworks-worker/src/person_replace.rs
@@ -200,8 +200,9 @@ pub(crate) fn box_mask(box_value: Option<&Value>, width: u32, height: u32) -> Rg
 ///
 /// The sidecar `mask` string is confined under `project_path` (`safe_project_path`,
 /// Component::Normal-only) so a tampered project file can't traverse out to an arbitrary
-/// readable image (sc-8876 / F-074); an unsafe path degrades to a box mask for that frame,
-/// counted as box-derived.
+/// readable image (sc-8876 / F-074); an unsafe path OR a corrupt/undecodable stored mask
+/// degrades to a box mask for that frame — the whole video replacement is never failed by
+/// one bad mask (sc-8902 / F-100) — with the degraded frame counted as box-derived.
 pub(crate) fn load_track_masks(
     project_path: &Path,
     track: &Value,
@@ -241,20 +242,29 @@ pub(crate) fn load_track_masks(
                 }
             })
             .filter(|path| path.exists());
-        match stored {
-            Some(path) => {
-                let loaded = crate::image_decode::decode_image_any(&path)
-                    .map_err(|error| {
-                        WorkerError::InvalidPayload(format!(
-                            "replacement mask {}: {error}",
-                            path.display()
-                        ))
-                    })?
-                    .to_luma8();
+        // Decode the stored segmentation mask; on a corrupt/undecodable file degrade to a box mask
+        // for that frame (sc-8902 / F-100) instead of `?`-failing the whole replace-person job — a
+        // *missing* file already falls back this way and the contract never fails a located-person
+        // track in the mask pass. The degraded frame counts as box-derived, so the reported mode
+        // (`segmentation`/`mixed`/`degraded_box`) still reflects the true accounting.
+        let loaded = stored.and_then(|path| match crate::image_decode::decode_image_any(&path) {
+            Ok(image) => Some(image.to_luma8()),
+            Err(error) => {
+                tracing::warn!(
+                    event = "replace_person_mask_decode_failed",
+                    mask = %path.display(),
+                    %error,
+                    "stored replacement mask could not be decoded; degrading to box mask"
+                );
+                None
+            }
+        });
+        match loaded {
+            Some(luma) => {
                 // Match Pillow `convert("L").resize((w, h))` (default bilinear), then fan the
                 // single luma channel out to RGB (white = regenerate).
                 let resized = image::imageops::resize(
-                    &loaded,
+                    &luma,
                     width,
                     height,
                     image::imageops::FilterType::Triangle,
@@ -467,6 +477,51 @@ mod tests {
         assert!(white_pixels(&masks[0]) > 0);
         assert!(white_pixels(&masks[0]) < 64 * 64);
         let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn load_track_masks_degrades_to_box_on_corrupt_stored_mask() {
+        // sc-8902 / F-100: a stored mask that exists but can't be decoded must degrade to a box
+        // mask for that frame, not `?`-fail the whole replace-person job.
+        let dir = std::env::temp_dir().join(format!("sw_masks_{}", uuid::Uuid::new_v4().simple()));
+        std::fs::create_dir_all(&dir).unwrap();
+        // A file with a `.png` name but garbage bytes → decode fails.
+        std::fs::write(dir.join("corrupt.png"), b"not a real image").unwrap();
+        let track = json!({
+            "frames": [
+                {
+                    "box": { "x": 0.25, "y": 0.25, "width": 0.5, "height": 0.5 },
+                    "mask": "corrupt.png"
+                }
+            ]
+        });
+        let (masks, mode) = load_track_masks(&dir, &track, 64, 64, 1).unwrap();
+        assert_eq!(masks.len(), 1);
+        // Degraded to a box mask (not segmentation) and did not error.
+        assert_eq!(mode, MODE_DEGRADED_BOX);
+        assert!(white_pixels(&masks[0]) > 0);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_track_masks_mixed_mode_when_one_mask_is_corrupt() {
+        // A two-frame track where one stored mask decodes and one is corrupt → MIXED, still no error.
+        let dir = std::env::temp_dir().join(format!("sw_masks_{}", uuid::Uuid::new_v4().simple()));
+        std::fs::create_dir_all(&dir).unwrap();
+        image::GrayImage::from_pixel(10, 10, image::Luma([255]))
+            .save(dir.join("good.png"))
+            .unwrap();
+        std::fs::write(dir.join("bad.png"), b"corrupt").unwrap();
+        let track = json!({
+            "frames": [
+                { "box": { "x": 0.1, "y": 0.1, "width": 0.1, "height": 0.1 }, "mask": "good.png" },
+                { "box": { "x": 0.2, "y": 0.2, "width": 0.1, "height": 0.1 }, "mask": "bad.png" }
+            ]
+        });
+        let (masks, mode) = load_track_masks(&dir, &track, 32, 32, 2).unwrap();
+        assert_eq!(masks.len(), 2);
+        assert_eq!(mode, MODE_MIXED);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/person_replace.rs
+++ b/crates/sceneworks-worker/src/person_replace.rs
@@ -197,6 +197,11 @@ pub(crate) fn box_mask(box_value: Option<&Value>, width: u32, height: u32) -> Rg
 /// otherwise a box mask is rasterized from the (possibly corrected) box. Returns the masks
 /// plus the source mode: [`MODE_SEGMENTATION`] (all stored), [`MODE_DEGRADED_BOX`] (all
 /// box-derived), or [`MODE_MIXED`].
+///
+/// The sidecar `mask` string is confined under `project_path` (`safe_project_path`,
+/// Component::Normal-only) so a tampered project file can't traverse out to an arbitrary
+/// readable image (sc-8876 / F-074); an unsafe path degrades to a box mask for that frame,
+/// counted as box-derived.
 pub(crate) fn load_track_masks(
     project_path: &Path,
     track: &Value,
@@ -215,10 +220,26 @@ pub(crate) fn load_track_masks(
     let mut segmentation = 0usize;
     for index in &indices {
         let frame = &frames[*index];
+        // Confine the sidecar-supplied `mask` string under the project dir (sc-8876 / F-074):
+        // `safe_project_path` joins Component::Normal-only, so an absolute or `..`-traversing value
+        // (a tampered project file) never resolves outside `project_path` to pull an arbitrary
+        // readable image into the output. A rejected path is treated exactly like a corrupt/missing
+        // mask below — degrade to a box mask rather than read outside the trust boundary.
         let stored = frame
             .get("mask")
             .and_then(Value::as_str)
-            .map(|rel| project_path.join(rel))
+            .and_then(|rel| match crate::safe_project_path(project_path, rel) {
+                Ok(path) => Some(path),
+                Err(error) => {
+                    tracing::warn!(
+                        event = "replace_person_mask_unsafe_path",
+                        mask = rel,
+                        %error,
+                        "sidecar mask path escapes the project directory; degrading to box mask"
+                    );
+                    None
+                }
+            })
             .filter(|path| path.exists());
         match stored {
             Some(path) => {
@@ -414,6 +435,38 @@ mod tests {
         // The stored all-white mask resizes to a fully-white 32×32 (not the small box).
         assert_eq!(white_pixels(&masks[0]), 32 * 32);
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_track_masks_confines_traversing_mask_path_to_box() {
+        // sc-8876 / F-074: an absolute or `..`-traversing sidecar mask path must never resolve
+        // outside the project dir. Even if a matching file exists at the traversal target, the
+        // loader confines the join (Component::Normal-only) and degrades to a box mask.
+        let root = std::env::temp_dir().join(format!("sw_masks_{}", uuid::Uuid::new_v4().simple()));
+        let project = root.join("project");
+        let outside = root.join("secret");
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        // A readable image OUTSIDE the project that a traversal would otherwise pull in.
+        image::GrayImage::from_pixel(8, 8, image::Luma([255]))
+            .save(outside.join("leak.png"))
+            .unwrap();
+        let track = json!({
+            "frames": [
+                {
+                    "box": { "x": 0.25, "y": 0.25, "width": 0.5, "height": 0.5 },
+                    "mask": "../secret/leak.png"
+                }
+            ]
+        });
+        let (masks, mode) = load_track_masks(&project, &track, 64, 64, 1).unwrap();
+        // Confined + degraded: the box mask (not the leaked all-white image) is used.
+        assert_eq!(mode, MODE_DEGRADED_BOX);
+        // A 0.25..0.75 box (with 3% pad) is a strict subset of the frame — the leaked all-white
+        // image would have filled every pixel, so a partial fill proves the traversal was blocked.
+        assert!(white_pixels(&masks[0]) > 0);
+        assert!(white_pixels(&masks[0]) < 64 * 64);
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/progress.rs
+++ b/crates/sceneworks-worker/src/progress.rs
@@ -268,9 +268,11 @@ pub(crate) async fn mark_job_canceled(
 /// per-engine decision documented at its call site (sc-9123): the single-shot detectors
 /// (kps/SCRFD, person-detect/YOLO11) and the ArcFace embedding compare — each is one bounded
 /// forward pass on one image/frame (plus a cold weight load), so threading cancel through those
-/// engine surfaces would buy nothing the bounded join doesn't already give — and the interleave
-/// document write (bounded PNG encode + fs rename, where a mid-write abort is worse than
-/// finishing). Everything loop-shaped passes `Some`: SenseNova VQA/interleave threads a REAL
+/// engine surfaces would buy nothing the bounded join doesn't already give — the smart-select SAM3
+/// image ops (box/points, `segment_jobs`, sc-8908 / F-106), likewise one bounded SAM3 forward pass
+/// on one image with no per-step loop for a flag to poll (the video `propagate` path DOES thread a
+/// real flag) — and the interleave document write (bounded PNG encode + fs rename, where a mid-write
+/// abort is worse than finishing). Everything loop-shaped passes `Some`: SenseNova VQA/interleave threads a REAL
 /// `CancelFlag` the engines poll per decoded token and per denoise step (mlx-gen #634 + the candle
 /// sc-9123 sibling), and the worker-side pose loops (DWPose multi-image batch detect + the
 /// per-person skeleton render) check a real flag between iterations in worker code — no engine

--- a/crates/sceneworks-worker/src/scail2_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/scail2_gpu_smoke.rs
@@ -154,7 +154,8 @@ fn scail2_candle_gpu_smoke() {
     } else {
         crate::scail2_masks::BG_BLACK
     };
-    let driving_masks = crate::scail2_masks::paint_driving_masks(&drive_masks, drive_bg);
+    let driving_masks = crate::scail2_masks::paint_driving_masks(&drive_masks, drive_bg)
+        .expect("scail2 driving mask paint");
     assert_eq!(
         driving_masks.len(),
         driving.len(),

--- a/crates/sceneworks-worker/src/scail2_masks.rs
+++ b/crates/sceneworks-worker/src/scail2_masks.rs
@@ -61,7 +61,23 @@ fn filled(width: usize, height: usize, bg: [u8; 3]) -> Vec<u8> {
 }
 
 /// Paint one person's binary mask into the RGB buffer with `color`.
-fn paint(px: &mut [u8], mask: &[u8], color: [u8; 3]) {
+///
+/// The mask is one byte per pixel and `px` is three bytes per pixel, so a correct call has
+/// `mask.len() == px.len() / 3`. A mismatch can only mean the SAM3 pass produced a mask at a
+/// different resolution than the `width*height` the painter allocated from — an upstream
+/// dimension bug that would otherwise silently corrupt the color-coded conditioning (painting
+/// fewer pixels for a short mask, ignoring the tail of a long one). Surface it as a typed error
+/// instead of the old silent per-pixel guard (sc-8907 / F-105); the guard stays as defense in
+/// depth so a bug that slips the length check still can't write out of bounds.
+fn paint(px: &mut [u8], mask: &[u8], color: [u8; 3]) -> WorkerResult<()> {
+    if mask.len() != px.len() / 3 {
+        return Err(WorkerError::Engine(format!(
+            "scail2 mask/buffer size mismatch: mask has {} pixels, buffer holds {} \
+             (SAM3 mask resolution does not match the painted frame size)",
+            mask.len(),
+            px.len() / 3
+        )));
+    }
     for (p, &m) in mask.iter().enumerate() {
         if m > 0 {
             let o = p * 3;
@@ -70,12 +86,13 @@ fn paint(px: &mut [u8], mask: &[u8], color: [u8; 3]) {
             }
         }
     }
+    Ok(())
 }
 
 /// Paint the per-frame **driving** color masks: a solid `bg`, each tracked person filled its palette
 /// color. People are painted in left-to-right order so a right-neighbor overlap wins (the upstream
 /// paint order), keeping assignments deterministic. Returns one RGB mask per driving frame.
-pub(crate) fn paint_driving_masks(masks: &AllPersonMasks, bg: [u8; 3]) -> Vec<Image> {
+pub(crate) fn paint_driving_masks(masks: &AllPersonMasks, bg: [u8; 3]) -> WorkerResult<Vec<Image>> {
     let (w, h) = (masks.width as usize, masks.height as usize);
     masks
         .per_frame
@@ -87,14 +104,14 @@ pub(crate) fn paint_driving_masks(masks: &AllPersonMasks, bg: [u8; 3]) -> Vec<Im
                     continue;
                 };
                 if let Some((_, mask)) = frame.iter().find(|(o, _)| *o == oid) {
-                    paint(&mut px, mask, color);
+                    paint(&mut px, mask, color)?;
                 }
             }
-            Image {
+            Ok(Image {
                 width: masks.width,
                 height: masks.height,
                 pixels: px,
-            }
+            })
         })
         .collect()
 }
@@ -122,7 +139,7 @@ pub(crate) fn paint_reference_mask(masks: &AllPersonMasks, bg: [u8; 3]) -> Worke
             )
         })?;
     let mut px = filled(w, h, bg);
-    paint(&mut px, &primary.1, PALETTE[0]);
+    paint(&mut px, &primary.1, PALETTE[0])?;
     Ok(Image {
         width: masks.width,
         height: masks.height,
@@ -182,7 +199,7 @@ mod tests {
 
     #[test]
     fn driving_paints_palette_by_left_to_right_order_on_bg() {
-        let out = paint_driving_masks(&two_person_masks(), BG_BLACK);
+        let out = paint_driving_masks(&two_person_masks(), BG_BLACK).unwrap();
         assert_eq!(out.len(), 1);
         // pixel 0 = object 3 = order[0] = blue; pixel 1 = object 7 = order[1] = red.
         assert_eq!(&out[0].pixels[0..3], &PALETTE[0], "leftmost person → blue");
@@ -197,7 +214,7 @@ mod tests {
             width: 2,
             height: 1,
         };
-        let out = paint_driving_masks(&masks, BG_WHITE);
+        let out = paint_driving_masks(&masks, BG_WHITE).unwrap();
         assert_eq!(&out[0].pixels[0..3], &PALETTE[0], "person → blue");
         assert_eq!(&out[0].pixels[3..6], &BG_WHITE, "empty pixel → white bg");
     }
@@ -215,7 +232,7 @@ mod tests {
             width: 1,
             height: 1,
         };
-        let out = paint_driving_masks(&masks, BG_BLACK);
+        let out = paint_driving_masks(&masks, BG_BLACK).unwrap();
         assert_eq!(
             &out[0].pixels[0..3],
             &BG_BLACK,
@@ -242,6 +259,40 @@ mod tests {
             &out.pixels[3..6],
             &PALETTE[0],
             "largest person painted blue"
+        );
+    }
+
+    #[test]
+    fn driving_errors_on_mask_buffer_size_mismatch() {
+        // sc-8907 / F-105: a per-person SAM3 mask whose pixel count doesn't match the painted frame
+        // (declared 2x1 = 2 px, but the mask carries 3) is an upstream dimension bug — surface a
+        // typed error instead of silently painting a corrupted conditioning mask.
+        let masks = AllPersonMasks {
+            order: vec![1],
+            per_frame: vec![vec![(1, vec![255, 0, 255])]], // 3-px mask for a 2-px frame
+            width: 2,
+            height: 1,
+        };
+        let err = paint_driving_masks(&masks, BG_BLACK).unwrap_err();
+        assert!(
+            matches!(err, WorkerError::Engine(ref m) if m.contains("mask/buffer size mismatch")),
+            "expected a typed size-mismatch error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn reference_errors_on_mask_buffer_size_mismatch() {
+        // The reference painter shares the same guard: a mismatched primary-person mask errors.
+        let masks = AllPersonMasks {
+            order: vec![4],
+            per_frame: vec![vec![(4, vec![255, 255, 255, 255, 255])]], // 5-px mask for a 4-px frame
+            width: 4,
+            height: 1,
+        };
+        let err = paint_reference_mask(&masks, BG_WHITE).unwrap_err();
+        assert!(
+            matches!(err, WorkerError::Engine(ref m) if m.contains("mask/buffer size mismatch")),
+            "expected a typed size-mismatch error, got {err:?}"
         );
     }
 

--- a/crates/sceneworks-worker/src/segment_jobs.rs
+++ b/crates/sceneworks-worker/src/segment_jobs.rs
@@ -22,8 +22,6 @@ use std::path::{Path, PathBuf};
 
 use serde_json::{json, Value};
 
-use gen_core::CancelFlag;
-
 use crate::downloads::DownloadContext;
 use crate::person_segment_sam3::{
     ensure_segmenter_weights, segment_box_blocking, segment_points_blocking,
@@ -39,7 +37,6 @@ use sceneworks_core::project_store::ProjectStore;
 /// test): keep an instance when `σ(logit)·σ(presence) > THRESHOLD`, binarize its mask at `σ > MASK`.
 const SEGMENT_THRESHOLD: f32 = 0.5;
 const SEGMENT_MASK_THRESHOLD: f32 = 0.5;
-const CANCEL_MESSAGE: &str = "Smart-select canceled by user.";
 
 /// Resolve a `sourceAssetId` to its on-disk media path + the asset's `displayName` via the project
 /// sidecar (mirrors `upscale_jobs::resolve_source` / `image_adapters.find_asset_media_path`).
@@ -274,18 +271,27 @@ pub(crate) async fn run_image_segment_job(
         ),
     )
     .await?;
-    let cancel = CancelFlag::new();
     // The source read + full image decode is folded into each blocking task below (sc-8909 / F-107)
     // so it never stalls the async runtime thread; the task returns the decoded dimensions alongside
     // the mask so the `src_w*src_h` GrayImage can be built after.
     // Points → SAM3 tracker single-frame PVS (interactive clicks); box → SAM3 concept detector.
+    //
+    // Cancel is `None` by explicit per-engine decision (sc-8908 / F-106, mirroring the kps/SCRFD note
+    // at `run_blocking_with_heartbeat`): both `segment_points_blocking` and `segment_box_blocking` run
+    // ONE bounded SAM3 forward pass on ONE image (`Sam3Tracker::segment_points` /
+    // `Sam3ImageSegmenter::segment_with_boxes` at the pinned mlx-gen rev take no cancel flag and have
+    // no per-step/per-frame loop for a flag to poll — unlike the video `propagate` path, which does
+    // thread one). A flag here could only be tripped BEFORE the compute starts, which the bounded join
+    // already covers, so passing a `Some(flag)` that the engine never reads was a no-op that merely
+    // read as if the compute were cancelable. Threading a real flag would require a new engine seam for
+    // zero cancellation benefit, so we drop the un-trippable flag instead.
     let (mask, src_w, src_h) = if let Some(points) = points {
         run_blocking_with_heartbeat(
             api,
             settings,
             &job.id,
-            Some(cancel.clone()),
-            CANCEL_MESSAGE,
+            None,
+            "",
             "smart-select task",
             tokio::task::spawn_blocking(move || {
                 let source_image = crate::image_decode::decode_image_any(&source_path)
@@ -307,8 +313,8 @@ pub(crate) async fn run_image_segment_job(
             api,
             settings,
             &job.id,
-            Some(cancel.clone()),
-            CANCEL_MESSAGE,
+            None,
+            "",
             "smart-select task",
             tokio::task::spawn_blocking(move || {
                 let source_image = crate::image_decode::decode_image_any(&source_path)

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -4253,6 +4253,52 @@ async fn run_blocking_with_heartbeat_waits_for_blocking_task_winddown_on_post_fa
     );
 }
 
+/// sc-8908 (F-106) — the smart-select SAM3 image ops (box/points) pass `None` for `cancel` by
+/// explicit per-engine decision: each is one bounded SAM3 forward pass on one image with no
+/// per-step loop for a flag to poll, so there is no seam a `Some(flag)` could interrupt. This test
+/// locks the `None`-path contract the decision relies on: a bounded single-shot blocking task run
+/// with `cancel = None` resolves to its value, and (unlike the `Some(flag)` paths) the consumer
+/// never consults the cancel poll — so no "canceled" is ever posted even mid-run. If someone
+/// re-adds a `Some(flag)` that the SAM3 engine can't read, this stays green but the flag is a no-op
+/// (the F-106 finding); the guard against that is the documented `None`-caller list at the
+/// `run_blocking_with_heartbeat` definition, kept in sync with this call site.
+#[tokio::test]
+async fn run_blocking_with_heartbeat_none_cancel_returns_single_shot_value() {
+    let (base_url, posts) = spawn_no_user_cancel_capture_stub().await;
+    let mut settings = test_settings(base_url.clone(), None);
+    settings.api_url = base_url;
+    settings.heartbeat_seconds = 5;
+    let api = ApiClient::new(&settings);
+
+    // A bounded single-shot blocking task, the smart-select SAM3 shape: one forward pass, returns a
+    // value, no cancel flag consulted.
+    let task = tokio::task::spawn_blocking(|| Ok::<u32, WorkerError>(42));
+    let result = crate::run_blocking_with_heartbeat(
+        &api,
+        &settings,
+        "job-1",
+        None,
+        "",
+        "smart-select none-cancel test task",
+        task,
+    )
+    .await;
+
+    assert_eq!(
+        result.expect("the None-cancel single-shot task resolves to its value"),
+        42
+    );
+    // No terminal "canceled" progress was posted — the None path never consults the cancel poll.
+    let posted = posts.lock().expect("posts lock");
+    assert!(
+        posted.iter().all(|body| body
+            .get("status")
+            .and_then(Value::as_str)
+            .is_none_or(|s| s != "canceled")),
+        "the None-cancel path must never post a terminal canceled status"
+    );
+}
+
 /// sc-8804 (F-003) — the child-process leg: `run_ffmpeg` (media_jobs) and the `hf` CLI download
 /// (model_jobs) build their `tokio::process::Command` with `kill_on_drop(true)` so a
 /// heartbeat/cancel `?` early return reaps the child instead of leaving ffmpeg/`hf` writing partial

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -4269,10 +4269,7 @@ async fn resolve_candle_scail2_conditioning(
                     tracing::debug!(event = "scail2_sam3_propagate_progress", frame, total);
                 })),
             )?;
-            Ok(crate::scail2_masks::paint_driving_masks(
-                &masks,
-                crate::scail2_masks::BG_BLACK,
-            ))
+            crate::scail2_masks::paint_driving_masks(&masks, crate::scail2_masks::BG_BLACK)
         },
     )
     .await
@@ -5170,10 +5167,7 @@ async fn resolve_scail2_conditioning(
                     tracing::debug!(event = "scail2_sam3_propagate_progress", frame, total);
                 })),
             )?;
-            Ok(crate::scail2_masks::paint_driving_masks(
-                &masks,
-                crate::scail2_masks::BG_BLACK,
-            ))
+            crate::scail2_masks::paint_driving_masks(&masks, crate::scail2_masks::BG_BLACK)
         },
     )
     .await


### PR DESCRIPTION
Code-review remediation batch 4 (epic 8800, label `code-review-2026-07-01`). Five findings in `crates/sceneworks-worker`, one commit each.

## Stories

- **sc-8876 [F-074]** (security) — `person_replace::load_track_masks` joined the sidecar `mask` string onto `project_path` verbatim, so an absolute/`..` value read an arbitrary image outside the project (arbitrary-file-read over the LAN jobs API). Confined with `safe_project_path` (Component::Normal-only); a rejected path warns and degrades to a box mask.
- **sc-8902 [F-100]** (bug) — the same loader `?`-propagated a decode failure of a stored mask, failing the whole replace-person job while a *missing* mask already falls back to a box mask. Now a corrupt/undecodable mask warns and degrades to a box mask for that frame (counted as box-derived, so the reported mode stays honest).
- **sc-8907 [F-105]** (bug) — `scail2_masks::paint` silently ignored a mask longer/shorter than the `w*h` buffer, corrupting the color-coded conditioning on an upstream SAM3 dimension bug. Now returns a typed `WorkerError::Engine` on `mask.len() != px.len()/3` (per-pixel guard kept as defense in depth); propagated through `paint_driving_masks`/`paint_reference_mask` and the two video_jobs closures + gpu-smoke helper.
- **sc-8908 [F-106]** (bug) — `segment_jobs` created a `CancelFlag` the SAM3 image ops never read. At the pinned mlx-gen rev, `segment_points`/`segment_with_boxes` are single bounded forward passes with no cancel seam and no per-step loop (unlike the video `propagate` path), so wiring a real flag is not feasible and buys nothing over the bounded join. Dropped the un-trippable flag (pass `None`), matching the sibling single-shot detectors, and added smart-select SAM3 to the canonical `None`-caller list at `run_blocking_with_heartbeat`.
- **sc-8910 [F-108]** (efficiency) — every `kps_extract` re-read the ~100+ MB SCRFD weights and rebuilt the model. Now mirrors the sibling caches: `Weights` cached process-wide (`OnceLock<Mutex<Option<…>>>`, poison-recovery) + the built `Scrfd` cached per blocking thread (`thread_local!`, it embeds an `Rc` → `!Send`); the off-Mac candle `CandleFaceAnalysis` cached thread-local by dir.

## Tests

- `person_replace`: added confinement test (`../secret/leak.png` blocked → box mask), corrupt-mask degrade test, and mixed good+corrupt mode test.
- `scail2_masks`: added mask/buffer size-mismatch error tests for both `paint_driving_masks` and `paint_reference_mask`.
- `segment_jobs`/progress: added a `None`-cancel single-shot contract test (value returns; no terminal canceled ever posted).
- `kps_jobs`: the macOS + candle real-weights smoke tests now run a second extraction and assert byte-identical landmarks (cache reuse is transparent).

## Verification

- `cargo fmt --all -- --check`: clean
- `cargo clippy -p sceneworks-worker --all-targets -- -D warnings`: clean
- `cargo test -p sceneworks-worker --lib`: 600 passed, 0 failed
- candle parity: `cargo check -p sceneworks-worker --no-default-features -F backend-candle --all-targets`: clean
- gen-core skew gate (`check-gen-core-skew.sh --features backend-candle`): one resolution (no pins changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)