### PR TITLE
refactor(worker): supervisor/slug/test-helper + misc nits (epic 8800 batch 8)

### DIFF
--- a/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
@@ -590,8 +590,8 @@ pub(crate) const IMAGE_MODEL_CAPS: &[ModelCaps] = &[
     // Microsoft Lens / Lens-Turbo (epic 3164 / sc-5105 MLX; sc-5126 candle): pure T2I family. UNLIKE the
     // other candle families it DOES advertise on-the-fly quant AND LoRA/LoKr, so `candle_quant_lora` is
     // set — the first (and, with SD3.5/Krea, one of the) candle families exempt from the quant/LoRA → torch
-    // fallbacks. Lens was the LAST whole-model torch-only image family (`torch_only_image_model_epic` now
-    // matches nothing).
+    // fallbacks. Lens was the LAST whole-model torch-only image family — once it routed, the per-model
+    // torch-only image epic seam matched nothing and was retired (sc-8951).
     ModelCaps::new("lens", true, true, false, false, true),
     ModelCaps::new("lens_turbo", true, true, false, false, true),
     // Bernini still-image companion (epic 4699 / sc-5424): MLX-only id — `engine_id:"bernini"`

--- a/crates/sceneworks-core/src/jobs_store/routing/gaps.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/gaps.rs
@@ -611,23 +611,6 @@ pub(crate) fn classify_candle_video_gap(payload: &Map<String, Value>) -> Unsuppo
     )
 }
 
-/// The dedicated MLX-porting epic for a torch-only image model (epic 3482 policy: every
-/// unported model gets its own port epic + is dropped on Mac until it lands). `None` = a
-/// model we don't have a port epic for yet, which the oracle reports as "needs an epic".
-/// Keep in sync with `docs/mac-rust-gaps.md` §1.
-///
-/// **No whole-model torch-only image families remain.** Each was ported to MLX and moved into
-/// `MLX_ROUTED_MODELS`, so it never reaches this classifier: Kolors (epic 3090 / sc-3875), InstantID
-/// (epic 3109 / sc-3345), PuLID-FLUX (epic 3069 / sc-3344), z_image_edit (epic 3529 / sc-3923),
-/// Chroma (epic 3531 / sc-3843), SenseNova-U1 (epic 3180 / sc-3900), and finally Lens / Lens-Turbo
-/// (epic 3164 / sc-5105 — the LAST one). Models with a partial surface (e.g. InstantID pose-library,
-/// PuLID reference-less) are named per-feature in `classify_image_gap`, not here. This function is
-/// retained for the generic "unported model → needs a port epic" path and as the seam for any future
-/// torch-only image model: add a `match _model { "<id>" => Some("epic NNNN"), _ => None }` arm here.
-pub(crate) fn torch_only_image_model_epic(_model: &str) -> Option<&'static str> {
-    None
-}
-
 /// Name the precise gap for an ineligible `image_generate` / `image_edit` job: a torch-only
 /// model, or a torch-only feature on an otherwise-MLX family. Mirrors the per-family
 /// `*_mlx_eligible` gates so the reason matches why routing refused it.
@@ -636,13 +619,22 @@ pub(crate) fn classify_image_gap(payload: &Map<String, Value>) -> UnsupportedRea
         return UnsupportedReason::new(None, "image generation", "no model specified.", None);
     };
     if !MLX_ROUTED_MODELS.contains(&model) {
-        let epic = torch_only_image_model_epic(model);
-        let detail = if epic.is_some() {
-            "this model has no Rust/MLX engine yet; it is dropped on Mac until its port epic lands."
-        } else {
-            "this model has no Rust/MLX engine and no port epic yet — file a porting epic and drop it on Mac (epic 3482 policy)."
-        };
-        return UnsupportedReason::new(Some(model), "unsupported image model", detail, epic);
+        // No whole-model torch-only image family remains: every one was ported to MLX and moved
+        // into `MLX_ROUTED_MODELS`, so anything reaching here is an unported model with no port
+        // epic yet. Kolors (epic 3090 / sc-3875), InstantID (epic 3109 / sc-3345), PuLID-FLUX
+        // (epic 3069 / sc-3344), z_image_edit (epic 3529 / sc-3923), Chroma (epic 3531 /
+        // sc-3843), SenseNova-U1 (epic 3180 / sc-3900), and finally Lens / Lens-Turbo (epic 3164
+        // / sc-5105 — the LAST one) all routed. Models with a partial surface (e.g. InstantID
+        // pose-library, PuLID reference-less) are named per-feature below, not here. The old
+        // `torch_only_image_model_epic` seam was retired once it became permanently `None`
+        // (sc-8951); a future torch-only image model reintroduces per-model epic mapping here.
+        // Keep in sync with `docs/mac-rust-gaps.md` §1.
+        return UnsupportedReason::new(
+            Some(model),
+            "unsupported image model",
+            "this model has no Rust/MLX engine and no port epic yet — file a porting epic and drop it on Mac (epic 3482 policy).",
+            None,
+        );
     }
     // Third-party LyCORIS (LoHa / non-peft LoKr) now applies on every MLX provider (epic 3641,
     // sc-3642/3643/3671), so it is no longer an image gap.

--- a/crates/sceneworks-core/src/slug.rs
+++ b/crates/sceneworks-core/src/slug.rs
@@ -18,6 +18,54 @@ pub fn slugify(value: &str, fallback: &str, max_length: Option<usize>) -> String
     }
     if let Some(max_length) = max_length {
         slug.truncate(max_length);
+        // Truncating can split mid-separator (e.g. "my project"/max 3 -> "my-"), so
+        // re-run the trailing-dash trim afterwards to keep the slug clean (sc-8951).
+        while slug.ends_with('-') {
+            slug.pop();
+        }
     }
     slug
+}
+
+#[cfg(test)]
+mod tests {
+    use super::slugify;
+
+    #[test]
+    fn lowercases_and_collapses_separators() {
+        assert_eq!(slugify("My Project", "fallback", None), "my-project");
+        assert_eq!(slugify("  a  b  ", "fallback", None), "a-b");
+        assert_eq!(slugify("a__b--c", "fallback", None), "a-b-c");
+    }
+
+    #[test]
+    fn trims_leading_and_trailing_separators() {
+        assert_eq!(slugify("-hello-", "fallback", None), "hello");
+        assert_eq!(slugify("!!!name!!!", "fallback", None), "name");
+    }
+
+    #[test]
+    fn falls_back_when_nothing_survives() {
+        assert_eq!(slugify("", "fallback", None), "fallback");
+        assert_eq!(slugify("---", "fallback", None), "fallback");
+        assert_eq!(slugify("!@#", "fallback", None), "fallback");
+    }
+
+    /// sc-8951 / F-149: truncation must not reintroduce a trailing dash. `"my project"`
+    /// slugs to `"my-project"`; truncated to 3 that would be `"my-"`, which the
+    /// post-truncate trim cleans back to `"my"`.
+    #[test]
+    fn truncation_does_not_leave_a_trailing_dash() {
+        assert_eq!(slugify("my project", "fallback", Some(3)), "my");
+        // A mid-word boundary keeps its characters (no separator to trim).
+        assert_eq!(slugify("my project", "fallback", Some(4)), "my-p");
+        // Truncating exactly onto a separator strips it too.
+        assert_eq!(slugify("ab cd ef", "fallback", Some(3)), "ab");
+    }
+
+    #[test]
+    fn truncation_shorter_than_the_full_slug_still_yields_a_clean_prefix() {
+        assert_eq!(slugify("hello world", "fallback", Some(5)), "hello");
+        assert_eq!(slugify("hello world", "fallback", Some(100)), "hello-world");
+    }
 }

--- a/crates/sceneworks-worker/src/depth.rs
+++ b/crates/sceneworks-worker/src/depth.rs
@@ -38,50 +38,37 @@ pub const DEPTH_ANYTHING_V2_SMALL_REPO: &str = "depth-anything/Depth-Anything-V2
 /// this one file.)
 pub const DEPTH_ANYTHING_V2_FILE: &str = "model.safetensors";
 
+// The Depth Anything V2 backend crate, aliased per build so the estimator body below is written
+// once (sc-8952). macOS uses the native-MLX `mlx_gen_depth` port (sc-8242); off-Mac + candle uses
+// the candle/CUDA `candle_gen_depth` sibling (sc-8413). Both expose the same
+// `DepthAnythingV2::from_dir` + `estimate_control_rgb8` surface, so only the crate differs.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+use candle_gen_depth as depth_backend;
+#[cfg(target_os = "macos")]
+use mlx_gen_depth as depth_backend;
+
 /// Estimate a depth control image from an arbitrary RGB input, loading the Depth Anything V2
 /// estimator from `weights_dir` (a directory containing `model.safetensors`).
 ///
 /// `img` is the source RGB image; the returned [`image::RgbImage`] is the normalized
 /// grayscale-broadcast depth map at the SAME dimensions, drop-in for the `ControlKind::Depth`
-/// path (the sibling of `canny::canny_control_image_default`). macOS path: MLX inference.
-#[cfg(target_os = "macos")]
+/// path (the sibling of `canny::canny_control_image_default`).
+///
+/// The backend is chosen by `depth_backend` above: macOS runs the native-MLX inference (sc-8242);
+/// off-Mac + `backend-candle` runs the candle/CUDA port on the build's default device (CUDA when
+/// built+available, else CPU), replacing the prior "automatic depth estimation is macOS-only"
+/// error so the candle strict-control driver (sc-8304) can auto-estimate `ControlKind::Depth`.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 pub fn depth_control_image(
     img: &image::RgbImage,
     weights_dir: &std::path::Path,
 ) -> crate::WorkerResult<image::RgbImage> {
     use crate::WorkerError;
 
-    let model = mlx_gen_depth::DepthAnythingV2::from_dir(weights_dir)
-        .map_err(|error| WorkerError::Engine(format!("depth estimator load: {error}")))?;
-    let (w, h) = (img.width(), img.height());
-    let control = model
-        .estimate_control_rgb8(img.as_raw(), w, h)
-        .map_err(|error| WorkerError::Engine(format!("depth estimate: {error}")))?;
-    image::RgbImage::from_raw(w, h, control).ok_or_else(|| {
-        WorkerError::Engine("depth estimator returned a mis-sized control buffer".to_owned())
-    })
-}
-
-/// Off-Mac (Windows/Linux) candle/CUDA depth auto-estimation — the sibling of the macOS MLX path
-/// above, backed by the from-scratch `candle_gen_depth` Depth Anything V2 port (sc-8413, the
-/// Windows/CUDA twin of `mlx-gen-depth`).
-///
-/// Identical signature + contract to the macOS function: `img` is the source RGB image,
-/// `weights_dir` is the Depth-Anything-V2-Small snapshot dir holding `model.safetensors`, and the
-/// returned [`image::RgbImage`] is the normalized grayscale-broadcast depth control map at the SAME
-/// dimensions. `DepthAnythingV2::from_dir` runs on the build's default candle device (CUDA when
-/// built+available, else CPU); `estimate_control_rgb8` returns the `w·h·3` RGB control buffer.
-///
-/// Replaces the prior off-Mac "automatic depth estimation is macOS-only" error so the candle
-/// strict-control driver (sc-8304) can auto-estimate `ControlKind::Depth`.
-#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-pub fn depth_control_image(
-    img: &image::RgbImage,
-    weights_dir: &std::path::Path,
-) -> crate::WorkerResult<image::RgbImage> {
-    use crate::WorkerError;
-
-    let model = candle_gen_depth::DepthAnythingV2::from_dir(weights_dir)
+    let model = depth_backend::DepthAnythingV2::from_dir(weights_dir)
         .map_err(|error| WorkerError::Engine(format!("depth estimator load: {error}")))?;
     let (w, h) = (img.width(), img.height());
     let control = model

--- a/crates/sceneworks-worker/src/depth.rs
+++ b/crates/sceneworks-worker/src/depth.rs
@@ -68,6 +68,11 @@ pub fn depth_control_image(
 ) -> crate::WorkerResult<image::RgbImage> {
     use crate::WorkerError;
 
+    // ACCEPTED TRADEOFF (sc-8953 / F-151): this loads the ~100 MB Depth-Anything-V2-Small
+    // checkpoint from disk on every depth-controlled generation — there is no process-level cache
+    // of the estimator (unlike the generator cache). It is one load per generation of a Small
+    // model, dominated by the diffusion cost around it, so it is left uncached; add a cache here
+    // only if depth control becomes hot enough that the reload shows up in profiles.
     let model = depth_backend::DepthAnythingV2::from_dir(weights_dir)
         .map_err(|error| WorkerError::Engine(format!("depth estimator load: {error}")))?;
     let (w, h) = (img.width(), img.height());

--- a/crates/sceneworks-worker/src/flux1_control_mlx_smoke.rs
+++ b/crates/sceneworks-worker/src/flux1_control_mlx_smoke.rs
@@ -19,8 +19,9 @@
 //! FLUX1_CONTROL=~/.cache/huggingface/.../diffusion_pytorch_model.safetensors \
 //! cargo test -p sceneworks-worker --release flux1_dev_control_mlx_smoke -- --ignored --nocapture
 //! ```
-
-#![cfg(all(test, target_os = "macos"))]
+//!
+//! The `mod flux1_control_mlx_smoke;` declaration in `lib.rs` already carries the same
+//! `#[cfg(all(test, target_os = "macos"))]`, so no inner `#![cfg]` is needed here (sc-8952).
 
 use std::path::PathBuf;
 

--- a/crates/sceneworks-worker/src/footprint_measure.rs
+++ b/crates/sceneworks-worker/src/footprint_measure.rs
@@ -159,13 +159,10 @@ fn image_std(img: &Image) -> f64 {
 /// `get_active_memory()` post-gen WITHOUT releasing the cache, folding the gen's freeable transient
 /// INTO resident (inflating resident, understating peak−resident). Dropping the cache first leaves
 /// only the live weight arrays the generator still holds.
-fn measure_footprint(
-    model: &str,
-    tier: &str,
-    engine_id: &str,
-    dir: &Path,
-    req: GenerationRequest,
-) -> (u64, u64) {
+// Every caller discards the result — the resident/peak numbers are consumed off the printed
+// `[[FOOTPRINT]]` scrape line, not the return value — so this reports through stdout and returns
+// nothing (sc-8952).
+fn measure_footprint(model: &str, tier: &str, engine_id: &str, dir: &Path, req: GenerationRequest) {
     println!(
         "[footprint] loading {model} ({tier}) from {} ...",
         dir.display()
@@ -227,7 +224,6 @@ fn measure_footprint(
         transient as f64 / 1024.0 / 1024.0 / 1024.0,
         std,
     );
-    (resident, peak)
 }
 
 /// SDXL-family default request: 1024², real CFG. Kept modest on steps to keep the harness quick; the

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -1366,6 +1366,13 @@ fn write_upscaled_asset(
 
 /// The job-result shape the API streams from: `assetWrites` + the `generationSet`
 /// fact drive `persist_reported_assets` (idempotent per progress update).
+///
+/// ACCEPTED TRADEOFF (sc-8953 / F-151): this deep-clones the whole `asset_writes` vec into the
+/// result on every call, and the generation loop calls it on each `GenEvent::Step` — so the total
+/// serialization work is O(images² · steps) as `asset_writes` grows one entry per finished image.
+/// At current image counts (a handful per set) and step counts this is negligible next to the
+/// generation itself, so it is left as-is; if sets grow large, stream this only on `Image` /
+/// `Decoding` events (where the fact set actually changes) rather than on every step.
 fn streaming_result(plan: &ImagePlan, asset_writes: &[Value]) -> JsonObject {
     json!({
         "generationSetId": plan.genset_id,

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -1380,7 +1380,17 @@ fn load_engine(
     ip_adapter_dir: Option<PathBuf>,
 ) -> WorkerResult<Box<dyn Generator>> {
     let spec = load_spec(weights_dir, quant, adapters, ip_adapter_dir);
-    gen_core::load(engine_id, &spec)
+    load_control_engine(engine_id, &spec)
+}
+
+/// Shared real-weight smoke loader: resolve `engine_id` through the backend-neutral
+/// `gen_core::load` seam and wrap a failure as `WorkerError::Engine`. Every image
+/// control/base lane's `#[cfg(test)]` load wrapper funnels through here so the
+/// `gen_core::load` + `map_err` tail lives in one place (sc-8954). `cfg(target_os)`
+/// still decides which provider crate registered the engine, not this call.
+#[cfg(all(target_os = "macos", test))]
+fn load_control_engine(engine_id: &str, spec: &LoadSpec) -> WorkerResult<Box<dyn Generator>> {
+    gen_core::load(engine_id, spec)
         .map_err(|error| WorkerError::Engine(format!("{engine_id} load failed: {error}")))
 }
 

--- a/crates/sceneworks-worker/src/image_jobs/flux1_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux1_control.rs
@@ -214,8 +214,7 @@ fn flux1_control_load(
     adapters: Vec<AdapterSpec>,
 ) -> WorkerResult<Box<dyn Generator>> {
     let spec = flux1_control_spec(weights_dir, control_weights, quant, adapters);
-    gen_core::load(FLUX1_DEV_CONTROL_ENGINE_ID, &spec)
-        .map_err(|error| WorkerError::Engine(format!("FLUX.1-dev control load failed: {error}")))
+    load_control_engine(FLUX1_DEV_CONTROL_ENGINE_ID, &spec)
 }
 
 /// Real FLUX.1-dev strict-control generation: one image per pose, each conditioned on the requested

--- a/crates/sceneworks-worker/src/image_jobs/flux2.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2.rs
@@ -893,8 +893,7 @@ fn flux2_control_load(
     adapters: Vec<AdapterSpec>,
 ) -> WorkerResult<Box<dyn Generator>> {
     let spec = flux2_control_spec(weights_dir, control_weights, quant, adapters);
-    gen_core::load(FLUX2_DEV_CONTROL_ENGINE_ID, &spec)
-        .map_err(|error| WorkerError::Engine(format!("FLUX.2-dev control load failed: {error}")))
+    load_control_engine(FLUX2_DEV_CONTROL_ENGINE_ID, &spec)
 }
 
 /// Real FLUX.2-dev strict-pose generation: one image per pose, each conditioned on a DWPose skeleton

--- a/crates/sceneworks-worker/src/image_jobs/instantid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/instantid.rs
@@ -153,6 +153,12 @@ fn instantid_image_count(request: &ImageRequest, settings: &Settings) -> u32 {
 /// Resolve the active angle-set collection for this job (sc-4450): the per-generation override
 /// (`advanced.keypointCollectionId`) → the user default → the built-in 11. Built-in fallback on
 /// any store error so angle generation never hard-fails on a Key Point Library hiccup.
+///
+/// ACCEPTED TRADEOFF (sc-8953 / F-151): for an angle-set job this runs its `ProjectStore` lookup
+/// twice — once via `instantid_image_count` at plan time and once here at generation time. It is a
+/// single small indexed read against the local SQLite store, negligible next to the generation, so
+/// the duplicate is left as-is; the fix (resolve once and thread the collection through the plan)
+/// is deferred until it matters.
 fn active_angle_collection(
     request: &ImageRequest,
     settings: &Settings,

--- a/crates/sceneworks-worker/src/image_jobs/qwen.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen.rs
@@ -56,9 +56,7 @@ fn qwen_control_load(
     adapters: Vec<AdapterSpec>,
 ) -> WorkerResult<Box<dyn Generator>> {
     let spec = qwen_control_spec(weights_dir, control_weights, quant, adapters);
-    gen_core::load(QWEN_CONTROL_ENGINE_ID, &spec).map_err(|error| {
-        WorkerError::Engine(format!("Qwen strict-pose control load failed: {error}"))
-    })
+    load_control_engine(QWEN_CONTROL_ENGINE_ID, &spec)
 }
 
 /// Generate one Qwen strict-pose image: the pre-built `conditioning` (the required `Control`, assembled by

--- a/crates/sceneworks-worker/src/image_jobs/zimage.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage.rs
@@ -144,8 +144,7 @@ fn zimage_control_load(
     adapters: Vec<AdapterSpec>,
 ) -> WorkerResult<Box<dyn Generator>> {
     let spec = zimage_control_spec(weights_dir, control_weights, quant, adapters);
-    gen_core::load(ZIMAGE_CONTROL_ENGINE_ID, &spec)
-        .map_err(|error| WorkerError::Engine(format!("Z-Image control load failed: {error}")))
+    load_control_engine(ZIMAGE_CONTROL_ENGINE_ID, &spec)
 }
 
 #[cfg(all(target_os = "macos", test))]
@@ -157,8 +156,7 @@ fn zimage_base_control_load(
 ) -> WorkerResult<Box<dyn Generator>> {
     // Shares the Turbo control's `LoadSpec` shape (base dir + control overlay); only the engine id differs.
     let spec = zimage_control_spec(weights_dir, control_weights, quant, adapters);
-    gen_core::load(ZIMAGE_BASE_CONTROL_ENGINE_ID, &spec)
-        .map_err(|error| WorkerError::Engine(format!("Z-Image base control load failed: {error}")))
+    load_control_engine(ZIMAGE_BASE_CONTROL_ENGINE_ID, &spec)
 }
 
 /// Generate one strict-pose image: the pre-built `conditioning` (the required `Control` plus an optional

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -571,7 +571,11 @@ pub async fn run_worker_loop(settings: Settings) -> WorkerResult<()> {
                 // mid-write), and posts a terminal `Canceled` for the job before returning
                 // `ShutdownDuringJob` so the loop exits with the job in a prompt terminal state.
                 match run_job_with_shutdown(&api, &settings, &http_client, job).await {
-                    JobOutcome::Completed => idle_heartbeat.mark_due(),
+                    // `run_utility_job` already posts a terminal Idle heartbeat at its end, so the
+                    // scheduler should treat that as the just-sent one and wait a full interval —
+                    // marking it *due* here made the next `poll_once` fire a redundant second Idle
+                    // heartbeat right away (sc-8952).
+                    JobOutcome::Completed => idle_heartbeat.mark_sent(),
                     JobOutcome::ShutdownDuringJob => {
                         let _ = heartbeat(&api, &settings, WorkerStatus::Offline, None).await;
                         return Ok(());
@@ -790,10 +794,6 @@ impl IdleHeartbeat {
 
     fn mark_sent(&mut self) {
         self.next_due = Instant::now() + self.interval;
-    }
-
-    fn mark_due(&mut self) {
-        self.next_due = Instant::now();
     }
 }
 

--- a/crates/sceneworks-worker/src/ort_cuda.rs
+++ b/crates/sceneworks-worker/src/ort_cuda.rs
@@ -115,6 +115,12 @@ fn prepend_dll_search_path(dirs: &[&PathBuf]) {
     let existing = std::env::var_os("PATH").unwrap_or_default();
     prefix.extend(std::env::split_paths(&existing));
     if let Ok(joined) = std::env::join_paths(prefix) {
+        // SAFETY (pre-written for the edition-2024 `set_var` unsafe reclassification): this
+        // mutates the process-global `PATH`, which is a data race if another thread reads/writes
+        // the environment concurrently. It is sound here because the only caller,
+        // `preload_cuda_dylibs`, runs this inside a `OnceLock::get_or_init` at CUDA-EP init —
+        // before any `ort` session (and its worker threads) is built — so no concurrent env
+        // access is in flight. When the workspace moves to edition 2024, wrap this in `unsafe {}`.
         std::env::set_var("PATH", joined);
     }
 }

--- a/crates/sceneworks-worker/src/person_jobs.rs
+++ b/crates/sceneworks-worker/src/person_jobs.rs
@@ -724,8 +724,10 @@ impl Yolo {
         let x = self.c3k2(&x, 8, true)?; // 20,512
         let x = self.sppf(&x, 9)?; // 20,512
         let x = self.c2psa(&x, 10)?; // 20,512
+
+        // One saved copy of the C2PSA output, reused by the P5 neck concat (below) and returned in
+        // `YoloForward.block10` (sc-8952).
         let block10 = x.clone();
-        let b10 = x.clone();
         // neck (PANet)
         let x = upsample_nearest(&x, 2)?; // 40,512
         let x = concatenate_axis(&[&x, &b6], 3)?; // 40,1024
@@ -738,7 +740,7 @@ impl Yolo {
         let x = concatenate_axis(&[&x, &b13], 3)?; // 40,768
         let p4 = self.c3k2(&x, 19, true)?; // 40,512  → P4
         let x = self.conv(&p4, "model.20", 2, 1, true)?; // 20,512
-        let x = concatenate_axis(&[&x, &b10], 3)?; // 20,1024
+        let x = concatenate_axis(&[&x, &block10], 3)?; // 20,1024
         let p5 = self.c3k2(&x, 22, true)?; // 20,512  → P5
 
         let output = self.detect(&p3, &p4, &p5)?;

--- a/crates/sceneworks-worker/src/person_segment.rs
+++ b/crates/sceneworks-worker/src/person_segment.rs
@@ -305,6 +305,13 @@ pub(crate) fn propagate_track_blocking(
     }
 
     // Pass 2: re-seed the prompt + every weak frame as box anchors and re-propagate.
+    //
+    // ACCEPTED TRADEOFF (sc-8953 / F-151): `run` rebuilds the tracking state via
+    // `init_state_from_frames` (re-encoding all frames) and re-propagates from scratch. That
+    // repeats pass 1's per-frame encode, but `Sam2VideoPredictor` exposes no way to reset the
+    // prompts on an existing state, so a fresh state is the only correct way to re-seed. It is
+    // bounded (the clip is capped at ≤24 frames) and only runs when pass 1 actually drifted, so
+    // the extra encode is left as-is; revisit only if the engine later exposes state reuse.
     let mut seeds = vec![(0usize, prompt)];
     seeds.extend(weak);
     run(&seeds)

--- a/crates/sceneworks-worker/src/pose_jobs.rs
+++ b/crates/sceneworks-worker/src/pose_jobs.rs
@@ -1173,8 +1173,11 @@ async fn run_pose_detect_inner(
                     let skeleton =
                         draw_wholebody(side, side, &body_t, Some(&hands_t), Some(&face_t), stick);
                     let preview = out_dir.join(format!("{stem}_p{person_index}_skel.png"));
+                    // A failed preview encode/write is an output-side fault, not a bad user
+                    // payload — classify it as `Engine` so it isn't mislabeled as user error
+                    // (sc-8952). `ImageError` is not an `io::Error`, so `Io` doesn't fit.
                     skeleton.save(&preview).map_err(|e| {
-                        WorkerError::InvalidPayload(format!("pose preview write: {e}"))
+                        WorkerError::Engine(format!("pose preview write: {e}"))
                     })?;
 
                     poses.push(json!({

--- a/crates/sceneworks-worker/src/scail2_masks.rs
+++ b/crates/sceneworks-worker/src/scail2_masks.rs
@@ -41,16 +41,6 @@ pub(crate) const PALETTE: [[u8; 3]; 6] = [
 pub(crate) const BG_BLACK: [u8; 3] = [0, 0, 0];
 pub(crate) const BG_WHITE: [u8; 3] = [255, 255, 255];
 
-/// The palette color for an object id, or `None` if the object is past the 6-color cap (SCAIL-2's
-/// scheme has six person classes; extra people get no color and read as background).
-fn color_for(order: &[i32], oid: i32) -> Option<[u8; 3]> {
-    order
-        .iter()
-        .position(|&o| o == oid)
-        .filter(|&i| i < PALETTE.len())
-        .map(|i| PALETTE[i])
-}
-
 /// Fill an RGB pixel buffer with a solid background color.
 fn filled(width: usize, height: usize, bg: [u8; 3]) -> Vec<u8> {
     let mut px = vec![0u8; width * height * 3];
@@ -99,8 +89,11 @@ pub(crate) fn paint_driving_masks(masks: &AllPersonMasks, bg: [u8; 3]) -> Worker
         .iter()
         .map(|frame| {
             let mut px = filled(w, h, bg);
-            for &oid in &masks.order {
-                let Some(color) = color_for(&masks.order, oid) else {
+            // The paint order *is* the palette order, so a person's index in `order`
+            // is its color index — take it from `enumerate` instead of re-searching
+            // `order` per person (was O(n²) via `position`) (sc-8952).
+            for (index, &oid) in masks.order.iter().enumerate() {
+                let Some(&color) = PALETTE.get(index) else {
                     continue;
                 };
                 if let Some((_, mask)) = frame.iter().find(|(o, _)| *o == oid) {

--- a/crates/sceneworks-worker/src/supervisor.rs
+++ b/crates/sceneworks-worker/src/supervisor.rs
@@ -14,6 +14,14 @@ pub(crate) struct SupervisedChild {
     /// for a while resets its restart backoff instead of ratcheting it up forever
     /// (sc-4282 / F-MLXW-20).
     pub(crate) spawned_at: Instant,
+    /// Set once a child has exited and been attributed, holding the `Instant` at
+    /// which its backoff elapses and it becomes eligible to respawn. While this is
+    /// `Some`, the child's dead process has already been reaped and reported, so it
+    /// is skipped by exit detection and only revisited to respawn. Tracking the
+    /// deadline per child (instead of sleeping the backoff inline) keeps one
+    /// crash-looping child's delay from stalling the restart of its healthy siblings
+    /// or the detection of further exits (sc-8899 / F-097).
+    pub(crate) next_restart_at: Option<Instant>,
 }
 
 /// A child that stayed alive at least this long before exiting is treated as
@@ -64,6 +72,7 @@ pub(crate) async fn supervise_children(
                 process,
                 restart_attempt: 0,
                 spawned_at: Instant::now(),
+                next_restart_at: None,
             },
         );
     }
@@ -98,8 +107,39 @@ pub(crate) async fn restart_exited_children_with_spawner<F>(
 where
     F: FnMut(&Settings, &WorkerSpec) -> WorkerResult<Child>,
 {
-    let mut exited = Vec::new();
+    restart_exited_children_at(settings, children, &mut spawner, Instant::now()).await
+}
+
+/// Non-blocking supervision tick. Each call does two independent passes over every
+/// child so no single child's backoff can stall the others (sc-8899 / F-097):
+///
+/// 1. **Detect** newly-exited children (those not already awaiting a restart),
+///    attribute an abnormal death, and stamp a per-child `next_restart_at` deadline
+///    from its backoff. Nothing sleeps here.
+/// 2. **Respawn** every child whose `next_restart_at` deadline has passed by `now`.
+///
+/// Because the backoff lives on each child as a deadline rather than an inline
+/// sleep, a 30 s backoff on one crash-looping child no longer delays restarting a
+/// healthy sibling or detecting a further exit — both are handled on the very next
+/// 1 s tick. Shutdown is not handled here (the tick never blocks); the supervision
+/// loop's own `shutdown_signal()` branch races each tick.
+pub(crate) async fn restart_exited_children_at<F>(
+    settings: &Settings,
+    children: &mut HashMap<String, SupervisedChild>,
+    spawner: &mut F,
+    now: Instant,
+) -> WorkerResult<()>
+where
+    F: FnMut(&Settings, &WorkerSpec) -> WorkerResult<Child>,
+{
+    // Pass 1: detect newly-exited children and stamp each with its restart deadline.
+    // Children already awaiting a restart (`next_restart_at` set) have had their dead
+    // process reaped and reported, so they are skipped here and handled in pass 2.
+    let mut newly_exited = Vec::new();
     for (worker_id, child) in children.iter_mut() {
+        if child.next_restart_at.is_some() {
+            continue;
+        }
         if let Some(status) = child.process.try_wait()? {
             // A child that ran healthily for a while before exiting starts its
             // backoff fresh, so rare widely-spaced crashes don't ratchet the delay
@@ -111,6 +151,7 @@ where
             // backoff below both read the same stored value.
             child.restart_attempt = child.restart_attempt.saturating_add(1);
             let delay = retry_delay(settings.poll_seconds, child.restart_attempt);
+            child.next_restart_at = Some(now + Duration::from_secs(delay));
             // A child that terminated abnormally never got to report it. A
             // terminating signal (SIGKILL/OOM, SIGABRT, SIGSEGV, …) is an
             // uncatchable death; a non-zero exit code is a self-terminated process
@@ -132,33 +173,34 @@ where
                     "restartInSeconds": delay,
                 }),
             );
-            exited.push((worker_id.clone(), signal, exit_code));
+            newly_exited.push((worker_id.clone(), signal, exit_code));
         }
     }
-    for (worker_id, signal, exit_code) in exited {
-        // Surface an abnormal death to the user before the backoff sleep, so a job
-        // that died fails promptly instead of hanging until restart. A clean exit-0
-        // is a graceful stop (e.g. the child caught a shutdown signal and exited
-        // itself) and is never reported (sc-6320).
+    // Surface each abnormal death to the user immediately, without waiting on the
+    // backoff, so a job that died fails promptly instead of hanging until restart. A
+    // clean exit-0 is a graceful stop (e.g. the child caught a shutdown signal and
+    // exited itself) and is never reported (sc-6320).
+    for (worker_id, signal, exit_code) in newly_exited {
         if child_died_abnormally(signal, exit_code) {
             report_worker_terminated(settings, &worker_id, signal, exit_code).await;
         }
-        let Some(mut child) = children.remove(&worker_id) else {
+    }
+
+    // Pass 2: respawn every child whose backoff deadline has elapsed. Each is
+    // independent, so several siblings can come back on the same tick and a still-
+    // backing-off child simply waits its turn without blocking anyone.
+    let ready: Vec<String> = children
+        .iter()
+        .filter(|(_, child)| child.next_restart_at.is_some_and(|at| now >= at))
+        .map(|(worker_id, _)| worker_id.clone())
+        .collect();
+    for worker_id in ready {
+        let Some(child) = children.get_mut(&worker_id) else {
             continue;
         };
-        let delay = retry_delay(settings.poll_seconds, child.restart_attempt);
-        tokio::select! {
-            _ = tokio::time::sleep(Duration::from_secs(delay)) => {}
-            _ = shutdown_signal() => {
-                children.insert(worker_id, child);
-                stop_children(settings, children).await;
-                return Ok(());
-            }
-        }
-        let process = spawner(settings, &child.spec)?;
-        child.process = process;
-        child.spawned_at = Instant::now();
-        children.insert(child.spec.worker_id.clone(), child);
+        child.process = spawner(settings, &child.spec)?;
+        child.spawned_at = now;
+        child.next_restart_at = None;
     }
     Ok(())
 }

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -3769,16 +3769,6 @@ fn idle_heartbeat_allows_immediate_resend_when_interval_is_zero() {
     assert!(heartbeat.should_send());
 }
 
-#[test]
-fn idle_heartbeat_can_be_forced_due_after_work() {
-    let mut heartbeat = IdleHeartbeat::new(Duration::from_secs(60));
-
-    heartbeat.mark_sent();
-    assert!(!heartbeat.should_send());
-    heartbeat.mark_due();
-    assert!(heartbeat.should_send());
-}
-
 fn spawn_exit_child() -> tokio::process::Child {
     let mut command = if cfg!(windows) {
         let mut command = tokio::process::Command::new("cmd");

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -49,7 +49,7 @@ use super::model_jobs::{
 #[cfg(unix)]
 use super::supervisor::terminating_signal;
 use super::supervisor::{
-    auto_worker_specs, child_died_abnormally, child_environment,
+    auto_worker_specs, child_died_abnormally, child_environment, restart_exited_children_at,
     restart_exited_children_with_spawner, utility_worker_specs, SupervisedChild, WorkerSpec,
 };
 use super::{
@@ -1310,22 +1310,56 @@ async fn supervisor_restarts_exited_children_with_backoff_state() {
             process: exited,
             restart_attempt: 0,
             spawned_at: std::time::Instant::now(),
+            next_restart_at: None,
         },
     )]);
-    let mut spawns = 0_u32;
-
-    restart_exited_children_with_spawner(&settings, &mut children, |_settings, _spec| {
-        spawns += 1;
+    let spawns = std::cell::Cell::new(0_u32);
+    let mut spawner = |_settings: &_, _spec: &WorkerSpec| {
+        spawns.set(spawns.get() + 1);
         Ok(spawn_sleep_child())
-    })
-    .await
-    .expect("child restarts");
+    };
 
-    assert_eq!(spawns, 1);
+    // Detection tick: the exit is reaped and a backoff deadline is stamped, but the
+    // child is not respawned yet because its backoff has not elapsed (sc-8899).
+    let t0 = std::time::Instant::now();
+    restart_exited_children_at(&settings, &mut children, &mut spawner, t0)
+        .await
+        .expect("exit is detected");
+    assert_eq!(
+        spawns.get(),
+        0,
+        "detection tick does not respawn before backoff"
+    );
+    {
+        let child = children
+            .get("worker-gpu-auto-0")
+            .expect("exited child stays tracked while backing off");
+        assert_eq!(child.restart_attempt, 1);
+        assert!(
+            child.next_restart_at.is_some(),
+            "a backoff deadline is stamped on the exited child"
+        );
+    }
+
+    // Restart tick past the backoff deadline: the child is respawned exactly once.
+    restart_exited_children_at(
+        &settings,
+        &mut children,
+        &mut spawner,
+        t0 + Duration::from_secs(30),
+    )
+    .await
+    .expect("child restarts once its backoff elapses");
+
+    assert_eq!(spawns.get(), 1);
     let child = children
         .get_mut("worker-gpu-auto-0")
         .expect("restarted child is tracked");
     assert_eq!(child.restart_attempt, 1);
+    assert!(
+        child.next_restart_at.is_none(),
+        "the backoff deadline clears once the child is respawned"
+    );
     assert!(child
         .process
         .try_wait()
@@ -1333,6 +1367,96 @@ async fn supervisor_restarts_exited_children_with_backoff_state() {
         .is_none());
     let _ = child.process.start_kill();
     let _ = child.process.wait().await;
+}
+
+/// sc-8899 / F-097: one child's restart backoff must not stall the whole
+/// supervision tick. A crash-looping child with a long backoff and a healthy
+/// sibling that just crashed are handled independently — the sibling restarts on
+/// the next eligible tick while the still-backing-off child simply waits its turn.
+#[tokio::test]
+async fn supervisor_backoff_on_one_child_does_not_stall_another() {
+    let settings = test_settings("http://127.0.0.1".to_owned(), None);
+
+    // A crash-looping child mid-backoff: already reaped, with a deadline 30 s out.
+    let mut looping = spawn_exit_child();
+    for _ in 0..20 {
+        if looping.try_wait().expect("child status checks").is_some() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    let t0 = std::time::Instant::now();
+    let looping_child = SupervisedChild {
+        spec: WorkerSpec {
+            worker_id: "worker-gpu-auto-0".to_owned(),
+            gpu_id: "0".to_owned(),
+        },
+        process: looping,
+        restart_attempt: 6,
+        spawned_at: t0,
+        next_restart_at: Some(t0 + Duration::from_secs(30)),
+    };
+
+    // A healthy sibling that already crashed and whose short backoff is now due.
+    let mut sibling = spawn_exit_child();
+    for _ in 0..20 {
+        if sibling.try_wait().expect("child status checks").is_some() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    let sibling_child = SupervisedChild {
+        spec: WorkerSpec {
+            worker_id: "worker-gpu-auto-1".to_owned(),
+            gpu_id: "1".to_owned(),
+        },
+        process: sibling,
+        restart_attempt: 1,
+        spawned_at: t0,
+        next_restart_at: Some(t0 + Duration::from_secs(1)),
+    };
+
+    let mut children = HashMap::from([
+        ("worker-gpu-auto-0".to_owned(), looping_child),
+        ("worker-gpu-auto-1".to_owned(), sibling_child),
+    ]);
+    let mut restarted = Vec::new();
+    let mut spawner = |_settings: &_, spec: &WorkerSpec| {
+        restarted.push(spec.worker_id.clone());
+        Ok(spawn_sleep_child())
+    };
+
+    // A single tick at t0 + 5 s: the sibling's 1 s backoff is due while the looping
+    // child's 30 s backoff is not. The old inline-sleep design would have blocked the
+    // whole tick on whichever child was handled first; the per-child deadline model
+    // restarts only the due sibling and leaves the looping child untouched (sc-8899).
+    restart_exited_children_at(
+        &settings,
+        &mut children,
+        &mut spawner,
+        t0 + Duration::from_secs(5),
+    )
+    .await
+    .expect("tick completes without stalling on the backing-off child");
+
+    assert_eq!(
+        restarted,
+        vec!["worker-gpu-auto-1".to_owned()],
+        "the due sibling restarts while the looping child is still backing off"
+    );
+    assert!(
+        children["worker-gpu-auto-0"].next_restart_at.is_some(),
+        "the looping child keeps its unexpired backoff deadline"
+    );
+    assert!(
+        children["worker-gpu-auto-1"].next_restart_at.is_none(),
+        "the restarted sibling has its deadline cleared"
+    );
+
+    for child in children.values_mut() {
+        let _ = child.process.start_kill();
+        let _ = child.process.wait().await;
+    }
 }
 
 /// sc-4282 / F-MLXW-20: a child that ran healthily past the reset threshold
@@ -1364,18 +1488,21 @@ async fn supervisor_resets_backoff_after_a_healthy_run() {
             spawned_at: std::time::Instant::now()
                 .checked_sub(Duration::from_secs(360))
                 .expect("monotonic clock backdates 6 minutes"),
+            next_restart_at: None,
         },
     )]);
 
+    // The backoff reset happens when the exit is detected, so a single detection
+    // tick is enough to observe it (the respawn itself waits for the backoff).
     restart_exited_children_with_spawner(&settings, &mut children, |_settings, _spec| {
         Ok(spawn_sleep_child())
     })
     .await
-    .expect("child restarts");
+    .expect("exit is detected");
 
     let child = children
         .get_mut("worker-gpu-auto-0")
-        .expect("restarted child is tracked");
+        .expect("exited child stays tracked while backing off");
     // Reset to 0 on the healthy run, then advanced once for this restart.
     assert_eq!(
         child.restart_attempt, 1,

--- a/docs/mac-rust-gaps.md
+++ b/docs/mac-rust-gaps.md
@@ -48,7 +48,7 @@ Image models in `MODEL_TARGETS` that are **not** in `MLX_ROUTED_MODELS` → the 
 adapter is authoritative on Mac. **Policy (Michael, 2026-06-07): every unported model gets its
 own MLX-porting epic and is *dropped on Mac only* (UI-gated, sc-3486) until that port lands —
 Windows/Linux keep the torch path.** Nothing here is a permanent drop. `mac_rust_supported` →
-`torch_only_image_model_epic(model)` names the specific epic below.
+`classify_image_gap` names the specific epic below.
 
 | Model id | Family | Mac disposition | Porting epic |
 |---|---|---|---|
@@ -56,13 +56,14 @@ Windows/Linux keep the torch path.** Nothing here is a permanent drop. `mac_rust
 | `pulid_flux_dev` | flux (PuLID) | 🔵 Port → drop-on-Mac until then | epic 3069 (engine done; owes SceneWorks routing) |
 
 > **No whole-model torch-only image families remain.** `lens` / `lens_turbo` were the last; they
-> are MLX on Mac as of epic 3164 / sc-5105 (see §6). `torch_only_image_model_epic` now names nothing
-> — the gap path fires only for a hypothetical unported model id.
+> are MLX on Mac as of epic 3164 / sc-5105 (see §6). The per-model `torch_only_image_model_epic`
+> seam matched nothing and was retired (sc-8951); the gap path in `classify_image_gap` now fires
+> only for a hypothetical unported model id.
 
-> A torch-only image model with **no** porting epic yet → `torch_only_image_model_epic` returns
-> `None` and the oracle reports "needs a port epic (epic 3482 policy)"; file one + add it to the
-> match. FLUX.2-**dev** is not a Mac `MODEL_TARGETS` entry and is out of mlx-gen scope; third-party
-> **LyCORIS** is a feature gap, see §2.
+> A torch-only image model with **no** porting epic yet → `classify_image_gap` reports "needs a
+> port epic (epic 3482 policy)"; file one + reintroduce a per-model epic mapping in
+> `classify_image_gap`. FLUX.2-**dev** is not a Mac `MODEL_TARGETS` entry and is out of mlx-gen
+> scope; third-party **LyCORIS** is a feature gap, see §2.
 
 ## 2. Image feature gaps on MLX-routed families
 


### PR DESCRIPTION
Epic 8800 code-review remediation, batch 8. Five stories from the 2026-07-01 full code review.

## Stories

- **sc-8899 [F-097] (bug)** — `supervisor.rs`: one child's restart backoff no longer stalls the supervisor tick. Replaced the inline sequential backoff sleep with a per-child `next_restart_at: Instant` deadline. Each 1 s tick now does a non-blocking detect pass (reap + attribute abnormal death + stamp deadline) and a respawn pass (restart any child whose deadline elapsed). No tick sleeps on a backoff, so a 30 s backoff on one crash-looping child never delays restarting a healthy sibling or detecting a further exit.
- **sc-8951 [F-149] (bug/chore)** — `sceneworks-core/src/slug.rs`: `slugify` re-runs the trailing-dash trim after `truncate`, so a mid-boundary truncation (`"my project"`/max 3 → was `"my-"`) no longer leaves a trailing dash. Also retired the permanently-`None` `torch_only_image_model_epic` routing seam by inlining the `None` path into `classify_image_gap` (every torch-only image family has been ported to MLX); docs + catalog comment updated.
- **sc-8954 [F-152] (chore)** — `image_jobs/`: folded the six near-identical `#[cfg(all(target_os="macos", test))]` load wrappers (Z-Image Turbo/base, FLUX.2-dev, Qwen, FLUX.1-dev, base `load_engine`) into one shared `load_control_engine(engine_id, spec)` test helper in `base.rs`. Each lane keeps its own `*_control_spec` builder (still used by the production streaming path). Test-only, behavior-preserving.
- **sc-8952 [F-150] (chore)** — miscellaneous worker readability/redundancy nits (see below).
- **sc-8953 [F-151] (chore)** — recorded the four accepted efficiency tradeoffs (SAM2 pass-2 re-encode, depth per-call reload, image streaming-result clone, InstantID double angle-collection lookup) as in-code "ACCEPTED TRADEOFF" comments with the revisit trigger at each site. No behavior change (the review accepted these as-is).

## Files touched by sc-8952

`scail2_masks.rs` (enumerate-with-index instead of O(n²) `position()` re-search; removed now-dead `color_for`), `person_jobs.rs` (drop the duplicate `b10` C2PSA clone), `pose_jobs.rs` (preview-write failure → `Engine` not `InvalidPayload`), `depth.rs` (cfg-alias the depth backend crate → one shared body), `lib.rs` (`mark_sent()` instead of `mark_due()` after a completed job so `poll_once` doesn't fire a redundant second Idle heartbeat; removed now-dead `mark_due` + its test), `flux1_control_mlx_smoke.rs` (drop redundant inner `#![cfg]`), `footprint_measure.rs` (`measure_footprint` returns `()` — all callers discard the tuple), `ort_cuda.rs` (pre-write the edition-2024 `set_var` SAFETY comment).

## Tests

- New: supervisor `supervisor_backoff_on_one_child_does_not_stall_another` (a due sibling restarts while another child is mid-backoff); updated the two existing supervisor tests for the two-phase detect-then-respawn model via an injectable-clock helper.
- New: `slug::tests` module (truncation-trailing-dash + general slug contract).
- All other changes are behavior-preserving or comment-only.

## Verification

- `npm run rust:check` — fmt/clippy/test/build all clean; rust-api contracts unchanged.
- `cargo test -p sceneworks-worker --lib` — 610 passed, 0 failed (137 ignored real-weight smokes).
- `cargo test -p sceneworks-core --lib` — 384 passed.
- FRESH candle check (`cargo clean -p sceneworks-worker` + touch changed srcs, then `cargo test -p sceneworks-worker --no-default-features -F backend-candle --no-run`) — 0 errors, run both before and after merging `origin/main`.
- Merged `origin/main` (not rebased) before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)