### PR TITLE
fix(worker): download/path/store hardening + dedup (epic 8800 batch 7)

### DIFF
--- a/crates/sceneworks-core/src/credentials.rs
+++ b/crates/sceneworks-core/src/credentials.rs
@@ -182,6 +182,9 @@ impl CredentialFileStore {
         let tmp_path = self.path.with_extension(format!("{extension}.{token}.tmp"));
         write_secret_file(&tmp_path, body.as_bytes())?;
         std::fs::rename(&tmp_path, &self.path)?;
+        // Persist the rename itself so the new name survives a crash too (the temp
+        // fsync in `write_secret_file` only covered the bytes) (sc-8949 / F-147).
+        sync_parent_dir(&self.path);
         // Backstop: re-assert 0600 on the final path in case it already existed
         // with looser permissions on a platform without atomic-mode creation.
         restrict_permissions(&self.path)?;
@@ -193,6 +196,10 @@ impl CredentialFileStore {
 /// Unix so a secret is never momentarily readable by other local users. On other
 /// platforms this is a plain write (the desktop build keeps secrets in the OS
 /// keychain, not this file).
+///
+/// The `sync_all` flushes the bytes to disk before the caller renames the temp
+/// into place, so a crash can't leave a zero-length or partial credentials file
+/// where the atomic rename promised all-or-nothing (sc-8949 / F-147).
 #[cfg(unix)]
 fn write_secret_file(path: &Path, contents: &[u8]) -> io::Result<()> {
     use std::io::Write;
@@ -203,12 +210,27 @@ fn write_secret_file(path: &Path, contents: &[u8]) -> io::Result<()> {
         .truncate(true)
         .mode(0o600)
         .open(path)?;
-    file.write_all(contents)
+    file.write_all(contents)?;
+    file.sync_all()
 }
 
 #[cfg(not(unix))]
 fn write_secret_file(path: &Path, contents: &[u8]) -> io::Result<()> {
-    std::fs::write(path, contents)
+    use std::io::Write;
+    let mut file = std::fs::File::create(path)?;
+    file.write_all(contents)?;
+    file.sync_all()
+}
+
+/// fsync the directory holding `path` so a just-completed rename is durable. Best
+/// effort: the temp fsync already makes the credential bytes durable, so a platform
+/// that refuses to fsync a directory handle doesn't fail the write (sc-8949).
+fn sync_parent_dir(path: &Path) {
+    if let Some(parent) = path.parent() {
+        if let Ok(dir) = std::fs::File::open(parent) {
+            let _ = dir.sync_all();
+        }
+    }
 }
 
 /// Normalize a user-entered host or URL to a bare lower-cased host (strip scheme

--- a/crates/sceneworks-core/src/store_util.rs
+++ b/crates/sceneworks-core/src/store_util.rs
@@ -19,7 +19,8 @@ pub(crate) fn read_json(path: &Path) -> ProjectStoreResult<Value> {
 }
 
 /// Atomically writes `contents` to `path`: stage into a uniquely-named temp file
-/// in the same directory, then rename it into place.
+/// in the same directory, fsync the temp (and the directory) so its bytes hit the
+/// disk before the rename, then rename it into place.
 ///
 /// The temp suffix carries random bytes so two threads writing the *same* target
 /// never collide on the temp path. Previously the temp name was deterministic
@@ -27,6 +28,12 @@ pub(crate) fn read_json(path: &Path) -> ProjectStoreResult<Value> {
 /// into one temp file and the second `rename` failed once the first had already
 /// renamed the temp away (sc-1633). Pair with [`lock_project_files`] when the
 /// caller does a read-modify-write so concurrent updates don't clobber each other.
+///
+/// The `sync_all` before the rename closes the crash window the atomic pattern is
+/// meant to preclude: without it a filesystem may persist the rename before the
+/// temp's data, so a power loss right after the write could leave a zero-length or
+/// partial "atomically written" sidecar/manifest (sc-8949 / F-147). The parent-dir
+/// fsync then durably records the rename itself so the new name survives too.
 pub(crate) fn atomic_write(path: &Path, contents: &[u8]) -> ProjectStoreResult<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
@@ -37,9 +44,31 @@ pub(crate) fn atomic_write(path: &Path, contents: &[u8]) -> ProjectStoreResult<(
         .unwrap_or("json");
     let token = random_hex(8)?;
     let tmp_path = path.with_extension(format!("{extension}.{token}.tmp"));
-    fs::write(&tmp_path, contents)?;
+    write_and_sync(&tmp_path, contents)?;
     fs::rename(&tmp_path, path)?;
+    sync_parent_dir(path);
     Ok(())
+}
+
+/// Write `contents` to `path` and `sync_all` the handle so the bytes are durable
+/// before the caller renames the file into place (see [`atomic_write`]).
+fn write_and_sync(path: &Path, contents: &[u8]) -> ProjectStoreResult<()> {
+    use std::io::Write;
+    let mut file = fs::File::create(path)?;
+    file.write_all(contents)?;
+    file.sync_all()?;
+    Ok(())
+}
+
+/// fsync the directory holding `path` so a just-completed rename is itself durable.
+/// Best-effort: some platforms/filesystems refuse to open a directory for this, and
+/// the temp fsync already covers the data — so a failure here is not fatal.
+fn sync_parent_dir(path: &Path) {
+    if let Some(parent) = path.parent() {
+        if let Ok(dir) = fs::File::open(parent) {
+            let _ = dir.sync_all();
+        }
+    }
 }
 
 pub(crate) fn write_json<T: Serialize>(path: &Path, payload: &T) -> ProjectStoreResult<()> {
@@ -270,6 +299,30 @@ mod tests {
             .map(|_| random_hex(16).expect("id generates"))
             .collect::<HashSet<_>>();
         assert_eq!(ids.len(), 1000, "16-byte ids are unique across 1000 draws");
+    }
+
+    /// sc-8949 / F-147: `atomic_write` fsyncs the temp before renaming, so the
+    /// committed file carries the full contents and no `.tmp` staging file is left
+    /// behind. (A power-loss torn write can't be reproduced in a unit test, but this
+    /// pins the write-then-sync-then-rename result and guards against a regression
+    /// that drops the sync and re-introduces the deterministic temp name.)
+    #[test]
+    fn atomic_write_commits_full_contents_and_leaves_no_temp() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("nested").join("doc.json");
+        let payload = br#"{"k":"v"}"#;
+        atomic_write(&path, payload).expect("atomic_write succeeds");
+
+        assert_eq!(std::fs::read(&path).expect("file reads"), payload);
+
+        // No `*.tmp` staging file survived the commit.
+        let leftovers: Vec<_> = std::fs::read_dir(path.parent().unwrap())
+            .expect("dir reads")
+            .filter_map(Result::ok)
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .filter(|name| name.ends_with(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "unexpected temp files: {leftovers:?}");
     }
 
     #[test]

--- a/crates/sceneworks-core/src/training.rs
+++ b/crates/sceneworks-core/src/training.rs
@@ -2112,7 +2112,12 @@ fn combined_trigger_words(item_words: &[String], output_words: &[String]) -> Vec
     words
 }
 
-fn caption_with_trigger_words(caption: &str, trigger_words: &[String]) -> String {
+/// Compose a caption with its trigger words prepended (deduped case-insensitively
+/// against words already present in the caption, order-preserving). Shared by the
+/// training plan (this module) and the on-disk `.txt` caption sidecars
+/// (`training_store::write_dataset_caption_sidecars`) so the captions the trainer
+/// consumes and the sidecars a user inspects can never drift apart (sc-8892 / F-090).
+pub(crate) fn caption_with_trigger_words(caption: &str, trigger_words: &[String]) -> String {
     let cleaned = caption.split_whitespace().collect::<Vec<_>>().join(" ");
     let lower = cleaned.to_lowercase();
     let mut parts = trigger_words
@@ -2241,5 +2246,30 @@ mod tests {
             resolve_item_path(root, "images/photo.png").expect("safe path"),
             expected.display().to_string()
         );
+    }
+
+    /// sc-8892 / F-090: the single shared composer prepends trigger words that are
+    /// not already present (case-insensitive), preserves order, collapses whitespace,
+    /// and drops empties. This is the one function feeding both the training plan and
+    /// the `.txt` caption sidecars, so this contract is what keeps them in lockstep.
+    #[test]
+    fn caption_with_trigger_words_dedups_and_prepends() {
+        // Trigger words prepend, order preserved, caption appended.
+        assert_eq!(
+            caption_with_trigger_words("a photo", &["tok1".to_owned(), "tok2".to_owned()]),
+            "tok1, tok2, a photo"
+        );
+        // A trigger already present in the caption (case-insensitive) is not repeated.
+        assert_eq!(
+            caption_with_trigger_words("A TOK1 pose", &["tok1".to_owned()]),
+            "A TOK1 pose"
+        );
+        // Whitespace collapses and empty/blank trigger words are dropped.
+        assert_eq!(
+            caption_with_trigger_words("  a   photo ", &["".to_owned(), "  ".to_owned()]),
+            "a photo"
+        );
+        // Empty caption yields just the (unique) trigger words.
+        assert_eq!(caption_with_trigger_words("", &["tok1".to_owned()]), "tok1");
     }
 }

--- a/crates/sceneworks-core/src/training_store.rs
+++ b/crates/sceneworks-core/src/training_store.rs
@@ -16,8 +16,8 @@ use crate::store_util::{
 };
 use crate::time::utc_now;
 use crate::training::{
-    Caption, CaptionSource, TrainingDataset, TrainingDatasetItem, TrainingDatasetStatus,
-    TrainingModality, TRAINING_CONTRACT_SCHEMA_VERSION,
+    caption_with_trigger_words, Caption, CaptionSource, TrainingDataset, TrainingDatasetItem,
+    TrainingDatasetStatus, TrainingModality, TRAINING_CONTRACT_SCHEMA_VERSION,
 };
 
 const DATASET_MANIFEST_NAME: &str = "dataset.sceneworks.training-dataset.json";
@@ -1009,7 +1009,7 @@ fn write_dataset_caption_sidecars(
             &caption_path,
             &format!(
                 "{}\n",
-                caption_text_with_trigger_words(&item.caption.text, &item.caption.trigger_words)
+                caption_with_trigger_words(&item.caption.text, &item.caption.trigger_words)
             ),
         )?;
         sidecars.push(TrainingCaptionSidecar {
@@ -1019,21 +1019,6 @@ fn write_dataset_caption_sidecars(
         });
     }
     Ok(sidecars)
-}
-
-fn caption_text_with_trigger_words(caption: &str, trigger_words: &[String]) -> String {
-    let cleaned = caption.split_whitespace().collect::<Vec<_>>().join(" ");
-    let lower = cleaned.to_lowercase();
-    let mut parts = trigger_words
-        .iter()
-        .map(|word| word.trim())
-        .filter(|word| !word.is_empty() && !lower.contains(&word.to_lowercase()))
-        .map(str::to_owned)
-        .collect::<Vec<_>>();
-    if !cleaned.is_empty() {
-        parts.push(cleaned);
-    }
-    parts.join(", ")
 }
 
 fn materialize_items(

--- a/crates/sceneworks-worker/src/downloads.rs
+++ b/crates/sceneworks-worker/src/downloads.rs
@@ -1,6 +1,171 @@
 use super::*;
 use std::net::SocketAddr;
 
+// The cross-process download lock (F-098 / sc-8900) is only reachable from
+// `ensure_cached_file_verified`, which is gated to the macOS MLX runtime and the
+// off-Mac candle InstantID lane; gate the whole apparatus the same way so the bare
+// (non-macOS, non-candle) lib build — which still compiles `download_source_url` —
+// doesn't drag in an unused `fs2` import or dead lock helpers.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+use download_lock::DownloadLock;
+
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+mod download_lock {
+    use super::{task_join_error, WorkerError, WorkerResult};
+    use fs2::FileExt as _;
+    use std::path::{Path, PathBuf};
+    use std::time::{Duration, Instant};
+
+    /// Max time to block waiting for the cross-process download lock before giving up.
+    /// A peer legitimately holding it is streaming a (potentially multi-GB) weight
+    /// file, so this is far longer than the manifest lock's timeout — long enough to
+    /// outlast a real download, short enough that a crashed/stuck peer surfaces a
+    /// clear error rather than hanging the job forever (sc-8900).
+    const DOWNLOAD_LOCK_TIMEOUT: Duration = Duration::from_secs(3600);
+    /// Poll cadence while spin-waiting on `try_lock_exclusive` (fs2 has no timed
+    /// blocking-lock API, so we retry rather than block indefinitely). Coarser than
+    /// the manifest poll because a download hold is seconds-to-minutes, not sub-ms.
+    const DOWNLOAD_LOCK_POLL: Duration = Duration::from_millis(200);
+
+    /// RAII holder for a cross-process advisory *exclusive* lock on a `<target>.lock`
+    /// sibling, serializing the download of one cache target across the separate
+    /// utility-worker processes (F-098 / sc-8900). The default utility pool is 4
+    /// SEPARATE PROCESSES, so an in-process mutex cannot serialize them — two jobs
+    /// resolving the same runtime-weight file would each open the target and
+    /// interleave/append their writes, producing a corrupt file that can slip past
+    /// the size check when no sha256 is available. The lock releases when the
+    /// underlying handle drops. Mirrors `manifest::ManifestLock`.
+    pub(crate) struct DownloadLock {
+        _file: std::fs::File,
+    }
+
+    impl DownloadLock {
+        /// Acquire the exclusive lock for `target`, creating the parent dir and the
+        /// `.lock` sibling as needed. Blocking (spin-waits on the advisory lock), so
+        /// the caller runs it on the blocking pool.
+        pub(crate) fn acquire(target: &Path) -> WorkerResult<Self> {
+            let lock_path = download_lock_path(target);
+            if let Some(parent) = lock_path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            let file = std::fs::OpenOptions::new()
+                .create(true)
+                .read(true)
+                .write(true)
+                .truncate(false)
+                .open(&lock_path)?;
+            let deadline = Instant::now() + DOWNLOAD_LOCK_TIMEOUT;
+            // fs2 signals contention with a platform-specific error (`EWOULDBLOCK` on
+            // Unix, `ERROR_LOCK_VIOLATION` on Windows); compare by RAW OS CODE against
+            // fs2's own contention error so retry-vs-fail is correct on every platform
+            // (same posture as `manifest::ManifestLock`, sc-8843).
+            let contended = fs2::lock_contended_error().raw_os_error();
+            loop {
+                match file.try_lock_exclusive() {
+                    Ok(()) => return Ok(Self { _file: file }),
+                    Err(error) if error.raw_os_error() == contended => {
+                        if Instant::now() >= deadline {
+                            return Err(WorkerError::Io(std::io::Error::new(
+                                std::io::ErrorKind::TimedOut,
+                                format!(
+                                    "timed out after {DOWNLOAD_LOCK_TIMEOUT:?} waiting for download lock {}",
+                                    lock_path.display()
+                                ),
+                            )));
+                        }
+                        std::thread::sleep(DOWNLOAD_LOCK_POLL);
+                    }
+                    Err(error) => return Err(error.into()),
+                }
+            }
+        }
+
+        /// Acquire the lock on the blocking pool (the spin-wait must not stall the
+        /// async runtime), then hold the guard across the async download. The
+        /// `std::fs::File` handle is `Send`, so the guard lives across `.await` and
+        /// the advisory lock is held for the whole transfer.
+        pub(crate) async fn acquire_async(target: &Path) -> WorkerResult<Self> {
+            let target = target.to_path_buf();
+            tokio::task::spawn_blocking(move || DownloadLock::acquire(&target))
+                .await
+                .map_err(|error| task_join_error("download lock", error))?
+        }
+    }
+
+    /// The `.lock` sibling path for a download target. Kept alongside the target so
+    /// the lock scope is the exact file being written (per-file, not global), and two
+    /// downloads of *different* files never contend.
+    fn download_lock_path(target: &Path) -> PathBuf {
+        let mut name = target
+            .file_name()
+            .map(std::ffi::OsString::from)
+            .unwrap_or_default();
+        name.push(".download.lock");
+        target.with_file_name(name)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        /// sc-8900 / F-098: two holders of the same target's download lock are
+        /// mutually exclusive — the second `try_lock_exclusive` sees contention while
+        /// the first guard is alive, then succeeds once it drops. This is the
+        /// cross-process serialization primitive the utility-worker pool relies on
+        /// (exercised here across handles within one process).
+        #[test]
+        fn download_lock_is_exclusive_per_target_and_releases_on_drop() {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let target = dir.path().join("weights").join("model.safetensors");
+
+            let first = DownloadLock::acquire(&target).expect("first lock acquires");
+
+            // A second exclusive lock on the SAME target's lock file must be contended
+            // while the first is held. Probe the raw fs2 primitive directly so the test
+            // doesn't block on the (1 hour) acquire timeout.
+            let lock_path = download_lock_path(&target);
+            let probe = std::fs::OpenOptions::new()
+                .create(true)
+                .read(true)
+                .write(true)
+                .truncate(false)
+                .open(&lock_path)
+                .expect("probe opens lock file");
+            let contended = fs2::lock_contended_error().raw_os_error();
+            let held = probe.try_lock_exclusive();
+            assert_eq!(
+                held.as_ref().err().and_then(|e| e.raw_os_error()),
+                contended,
+                "second exclusive lock must be contended while the first is held"
+            );
+
+            // Once the first guard drops, the same target locks cleanly again.
+            drop(first);
+            DownloadLock::acquire(&target).expect("lock re-acquires after release");
+
+            // A DIFFERENT target never contends with the first.
+            let other = dir.path().join("weights").join("other.safetensors");
+            let _first_other = DownloadLock::acquire(&other).expect("distinct target locks");
+        }
+
+        /// The lock file is a `.download.lock` sibling of the target (per-file scope),
+        /// so distinct targets get distinct lock paths.
+        #[test]
+        fn download_lock_path_is_per_file_sibling() {
+            let a = download_lock_path(Path::new("/data/models/a.safetensors"));
+            let b = download_lock_path(Path::new("/data/models/b.safetensors"));
+            assert_eq!(a, Path::new("/data/models/a.safetensors.download.lock"));
+            assert_ne!(a, b);
+        }
+    }
+}
+
 /// Download `url` to `target` on first use. Existing complete files are reused;
 /// partial files resume with HTTP Range when the caller can provide `expected_size`.
 /// The transfer shares model-download progress/cancel plumbing instead of buffering
@@ -39,6 +204,12 @@ pub(crate) async fn ensure_cached_file_verified(
     expected_size: Option<u64>,
     expected_sha256: Option<&str>,
 ) -> WorkerResult<PathBuf> {
+    // Serialize the whole cache-check + transfer for this target across the separate
+    // utility-worker processes so two jobs can't interleave/append writes to the same
+    // partial file and leave a corrupt result (F-098 / sc-8900). The cache-hit
+    // short-circuit lives inside the lock too, so a peer mid-transfer can't be read as
+    // "already complete". The guard is held for the whole function.
+    let _lock = DownloadLock::acquire_async(target).await?;
     let expected_size = match expected_size {
         Some(size) => Some(size),
         None => remote_content_length(context.client, url).await?,

--- a/crates/sceneworks-worker/src/imports.rs
+++ b/crates/sceneworks-worker/src/imports.rs
@@ -10,13 +10,20 @@ pub(crate) async fn import_lora_source_path(
     target_dir: &Path,
     prefer_move: bool,
 ) -> WorkerResult<()> {
-    let source = source.canonicalize()?;
-    if !source.exists() {
-        return Err(WorkerError::Io(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            format!("LoRA source not found: {}", source.display()),
-        )));
-    }
+    // `canonicalize` already fails `NotFound` when the source is missing, so the
+    // old `!source.exists()` guard that followed it was dead code and its friendly
+    // message never fired for the common case. Map the `NotFound` here instead so
+    // a missing source still surfaces the actionable error (sc-8898 / F-096).
+    let source = source.canonicalize().map_err(|error| {
+        if error.kind() == std::io::ErrorKind::NotFound {
+            WorkerError::Io(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("LoRA source not found: {}", source.display()),
+            ))
+        } else {
+            WorkerError::Io(error)
+        }
+    })?;
     tokio::fs::create_dir_all(target_dir).await?;
     if source.is_dir() {
         copy_dir_recursive(&source, target_dir).await?;

--- a/crates/sceneworks-worker/src/paths.rs
+++ b/crates/sceneworks-worker/src/paths.rs
@@ -124,9 +124,14 @@ pub(crate) fn normalize_app_managed_path(
     if raw_path.is_empty() {
         return Err(WorkerError::InvalidPayload(format!("{label} is required.")));
     }
+    // Canonicalize before the confinement check so a symlink (or `..`) under the
+    // data dir can't satisfy a purely-lexical `starts_with` and land the write
+    // outside; allow either the lexical or the canonical root so a not-yet-created
+    // target still matches (sc-8877 / F-075), mirroring `normalize_app_managed_lora_path`.
     let data_dir = normalized_data_dir(settings)?;
-    let path = normalize_absolute_path(Path::new(raw_path))?;
-    ensure_path_under(path, &[data_dir], label)
+    let canonical_data_dir = normalize_existing_or_absolute(&settings.data_dir)?;
+    let path = normalize_existing_or_absolute(Path::new(raw_path))?;
+    ensure_path_under(path, &[data_dir, canonical_data_dir], label)
 }
 
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
@@ -166,10 +171,20 @@ pub(crate) fn normalize_app_managed_model_path(
     if raw_path.is_empty() {
         return Err(WorkerError::InvalidPayload(format!("{label} is required.")));
     }
+    // Canonicalize the input and allow either the lexical or canonical form of each
+    // root, so a symlink/`..` can't slip past the confinement check (sc-8877 / F-075),
+    // matching `normalize_app_managed_lora_path` (same roots).
     let data_dir = normalized_data_dir(settings)?;
+    let canonical_data_dir = normalize_existing_or_absolute(&settings.data_dir)?;
     let hf_cache = normalize_absolute_path(&huggingface_hub_cache_dir(&settings.data_dir))?;
-    let path = normalize_absolute_path(Path::new(raw_path))?;
-    ensure_path_under(path, &[data_dir, hf_cache], label)
+    let canonical_hf_cache =
+        normalize_existing_or_absolute(&huggingface_hub_cache_dir(&settings.data_dir))?;
+    let path = normalize_existing_or_absolute(Path::new(raw_path))?;
+    ensure_path_under(
+        path,
+        &[data_dir, canonical_data_dir, hf_cache, canonical_hf_cache],
+        label,
+    )
 }
 
 /// Confine a LoRA adapter path taken from a job payload to an app-managed root
@@ -268,6 +283,10 @@ pub(crate) fn resolve_training_output_dir(
     output_dir: &str,
     label: &str,
 ) -> WorkerResult<PathBuf> {
+    // `normalize_app_managed_path` now returns the canonicalized path (sc-8877), so
+    // build each sub-root in both its lexical and canonical form to keep this second
+    // `starts_with` consistent (a canonical path never starts_with a lexical root
+    // when the two differ, e.g. macOS `/var` -> `/private/var`).
     let path = normalize_app_managed_path(settings, output_dir, label)?;
     let data_dir = normalized_data_dir(settings)?;
     // Global-scope outputs land in `<data>/loras` (or `<data>/models` for full
@@ -276,11 +295,13 @@ pub(crate) fn resolve_training_output_dir(
     // `resolve_training_output_location` computes API-side from trusted inputs.
     // All three stay inside the app data dir, so allow the projects tree too
     // rather than rejecting every project-scoped run.
-    let allowed_roots = [
-        data_dir.join("loras"),
-        data_dir.join("models"),
-        data_dir.join("projects"),
-    ];
+    let mut allowed_roots = Vec::with_capacity(6);
+    for sub in ["loras", "models", "projects"] {
+        allowed_roots.push(data_dir.join(sub));
+        allowed_roots.push(normalize_existing_or_absolute(
+            &settings.data_dir.join(sub),
+        )?);
+    }
     ensure_path_under(path, &allowed_roots, label)
 }
 
@@ -290,15 +311,19 @@ pub(crate) fn resolve_dataset_item_path(
     image_path: &str,
     label: &str,
 ) -> WorkerResult<PathBuf> {
+    // `root` is now canonicalized (sc-8877), so canonicalize the resolved image path
+    // too — otherwise an absolute image path stays lexical (e.g. macOS `/var/...`)
+    // and never starts_with a canonical root (`/private/var/...`). Canonicalizing the
+    // image also closes the symlink-escape the lexical check missed.
     let root = normalize_app_managed_path(settings, dataset_root, "Dataset root")?;
     let raw_image = Path::new(image_path.trim());
     if image_path.trim().is_empty() {
         return Err(WorkerError::InvalidPayload(format!("{label} is required.")));
     }
     let path = if raw_image.is_absolute() {
-        normalize_absolute_path(raw_image)?
+        normalize_existing_or_absolute(raw_image)?
     } else {
-        normalize_absolute_path(&root.join(raw_image))?
+        normalize_existing_or_absolute(&root.join(raw_image))?
     };
     ensure_path_under(path, &[root], label)
 }
@@ -365,16 +390,23 @@ pub(crate) fn resolve_lora_import_target(
     payload: &JsonObject,
     fallback_target: PathBuf,
 ) -> WorkerResult<PathBuf> {
-    let target = normalize_absolute_path(
-        &optional_payload_string(payload, "targetDir")
-            .map(PathBuf::from)
-            .unwrap_or(fallback_target),
-    )?;
-    let mut allowed_roots = vec![normalize_absolute_path(&settings.data_dir.join("loras"))?];
+    let requested = optional_payload_string(payload, "targetDir")
+        .map(PathBuf::from)
+        .unwrap_or(fallback_target);
+    // Canonicalize the target before the confinement check so a symlink/`..` under
+    // the managed root can't pass a purely-lexical `starts_with` and redirect the
+    // write outside; allow each root's lexical or canonical form so a not-yet-created
+    // target dir still matches (sc-8877 / F-075).
+    let target = normalize_existing_or_absolute(&requested)?;
+    let loras_root = settings.data_dir.join("loras");
+    let mut allowed_roots = vec![
+        normalize_absolute_path(&loras_root)?,
+        normalize_existing_or_absolute(&loras_root)?,
+    ];
     if let Some(project_path) = project_path_for_payload(settings, payload)? {
-        allowed_roots.push(normalize_absolute_path(
-            &project_path.join("loras").join("imports"),
-        )?);
+        let project_imports = project_path.join("loras").join("imports");
+        allowed_roots.push(normalize_absolute_path(&project_imports)?);
+        allowed_roots.push(normalize_existing_or_absolute(&project_imports)?);
     }
     if allowed_roots.iter().any(|root| target.starts_with(root)) {
         return Ok(target);
@@ -390,12 +422,18 @@ pub(crate) fn resolve_model_import_target(
     payload: &JsonObject,
     fallback_target: PathBuf,
 ) -> WorkerResult<PathBuf> {
-    let target = normalize_absolute_path(
-        &optional_payload_string(payload, "targetDir")
-            .map(PathBuf::from)
-            .unwrap_or(fallback_target),
-    )?;
-    let allowed_roots = [normalize_absolute_path(&settings.data_dir.join("models"))?];
+    let requested = optional_payload_string(payload, "targetDir")
+        .map(PathBuf::from)
+        .unwrap_or(fallback_target);
+    // Canonicalize before the confinement check so a symlink/`..` can't escape the
+    // lexical `starts_with`; allow the managed root's lexical or canonical form so a
+    // not-yet-created target still matches (sc-8877 / F-075).
+    let target = normalize_existing_or_absolute(&requested)?;
+    let models_root = settings.data_dir.join("models");
+    let allowed_roots = [
+        normalize_absolute_path(&models_root)?,
+        normalize_existing_or_absolute(&models_root)?,
+    ];
     if allowed_roots.iter().any(|root| target.starts_with(root)) {
         return Ok(target);
     }
@@ -408,9 +446,16 @@ pub(crate) fn resolve_model_convert_output(
     settings: &Settings,
     output_dir: &str,
 ) -> WorkerResult<PathBuf> {
-    let target = normalize_absolute_path(&PathBuf::from(output_dir))?;
-    let allowed_root = normalize_absolute_path(&settings.data_dir.join("models"))?;
-    if target.starts_with(&allowed_root) {
+    // Canonicalize before the confinement check so a symlink/`..` can't escape the
+    // lexical `starts_with`; allow the managed root's lexical or canonical form so a
+    // not-yet-created output dir still matches (sc-8877 / F-075).
+    let target = normalize_existing_or_absolute(Path::new(output_dir))?;
+    let models_root = settings.data_dir.join("models");
+    let allowed_roots = [
+        normalize_absolute_path(&models_root)?,
+        normalize_existing_or_absolute(&models_root)?,
+    ];
+    if allowed_roots.iter().any(|root| target.starts_with(root)) {
         return Ok(target);
     }
     Err(WorkerError::InvalidPayload(

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -3035,6 +3035,86 @@ fn lora_paths_resolve_symlinks_before_root_check() {
     assert!(error.to_string().contains("LoRA path must be inside"));
 }
 
+// sc-8877 / F-075: the write-target confinement helpers must canonicalize before the
+// root check so a symlink planted under a managed root can't smuggle a write outside
+// via a purely-lexical `starts_with`. Covers all five that used the weaker check.
+#[cfg(unix)]
+#[test]
+fn app_managed_helpers_resolve_symlinks_before_root_check() {
+    let temp = tempdir().expect("tempdir creates");
+    let data_dir = temp.path().join("data");
+    let models_dir = data_dir.join("models");
+    let loras_dir = data_dir.join("loras");
+    let outside_dir = temp.path().join("outside");
+    std::fs::create_dir_all(&models_dir).expect("models dir creates");
+    std::fs::create_dir_all(&loras_dir).expect("loras dir creates");
+    std::fs::create_dir_all(&outside_dir).expect("outside dir creates");
+
+    let mut settings = test_settings("http://127.0.0.1".to_owned(), None);
+    settings.data_dir = data_dir.clone();
+
+    // A symlink under a managed root pointing at an outside dir: a lexical
+    // `starts_with` would accept it; canonicalization must make each helper reject it.
+    let outside_target = outside_dir.join("escape");
+    std::fs::create_dir_all(&outside_target).expect("outside target creates");
+
+    // normalize_app_managed_path (write target confined to data_dir)
+    let path_link = data_dir.join("path-escape");
+    std::os::unix::fs::symlink(&outside_target, &path_link).expect("symlink creates");
+    let err =
+        super::normalize_app_managed_path(&settings, &path_link.display().to_string(), "Path")
+            .expect_err("symlinked path escape rejects");
+    assert!(err.to_string().contains("app-managed directory"));
+
+    // normalize_app_managed_model_path (read source confined to data_dir/hf_cache)
+    let model_link = models_dir.join("model-escape");
+    std::os::unix::fs::symlink(&outside_target, &model_link).expect("symlink creates");
+    let err = super::normalize_app_managed_model_path(
+        &settings,
+        &model_link.display().to_string(),
+        "Model",
+    )
+    .expect_err("symlinked model escape rejects");
+    assert!(err.to_string().contains("app-managed directory"));
+
+    // resolve_lora_import_target (write target confined to data/loras)
+    let lora_link = loras_dir.join("lora-escape");
+    std::os::unix::fs::symlink(&outside_target, &lora_link).expect("symlink creates");
+    let mut lora_payload = JsonObject::new();
+    lora_payload.insert(
+        "targetDir".to_owned(),
+        Value::String(lora_link.display().to_string()),
+    );
+    let err = super::resolve_lora_import_target(&settings, &lora_payload, loras_dir.clone())
+        .expect_err("symlinked lora targetDir escape rejects");
+    assert!(err.to_string().contains("data/loras"));
+
+    // resolve_model_import_target (write target confined to data/models)
+    let import_link = models_dir.join("import-escape");
+    std::os::unix::fs::symlink(&outside_target, &import_link).expect("symlink creates");
+    let mut model_payload = JsonObject::new();
+    model_payload.insert(
+        "targetDir".to_owned(),
+        Value::String(import_link.display().to_string()),
+    );
+    let err = super::resolve_model_import_target(&settings, &model_payload, models_dir.clone())
+        .expect_err("symlinked model targetDir escape rejects");
+    assert!(err.to_string().contains("data/models"));
+
+    // resolve_model_convert_output (write target confined to data/models)
+    let convert_link = models_dir.join("convert-escape");
+    std::os::unix::fs::symlink(&outside_target, &convert_link).expect("symlink creates");
+    let err = super::resolve_model_convert_output(&settings, &convert_link.display().to_string())
+        .expect_err("symlinked convert outputDir escape rejects");
+    assert!(err.to_string().contains("data/models"));
+
+    // Sanity: a genuine dir under a managed root still resolves (not over-rejected).
+    let real = models_dir.join("real_model");
+    std::fs::create_dir_all(&real).expect("real model dir creates");
+    super::normalize_app_managed_model_path(&settings, &real.display().to_string(), "Model")
+        .expect("a real managed dir is still accepted");
+}
+
 // sc-8821 / F-019: payload-supplied weight filenames (`advanced.controlWeights.filename`,
 // `advanced.pidCheckpoint.filename`) are joined under a resolved HF snapshot / app-cache
 // dir, so they must be a single plain path component — traversal, absolute paths, and

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -3312,6 +3312,34 @@ fn import_source_symlink_escape_is_rejected() {
         .contains("LoRA import sourcePath must be inside"));
 }
 
+// sc-8898 / F-096: a missing import source now surfaces the friendly "LoRA source
+// not found" message. Previously `canonicalize()` failed NotFound first and the
+// `!exists()` branch that built this message was dead, so the user only saw the
+// raw OS error.
+#[tokio::test]
+async fn missing_lora_import_source_reports_friendly_not_found() {
+    let temp = tempdir().expect("tempdir creates");
+    let missing = temp.path().join("does-not-exist.safetensors");
+    let target_dir = temp.path().join("target");
+
+    let error = import_lora_source_path(&missing, &target_dir, false)
+        .await
+        .expect_err("missing source errors");
+
+    match error {
+        WorkerError::Io(io_error) => {
+            assert_eq!(io_error.kind(), std::io::ErrorKind::NotFound);
+            assert!(
+                io_error.to_string().contains("LoRA source not found"),
+                "unexpected message: {io_error}"
+            );
+        }
+        other => panic!("expected NotFound Io error, got {other:?}"),
+    }
+    // The target dir is not created for a missing source (the copy never runs).
+    assert!(!target_dir.exists());
+}
+
 #[tokio::test]
 async fn ffmpeg_runner_surfaces_bounded_stderr_from_failing_process() {
     let args = if cfg!(windows) {


### PR DESCRIPTION
Code-review remediation batch (epic 8800, batch 7) — 5 stories from `CODE_REVIEW_2026-07-01.md`. One commit per story; all tests green; `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` clean; FRESH candle-gated lib-test compile passes.

## Stories

- **sc-8900 [F-098]** — Guard interleaved writes when two utility workers download the same file (`downloads.rs`). The default 4-process utility pool could have two jobs resume/append the same cache target concurrently, producing a corrupt file that slips past the size check when no sha256 is available. Serialize the whole cache-check + transfer under a cross-process advisory **exclusive** lock on a `<target>.download.lock` sibling (mirrors `manifest::ManifestLock`; acquired on the blocking pool, `Send` guard held across the async transfer; cache-hit short-circuit runs inside the lock).
- **sc-8877 [F-075]** — Canonicalize before `ensure_path_under` in the lexical-only confinement helpers (`paths.rs`). `normalize_app_managed_path`, `normalize_app_managed_model_path`, `resolve_lora_import_target`, `resolve_model_import_target`, `resolve_model_convert_output` did a purely-lexical `starts_with` with no symlink resolution; a symlink/`..` under `data/models`/`data/loras` could redirect a confined-looking write outside. Routed all five through `normalize_existing_or_absolute` with lexical-OR-canonical roots (matching `normalize_app_managed_lora_path`); propagated the now-canonical return through `resolve_training_output_dir` + `resolve_dataset_item_path`.
- **sc-8949 [F-147]** — `atomic_write`/`write_secret_file` never fsync before rename (`store_util.rs`, `credentials.rs`). On power loss a filesystem could persist the rename before the temp's data, leaving a zero-length/partial "atomically written" sidecar/manifest/credentials file. Added `sync_all` on the temp before the rename + a best-effort parent-dir fsync after it.
- **sc-8898 [F-096]** — Confine payload-path imports; drop the dead `exists()` after `canonicalize()` in LoRA import (`imports.rs`). `canonicalize()` already fails NotFound when the source is missing, so the following `!exists()` branch (and its friendly message) was unreachable. Map the canonicalize NotFound to the friendly message and drop the dead check. (Both live call sites already confine the client-supplied source via `resolve_import_source_path`.)
- **sc-8892 [F-090]** — Remove the duplicated trigger-word caption composer (`training_store.rs`, `training.rs`). `caption_text_with_trigger_words` and `caption_with_trigger_words` were line-for-line identical (sidecars vs training plan); kept one `pub(crate)` `caption_with_trigger_words` in `training.rs` and call it from `training_store.rs`. Behavior-preserving.

## Tests added

- `store_util`: `atomic_write_commits_full_contents_and_leaves_no_temp`
- `training`: `caption_with_trigger_words_dedups_and_prepends`
- worker `tests`: `app_managed_helpers_resolve_symlinks_before_root_check` (all 5 sc-8877 helpers), `missing_lora_import_source_reports_friendly_not_found`
- `downloads::download_lock`: `download_lock_is_exclusive_per_target_and_releases_on_drop`, `download_lock_path_is_per_file_sibling`

## Verification

- `cargo test -p sceneworks-core --lib` — 381 passed
- `cargo test -p sceneworks-worker --lib` — 605 passed
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- FRESH candle check (`cargo clean -p sceneworks-worker` then `cargo test -p sceneworks-worker --no-default-features -F backend-candle --no-run`) — 0 errors
- Bare `cargo check -p sceneworks-worker --no-default-features` — clean (no unused `fs2` import; download lock is cfg-gated to the macOS/candle lanes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)