### PR TITLE
fix: test-infra honesty + rust-api validation/caching (epic 8800 batch C1)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -73,8 +73,15 @@ jobs:
       - name: Build Rust API before contract tests
         run: cargo build -q -p sceneworks-rust-api
       - name: Run end-to-end job pipeline test
+        # tests/conftest.py fails this gate (via `require_tool` + an all-skipped
+        # session guard) if `CI` is set and every collected test skips -- e.g. a
+        # future change dropping the cargo toolchain would otherwise turn the gate
+        # into a silent green no-op. GitHub Actions sets CI=true automatically
+        # (sc-8935 / F-133).
         run: python -m pytest -q -m e2e --strict-markers
       - name: Run Rust API contract snapshot tests
+        # Same all-skipped guard as the e2e step: a parity run that exercised
+        # nothing fails instead of reporting success (sc-8935 / F-133).
         run: python -m pytest -q -m parity --strict-markers
       - name: Smoke default Rust API Docker runtime
         run: npm run check:docker:rust-api

--- a/crates/sceneworks-core/src/character_store.rs
+++ b/crates/sceneworks-core/src/character_store.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, UNIX_EPOCH};
@@ -7,7 +8,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 
 use crate::asset_index::{
-    find_asset_sidecar_path_on_connection, index_asset_on_connection, normalize_asset,
+    find_asset_sidecar_path_on_connection, index_asset_on_connection, normalize_asset_cached,
+    GenerationSetCache,
 };
 use crate::contracts;
 use crate::project_store::{apply_project_migrations, ProjectStoreError, ProjectStoreResult};
@@ -119,6 +121,10 @@ impl<'a> CharacterStore<'a> {
             .query_map([], |row| row.get::<_, String>(0))?
             .collect::<Result<Vec<_>, _>>()?;
 
+        // One connection + asset-summary memo shared across the whole listing, so
+        // an asset referenced by several characters is resolved once rather than
+        // once per (character, reference) pair (sc-8894 / F-092).
+        let mut cache = CharacterHydrationCache::new(&self.project_path)?;
         let mut characters = Vec::new();
         for sidecar_rel in rows {
             let sidecar_path = self.project_path.join(sidecar_rel);
@@ -136,10 +142,11 @@ impl<'a> CharacterStore<'a> {
             {
                 continue;
             }
-            characters.push(hydrate_character(
+            characters.push(hydrate_character_cached(
                 project_id,
                 &self.project_path,
                 character,
+                &mut cache,
             )?);
         }
         characters.sort_by(|left, right| {
@@ -1089,7 +1096,67 @@ fn write_character(
 fn hydrate_character(
     project_id: &str,
     project_path: &Path,
+    character: Value,
+) -> ProjectStoreResult<Value> {
+    // A single connection + caches shared across every reference of this
+    // character, and (via `list_characters`, which threads the same maps)
+    // across every character in a listing. `character_asset_summary`
+    // previously opened a fresh SQLite connection (+ ran migrations) and
+    // re-read the sidecar per reference, so a Character Studio listing was
+    // O(characters x references) connections and sidecar reads (sc-8894 /
+    // F-092).
+    let mut cache = CharacterHydrationCache::new(project_path)?;
+    hydrate_character_cached(project_id, project_path, character, &mut cache)
+}
+
+/// Per-listing caches shared by every `hydrate_character` call so a batch
+/// listing opens the project DB once, applies migrations once, and reads each
+/// referenced asset's sidecar at most once regardless of how many characters or
+/// references point at it (sc-8894 / F-092).
+struct CharacterHydrationCache {
+    connection: Connection,
+    generation_sets: GenerationSetCache,
+    /// asset id -> resolved summary (`None` when the asset has no sidecar), so a
+    /// repeated asset id across references/characters is resolved once.
+    asset_summaries: HashMap<String, Option<Value>>,
+}
+
+impl CharacterHydrationCache {
+    fn new(project_path: &Path) -> ProjectStoreResult<Self> {
+        Ok(Self {
+            connection: connect_project_db(project_path)?,
+            generation_sets: GenerationSetCache::default(),
+            asset_summaries: HashMap::new(),
+        })
+    }
+
+    fn asset_summary(
+        &mut self,
+        project_id: &str,
+        project_path: &Path,
+        asset_id: &str,
+    ) -> ProjectStoreResult<Option<Value>> {
+        if let Some(summary) = self.asset_summaries.get(asset_id) {
+            return Ok(summary.clone());
+        }
+        let summary = character_asset_summary(
+            &self.connection,
+            &mut self.generation_sets,
+            project_id,
+            project_path,
+            asset_id,
+        )?;
+        self.asset_summaries
+            .insert(asset_id.to_owned(), summary.clone());
+        Ok(summary)
+    }
+}
+
+fn hydrate_character_cached(
+    project_id: &str,
+    project_path: &Path,
     mut character: Value,
+    cache: &mut CharacterHydrationCache,
 ) -> ProjectStoreResult<Value> {
     let references = character
         .get("references")
@@ -1102,7 +1169,8 @@ fn hydrate_character(
                 .get("assetId")
                 .and_then(Value::as_str)
                 .and_then(|asset_id| {
-                    character_asset_summary(project_id, project_path, asset_id)
+                    cache
+                        .asset_summary(project_id, project_path, asset_id)
                         .ok()
                         .flatten()
                 })
@@ -1133,14 +1201,18 @@ fn hydrate_character(
 }
 
 fn character_asset_summary(
+    connection: &Connection,
+    generation_sets: &mut GenerationSetCache,
     project_id: &str,
     project_path: &Path,
     asset_id: &str,
 ) -> ProjectStoreResult<Option<Value>> {
-    let Some(sidecar_path) = find_asset_sidecar_path(project_path, asset_id)? else {
+    let Some(sidecar_path) =
+        find_asset_sidecar_path_on_connection(connection, project_path, asset_id)?
+    else {
         return Ok(None);
     };
-    let asset = normalize_asset(project_id, project_path, &sidecar_path)?;
+    let asset = normalize_asset_cached(project_id, project_path, &sidecar_path, generation_sets)?;
     Ok(Some(json!({
         "id": asset.get("id").cloned().unwrap_or(Value::Null),
         "type": asset.get("type").cloned().unwrap_or(Value::Null),
@@ -1237,16 +1309,6 @@ fn remove_asset_references_from_character(
     }
 
     Ok(changed)
-}
-
-/// Thin DB-prep wrapper over the shared resolver in `asset_index` (sc-4272).
-fn find_asset_sidecar_path(
-    project_path: &Path,
-    asset_id: &str,
-) -> ProjectStoreResult<Option<PathBuf>> {
-    let connection = connect_project_db(project_path)?;
-    apply_project_migrations(&connection)?;
-    find_asset_sidecar_path_on_connection(&connection, project_path, asset_id)
 }
 
 fn copy_lora_into_project(
@@ -1600,5 +1662,190 @@ mod tests {
                 .unwrap_or_else(|| panic!("missing top-level key {key} after position {cursor}"));
             cursor += found + key.len();
         }
+    }
+
+    /// sc-8894 (F-092): the per-listing cache resolves an asset summary once and
+    /// serves every later lookup of the same id (across references and
+    /// characters) from memory instead of re-opening the DB + re-reading the
+    /// sidecar. Both a present asset and a missing one (cached as `None`) hit the
+    /// memo on the second lookup.
+    #[test]
+    fn hydration_cache_memoizes_repeated_asset_summaries() {
+        use crate::project_store::ProjectStore;
+
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let data_dir = temp_dir.path().join("data");
+        let store = ProjectStore::new(&data_dir, "test-version");
+        let project = store.create_project("Cache").expect("project creates");
+        let project_path = PathBuf::from(&project.path);
+
+        let asset = store
+            .persist_generated_asset(
+                &project.id,
+                "job-1",
+                "genset_x",
+                &json!({
+                    "assetId": "asset_shared1",
+                    "mediaPath": "assets/images/genset_x/asset_shared1.png",
+                    "mimeType": "image/png",
+                    "width": 64,
+                    "height": 64,
+                    "normalizedWidth": 64,
+                    "normalizedHeight": 64,
+                    "count": 1,
+                    "family": "z-image",
+                    "seed": 1,
+                    "index": 0,
+                    "displayName": "shared #1",
+                    "createdAt": "2026-07-03T00:00:00Z",
+                    "mode": "text_to_image",
+                    "model": "z_image_turbo",
+                    "adapter": "z_image_diffusers",
+                    "prompt": "x",
+                    "loras": [],
+                }),
+            )
+            .expect("asset persists");
+        let asset_id = asset["id"].as_str().expect("asset id").to_owned();
+
+        let mut cache = CharacterHydrationCache::new(&project_path).expect("cache opens");
+
+        // First lookup resolves + memoizes; the summary carries the sidecar facts.
+        let first = cache
+            .asset_summary(&project.id, &project_path, &asset_id)
+            .expect("first lookup")
+            .expect("asset resolves to a summary");
+        assert_eq!(first["id"], json!(asset_id));
+        assert_eq!(first["type"], json!("image"));
+        assert_eq!(first["displayName"], json!("shared #1"));
+        assert_eq!(cache.asset_summaries.len(), 1);
+
+        // Second lookup of the same id is served from the memo, byte-identical.
+        let second = cache
+            .asset_summary(&project.id, &project_path, &asset_id)
+            .expect("second lookup")
+            .expect("asset still resolves");
+        assert_eq!(first, second);
+        assert_eq!(
+            cache.asset_summaries.len(),
+            1,
+            "no new memo entry on a repeat"
+        );
+
+        // A missing asset caches its `None` so a repeated miss is also memoized.
+        assert!(cache
+            .asset_summary(&project.id, &project_path, "asset_absent")
+            .expect("miss lookup")
+            .is_none());
+        assert_eq!(cache.asset_summaries.len(), 2);
+        assert!(cache
+            .asset_summary(&project.id, &project_path, "asset_absent")
+            .expect("repeat miss lookup")
+            .is_none());
+        assert_eq!(
+            cache.asset_summaries.len(),
+            2,
+            "no new memo entry on a repeat miss"
+        );
+    }
+
+    /// sc-8894 (F-092): the caching refactor is behavior-preserving — two
+    /// characters referencing the SAME asset each get the identical hydrated
+    /// `asset` summary through the public `list_characters` (which now shares one
+    /// cache), and `get_character` produces the same summary.
+    #[test]
+    fn list_characters_hydrates_shared_asset_reference_consistently() {
+        use crate::project_store::ProjectStore;
+
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let data_dir = temp_dir.path().join("data");
+        let store = ProjectStore::new(&data_dir, "test-version");
+        let project = store.create_project("Shared Ref").expect("project creates");
+        let project_path = PathBuf::from(&project.path);
+
+        let asset = store
+            .persist_generated_asset(
+                &project.id,
+                "job-1",
+                "genset_x",
+                &json!({
+                    "assetId": "asset_shared2",
+                    "mediaPath": "assets/images/genset_x/asset_shared2.png",
+                    "mimeType": "image/png",
+                    "width": 64,
+                    "height": 64,
+                    "normalizedWidth": 64,
+                    "normalizedHeight": 64,
+                    "count": 1,
+                    "family": "z-image",
+                    "seed": 1,
+                    "index": 0,
+                    "displayName": "shared #2",
+                    "createdAt": "2026-07-03T00:00:00Z",
+                    "mode": "text_to_image",
+                    "model": "z_image_turbo",
+                    "adapter": "z_image_diffusers",
+                    "prompt": "x",
+                    "loras": [],
+                }),
+            )
+            .expect("asset persists");
+        let asset_id = asset["id"].as_str().expect("asset id").to_owned();
+
+        let characters = CharacterStore::new(&data_dir, &project_path);
+        let mut ids = Vec::new();
+        for name in ["Ada", "Bea"] {
+            let created = characters
+                .create_character(
+                    &project.id,
+                    CharacterCreateInput {
+                        name: name.to_owned(),
+                        character_type: "person".to_owned(),
+                        description: String::new(),
+                    },
+                )
+                .expect("character creates");
+            let character_id = created["id"].as_str().expect("character id").to_owned();
+            characters
+                .add_reference(
+                    &project.id,
+                    &character_id,
+                    CharacterReferenceInput {
+                        asset_id: asset_id.clone(),
+                        approved: true,
+                        role: "hero".to_owned(),
+                        notes: String::new(),
+                    },
+                )
+                .expect("reference attaches");
+            ids.push(character_id);
+        }
+
+        let listed = characters
+            .list_characters(&project.id, false)
+            .expect("list hydrates");
+        assert_eq!(listed.len(), 2);
+        for character in &listed {
+            let reference = &character["references"][0];
+            assert_eq!(reference["assetId"], json!(asset_id));
+            let summary = &reference["asset"];
+            assert_eq!(summary["id"], json!(asset_id));
+            assert_eq!(summary["type"], json!("image"));
+            assert_eq!(summary["displayName"], json!("shared #2"));
+        }
+        // Both characters resolved the SAME shared asset to an identical summary.
+        assert_eq!(
+            listed[0]["references"][0]["asset"],
+            listed[1]["references"][0]["asset"]
+        );
+
+        // `get_character` (single-character path) yields the same summary.
+        let single = characters
+            .get_character(&project.id, &ids[0])
+            .expect("get hydrates");
+        assert_eq!(
+            single["references"][0]["asset"],
+            listed[0]["references"][0]["asset"]
+        );
     }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
+
+import pytest
 
 
 # The retired Python worker's test suite (16 `tests/test_worker_*.py` /
@@ -12,3 +15,75 @@ from pathlib import Path
 # audits, the convert-script unit test) only need `packages/shared` on the path.
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "packages" / "shared"))
+
+
+def running_in_ci() -> bool:
+    """GitHub Actions (and most CI providers) set ``CI=true``."""
+    return os.getenv("CI", "").strip().lower() in {"1", "true", "yes"}
+
+
+# The CI gate steps this guard protects run a single marker at a time
+# (`-m e2e`, `-m parity`). We only enforce "must not be all-skipped" for those,
+# so the light-dep default lane and local ad-hoc filtered runs are unaffected.
+_GUARDED_MARKERS = ("e2e", "parity")
+
+
+def _guarded_marker(config: pytest.Config) -> str | None:
+    markexpr = str(getattr(config.option, "markexpr", "") or "")
+    for marker in _GUARDED_MARKERS:
+        # Match the CI invocation `-m e2e` / `-m parity` (not `not e2e`).
+        if markexpr.strip() == marker:
+            return marker
+    return None
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    """Fail an e2e/parity CI gate that exercised nothing.
+
+    pytest exits 0 when every collected test skips, so a future workflow change
+    that dropped the required toolchain (cargo, ffmpeg, ...) would turn one of
+    these gates into a silent no-op that still reports success. In CI, require
+    at least one collected test in a guarded gate to actually run (sc-8935 /
+    F-133). Individual fixtures also upgrade a missing-cargo skip to a failure
+    via `require_tool`, so this is defense in depth for any other skip source.
+    """
+    if not running_in_ci():
+        return
+    marker = _guarded_marker(session.config)
+    if marker is None:
+        return
+    # Nothing collected (e.g. no test file matched) is a separate signal handled
+    # by pytest's own exit code 5; only guard the all-skipped case here.
+    collected = getattr(session, "testscollected", 0)
+    if collected == 0:
+        return
+    reporter = session.config.pluginmanager.get_plugin("terminalreporter")
+    ran = 0
+    if reporter is not None:
+        ran = len(reporter.stats.get("passed", [])) + len(reporter.stats.get("failed", []))
+        ran += len(reporter.stats.get("error", []))
+    if ran == 0:
+        session.exitstatus = pytest.ExitCode.TESTS_FAILED
+        reporter = session.config.pluginmanager.get_plugin("terminalreporter")
+        if reporter is not None:
+            reporter.write_line(
+                f"ERROR: the `-m {marker}` CI gate collected {collected} test(s) but ran none "
+                "(all skipped) -- the required toolchain is missing, so this gate exercised "
+                "nothing. Failing instead of reporting a silent green (sc-8935 / F-133).",
+                red=True,
+            )
+
+
+def require_tool(name: str, purpose: str) -> None:
+    """Guard a test on an external tool: fail in CI (where the toolchain is
+    provisioned by earlier workflow steps, so a miss means the workflow broke),
+    skip locally (so a developer without the tool isn't blocked). This keeps a
+    dropped CI toolchain from silently no-op'ing the e2e gate (sc-8935 / F-133)."""
+    import shutil
+
+    if shutil.which(name) is not None:
+        return
+    message = f"{name} is required for {purpose}"
+    if running_in_ci():
+        pytest.fail(f"{message} but is missing in CI -- the workflow toolchain regressed.")
+    pytest.skip(message)

--- a/tests/rust_api_harness.py
+++ b/tests/rust_api_harness.py
@@ -1,0 +1,78 @@
+"""Shared helpers for the live Rust API test files (sc-8934 / F-132).
+
+`test_rust_api_worker_smoke.py` (e2e) and `test_rust_api_contract_snapshots.py`
+(parity) both spawn the real `sceneworks-rust-api` binary and drive it over HTTP.
+They previously kept copy-pasted `free_port` / `wait_for_health` / PNG / safetensors
+builders that had already drifted -- one copy carried a corrupt `PNG_1X1` (a stray
+`\\x01` before the IHDR CRC made it undecodable). This module is the single source
+of truth for those fixtures so they can't diverge again.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import subprocess
+import time
+
+import httpx
+
+# A minimal, fully valid 1x1 8-bit RGB PNG. Every chunk CRC is correct
+# (IHDR 907753de, IDAT 33129514, IEND ae426082), unlike the corrupt copy this
+# replaces. The Rust API does not currently decode uploaded images, but pinning
+# the upload contract to a decodable PNG keeps the fixture honest if validation
+# is ever added.
+PNG_1X1 = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\x0cIDATx\xdac\xf8\xff\xff?"
+    b"\x00\x05\xfe\x02\xfe3\x12\x95\x14\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+
+def free_port() -> int:
+    """Bind an ephemeral loopback port and hand back its number for the API."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def safetensors_bytes() -> bytes:
+    """A valid safetensors payload: 8-byte little-endian header length + a JSON
+    header + a small tensor body. The LoRA import path inspects the header for
+    architecture detection, so a stub like ``b"lora"`` is rejected with an
+    invalid-header 400. The trailing body lets copy round-trip assertions compare
+    against the exact bytes."""
+    header = json.dumps({"__metadata__": {"format": "pt"}}, separators=(",", ":")).encode("utf-8")
+    return len(header).to_bytes(8, "little") + header + b"tensor-bytes"
+
+
+# Historical alias used by the e2e smoke file; kept so both files share one impl.
+minimal_safetensors = safetensors_bytes
+
+
+def wait_for_health(
+    base_url: str,
+    process: subprocess.Popen,
+    runtime: str = "rust",
+    timeout_seconds: float = 30.0,
+) -> None:
+    """Poll ``/api/v1/health`` until the spawned API answers 200, surfacing an
+    early exit (with captured stderr) instead of hanging until the deadline."""
+    deadline = time.monotonic() + timeout_seconds
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            stderr = process.stderr.read() if process.stderr else ""
+            raise AssertionError(
+                f"{runtime} API exited early with code {process.returncode}: {stderr}"
+            )
+        try:
+            response = httpx.get(f"{base_url}/api/v1/health", timeout=1)
+            if response.status_code == 200:
+                return
+        except httpx.HTTPError as exc:
+            last_error = exc
+        time.sleep(0.25)
+    raise AssertionError(
+        f"{runtime} API did not become healthy within {timeout_seconds:.0f}s: {last_error}"
+    )

--- a/tests/test_rust_api_contract_snapshots.py
+++ b/tests/test_rust_api_contract_snapshots.py
@@ -4,10 +4,8 @@ import atexit
 import json
 import os
 import re
-import socket
 import sqlite3
 import subprocess
-import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
@@ -15,6 +13,11 @@ from typing import Any
 
 import httpx
 import pytest
+
+# Shared, corruption-free fixtures (sc-8934 / F-132): the PNG + safetensors
+# builder and the API-spawn helpers used to be copy-pasted (and had drifted)
+# between this file and test_rust_api_worker_smoke.py.
+from rust_api_harness import PNG_1X1, free_port, safetensors_bytes, wait_for_health
 
 
 pytestmark = pytest.mark.parity
@@ -30,17 +33,6 @@ UPDATE_SNAPSHOTS = os.getenv(
     "yes",
 }
 UPDATED_SNAPSHOTS: dict[str, Any] = {}
-PNG_1X1 = (
-    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"
-    b"\x00\x00\x00\x01\x08\x02\x00\x00\x00\x01\x90wS\xde"
-    b"\x00\x00\x00\x0cIDAT\x08\xd7c\xf8\xff\xff?\x00\x05\xfe"
-    b"\x02\xfeA\xe2&\x9b\x00\x00\x00\x00IEND\xaeB`\x82"
-)
-
-
-def safetensors_bytes() -> bytes:
-    header = json.dumps({"__metadata__": {"format": "pt"}}, separators=(",", ":")).encode("utf-8")
-    return len(header).to_bytes(8, "little") + header + b"tensor-bytes"
 
 
 TIMESTAMP_RE = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z")
@@ -76,12 +68,6 @@ def write_updated_snapshots() -> None:
 
 
 atexit.register(write_updated_snapshots)
-
-
-def free_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(("127.0.0.1", 0))
-        return int(sock.getsockname()[1])
 
 
 def write_contract_manifests(config_dir: Path) -> None:
@@ -173,23 +159,6 @@ def write_contract_manifests(config_dir: Path) -> None:
         '{ "schemaVersion": 1, "loras": [] }\n',
         encoding="utf-8",
     )
-
-
-def wait_for_health(base_url: str, process: subprocess.Popen[str], runtime: str) -> None:
-    deadline = time.monotonic() + 30
-    last_error: Exception | None = None
-    while time.monotonic() < deadline:
-        if process.poll() is not None:
-            stderr = process.stderr.read() if process.stderr else ""
-            raise AssertionError(f"{runtime} API exited early with code {process.returncode}: {stderr}")
-        try:
-            response = httpx.get(f"{base_url}/api/v1/health", timeout=1)
-            if response.status_code == 200:
-                return
-        except httpx.HTTPError as exc:
-            last_error = exc
-        time.sleep(0.25)
-    raise AssertionError(f"{runtime} API did not become healthy within 30s: {last_error}")
 
 
 def parse_response_body(response: httpx.Response) -> Any:

--- a/tests/test_rust_api_worker_smoke.py
+++ b/tests/test_rust_api_worker_smoke.py
@@ -11,6 +11,10 @@ from uuid import uuid4
 import httpx
 import pytest
 
+# In CI a missing cargo means the workflow toolchain regressed, so `require_tool`
+# fails the e2e gate instead of letting it skip to a silent green (sc-8935 / F-133).
+from conftest import require_tool
+
 # Shared, corruption-free fixtures (sc-8934 / F-132): PNG + safetensors builders
 # and the API-spawn helpers, previously copy-pasted (and drifted) between this
 # file and test_rust_api_contract_snapshots.py.
@@ -209,8 +213,7 @@ def wait_for_job_status(base_url: str, job_id: str, status: str, process: subpro
 
 @pytest.fixture()
 def rust_api(tmp_path):
-    if shutil.which("cargo") is None:
-        pytest.skip("cargo is required for the Rust API smoke test")
+    require_tool("cargo", "the Rust API smoke test")
 
     port = free_port()
     base_url = f"http://127.0.0.1:{port}"
@@ -473,8 +476,7 @@ def test_character_image_angle_and_pose_sets_carry_loras_through_worker(rust_api
 
 
 def test_rust_worker_claims_and_completes_lora_import_against_rust_api_binary(rust_api, tmp_path):
-    if shutil.which("cargo") is None:
-        pytest.skip("cargo is required for the Rust worker smoke test")
+    require_tool("cargo", "the Rust worker smoke test")
 
     # The Rust API only imports a sourcePath from app-managed roots (data/loras,
     # project loras, or staged uploads) for path safety; stage the source inside
@@ -531,8 +533,11 @@ def test_rust_worker_claims_and_completes_lora_import_against_rust_api_binary(ru
 
 
 def test_rust_worker_completes_ffmpeg_frame_and_timeline_jobs_against_rust_api_binary(rust_api, tmp_path):
-    if shutil.which("cargo") is None:
-        pytest.skip("cargo is required for the Rust worker smoke test")
+    require_tool("cargo", "the Rust worker smoke test")
+    # ffmpeg is intentionally NOT provisioned in the `check.yml` CI (only in the
+    # desktop/release packaging workflows), so this stays a plain skip: it must not
+    # red the e2e gate. The all-skipped guard in conftest still fires if cargo (and
+    # thus every other e2e test) also went missing (sc-8935 / F-133).
     if shutil.which("ffmpeg") is None:
         pytest.skip("ffmpeg is required for the FFmpeg worker smoke test")
 

--- a/tests/test_rust_api_worker_smoke.py
+++ b/tests/test_rust_api_worker_smoke.py
@@ -4,13 +4,22 @@ import json
 import os
 from pathlib import Path
 import shutil
-import socket
 import subprocess
 import time
 from uuid import uuid4
 
 import httpx
 import pytest
+
+# Shared, corruption-free fixtures (sc-8934 / F-132): PNG + safetensors builders
+# and the API-spawn helpers, previously copy-pasted (and drifted) between this
+# file and test_rust_api_contract_snapshots.py.
+from rust_api_harness import (
+    PNG_1X1,
+    free_port,
+    minimal_safetensors as _minimal_safetensors,
+    wait_for_health,
+)
 
 # sc-8861 (F-059): these e2e tests used to drive the live Rust API via
 # `scene_worker.runtime.ApiClient` and run the image pipeline with the in-process
@@ -178,44 +187,6 @@ def complete_image_job(
 
 
 ROOT = Path(__file__).resolve().parents[1]
-
-
-def _minimal_safetensors() -> bytes:
-    # Smallest valid safetensors: 8-byte little-endian header length + JSON header.
-    # The import path inspects this header for architecture detection, so a stub
-    # like b"lora" is rejected with an invalid-header 400.
-    header = b'{"__metadata__":{"format":"pt"}}'
-    return len(header).to_bytes(8, "little") + header
-
-
-PNG_1X1 = (
-    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"
-    b"\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde\x00"
-    b"\x00\x00\x0cIDAT\x08\xd7c\xf8\xff\xff?\x00\x05\xfe"
-    b"\x02\xfeA\xe2&\x9b\x00\x00\x00\x00IEND\xaeB`\x82"
-)
-
-
-def free_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(("127.0.0.1", 0))
-        return int(sock.getsockname()[1])
-
-
-def wait_for_health(base_url: str, process: subprocess.Popen) -> None:
-    deadline = time.monotonic() + 30
-    last_error: Exception | None = None
-    while time.monotonic() < deadline:
-        if process.poll() is not None:
-            raise AssertionError(f"Rust API exited early with code {process.returncode}")
-        try:
-            response = httpx.get(f"{base_url}/api/v1/health", timeout=1)
-            if response.status_code == 200:
-                return
-        except httpx.HTTPError as exc:
-            last_error = exc
-        time.sleep(0.25)
-    raise AssertionError(f"Rust API did not become healthy: {last_error}")
 
 
 def wait_for_job_status(base_url: str, job_id: str, status: str, process: subprocess.Popen) -> dict:


### PR DESCRIPTION
Code-review remediation batch (epic 8800, code-review-2026-07-01). Five stories; three needed work, two were already resolved on `main`.

## Stories

### sc-8894 [F-092] Cache asset-summary lookups when hydrating character references (chore/efficiency)
`hydrate_character` called `character_asset_summary` per reference, each opening a **new** SQLite connection (+`apply_project_migrations`) and re-reading the sidecar, so a Character Studio listing was O(characters × references) connections + sidecar reads. Added a per-listing `CharacterHydrationCache` (one connection, shared `GenerationSetCache`, and an asset-id → summary memo including cached misses). `list_characters` now threads a single cache across every character; `get_character` uses a one-shot cache. Behavior-preserving. Removed the now-dead `find_asset_sidecar_path` wrapper.
- Tests: `hydration_cache_memoizes_repeated_asset_summaries` (memo hits for present + missing assets), `list_characters_hydrates_shared_asset_reference_consistently` (two characters sharing one asset get the identical hydrated summary; `get_character` matches).

### sc-8934 [F-132] Corrupt PNG fixture + duplicated harness in the live API test files (bug/test)
`test_rust_api_contract_snapshots.py`'s `PNG_1X1` had a stray `\x01` before the IHDR CRC (stored `01907753` vs correct `907753de`) — an undecodable PNG posted by every asset-upload parity test. The `free_port`/`wait_for_health`/PNG/safetensors builders were also copy-pasted (and drifted) between the parity and e2e files. Added `tests/rust_api_harness.py` as the single source of truth (a valid 1×1 PNG with all chunk CRCs verified + the spawn helpers), imported explicitly by both live test files.
- Verified: full parity suite (12 passed) and e2e suite (4 passed, 1 ffmpeg-skip) green against the built API. The upload snapshot is unchanged — the API does not decode uploaded image bytes (`file.width/height` stay `null`), so no regeneration was needed.

### sc-8935 [F-133] e2e/parity gates pass green if all tests skip; star-import shared harness (bug/test)
pytest exits 0 when every collected test skips, so a future workflow change dropping the toolchain (cargo) would turn the `-m e2e`/`-m parity` gates into silent green no-ops. Routed the e2e cargo skips through a `require_tool` helper that **fails in CI** (toolchain is provisioned by earlier steps, so a miss = workflow regression) while still skipping locally, plus a `conftest.pytest_sessionfinish` guard that fails a guarded gate in CI if tests were collected but none ran. `ffmpeg` stays a plain skip (intentionally not provisioned in `check.yml`); a legitimate ffmpeg-only skip with cargo present still passes. `check.yml` gets documenting comments only (run commands unchanged; YAML re-validated).
- **Star-import part already resolved**: `worker_runtime_shared.py` and every `import *` file were deleted in sc-8863; the new harness uses explicit imports.
- Verified: all-skip e2e/parity under `CI=true` now exit non-zero; normal-local and cargo-present-CI runs stay green (exit 0).

### sc-8863 [F-061] — ALREADY RESOLVED
Merged to `main` via PR #1151 (retired Python worker test suite deleted after live gates extracted). No change here.

### sc-8871 [F-069] — ALREADY RESOLVED
Merged to `main` as `ddb01a5b` via PR #1140 (`save_timeline` runs `is_safe_id` before deriving the path). Confirmed present in this branch's base. No change here.

## Verification
- `cargo fmt --all -- --check`: clean (workspace).
- `cargo clippy -p sceneworks-core -p sceneworks-rust-api --all-targets -- -D warnings`: clean.
- `cargo test -p sceneworks-core` (379 lib + integration) and `-p sceneworks-rust-api`: green.
- Python (CI-pinned `pytest==9.0.2`, `httpx==0.28.1`): light-dep lane 12 passed; parity 12 passed; e2e 4 passed / 1 ffmpeg-skip — all against the built `sceneworks-rust-api` binary.
- `check.yml` re-parsed with a YAML loader: valid, gate `run:` commands byte-unchanged.
- Merged `origin/main` (not rebased) before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)