### PR TITLE
fix(web): per-asset seed for viewer reuse; drop copy-seed chip

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -4,7 +4,7 @@ import { pollJobToCompletion } from "./pollJob.js";
 import { Icon } from "./components/Icons.jsx";
 import { Logo } from "./components/Logo.jsx";
 import { StatusDot } from "./components/StatusDot.jsx";
-import { FullscreenPreview } from "./components/assetPanels.jsx";
+import { FullscreenPreview, assetSeed } from "./components/assetPanels.jsx";
 import { fallbackModels, terminalStatuses } from "./constants.js";
 import { LibraryScreen } from "./screens/LibraryScreen.jsx";
 import { PoseLibraryScreen } from "./screens/PoseLibraryScreen.jsx";
@@ -1838,6 +1838,12 @@ export function App() {
     if (!asset || !recipe) {
       return;
     }
+    // Keep-seed replays THIS image's own seed for a byte-for-byte rerun (e.g. to
+    // reproduce and upscale with PiD). assetSeed prefers the per-asset recipe over the
+    // set's shared base seed, so reuse honors the exact image the user is viewing.
+    // Null → Image Studio leaves the seed random (a close variation), the default.
+    const seed = assetSeed(asset);
+    const replaySeed = options.keepSeed && seed != null && seed !== "" ? seed : null;
     setSelectedAssetId(asset.id);
     closePreview();
     setStudioLaunch({
@@ -1846,9 +1852,7 @@ export function App() {
       assetId: asset.id,
       sourceAssetId: asset.lineage?.sourceAssetId ?? null,
       recipe,
-      // When set, Image Studio replays the saved seed for a byte-for-byte rerun
-      // (e.g. reproduce the image to upscale with PiD) instead of a random variation.
-      keepSeed: Boolean(options.keepSeed),
+      replaySeed,
     });
     setActiveView("Image");
   }

--- a/apps/web/src/App.preview.test.jsx
+++ b/apps/web/src/App.preview.test.jsx
@@ -2,7 +2,7 @@ import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AssetPickerField } from "./components/AssetPicker.jsx";
-import { FullscreenPreview, PREVIEW_FIT_VIEW, PREVIEW_MAX_SCALE, PREVIEW_MIN_SCALE, clampPan, zoomView } from "./components/assetPanels.jsx";
+import { FullscreenPreview, PREVIEW_FIT_VIEW, PREVIEW_MAX_SCALE, PREVIEW_MIN_SCALE, assetSeed, clampPan, zoomView } from "./components/assetPanels.jsx";
 import { FakeEventSource, response, changeField } from "./main.testSupport.jsx";
 
 describe("SceneWorks app shell", () => {
@@ -428,7 +428,23 @@ describe("SceneWorks app shell", () => {
     expect(onUseRecipe).toHaveBeenCalledWith(asset, { keepSeed: false });
   });
 
-  it("surfaces a copyable seed and a keep-seed toggle for recipe reuse", async () => {
+  it("resolves each image's own seed, preferring the per-asset recipe over the shared set seed", () => {
+    // Two siblings of one generation set: the set recipe carries the batch's base seed
+    // (7), while each image records its own seed. assetSeed must return the per-image
+    // value so navigating between siblings updates the seed (and reuse reproduces the
+    // exact image), not the constant set seed.
+    const setRecipe = { model: "z_image_turbo", seed: 7 };
+    const first = { id: "a", recipe: { model: "z_image_turbo", seed: 7 }, generationSet: { recipe: setRecipe } };
+    const second = { id: "b", recipe: { model: "z_image_turbo", seed: 42 }, generationSet: { recipe: setRecipe } };
+    expect(assetSeed(first)).toBe(7);
+    expect(assetSeed(second)).toBe(42);
+    // Falls back to the set seed when the asset has no per-asset recipe, and honors seed 0.
+    expect(assetSeed({ id: "c", generationSet: { recipe: setRecipe } })).toBe(7);
+    expect(assetSeed({ id: "d", recipe: { seed: 0 } })).toBe(0);
+    expect(assetSeed({ id: "e" })).toBeNull();
+  });
+
+  it("offers a keep-seed toggle only when the asset carries a seed", async () => {
     const noop = () => {};
     const onUseRecipe = vi.fn();
     const asset = {
@@ -457,10 +473,10 @@ describe("SceneWorks app shell", () => {
       );
     });
 
-    // Seed is shown in the meta panel.
-    expect(document.body.querySelector(".preview-seed-value").textContent).toBe("1234");
+    // The toggle appears because the recipe carries a seed.
+    expect(document.body.querySelector(".preview-keep-seed")).not.toBeNull();
 
-    // Toggle keep-seed on, then reuse the recipe.
+    // Toggle keep-seed on, then reuse the recipe — the choice rides on onUseRecipe.
     await act(async () => {
       document.body.querySelector(".preview-keep-seed input[type=\"checkbox\"]").click();
     });

--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -22,6 +22,14 @@ export const PREVIEW_FIT_VIEW = { scale: 1, x: 0, y: 0 };
 
 const clampScale = (value) => Math.min(PREVIEW_MAX_SCALE, Math.max(PREVIEW_MIN_SCALE, value));
 
+// The seed used to generate a specific image. Each image records its own seed on its
+// per-asset recipe; the generation-set recipe only carries the batch's shared base
+// seed, so the per-asset value must win — otherwise every sibling in a set reports the
+// same seed. Used both for the "Keep seed" gate and to replay the exact seed on reuse.
+export function assetSeed(asset) {
+  return asset?.recipe?.seed ?? asset?.generationSet?.recipe?.seed ?? null;
+}
+
 // Cursor-anchored zoom: keep the image point under `pointer` (stage-relative px)
 // stationary while multiplying the scale by `factor`. Pure so the anchoring math
 // is unit-testable in isolation; mirrors ImageEditor's handleWheel/zoomAtCenter.
@@ -717,37 +725,18 @@ export function FullscreenPreview({
   }, [asset.id, asset.variants?.upscaled?.id]);
   const displayedAsset = hasUpscaleVariants ? asset.variants[variantMode] : asset;
 
-  // Seed lives on the generation recipe. Surface it so users can copy it and pair
-  // it with "Use this recipe" to reproduce the exact image (e.g. for PiD upscaling).
-  // Resolve the same way "Use this recipe" does. Guard with `!= null` — seed 0 is valid.
-  const recipe = asset.generationSet?.recipe ?? asset.recipe ?? null;
-  const seed = recipe?.seed;
+  // Each generated image has its OWN seed on its per-asset recipe (asset.recipe.seed).
+  // The generation-set recipe only carries the batch's base seed — shared across every
+  // image in the set — so prefer the per-asset seed; otherwise the value never changes
+  // as you navigate between siblings of the same set. Guard with `!= null` — seed 0 is valid.
+  const seed = assetSeed(asset);
   const hasSeed = seed != null && seed !== "";
-  const [seedCopied, setSeedCopied] = React.useState(false);
   // "Use this recipe" defaults to a random seed (a close variation). Toggle this on
-  // to replay the exact seed for a byte-for-byte reproduction (e.g. PiD upscaling).
+  // to replay THIS image's exact seed for a byte-for-byte reproduction (e.g. PiD upscaling).
   const [keepSeed, setKeepSeed] = React.useState(false);
   React.useEffect(() => {
     setKeepSeed(false);
   }, [asset.id]);
-  const copySeed = React.useCallback(async () => {
-    if (!hasSeed) {
-      return;
-    }
-    try {
-      await navigator.clipboard.writeText(String(seed));
-      setSeedCopied(true);
-    } catch {
-      // Clipboard unavailable (e.g. insecure context) — leave the label unchanged.
-    }
-  }, [hasSeed, seed]);
-  React.useEffect(() => {
-    if (!seedCopied) {
-      return undefined;
-    }
-    const timer = setTimeout(() => setSeedCopied(false), 1500);
-    return () => clearTimeout(timer);
-  }, [seedCopied]);
 
   // Zoom/pan is IMAGES ONLY — video keeps its native <video> controls and gets no
   // zoom overlay/UI (sc-8728). `isVideo` gates the whole zoom surface.
@@ -1061,18 +1050,6 @@ export function FullscreenPreview({
           <div className="preview-modal-meta">
             <strong>{asset.displayName}</strong>
             <span>{asset.recipe?.model}</span>
-            {hasSeed ? (
-              <button
-                className="preview-seed"
-                onClick={copySeed}
-                title="Copy seed to clipboard"
-                type="button"
-              >
-                <span className="preview-seed-label">Seed</span>
-                <span className="preview-seed-value">{seed}</span>
-                <span className="preview-seed-hint">{seedCopied ? "Copied" : "Copy"}</span>
-              </button>
-            ) : null}
           </div>
           {hasUpscaleVariants ? (
             <div className="segmented-control compact-segment preview-variant-toggle" aria-label="Image variant">

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -985,11 +985,11 @@ export function ImageStudio() {
     promptEdited.current = true;
     setNegativePrompt(String(recipe.negativePrompt ?? ""));
     // Recipe replay leaves Seed random by default so "Use this recipe" makes a close
-    // variation instead of a byte-for-byte rerun. When the launcher asks to keep the
-    // seed (viewer "Keep seed" toggle), replay the saved seed for an exact reproduction.
-    // Guard with `!= null` so seed 0 is honored.
-    const replaySeed = launchRequest.keepSeed && recipe.seed != null && recipe.seed !== "";
-    setSeed(replaySeed ? String(recipe.seed) : "");
+    // variation instead of a byte-for-byte rerun. When the launcher passes a replaySeed
+    // (viewer "Keep seed" toggle), it is already resolved to THIS image's own seed —
+    // replay it verbatim for an exact reproduction. Guard with `!= null` so seed 0 is honored.
+    const replaySeed = launchRequest.replaySeed;
+    setSeed(replaySeed != null && replaySeed !== "" ? String(replaySeed) : "");
     const countValue = finiteRecipeNumber(settings.count);
     if (countValue) {
       setCount(countValue);

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7742,45 +7742,10 @@ details[open] > summary.lora-scope-group-heading::before,
 }
 
 .preview-modal-meta strong,
-.preview-modal-meta > span {
+.preview-modal-meta span {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-/* Copyable seed chip — lets users grab the seed for a byte-for-byte rerun
-   (e.g. reproduce the image to upscale with PiD). */
-.preview-seed {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  align-self: start;
-  margin-top: 1px;
-  padding: 2px 8px;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: transparent;
-  color: var(--text-muted);
-  font-size: 12px;
-  line-height: 1.4;
-  cursor: pointer;
-}
-
-.preview-seed:hover {
-  border-color: var(--border-strong);
-  background: var(--surface-hover);
-}
-
-.preview-seed-value {
-  font-variant-numeric: tabular-nums;
-  color: inherit;
-}
-
-.preview-seed-hint {
-  color: var(--accent);
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
 }
 
 /* Keep-seed toggle sits inline with the preview action buttons. */


### PR DESCRIPTION
Follow-up to #1160 (copyable seed + keep-seed toggle).

## Problems

1. **Seed was stale across navigation.** The viewer resolved the seed as `generationSet.recipe ?? asset.recipe`, preferring the **generation-set** recipe — which only stores the batch's shared **base** seed. So navigating left/right between images of the same set showed the same seed, and "Keep seed" reuse replayed the base seed instead of the viewed image's own seed. Each generated image actually records its own seed on its per-asset recipe (`asset.recipe.seed`, written per image by the worker — `project_store.rs`).
2. **Copy-seed chip overflowed the modal.** The chip floated off the bottom of the viewer footer, and it's redundant now that the toggle carries the seed through reuse.

## Changes

- **New `assetSeed(asset)` helper** (`components/assetPanels.jsx`): resolves `asset.recipe?.seed ?? asset.generationSet?.recipe?.seed` — per-asset seed wins, set seed is the fallback. Guards seed 0.
- **FullscreenPreview**: seed now comes from `assetSeed`, so the Keep-seed toggle reflects the image actually in view and updates on prev/next navigation. Removed the copyable seed chip and its state/effects/CSS.
- **`App.sendAssetRecipeToImage`**: resolves the per-asset seed via `assetSeed` and passes a single `replaySeed` (this image's own seed when Keep-seed is on, else `null`) onto the studio launch.
- **ImageStudio recipe replay**: consumes `launchRequest.replaySeed` verbatim (guarded so seed 0 is honored) instead of re-deriving from the shared set recipe.

Net result: with **Keep seed** on, "Use this recipe" reproduces the exact image currently in the viewer — even after scrolling through a batch — which is the byte-for-byte input PiD upscaling needs.

## Tests

- Added a unit test for `assetSeed` (per-asset seed preferred over shared set seed; falls back to set seed; honors seed 0; null when absent).
- Updated the FullscreenPreview reuse test: the chip is gone; asserts the Keep-seed toggle appears only when a seed exists and that `onUseRecipe(asset, { keepSeed })` still carries the choice.

## Verification

- `npm run build` — 0 errors
- `npm run lint` — 0 errors on touched files
- `vitest` full suite — 1168/1168 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
